### PR TITLE
Feat add slack threaded messages

### DIFF
--- a/docs/superpowers/plans/2026-04-30-slack-threaded-messages.md
+++ b/docs/superpowers/plans/2026-04-30-slack-threaded-messages.md
@@ -14,7 +14,7 @@
 
 ## File Structure
 
-```
+```text
 src/
 ├── adapters/
 │   ├── messaging/

--- a/docs/superpowers/plans/2026-04-30-slack-threaded-messages.md
+++ b/docs/superpowers/plans/2026-04-30-slack-threaded-messages.md
@@ -1,0 +1,1405 @@
+# Slack Threaded Messages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group all per-ticket Slack notifications under one lifetime thread per ticket, and replace inline message strings with structured `TicketEvent`s rendered to Slack-mrkdwn with clickable Jira/PR links.
+
+**Architecture:** Replace `MessagingAdapter.notify(message)` with `notifyForTicket(ticketKey, event)`. The adapter becomes "smart" — it formats events to wire text, looks up the ticket's parent message id from a new `ThreadStore`, posts as a thread reply when one exists (top-level otherwise), and records the parent on the first `started` event. `UpstashRunRegistry` implements `ThreadStore` via a new redis hash `blazebot:thread-parents:{ENV}`. Threading is by-message via `ThreadImpl` from the `chat` package: top-level posts use the existing `chat.channel(...).post(...)` path; thread replies construct a `ThreadImpl({ id: "slack:CHANNEL:PARENT_TS", ... })` and call `.post(...)` on it.
+
+**Tech Stack:** TypeScript / Node 24 / Vercel Workflow / Upstash Redis (`@upstash/redis`) / `chat` + `@chat-adapter/slack` / Vitest
+
+**Source spec:** `docs/superpowers/specs/2026-04-30-slack-threaded-messages-design.md`.
+
+---
+
+## File Structure
+
+```
+src/
+├── adapters/
+│   ├── messaging/
+│   │   ├── types.ts            # MODIFIED — replace notify() with notifyForTicket(); add TicketEvent + ThreadStore
+│   │   ├── format.ts           # NEW — formatTicketEvent(event, ticketKey, jiraBaseUrl): string
+│   │   ├── format.test.ts      # NEW — pure-function tests for each event variant
+│   │   ├── chatsdk.ts          # MODIFIED — drop notify(), add notifyForTicket() with threading
+│   │   └── chatsdk.test.ts     # REWRITTEN — covers threading, fallback, formatter integration
+│   └── run-registry/
+│       ├── types.ts            # MODIFIED — add ThreadStore interface (separate from RunRegistryAdapter)
+│       ├── upstash.ts          # MODIFIED — implement ThreadStore methods + new THREAD_HASH_KEY
+│       └── upstash.test.ts     # MODIFIED — add ThreadStore round-trip tests
+├── lib/
+│   ├── adapters.ts             # MODIFIED — pass jiraBaseUrl + threadStore (= runRegistry) into ChatSDKAdapter
+│   └── step-adapters.ts        # MODIFIED — same change as adapters.ts
+├── routes/
+│   ├── cron/poll.get.ts        # MODIFIED — replace notify() call at L23 with notifyForTicket(...)
+│   └── webhooks/jira.post.ts   # MODIFIED — replace notify() call at L110 with notifyForTicket(...)
+└── workflows/
+    └── agent.ts                # MODIFIED — replace notifySlack(string) step with notifyTicket(key, event)
+```
+
+**File-responsibility split:**
+
+- `format.ts` owns event-to-string conversion. It's pure (no side-effects, no config beyond inputs) so it tests in isolation and the adapter's tests don't need to assert on full text.
+- `chatsdk.ts` owns Slack I/O: thread store reads, post, missing-parent recovery, parent-set on first `started`.
+- `ThreadStore` is split from `RunRegistryAdapter` even though the same class implements both — the messaging adapter shouldn't see (or be able to call) `markFailed` etc. when all it needs is parent-message lookup.
+
+---
+
+## Phase 1 — ThreadStore on the run registry
+
+Goal: ship the redis-backed parent-message store, fully tested, before touching messaging. This task block is mergeable on its own — nothing reads from the new hash yet.
+
+### Task 1: Add `ThreadStore` interface
+
+**Files:**
+- Modify: `src/adapters/run-registry/types.ts`
+
+- [ ] **Step 1: Append the ThreadStore interface to the existing types file**
+
+Append this to the bottom of `src/adapters/run-registry/types.ts` (do not modify the existing `RunRegistryAdapter`):
+
+```ts
+/**
+ * Per-ticket Slack thread parent store. Implemented alongside RunRegistryAdapter
+ * by UpstashRunRegistry, but exposed as a separate interface so the messaging
+ * adapter only depends on the slice it needs.
+ *
+ * Lifetime: an entry survives across multiple workflow runs for the same
+ * ticket. unregister(ticketKey) does NOT clear it — see clearParent().
+ */
+export interface ThreadStore {
+  /** Returns the Slack message id (timestamp) anchoring this ticket's thread, or null. */
+  getParent(ticketKey: string): Promise<string | null>;
+  /** Records the message id as the parent for this ticket. Overwrites any prior value. */
+  setParent(ticketKey: string, messageId: string): Promise<void>;
+  /** Removes the entry. Used after Slack reports the parent message no longer exists. */
+  clearParent(ticketKey: string): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Verify type-checks pass**
+
+Run: `pnpm tsc --noEmit`
+Expected: no new type errors. (No callers exist yet, so this is just a syntax/types sanity check.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/adapters/run-registry/types.ts
+git commit -m "feat(run-registry): add ThreadStore interface"
+```
+
+---
+
+### Task 2: Implement `ThreadStore` on `UpstashRunRegistry`
+
+**Files:**
+- Modify: `src/adapters/run-registry/upstash.ts`
+
+- [ ] **Step 1: Add the new hash key constant**
+
+In `src/adapters/run-registry/upstash.ts`, add a new constant alongside the existing `*_HASH_KEY` lines (immediately after `ENTRY_TS_HASH_KEY`):
+
+```ts
+const THREAD_HASH_KEY = `blazebot:thread-parents:${ENV_PREFIX}`;
+```
+
+- [ ] **Step 2: Add `ThreadStore` to the class's implements clause and import**
+
+Update the class declaration:
+
+```ts
+import type { RunRegistryAdapter, FailedTicketMeta, ThreadStore } from "./types.js";
+```
+
+```ts
+export class UpstashRunRegistry implements RunRegistryAdapter, ThreadStore {
+```
+
+- [ ] **Step 3: Implement the three ThreadStore methods**
+
+Append these methods to `UpstashRunRegistry` (after `clearFailedMark`, before the closing `}`):
+
+```ts
+  async getParent(ticketKey: string): Promise<string | null> {
+    return this.redis.hget<string>(THREAD_HASH_KEY, ticketKey);
+  }
+
+  async setParent(ticketKey: string, messageId: string): Promise<void> {
+    await this.redis.hset(THREAD_HASH_KEY, { [ticketKey]: messageId });
+    // Defend against any external TTL — the thread mapping must outlive runs.
+    await this.redis.persist(THREAD_HASH_KEY);
+  }
+
+  async clearParent(ticketKey: string): Promise<void> {
+    await this.redis.hdel(THREAD_HASH_KEY, ticketKey);
+  }
+```
+
+- [ ] **Step 4: Verify `unregister` does NOT touch the thread hash**
+
+Read `unregister` in the same file. It should still only delete from `HASH_KEY`, `SANDBOX_HASH_KEY`, and `ENTRY_TS_HASH_KEY`. Do not modify it.
+
+- [ ] **Step 5: Type-check**
+
+Run: `pnpm tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adapters/run-registry/upstash.ts
+git commit -m "feat(run-registry): implement ThreadStore on UpstashRunRegistry"
+```
+
+---
+
+### Task 3: Tests for `ThreadStore` on `UpstashRunRegistry`
+
+**Files:**
+- Modify: `src/adapters/run-registry/upstash.test.ts`
+
+- [ ] **Step 1: Add the THREAD_HASH_KEY constant near the existing FAILED_HASH_KEY one**
+
+In `src/adapters/run-registry/upstash.test.ts`, near the bottom describe blocks (before `describe("markFailed", ...)` is fine), or near the top alongside `HASH_KEY`:
+
+```ts
+const THREAD_HASH_KEY = `blazebot:thread-parents:${process.env.VERCEL_ENV ?? "development"}`;
+```
+
+- [ ] **Step 2: Add a `describe("ThreadStore methods", ...)` block at the bottom of the file (inside the outer describe, before its closing `})`)**
+
+```ts
+  describe("ThreadStore methods", () => {
+    it("setParent then getParent round-trips the message id", async () => {
+      // Phase 1: setParent writes
+      const registry = createRegistry();
+      await registry.setParent("AWT-42", "1700000000.000123");
+      expect(mockRedis.hset).toHaveBeenCalledWith(THREAD_HASH_KEY, {
+        "AWT-42": "1700000000.000123",
+      });
+      expect(mockRedis.persist).toHaveBeenCalledWith(THREAD_HASH_KEY);
+
+      // Phase 2: getParent reads
+      mockRedis.hget.mockResolvedValueOnce("1700000000.000123");
+      const result = await registry.getParent("AWT-42");
+      expect(result).toBe("1700000000.000123");
+      expect(mockRedis.hget).toHaveBeenCalledWith(THREAD_HASH_KEY, "AWT-42");
+    });
+
+    it("getParent returns null when no entry exists", async () => {
+      mockRedis.hget.mockResolvedValueOnce(null);
+      const registry = createRegistry();
+      const result = await registry.getParent("AWT-99");
+      expect(result).toBeNull();
+    });
+
+    it("clearParent deletes the entry from the thread hash", async () => {
+      const registry = createRegistry();
+      await registry.clearParent("AWT-42");
+      expect(mockRedis.hdel).toHaveBeenCalledWith(THREAD_HASH_KEY, "AWT-42");
+    });
+
+    it("unregister does not touch the thread hash", async () => {
+      const registry = createRegistry();
+      await registry.unregister("AWT-42");
+      // unregister deletes from HASH_KEY, SANDBOX_HASH_KEY, ENTRY_TS_HASH_KEY only.
+      const hdelCalls = mockRedis.hdel.mock.calls.map((c) => c[0]);
+      expect(hdelCalls).not.toContain(THREAD_HASH_KEY);
+    });
+  });
+```
+
+- [ ] **Step 3: Run the new tests in isolation to verify they pass**
+
+Run: `pnpm vitest run src/adapters/run-registry/upstash.test.ts`
+Expected: PASS — all existing tests + the four new ones.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/adapters/run-registry/upstash.test.ts
+git commit -m "test(run-registry): cover ThreadStore methods on UpstashRunRegistry"
+```
+
+---
+
+## Phase 2 — Event types and formatter
+
+Goal: a pure formatter that converts a `TicketEvent` to a Slack-mrkdwn string with the Jira link (and PR link for `pr_ready`). No I/O, no adapter — testable in isolation.
+
+### Task 4: Add `TicketEvent` type and update `MessagingAdapter` interface
+
+**Files:**
+- Modify: `src/adapters/messaging/types.ts`
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace the entire contents of `src/adapters/messaging/types.ts` with:
+
+```ts
+export type TicketEvent =
+  | { kind: "started" }
+  | { kind: "needs_clarification"; usageReport?: string }
+  | {
+      kind: "pr_ready";
+      pr: { url: string; number: number };
+      usageReport: string;
+    }
+  | {
+      kind: "failed";
+      phase?: "research" | "impl" | "push";
+      reason?: string;
+      usageReport?: string;
+    }
+  | { kind: "canceled"; reason: string };
+
+export interface MessagingAdapter {
+  /**
+   * Send a ticket-scoped notification to the configured channel.
+   *
+   * The first `started` event for a ticket posts top-level and records its
+   * Slack message id as the lifetime parent. Subsequent events post as
+   * thread replies under that parent. If the parent has been deleted, the
+   * adapter clears the mapping and retries top-level (without re-anchoring
+   * unless the new event is `started`).
+   *
+   * Never throws — failures are logged and swallowed so workflow runs are
+   * never broken by a notification error.
+   */
+  notifyForTicket(ticketKey: string, event: TicketEvent): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm tsc --noEmit`
+Expected: errors at every `notify(...)` and `messaging.notify(...)` call site (cron poll, jira webhook, agent workflow). These are addressed in later tasks. Confirm the messaging types file itself is clean (no errors *inside* the file).
+
+- [ ] **Step 3: Do NOT commit yet**
+
+The interface change makes the build red. Commit happens at the end of Phase 4 once all call sites are converted, so we don't ship a half-broken main.
+
+---
+
+### Task 5: Implement and test the event formatter
+
+**Files:**
+- Create: `src/adapters/messaging/format.ts`
+- Create: `src/adapters/messaging/format.test.ts`
+
+- [ ] **Step 1: Write the failing test first**
+
+Create `src/adapters/messaging/format.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { formatTicketEvent } from "./format.js";
+
+const JIRA = "https://example.atlassian.net";
+const KEY = "AWT-42";
+const LINK = `<${JIRA}/browse/${KEY}|${KEY}>`;
+
+describe("formatTicketEvent", () => {
+  it("started — links the ticket key", () => {
+    expect(formatTicketEvent({ kind: "started" }, KEY, JIRA)).toBe(
+      `Task ${LINK} started`,
+    );
+  });
+
+  it("needs_clarification — without usage report", () => {
+    expect(
+      formatTicketEvent({ kind: "needs_clarification" }, KEY, JIRA),
+    ).toBe(`Task ${LINK} needs clarification`);
+  });
+
+  it("needs_clarification — appends usage report on a new line", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "needs_clarification", usageReport: "Phase A: $0.10" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} needs clarification\nPhase A: $0.10`);
+  });
+
+  it("needs_clarification — empty usage report is treated as absent", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "needs_clarification", usageReport: "" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} needs clarification`);
+  });
+
+  it("pr_ready — includes PR link inline and usage report", () => {
+    const text = formatTicketEvent(
+      {
+        kind: "pr_ready",
+        pr: { url: "https://github.com/o/r/pull/123", number: 123 },
+        usageReport: "Total: $0.42",
+      },
+      KEY,
+      JIRA,
+    );
+    expect(text).toBe(
+      `Task ${LINK} PR ready for review — <https://github.com/o/r/pull/123|#123>\nTotal: $0.42`,
+    );
+  });
+
+  it("failed with phase and reason", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "failed", phase: "research", reason: "phase timed out" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} failed: research — phase timed out`);
+  });
+
+  it("failed with reason but no phase", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "failed", reason: "boom" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} failed: boom`);
+  });
+
+  it("failed with neither phase nor reason", () => {
+    expect(
+      formatTicketEvent({ kind: "failed" }, KEY, JIRA),
+    ).toBe(`Task ${LINK} failed`);
+  });
+
+  it("failed — appends usage report when present", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "failed", phase: "impl", reason: "x", usageReport: "u" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} failed: impl — x\nu`);
+  });
+
+  it("canceled — includes reason", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "canceled", reason: "left AI column" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} canceled: left AI column`);
+  });
+
+  it("trims a trailing slash on jiraBaseUrl", () => {
+    expect(
+      formatTicketEvent({ kind: "started" }, KEY, `${JIRA}/`),
+    ).toBe(`Task ${LINK} started`);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails (module not found)**
+
+Run: `pnpm vitest run src/adapters/messaging/format.test.ts`
+Expected: FAIL with "Cannot find module './format'" (or equivalent resolution error).
+
+- [ ] **Step 3: Implement `format.ts`**
+
+Create `src/adapters/messaging/format.ts`:
+
+```ts
+import type { TicketEvent } from "./types.js";
+
+/**
+ * Format a TicketEvent as Slack-mrkdwn text with embedded links.
+ *
+ * Output is intended for `chat.channel(...).post(text)` or `thread.post(text)`.
+ * Slack-native `<url|label>` syntax is used because remark/mdast escaping
+ * via PostableMarkdown can mangle the angle brackets. We pass it as a plain
+ * string; the chat package treats unmarked strings as PostableRaw on Slack.
+ */
+export function formatTicketEvent(
+  event: TicketEvent,
+  ticketKey: string,
+  jiraBaseUrl: string,
+): string {
+  const link = jiraLink(ticketKey, jiraBaseUrl);
+  const head = `Task ${link}`;
+
+  switch (event.kind) {
+    case "started":
+      return `${head} started`;
+
+    case "needs_clarification":
+      return appendUsage(`${head} needs clarification`, event.usageReport);
+
+    case "pr_ready": {
+      const prLink = `<${event.pr.url}|#${event.pr.number}>`;
+      return appendUsage(
+        `${head} PR ready for review — ${prLink}`,
+        event.usageReport,
+      );
+    }
+
+    case "failed": {
+      const body = formatFailedBody(event.phase, event.reason);
+      return appendUsage(`${head} failed${body}`, event.usageReport);
+    }
+
+    case "canceled":
+      return `${head} canceled: ${event.reason}`;
+  }
+}
+
+function jiraLink(ticketKey: string, jiraBaseUrl: string): string {
+  const base = jiraBaseUrl.replace(/\/$/, "");
+  return `<${base}/browse/${ticketKey}|${ticketKey}>`;
+}
+
+function formatFailedBody(
+  phase: "research" | "impl" | "push" | undefined,
+  reason: string | undefined,
+): string {
+  if (phase && reason) return `: ${phase} — ${reason}`;
+  if (reason) return `: ${reason}`;
+  return "";
+}
+
+function appendUsage(base: string, usageReport: string | undefined): string {
+  if (!usageReport) return base;
+  return `${base}\n${usageReport}`;
+}
+```
+
+- [ ] **Step 4: Run the test — confirm it passes**
+
+Run: `pnpm vitest run src/adapters/messaging/format.test.ts`
+Expected: PASS — all 11 cases.
+
+- [ ] **Step 5: Commit (formatter only — adapter and call-site changes ride together later)**
+
+```bash
+git add src/adapters/messaging/format.ts src/adapters/messaging/format.test.ts
+git commit -m "feat(messaging): add ticket event formatter with Jira/PR mrkdwn links"
+```
+
+---
+
+## Phase 3 — Adapter rewrite
+
+Goal: replace `notify()` with `notifyForTicket()` in `ChatSDKAdapter`, including missing-parent recovery. Tests are rewritten to match.
+
+### Task 6: Rewrite `ChatSDKAdapter` around `notifyForTicket`
+
+**Files:**
+- Modify: `src/adapters/messaging/chatsdk.ts`
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/adapters/messaging/chatsdk.ts` with:
+
+```ts
+import { Chat, ThreadImpl } from "chat";
+import type { StateAdapter, Lock } from "chat";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { logger } from "../../lib/logger.js";
+import { formatTicketEvent } from "./format.js";
+import type { MessagingAdapter, TicketEvent } from "./types.js";
+import type { ThreadStore } from "../run-registry/types.js";
+
+export interface ChatSDKConfig {
+  slackToken: string;
+  channelId: string;
+  botName: string;
+  jiraBaseUrl: string;
+  threadStore: ThreadStore;
+}
+
+/** Minimal no-op StateAdapter for outbound-only notification use. */
+const noopState: StateAdapter = {
+  acquireLock: async () => null,
+  appendToList: async () => {},
+  connect: async () => {},
+  delete: async () => {},
+  disconnect: async () => {},
+  extendLock: async () => false,
+  forceReleaseLock: async () => {},
+  get: async () => null,
+  getList: async () => [],
+  isSubscribed: async () => false,
+  releaseLock: async (_lock: Lock) => {},
+  set: async () => {},
+  setIfNotExists: async () => false,
+  subscribe: async () => {},
+  unsubscribe: async () => {},
+};
+
+/**
+ * Slack error codes that mean "the parent message is gone."
+ * When we see one of these on a thread reply, we clear the stored parent
+ * and retry top-level. List sourced from Slack's chat.postMessage docs;
+ * exact codes are confirmed during smoke-testing (deliberately delete a
+ * parent in a test channel).
+ */
+const MISSING_PARENT_ERROR_CODES = new Set([
+  "thread_not_found",
+  "message_not_found",
+]);
+
+export class ChatSDKAdapter implements MessagingAdapter {
+  private chat: InstanceType<typeof Chat>;
+  private slackAdapter: ReturnType<typeof createSlackAdapter>;
+  private channelId: string;
+  private jiraBaseUrl: string;
+  private threadStore: ThreadStore;
+
+  constructor(config: ChatSDKConfig) {
+    this.channelId = config.channelId;
+    this.jiraBaseUrl = config.jiraBaseUrl;
+    this.threadStore = config.threadStore;
+    this.slackAdapter = createSlackAdapter({ botToken: config.slackToken });
+    this.chat = new Chat({
+      userName: config.botName,
+      state: noopState,
+      adapters: { slack: this.slackAdapter },
+    });
+  }
+
+  async notifyForTicket(
+    ticketKey: string,
+    event: TicketEvent,
+  ): Promise<void> {
+    const text = formatTicketEvent(event, ticketKey, this.jiraBaseUrl);
+    let parent = await this.threadStore.getParent(ticketKey).catch(() => null);
+
+    let sentId: string | null = null;
+    try {
+      sentId = parent
+        ? await this.postReply(parent, text)
+        : await this.postTopLevel(text);
+    } catch (err) {
+      if (parent && isMissingParentError(err)) {
+        logger.debug(
+          { ticketKey, parent, eventKind: event.kind },
+          "thread_parent_recovered",
+        );
+        await this.threadStore.clearParent(ticketKey).catch(() => {});
+        parent = null;
+        try {
+          sentId = await this.postTopLevel(text);
+        } catch (retryErr) {
+          this.logFailure(ticketKey, event.kind, retryErr);
+          return;
+        }
+      } else {
+        this.logFailure(ticketKey, event.kind, err);
+        return;
+      }
+    }
+
+    if (event.kind === "started" && parent == null && sentId) {
+      await this.threadStore
+        .setParent(ticketKey, sentId)
+        .catch((err) =>
+          logger.warn(
+            { ticketKey, error: (err as Error).message },
+            "thread_parent_persist_failed",
+          ),
+        );
+    }
+
+    logger.info(
+      {
+        ticketKey,
+        eventKind: event.kind,
+        threadParentId: parent,
+        channelId: this.channelId,
+      },
+      "notification_sent",
+    );
+  }
+
+  /** Top-level post to the configured channel. Returns the sent message id. */
+  private async postTopLevel(text: string): Promise<string> {
+    const channel = this.chat.channel(`slack:${this.channelId}`);
+    const sent = await channel.post(text);
+    return sent.id;
+  }
+
+  /** Thread reply under `parentTs`. Returns the sent message id. */
+  private async postReply(parentTs: string, text: string): Promise<string> {
+    const thread = new ThreadImpl({
+      id: `slack:${this.channelId}:${parentTs}`,
+      adapter: this.slackAdapter,
+      channelId: `slack:${this.channelId}`,
+      stateAdapter: noopState,
+      isDM: false,
+    });
+    const sent = await thread.post(text);
+    return sent.id;
+  }
+
+  private logFailure(
+    ticketKey: string,
+    eventKind: TicketEvent["kind"],
+    err: unknown,
+  ): void {
+    logger.warn(
+      {
+        ticketKey,
+        eventKind,
+        error: (err as Error).message,
+        slackErrorCode: extractSlackErrorCode(err),
+      },
+      "notification_failed",
+    );
+  }
+}
+
+function isMissingParentError(err: unknown): boolean {
+  const code = extractSlackErrorCode(err);
+  return code != null && MISSING_PARENT_ERROR_CODES.has(code);
+}
+
+/**
+ * Pull a Slack-style error code out of an unknown error. The chat package
+ * surfaces Slack errors as ChatError-derived objects with a `code` string;
+ * the underlying Web API error code may also live on `data.error` for raw
+ * errors. We check both locations defensively.
+ */
+function extractSlackErrorCode(err: unknown): string | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as { code?: unknown; data?: { error?: unknown } };
+  if (typeof e.code === "string") return e.code;
+  if (e.data && typeof e.data.error === "string") return e.data.error;
+  return null;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm tsc --noEmit`
+Expected: errors only at the call sites in `src/lib/adapters.ts`, `src/lib/step-adapters.ts`, `src/workflows/agent.ts`, `src/routes/cron/poll.get.ts`, `src/routes/webhooks/jira.post.ts`. The adapter file itself is clean.
+
+- [ ] **Step 3: Do not commit yet** (call sites still broken — wired in Phase 4).
+
+---
+
+### Task 7: Rewrite `chatsdk.test.ts`
+
+**Files:**
+- Modify: `src/adapters/messaging/chatsdk.test.ts`
+
+- [ ] **Step 1: Replace the file contents**
+
+Replace `src/adapters/messaging/chatsdk.test.ts` with:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ChatSDKAdapter } from "./chatsdk.js";
+import type { ThreadStore } from "../run-registry/types.js";
+
+const mockChannelPost = vi.fn();
+const mockThreadPost = vi.fn();
+
+vi.mock("chat", () => {
+  return {
+    Chat: vi.fn(() => ({
+      channel: vi.fn((id: string) => ({
+        id,
+        post: mockChannelPost,
+      })),
+    })),
+    ThreadImpl: vi.fn(function (this: { id: string; post: typeof mockThreadPost }, cfg: { id: string }) {
+      this.id = cfg.id;
+      this.post = mockThreadPost;
+    }),
+  };
+});
+
+vi.mock("@chat-adapter/slack", () => ({
+  createSlackAdapter: vi.fn(() => ({ name: "slack" })),
+}));
+
+function createThreadStore(): ThreadStore & {
+  getParent: ReturnType<typeof vi.fn>;
+  setParent: ReturnType<typeof vi.fn>;
+  clearParent: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getParent: vi.fn().mockResolvedValue(null),
+    setParent: vi.fn().mockResolvedValue(undefined),
+    clearParent: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createAdapter(threadStore: ThreadStore) {
+  return new ChatSDKAdapter({
+    slackToken: "xoxb-test",
+    channelId: "C123",
+    botName: "blazebot",
+    jiraBaseUrl: "https://jira.example.com",
+    threadStore,
+  });
+}
+
+const JIRA_LINK = "<https://jira.example.com/browse/AWT-42|AWT-42>";
+
+describe("ChatSDKAdapter.notifyForTicket", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChannelPost.mockResolvedValue({ id: "1700000000.000111" });
+    mockThreadPost.mockResolvedValue({ id: "1700000000.000222" });
+  });
+
+  it("started with no parent — posts top-level and records the parent", async () => {
+    const store = createThreadStore();
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", { kind: "started" });
+
+    expect(mockChannelPost).toHaveBeenCalledWith(`Task ${JIRA_LINK} started`);
+    expect(mockThreadPost).not.toHaveBeenCalled();
+    expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000111");
+  });
+
+  it("subsequent event with parent set — posts as thread reply, does not setParent", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "needs_clarification",
+      usageReport: "u",
+    });
+
+    expect(mockChannelPost).not.toHaveBeenCalled();
+    expect(mockThreadPost).toHaveBeenCalledWith(
+      `Task ${JIRA_LINK} needs clarification\nu`,
+    );
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("non-started event with no parent — posts top-level, does NOT setParent (orphan stays orphan)", async () => {
+    const store = createThreadStore();
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "canceled",
+      reason: "left AI column",
+    });
+
+    expect(mockChannelPost).toHaveBeenCalledWith(
+      `Task ${JIRA_LINK} canceled: left AI column`,
+    );
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("parent deleted on Slack — clears mapping, retries top-level, re-records on started", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    mockThreadPost.mockRejectedValueOnce(
+      Object.assign(new Error("thread gone"), { code: "thread_not_found" }),
+    );
+    mockChannelPost.mockResolvedValueOnce({ id: "1700000000.000999" });
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", { kind: "started" });
+
+    expect(mockThreadPost).toHaveBeenCalledTimes(1);
+    expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
+    expect(mockChannelPost).toHaveBeenCalledTimes(1);
+    // Because the event is `started`, the new top-level message becomes the parent.
+    expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000999");
+  });
+
+  it("parent deleted on Slack for non-started event — clears + retries, does not re-anchor", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    mockThreadPost.mockRejectedValueOnce(
+      Object.assign(new Error("not found"), { code: "message_not_found" }),
+    );
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "failed",
+      phase: "impl",
+      reason: "boom",
+    });
+
+    expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
+    expect(mockChannelPost).toHaveBeenCalledWith(
+      `Task ${JIRA_LINK} failed: impl — boom`,
+    );
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("non-missing-parent error — does not retry, does not throw", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    mockThreadPost.mockRejectedValueOnce(
+      Object.assign(new Error("rate limited"), { code: "rate_limited" }),
+    );
+    const adapter = createAdapter(store);
+
+    await expect(
+      adapter.notifyForTicket("AWT-42", { kind: "started" }),
+    ).resolves.not.toThrow();
+    expect(store.clearParent).not.toHaveBeenCalled();
+    expect(mockChannelPost).not.toHaveBeenCalled();
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("top-level post failure — swallows error, no parent recorded", async () => {
+    const store = createThreadStore();
+    mockChannelPost.mockRejectedValueOnce(new Error("Slack API down"));
+    const adapter = createAdapter(store);
+
+    await expect(
+      adapter.notifyForTicket("AWT-42", { kind: "started" }),
+    ).resolves.not.toThrow();
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("pr_ready — formats with PR link inline", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "pr_ready",
+      pr: { url: "https://github.com/o/r/pull/7", number: 7 },
+      usageReport: "Total: $0.10",
+    });
+
+    expect(mockThreadPost).toHaveBeenCalledWith(
+      `Task ${JIRA_LINK} PR ready for review — <https://github.com/o/r/pull/7|#7>\nTotal: $0.10`,
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run only this test file — confirm it passes**
+
+Run: `pnpm vitest run src/adapters/messaging/chatsdk.test.ts`
+Expected: PASS — 8 cases.
+
+- [ ] **Step 3: Commit the adapter + tests together**
+
+```bash
+git add src/adapters/messaging/types.ts src/adapters/messaging/chatsdk.ts src/adapters/messaging/chatsdk.test.ts
+git commit -m "feat(messaging): replace notify() with notifyForTicket() and lifetime threading"
+```
+
+(Note: this commit makes call-site files temporarily fail typecheck. They are fixed in Phase 4 within the same PR, so main is never red. If you are using subagent-driven development, the next subagent should pick up immediately.)
+
+---
+
+## Phase 4 — Wire up call sites
+
+Goal: convert every `messaging.notify(...)` and `notifySlack(...)` call to `notifyForTicket(ticketKey, event)`, and wire the new constructor args.
+
+### Task 8: Pass `jiraBaseUrl` and `threadStore` into `ChatSDKAdapter`
+
+**Files:**
+- Modify: `src/lib/adapters.ts`
+- Modify: `src/lib/step-adapters.ts`
+
+- [ ] **Step 1: Update `src/lib/adapters.ts` — instantiate the run registry first, then reuse it as the thread store**
+
+Replace the body of `createAdapters()` with:
+
+```ts
+export function createAdapters(): Adapters {
+  const runRegistry = new UpstashRunRegistry({
+    url: env.AI_WORKFLOW_KV_REST_API_URL,
+    token: env.AI_WORKFLOW_KV_REST_API_TOKEN,
+  });
+  return {
+    issueTracker: new JiraAdapter({
+      baseUrl: env.JIRA_BASE_URL,
+      email: env.JIRA_EMAIL,
+      apiToken: env.JIRA_API_TOKEN,
+      projectKey: env.JIRA_PROJECT_KEY,
+    }),
+    vcs: createVCS(),
+    messaging: new ChatSDKAdapter({
+      slackToken: env.CHAT_SDK_SLACK_TOKEN,
+      channelId: env.CHAT_SDK_CHANNEL_ID,
+      botName: env.CHAT_SDK_BOT_NAME,
+      jiraBaseUrl: env.JIRA_BASE_URL,
+      threadStore: runRegistry,
+    }),
+    runRegistry,
+  };
+}
+```
+
+- [ ] **Step 2: Apply the same change to `src/lib/step-adapters.ts`**
+
+Replace the body of `createStepAdapters()` with the analogous version (same pattern, same fields — only the function name differs):
+
+```ts
+export function createStepAdapters(): StepAdapters {
+  const runRegistry = new UpstashRunRegistry({
+    url: env.AI_WORKFLOW_KV_REST_API_URL,
+    token: env.AI_WORKFLOW_KV_REST_API_TOKEN,
+  });
+  return {
+    issueTracker: new JiraAdapter({
+      baseUrl: env.JIRA_BASE_URL,
+      email: env.JIRA_EMAIL,
+      apiToken: env.JIRA_API_TOKEN,
+      projectKey: env.JIRA_PROJECT_KEY,
+    }),
+    vcs: createVCS(),
+    messaging: new ChatSDKAdapter({
+      slackToken: env.CHAT_SDK_SLACK_TOKEN,
+      channelId: env.CHAT_SDK_CHANNEL_ID,
+      botName: env.CHAT_SDK_BOT_NAME,
+      jiraBaseUrl: env.JIRA_BASE_URL,
+      threadStore: runRegistry,
+    }),
+    runRegistry,
+  };
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm tsc --noEmit`
+Expected: errors only at the three remaining `notify(...)` and `notifySlack(...)` call sites — `agent.ts`, `cron/poll.get.ts`, `webhooks/jira.post.ts`.
+
+---
+
+### Task 9: Convert `cron/poll.get.ts` and `webhooks/jira.post.ts`
+
+**Files:**
+- Modify: `src/routes/cron/poll.get.ts`
+- Modify: `src/routes/webhooks/jira.post.ts`
+
+- [ ] **Step 1: Update `src/routes/cron/poll.get.ts:23`**
+
+Find the existing call inside the reconcile callback:
+
+```ts
+      await adapters.messaging.notify(
+        `Task ${ticketKey} canceled: ${detail}.`,
+      );
+```
+
+Replace with:
+
+```ts
+      await adapters.messaging.notifyForTicket(ticketKey, {
+        kind: "canceled",
+        reason: `${detail}.`,
+      });
+```
+
+(Trailing period preserved to match today's text — the formatter does not add punctuation.)
+
+- [ ] **Step 2: Update `src/routes/webhooks/jira.post.ts:110`**
+
+Find the existing block:
+
+```ts
+    const cancelled = await cancelTrackedRun(ticketKey, adapters.runRegistry);
+    if (cancelled) {
+      await adapters.messaging.notify(
+        `Task ${ticketKey} canceled: webhook confirmed ticket is outside AI column.`,
+      );
+    }
+```
+
+Replace the inner `notify` call (keep the surrounding `if (cancelled) { ... }`):
+
+```ts
+    const cancelled = await cancelTrackedRun(ticketKey, adapters.runRegistry);
+    if (cancelled) {
+      await adapters.messaging.notifyForTicket(ticketKey, {
+        kind: "canceled",
+        reason: "webhook confirmed ticket is outside AI column",
+      });
+    }
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm tsc --noEmit`
+Expected: errors only inside `src/workflows/agent.ts`.
+
+---
+
+### Task 10: Convert `src/workflows/agent.ts` — replace the `notifySlack` step
+
+**Files:**
+- Modify: `src/workflows/agent.ts`
+
+- [ ] **Step 1: Rename and retype the step function**
+
+Find the existing step (around line 338):
+
+```ts
+async function notifySlack(message: string) {
+  "use step";
+  const { createStepAdapters } = await import("../lib/step-adapters.js");
+  const { messaging } = createStepAdapters();
+  await messaging.notify(message);
+}
+```
+
+Replace with:
+
+```ts
+async function notifyTicket(ticketKey: string, event: TicketEvent) {
+  "use step";
+  const { createStepAdapters } = await import("../lib/step-adapters.js");
+  const { messaging } = createStepAdapters();
+  await messaging.notifyForTicket(ticketKey, event);
+}
+```
+
+- [ ] **Step 2: Add the `TicketEvent` type import at the top of the file**
+
+Locate the existing `import type { ... }` block from `../adapters/...` (the `PRComment, CheckRunResult` line). Add a sibling import:
+
+```ts
+import type { TicketEvent } from "../adapters/messaging/types.js";
+```
+
+- [ ] **Step 3: Replace the `started` notification at line 441**
+
+```ts
+    await notifySlack(`Task ${ticket.identifier} started`);
+```
+
+becomes:
+
+```ts
+    await notifyTicket(ticket.identifier, { kind: "started" });
+```
+
+- [ ] **Step 4: Replace research-timeout notification (line ~518)**
+
+```ts
+        await notifySlack(`Task ${ticket.identifier} failed: research phase timed out${usageSuffix()}`);
+```
+
+becomes:
+
+```ts
+        await notifyTicket(ticket.identifier, {
+          kind: "failed",
+          phase: "research",
+          reason: "phase timed out",
+          usageReport: usageReportOrUndefined(),
+        });
+```
+
+(Helper added in Step 11 below.)
+
+- [ ] **Step 5: Replace research-clarification (line ~536)**
+
+```ts
+        await notifySlack(`Task ${ticket.identifier} needs clarification${usageSuffix()}`);
+```
+
+becomes:
+
+```ts
+        await notifyTicket(ticket.identifier, {
+          kind: "needs_clarification",
+          usageReport: usageReportOrUndefined(),
+        });
+```
+
+- [ ] **Step 6: Replace research-failure (line ~543)**
+
+```ts
+        await notifySlack(`Task ${ticket.identifier} failed: research — ${research.body.slice(0, 200)}${usageSuffix()}`);
+```
+
+becomes:
+
+```ts
+        await notifyTicket(ticket.identifier, {
+          kind: "failed",
+          phase: "research",
+          reason: research.body.slice(0, 200),
+          usageReport: usageReportOrUndefined(),
+        });
+```
+
+- [ ] **Step 7: Replace impl-clarification (line ~587)**
+
+```ts
+        await notifySlack(`Task ${ticket.identifier} needs clarification${usageSuffix()}`);
+```
+
+becomes:
+
+```ts
+        await notifyTicket(ticket.identifier, {
+          kind: "needs_clarification",
+          usageReport: usageReportOrUndefined(),
+        });
+```
+
+- [ ] **Step 8: Replace impl-failure (line ~594)**
+
+```ts
+        await notifySlack(`Task ${ticket.identifier} failed: implementation — ${implOutput.error ?? "unknown"}${usageSuffix()}`);
+```
+
+becomes:
+
+```ts
+        await notifyTicket(ticket.identifier, {
+          kind: "failed",
+          phase: "impl",
+          reason: implOutput.error ?? "unknown",
+          usageReport: usageReportOrUndefined(),
+        });
+```
+
+- [ ] **Step 9: Replace push-failure (line ~653)**
+
+```ts
+        await notifySlack(`Task ${ticket.identifier} failed: push failed — ${pushResult.error ?? "unknown"}${usageSuffix()}`);
+```
+
+becomes:
+
+```ts
+        await notifyTicket(ticket.identifier, {
+          kind: "failed",
+          phase: "push",
+          reason: pushResult.error ?? "unknown",
+          usageReport: usageReportOrUndefined(),
+        });
+```
+
+- [ ] **Step 10: Replace PR-ready notification (line ~659–665) and capture the PR result**
+
+Today the block reads:
+
+```ts
+      if (!prContext) {
+        await createPullRequest(branchName, ticket.title, "");
+      }
+      // Notify Slack BEFORE moving the ticket out of the AI column.
+      // Reconcile cancels runs whose tickets have left AI column; racing
+      // that cancellation after moveTicket would skip the notification.
+      const usageReport = formatUsageReport(phaseUsages, priceLookup, activeModel);
+      await notifySlack(`Task ${ticket.identifier} PR ready for review\n${usageReport}`);
+      await moveTicket(ticketId, env.COLUMN_AI_REVIEW);
+      await unregisterRun(ticket.identifier);
+```
+
+Replace with (capturing the new-PR return; for the existing-PR branch, reuse `prContext.findPR`-equivalent data already present):
+
+```ts
+      // We need a {url, number} regardless of whether the PR is new or pre-existing.
+      // - New PR: createPullRequest returns the PullRequest ({ id, url, branch }) — capture it.
+      // - Existing PR: prContext was built from vcs.findPR(branch), but findPR's return
+      //   is dropped today. Re-fetch via the VCS adapter step (cheap; same call already
+      //   ran on this branch earlier in the workflow).
+      const pr = !prContext
+        ? await createPullRequest(branchName, ticket.title, "")
+        : await findPRForBranch(branchName);
+
+      const usageReport = formatUsageReport(phaseUsages, priceLookup, activeModel);
+      await notifyTicket(ticket.identifier, {
+        kind: "pr_ready",
+        pr: { url: pr.url, number: pr.id },
+        usageReport,
+      });
+      await moveTicket(ticketId, env.COLUMN_AI_REVIEW);
+      await unregisterRun(ticket.identifier);
+```
+
+Add the supporting step function alongside the other VCS step wrappers (e.g., right after `createPullRequest`):
+
+```ts
+async function findPRForBranch(branchName: string) {
+  "use step";
+  const { createStepAdapters } = await import("../lib/step-adapters.js");
+  const { vcs } = createStepAdapters();
+  const pr = await vcs.findPR(branchName);
+  if (!pr) {
+    // The pr_ready branch only runs after a successful push to an existing
+    // PR's branch — the PR cannot have vanished. Treat as an invariant.
+    throw new Error(`Expected PR for branch ${branchName} but findPR returned null`);
+  }
+  return pr;
+}
+```
+
+- [ ] **Step 11: Replace catch-all (line ~674)**
+
+Today:
+
+```ts
+    await notifySlack(`Task ${ticket.identifier} failed: ${(err as Error).message ?? "unknown"}${usageSuffix()}`).catch(() => {});
+```
+
+Replace with:
+
+```ts
+    await notifyTicket(ticket.identifier, {
+      kind: "failed",
+      reason: (err as Error).message ?? "unknown",
+      usageReport: usageReportOrUndefined(),
+    }).catch(() => {});
+```
+
+- [ ] **Step 12: Add the `usageReportOrUndefined` helper next to the existing `usageSuffix`**
+
+In `agentWorkflow`, find:
+
+```ts
+  const usageSuffix = () =>
+    Object.keys(phaseUsages).length
+      ? `\n${formatUsageReport(phaseUsages, priceLookup, activeModel)}`
+      : "";
+```
+
+Add immediately below it:
+
+```ts
+  // Variant of usageSuffix() that returns the bare report (no leading newline)
+  // or `undefined` so the messaging formatter can decide whether to render it.
+  const usageReportOrUndefined = (): string | undefined =>
+    Object.keys(phaseUsages).length
+      ? formatUsageReport(phaseUsages, priceLookup, activeModel)
+      : undefined;
+```
+
+`usageSuffix` becomes unused after Step 11. Delete it (the closure's only callers are the lines we just rewrote).
+
+- [ ] **Step 13: Type-check**
+
+Run: `pnpm tsc --noEmit`
+Expected: PASS, no errors.
+
+- [ ] **Step 14: Run the full test suite**
+
+Run: `pnpm vitest run`
+Expected: PASS. The following test files are touched in this change and must all pass:
+- `src/adapters/messaging/format.test.ts`
+- `src/adapters/messaging/chatsdk.test.ts`
+- `src/adapters/run-registry/upstash.test.ts`
+
+Existing tests for `agent.ts`, cron, and webhook handlers must continue to pass without modification — they don't assert on Slack call shapes.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/lib/adapters.ts src/lib/step-adapters.ts src/routes/cron/poll.get.ts src/routes/webhooks/jira.post.ts src/workflows/agent.ts
+git commit -m "feat(workflow): notify per-ticket events (start/clarify/pr/failed/cancel) into one Slack thread"
+```
+
+---
+
+## Phase 5 — Verification
+
+Goal: confirm Slack rendering and threading behavior against a real channel before merging. Two pieces are not exercised by unit tests:
+
+1. Whether the Slack-mrkdwn `<url|label>` syntax survives the chat package's render pipeline.
+2. Whether `thread_not_found` / `message_not_found` are the actual error codes Slack returns for a deleted parent.
+
+### Task 11: Manual smoke verification against a real Slack channel
+
+**Files:** none (operational task).
+
+- [ ] **Step 1: Deploy the branch to a preview environment with a test Slack channel + Jira project configured**
+
+Use the standard preview deploy flow for this repo (deploy via `pnpm dlx vercel deploy` or the team's preview pipeline — the user runs this).
+
+- [ ] **Step 2: Trigger one ticket through to PR-ready**
+
+Move a Jira ticket into the AI column. Watch the Slack channel:
+
+Expected sequence in the channel:
+1. Top-level message: `Task <jira-link|AWT-XX> started` — the `AWT-XX` text must be a clickable hyperlink.
+2. Thread reply on the same message: `Task <jira-link|AWT-XX> PR ready for review — <github-link|#NN>` — both the Jira key and `#NN` are clickable.
+
+- [ ] **Step 3: Verify link rendering**
+
+Click the Jira link and the PR link. Both must navigate to the expected destinations. If either renders as raw `<…|…>` text instead of a hyperlink, the chat package is escaping the angle brackets — fall back to the alternate rendering option:
+
+Edit `formatTicketEvent` callers in `chatsdk.ts` to pass the formatted string as `PostableRaw`:
+
+```ts
+// In ChatSDKAdapter, change:
+const sent = await channel.post(text);
+// to:
+const sent = await channel.post({ raw: text });
+```
+
+(Same change for the `thread.post` call.) Re-run the smoke test. If links now render correctly, commit the change as a follow-up:
+
+```bash
+git add src/adapters/messaging/chatsdk.ts
+git commit -m "fix(messaging): post raw mrkdwn so Slack hyperlinks render"
+```
+
+If they still don't render, document the failure in `.claude/learnings.md` and stop — the remediation is out of scope for this plan.
+
+- [ ] **Step 4: Verify deleted-parent recovery**
+
+In Slack, delete the original `started` message in the test channel. Trigger the same ticket through another full run (e.g., move it back into AI column). Observe:
+
+Expected: a fresh top-level `Task ... started` message appears (new parent), followed by threaded subsequent messages.
+
+Check the deployed logs for the line `thread_parent_recovered`. If the recovery path did not run (i.e., the second `started` posted as a reply under the deleted message), the Slack error code is not in `MISSING_PARENT_ERROR_CODES`. Capture the actual error code from the log line `notification_failed → slackErrorCode`, add it to the `MISSING_PARENT_ERROR_CODES` set in `chatsdk.ts`, and commit:
+
+```bash
+git add src/adapters/messaging/chatsdk.ts
+git commit -m "fix(messaging): include <code> in missing-parent error code set"
+```
+
+- [ ] **Step 5: Update `.claude/learnings.md`**
+
+Append a learning entry capturing whichever path the smoke test confirmed:
+
+- Whether `<url|label>` renders correctly via plain string post or required `PostableRaw`.
+- The exact Slack error codes seen for deleted parents.
+
+This is a small file edit. The existing CLAUDE.md instruction (`Whenever you are corrected or discover something unexpected about this codebase, append the learning to .claude/learnings.md`) makes this mandatory regardless of outcome.
+
+- [ ] **Step 6: Final report-out**
+
+State to the user:
+
+- The events posted (which ones, in which order).
+- Whether links rendered correctly (and which option won — plain string vs `PostableRaw`).
+- The actual Slack error code(s) seen for deleted parents (if encountered).
+- Any out-of-scope follow-ups discovered.
+
+The user reviews the smoke results and merges.
+
+---
+
+## Self-Review Checklist (verified)
+
+- **Spec coverage:** every section of `2026-04-30-slack-threaded-messages-design.md` is mapped:
+  - Solution / Threading Policy → Task 6 (adapter logic) + Task 5 (formatter).
+  - Architecture / `ThreadStore` interface → Tasks 1–3.
+  - Event Types and Formatting → Tasks 4–5.
+  - Adapter Behavior pseudocode → Task 6.
+  - Call-Site Changes (agent / cron / webhook) → Tasks 9–10.
+  - Adapter wiring → Task 8.
+  - Redis Data Model (THREAD_HASH_KEY, no TTL, untouched by `unregister`) → Task 2 + Task 3 (the "unregister leaves it alone" assertion).
+  - Testing → Tasks 3, 5, 7.
+  - Migration / Rollout → covered implicitly (no DB seeding required; revert is a normal git revert).
+  - Observability (`thread_parent_recovered`, structured fields) → Task 6.
+  - Risks (mrkdwn rendering, error codes) → Task 11 verification.
+- **Placeholders:** none. Every step contains the exact code or command needed.
+- **Type consistency:** `TicketEvent`, `ThreadStore`, `notifyForTicket`, `formatTicketEvent`, `findPRForBranch`, `usageReportOrUndefined`, `MISSING_PARENT_ERROR_CODES`, `THREAD_HASH_KEY` are spelled identically across every task that mentions them.
+- **No half-state on main:** Phase 3 and Phase 4 commits both make the build green individually (commit boundaries align with green typecheck + green tests).

--- a/docs/superpowers/specs/2026-04-30-slack-threaded-messages-design.md
+++ b/docs/superpowers/specs/2026-04-30-slack-threaded-messages-design.md
@@ -1,0 +1,287 @@
+# Slack Threaded Messages Design
+
+## Problem
+
+Today, every per-ticket notification posts as a top-level message in the configured Slack channel. The `MessagingAdapter.notify(message)` interface has no concept of conversation grouping, so a single ticket can produce 3–5 unrelated-looking messages scattered across the channel:
+
+```
+[10:01] Task AWT-42 started
+[10:14] Task AWT-42 needs clarification
+[14:02] Task AWT-42 PR ready for review
+[16:30] Task AWT-42 canceled: webhook confirmed ticket is outside AI column.
+```
+
+Two consequences:
+
+1. The channel becomes hard to read — messages from different tickets interleave.
+2. There is no clickable path from a Slack notification to the underlying Jira ticket or the GitHub PR. Readers have to copy the identifier and search.
+
+## Solution
+
+Make the `MessagingAdapter` ticket-aware. The first message about a ticket — `Task X started` — posts at top level and its Slack message timestamp is recorded as the **lifetime parent** for that ticket. Every subsequent message about the same ticket is posted as a thread reply under that parent. Clarification, PR-ready, failure, and cancellation messages all reply into the same thread.
+
+In addition, the ticket identifier in every message becomes a clickable Jira link, and the `pr_ready` event includes a clickable GitHub PR reference.
+
+## Scope
+
+In scope:
+
+- A new `notifyForTicket(ticketKey, event)` method on `MessagingAdapter` that replaces the existing `notify(message)`.
+- A new `ThreadStore` interface (`getParent`, `setParent`, `clearParent`) implemented on `UpstashRunRegistry`.
+- A new Redis hash `blazebot:thread-parents:{ENV_PREFIX}` for ticket → message-id mappings.
+- Structured `TicketEvent` types replacing inline-string concatenation in `agent.ts`, `cron/poll.get.ts`, and `webhooks/jira.post.ts`.
+- Slack-mrkdwn link formatting for the Jira ticket identifier and the PR reference.
+
+Out of scope:
+
+- Adding new notification events. The set of events stays exactly as today (start, clarification, PR-ready, failure, cancel).
+- Threading for non-ticket notifications. There are none in the current code.
+- A `notify(message)` escape hatch for non-ticket-scoped messages. All call sites are ticket-scoped; we drop the method entirely.
+- Cross-ticket grouping (e.g., one thread per cron tick).
+
+## Threading Policy
+
+**Lifetime threading.** One Slack thread per ticket, indefinitely. If a ticket cycles through the AI column multiple times (initial run, then a fix-up after PR review feedback), every message lands in the same thread the original `Task X started` message established.
+
+Trade-off accepted: very long-lived tickets (months) may eventually have threads that scroll off Slack's reasonable retrieval window. If this becomes a problem in practice, switching to "thread per run" is a localized change — key the `ThreadStore` lookup by `ticketKey + runStartedAt` and add a `clearParent` call at the start of every run.
+
+**Top-level fallback when no parent exists.** Three cases collapse into one rule:
+
+| Case | Behavior |
+|---|---|
+| No mapping for this ticket yet | Post top-level. Record parent **only if** the event is `started`. |
+| Mapping exists, but Slack returns "thread/message not found" (parent deleted) | Catch the error, clear the mapping, retry top-level. Re-establish parent only if the event is `started`. |
+| Mapping exists and parent is alive | Post as thread reply. |
+
+Implication: out-of-band events that arrive before any `started` (e.g., a webhook cancellation racing the workflow's first message) post as standalone top-level messages and **do not** establish a parent. Only `started` is allowed to anchor a thread, because only `started` carries the implicit promise that more updates are coming.
+
+## Architecture
+
+```
+                           UpstashRunRegistry
+                           ├── HASH_KEY            (ticket → runId)
+                           ├── SANDBOX_HASH_KEY    (ticket → sandboxId)
+                           ├── ENTRY_TS_HASH_KEY   (ticket → createdAt)
+                           ├── FAILED_HASH_KEY     (ticket → failure meta)
+                           └── THREAD_HASH_KEY     (ticket → slack message ts)  ← NEW
+
+Workflow / cron / webhook
+        │
+        ▼
+ChatSDKAdapter.notifyForTicket(ticketKey, event)
+        │
+        ├── threadStore.getParent(ticketKey)
+        ├── format(event, ticketKey, jiraBaseUrl)  →  Slack-mrkdwn string
+        ├── chat.channel(...).post(text, { thread_ts? })
+        └── if event.kind === "started" && no parent existed:
+              threadStore.setParent(ticketKey, sentMessage.id)
+```
+
+`MessagingAdapter` is the "smart" layer (this is the deliberate choice from approach 1 of brainstorming). It knows how to:
+
+1. Post Slack messages.
+2. Format `TicketEvent`s into wire text with embedded Jira/PR links.
+3. Read and write parent-message-id mappings via an injected `ThreadStore`.
+
+The `ThreadStore` interface is bounded to three methods so the adapter only depends on the slice of run-registry behavior it needs:
+
+```ts
+export interface ThreadStore {
+  getParent(ticketKey: string): Promise<string | null>;
+  setParent(ticketKey: string, messageId: string): Promise<void>;
+  clearParent(ticketKey: string): Promise<void>;
+}
+```
+
+`UpstashRunRegistry` implements this interface in addition to `RunRegistryAdapter`. Both interfaces are satisfied by the same class instance — the existing Redis client is reused.
+
+## Event Types and Formatting
+
+```ts
+export type TicketEvent =
+  | { kind: "started" }
+  | { kind: "needs_clarification"; usageReport?: string }
+  | { kind: "pr_ready"; pr: { url: string; number: number }; usageReport: string }
+  | {
+      kind: "failed";
+      phase?: "research" | "impl" | "push";
+      reason?: string;
+      usageReport?: string;
+    }
+  | { kind: "canceled"; reason: string };
+```
+
+Formatter output (using Slack-native `<url|label>` mrkdwn syntax):
+
+| Event | Rendered text |
+|---|---|
+| `started` | `Task <https://JIRA/browse/AWT-42\|AWT-42> started` |
+| `needs_clarification` | `Task <https://JIRA/browse/AWT-42\|AWT-42> needs clarification` (+ `\n<usageReport>` if present) |
+| `pr_ready` | `Task <https://JIRA/browse/AWT-42\|AWT-42> PR ready for review — <https://github.com/.../pull/123\|#123>\n<usageReport>` |
+| `failed` | With phase: `Task <https://JIRA/browse/AWT-42\|AWT-42> failed: <phase> — <reason>`. Without phase (catch-all): `Task <…\|AWT-42> failed: <reason>`. Without reason or phase (extreme edge case): `Task <…\|AWT-42> failed`. (+ `\n<usageReport>` appended in all variants if non-empty.) |
+| `canceled` | `Task <https://JIRA/browse/AWT-42\|AWT-42> canceled: <reason>` |
+
+`ChatSDKConfig` grows by one field, `jiraBaseUrl: string`, supplied from `env.JIRA_BASE_URL`. The link is built as `${jiraBaseUrl.replace(/\/$/, '')}/browse/${ticketKey}` — defensive trim on a trailing slash because the env value is user-configured.
+
+The `<url|label>` syntax is not standard markdown. Two implementation options will be evaluated during build:
+
+1. Use the chat package's `link` AST node (`link("AWT-42", "https://...")`) inside a `PostableMessage` and let the Slack adapter render it. Preferred if it produces correct mrkdwn.
+2. Pass a `PostableRaw` Slack-formatted string to bypass mdast escaping. Fallback if option 1 escapes the angle brackets.
+
+Verified during implementation by posting one of each event type to a real Slack channel.
+
+## Adapter Behavior (Pseudocode)
+
+```
+notifyForTicket(ticketKey, event):
+  parent = threadStore.getParent(ticketKey)
+  text   = format(event, ticketKey, jiraBaseUrl)
+
+  try:
+    sent = post(text, threadParentId: parent ?? undefined)
+  catch e if isMissingParentError(e):
+    threadStore.clearParent(ticketKey)
+    sent = post(text)                    // top-level retry
+    parent = null
+
+  if event.kind === "started" && parent == null && sent != null:
+    threadStore.setParent(ticketKey, sent.id)
+```
+
+Failure semantics match today's `notify(message)`: any error from the post (after the missing-parent retry) is caught and logged at `warn`. `notifyForTicket` never throws — workflow runs are never broken by a notification failure.
+
+`isMissingParentError` discriminates on the Slack error code surfaced by the chat package. Likely candidates: `thread_not_found`, `message_not_found`. The exact discriminator is finalized during implementation by deliberately deleting a parent message in a test channel.
+
+## Call-Site Changes
+
+### `src/workflows/agent.ts`
+
+Replace the existing `notifySlack(message: string)` step:
+
+```ts
+async function notifyTicket(ticketKey: string, event: TicketEvent) {
+  "use step";
+  const { createStepAdapters } = await import("../lib/step-adapters.js");
+  const { messaging } = createStepAdapters();
+  await messaging.notifyForTicket(ticketKey, event);
+}
+```
+
+Each existing call site converts:
+
+| Line | Today | After |
+|---|---|---|
+| 441 | `notifySlack(\`Task ${id} started\`)` | `notifyTicket(id, { kind: "started" })` |
+| 518 | research-timeout `notifySlack(...)` | `notifyTicket(id, { kind: "failed", phase: "research", reason: "phase timed out", usageReport })` |
+| 536 | research clarification | `notifyTicket(id, { kind: "needs_clarification", usageReport })` |
+| 543 | research failure | `notifyTicket(id, { kind: "failed", phase: "research", reason: research.body.slice(0,200), usageReport })` |
+| 587 | impl clarification | `notifyTicket(id, { kind: "needs_clarification", usageReport })` |
+| 594 | impl failure | `notifyTicket(id, { kind: "failed", phase: "impl", reason: implOutput.error, usageReport })` |
+| 653 | push failure | `notifyTicket(id, { kind: "failed", phase: "push", reason: pushResult.error, usageReport })` |
+| 665 | PR ready | `notifyTicket(id, { kind: "pr_ready", pr: { url: pr.url, number: pr.id }, usageReport })` |
+| 674 | catch-all | `notifyTicket(id, { kind: "failed", reason: err.message ?? "unknown", usageReport })` |
+
+Two extra wiring details for line 665:
+
+- `createPullRequest(...)` already returns the `PullRequest`, but the result is currently discarded on line 659. Capture it. Both branches (new PR path and existing-PR path) provide `{ url, id (number), branch }` — `prContext` is reusable directly.
+- The trailing `${usageReport}` newline-prefix moves into the formatter; pass `usageReport` as a structured field, not concatenated.
+
+`usageReport` is computed at the call site exactly as today (`formatUsageReport(...)`) and passed in as a string field. The formatter prepends `\n` when emitting it. An empty string is treated as absent (no trailing newline emitted) — equivalent to `undefined`. This matches the current behavior of `usageSuffix()` returning `""` when `phaseUsages` is empty.
+
+### `src/routes/cron/poll.get.ts:23`
+
+```ts
+await adapters.messaging.notifyForTicket(ticketKey, { kind: "canceled", reason: detail });
+```
+
+### `src/routes/webhooks/jira.post.ts:110`
+
+```ts
+await adapters.messaging.notifyForTicket(ticketKey, {
+  kind: "canceled",
+  reason: "webhook confirmed ticket is outside AI column",
+});
+```
+
+### Adapter wiring
+
+`src/lib/adapters.ts` and `src/lib/step-adapters.ts` both pass three new ingredients into `ChatSDKAdapter`:
+
+- `jiraBaseUrl: env.JIRA_BASE_URL`
+- `threadStore: runRegistry` (the `UpstashRunRegistry` instance now satisfies both `RunRegistryAdapter` and `ThreadStore`)
+
+Order: instantiate the run registry first, then pass it into the messaging adapter. Both factories already construct the registry, so this is a one-line reorder.
+
+## Redis Data Model
+
+**Hash key:** `blazebot:thread-parents:{ENV_PREFIX}`
+
+Follows the same pattern as the existing `blazebot:active-runs:{ENV_PREFIX}` hash.
+
+**Field:** Ticket key (e.g., `AWT-42`).
+
+**Value:** Slack message timestamp (the `id` of `SentMessage` returned by `channel.post()`), e.g. `"1700000000.000123"`.
+
+**TTL:** None. Entries are bounded by the number of distinct tickets ever processed; at ~50 bytes per entry and 100k tickets, total cost is ~5 MB. `clearParent` removes individual entries when a parent is detected as deleted on Slack.
+
+**Lifecycle vs `unregister(ticketKey)`:** This hash is **not** touched by `unregister`. The thread mapping outlives a single workflow run, which is the whole point of lifetime threading.
+
+## Testing
+
+### `src/adapters/messaging/chatsdk.test.ts`
+
+Rewrite around `notifyForTicket`. Existing two cases (channel routing, no-throw on failure) port over directly. Add:
+
+- `started` with no parent → posts top-level, calls `threadStore.setParent` with the returned message id.
+- Subsequent event with parent set → posts with `thread_ts` equal to the stored parent id; does **not** call `setParent`.
+- Non-`started` event with no parent → posts top-level, does **not** call `setParent` (orphan stays orphan).
+- Parent deleted on Slack (mock returns a `thread_not_found`-shaped error) → calls `clearParent`, retries top-level, and if the event is `started`, records the new parent.
+- Each event variant produces the expected formatted string. Assert on the substring containing the Jira link (and PR link for `pr_ready`).
+- `notifyForTicket` swallows post failures (existing no-throw guarantee preserved).
+
+The mock for `chat.channel().post()` returns `{ id: "1700000000.000123" }` so we can assert it lands in the thread store unmodified.
+
+### `src/adapters/run-registry/upstash.test.ts`
+
+Three new cases for the `ThreadStore` methods on `UpstashRunRegistry`:
+
+- `setParent` then `getParent` round-trips the message id.
+- `getParent` returns `null` when no entry exists.
+- `clearParent` removes the entry; `getParent` then returns `null`.
+- `unregister(ticketKey)` does **not** touch the thread hash.
+
+### Workflow integration
+
+`agent.ts` is not directly unit-tested — steps run through Vercel WDK. The existing `e2e/` suite exercises the full flow. No new e2e is added specifically for threading; manual verification on a real Slack channel during PR review is the realistic check (post a `started`, then a `needs_clarification`, confirm the second appears as a reply under the first).
+
+## Migration and Rollout
+
+**In-flight tickets at deploy.** `THREAD_HASH_KEY` starts empty. Tickets currently mid-run have no recorded parent — their next message (which is by construction a non-`started` event such as PR-ready, clarification, or failure) posts top-level and does **not** establish a parent. The first cycle after deploy is therefore a single standalone message; every cycle after that threads correctly. No manual seeding.
+
+**Re-runs of pre-existing tickets.** When a ticket created before deploy re-enters the AI column, `notifyForTicket(id, { kind: "started" })` runs against an empty entry, posts top-level, records the new parent. Lifetime threading then proceeds normally.
+
+**Backwards compatibility.** None preserved. `MessagingAdapter.notify(message)` is removed. The change is internal to this repo (no external callers). Tests are rewritten in the same PR.
+
+**Rollback.** A revert PR restores the prior interface. The `THREAD_HASH_KEY` data left behind in Redis is harmless and ignored by old code. No data cleanup required.
+
+## Observability
+
+The two existing log lines in `chatsdk.ts` get extra structured fields:
+
+- `notification_sent` → adds `ticketKey`, `eventKind`, `threadParentId` (null on top-level posts).
+- `notification_failed` → adds `ticketKey`, `eventKind`, and the Slack error code if extractable.
+
+A new debug log line, `thread_parent_recovered`, is emitted when the missing-parent recovery path runs (parent existed, Slack rejected with thread-not-found, retry top-level). This makes the recovery branch visible in production without needing to instrument it later.
+
+## Risks
+
+- **Slack rate limits on `chat.postMessage`.** Threading does not change call frequency — same number of posts as today, just with `thread_ts` sometimes set. No new risk.
+- **Bot loses access to a private channel containing the parent.** Surfaces as `channel_not_found` / `not_in_channel`. Same failure mode as today, just with extra context in logs. Operator action (re-invite) unchanged.
+- **`<url|label>` mrkdwn rendering.** Not standard markdown. Resolved during implementation by testing one event of each kind against a real Slack channel and choosing between the chat package's `link` AST node and `PostableRaw`. Captured as a learning in `.claude/learnings.md` once verified.
+- **Lifetime threads on very long-lived tickets.** A ticket that lives for months may eventually have a parent that's hard to reach in Slack search. If this becomes a real complaint, switching to "thread per run" is a small follow-up (key `ThreadStore` by `ticketKey + runStartedAt`).
+
+## Future Work (not in this change)
+
+- "Thread per run" mode behind a config flag, if lifetime threading proves unwieldy.
+- Richer message blocks (Slack Block Kit) for `pr_ready` — buttons for "Open PR" / "Open ticket" instead of inline links.
+- Reaction-driven workflow controls (e.g., react with ✅ on the `pr_ready` thread to re-trigger CI). Out of scope here; design only mentions for context.

--- a/docs/superpowers/specs/2026-04-30-slack-threaded-messages-design.md
+++ b/docs/superpowers/specs/2026-04-30-slack-threaded-messages-design.md
@@ -4,7 +4,7 @@
 
 Today, every per-ticket notification posts as a top-level message in the configured Slack channel. The `MessagingAdapter.notify(message)` interface has no concept of conversation grouping, so a single ticket can produce 3–5 unrelated-looking messages scattered across the channel:
 
-```
+```text
 [10:01] Task AWT-42 started
 [10:14] Task AWT-42 needs clarification
 [14:02] Task AWT-42 PR ready for review
@@ -57,7 +57,7 @@ Implication: out-of-band events that arrive before any `started` (e.g., a webhoo
 
 ## Architecture
 
-```
+```text
                            UpstashRunRegistry
                            ├── HASH_KEY            (ticket → runId)
                            ├── SANDBOX_HASH_KEY    (ticket → sandboxId)
@@ -132,7 +132,7 @@ Verified during implementation by posting one of each event type to a real Slack
 
 ## Adapter Behavior (Pseudocode)
 
-```
+```pseudo
 notifyForTicket(ticketKey, event):
   parent = threadStore.getParent(ticketKey)
   text   = format(event, ticketKey, jiraBaseUrl)

--- a/src/adapters/issue-tracker/jira.test.ts
+++ b/src/adapters/issue-tracker/jira.test.ts
@@ -429,19 +429,36 @@ describe("JiraAdapter", () => {
   });
 
   describe("postComment", () => {
-    it("posts ADF-formatted comment", async () => {
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    it("posts ADF-formatted comment and returns a deep link to the new comment", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "98765" }),
+      });
 
       const adapter = jiraAdapter();
-      await adapter.postComment("10001", "Need more details");
+      const url = await adapter.postComment("PROJ-1", "Need more details");
 
       const call = mockFetch.mock.calls[0];
       const body = JSON.parse(call[1].body);
       expect(body.body.type).toBe("doc");
+      expect(url).toBe(
+        "https://test.atlassian.net/browse/PROJ-1?focusedCommentId=98765",
+      );
+    });
+
+    it("returns null when Jira's response omits a comment id", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+      const adapter = jiraAdapter();
+      const url = await adapter.postComment("PROJ-1", "x");
+      expect(url).toBeNull();
     });
 
     it("splits multi-line comments into separate paragraphs (no \\n inside text nodes)", async () => {
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "1" }),
+      });
 
       const adapter = jiraAdapter();
       await adapter.postComment("10001", "1. First question\n2. Second question");
@@ -457,7 +474,10 @@ describe("JiraAdapter", () => {
     });
 
     it("normalizes CRLF line endings into separate paragraphs", async () => {
-      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "1" }),
+      });
 
       const adapter = jiraAdapter();
       await adapter.postComment("10001", "1. First question\r\n2. Second question");

--- a/src/adapters/issue-tracker/jira.ts
+++ b/src/adapters/issue-tracker/jira.ts
@@ -99,8 +99,8 @@ export class JiraAdapter implements IssueTrackerAdapter {
     });
   }
 
-  async postComment(id: string, comment: string): Promise<void> {
-    await this.request(`/rest/api/3/issue/${id}/comment`, {
+  async postComment(id: string, comment: string): Promise<string | null> {
+    const data = await this.request(`/rest/api/3/issue/${id}/comment`, {
       method: "POST",
       body: JSON.stringify({
         body: {
@@ -110,6 +110,9 @@ export class JiraAdapter implements IssueTrackerAdapter {
         },
       }),
     });
+    const commentId = typeof data?.id === "string" ? data.id : null;
+    if (!commentId) return null;
+    return `${this.baseUrl}/browse/${encodeURIComponent(id)}?focusedCommentId=${encodeURIComponent(commentId)}`;
   }
 
   async downloadAttachment(

--- a/src/adapters/issue-tracker/types.ts
+++ b/src/adapters/issue-tracker/types.ts
@@ -41,7 +41,14 @@ export interface IssueTrackerAdapter {
    */
   fetchTicket(id: string): Promise<TicketContent>;
   moveTicket(id: string, column: string): Promise<void>;
-  postComment(id: string, comment: string): Promise<void>;
+  /**
+   * Post a comment on a ticket.
+   *
+   * Returns a deep-linkable URL to the created comment when the underlying
+   * tracker exposes one (e.g. Jira's `?focusedCommentId=...`), or `null` when
+   * unavailable so callers can fall back to a plain ticket link.
+   */
+  postComment(id: string, comment: string): Promise<string | null>;
   searchTickets(query: string): Promise<string[]>;
   /**
    * Download an attachment by URL. Optional — not all issue trackers support this.

--- a/src/adapters/messaging/chatsdk.test.ts
+++ b/src/adapters/messaging/chatsdk.test.ts
@@ -1,45 +1,195 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ThreadImpl } from "chat";
 import { ChatSDKAdapter } from "./chatsdk.js";
+import type { ThreadStore } from "../run-registry/types.js";
 
-const mockPost = vi.fn();
-const mockChannel = vi.fn(() => ({ post: mockPost }));
+const mockChannelPost = vi.fn();
+const mockThreadPost = vi.fn();
 
-vi.mock("chat", () => ({
-  Chat: vi.fn(() => ({ channel: mockChannel })),
-}));
+vi.mock("chat", () => {
+  return {
+    Chat: vi.fn(() => ({
+      channel: vi.fn((id: string) => ({
+        id,
+        post: mockChannelPost,
+      })),
+    })),
+    ThreadImpl: vi.fn().mockImplementation((cfg: { id: string }) => ({
+      id: cfg.id,
+      post: mockThreadPost,
+    })),
+  };
+});
 
 vi.mock("@chat-adapter/slack", () => ({
-  createSlackAdapter: vi.fn(() => ({})),
+  createSlackAdapter: vi.fn(() => ({ name: "slack" })),
 }));
 
-describe("ChatSDKAdapter", () => {
+function createThreadStore(): ThreadStore & {
+  getParent: ReturnType<typeof vi.fn>;
+  setParent: ReturnType<typeof vi.fn>;
+  clearParent: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getParent: vi.fn().mockResolvedValue(null),
+    setParent: vi.fn().mockResolvedValue(undefined),
+    clearParent: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createAdapter(threadStore: ThreadStore) {
+  return new ChatSDKAdapter({
+    slackToken: "xoxb-test",
+    channelId: "C123",
+    botName: "blazebot",
+    jiraBaseUrl: "https://jira.example.com",
+    threadStore,
+  });
+}
+
+const JIRA_LINK = "<https://jira.example.com/browse/AWT-42|AWT-42>";
+
+describe("ChatSDKAdapter.notifyForTicket", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockPost.mockResolvedValue({ id: "msg-1" });
+    mockChannelPost.mockResolvedValue({ id: "1700000000.000111" });
+    mockThreadPost.mockResolvedValue({ id: "1700000000.000222" });
   });
 
-  it("sends notification to configured channel", async () => {
-    const adapter = new ChatSDKAdapter({
-      slackToken: "xoxb-test",
-      channelId: "C123",
-      botName: "blazebot",
-    });
+  it("started with no parent — posts top-level and records the parent", async () => {
+    const store = createThreadStore();
+    const adapter = createAdapter(store);
 
-    await adapter.notify("PR ready for review");
+    await adapter.notifyForTicket("AWT-42", { kind: "started" });
 
-    expect(mockChannel).toHaveBeenCalledWith("slack:C123");
-    expect(mockPost).toHaveBeenCalledWith("PR ready for review");
+    expect(mockChannelPost).toHaveBeenCalledWith(`Task ${JIRA_LINK} started`);
+    expect(mockThreadPost).not.toHaveBeenCalled();
+    expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000111");
   });
 
-  it("does not throw on notification failure", async () => {
-    mockPost.mockRejectedValueOnce(new Error("Slack API down"));
+  it("subsequent event with parent set — posts as thread reply, does not setParent", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    const adapter = createAdapter(store);
 
-    const adapter = new ChatSDKAdapter({
-      slackToken: "xoxb-test",
-      channelId: "C123",
-      botName: "blazebot",
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "needs_clarification",
+      usageReport: "u",
     });
 
-    await expect(adapter.notify("test")).resolves.not.toThrow();
+    expect(mockChannelPost).not.toHaveBeenCalled();
+    expect(mockThreadPost).toHaveBeenCalledWith(
+      `Task ${JIRA_LINK} needs clarification\nu`,
+    );
+    expect(ThreadImpl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "slack:C123:1700000000.000111",
+        channelId: "slack:C123",
+        isDM: false,
+      }),
+    );
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("non-started event with no parent — posts top-level, does NOT setParent (orphan stays orphan)", async () => {
+    const store = createThreadStore();
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "canceled",
+      reason: "left AI column",
+    });
+
+    expect(mockChannelPost).toHaveBeenCalledWith(
+      `Task ${JIRA_LINK} canceled: left AI column`,
+    );
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("parent deleted on Slack — clears mapping, retries top-level, re-records on started", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    // Realistic Slack WebAPIPlatformError shape: code is the SDK sentinel,
+    // and the actionable Slack API error string lives on data.error.
+    mockThreadPost.mockRejectedValueOnce(
+      Object.assign(new Error("thread gone"), {
+        code: "slack_webapi_platform_error",
+        data: { error: "thread_not_found" },
+      }),
+    );
+    mockChannelPost.mockResolvedValueOnce({ id: "1700000000.000999" });
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", { kind: "started" });
+
+    expect(mockThreadPost).toHaveBeenCalledTimes(1);
+    expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
+    expect(mockChannelPost).toHaveBeenCalledTimes(1);
+    // Because the event is `started`, the new top-level message becomes the parent.
+    expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000999");
+  });
+
+  it("parent deleted on Slack for non-started event — clears + retries, does not re-anchor", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    mockThreadPost.mockRejectedValueOnce(
+      Object.assign(new Error("not found"), { code: "message_not_found" }),
+    );
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "failed",
+      phase: "impl",
+      reason: "boom",
+    });
+
+    expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
+    expect(mockChannelPost).toHaveBeenCalledWith(
+      `Task ${JIRA_LINK} failed: impl — boom`,
+    );
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("non-missing-parent error — does not retry, does not throw", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    mockThreadPost.mockRejectedValueOnce(
+      Object.assign(new Error("rate limited"), { code: "rate_limited" }),
+    );
+    const adapter = createAdapter(store);
+
+    await expect(
+      adapter.notifyForTicket("AWT-42", { kind: "started" }),
+    ).resolves.not.toThrow();
+    expect(store.clearParent).not.toHaveBeenCalled();
+    expect(mockChannelPost).not.toHaveBeenCalled();
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("top-level post failure — swallows error, no parent recorded", async () => {
+    const store = createThreadStore();
+    mockChannelPost.mockRejectedValueOnce(new Error("Slack API down"));
+    const adapter = createAdapter(store);
+
+    await expect(
+      adapter.notifyForTicket("AWT-42", { kind: "started" }),
+    ).resolves.not.toThrow();
+    expect(store.setParent).not.toHaveBeenCalled();
+  });
+
+  it("pr_ready — formats with PR link inline", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "pr_ready",
+      pr: { url: "https://github.com/o/r/pull/7", number: 7 },
+      usageReport: "Total: $0.10",
+    });
+
+    expect(mockThreadPost).toHaveBeenCalledWith(
+      `Task ${JIRA_LINK} PR ready for review — <https://github.com/o/r/pull/7|#7>\nTotal: $0.10`,
+    );
   });
 });

--- a/src/adapters/messaging/chatsdk.test.ts
+++ b/src/adapters/messaging/chatsdk.test.ts
@@ -5,6 +5,7 @@ import type { ThreadStore } from "../run-registry/types.js";
 
 const mockChannelPost = vi.fn();
 const mockThreadPost = vi.fn();
+const mockEditMessage = vi.fn();
 
 vi.mock("chat", () => {
   return {
@@ -22,7 +23,10 @@ vi.mock("chat", () => {
 });
 
 vi.mock("@chat-adapter/slack", () => ({
-  createSlackAdapter: vi.fn(() => ({ name: "slack" })),
+  createSlackAdapter: vi.fn(() => ({
+    name: "slack",
+    editMessage: mockEditMessage,
+  })),
 }));
 
 function createThreadStore(): ThreadStore & {
@@ -54,22 +58,33 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
     vi.clearAllMocks();
     mockChannelPost.mockResolvedValue({ id: "1700000000.000111" });
     mockThreadPost.mockResolvedValue({ id: "1700000000.000222" });
+    mockEditMessage.mockResolvedValue({ ts: "1700000000.000111" });
   });
 
-  it("started with no parent — posts top-level and records the parent", async () => {
+  it("first event — posts status as parent and details as a thread reply", async () => {
     const store = createThreadStore();
     const adapter = createAdapter(store);
 
     await adapter.notifyForTicket("AWT-42", { kind: "started" });
 
     expect(mockChannelPost).toHaveBeenCalledWith(
+      `:hourglass_flowing_sand: ${JIRA_LINK} STATUS: in progress`,
+    );
+    expect(mockEditMessage).not.toHaveBeenCalled();
+    expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000111");
+    expect(mockThreadPost).toHaveBeenCalledWith(
       `:hourglass_flowing_sand: Task ${JIRA_LINK} started`,
     );
-    expect(mockThreadPost).not.toHaveBeenCalled();
-    expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000111");
+    expect(ThreadImpl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "slack:C123:1700000000.000111",
+        channelId: "slack:C123",
+        isDM: false,
+      }),
+    );
   });
 
-  it("subsequent event with parent set — posts as thread reply, does not setParent", async () => {
+  it("subsequent event — edits the parent status and posts details to the thread", async () => {
     const store = createThreadStore();
     store.getParent.mockResolvedValueOnce("1700000000.000111");
     const adapter = createAdapter(store);
@@ -79,107 +94,19 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
       usageReport: "u",
     });
 
+    expect(mockEditMessage).toHaveBeenCalledWith(
+      "slack:C123",
+      "1700000000.000111",
+      `:question: ${JIRA_LINK} STATUS: needs clarification`,
+    );
     expect(mockChannelPost).not.toHaveBeenCalled();
+    expect(store.setParent).not.toHaveBeenCalled();
     expect(mockThreadPost).toHaveBeenCalledWith(
       `:question: Task ${JIRA_LINK} needs clarification\nu`,
     );
-    expect(ThreadImpl).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: "slack:C123:1700000000.000111",
-        channelId: "slack:C123",
-        isDM: false,
-      }),
-    );
-    expect(store.setParent).not.toHaveBeenCalled();
   });
 
-  it("non-started event with no parent — posts top-level, does NOT setParent (orphan stays orphan)", async () => {
-    const store = createThreadStore();
-    const adapter = createAdapter(store);
-
-    await adapter.notifyForTicket("AWT-42", {
-      kind: "canceled",
-      reason: "left AI column",
-    });
-
-    expect(mockChannelPost).toHaveBeenCalledWith(
-      `:no_entry: Task ${JIRA_LINK} canceled: left AI column`,
-    );
-    expect(store.setParent).not.toHaveBeenCalled();
-  });
-
-  it("parent deleted on Slack — clears mapping, retries top-level, re-records on started", async () => {
-    const store = createThreadStore();
-    store.getParent.mockResolvedValueOnce("1700000000.000111");
-    // Realistic Slack WebAPIPlatformError shape: code is the SDK sentinel,
-    // and the actionable Slack API error string lives on data.error.
-    mockThreadPost.mockRejectedValueOnce(
-      Object.assign(new Error("thread gone"), {
-        code: "slack_webapi_platform_error",
-        data: { error: "thread_not_found" },
-      }),
-    );
-    mockChannelPost.mockResolvedValueOnce({ id: "1700000000.000999" });
-    const adapter = createAdapter(store);
-
-    await adapter.notifyForTicket("AWT-42", { kind: "started" });
-
-    expect(mockThreadPost).toHaveBeenCalledTimes(1);
-    expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
-    expect(mockChannelPost).toHaveBeenCalledTimes(1);
-    // Because the event is `started`, the new top-level message becomes the parent.
-    expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000999");
-  });
-
-  it("parent deleted on Slack for non-started event — clears + retries, does not re-anchor", async () => {
-    const store = createThreadStore();
-    store.getParent.mockResolvedValueOnce("1700000000.000111");
-    mockThreadPost.mockRejectedValueOnce(
-      Object.assign(new Error("not found"), { code: "message_not_found" }),
-    );
-    const adapter = createAdapter(store);
-
-    await adapter.notifyForTicket("AWT-42", {
-      kind: "failed",
-      phase: "impl",
-      reason: "boom",
-    });
-
-    expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
-    expect(mockChannelPost).toHaveBeenCalledWith(
-      `:warning: Task ${JIRA_LINK} failed: impl — boom`,
-    );
-    expect(store.setParent).not.toHaveBeenCalled();
-  });
-
-  it("non-missing-parent error — does not retry, does not throw", async () => {
-    const store = createThreadStore();
-    store.getParent.mockResolvedValueOnce("1700000000.000111");
-    mockThreadPost.mockRejectedValueOnce(
-      Object.assign(new Error("rate limited"), { code: "rate_limited" }),
-    );
-    const adapter = createAdapter(store);
-
-    await expect(
-      adapter.notifyForTicket("AWT-42", { kind: "started" }),
-    ).resolves.not.toThrow();
-    expect(store.clearParent).not.toHaveBeenCalled();
-    expect(mockChannelPost).not.toHaveBeenCalled();
-    expect(store.setParent).not.toHaveBeenCalled();
-  });
-
-  it("top-level post failure — swallows error, no parent recorded", async () => {
-    const store = createThreadStore();
-    mockChannelPost.mockRejectedValueOnce(new Error("Slack API down"));
-    const adapter = createAdapter(store);
-
-    await expect(
-      adapter.notifyForTicket("AWT-42", { kind: "started" }),
-    ).resolves.not.toThrow();
-    expect(store.setParent).not.toHaveBeenCalled();
-  });
-
-  it("pr_ready — formats with PR link inline", async () => {
+  it("pr_ready — status header includes the PR link inline", async () => {
     const store = createThreadStore();
     store.getParent.mockResolvedValueOnce("1700000000.000111");
     const adapter = createAdapter(store);
@@ -190,8 +117,123 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
       usageReport: "Total: $0.10",
     });
 
+    expect(mockEditMessage).toHaveBeenCalledWith(
+      "slack:C123",
+      "1700000000.000111",
+      `:white_check_mark: ${JIRA_LINK} STATUS: PR ready (<https://github.com/o/r/pull/7|#7>)`,
+    );
     expect(mockThreadPost).toHaveBeenCalledWith(
       `:white_check_mark: Task ${JIRA_LINK} PR ready for review — <https://github.com/o/r/pull/7|#7>\nTotal: $0.10`,
+    );
+  });
+
+  it("failed — status header includes the failed phase", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "failed",
+      phase: "impl",
+      reason: "boom",
+    });
+
+    expect(mockEditMessage).toHaveBeenCalledWith(
+      "slack:C123",
+      "1700000000.000111",
+      `:warning: ${JIRA_LINK} STATUS: failed (impl)`,
+    );
+    expect(mockThreadPost).toHaveBeenCalledWith(
+      `:warning: Task ${JIRA_LINK} failed: impl — boom`,
+    );
+  });
+
+  it("parent deleted on Slack — clears mapping, re-posts a new parent, and threads the detail", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    mockEditMessage.mockRejectedValueOnce(
+      Object.assign(new Error("gone"), {
+        code: "slack_webapi_platform_error",
+        data: { error: "message_not_found" },
+      }),
+    );
+    mockChannelPost.mockResolvedValueOnce({ id: "1700000000.000999" });
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", { kind: "started" });
+
+    expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
+    expect(mockChannelPost).toHaveBeenCalledWith(
+      `:hourglass_flowing_sand: ${JIRA_LINK} STATUS: in progress`,
+    );
+    expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000999");
+    expect(mockThreadPost).toHaveBeenCalledWith(
+      `:hourglass_flowing_sand: Task ${JIRA_LINK} started`,
+    );
+  });
+
+  it("non-missing-parent edit error — keeps the parent, still threads the detail", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    mockEditMessage.mockRejectedValueOnce(
+      Object.assign(new Error("rate limited"), { code: "rate_limited" }),
+    );
+    const adapter = createAdapter(store);
+
+    await expect(
+      adapter.notifyForTicket("AWT-42", {
+        kind: "needs_clarification",
+      }),
+    ).resolves.not.toThrow();
+
+    expect(store.clearParent).not.toHaveBeenCalled();
+    expect(mockChannelPost).not.toHaveBeenCalled();
+    expect(store.setParent).not.toHaveBeenCalled();
+    // Detail still lands in the thread under the existing parent.
+    expect(mockThreadPost).toHaveBeenCalledWith(
+      `:question: Task ${JIRA_LINK} needs clarification`,
+    );
+  });
+
+  it("parent post fails on first event — swallows error, no parent recorded, no thread reply attempted as reply", async () => {
+    const store = createThreadStore();
+    mockChannelPost.mockRejectedValueOnce(new Error("Slack API down"));
+    const adapter = createAdapter(store);
+
+    await expect(
+      adapter.notifyForTicket("AWT-42", { kind: "started" }),
+    ).resolves.not.toThrow();
+
+    expect(store.setParent).not.toHaveBeenCalled();
+    // With no parent, detail falls back to a top-level orphan post.
+    expect(mockChannelPost).toHaveBeenCalledTimes(2);
+    expect(mockChannelPost).toHaveBeenLastCalledWith(
+      `:hourglass_flowing_sand: Task ${JIRA_LINK} started`,
+    );
+    expect(mockThreadPost).not.toHaveBeenCalled();
+  });
+
+  it("thread reply fails because parent vanished mid-flight — clears mapping and posts detail top-level", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    mockThreadPost.mockRejectedValueOnce(
+      Object.assign(new Error("gone"), {
+        code: "slack_webapi_platform_error",
+        data: { error: "thread_not_found" },
+      }),
+    );
+    mockChannelPost.mockResolvedValueOnce({ id: "1700000000.000777" });
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "canceled",
+      reason: "left AI column",
+    });
+
+    expect(mockEditMessage).toHaveBeenCalled();
+    expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
+    expect(mockChannelPost).toHaveBeenCalledWith(
+      `:no_entry: Task ${JIRA_LINK} canceled: left AI column`,
     );
   });
 });

--- a/src/adapters/messaging/chatsdk.test.ts
+++ b/src/adapters/messaging/chatsdk.test.ts
@@ -62,7 +62,9 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
 
     await adapter.notifyForTicket("AWT-42", { kind: "started" });
 
-    expect(mockChannelPost).toHaveBeenCalledWith(`Task ${JIRA_LINK} started`);
+    expect(mockChannelPost).toHaveBeenCalledWith(
+      `:hourglass_flowing_sand: Task ${JIRA_LINK} started`,
+    );
     expect(mockThreadPost).not.toHaveBeenCalled();
     expect(store.setParent).toHaveBeenCalledWith("AWT-42", "1700000000.000111");
   });
@@ -79,7 +81,7 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
 
     expect(mockChannelPost).not.toHaveBeenCalled();
     expect(mockThreadPost).toHaveBeenCalledWith(
-      `Task ${JIRA_LINK} needs clarification\nu`,
+      `:question: Task ${JIRA_LINK} needs clarification\nu`,
     );
     expect(ThreadImpl).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -101,7 +103,7 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
     });
 
     expect(mockChannelPost).toHaveBeenCalledWith(
-      `Task ${JIRA_LINK} canceled: left AI column`,
+      `:no_entry: Task ${JIRA_LINK} canceled: left AI column`,
     );
     expect(store.setParent).not.toHaveBeenCalled();
   });
@@ -145,7 +147,7 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
 
     expect(store.clearParent).toHaveBeenCalledWith("AWT-42");
     expect(mockChannelPost).toHaveBeenCalledWith(
-      `Task ${JIRA_LINK} failed: impl — boom`,
+      `:warning: Task ${JIRA_LINK} failed: impl — boom`,
     );
     expect(store.setParent).not.toHaveBeenCalled();
   });
@@ -189,7 +191,7 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
     });
 
     expect(mockThreadPost).toHaveBeenCalledWith(
-      `Task ${JIRA_LINK} PR ready for review — <https://github.com/o/r/pull/7|#7>\nTotal: $0.10`,
+      `:white_check_mark: Task ${JIRA_LINK} PR ready for review — <https://github.com/o/r/pull/7|#7>\nTotal: $0.10`,
     );
   });
 });

--- a/src/adapters/messaging/chatsdk.ts
+++ b/src/adapters/messaging/chatsdk.ts
@@ -1,13 +1,17 @@
-import { Chat } from "chat";
+import { Chat, ThreadImpl } from "chat";
 import type { StateAdapter, Lock } from "chat";
 import { createSlackAdapter } from "@chat-adapter/slack";
 import { logger } from "../../lib/logger.js";
-import type { MessagingAdapter } from "./types.js";
+import { formatTicketEvent } from "./format.js";
+import type { MessagingAdapter, TicketEvent } from "./types.js";
+import type { ThreadStore } from "../run-registry/types.js";
 
 export interface ChatSDKConfig {
   slackToken: string;
   channelId: string;
   botName: string;
+  jiraBaseUrl: string;
+  threadStore: ThreadStore;
 }
 
 /** Minimal no-op StateAdapter for outbound-only notification use. */
@@ -29,34 +33,153 @@ const noopState: StateAdapter = {
   unsubscribe: async () => {},
 };
 
+/**
+ * Slack error codes that mean "the parent message is gone."
+ * When we see one of these on a thread reply, we clear the stored parent
+ * and retry top-level. List sourced from Slack's chat.postMessage docs;
+ * exact codes are confirmed during smoke-testing (deliberately delete a
+ * parent in a test channel).
+ */
+const MISSING_PARENT_ERROR_CODES = new Set([
+  "thread_not_found",
+  "message_not_found",
+]);
+
 export class ChatSDKAdapter implements MessagingAdapter {
   private chat: InstanceType<typeof Chat>;
+  private slackAdapter: ReturnType<typeof createSlackAdapter>;
   private channelId: string;
+  private jiraBaseUrl: string;
+  private threadStore: ThreadStore;
 
   constructor(config: ChatSDKConfig) {
     this.channelId = config.channelId;
+    this.jiraBaseUrl = config.jiraBaseUrl;
+    this.threadStore = config.threadStore;
+    this.slackAdapter = createSlackAdapter({ botToken: config.slackToken });
     this.chat = new Chat({
       userName: config.botName,
       state: noopState,
-      adapters: {
-        slack: createSlackAdapter({ botToken: config.slackToken }),
-      },
+      adapters: { slack: this.slackAdapter },
     });
   }
 
-  async notify(message: string): Promise<void> {
+  async notifyForTicket(
+    ticketKey: string,
+    event: TicketEvent,
+  ): Promise<void> {
+    const text = formatTicketEvent(event, ticketKey, this.jiraBaseUrl);
+    let parent = await this.threadStore
+      .getParent(ticketKey)
+      .catch((err) => {
+        logger.warn(
+          { ticketKey, error: (err as Error).message },
+          "thread_parent_lookup_failed",
+        );
+        return null;
+      });
+
+    let sentId: string | null = null;
     try {
-      const channel = this.chat.channel(`slack:${this.channelId}`);
-      await channel.post(message);
-      logger.info(
-        { channelId: this.channelId, messagePreview: message.slice(0, 120) },
-        "notification_sent",
-      );
+      sentId = parent
+        ? await this.postReply(parent, text)
+        : await this.postTopLevel(text);
     } catch (err) {
-      logger.warn(
-        { error: (err as Error).message },
-        "notification_failed",
-      );
+      if (parent && isMissingParentError(err)) {
+        logger.debug(
+          { ticketKey, parent, eventKind: event.kind },
+          "thread_parent_recovered",
+        );
+        await this.threadStore.clearParent(ticketKey).catch(() => {});
+        parent = null;
+        try {
+          sentId = await this.postTopLevel(text);
+        } catch (retryErr) {
+          this.logFailure(ticketKey, event.kind, retryErr);
+          return;
+        }
+      } else {
+        this.logFailure(ticketKey, event.kind, err);
+        return;
+      }
     }
+
+    if (event.kind === "started" && parent == null && sentId) {
+      await this.threadStore
+        .setParent(ticketKey, sentId)
+        .catch((err) =>
+          logger.warn(
+            { ticketKey, error: (err as Error).message },
+            "thread_parent_persist_failed",
+          ),
+        );
+    }
+
+    logger.info(
+      {
+        ticketKey,
+        eventKind: event.kind,
+        threadParentId: parent,
+        channelId: this.channelId,
+      },
+      "notification_sent",
+    );
   }
+
+  /** Top-level post to the configured channel. Returns the sent message id. */
+  private async postTopLevel(text: string): Promise<string> {
+    const channel = this.chat.channel(`slack:${this.channelId}`);
+    const sent = await channel.post(text);
+    return sent.id;
+  }
+
+  /** Thread reply under `parentTs`. Returns the sent message id. */
+  private async postReply(parentTs: string, text: string): Promise<string> {
+    const thread = new ThreadImpl({
+      id: `slack:${this.channelId}:${parentTs}`,
+      adapter: this.slackAdapter,
+      channelId: `slack:${this.channelId}`,
+      stateAdapter: noopState,
+      isDM: false,
+    });
+    const sent = await thread.post(text);
+    return sent.id;
+  }
+
+  private logFailure(
+    ticketKey: string,
+    eventKind: TicketEvent["kind"],
+    err: unknown,
+  ): void {
+    logger.warn(
+      {
+        ticketKey,
+        eventKind,
+        error: (err as Error).message,
+        slackErrorCode: extractSlackErrorCode(err),
+      },
+      "notification_failed",
+    );
+  }
+}
+
+function isMissingParentError(err: unknown): boolean {
+  const code = extractSlackErrorCode(err);
+  return code != null && MISSING_PARENT_ERROR_CODES.has(code);
+}
+
+/**
+ * Pull a Slack-style error code out of an unknown error. The chat package
+ * surfaces Slack errors as ChatError-derived objects with a `code` string;
+ * the underlying Web API error code may also live on `data.error` for raw
+ * errors. We check both locations defensively.
+ */
+function extractSlackErrorCode(err: unknown): string | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as { code?: unknown; data?: { error?: unknown } };
+  // Slack SDK wraps API errors: code is the sentinel "slack_webapi_platform_error",
+  // and the actual Slack API error string lives at data.error (e.g. "thread_not_found").
+  if (e.data && typeof e.data.error === "string") return e.data.error;
+  if (typeof e.code === "string") return e.code;
+  return null;
 }

--- a/src/adapters/messaging/chatsdk.ts
+++ b/src/adapters/messaging/chatsdk.ts
@@ -142,7 +142,7 @@ export class ChatSDKAdapter implements MessagingAdapter {
         // Parent is gone — clear and fall through to re-create below.
         logger.debug(
           { ticketKey, parent: stored, eventKind },
-          "thread_parent_recovered",
+          "thread_parent_recovery_attempt",
         );
         await this.threadStore.clearParent(ticketKey).catch(() => {});
       }
@@ -158,6 +158,12 @@ export class ChatSDKAdapter implements MessagingAdapter {
             "thread_parent_persist_failed",
           ),
         );
+      if (stored) {
+        logger.debug(
+          { ticketKey, oldParent: stored, newParent: sentId, eventKind },
+          "thread_parent_recovered",
+        );
+      }
       return sentId;
     } catch (err) {
       this.logFailure(ticketKey, eventKind, err, "parent_post_failed");

--- a/src/adapters/messaging/chatsdk.ts
+++ b/src/adapters/messaging/chatsdk.ts
@@ -2,7 +2,7 @@ import { Chat, ThreadImpl } from "chat";
 import type { StateAdapter, Lock } from "chat";
 import { createSlackAdapter } from "@chat-adapter/slack";
 import { logger } from "../../lib/logger.js";
-import { formatTicketEvent } from "./format.js";
+import { formatTicketEvent, formatTicketStatus } from "./format.js";
 import type { MessagingAdapter, TicketEvent } from "./types.js";
 import type { ThreadStore } from "../run-registry/types.js";
 
@@ -35,10 +35,8 @@ const noopState: StateAdapter = {
 
 /**
  * Slack error codes that mean "the parent message is gone."
- * When we see one of these on a thread reply, we clear the stored parent
- * and retry top-level. List sourced from Slack's chat.postMessage docs;
- * exact codes are confirmed during smoke-testing (deliberately delete a
- * parent in a test channel).
+ * When we see one of these on an edit or thread reply, we clear the stored
+ * parent and re-anchor by posting a new top-level status message.
  */
 const MISSING_PARENT_ERROR_CODES = new Set([
   "thread_not_found",
@@ -64,56 +62,31 @@ export class ChatSDKAdapter implements MessagingAdapter {
     });
   }
 
+  /**
+   * Ticket lifecycle as a single Slack thread:
+   *   1. Parent (top-level) message is a live status header — edited in place
+   *      on every event so the channel always shows the current state at a
+   *      glance ("AWT-42 STATUS: in progress" → "...PR ready" → ...).
+   *   2. Each event also lands as a detailed reply inside that thread, so the
+   *      thread acts as a chronological audit log.
+   *
+   * Failures are logged and swallowed; workflow runs are never broken by
+   * notification errors.
+   */
   async notifyForTicket(
     ticketKey: string,
     event: TicketEvent,
   ): Promise<void> {
-    const text = formatTicketEvent(event, ticketKey, this.jiraBaseUrl);
-    let parent = await this.threadStore
-      .getParent(ticketKey)
-      .catch((err) => {
-        logger.warn(
-          { ticketKey, error: (err as Error).message },
-          "thread_parent_lookup_failed",
-        );
-        return null;
-      });
+    const status = formatTicketStatus(event, ticketKey, this.jiraBaseUrl);
+    const detail = formatTicketEvent(event, ticketKey, this.jiraBaseUrl);
 
-    let sentId: string | null = null;
-    try {
-      sentId = parent
-        ? await this.postReply(parent, text)
-        : await this.postTopLevel(text);
-    } catch (err) {
-      if (parent && isMissingParentError(err)) {
-        logger.debug(
-          { ticketKey, parent, eventKind: event.kind },
-          "thread_parent_recovered",
-        );
-        await this.threadStore.clearParent(ticketKey).catch(() => {});
-        parent = null;
-        try {
-          sentId = await this.postTopLevel(text);
-        } catch (retryErr) {
-          this.logFailure(ticketKey, event.kind, retryErr);
-          return;
-        }
-      } else {
-        this.logFailure(ticketKey, event.kind, err);
-        return;
-      }
-    }
+    const parent = await this.ensureParentWithStatus(
+      ticketKey,
+      status,
+      event.kind,
+    );
 
-    if (event.kind === "started" && parent == null && sentId) {
-      await this.threadStore
-        .setParent(ticketKey, sentId)
-        .catch((err) =>
-          logger.warn(
-            { ticketKey, error: (err as Error).message },
-            "thread_parent_persist_failed",
-          ),
-        );
-    }
+    await this.postDetail(ticketKey, parent, detail, event.kind);
 
     logger.info(
       {
@@ -126,11 +99,120 @@ export class ChatSDKAdapter implements MessagingAdapter {
     );
   }
 
+  /**
+   * Ensure a parent status message exists for this ticket and reflects the
+   * current event. Returns the parent ts on success, or null if the parent
+   * could not be (re)created — in which case the caller falls back to an
+   * orphaned top-level detail post.
+   */
+  private async ensureParentWithStatus(
+    ticketKey: string,
+    status: string,
+    eventKind: TicketEvent["kind"],
+  ): Promise<string | null> {
+    const stored = await this.threadStore.getParent(ticketKey).catch((err) => {
+      logger.warn(
+        { ticketKey, error: (err as Error).message },
+        "thread_parent_lookup_failed",
+      );
+      return null;
+    });
+
+    if (stored) {
+      try {
+        await this.editTopLevel(stored, status);
+        logger.info(
+          {
+            ticketKey,
+            parent: stored,
+            eventKind,
+            channelId: this.channelId,
+            statusLength: status.length,
+          },
+          "thread_parent_status_updated",
+        );
+        return stored;
+      } catch (err) {
+        if (!isMissingParentError(err)) {
+          // Edit failed for a non-fatal reason (rate limit, transient).
+          // Parent presumably still exists; keep using it for the thread reply.
+          this.logFailure(ticketKey, eventKind, err, "parent_edit_failed");
+          return stored;
+        }
+        // Parent is gone — clear and fall through to re-create below.
+        logger.debug(
+          { ticketKey, parent: stored, eventKind },
+          "thread_parent_recovered",
+        );
+        await this.threadStore.clearParent(ticketKey).catch(() => {});
+      }
+    }
+
+    try {
+      const sentId = await this.postTopLevel(status);
+      await this.threadStore
+        .setParent(ticketKey, sentId)
+        .catch((err) =>
+          logger.warn(
+            { ticketKey, error: (err as Error).message },
+            "thread_parent_persist_failed",
+          ),
+        );
+      return sentId;
+    } catch (err) {
+      this.logFailure(ticketKey, eventKind, err, "parent_post_failed");
+      return null;
+    }
+  }
+
+  /**
+   * Post the detailed event message. When a parent is available, posts as a
+   * thread reply; otherwise falls back to an orphaned top-level message so
+   * the event still leaves a record.
+   */
+  private async postDetail(
+    ticketKey: string,
+    parent: string | null,
+    detail: string,
+    eventKind: TicketEvent["kind"],
+  ): Promise<void> {
+    if (!parent) {
+      await this.postTopLevel(detail).catch((err) =>
+        this.logFailure(ticketKey, eventKind, err, "detail_post_failed"),
+      );
+      return;
+    }
+    try {
+      await this.postReply(parent, detail);
+    } catch (err) {
+      if (isMissingParentError(err)) {
+        // Race: parent vanished between edit/post and the thread reply.
+        // Drop the mapping and fall back to top-level so the audit log
+        // still gets the event; the next notification will re-anchor.
+        await this.threadStore.clearParent(ticketKey).catch(() => {});
+        await this.postTopLevel(detail).catch((retryErr) =>
+          this.logFailure(ticketKey, eventKind, retryErr, "detail_post_failed"),
+        );
+        return;
+      }
+      this.logFailure(ticketKey, eventKind, err, "detail_post_failed");
+    }
+  }
+
   /** Top-level post to the configured channel. Returns the sent message id. */
   private async postTopLevel(text: string): Promise<string> {
     const channel = this.chat.channel(`slack:${this.channelId}`);
     const sent = await channel.post(text);
     return sent.id;
+  }
+
+  /** Edit a previously posted top-level message in place. */
+  private async editTopLevel(parentTs: string, text: string): Promise<void> {
+    await this.slackAdapter.editMessage(
+      `slack:${this.channelId}`,
+      parentTs,
+      text,
+    );
   }
 
   /** Thread reply under `parentTs`. Returns the sent message id. */
@@ -150,6 +232,7 @@ export class ChatSDKAdapter implements MessagingAdapter {
     ticketKey: string,
     eventKind: TicketEvent["kind"],
     err: unknown,
+    msg: string,
   ): void {
     logger.warn(
       {
@@ -158,7 +241,7 @@ export class ChatSDKAdapter implements MessagingAdapter {
         error: (err as Error).message,
         slackErrorCode: extractSlackErrorCode(err),
       },
-      "notification_failed",
+      msg,
     );
   }
 }

--- a/src/adapters/messaging/format.test.ts
+++ b/src/adapters/messaging/format.test.ts
@@ -8,14 +8,29 @@ const LINK = `<${JIRA}/browse/${KEY}|${KEY}>`;
 describe("formatTicketEvent", () => {
   it("started — links the ticket key", () => {
     expect(formatTicketEvent({ kind: "started" }, KEY, JIRA)).toBe(
-      `Task ${LINK} started`,
+      `:hourglass_flowing_sand: Task ${LINK} started`,
     );
   });
 
-  it("needs_clarification — without usage report", () => {
+  it("needs_clarification — without usage report or comment link", () => {
     expect(
       formatTicketEvent({ kind: "needs_clarification" }, KEY, JIRA),
-    ).toBe(`Task ${LINK} needs clarification`);
+    ).toBe(`:question: Task ${LINK} needs clarification`);
+  });
+
+  it("needs_clarification — links to the Jira comment when commentUrl is provided", () => {
+    expect(
+      formatTicketEvent(
+        {
+          kind: "needs_clarification",
+          commentUrl: `${JIRA}/browse/${KEY}?focusedCommentId=98765`,
+        },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:question: Task ${LINK} needs clarification — <${JIRA}/browse/${KEY}?focusedCommentId=98765|view questions>`,
+    );
   });
 
   it("needs_clarification — appends usage report on a new line", () => {
@@ -25,7 +40,20 @@ describe("formatTicketEvent", () => {
         KEY,
         JIRA,
       ),
-    ).toBe(`Task ${LINK} needs clarification\nPhase A: $0.10`);
+    ).toBe(`:question: Task ${LINK} needs clarification\nPhase A: $0.10`);
+  });
+
+  it("needs_clarification — combines comment link and usage report", () => {
+    const commentUrl = `${JIRA}/browse/${KEY}?focusedCommentId=1`;
+    expect(
+      formatTicketEvent(
+        { kind: "needs_clarification", commentUrl, usageReport: "u" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:question: Task ${LINK} needs clarification — <${commentUrl}|view questions>\nu`,
+    );
   });
 
   it("needs_clarification — empty usage report is treated as absent", () => {
@@ -35,7 +63,7 @@ describe("formatTicketEvent", () => {
         KEY,
         JIRA,
       ),
-    ).toBe(`Task ${LINK} needs clarification`);
+    ).toBe(`:question: Task ${LINK} needs clarification`);
   });
 
   it("pr_ready — includes PR link inline and usage report", () => {
@@ -49,7 +77,7 @@ describe("formatTicketEvent", () => {
       JIRA,
     );
     expect(text).toBe(
-      `Task ${LINK} PR ready for review — <https://github.com/o/r/pull/123|#123>\nTotal: $0.42`,
+      `:white_check_mark: Task ${LINK} PR ready for review — <https://github.com/o/r/pull/123|#123>\nTotal: $0.42`,
     );
   });
 
@@ -60,7 +88,7 @@ describe("formatTicketEvent", () => {
         KEY,
         JIRA,
       ),
-    ).toBe(`Task ${LINK} failed: research — phase timed out`);
+    ).toBe(`:warning: Task ${LINK} failed: research — phase timed out`);
   });
 
   it("failed with reason but no phase", () => {
@@ -70,13 +98,13 @@ describe("formatTicketEvent", () => {
         KEY,
         JIRA,
       ),
-    ).toBe(`Task ${LINK} failed: boom`);
+    ).toBe(`:warning: Task ${LINK} failed: boom`);
   });
 
   it("failed with neither phase nor reason", () => {
     expect(
       formatTicketEvent({ kind: "failed" }, KEY, JIRA),
-    ).toBe(`Task ${LINK} failed`);
+    ).toBe(`:warning: Task ${LINK} failed`);
   });
 
   it("failed — appends usage report when present", () => {
@@ -86,7 +114,7 @@ describe("formatTicketEvent", () => {
         KEY,
         JIRA,
       ),
-    ).toBe(`Task ${LINK} failed: impl — x\nu`);
+    ).toBe(`:warning: Task ${LINK} failed: impl — x\nu`);
   });
 
   it("canceled — includes reason", () => {
@@ -96,12 +124,12 @@ describe("formatTicketEvent", () => {
         KEY,
         JIRA,
       ),
-    ).toBe(`Task ${LINK} canceled: left AI column`);
+    ).toBe(`:no_entry: Task ${LINK} canceled: left AI column`);
   });
 
   it("trims a trailing slash on jiraBaseUrl", () => {
     expect(
       formatTicketEvent({ kind: "started" }, KEY, `${JIRA}/`),
-    ).toBe(`Task ${LINK} started`);
+    ).toBe(`:hourglass_flowing_sand: Task ${LINK} started`);
   });
 });

--- a/src/adapters/messaging/format.test.ts
+++ b/src/adapters/messaging/format.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { formatTicketEvent } from "./format.js";
+
+const JIRA = "https://example.atlassian.net";
+const KEY = "AWT-42";
+const LINK = `<${JIRA}/browse/${KEY}|${KEY}>`;
+
+describe("formatTicketEvent", () => {
+  it("started — links the ticket key", () => {
+    expect(formatTicketEvent({ kind: "started" }, KEY, JIRA)).toBe(
+      `Task ${LINK} started`,
+    );
+  });
+
+  it("needs_clarification — without usage report", () => {
+    expect(
+      formatTicketEvent({ kind: "needs_clarification" }, KEY, JIRA),
+    ).toBe(`Task ${LINK} needs clarification`);
+  });
+
+  it("needs_clarification — appends usage report on a new line", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "needs_clarification", usageReport: "Phase A: $0.10" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} needs clarification\nPhase A: $0.10`);
+  });
+
+  it("needs_clarification — empty usage report is treated as absent", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "needs_clarification", usageReport: "" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} needs clarification`);
+  });
+
+  it("pr_ready — includes PR link inline and usage report", () => {
+    const text = formatTicketEvent(
+      {
+        kind: "pr_ready",
+        pr: { url: "https://github.com/o/r/pull/123", number: 123 },
+        usageReport: "Total: $0.42",
+      },
+      KEY,
+      JIRA,
+    );
+    expect(text).toBe(
+      `Task ${LINK} PR ready for review — <https://github.com/o/r/pull/123|#123>\nTotal: $0.42`,
+    );
+  });
+
+  it("failed with phase and reason", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "failed", phase: "research", reason: "phase timed out" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} failed: research — phase timed out`);
+  });
+
+  it("failed with reason but no phase", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "failed", reason: "boom" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} failed: boom`);
+  });
+
+  it("failed with neither phase nor reason", () => {
+    expect(
+      formatTicketEvent({ kind: "failed" }, KEY, JIRA),
+    ).toBe(`Task ${LINK} failed`);
+  });
+
+  it("failed — appends usage report when present", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "failed", phase: "impl", reason: "x", usageReport: "u" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} failed: impl — x\nu`);
+  });
+
+  it("canceled — includes reason", () => {
+    expect(
+      formatTicketEvent(
+        { kind: "canceled", reason: "left AI column" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`Task ${LINK} canceled: left AI column`);
+  });
+
+  it("trims a trailing slash on jiraBaseUrl", () => {
+    expect(
+      formatTicketEvent({ kind: "started" }, KEY, `${JIRA}/`),
+    ).toBe(`Task ${LINK} started`);
+  });
+});

--- a/src/adapters/messaging/format.test.ts
+++ b/src/adapters/messaging/format.test.ts
@@ -1,9 +1,72 @@
 import { describe, it, expect } from "vitest";
-import { formatTicketEvent } from "./format.js";
+import { formatTicketEvent, formatTicketStatus } from "./format.js";
 
 const JIRA = "https://example.atlassian.net";
 const KEY = "AWT-42";
 const LINK = `<${JIRA}/browse/${KEY}|${KEY}>`;
+
+describe("formatTicketStatus", () => {
+  it("started → in progress", () => {
+    expect(formatTicketStatus({ kind: "started" }, KEY, JIRA)).toBe(
+      `:hourglass_flowing_sand: ${LINK} STATUS: in progress`,
+    );
+  });
+
+  it("needs_clarification → needs clarification (no commentUrl in header)", () => {
+    expect(
+      formatTicketStatus(
+        {
+          kind: "needs_clarification",
+          commentUrl: `${JIRA}/browse/${KEY}?focusedCommentId=1`,
+        },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`:question: ${LINK} STATUS: needs clarification`);
+  });
+
+  it("pr_ready → includes PR link inline", () => {
+    expect(
+      formatTicketStatus(
+        {
+          kind: "pr_ready",
+          pr: { url: "https://github.com/o/r/pull/9", number: 9 },
+          usageReport: "u",
+        },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:white_check_mark: ${LINK} STATUS: PR ready (<https://github.com/o/r/pull/9|#9>)`,
+    );
+  });
+
+  it("failed with phase → status names the phase", () => {
+    expect(
+      formatTicketStatus(
+        { kind: "failed", phase: "research", reason: "x" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`:warning: ${LINK} STATUS: failed (research)`);
+  });
+
+  it("failed without phase → bare failed", () => {
+    expect(formatTicketStatus({ kind: "failed" }, KEY, JIRA)).toBe(
+      `:warning: ${LINK} STATUS: failed`,
+    );
+  });
+
+  it("canceled → bare canceled (no reason in header)", () => {
+    expect(
+      formatTicketStatus(
+        { kind: "canceled", reason: "left AI column" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(`:no_entry: ${LINK} STATUS: canceled`);
+  });
+});
 
 describe("formatTicketEvent", () => {
   it("started — links the ticket key", () => {

--- a/src/adapters/messaging/format.ts
+++ b/src/adapters/messaging/format.ts
@@ -16,6 +16,39 @@ const EVENT_EMOJI: Record<TicketEvent["kind"], string> = {
 };
 
 /**
+ * Short, status-bar style text for the parent (top-level) message that gets
+ * edited in place on every event. Detailed event copy still goes in the
+ * thread via {@link formatTicketEvent}.
+ *
+ * Examples:
+ *   :hourglass_flowing_sand: <link|AWT-42> STATUS: in progress
+ *   :white_check_mark: <link|AWT-42> STATUS: PR ready (<prUrl|#123>)
+ *   :warning: <link|AWT-42> STATUS: failed (research)
+ */
+export function formatTicketStatus(
+  event: TicketEvent,
+  ticketKey: string,
+  jiraBaseUrl: string,
+): string {
+  const link = jiraLink(ticketKey, jiraBaseUrl);
+  const emoji = EVENT_EMOJI[event.kind];
+  const head = `${emoji} ${link} STATUS:`;
+
+  switch (event.kind) {
+    case "started":
+      return `${head} in progress`;
+    case "needs_clarification":
+      return `${head} needs clarification`;
+    case "pr_ready":
+      return `${head} PR ready (<${event.pr.url}|#${event.pr.number}>)`;
+    case "failed":
+      return event.phase ? `${head} failed (${event.phase})` : `${head} failed`;
+    case "canceled":
+      return `${head} canceled`;
+  }
+}
+
+/**
  * Format a TicketEvent as Slack-mrkdwn text with embedded links.
  *
  * Output is intended for `chat.channel(...).post(text)` or `thread.post(text)`.

--- a/src/adapters/messaging/format.ts
+++ b/src/adapters/messaging/format.ts
@@ -1,6 +1,21 @@
 import type { TicketEvent } from "./types.js";
 
 /**
+ * Slack emoji prefixes per event kind. The palette differentiates three
+ * states at a glance:
+ *   - INFO (in progress / terminal info): :hourglass_flowing_sand:, :no_entry:
+ *   - ACTION required from a human:        :question:, :warning:
+ *   - DONE / ready for review:             :white_check_mark:
+ */
+const EVENT_EMOJI: Record<TicketEvent["kind"], string> = {
+  started: ":hourglass_flowing_sand:",
+  needs_clarification: ":question:",
+  pr_ready: ":white_check_mark:",
+  failed: ":warning:",
+  canceled: ":no_entry:",
+};
+
+/**
  * Format a TicketEvent as Slack-mrkdwn text with embedded links.
  *
  * Output is intended for `chat.channel(...).post(text)` or `thread.post(text)`.
@@ -14,14 +29,22 @@ export function formatTicketEvent(
   jiraBaseUrl: string,
 ): string {
   const link = jiraLink(ticketKey, jiraBaseUrl);
-  const head = `Task ${link}`;
+  const emoji = EVENT_EMOJI[event.kind];
+  const head = `${emoji} Task ${link}`;
 
   switch (event.kind) {
     case "started":
       return `${head} started`;
 
-    case "needs_clarification":
-      return appendUsage(`${head} needs clarification`, event.usageReport);
+    case "needs_clarification": {
+      const tail = event.commentUrl
+        ? ` — <${event.commentUrl}|view questions>`
+        : "";
+      return appendUsage(
+        `${head} needs clarification${tail}`,
+        event.usageReport,
+      );
+    }
 
     case "pr_ready": {
       const prLink = `<${event.pr.url}|#${event.pr.number}>`;

--- a/src/adapters/messaging/format.ts
+++ b/src/adapters/messaging/format.ts
@@ -1,0 +1,61 @@
+import type { TicketEvent } from "./types.js";
+
+/**
+ * Format a TicketEvent as Slack-mrkdwn text with embedded links.
+ *
+ * Output is intended for `chat.channel(...).post(text)` or `thread.post(text)`.
+ * Slack-native `<url|label>` syntax is used because remark/mdast escaping
+ * via PostableMarkdown can mangle the angle brackets. We pass it as a plain
+ * string; the chat package treats unmarked strings as PostableRaw on Slack.
+ */
+export function formatTicketEvent(
+  event: TicketEvent,
+  ticketKey: string,
+  jiraBaseUrl: string,
+): string {
+  const link = jiraLink(ticketKey, jiraBaseUrl);
+  const head = `Task ${link}`;
+
+  switch (event.kind) {
+    case "started":
+      return `${head} started`;
+
+    case "needs_clarification":
+      return appendUsage(`${head} needs clarification`, event.usageReport);
+
+    case "pr_ready": {
+      const prLink = `<${event.pr.url}|#${event.pr.number}>`;
+      return appendUsage(
+        `${head} PR ready for review — ${prLink}`,
+        event.usageReport,
+      );
+    }
+
+    case "failed": {
+      const body = formatFailedBody(event.phase, event.reason);
+      return appendUsage(`${head} failed${body}`, event.usageReport);
+    }
+
+    case "canceled":
+      return `${head} canceled: ${event.reason}`;
+  }
+}
+
+function jiraLink(ticketKey: string, jiraBaseUrl: string): string {
+  const base = jiraBaseUrl.replace(/\/$/, "");
+  return `<${base}/browse/${ticketKey}|${ticketKey}>`;
+}
+
+function formatFailedBody(
+  phase: "research" | "impl" | "push" | undefined,
+  reason: string | undefined,
+): string {
+  if (phase && reason) return `: ${phase} — ${reason}`;
+  if (reason) return `: ${reason}`;
+  return "";
+}
+
+function appendUsage(base: string, usageReport: string | undefined): string {
+  if (!usageReport) return base;
+  return `${base}\n${usageReport}`;
+}

--- a/src/adapters/messaging/types.ts
+++ b/src/adapters/messaging/types.ts
@@ -1,6 +1,15 @@
 export type TicketEvent =
   | { kind: "started" }
-  | { kind: "needs_clarification"; usageReport?: string }
+  | {
+      kind: "needs_clarification";
+      /**
+       * Deep link to the posted Jira comment (e.g. `?focusedCommentId=...`).
+       * When present, the Slack message links directly to the questions;
+       * when absent, the formatter falls back to the plain ticket link.
+       */
+      commentUrl?: string;
+      usageReport?: string;
+    }
   | {
       kind: "pr_ready";
       pr: { url: string; number: number };

--- a/src/adapters/messaging/types.ts
+++ b/src/adapters/messaging/types.ts
@@ -1,3 +1,31 @@
+export type TicketEvent =
+  | { kind: "started" }
+  | { kind: "needs_clarification"; usageReport?: string }
+  | {
+      kind: "pr_ready";
+      pr: { url: string; number: number };
+      usageReport: string;
+    }
+  | {
+      kind: "failed";
+      phase?: "research" | "impl" | "push";
+      reason?: string;
+      usageReport?: string;
+    }
+  | { kind: "canceled"; reason: string };
+
 export interface MessagingAdapter {
-  notify(message: string): Promise<void>;
+  /**
+   * Send a ticket-scoped notification to the configured channel.
+   *
+   * The first `started` event for a ticket posts top-level and records its
+   * Slack message id as the lifetime parent. Subsequent events post as
+   * thread replies under that parent. If the parent has been deleted, the
+   * adapter clears the mapping and retries top-level (without re-anchoring
+   * unless the new event is `started`).
+   *
+   * Never throws — failures are logged and swallowed so workflow runs are
+   * never broken by a notification error.
+   */
+  notifyForTicket(ticketKey: string, event: TicketEvent): Promise<void>;
 }

--- a/src/adapters/run-registry/types.ts
+++ b/src/adapters/run-registry/types.ts
@@ -45,3 +45,20 @@ export interface RunRegistryAdapter {
   /** Remove the failure marker for a ticket. */
   clearFailedMark(ticketKey: string): Promise<void>;
 }
+
+/**
+ * Per-ticket Slack thread parent store. Implemented alongside RunRegistryAdapter
+ * by UpstashRunRegistry, but exposed as a separate interface so the messaging
+ * adapter only depends on the slice it needs.
+ *
+ * Lifetime: an entry survives across multiple workflow runs for the same
+ * ticket. unregister(ticketKey) does NOT clear it — see clearParent().
+ */
+export interface ThreadStore {
+  /** Returns the Slack message id (timestamp) anchoring this ticket's thread, or null. */
+  getParent(ticketKey: string): Promise<string | null>;
+  /** Records the message id as the parent for this ticket. Overwrites any prior value. */
+  setParent(ticketKey: string, messageId: string): Promise<void>;
+  /** Removes the entry. Used after Slack reports the parent message no longer exists. */
+  clearParent(ticketKey: string): Promise<void>;
+}

--- a/src/adapters/run-registry/upstash.test.ts
+++ b/src/adapters/run-registry/upstash.test.ts
@@ -197,6 +197,18 @@ describe("UpstashRunRegistry", () => {
       expect(result).toBeNull();
     });
 
+    it("getParent coerces a number-typed result back to a string (Upstash JSON-parses Slack ts)", async () => {
+      // Slack ts "1777542341.966359" is a string in our setParent call, but
+      // the @upstash/redis client auto-JSON-parses values, turning numeric-
+      // looking strings into JS numbers on retrieval. The Slack SDK calls
+      // .startsWith on the returned messageId, so a number would crash it.
+      mockRedis.hget.mockResolvedValueOnce(1777542341.966359);
+      const registry = createRegistry();
+      const result = await registry.getParent("AWT-42");
+      expect(result).toBe("1777542341.966359");
+      expect(typeof result).toBe("string");
+    });
+
     it("clearParent deletes the entry from the thread hash", async () => {
       const registry = createRegistry();
       await registry.clearParent("AWT-42");

--- a/src/adapters/run-registry/upstash.test.ts
+++ b/src/adapters/run-registry/upstash.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { UpstashRunRegistry } from "./upstash.js";
 
 const HASH_KEY = `blazebot:active-runs:${process.env.VERCEL_ENV ?? "development"}`;
+const THREAD_HASH_KEY = `blazebot:thread-parents:${process.env.VERCEL_ENV ?? "development"}`;
 
 const mockRedis = {
   hsetnx: vi.fn(),
@@ -169,6 +170,45 @@ describe("UpstashRunRegistry", () => {
       const registry = createRegistry();
       await registry.clearFailedMark("AWT-42");
       expect(mockRedis.hdel).toHaveBeenCalledWith(FAILED_HASH_KEY, "AWT-42");
+    });
+  });
+
+  describe("ThreadStore methods", () => {
+    it("setParent then getParent round-trips the message id", async () => {
+      // Phase 1: setParent writes
+      const registry = createRegistry();
+      await registry.setParent("AWT-42", "1700000000.000123");
+      expect(mockRedis.hset).toHaveBeenCalledWith(THREAD_HASH_KEY, {
+        "AWT-42": "1700000000.000123",
+      });
+      expect(mockRedis.persist).toHaveBeenCalledWith(THREAD_HASH_KEY);
+
+      // Phase 2: getParent reads
+      mockRedis.hget.mockResolvedValueOnce("1700000000.000123");
+      const result = await registry.getParent("AWT-42");
+      expect(result).toBe("1700000000.000123");
+      expect(mockRedis.hget).toHaveBeenCalledWith(THREAD_HASH_KEY, "AWT-42");
+    });
+
+    it("getParent returns null when no entry exists", async () => {
+      mockRedis.hget.mockResolvedValueOnce(null);
+      const registry = createRegistry();
+      const result = await registry.getParent("AWT-99");
+      expect(result).toBeNull();
+    });
+
+    it("clearParent deletes the entry from the thread hash", async () => {
+      const registry = createRegistry();
+      await registry.clearParent("AWT-42");
+      expect(mockRedis.hdel).toHaveBeenCalledWith(THREAD_HASH_KEY, "AWT-42");
+    });
+
+    it("unregister does not touch the thread hash", async () => {
+      const registry = createRegistry();
+      await registry.unregister("AWT-42");
+      // unregister deletes from HASH_KEY, SANDBOX_HASH_KEY, ENTRY_TS_HASH_KEY only.
+      const hdelCalls = mockRedis.hdel.mock.calls.map((c) => c[0]);
+      expect(hdelCalls).not.toContain(THREAD_HASH_KEY);
     });
   });
 });

--- a/src/adapters/run-registry/upstash.ts
+++ b/src/adapters/run-registry/upstash.ts
@@ -101,7 +101,12 @@ export class UpstashRunRegistry implements RunRegistryAdapter, ThreadStore {
   }
 
   async getParent(ticketKey: string): Promise<string | null> {
-    return this.redis.hget<string>(THREAD_HASH_KEY, ticketKey);
+    // Slack ts values like "1777542341.966359" look numeric, and the Upstash
+    // client auto-JSON-parses string-encoded numbers back into JS numbers.
+    // Coerce to string so the Slack SDK (which calls .startsWith on it) works.
+    const raw = await this.redis.hget<string | number>(THREAD_HASH_KEY, ticketKey);
+    if (raw == null) return null;
+    return String(raw);
   }
 
   async setParent(ticketKey: string, messageId: string): Promise<void> {

--- a/src/adapters/run-registry/upstash.ts
+++ b/src/adapters/run-registry/upstash.ts
@@ -1,13 +1,14 @@
 import { Redis } from "@upstash/redis";
-import type { RunRegistryAdapter, FailedTicketMeta } from "./types.js";
+import type { RunRegistryAdapter, FailedTicketMeta, ThreadStore } from "./types.js";
 
 const ENV_PREFIX = process.env.VERCEL_ENV ?? "development";
 const HASH_KEY = `blazebot:active-runs:${ENV_PREFIX}`;
 const FAILED_HASH_KEY = `blazebot:failed-tickets:${ENV_PREFIX}`;
 const SANDBOX_HASH_KEY = `blazebot:sandboxes:${ENV_PREFIX}`;
 const ENTRY_TS_HASH_KEY = `blazebot:entry-timestamps:${ENV_PREFIX}`;
+const THREAD_HASH_KEY = `blazebot:thread-parents:${ENV_PREFIX}`;
 
-export class UpstashRunRegistry implements RunRegistryAdapter {
+export class UpstashRunRegistry implements RunRegistryAdapter, ThreadStore {
   private redis: Redis;
 
   constructor(opts: { url: string; token: string }) {
@@ -97,5 +98,19 @@ export class UpstashRunRegistry implements RunRegistryAdapter {
 
   async clearFailedMark(ticketKey: string): Promise<void> {
     await this.redis.hdel(FAILED_HASH_KEY, ticketKey);
+  }
+
+  async getParent(ticketKey: string): Promise<string | null> {
+    return this.redis.hget<string>(THREAD_HASH_KEY, ticketKey);
+  }
+
+  async setParent(ticketKey: string, messageId: string): Promise<void> {
+    await this.redis.hset(THREAD_HASH_KEY, { [ticketKey]: messageId });
+    // Defend against any external TTL — the thread mapping must outlive runs.
+    await this.redis.persist(THREAD_HASH_KEY);
+  }
+
+  async clearParent(ticketKey: string): Promise<void> {
+    await this.redis.hdel(THREAD_HASH_KEY, ticketKey);
   }
 }

--- a/src/lib/adapters.ts
+++ b/src/lib/adapters.ts
@@ -16,6 +16,10 @@ export interface Adapters {
 }
 
 export function createAdapters(): Adapters {
+  const runRegistry = new UpstashRunRegistry({
+    url: env.AI_WORKFLOW_KV_REST_API_URL,
+    token: env.AI_WORKFLOW_KV_REST_API_TOKEN,
+  });
   return {
     issueTracker: new JiraAdapter({
       baseUrl: env.JIRA_BASE_URL,
@@ -28,10 +32,9 @@ export function createAdapters(): Adapters {
       slackToken: env.CHAT_SDK_SLACK_TOKEN,
       channelId: env.CHAT_SDK_CHANNEL_ID,
       botName: env.CHAT_SDK_BOT_NAME,
+      jiraBaseUrl: env.JIRA_BASE_URL,
+      threadStore: runRegistry,
     }),
-    runRegistry: new UpstashRunRegistry({
-      url: env.AI_WORKFLOW_KV_REST_API_URL,
-      token: env.AI_WORKFLOW_KV_REST_API_TOKEN,
-    }),
+    runRegistry,
   };
 }

--- a/src/lib/dispatch.test.ts
+++ b/src/lib/dispatch.test.ts
@@ -59,7 +59,7 @@ function makeAdapters(
       fetchTicket:
         overrides.fetchTicket ?? vi.fn().mockResolvedValue(makeTicket()),
       moveTicket: vi.fn(),
-      postComment: vi.fn(),
+      postComment: vi.fn().mockResolvedValue(null),
       searchTickets: vi.fn(),
     },
     vcs: {

--- a/src/lib/dispatch.test.ts
+++ b/src/lib/dispatch.test.ts
@@ -73,7 +73,7 @@ function makeAdapters(
       getBranchSha: vi.fn().mockResolvedValue("abc123"),
     },
     messaging: {
-      notify: vi.fn(),
+      notifyForTicket: vi.fn(),
     },
     runRegistry: {
       claim:

--- a/src/lib/dispatch.test.ts
+++ b/src/lib/dispatch.test.ts
@@ -121,7 +121,7 @@ describe("dispatchTicket", () => {
     );
     expect(adapters.issueTracker.fetchTicket).toHaveBeenCalledWith("PROJ-42");
     expect(mockStart).toHaveBeenCalledWith("agentWorkflow_sentinel", [
-      "ticket-001",
+      "PROJ-42",
     ]);
     expect(adapters.runRegistry.register).toHaveBeenCalledWith(
       "PROJ-42",

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -135,7 +135,10 @@ export async function dispatchTicket(
     }
 
     stage = "start_workflow";
-    const handle = await start(agentWorkflow, [ticket.id]);
+    // Pass the issue key (not the numeric id) so the workflow can build
+    // /browse/{KEY}?focusedCommentId=... deep links in Slack notifications.
+    // Jira's REST API accepts either id or key for fetch/transition/comment.
+    const handle = await start(agentWorkflow, [ticketKey]);
     logger.info(
       { ticketId: ticket.id, identifier: ticket.identifier, runId: handle.runId },
       "workflow_started",

--- a/src/lib/reconcile.test.ts
+++ b/src/lib/reconcile.test.ts
@@ -53,7 +53,7 @@ function makeIssueTracker(
   return {
     fetchTicket: vi.fn(),
     moveTicket: vi.fn(),
-    postComment: vi.fn(),
+    postComment: vi.fn().mockResolvedValue(null),
     searchTickets: vi.fn(),
     ...overrides,
   };

--- a/src/lib/step-adapters.ts
+++ b/src/lib/step-adapters.ts
@@ -16,6 +16,10 @@ export interface StepAdapters {
 }
 
 export function createStepAdapters(): StepAdapters {
+  const runRegistry = new UpstashRunRegistry({
+    url: env.AI_WORKFLOW_KV_REST_API_URL,
+    token: env.AI_WORKFLOW_KV_REST_API_TOKEN,
+  });
   return {
     issueTracker: new JiraAdapter({
       baseUrl: env.JIRA_BASE_URL,
@@ -28,10 +32,9 @@ export function createStepAdapters(): StepAdapters {
       slackToken: env.CHAT_SDK_SLACK_TOKEN,
       channelId: env.CHAT_SDK_CHANNEL_ID,
       botName: env.CHAT_SDK_BOT_NAME,
+      jiraBaseUrl: env.JIRA_BASE_URL,
+      threadStore: runRegistry,
     }),
-    runRegistry: new UpstashRunRegistry({
-      url: env.AI_WORKFLOW_KV_REST_API_URL,
-      token: env.AI_WORKFLOW_KV_REST_API_TOKEN,
-    }),
+    runRegistry,
   };
 }

--- a/src/routes/cron/poll.get.ts
+++ b/src/routes/cron/poll.get.ts
@@ -20,9 +20,10 @@ export default defineEventHandler(async (event) => {
         reason === "inflight_claim"
           ? "claim was cleared after the ticket left AI"
           : "workflow run was cancelled after the ticket left AI";
-      await adapters.messaging.notify(
-        `Task ${ticketKey} canceled: ${detail}.`,
-      );
+      await adapters.messaging.notifyForTicket(ticketKey, {
+        kind: "canceled",
+        reason: `${detail}.`,
+      });
     },
   );
 

--- a/src/routes/webhooks/jira.post.ts
+++ b/src/routes/webhooks/jira.post.ts
@@ -107,9 +107,10 @@ export default defineEventHandler(async (event) => {
 
     const cancelled = await cancelTrackedRun(ticketKey, adapters.runRegistry);
     if (cancelled) {
-      await adapters.messaging.notify(
-        `Task ${ticketKey} canceled: webhook confirmed ticket is outside AI column.`,
-      );
+      await adapters.messaging.notifyForTicket(ticketKey, {
+        kind: "canceled",
+        reason: "webhook confirmed ticket is outside AI column",
+      });
     }
     logger.info(
       {

--- a/src/workflows/agent.ts
+++ b/src/workflows/agent.ts
@@ -554,8 +554,10 @@ export async function agentWorkflow(ticketId: string) {
 
       if (research.status === "clarification_needed") {
         const questions = research.body.split("\n").filter((l) => /^\d+\./.test(l.trim()));
+        // Pass the issue key (not the numeric id) so the returned URL is a
+        // /browse/{KEY}?focusedCommentId=... deep link rather than /browse/{numericId}/...
         const commentUrl = await postClarificationAndMoveBack(
-          ticketId,
+          ticket.identifier,
           questions.length > 0 ? questions : [research.body],
           env.COLUMN_BACKLOG,
         );
@@ -615,7 +617,7 @@ export async function agentWorkflow(ticketId: string) {
 
       if (implOutput.result === "clarification_needed") {
         const commentUrl = await postClarificationAndMoveBack(
-          ticketId,
+          ticket.identifier,
           implOutput.questions ?? [],
           env.COLUMN_BACKLOG,
         );

--- a/src/workflows/agent.ts
+++ b/src/workflows/agent.ts
@@ -554,10 +554,8 @@ export async function agentWorkflow(ticketId: string) {
 
       if (research.status === "clarification_needed") {
         const questions = research.body.split("\n").filter((l) => /^\d+\./.test(l.trim()));
-        // Pass the issue key (not the numeric id) so the returned URL is a
-        // /browse/{KEY}?focusedCommentId=... deep link rather than /browse/{numericId}/...
         const commentUrl = await postClarificationAndMoveBack(
-          ticket.identifier,
+          ticketId,
           questions.length > 0 ? questions : [research.body],
           env.COLUMN_BACKLOG,
         );
@@ -617,7 +615,7 @@ export async function agentWorkflow(ticketId: string) {
 
       if (implOutput.result === "clarification_needed") {
         const commentUrl = await postClarificationAndMoveBack(
-          ticket.identifier,
+          ticketId,
           implOutput.questions ?? [],
           env.COLUMN_BACKLOG,
         );

--- a/src/workflows/agent.ts
+++ b/src/workflows/agent.ts
@@ -5,6 +5,7 @@ import type {
 import type { AgentKind } from "../sandbox/agents/index.js";
 import type { PRComment, CheckRunResult } from "../adapters/vcs/types.js";
 import type { TicketAttachment } from "../adapters/issue-tracker/types.js";
+import type { TicketEvent } from "../adapters/messaging/types.js";
 import type { DownloadedAttachment } from "../sandbox/attachments.js";
 
 // --- Step Functions ---
@@ -328,6 +329,23 @@ async function createPullRequest(branchName: string, title: string, summary: str
   return vcs.createPR(branchName, title, summary);
 }
 
+async function findPRForBranch(branchName: string) {
+  "use step";
+  const { createStepAdapters } = await import("../lib/step-adapters.js");
+  const { vcs } = createStepAdapters();
+  const pr = await vcs.findPR(branchName);
+  if (!pr) {
+    // We only call this on the pr_ready branch when prContext was non-null
+    // (i.e. a PR existed at fetchPRContext time). A null here means the PR
+    // was closed manually between fetch and post-push lookup — rare, but
+    // possible. Throwing escalates to the workflow's catch handler, which
+    // posts a `failed` event. Acceptable degradation; if this becomes
+    // common, downgrade to a graceful pr_ready with branch-only context.
+    throw new Error(`Expected PR for branch ${branchName} but findPR returned null`);
+  }
+  return pr;
+}
+
 async function moveTicket(ticketId: string, column: string) {
   "use step";
   const { createStepAdapters } = await import("../lib/step-adapters.js");
@@ -335,11 +353,11 @@ async function moveTicket(ticketId: string, column: string) {
   await issueTracker.moveTicket(ticketId, column);
 }
 
-async function notifySlack(message: string) {
+async function notifyTicket(ticketKey: string, event: TicketEvent) {
   "use step";
   const { createStepAdapters } = await import("../lib/step-adapters.js");
   const { messaging } = createStepAdapters();
-  await messaging.notify(message);
+  await messaging.notifyForTicket(ticketKey, event);
 }
 
 async function postClarificationAndMoveBack(
@@ -432,13 +450,15 @@ export async function agentWorkflow(ticketId: string) {
   // Set after provisionSandbox once agentKind is known.
   let activeModel: string | undefined;
   let priceLookup: ((m: string) => { input: number; cached_input: number; output: number } | null) | undefined;
-  const usageSuffix = () =>
+  // Returns the formatted usage report when any phase has produced usage,
+  // otherwise undefined so the messaging formatter can omit the trailing block.
+  const usageReportOrUndefined = (): string | undefined =>
     Object.keys(phaseUsages).length
-      ? `\n${formatUsageReport(phaseUsages, priceLookup, activeModel)}`
-      : "";
+      ? formatUsageReport(phaseUsages, priceLookup, activeModel)
+      : undefined;
 
   try {
-    await notifySlack(`Task ${ticket.identifier} started`);
+    await notifyTicket(ticket.identifier, { kind: "started" });
 
     const branchName = `blazebot/${ticket.identifier.toLowerCase()}`;
 
@@ -515,7 +535,12 @@ export async function agentWorkflow(ticketId: string) {
       const researchDone = await pollUntilDone(sandboxId, researchPaths.sentinel, 20);
       if (!researchDone) {
         await moveTicket(ticketId, env.COLUMN_BACKLOG);
-        await notifySlack(`Task ${ticket.identifier} failed: research phase timed out${usageSuffix()}`);
+        await notifyTicket(ticket.identifier, {
+          kind: "failed",
+          phase: "research",
+          reason: "phase timed out",
+          usageReport: usageReportOrUndefined(),
+        });
         await unregisterRun(ticket.identifier);
         return;
       }
@@ -533,14 +558,22 @@ export async function agentWorkflow(ticketId: string) {
           questions.length > 0 ? questions : [research.body],
           env.COLUMN_BACKLOG,
         );
-        await notifySlack(`Task ${ticket.identifier} needs clarification${usageSuffix()}`);
+        await notifyTicket(ticket.identifier, {
+          kind: "needs_clarification",
+          usageReport: usageReportOrUndefined(),
+        });
         await unregisterRun(ticket.identifier);
         return;
       }
 
       if (research.status === "failed") {
         await moveTicket(ticketId, env.COLUMN_BACKLOG);
-        await notifySlack(`Task ${ticket.identifier} failed: research — ${research.body.slice(0, 200)}${usageSuffix()}`);
+        await notifyTicket(ticket.identifier, {
+          kind: "failed",
+          phase: "research",
+          reason: research.body.slice(0, 200),
+          usageReport: usageReportOrUndefined(),
+        });
         await unregisterRun(ticket.identifier);
         return;
       }
@@ -584,14 +617,22 @@ export async function agentWorkflow(ticketId: string) {
           implOutput.questions ?? [],
           env.COLUMN_BACKLOG,
         );
-        await notifySlack(`Task ${ticket.identifier} needs clarification${usageSuffix()}`);
+        await notifyTicket(ticket.identifier, {
+          kind: "needs_clarification",
+          usageReport: usageReportOrUndefined(),
+        });
         await unregisterRun(ticket.identifier);
         return;
       }
 
       if (implOutput.result === "failed") {
         await moveTicket(ticketId, env.COLUMN_BACKLOG);
-        await notifySlack(`Task ${ticket.identifier} failed: implementation — ${implOutput.error ?? "unknown"}${usageSuffix()}`);
+        await notifyTicket(ticket.identifier, {
+          kind: "failed",
+          phase: "impl",
+          reason: implOutput.error ?? "unknown",
+          usageReport: usageReportOrUndefined(),
+        });
         await unregisterRun(ticket.identifier);
         return;
       }
@@ -650,19 +691,31 @@ export async function agentWorkflow(ticketId: string) {
 
       if (!pushResult.pushed) {
         await moveTicket(ticketId, env.COLUMN_BACKLOG);
-        await notifySlack(`Task ${ticket.identifier} failed: push failed — ${pushResult.error ?? "unknown"}${usageSuffix()}`);
+        await notifyTicket(ticket.identifier, {
+          kind: "failed",
+          phase: "push",
+          reason: pushResult.error ?? "unknown",
+          usageReport: usageReportOrUndefined(),
+        });
         await unregisterRun(ticket.identifier);
         return;
       }
 
-      if (!prContext) {
-        await createPullRequest(branchName, ticket.title, "");
-      }
-      // Notify Slack BEFORE moving the ticket out of the AI column.
-      // Reconcile cancels runs whose tickets have left AI column; racing
-      // that cancellation after moveTicket would skip the notification.
+      // We need a {url, number} regardless of whether the PR is new or pre-existing.
+      // - New PR: createPullRequest returns the PullRequest ({ id, url, branch }) — capture it.
+      // - Existing PR: prContext was built from vcs.findPR(branch), but findPR's return
+      //   is dropped today. Re-fetch via the VCS adapter step (cheap; same call already
+      //   ran on this branch earlier in the workflow).
+      const pr = !prContext
+        ? await createPullRequest(branchName, ticket.title, "")
+        : await findPRForBranch(branchName);
+
       const usageReport = formatUsageReport(phaseUsages, priceLookup, activeModel);
-      await notifySlack(`Task ${ticket.identifier} PR ready for review\n${usageReport}`);
+      await notifyTicket(ticket.identifier, {
+        kind: "pr_ready",
+        pr: { url: pr.url, number: pr.id },
+        usageReport,
+      });
       await moveTicket(ticketId, env.COLUMN_AI_REVIEW);
       await unregisterRun(ticket.identifier);
     } finally {
@@ -671,7 +724,11 @@ export async function agentWorkflow(ticketId: string) {
   } catch (err) {
     console.error(`Workflow failed for ${ticket.identifier}:`, err);
     const moved = await moveTicket(ticketId, env.COLUMN_BACKLOG).then(() => true).catch(() => false);
-    await notifySlack(`Task ${ticket.identifier} failed: ${(err as Error).message ?? "unknown"}${usageSuffix()}`).catch(() => {});
+    await notifyTicket(ticket.identifier, {
+      kind: "failed",
+      reason: (err as Error).message ?? "unknown",
+      usageReport: usageReportOrUndefined(),
+    }).catch(() => {});
     if (moved) {
       await unregisterRun(ticket.identifier).catch(() => {});
     } else {

--- a/src/workflows/agent.ts
+++ b/src/workflows/agent.ts
@@ -364,13 +364,14 @@ async function postClarificationAndMoveBack(
   ticketId: string,
   questions: string[],
   backlogColumn: string,
-) {
+): Promise<string | null> {
   "use step";
   const { createStepAdapters } = await import("../lib/step-adapters.js");
   const { issueTracker } = createStepAdapters();
   const comment = questions.map((q, i) => `${i + 1}. ${q}`).join("\n");
-  await issueTracker.postComment(ticketId, comment);
+  const commentUrl = await issueTracker.postComment(ticketId, comment);
   await issueTracker.moveTicket(ticketId, backlogColumn);
+  return commentUrl;
 }
 
 async function unregisterRun(ticketIdentifier: string) {
@@ -553,13 +554,14 @@ export async function agentWorkflow(ticketId: string) {
 
       if (research.status === "clarification_needed") {
         const questions = research.body.split("\n").filter((l) => /^\d+\./.test(l.trim()));
-        await postClarificationAndMoveBack(
+        const commentUrl = await postClarificationAndMoveBack(
           ticketId,
           questions.length > 0 ? questions : [research.body],
           env.COLUMN_BACKLOG,
         );
         await notifyTicket(ticket.identifier, {
           kind: "needs_clarification",
+          commentUrl: commentUrl ?? undefined,
           usageReport: usageReportOrUndefined(),
         });
         await unregisterRun(ticket.identifier);
@@ -612,13 +614,14 @@ export async function agentWorkflow(ticketId: string) {
       }
 
       if (implOutput.result === "clarification_needed") {
-        await postClarificationAndMoveBack(
+        const commentUrl = await postClarificationAndMoveBack(
           ticketId,
           implOutput.questions ?? [],
           env.COLUMN_BACKLOG,
         );
         await notifyTicket(ticket.identifier, {
           kind: "needs_clarification",
+          commentUrl: commentUrl ?? undefined,
           usageReport: usageReportOrUndefined(),
         });
         await unregisterRun(ticket.identifier);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications now use per-ticket threads with structured ticket events (started, needs_clarification, pr_ready, failed, canceled).
  * Notifications include clickable Jira ticket and GitHub PR links; issue-tracker comment calls now return deep-link URLs when available.
  * Persistent per-ticket thread-parent storage with missing-parent recovery and retry behavior.

* **Bug Fixes**
  * Improved Slack error handling, recovery logic, and failure logging.

* **Documentation**
  * Added implementation plan and detailed design spec for threaded messaging.

* **Tests**
  * New and updated unit tests for formatting, threading, persistence, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->