### PR TITLE
Fix/webhook polling race conditions

### DIFF
--- a/src/lib/cancel-run.test.ts
+++ b/src/lib/cancel-run.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
+
+const mockGetRun = vi.fn();
+vi.mock("workflow/api", () => ({
+  getRun: (...args: any[]) => mockGetRun(...args),
+}));
+
+function makeRegistry(overrides: Partial<RunRegistryAdapter> = {}): RunRegistryAdapter {
+  return {
+    claim: vi.fn(),
+    register: vi.fn(),
+    getRunId: vi.fn(),
+    unregister: overrides.unregister ?? vi.fn().mockResolvedValue(undefined),
+    listAll: vi.fn(),
+  };
+}
+
+describe("cancelRun", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("cancels the run and unregisters", async () => {
+    const mockCancel = vi.fn().mockResolvedValue(undefined);
+    mockGetRun.mockReturnValue({ cancel: mockCancel });
+    const registry = makeRegistry();
+
+    const { cancelRun } = await import("./cancel-run.js");
+    const result = await cancelRun("PROJ-1", "run_abc", registry);
+
+    expect(result).toBe(true);
+    expect(mockGetRun).toHaveBeenCalledWith("run_abc");
+    expect(mockCancel).toHaveBeenCalled();
+    expect(registry.unregister).toHaveBeenCalledWith("PROJ-1");
+  });
+
+  it("returns false and still unregisters when cancel throws", async () => {
+    mockGetRun.mockReturnValue({
+      cancel: vi.fn().mockRejectedValue(new Error("run gone")),
+    });
+    const registry = makeRegistry();
+
+    const { cancelRun } = await import("./cancel-run.js");
+    const result = await cancelRun("PROJ-1", "run_abc", registry);
+
+    expect(result).toBe(false);
+    expect(registry.unregister).toHaveBeenCalledWith("PROJ-1");
+  });
+
+  it("is idempotent — second call on same ticket returns false without throwing", async () => {
+    mockGetRun.mockReturnValue({
+      cancel: vi.fn().mockRejectedValue(new Error("already cancelled")),
+    });
+    const unregister = vi.fn().mockResolvedValue(undefined);
+    const registry = makeRegistry({ unregister });
+
+    const { cancelRun } = await import("./cancel-run.js");
+    await cancelRun("PROJ-1", "run_abc", registry);
+    const result = await cancelRun("PROJ-1", "run_abc", registry);
+
+    expect(result).toBe(false);
+    expect(unregister).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/cancel-run.ts
+++ b/src/lib/cancel-run.ts
@@ -1,0 +1,29 @@
+import { getRun } from "workflow/api";
+import { logger } from "./logger.js";
+import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
+
+/**
+ * Cancel a workflow run and unregister it from the registry.
+ * Idempotent: safe to call multiple times for the same ticket.
+ * Returns true if cancel succeeded, false if it errored (still unregisters).
+ */
+export async function cancelRun(
+  ticketKey: string,
+  runId: string,
+  runRegistry: RunRegistryAdapter,
+): Promise<boolean> {
+  let cancelled = false;
+  try {
+    const run = getRun(runId);
+    await run.cancel();
+    cancelled = true;
+  } catch (err) {
+    logger.warn(
+      { ticketKey, runId, error: (err as Error).message },
+      "cancel_run_error",
+    );
+  }
+
+  await runRegistry.unregister(ticketKey).catch(() => {});
+  return cancelled;
+}

--- a/src/lib/dispatch.test.ts
+++ b/src/lib/dispatch.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Adapters } from "./adapters.js";
 import type { TicketContent } from "../adapters/issue-tracker/types.js";
 
-
 const mockStart = vi.fn();
 const mockGetRun = vi.fn();
 vi.mock("workflow/api", () => ({
@@ -25,7 +24,6 @@ vi.mock("@vercel/sandbox", () => ({
   },
 }));
 
-
 function makeTicket(overrides: Partial<TicketContent> = {}): TicketContent {
   return {
     id: "ticket-001",
@@ -40,20 +38,22 @@ function makeTicket(overrides: Partial<TicketContent> = {}): TicketContent {
   };
 }
 
-function makeAdapters(overrides: Partial<{
-  claim: ReturnType<typeof vi.fn>;
-  register: ReturnType<typeof vi.fn>;
-  unregister: ReturnType<typeof vi.fn>;
-  getRunId: ReturnType<typeof vi.fn>;
-  fetchTicket: ReturnType<typeof vi.fn>;
-  findPR: ReturnType<typeof vi.fn>;
-}>= {}): Adapters {
-  // Track the claim value so getRunId can return it by default
+function makeAdapters(
+  overrides: Partial<{
+    claim: ReturnType<typeof vi.fn>;
+    register: ReturnType<typeof vi.fn>;
+    unregister: ReturnType<typeof vi.fn>;
+    getRunId: ReturnType<typeof vi.fn>;
+    fetchTicket: ReturnType<typeof vi.fn>;
+    findPR: ReturnType<typeof vi.fn>;
+  }> = {},
+): Adapters {
   let claimedValue: string | undefined;
 
   return {
     issueTracker: {
-      fetchTicket: overrides.fetchTicket ?? vi.fn().mockResolvedValue(makeTicket()),
+      fetchTicket:
+        overrides.fetchTicket ?? vi.fn().mockResolvedValue(makeTicket()),
       moveTicket: vi.fn(),
       postComment: vi.fn(),
       searchTickets: vi.fn(),
@@ -70,18 +70,21 @@ function makeAdapters(overrides: Partial<{
       notify: vi.fn(),
     },
     runRegistry: {
-      claim: overrides.claim ?? vi.fn().mockImplementation(async (_key: string, value: string) => {
-        claimedValue = value;
-        return true;
-      }),
+      claim:
+        overrides.claim ??
+        vi.fn().mockImplementation(async (_key: string, value: string) => {
+          claimedValue = value;
+          return true;
+        }),
       register: overrides.register ?? vi.fn().mockResolvedValue(undefined),
       unregister: overrides.unregister ?? vi.fn().mockResolvedValue(undefined),
-      getRunId: overrides.getRunId ?? vi.fn().mockImplementation(async () => claimedValue),
+      getRunId:
+        overrides.getRunId ??
+        vi.fn().mockImplementation(async () => claimedValue),
       listAll: vi.fn(),
     },
   };
 }
-
 
 describe("dispatchTicket", () => {
   beforeEach(() => {
@@ -99,24 +102,44 @@ describe("dispatchTicket", () => {
     const result = await dispatchTicket("PROJ-42", adapters, 5);
 
     expect(result).toEqual({ started: true, runId: "run_123" });
-    expect(adapters.runRegistry.claim).toHaveBeenCalledWith("PROJ-42", expect.stringMatching(/^claiming:\d+$/));
+    expect(adapters.runRegistry.claim).toHaveBeenCalledWith(
+      "PROJ-42",
+      expect.stringMatching(/^claiming:\d+$/),
+    );
     expect(adapters.issueTracker.fetchTicket).toHaveBeenCalledWith("PROJ-42");
     expect(adapters.vcs.findPR).toHaveBeenCalledWith("blazebot/proj-42");
-    expect(mockStart).toHaveBeenCalledWith("implementationWorkflow_sentinel", ["ticket-001"]);
-    expect(adapters.runRegistry.register).toHaveBeenCalledWith("PROJ-42", "run_123");
+    expect(mockStart).toHaveBeenCalledWith("implementationWorkflow_sentinel", [
+      "ticket-001",
+    ]);
+    expect(adapters.runRegistry.register).toHaveBeenCalledWith(
+      "PROJ-42",
+      "run_123",
+    );
   });
 
   it("dispatches review-fix workflow when PR exists", async () => {
     const adapters = makeAdapters({
-      findPR: vi.fn().mockResolvedValue({ id: 7, url: "https://github.com/pr/7", branch: "blazebot/proj-42" }),
+      findPR: vi
+        .fn()
+        .mockResolvedValue({
+          id: 7,
+          url: "https://github.com/pr/7",
+          branch: "blazebot/proj-42",
+        }),
     });
     const { dispatchTicket } = await import("./dispatch.js");
 
     const result = await dispatchTicket("PROJ-42", adapters, 5);
 
     expect(result).toEqual({ started: true, runId: "run_123" });
-    expect(mockStart).toHaveBeenCalledWith("reviewFixWorkflow_sentinel", ["ticket-001", "blazebot/proj-42"]);
-    expect(adapters.runRegistry.register).toHaveBeenCalledWith("PROJ-42", "run_123");
+    expect(mockStart).toHaveBeenCalledWith("reviewFixWorkflow_sentinel", [
+      "ticket-001",
+      "blazebot/proj-42",
+    ]);
+    expect(adapters.runRegistry.register).toHaveBeenCalledWith(
+      "PROJ-42",
+      "run_123",
+    );
   });
 
   it("returns already_claimed when claim fails", async () => {

--- a/src/lib/dispatch.test.ts
+++ b/src/lib/dispatch.test.ts
@@ -4,8 +4,10 @@ import type { TicketContent } from "../adapters/issue-tracker/types.js";
 
 
 const mockStart = vi.fn();
+const mockGetRun = vi.fn();
 vi.mock("workflow/api", () => ({
   start: (...args: any[]) => mockStart(...args),
+  getRun: (...args: any[]) => mockGetRun(...args),
 }));
 
 vi.mock("../workflows/implementation.js", () => ({
@@ -42,9 +44,13 @@ function makeAdapters(overrides: Partial<{
   claim: ReturnType<typeof vi.fn>;
   register: ReturnType<typeof vi.fn>;
   unregister: ReturnType<typeof vi.fn>;
+  getRunId: ReturnType<typeof vi.fn>;
   fetchTicket: ReturnType<typeof vi.fn>;
   findPR: ReturnType<typeof vi.fn>;
 }>= {}): Adapters {
+  // Track the claim value so getRunId can return it by default
+  let claimedValue: string | undefined;
+
   return {
     issueTracker: {
       fetchTicket: overrides.fetchTicket ?? vi.fn().mockResolvedValue(makeTicket()),
@@ -64,10 +70,13 @@ function makeAdapters(overrides: Partial<{
       notify: vi.fn(),
     },
     runRegistry: {
-      claim: overrides.claim ?? vi.fn().mockResolvedValue(true),
+      claim: overrides.claim ?? vi.fn().mockImplementation(async (_key: string, value: string) => {
+        claimedValue = value;
+        return true;
+      }),
       register: overrides.register ?? vi.fn().mockResolvedValue(undefined),
       unregister: overrides.unregister ?? vi.fn().mockResolvedValue(undefined),
-      getRunId: vi.fn(),
+      getRunId: overrides.getRunId ?? vi.fn().mockImplementation(async () => claimedValue),
       listAll: vi.fn(),
     },
   };
@@ -90,7 +99,7 @@ describe("dispatchTicket", () => {
     const result = await dispatchTicket("PROJ-42", adapters, 5);
 
     expect(result).toEqual({ started: true, runId: "run_123" });
-    expect(adapters.runRegistry.claim).toHaveBeenCalledWith("PROJ-42", "claiming");
+    expect(adapters.runRegistry.claim).toHaveBeenCalledWith("PROJ-42", expect.stringMatching(/^claiming:\d+$/));
     expect(adapters.issueTracker.fetchTicket).toHaveBeenCalledWith("PROJ-42");
     expect(adapters.vcs.findPR).toHaveBeenCalledWith("blazebot/proj-42");
     expect(mockStart).toHaveBeenCalledWith("implementationWorkflow_sentinel", ["ticket-001"]);
@@ -141,6 +150,25 @@ describe("dispatchTicket", () => {
     expect(result).toEqual({ started: false, reason: "at_capacity" });
     expect(adapters.runRegistry.claim).not.toHaveBeenCalled();
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("aborts workflow if claim was removed during dispatch", async () => {
+    const mockCancel = vi.fn().mockResolvedValue(undefined);
+    mockGetRun.mockReturnValue({ cancel: mockCancel });
+
+    // getRunId returns null — claim was removed by a cancel while workflow was starting
+    const adapters = makeAdapters({
+      getRunId: vi.fn().mockResolvedValue(null),
+    });
+    const { dispatchTicket } = await import("./dispatch.js");
+
+    const result = await dispatchTicket("PROJ-42", adapters, 5);
+
+    expect(result).toEqual({ started: false, reason: "already_claimed" });
+    expect(mockStart).toHaveBeenCalled();
+    expect(mockGetRun).toHaveBeenCalledWith("run_123");
+    expect(mockCancel).toHaveBeenCalled();
+    expect(adapters.runRegistry.register).not.toHaveBeenCalled();
   });
 
   it("unregisters claim and returns error on dispatch failure", async () => {

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -14,20 +14,6 @@ export function getClaimTimestamp(runId: string): number {
   return parseInt(runId.slice(CLAIMING_PREFIX.length), 10);
 }
 
-async function getActiveSandboxCount(): Promise<number> {
-  try {
-    const { Sandbox } = await import("@vercel/sandbox");
-    const { json } = await Sandbox.list({ limit: 100 });
-    return json.sandboxes.filter((s: any) => s.status === "running").length;
-  } catch (err) {
-    logger.warn(
-      { error: (err as Error).message },
-      "sandbox_count_check_failed",
-    );
-    return 0;
-  }
-}
-
 export interface DispatchResult {
   started: boolean;
   runId?: string;
@@ -41,73 +27,97 @@ export async function dispatchTicket(
 ): Promise<DispatchResult> {
   const { issueTracker, vcs, runRegistry } = adapters;
 
-  const activeSandboxes = await getActiveSandboxCount();
-  if (activeSandboxes >= maxConcurrentAgents) {
-    logger.info(
-      { active: activeSandboxes, max: maxConcurrentAgents },
-      "dispatch_at_capacity",
-    );
+  if (await isAtCapacity(maxConcurrentAgents)) {
     return { started: false, reason: "at_capacity" };
   }
 
   const claimValue = `${CLAIMING_PREFIX}${Date.now()}`;
   const claimed = await runRegistry.claim(ticketKey, claimValue);
   if (!claimed) {
-    logger.info({ ticketKey }, "dispatch_ticket_already_claimed");
+    logger.info({ ticketKey }, "dispatch_already_claimed");
     return { started: false, reason: "already_claimed" };
   }
 
   try {
     const ticket = await issueTracker.fetchTicket(ticketKey);
     const branchName = `blazebot/${ticket.identifier.toLowerCase()}`;
-    const existingPR = await vcs.findPR(branchName);
 
-    let handle;
-    if (existingPR) {
-      handle = await start(reviewFixWorkflow, [ticket.id, branchName]);
-      logger.info(
-        {
-          ticketId: ticket.id,
-          identifier: ticket.identifier,
-          runId: handle.runId,
-        },
-        "workflow_started_review_fix",
-      );
-    } else {
-      handle = await start(implementationWorkflow, [ticket.id]);
-      logger.info(
-        {
-          ticketId: ticket.id,
-          identifier: ticket.identifier,
-          runId: handle.runId,
-        },
-        "workflow_started_implementation",
-      );
-    }
+    const handle = await startWorkflow(ticket, branchName, vcs);
 
-    // Verify claim wasn't cancelled while the workflow was starting.
-    // If a cancel removed our sentinel, abort the just-started workflow.
-    const currentRunId = await runRegistry.getRunId(ticketKey);
-    if (currentRunId !== claimValue) {
-      logger.info(
-        { ticketKey, runId: handle.runId },
-        "dispatch_aborted_claim_cancelled",
-      );
-      try {
-        const run = getRun(handle.runId);
-        await run.cancel();
-      } catch {}
+    const claimStillHeld = await verifyClaimNotCancelled(
+      ticketKey,
+      claimValue,
+      runRegistry,
+    );
+    if (!claimStillHeld) {
+      await abortWorkflow(handle.runId, ticketKey);
       return { started: false, reason: "already_claimed" };
     }
 
-    await runRegistry.register(ticket.identifier, handle.runId);
+    await runRegistry.register(ticketKey, handle.runId);
     return { started: true, runId: handle.runId };
   } catch (err) {
     await runRegistry.unregister(ticketKey).catch(() => {});
     logger.warn(
       { ticketKey, error: (err as Error).message },
-      "dispatch_ticket_error",
+      "dispatch_error",
     );
     return { started: false, reason: "error" };
   }
+}
+
+async function isAtCapacity(max: number): Promise<boolean> {
+  const active = await getActiveSandboxCount();
+  if (active < max) return false;
+
+  logger.info({ active, max }, "dispatch_at_capacity");
+  return true;
+}
+
+async function getActiveSandboxCount(): Promise<number> {
+  try {
+    const { Sandbox } = await import("@vercel/sandbox");
+    const { json } = await Sandbox.list({ limit: 100 });
+    return json.sandboxes.filter((s: any) => s.status === "running").length;
+  } catch (err) {
+    logger.warn({ error: (err as Error).message }, "sandbox_count_check_failed");
+    return 0;
+  }
+}
+
+async function startWorkflow(
+  ticket: { id: string; identifier: string },
+  branchName: string,
+  vcs: Adapters["vcs"],
+) {
+  const existingPR = await vcs.findPR(branchName);
+
+  const handle = existingPR
+    ? await start(reviewFixWorkflow, [ticket.id, branchName])
+    : await start(implementationWorkflow, [ticket.id]);
+
+  const workflowType = existingPR ? "review_fix" : "implementation";
+  logger.info(
+    { ticketId: ticket.id, identifier: ticket.identifier, runId: handle.runId },
+    `workflow_started_${workflowType}`,
+  );
+
+  return handle;
+}
+
+async function verifyClaimNotCancelled(
+  ticketKey: string,
+  expectedClaimValue: string,
+  runRegistry: Adapters["runRegistry"],
+): Promise<boolean> {
+  const currentValue = await runRegistry.getRunId(ticketKey);
+  return currentValue === expectedClaimValue;
+}
+
+async function abortWorkflow(runId: string, ticketKey: string): Promise<void> {
+  logger.info({ ticketKey, runId }, "dispatch_aborted_claim_cancelled");
+  try {
+    const run = getRun(runId);
+    await run.cancel();
+  } catch {}
 }

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -1,10 +1,18 @@
-import { start } from "workflow/api";
+import { start, getRun } from "workflow/api";
 import { implementationWorkflow } from "../workflows/implementation.js";
 import { reviewFixWorkflow } from "../workflows/review-fix.js";
 import { logger } from "./logger.js";
 import type { Adapters } from "./adapters.js";
 
-export const CLAIMING_SENTINEL = "claiming";
+const CLAIMING_PREFIX = "claiming:";
+
+export function isClaimingSentinel(runId: string): boolean {
+  return runId.startsWith(CLAIMING_PREFIX);
+}
+
+export function getClaimTimestamp(runId: string): number {
+  return parseInt(runId.slice(CLAIMING_PREFIX.length), 10);
+}
 
 async function getActiveSandboxCount(): Promise<number> {
   try {
@@ -42,7 +50,8 @@ export async function dispatchTicket(
     return { started: false, reason: "at_capacity" };
   }
 
-  const claimed = await runRegistry.claim(ticketKey, CLAIMING_SENTINEL);
+  const claimValue = `${CLAIMING_PREFIX}${Date.now()}`;
+  const claimed = await runRegistry.claim(ticketKey, claimValue);
   if (!claimed) {
     logger.info({ ticketKey }, "dispatch_ticket_already_claimed");
     return { started: false, reason: "already_claimed" };
@@ -74,6 +83,21 @@ export async function dispatchTicket(
         },
         "workflow_started_implementation",
       );
+    }
+
+    // Verify claim wasn't cancelled while the workflow was starting.
+    // If a cancel removed our sentinel, abort the just-started workflow.
+    const currentRunId = await runRegistry.getRunId(ticketKey);
+    if (currentRunId !== claimValue) {
+      logger.info(
+        { ticketKey, runId: handle.runId },
+        "dispatch_aborted_claim_cancelled",
+      );
+      try {
+        const run = getRun(handle.runId);
+        await run.cancel();
+      } catch {}
+      return { started: false, reason: "already_claimed" };
     }
 
     await runRegistry.register(ticket.identifier, handle.runId);

--- a/src/lib/jira-webhook.ts
+++ b/src/lib/jira-webhook.ts
@@ -41,7 +41,6 @@ export function parseJiraWebhookEvent(
 
   const items: any[] | undefined = payload?.changelog?.items;
   if (!Array.isArray(items)) {
-    console.log("[DEBUG] No changelog.items array", { ticketKey, changelog: payload?.changelog });
     return { ticketKey, action: "ignore" };
   }
 
@@ -50,11 +49,8 @@ export function parseJiraWebhookEvent(
   );
 
   if (!statusChange) {
-    console.log("[DEBUG] No status change in items", { ticketKey, items });
     return { ticketKey, action: "ignore" };
   }
-
-  console.log("[DEBUG] statusChange found", { ticketKey, statusChange, targetColumn });
 
   if (statusChange.toString === targetColumn) {
     return { ticketKey, action: "dispatch" };

--- a/src/lib/reconcile.test.ts
+++ b/src/lib/reconcile.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
+
+const mockGetRun = vi.fn();
+vi.mock("workflow/api", () => ({
+  getRun: (...args: any[]) => mockGetRun(...args),
+}));
+
+const mockCancelRun = vi.fn();
+vi.mock("./cancel-run.js", () => ({
+  cancelRun: (...args: any[]) => mockCancelRun(...args),
+}));
+
+function makeRegistry(
+  runs: Array<{ ticketKey: string; runId: string }> = [],
+): RunRegistryAdapter {
+  return {
+    claim: vi.fn(),
+    register: vi.fn(),
+    getRunId: vi.fn(),
+    unregister: vi.fn().mockResolvedValue(undefined),
+    listAll: vi.fn().mockResolvedValue(runs),
+  };
+}
+
+describe("reconcileRuns", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("skips fresh claiming entries", async () => {
+    const registry = makeRegistry([
+      { ticketKey: "PROJ-1", runId: `claiming:${Date.now()}` },
+    ]);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    const result = await reconcileRuns(new Set(["PROJ-1"]), registry);
+
+    expect(result).toEqual({ cancelled: 0, cleaned: 0 });
+    expect(registry.unregister).not.toHaveBeenCalled();
+    expect(mockGetRun).not.toHaveBeenCalled();
+    expect(mockCancelRun).not.toHaveBeenCalled();
+  });
+
+  it("cleans stale claiming entries", async () => {
+    const tenMinAgo = Date.now() - 10 * 60 * 1000;
+    const registry = makeRegistry([
+      { ticketKey: "PROJ-1", runId: `claiming:${tenMinAgo}` },
+    ]);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    const result = await reconcileRuns(new Set(["PROJ-1"]), registry);
+
+    expect(result).toEqual({ cancelled: 0, cleaned: 1 });
+    expect(registry.unregister).toHaveBeenCalledWith("PROJ-1");
+  });
+
+
+  it("cancels fresh claiming entries for tickets that left AI column", async () => {
+    const registry = makeRegistry([
+      { ticketKey: "PROJ-1", runId: `claiming:${Date.now()}` },
+    ]);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    // PROJ-1 is NOT in the AI column set
+    const result = await reconcileRuns(new Set(), registry);
+
+    expect(result).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(registry.unregister).toHaveBeenCalledWith("PROJ-1");
+    expect(mockCancelRun).not.toHaveBeenCalled();
+  });
+
+  it("cleans completed runs that are still in AI column", async () => {
+    const registry = makeRegistry([
+      { ticketKey: "PROJ-1", runId: "run_done" },
+    ]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    const result = await reconcileRuns(new Set(["PROJ-1"]), registry);
+
+    expect(result).toEqual({ cancelled: 0, cleaned: 1 });
+    expect(registry.unregister).toHaveBeenCalledWith("PROJ-1");
+    expect(mockCancelRun).not.toHaveBeenCalled();
+  });
+
+  it("cleans failed runs", async () => {
+    const registry = makeRegistry([
+      { ticketKey: "PROJ-1", runId: "run_fail" },
+    ]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("failed") });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    const result = await reconcileRuns(new Set(["PROJ-1"]), registry);
+
+    expect(result).toEqual({ cancelled: 0, cleaned: 1 });
+  });
+
+  it("leaves running runs in AI column alone", async () => {
+    const registry = makeRegistry([
+      { ticketKey: "PROJ-1", runId: "run_active" },
+    ]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    const result = await reconcileRuns(new Set(["PROJ-1"]), registry);
+
+    expect(result).toEqual({ cancelled: 0, cleaned: 0 });
+    expect(registry.unregister).not.toHaveBeenCalled();
+  });
+
+  it("cancels runs for tickets that left AI column", async () => {
+    const registry = makeRegistry([
+      { ticketKey: "PROJ-1", runId: "run_stale" },
+    ]);
+    mockCancelRun.mockResolvedValue(true);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    const result = await reconcileRuns(new Set(), registry); // PROJ-1 not in AI column
+
+    expect(result).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockCancelRun).toHaveBeenCalledWith("PROJ-1", "run_stale", registry);
+  });
+
+  it("cleans unreachable runs (getRun throws)", async () => {
+    const registry = makeRegistry([
+      { ticketKey: "PROJ-1", runId: "run_ghost" },
+    ]);
+    mockGetRun.mockReturnValue({
+      get status() { return Promise.reject(new Error("not found")); },
+    });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    const result = await reconcileRuns(new Set(["PROJ-1"]), registry);
+
+    expect(result).toEqual({ cancelled: 0, cleaned: 1 });
+    expect(registry.unregister).toHaveBeenCalledWith("PROJ-1");
+  });
+});

--- a/src/lib/reconcile.ts
+++ b/src/lib/reconcile.ts
@@ -5,16 +5,8 @@ import { logger } from "./logger.js";
 import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
 
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
-const STALE_CLAIM_MS = 5 * 60 * 1000; // 5 minutes
+const STALE_CLAIM_MS = 5 * 60 * 1000;
 
-/**
- * Reconcile the run registry against current AI-column tickets.
- * - Cleans completed/failed/unreachable runs
- * - Cancels runs for tickets that left the AI column
- * - Skips in-flight claims (CLAIMING_SENTINEL)
- *
- * All operations are idempotent — safe to run concurrently with webhooks.
- */
 export async function reconcileRuns(
   aiColumnTickets: Set<string>,
   runRegistry: RunRegistryAdapter,
@@ -25,42 +17,73 @@ export async function reconcileRuns(
 
   for (const { ticketKey, runId } of activeRuns) {
     if (isClaimingSentinel(runId)) {
-      if (Date.now() - getClaimTimestamp(runId) > STALE_CLAIM_MS) {
-        await runRegistry.unregister(ticketKey);
-        logger.warn({ ticketKey, runId }, "reconcile_cleaned_stale_claim");
-        cleaned++;
-      } else if (!aiColumnTickets.has(ticketKey)) {
-        // Ticket left AI column while dispatch is in-flight — clear the claim
-        // so the dispatch detects cancellation and aborts the workflow
-        await runRegistry.unregister(ticketKey);
-        logger.info({ ticketKey, runId }, "reconcile_cancelled_inflight_claim");
-        cancelled++;
-      }
+      const result = await reconcileInflightClaim(
+        ticketKey,
+        runId,
+        aiColumnTickets,
+        runRegistry,
+      );
+      cancelled += result.cancelled;
+      cleaned += result.cleaned;
       continue;
     }
 
-    if (aiColumnTickets.has(ticketKey)) {
-      // Ticket still in AI column — clean if run is done
-      try {
-        const run = getRun(runId);
-        const status = await run.status;
-        if (TERMINAL_STATUSES.has(status)) {
-          await runRegistry.unregister(ticketKey);
-          logger.info({ ticketKey, runId, status }, "reconcile_cleaned_done");
-          cleaned++;
-        }
-      } catch {
-        await runRegistry.unregister(ticketKey).catch(() => {});
-        logger.warn({ ticketKey, runId }, "reconcile_cleaned_unreachable");
-        cleaned++;
-      }
+    const ticketStillInAiColumn = aiColumnTickets.has(ticketKey);
+
+    if (ticketStillInAiColumn) {
+      cleaned += await cleanFinishedRun(ticketKey, runId, runRegistry);
     } else {
-      // Ticket left AI column — cancel the run
-      const ok = await cancelRun(ticketKey, runId, runRegistry);
-      logger.info({ ticketKey, runId, ok }, "reconcile_cancelled_stale");
+      await cancelRun(ticketKey, runId, runRegistry);
+      logger.info({ ticketKey, runId }, "reconcile_cancelled_orphaned_run");
       cancelled++;
     }
   }
 
   return { cancelled, cleaned };
+}
+
+async function reconcileInflightClaim(
+  ticketKey: string,
+  runId: string,
+  aiColumnTickets: Set<string>,
+  runRegistry: RunRegistryAdapter,
+): Promise<{ cancelled: number; cleaned: number }> {
+  const claimAge = Date.now() - getClaimTimestamp(runId);
+  const claimIsStale = claimAge > STALE_CLAIM_MS;
+  const ticketLeftAiColumn = !aiColumnTickets.has(ticketKey);
+
+  if (claimIsStale) {
+    await runRegistry.unregister(ticketKey);
+    logger.warn({ ticketKey, runId }, "reconcile_cleaned_stale_claim");
+    return { cancelled: 0, cleaned: 1 };
+  }
+
+  if (ticketLeftAiColumn) {
+    await runRegistry.unregister(ticketKey);
+    logger.info({ ticketKey, runId }, "reconcile_cancelled_inflight_claim");
+    return { cancelled: 1, cleaned: 0 };
+  }
+
+  return { cancelled: 0, cleaned: 0 };
+}
+
+async function cleanFinishedRun(
+  ticketKey: string,
+  runId: string,
+  runRegistry: RunRegistryAdapter,
+): Promise<number> {
+  try {
+    const run = getRun(runId);
+    const status = await run.status;
+
+    if (!TERMINAL_STATUSES.has(status)) return 0;
+
+    await runRegistry.unregister(ticketKey);
+    logger.info({ ticketKey, runId, status }, "reconcile_cleaned_finished_run");
+    return 1;
+  } catch {
+    await runRegistry.unregister(ticketKey).catch(() => {});
+    logger.warn({ ticketKey, runId }, "reconcile_cleaned_unreachable_run");
+    return 1;
+  }
 }

--- a/src/lib/reconcile.ts
+++ b/src/lib/reconcile.ts
@@ -1,0 +1,66 @@
+import { getRun } from "workflow/api";
+import { isClaimingSentinel, getClaimTimestamp } from "./dispatch.js";
+import { cancelRun } from "./cancel-run.js";
+import { logger } from "./logger.js";
+import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
+
+const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
+const STALE_CLAIM_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Reconcile the run registry against current AI-column tickets.
+ * - Cleans completed/failed/unreachable runs
+ * - Cancels runs for tickets that left the AI column
+ * - Skips in-flight claims (CLAIMING_SENTINEL)
+ *
+ * All operations are idempotent — safe to run concurrently with webhooks.
+ */
+export async function reconcileRuns(
+  aiColumnTickets: Set<string>,
+  runRegistry: RunRegistryAdapter,
+): Promise<{ cancelled: number; cleaned: number }> {
+  const activeRuns = await runRegistry.listAll();
+  let cancelled = 0;
+  let cleaned = 0;
+
+  for (const { ticketKey, runId } of activeRuns) {
+    if (isClaimingSentinel(runId)) {
+      if (Date.now() - getClaimTimestamp(runId) > STALE_CLAIM_MS) {
+        await runRegistry.unregister(ticketKey);
+        logger.warn({ ticketKey, runId }, "reconcile_cleaned_stale_claim");
+        cleaned++;
+      } else if (!aiColumnTickets.has(ticketKey)) {
+        // Ticket left AI column while dispatch is in-flight — clear the claim
+        // so the dispatch detects cancellation and aborts the workflow
+        await runRegistry.unregister(ticketKey);
+        logger.info({ ticketKey, runId }, "reconcile_cancelled_inflight_claim");
+        cancelled++;
+      }
+      continue;
+    }
+
+    if (aiColumnTickets.has(ticketKey)) {
+      // Ticket still in AI column — clean if run is done
+      try {
+        const run = getRun(runId);
+        const status = await run.status;
+        if (TERMINAL_STATUSES.has(status)) {
+          await runRegistry.unregister(ticketKey);
+          logger.info({ ticketKey, runId, status }, "reconcile_cleaned_done");
+          cleaned++;
+        }
+      } catch {
+        await runRegistry.unregister(ticketKey).catch(() => {});
+        logger.warn({ ticketKey, runId }, "reconcile_cleaned_unreachable");
+        cleaned++;
+      }
+    } else {
+      // Ticket left AI column — cancel the run
+      const ok = await cancelRun(ticketKey, runId, runRegistry);
+      logger.info({ ticketKey, runId, ok }, "reconcile_cancelled_stale");
+      cancelled++;
+    }
+  }
+
+  return { cancelled, cleaned };
+}

--- a/src/routes/cron/poll.get.ts
+++ b/src/routes/cron/poll.get.ts
@@ -6,29 +6,11 @@ import { reconcileRuns } from "../../lib/reconcile.js";
 import { logger } from "../../lib/logger.js";
 
 export default defineEventHandler(async (event) => {
-  if (env.CRON_SECRET) {
-    const auth = getHeader(event, "authorization");
-    if (auth !== `Bearer ${env.CRON_SECRET}`) {
-      throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
-    }
-  }
+  verifyCronAuth(getHeader(event, "authorization"));
 
   const adapters = createAdapters();
-
-  const jql = `project = ${env.JIRA_PROJECT_KEY} AND status = "${env.COLUMN_AI}"`;
-  const ticketKeys = await adapters.issueTracker.searchTickets(jql);
-
-  logger.info({ ticketCount: ticketKeys.length }, "poll_discovered_tickets");
-
-  // Dispatch new tickets
-  const started: string[] = [];
-  for (const key of ticketKeys) {
-    const result = await dispatchTicket(key, adapters, env.MAX_CONCURRENT_AGENTS);
-    if (result.started) started.push(key);
-    if (result.reason === "at_capacity") break;
-  }
-
-  // Reconcile stale/dead runs
+  const ticketKeys = await discoverAiColumnTickets(adapters);
+  const started = await dispatchDiscoveredTickets(ticketKeys, adapters);
   const { cancelled, cleaned } = await reconcileRuns(
     new Set(ticketKeys),
     adapters.runRegistry,
@@ -42,3 +24,34 @@ export default defineEventHandler(async (event) => {
     cleaned,
   };
 });
+
+function verifyCronAuth(authHeader: string | undefined): void {
+  if (!env.CRON_SECRET) return;
+  if (authHeader === `Bearer ${env.CRON_SECRET}`) return;
+
+  throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+}
+
+async function discoverAiColumnTickets(
+  adapters: ReturnType<typeof createAdapters>,
+): Promise<string[]> {
+  const jql = `project = ${env.JIRA_PROJECT_KEY} AND status = "${env.COLUMN_AI}"`;
+  const ticketKeys = await adapters.issueTracker.searchTickets(jql);
+  logger.info({ ticketCount: ticketKeys.length }, "poll_discovered_tickets");
+  return ticketKeys;
+}
+
+async function dispatchDiscoveredTickets(
+  ticketKeys: string[],
+  adapters: ReturnType<typeof createAdapters>,
+): Promise<string[]> {
+  const started: string[] = [];
+
+  for (const key of ticketKeys) {
+    const result = await dispatchTicket(key, adapters, env.MAX_CONCURRENT_AGENTS);
+    if (result.started) started.push(key);
+    if (result.reason === "at_capacity") break;
+  }
+
+  return started;
+}

--- a/src/routes/cron/poll.get.ts
+++ b/src/routes/cron/poll.get.ts
@@ -1,8 +1,8 @@
 import { defineEventHandler, getHeader, createError } from "h3";
-import { getRun } from "workflow/api";
 import { env } from "../../../env.js";
 import { createAdapters } from "../../lib/adapters.js";
-import { dispatchTicket, CLAIMING_SENTINEL } from "../../lib/dispatch.js";
+import { dispatchTicket } from "../../lib/dispatch.js";
+import { reconcileRuns } from "../../lib/reconcile.js";
 import { logger } from "../../lib/logger.js";
 
 export default defineEventHandler(async (event) => {
@@ -14,74 +14,25 @@ export default defineEventHandler(async (event) => {
   }
 
   const adapters = createAdapters();
-  const { issueTracker, runRegistry } = adapters;
 
   const jql = `project = ${env.JIRA_PROJECT_KEY} AND status = "${env.COLUMN_AI}"`;
-  const ticketKeys = await issueTracker.searchTickets(jql);
+  const ticketKeys = await adapters.issueTracker.searchTickets(jql);
 
   logger.info({ ticketCount: ticketKeys.length }, "poll_discovered_tickets");
 
+  // Dispatch new tickets
   const started: string[] = [];
   for (const key of ticketKeys) {
-    const result = await dispatchTicket(
-      key,
-      adapters,
-      env.MAX_CONCURRENT_AGENTS,
-    );
-    if (result.started) {
-      started.push(key);
-    }
-    if (result.reason === "at_capacity") {
-      break;
-    }
+    const result = await dispatchTicket(key, adapters, env.MAX_CONCURRENT_AGENTS);
+    if (result.started) started.push(key);
+    if (result.reason === "at_capacity") break;
   }
 
-  // Reconcile registry: cancel stale runs and clean up dead entries
-  const aiColumnSet = new Set(ticketKeys);
-  const activeRuns = await runRegistry.listAll();
-  let cancelled = 0;
-  let cleaned = 0;
-
-  for (const { ticketKey, runId } of activeRuns) {
-    if (runId === CLAIMING_SENTINEL) {
-      continue;
-    }
-
-    if (aiColumnSet.has(ticketKey)) {
-      try {
-        const run = getRun(runId);
-        const status = await run.status;
-        if (
-          status === "completed" ||
-          status === "failed" ||
-          status === "cancelled"
-        ) {
-          await runRegistry.unregister(ticketKey);
-          logger.info({ ticketKey, runId, status }, "poll_cleaned_dead_run");
-          cleaned++;
-        }
-      } catch {
-        await runRegistry.unregister(ticketKey).catch(() => {});
-        logger.warn({ ticketKey, runId }, "poll_cleaned_unreachable_run");
-        cleaned++;
-      }
-      continue;
-    }
-
-    try {
-      const run = getRun(runId);
-      await run.cancel();
-      await runRegistry.unregister(ticketKey);
-      logger.info({ ticketKey, runId }, "poll_cancelled_stale_run");
-      cancelled++;
-    } catch (err) {
-      await runRegistry.unregister(ticketKey).catch(() => {});
-      logger.warn(
-        { ticketKey, runId, error: (err as Error).message },
-        "poll_stale_run_cleanup_error",
-      );
-    }
-  }
+  // Reconcile stale/dead runs
+  const { cancelled, cleaned } = await reconcileRuns(
+    new Set(ticketKeys),
+    adapters.runRegistry,
+  );
 
   return {
     status: "ok",

--- a/src/routes/webhooks/jira.post.ts
+++ b/src/routes/webhooks/jira.post.ts
@@ -10,50 +10,64 @@ import { createAdapters } from "../../lib/adapters.js";
 import { logger } from "../../lib/logger.js";
 
 export default defineEventHandler(async (event) => {
-  const rawBody = await readRawBody(event);
-  if (!rawBody) {
-    throw createError({ statusCode: 400, statusMessage: "Empty body" });
-  }
-
-  const signature = getHeader(event, "x-hub-signature");
-  if (
-    !verifyJiraWebhookSignature(rawBody, signature, env.JIRA_WEBHOOK_SECRET)
-  ) {
-    throw createError({ statusCode: 401, statusMessage: "Invalid signature" });
-  }
-
-  const payload = JSON.parse(rawBody);
+  const rawBody = readVerifiedBody(event);
+  const payload = JSON.parse(await rawBody);
   const { ticketKey, action } = parseJiraWebhookEvent(payload, env.COLUMN_AI);
 
   if (action === "ignore") {
-    logger.info(
-      { ticketKey, event: payload.webhookEvent },
-      "webhook_event_ignored",
-    );
+    logger.info({ ticketKey, event: payload.webhookEvent }, "webhook_ignored");
     return { ok: true, action: "ignored" };
   }
 
   const adapters = createAdapters();
 
   if (action === "cancel") {
-    const runId = await adapters.runRegistry.getRunId(ticketKey);
-    if (!runId) {
-      logger.info({ ticketKey }, "webhook_cancel_no_active_run");
-      return { ok: true, action: "cancel", cancelled: false };
-    }
-
-    if (isClaimingSentinel(runId)) {
-      // Dispatch is in-flight — remove the claim so dispatch detects cancellation
-      await adapters.runRegistry.unregister(ticketKey);
-      logger.info({ ticketKey }, "webhook_cancel_cleared_claim");
-      return { ok: true, action: "cancel", cancelled: true };
-    }
-
-    const cancelled = await cancelRun(ticketKey, runId, adapters.runRegistry);
-    logger.info({ ticketKey, runId, cancelled }, "webhook_cancel_result");
-    return { ok: true, action: "cancel", cancelled, runId };
+    return handleCancellation(ticketKey, adapters);
   }
 
+  return handleDispatch(ticketKey, adapters);
+});
+
+async function readVerifiedBody(event: any): Promise<string> {
+  const rawBody = await readRawBody(event);
+  if (!rawBody) {
+    throw createError({ statusCode: 400, statusMessage: "Empty body" });
+  }
+
+  const signature = getHeader(event, "x-hub-signature");
+  if (!verifyJiraWebhookSignature(rawBody, signature, env.JIRA_WEBHOOK_SECRET)) {
+    throw createError({ statusCode: 401, statusMessage: "Invalid signature" });
+  }
+
+  return rawBody;
+}
+
+async function handleCancellation(
+  ticketKey: string,
+  adapters: ReturnType<typeof createAdapters>,
+) {
+  const runId = await adapters.runRegistry.getRunId(ticketKey);
+
+  if (!runId) {
+    logger.info({ ticketKey }, "webhook_cancel_no_active_run");
+    return { ok: true, action: "cancel", cancelled: false };
+  }
+
+  if (isClaimingSentinel(runId)) {
+    await adapters.runRegistry.unregister(ticketKey);
+    logger.info({ ticketKey }, "webhook_cancel_cleared_inflight_claim");
+    return { ok: true, action: "cancel", cancelled: true };
+  }
+
+  const cancelled = await cancelRun(ticketKey, runId, adapters.runRegistry);
+  logger.info({ ticketKey, runId, cancelled }, "webhook_cancel_result");
+  return { ok: true, action: "cancel", cancelled, runId };
+}
+
+async function handleDispatch(
+  ticketKey: string,
+  adapters: ReturnType<typeof createAdapters>,
+) {
   logger.info({ ticketKey }, "webhook_dispatching");
 
   const result = await dispatchTicket(
@@ -71,4 +85,4 @@ export default defineEventHandler(async (event) => {
     runId: result.runId,
     reason: result.reason,
   };
-});
+}

--- a/src/routes/webhooks/jira.post.ts
+++ b/src/routes/webhooks/jira.post.ts
@@ -1,11 +1,11 @@
 import { defineEventHandler, getHeader, readRawBody, createError } from "h3";
-import { getRun } from "workflow/api";
 import { env } from "../../../env.js";
 import {
   verifyJiraWebhookSignature,
   parseJiraWebhookEvent,
 } from "../../lib/jira-webhook.js";
-import { dispatchTicket } from "../../lib/dispatch.js";
+import { cancelRun } from "../../lib/cancel-run.js";
+import { dispatchTicket, isClaimingSentinel } from "../../lib/dispatch.js";
 import { createAdapters } from "../../lib/adapters.js";
 import { logger } from "../../lib/logger.js";
 
@@ -42,19 +42,16 @@ export default defineEventHandler(async (event) => {
       return { ok: true, action: "cancel", cancelled: false };
     }
 
-    try {
-      const run = getRun(runId);
-      await run.cancel();
-    } catch (err) {
-      logger.warn(
-        { ticketKey, runId, error: (err as Error).message },
-        "webhook_cancel_run_error",
-      );
+    if (isClaimingSentinel(runId)) {
+      // Dispatch is in-flight — remove the claim so dispatch detects cancellation
+      await adapters.runRegistry.unregister(ticketKey);
+      logger.info({ ticketKey }, "webhook_cancel_cleared_claim");
+      return { ok: true, action: "cancel", cancelled: true };
     }
 
-    await adapters.runRegistry.unregister(ticketKey).catch(() => {});
-    logger.info({ ticketKey, runId }, "webhook_cancelled_run");
-    return { ok: true, action: "cancel", cancelled: true, runId };
+    const cancelled = await cancelRun(ticketKey, runId, adapters.runRegistry);
+    logger.info({ ticketKey, runId, cancelled }, "webhook_cancel_result");
+    return { ok: true, action: "cancel", cancelled, runId };
   }
 
   logger.info({ ticketKey }, "webhook_dispatching");


### PR DESCRIPTION
## Summary

- Timestamped claims (`claiming:<ts>`) instead of static `"claiming"` — enables stale detection and safe cancellation during dispatch
- Post-start claim verification — abort workflow if webhook cancelled the claim mid-dispatch
- Reconciliation now cleans stale claims instead of skipping them
- Extracted `reconcile.ts` and `cancel-run.ts` for readability

## Problem

Stale `"claiming"` entry after a crash blocked the ticket forever (no self-healing). Webhook cancel during dispatch (~0.5-1s window) left orphaned workflows.
