### PR TITLE
feat: add bidirectional slack integration

### DIFF
--- a/.claude/skills/init-slack/SKILL.md
+++ b/.claude/skills/init-slack/SKILL.md
@@ -47,19 +47,19 @@ The bot must be invited to the channel: `/invite @blazebot` from inside the chan
 
 ## Step 3 — Emit paste-template
 
-```
+```bash
 CHAT_SDK_SLACK_TOKEN=<value>
 CHAT_SDK_CHANNEL_ID=<value>
 SLACK_SIGNING_SECRET=<value>
 ```
 
 If non-default bot name:
-```
+```bash
 CHAT_SDK_BOT_NAME=<value>
 ```
 
 If restricting slash commands to specific users:
-```
+```bash
 SLACK_ALLOWED_USER_IDS=U0123,U4567
 ```
 

--- a/.claude/skills/init-slack/SKILL.md
+++ b/.claude/skills/init-slack/SKILL.md
@@ -33,6 +33,8 @@ Ask:
 - `CHAT_SDK_SLACK_TOKEN` — bot token, starts with `xoxb-`
 - `CHAT_SDK_CHANNEL_ID` — channel ID like `C0123456789` (not `#channel-name`)
 - `CHAT_SDK_BOT_NAME` — defaults to `blazebot`; only ask if the user wants to override
+- `SLACK_SIGNING_SECRET` — required. App settings → **Basic Information** → **App Credentials** → **Signing Secret**. Used to verify inbound `/ai-workflow` slash command requests. See `references/slash-commands.md` for the full slash-command setup.
+- `SLACK_ALLOWED_USER_IDS` — optional. Comma-separated Slack user IDs (`U…`) allowed to run `/ai-workflow`. Empty = anyone in the workspace.
 
 ### Finding the channel ID
 
@@ -48,6 +50,7 @@ The bot must be invited to the channel: `/invite @blazebot` from inside the chan
 ```
 CHAT_SDK_SLACK_TOKEN=<value>
 CHAT_SDK_CHANNEL_ID=<value>
+SLACK_SIGNING_SECRET=<value>
 ```
 
 If non-default bot name:
@@ -55,7 +58,22 @@ If non-default bot name:
 CHAT_SDK_BOT_NAME=<value>
 ```
 
+If restricting slash commands to specific users:
+```
+SLACK_ALLOWED_USER_IDS=U0123,U4567
+```
+
 Tell the user to paste into Vercel → Project Settings → Environment Variables (all three environments), save, and reply when done.
+
+## Step 4 — Register the slash command
+
+After the env vars are saved and the project has been deployed at least once, the operator must register the slash command in Slack:
+
+- Slash Commands → **Create New Command** → `/ai-workflow`
+- Request URL: `https://<your-vercel-domain>/webhooks/slack`
+- Reinstall the app so Slack picks up the new command
+
+Full walkthrough in `references/slash-commands.md`.
 
 ## Don'ts
 

--- a/.claude/skills/init-slack/references/slash-commands.md
+++ b/.claude/skills/init-slack/references/slash-commands.md
@@ -1,0 +1,74 @@
+# Slack slash commands setup
+
+The `/ai-workflow` slash command lets operators inspect and control workflow runs from inside Slack. Three subcommands today:
+
+- `/ai-workflow list` — show every tracked workflow run
+- `/ai-workflow status <KEY>` — show the run + sandbox tied to a Jira ticket (e.g. `AWT-42`)
+- `/ai-workflow cancel <KEY>` — cancel the workflow run for a ticket
+
+The command is gated by Slack's request signature (HMAC over the raw body) and an optional user allowlist.
+
+## Prereqs
+
+- The Blazebot Slack app already exists and has a bot token configured (see `bot-app-setup.md`).
+- The repo is deployed at least once to Vercel — the slash command needs a public Request URL.
+
+## Step 1 — Get the Signing Secret
+
+In api.slack.com → your Blazebot app → **Basic Information** → **App Credentials** → **Signing Secret** → **Show** → copy.
+
+This is `SLACK_SIGNING_SECRET`. Store it in Vercel for **all three environments** (Production, Preview, Development). Without it the route 401s every request — slash commands won't work.
+
+## Step 2 — (Optional) Restrict who can run /ai-workflow
+
+If you don't want any random workspace member to be able to cancel runs, set `SLACK_ALLOWED_USER_IDS` to a comma-separated list of Slack user IDs.
+
+How to find a user ID: in Slack, click the person → **View full profile** → **More** (`⋮`) → **Copy member ID** (looks like `U0123ABCD`).
+
+```
+SLACK_ALLOWED_USER_IDS=U0123ABCD,U4567WXYZ
+```
+
+Leave unset for "anyone in the workspace".
+
+## Step 3 — Register the slash command in Slack
+
+App settings → **Slash Commands** → **Create New Command**:
+
+| Field | Value |
+| --- | --- |
+| Command | `/ai-workflow` |
+| Request URL | `https://<your-vercel-domain>/webhooks/slack` |
+| Short description | `Inspect and control AI workflow runs` |
+| Usage hint | `list \| status <KEY> \| cancel <KEY>` |
+
+Save. If the app is already installed, Slack will prompt you to **Reinstall** so the new command is registered with the workspace.
+
+## Step 4 — Smoke test
+
+In any channel the bot can see:
+
+```
+/ai-workflow list
+```
+
+Expect:
+
+1. An ephemeral "Working on `/ai-workflow list`…" message (within ~1s).
+2. A second message visible in the channel with either the list of active runs or "No active workflows."
+
+If you instead see Slack's "operation_timeout" error, the function probably can't reach Upstash — check Vercel runtime logs for the `slack_command_dispatching` log line.
+
+## Troubleshooting
+
+- **`/ai-workflow` returns "command failed with the error 'dispatch_failed'"** — Slack thinks the URL didn't 200. Check Vercel logs; usually a missing `SLACK_SIGNING_SECRET` (route 401s) or a 5xx from Nitro startup.
+- **`Not authorized.`** — your user ID isn't in `SLACK_ALLOWED_USER_IDS`. Add it or unset the variable.
+- **Cancel says "is mid-dispatch"** — a workflow was just claimed but not yet started. Wait a moment, then re-run the cancel.
+
+## Rotation
+
+Slack signing secrets don't expire but can be rotated. To rotate:
+
+1. App settings → **Basic Information** → **Signing Secret** → **Regenerate**.
+2. Update `SLACK_SIGNING_SECRET` in Vercel for all three environments.
+3. Redeploy. Until the new deployment is live, every slash command will 401.

--- a/.claude/skills/init-slack/references/slash-commands.md
+++ b/.claude/skills/init-slack/references/slash-commands.md
@@ -25,7 +25,7 @@ If you don't want any random workspace member to be able to cancel runs, set `SL
 
 How to find a user ID: in Slack, click the person → **View full profile** → **More** (`⋮`) → **Copy member ID** (looks like `U0123ABCD`).
 
-```
+```bash
 SLACK_ALLOWED_USER_IDS=U0123ABCD,U4567WXYZ
 ```
 
@@ -48,7 +48,7 @@ Save. If the app is already installed, Slack will prompt you to **Reinstall** so
 
 In any channel the bot can see:
 
-```
+```bash
 /ai-workflow list
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,12 +127,16 @@ GITHUB_REPO=your-repo                  # Target repository name
 GITHUB_BASE_BRANCH=main               # Branch PRs will target
 ```
 
-**Slack** — Bot notifications:
+**Slack** — Bot notifications and slash commands:
 ```bash
 CHAT_SDK_SLACK_TOKEN=xoxb-xxxxxxxxxxxx  # Slack bot token (chat:write scope)
 CHAT_SDK_CHANNEL_ID=C0123456789         # Channel ID for notifications
 CHAT_SDK_BOT_NAME=blazebot             # Display name for the bot
+SLACK_SIGNING_SECRET=xxxxxxxxxxxxxxxx   # Required for /ai-workflow slash commands
+SLACK_ALLOWED_USER_IDS=U0123,U4567      # Optional: comma-separated allowlist
 ```
+
+Operators can drive workflows directly from Slack with `/ai-workflow list | status <KEY> | cancel <KEY>` once `SLACK_SIGNING_SECRET` is set and the slash command is registered (Request URL: `https://<your-domain>/webhooks/slack`). See `.claude/skills/init-slack/references/slash-commands.md` for the full setup walkthrough.
 
 **Agent** — AI model configuration:
 ```bash
@@ -238,6 +242,8 @@ curl -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/cron/poll
 | `CHAT_SDK_SLACK_TOKEN` | Yes | — | Slack bot token |
 | `CHAT_SDK_CHANNEL_ID` | Yes | — | Notification channel ID |
 | `CHAT_SDK_BOT_NAME` | No | `blazebot` | Bot display name |
+| `SLACK_SIGNING_SECRET` | Yes | — | Slack app signing secret; verifies `/ai-workflow` slash commands |
+| `SLACK_ALLOWED_USER_IDS` | No | — | Comma-separated Slack user IDs allowed to run `/ai-workflow`; empty = anyone |
 | **Agent** | | | |
 | `AGENT_KIND` | No | `claude` | Runtime: `claude` or `codex` |
 | `ANTHROPIC_API_KEY` | Yes* | — | Anthropic API key (required when `AGENT_KIND=claude`) |

--- a/docs/superpowers/plans/2026-05-01-slack-slash-commands.md
+++ b/docs/superpowers/plans/2026-05-01-slack-slash-commands.md
@@ -1,0 +1,141 @@
+# Slack Slash Commands Implementation Plan
+
+**Goal:** Add inbound Slack slash commands (`/ai-workflow list | status <KEY> | cancel <KEY>`) so operators can inspect and control workflow runs from Slack.
+
+**Architecture:** One Nitro POST route at `/webhooks/slack` verifies Slack's HMAC signature, parses the slash command payload, ack's within 3s, and dispatches the subcommand to async handlers that read the existing `RunRegistryAdapter` and reuse `cancelRun()`. Results are posted back via Slack's `response_url`.
+
+**Tech Stack:** Nitro (h3), `@chat-adapter/slack` (already wired for outbound), Node `crypto` for HMAC, existing Upstash run registry, `workflow/api` for run cancel.
+
+**Out of scope (deferred):** interactive buttons, Events API / `app_mention`, multi-tenant routing, audit log persistence.
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+|---|---|
+| `src/routes/webhooks/slack.post.ts` | Route entry: verify signature, parse payload, ack, dispatch |
+| `src/lib/slack/verify.ts` | HMAC-SHA256 signature verification + timestamp drift check |
+| `src/lib/slack/commands.ts` | Subcommand parser + dispatcher (`list`, `status`, `cancel`) |
+| `src/lib/slack/respond.ts` | Helper to POST formatted text to Slack `response_url` |
+| `src/lib/slack/format.ts` | Format registry rows + status into Slack mrkdwn |
+| `env.ts` | Add `SLACK_SIGNING_SECRET` (required); optional `SLACK_ALLOWED_USER_IDS` |
+| `*.test.ts` siblings | Unit tests for verify, commands, format |
+
+`cancelRun` (`src/lib/cancel-run.ts`) and `RunRegistryAdapter.listAll/getRunId/getSandboxId` are reused as-is — no changes.
+
+---
+
+## Phase 1 — Signature verification (foundational, pure function)
+
+**Task 1.1:** Add `SLACK_SIGNING_SECRET: z.string().min(1)` to `env.ts` server schema. Add optional `SLACK_ALLOWED_USER_IDS: z.string().optional()` (comma-separated).
+
+**Task 1.2:** Implement `src/lib/slack/verify.ts`:
+- `verifySlackSignature({ rawBody, timestamp, signature, signingSecret })` → boolean
+- Compute `v0=` + HMAC-SHA256 over `v0:${timestamp}:${rawBody}` with `signingSecret`
+- Compare with `timingSafeEqual`
+- Reject if `Math.abs(now - timestamp) > 300` (5 min replay window)
+
+**Task 1.3:** TDD: cover (a) valid sig passes, (b) tampered body fails, (c) old timestamp fails, (d) length-mismatched signature fails without throwing.
+
+---
+
+## Phase 2 — Command parsing (pure)
+
+**Task 2.1:** Implement `src/lib/slack/commands.ts` with:
+```ts
+type ParsedCommand =
+  | { kind: "list" }
+  | { kind: "status"; ticketKey: string }
+  | { kind: "cancel"; ticketKey: string }
+  | { kind: "help" }
+  | { kind: "unknown"; raw: string };
+
+export function parseCommand(text: string): ParsedCommand;
+```
+- Trim, split on whitespace, lowercase verb
+- Validate ticket key matches `/^[A-Z][A-Z0-9]+-\d+$/` (uppercase first), else return `unknown`
+- Empty / `help` → help
+
+**Task 2.2:** TDD each branch including malformed keys (`abc`, `AWT`, `AWT-`, `awt-1` lowercased before validation).
+
+---
+
+## Phase 3 — Subcommand handlers
+
+Each returns a `string` (Slack mrkdwn) — no Slack I/O inside, so they're trivial to test.
+
+**Task 3.1:** `handleList(runRegistry)`:
+- `runRegistry.listAll()` → filter out claiming sentinels (use existing `isClaimingSentinel`)
+- Format each row: `• <jiraUrl|TICKET> — runId: \`xxx\`` (link via `JIRA_BASE_URL`)
+- Empty list → "No active workflows."
+
+**Task 3.2:** `handleStatus(runRegistry, ticketKey)`:
+- Look up `getRunId` + `getSandboxId`
+- Return `Not tracked.` / `TICKET → runId, sandbox: yes/no`
+- Out of scope: live workflow status from `workflow/api` (add only if registry-only is insufficient in practice)
+
+**Task 3.3:** `handleCancel(runRegistry, ticketKey)`:
+- `getRunId(ticketKey)` — if null, return `No active run for TICKET.`
+- If runId is a claiming sentinel, return `TICKET is mid-dispatch; try again in a moment.`
+- Otherwise call `cancelRun(ticketKey, runId, runRegistry)` and return result message.
+
+**Task 3.4:** TDD with stubbed `RunRegistryAdapter` — assert exact return strings. Don't mock `workflow/api`; instead inject a fake `cancelRun` via parameter so the handler stays a pure function over its dependencies.
+
+---
+
+## Phase 4 — Route wiring (the only place with side effects)
+
+**Task 4.1:** `src/routes/webhooks/slack.post.ts`:
+1. `readRawBody` (mirrors Jira webhook).
+2. Read headers `x-slack-request-timestamp`, `x-slack-signature`. Verify via Phase 1; on failure `throw createError({ statusCode: 401 })`.
+3. Parse `application/x-www-form-urlencoded` → `{ command, text, response_url, user_id, channel_id }`.
+4. Optional allowlist: if `SLACK_ALLOWED_USER_IDS` set and `user_id` not in it, reply 200 with ephemeral "Not authorized."
+5. `parseCommand(text)`. For `unknown`/`help`, respond synchronously with usage.
+6. For real commands: respond **immediately** with `{ response_type: "ephemeral", text: "Working on \`${command} ${text}\`…" }` (Slack's 3s budget).
+7. Schedule the handler in the background:
+   ```ts
+   event.waitUntil(runHandler(parsed, response_url, adapters));
+   ```
+   `runHandler` calls the appropriate `handle*`, then POSTs `{ response_type: "in_channel", text: result }` to `response_url`.
+8. `createAdapters()` is reused — same shape as Jira webhook.
+
+**Task 4.2:** `src/lib/slack/respond.ts`:
+- `postToResponseUrl(url, payload)` — `fetch(url, { method: "POST", body: JSON.stringify(payload), headers: { "content-type": "application/json" } })`
+- Log + swallow on failure (matches existing messaging adapter philosophy: notifications never break flows).
+
+**Task 4.3:** Integration test (vitest) that boots the route via Nitro test util or by calling the handler directly with a hand-crafted h3 event:
+- Valid signature + `list` → 200, ack body shape correct, `response_url` POSTed with formatted list.
+- Invalid signature → 401.
+- Disallowed user → 200 + "Not authorized."
+- `cancel AWT-42` with no entry → "No active run."
+- `cancel AWT-42` with entry → `cancelRun` invoked once with the right args.
+
+---
+
+## Phase 5 — Slack app config + docs (no code, but blocks shipping)
+
+**Task 5.1:** In api.slack.com app settings:
+- Slash Commands → add `/ai-workflow` → request URL `https://<host>/webhooks/slack`.
+- Reinstall app (`commands` scope is already granted on most chat-adapter installs; verify).
+- Copy the Signing Secret into Vercel env (`SLACK_SIGNING_SECRET`) for Production + Preview.
+
+**Task 5.2:** Update `init-slack` skill (`/Users/kacper/.claude/skills/init-slack`) to also prompt for `SLACK_SIGNING_SECRET` and mention the slash-command URL. Add a one-paragraph operator note in `README.md` under the existing Slack section.
+
+---
+
+## Verification checklist
+
+- [ ] `pnpm test` passes (new unit + integration tests)
+- [ ] Locally: `vercel dev` + `ngrok` → run `/ai-workflow list` from Slack, see ack <3s and final list message
+- [ ] Bad-signature curl returns 401
+- [ ] `/ai-workflow cancel AWT-<real ticket>` cancels the run and posts confirmation
+- [ ] Workflow-side: registry entry gone, sandbox stopped, Jira thread shows the existing cancel notification (already handled by `cancelRun`'s downstream)
+
+---
+
+## Risks / open questions
+
+1. **`event.waitUntil` on Nitro/Vercel preset** — confirm h3 exposes it (or use Nitro's `event.context.waitUntil` if applicable). Fallback: do the work synchronously and rely on Slack's 3s being usually achievable for a single Redis read; cancel uses two extra ops which is borderline. Safer to confirm waitUntil first.
+2. **Multi-channel installs** — current outbound adapter is single-channel via `CHAT_SDK_CHANNEL_ID`. Slash commands can come from any channel the bot is in; `response_url` makes that fine for replies, but if you want to *restrict* commands to one channel, add a channel allowlist alongside the user one.
+3. **Concurrency** — `cancel` racing the dispatch claim is already handled by `dispatch.ts`'s post-claim verification, so no new logic needed.

--- a/docs/superpowers/plans/2026-05-01-slack-slash-commands.md
+++ b/docs/superpowers/plans/2026-05-01-slack-slash-commands.md
@@ -120,7 +120,7 @@ Each returns a `string` (Slack mrkdwn) — no Slack I/O inside, so they're trivi
 - Reinstall app (`commands` scope is already granted on most chat-adapter installs; verify).
 - Copy the Signing Secret into Vercel env (`SLACK_SIGNING_SECRET`) for Production + Preview.
 
-**Task 5.2:** Update `init-slack` skill (`/Users/kacper/.claude/skills/init-slack`) to also prompt for `SLACK_SIGNING_SECRET` and mention the slash-command URL. Add a one-paragraph operator note in `README.md` under the existing Slack section.
+**Task 5.2:** Update `init-slack` skill (`.claude/skills/init-slack`) to also prompt for `SLACK_SIGNING_SECRET` and mention the slash-command URL. Add a one-paragraph operator note in `README.md` under the existing Slack section.
 
 ---
 

--- a/env.test.ts
+++ b/env.test.ts
@@ -18,6 +18,7 @@ describe("env", () => {
     CHAT_SDK_SLACK_TOKEN: "xoxb-test",
     CHAT_SDK_CHANNEL_ID: "C123",
     CHAT_SDK_BOT_NAME: "blazebot",
+    SLACK_SIGNING_SECRET: "fake-signing-secret",
     ANTHROPIC_API_KEY: "sk-ant-test",
     CLAUDE_MODEL: "claude-opus-4-6",
     COMMIT_AUTHOR: "ai-workflow-blazity",

--- a/env.ts
+++ b/env.ts
@@ -39,6 +39,11 @@ export const env = createEnv({
     CHAT_SDK_CHANNEL_ID: z.string().min(1),
     CHAT_SDK_BOT_NAME: z.string().default("blazebot"),
 
+    // Slack slash commands
+    SLACK_SIGNING_SECRET: z.string().min(1),
+    /** Comma-separated list of Slack user IDs allowed to invoke slash commands. Empty = anyone. */
+    SLACK_ALLOWED_USER_IDS: z.string().optional(),
+
     // Agent
     ANTHROPIC_API_KEY: z.string().min(1).optional(),
     CLAUDE_CODE_OAUTH_TOKEN: z.string().min(1).optional(),

--- a/src/lib/slack/commands.test.ts
+++ b/src/lib/slack/commands.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { parseCommand } from "./commands.js";
+
+describe("parseCommand", () => {
+  it("returns help for empty input", () => {
+    expect(parseCommand("")).toEqual({ kind: "help" });
+    expect(parseCommand("   ")).toEqual({ kind: "help" });
+  });
+
+  it("returns help for explicit help", () => {
+    expect(parseCommand("help")).toEqual({ kind: "help" });
+    expect(parseCommand("HELP")).toEqual({ kind: "help" });
+  });
+
+  it("parses list", () => {
+    expect(parseCommand("list")).toEqual({ kind: "list" });
+    expect(parseCommand("  LIST  ")).toEqual({ kind: "list" });
+  });
+
+  it("parses status with a valid ticket key", () => {
+    expect(parseCommand("status AWT-42")).toEqual({
+      kind: "status",
+      ticketKey: "AWT-42",
+    });
+  });
+
+  it("uppercases the ticket key on status", () => {
+    expect(parseCommand("status awt-42")).toEqual({
+      kind: "status",
+      ticketKey: "AWT-42",
+    });
+  });
+
+  it("parses cancel with a valid ticket key", () => {
+    expect(parseCommand("cancel AWT-42")).toEqual({
+      kind: "cancel",
+      ticketKey: "AWT-42",
+    });
+  });
+
+  it("returns unknown for status without a ticket key", () => {
+    expect(parseCommand("status")).toEqual({ kind: "unknown", raw: "status" });
+  });
+
+  it("returns unknown for cancel without a ticket key", () => {
+    expect(parseCommand("cancel")).toEqual({ kind: "unknown", raw: "cancel" });
+  });
+
+  it("returns unknown for malformed ticket keys", () => {
+    expect(parseCommand("status abc")).toEqual({
+      kind: "unknown",
+      raw: "status abc",
+    });
+    expect(parseCommand("status AWT")).toEqual({
+      kind: "unknown",
+      raw: "status AWT",
+    });
+    expect(parseCommand("status AWT-")).toEqual({
+      kind: "unknown",
+      raw: "status AWT-",
+    });
+    expect(parseCommand("status 42-AWT")).toEqual({
+      kind: "unknown",
+      raw: "status 42-AWT",
+    });
+  });
+
+  it("returns unknown for an unrecognised verb", () => {
+    expect(parseCommand("delete AWT-42")).toEqual({
+      kind: "unknown",
+      raw: "delete AWT-42",
+    });
+  });
+
+  it("ignores extra trailing whitespace and tokens after the ticket key", () => {
+    expect(parseCommand("status AWT-42  ")).toEqual({
+      kind: "status",
+      ticketKey: "AWT-42",
+    });
+  });
+});

--- a/src/lib/slack/commands.ts
+++ b/src/lib/slack/commands.ts
@@ -1,0 +1,29 @@
+const TICKET_KEY_RE = /^[A-Z][A-Z0-9]+-\d+$/;
+
+export type ParsedCommand =
+  | { kind: "list" }
+  | { kind: "status"; ticketKey: string }
+  | { kind: "cancel"; ticketKey: string }
+  | { kind: "help" }
+  | { kind: "unknown"; raw: string };
+
+export function parseCommand(text: string): ParsedCommand {
+  const trimmed = text.trim();
+  if (trimmed === "") return { kind: "help" };
+
+  const tokens = trimmed.split(/\s+/);
+  const verb = tokens[0]!.toLowerCase();
+  const arg = tokens[1]?.toUpperCase();
+
+  if (verb === "help") return { kind: "help" };
+  if (verb === "list") return { kind: "list" };
+
+  if (verb === "status" || verb === "cancel") {
+    if (arg && TICKET_KEY_RE.test(arg)) {
+      return { kind: verb, ticketKey: arg };
+    }
+    return { kind: "unknown", raw: trimmed };
+  }
+
+  return { kind: "unknown", raw: trimmed };
+}

--- a/src/lib/slack/format.test.ts
+++ b/src/lib/slack/format.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { formatRunList, formatRunStatus } from "./format.js";
+
+const JIRA_BASE_URL = "https://example.atlassian.net";
+
+describe("formatRunList", () => {
+  it("returns empty-state copy when there are no rows", () => {
+    expect(formatRunList([], JIRA_BASE_URL)).toBe("No active workflows.");
+  });
+
+  it("renders one bullet per ticket with a Jira link and runId", () => {
+    const out = formatRunList(
+      [
+        { ticketKey: "AWT-1", runId: "run_a" },
+        { ticketKey: "AWT-2", runId: "run_b" },
+      ],
+      JIRA_BASE_URL,
+    );
+    expect(out).toContain(
+      "• <https://example.atlassian.net/browse/AWT-1|AWT-1> — runId: `run_a`",
+    );
+    expect(out).toContain(
+      "• <https://example.atlassian.net/browse/AWT-2|AWT-2> — runId: `run_b`",
+    );
+  });
+
+  it("strips a trailing slash on the Jira base URL", () => {
+    const out = formatRunList(
+      [{ ticketKey: "AWT-1", runId: "run_a" }],
+      "https://example.atlassian.net/",
+    );
+    expect(out).toContain("https://example.atlassian.net/browse/AWT-1|AWT-1");
+    expect(out).not.toContain(".net//browse");
+  });
+});
+
+describe("formatRunStatus", () => {
+  it("renders untracked when runId is null", () => {
+    expect(
+      formatRunStatus("AWT-1", { runId: null, sandboxId: null }, JIRA_BASE_URL),
+    ).toBe("<https://example.atlassian.net/browse/AWT-1|AWT-1>: not tracked.");
+  });
+
+  it("renders runId and sandbox presence", () => {
+    expect(
+      formatRunStatus(
+        "AWT-1",
+        { runId: "run_a", sandboxId: "sbx_x" },
+        JIRA_BASE_URL,
+      ),
+    ).toBe(
+      "<https://example.atlassian.net/browse/AWT-1|AWT-1>: runId `run_a`, sandbox: yes",
+    );
+  });
+
+  it("renders sandbox: no when sandboxId is null", () => {
+    expect(
+      formatRunStatus(
+        "AWT-1",
+        { runId: "run_a", sandboxId: null },
+        JIRA_BASE_URL,
+      ),
+    ).toBe(
+      "<https://example.atlassian.net/browse/AWT-1|AWT-1>: runId `run_a`, sandbox: no",
+    );
+  });
+});

--- a/src/lib/slack/format.ts
+++ b/src/lib/slack/format.ts
@@ -1,0 +1,39 @@
+export interface RunRow {
+  ticketKey: string;
+  runId: string;
+}
+
+export interface RunStatusSnapshot {
+  runId: string | null;
+  sandboxId: string | null;
+}
+
+export function formatRunList(rows: RunRow[], jiraBaseUrl: string): string {
+  if (rows.length === 0) return "No active workflows.";
+  return rows
+    .map(({ ticketKey, runId }) => `• ${jiraLink(ticketKey, jiraBaseUrl)} — runId: \`${runId}\``)
+    .join("\n");
+}
+
+export function formatRunStatus(
+  ticketKey: string,
+  snapshot: RunStatusSnapshot,
+  jiraBaseUrl: string,
+): string {
+  const link = jiraLink(ticketKey, jiraBaseUrl);
+  if (!snapshot.runId) return `${link}: not tracked.`;
+  const sandbox = snapshot.sandboxId ? "yes" : "no";
+  return `${link}: runId \`${snapshot.runId}\`, sandbox: ${sandbox}`;
+}
+
+export const HELP_TEXT = [
+  "*Blazebot commands*",
+  "• `/ai-workflow list` — show every tracked workflow",
+  "• `/ai-workflow status <KEY>` — show the run + sandbox tied to a ticket",
+  "• `/ai-workflow cancel <KEY>` — cancel the workflow run for a ticket",
+].join("\n");
+
+function jiraLink(ticketKey: string, jiraBaseUrl: string): string {
+  const base = jiraBaseUrl.replace(/\/$/, "");
+  return `<${base}/browse/${ticketKey}|${ticketKey}>`;
+}

--- a/src/lib/slack/handlers.test.ts
+++ b/src/lib/slack/handlers.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from "vitest";
+import type { RunRegistryAdapter } from "../../adapters/run-registry/types.js";
+
+vi.mock("../../../env.js", () => ({ env: {} }));
+
+const { handleCancel, handleList, handleStatus } = await import("./handlers.js");
+
+const JIRA_BASE_URL = "https://example.atlassian.net";
+
+function makeRegistry(overrides: Partial<RunRegistryAdapter> = {}): RunRegistryAdapter {
+  return {
+    claim: vi.fn(),
+    register: vi.fn(),
+    getRunId: overrides.getRunId ?? vi.fn().mockResolvedValue(null),
+    unregister: vi.fn().mockResolvedValue(undefined),
+    listAll: overrides.listAll ?? vi.fn().mockResolvedValue([]),
+    registerSandbox: vi.fn().mockResolvedValue(undefined),
+    getSandboxId: overrides.getSandboxId ?? vi.fn().mockResolvedValue(null),
+    getEntryCreatedAt: vi.fn().mockResolvedValue(null),
+    markFailed: vi.fn().mockResolvedValue(undefined),
+    isTicketFailed: vi.fn().mockResolvedValue(false),
+    listAllFailed: vi.fn().mockResolvedValue([]),
+    clearFailedMark: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("handleList", () => {
+  it("returns the empty-state message when no entries", async () => {
+    const registry = makeRegistry({ listAll: vi.fn().mockResolvedValue([]) });
+    expect(await handleList(registry, JIRA_BASE_URL)).toBe("No active workflows.");
+  });
+
+  it("filters out claiming sentinels", async () => {
+    const registry = makeRegistry({
+      listAll: vi.fn().mockResolvedValue([
+        { ticketKey: "AWT-1", runId: "run_real" },
+        { ticketKey: "AWT-2", runId: "claiming:1700000000000" },
+      ]),
+    });
+    const out = await handleList(registry, JIRA_BASE_URL);
+    expect(out).toContain("AWT-1");
+    expect(out).toContain("run_real");
+    expect(out).not.toContain("AWT-2");
+  });
+
+  it("returns empty-state message when only claiming sentinels exist", async () => {
+    const registry = makeRegistry({
+      listAll: vi.fn().mockResolvedValue([
+        { ticketKey: "AWT-1", runId: "claiming:1700000000000" },
+      ]),
+    });
+    expect(await handleList(registry, JIRA_BASE_URL)).toBe("No active workflows.");
+  });
+});
+
+describe("handleStatus", () => {
+  it("reports not tracked when no runId", async () => {
+    const registry = makeRegistry({
+      getRunId: vi.fn().mockResolvedValue(null),
+    });
+    expect(await handleStatus(registry, "AWT-99", JIRA_BASE_URL)).toContain(
+      "not tracked",
+    );
+  });
+
+  it("reports runId + sandbox: yes when sandbox is registered", async () => {
+    const registry = makeRegistry({
+      getRunId: vi.fn().mockResolvedValue("run_a"),
+      getSandboxId: vi.fn().mockResolvedValue("sbx_z"),
+    });
+    expect(await handleStatus(registry, "AWT-1", JIRA_BASE_URL)).toContain(
+      "runId `run_a`, sandbox: yes",
+    );
+  });
+
+  it("reports sandbox: no when no sandbox", async () => {
+    const registry = makeRegistry({
+      getRunId: vi.fn().mockResolvedValue("run_a"),
+      getSandboxId: vi.fn().mockResolvedValue(null),
+    });
+    expect(await handleStatus(registry, "AWT-1", JIRA_BASE_URL)).toContain(
+      "sandbox: no",
+    );
+  });
+});
+
+describe("handleCancel", () => {
+  it("returns 'no active run' when registry has no entry", async () => {
+    const registry = makeRegistry({ getRunId: vi.fn().mockResolvedValue(null) });
+    const cancelRunFn = vi.fn();
+    const stopSandboxes = vi.fn();
+    const out = await handleCancel(
+      registry,
+      "AWT-1",
+      cancelRunFn,
+      stopSandboxes,
+    );
+    expect(out).toContain("No active run");
+    expect(out).toContain("AWT-1");
+    expect(cancelRunFn).not.toHaveBeenCalled();
+    expect(stopSandboxes).not.toHaveBeenCalled();
+  });
+
+  it("warns the user when the entry is a claiming sentinel and stops the sandbox", async () => {
+    const registry = makeRegistry({
+      getRunId: vi.fn().mockResolvedValue("claiming:1700000000000"),
+      getSandboxId: vi.fn().mockResolvedValue("sbx_z"),
+    });
+    const cancelRunFn = vi.fn();
+    const stopSandboxes = vi.fn().mockResolvedValue(1);
+    const out = await handleCancel(
+      registry,
+      "AWT-1",
+      cancelRunFn,
+      stopSandboxes,
+    );
+    expect(out).toContain("mid-dispatch");
+    expect(stopSandboxes).toHaveBeenCalledWith("AWT-1", "sbx_z");
+    expect(registry.unregister).toHaveBeenCalledWith("AWT-1");
+    expect(cancelRunFn).not.toHaveBeenCalled();
+  });
+
+  it("calls cancelRun with ticket key + runId + registry, and reports success", async () => {
+    const registry = makeRegistry({
+      getRunId: vi.fn().mockResolvedValue("run_a"),
+    });
+    const cancelRunFn = vi.fn().mockResolvedValue(true);
+    const stopSandboxes = vi.fn();
+    const out = await handleCancel(
+      registry,
+      "AWT-1",
+      cancelRunFn,
+      stopSandboxes,
+    );
+    expect(cancelRunFn).toHaveBeenCalledWith("AWT-1", "run_a", registry);
+    expect(out).toContain("Cancelled");
+    expect(out).toContain("AWT-1");
+  });
+
+  it("reports cancel-failed-but-cleanup-done when cancelRun returns false", async () => {
+    const registry = makeRegistry({
+      getRunId: vi.fn().mockResolvedValue("run_a"),
+    });
+    const cancelRunFn = vi.fn().mockResolvedValue(false);
+    const out = await handleCancel(registry, "AWT-1", cancelRunFn, vi.fn());
+    expect(out).toContain("AWT-1");
+    expect(out.toLowerCase()).toContain("could not");
+  });
+});

--- a/src/lib/slack/handlers.ts
+++ b/src/lib/slack/handlers.ts
@@ -1,5 +1,6 @@
 import type { RunRegistryAdapter } from "../../adapters/run-registry/types.js";
 import { isClaimingSentinel } from "../dispatch.js";
+import { logger } from "../logger.js";
 import { formatRunList, formatRunStatus } from "./format.js";
 
 export type CancelRunFn = (
@@ -27,10 +28,18 @@ export async function handleStatus(
   ticketKey: string,
   jiraBaseUrl: string,
 ): Promise<string> {
-  const [runId, sandboxId] = await Promise.all([
-    registry.getRunId(ticketKey),
-    registry.getSandboxId(ticketKey),
-  ]);
+  // Sandbox lookup is best-effort: a missing or transiently-failing sandbox
+  // shouldn't blank out the runId we *can* read.
+  const runId = await registry.getRunId(ticketKey);
+  let sandboxId: string | null = null;
+  try {
+    sandboxId = await registry.getSandboxId(ticketKey);
+  } catch (err) {
+    logger.warn(
+      { ticketKey, error: (err as Error).message },
+      "slack_status_sandbox_lookup_failed",
+    );
+  }
   return formatRunStatus(ticketKey, { runId, sandboxId }, jiraBaseUrl);
 }
 
@@ -48,9 +57,39 @@ export async function handleCancel(
     // real runId. We can't cancel a workflow whose id we don't know. Stop any
     // sandbox that may have leaked and clear the entry so the next dispatch
     // sees a clean slot — same shape as the jira webhook handles it.
-    const sandboxId = await registry.getSandboxId(ticketKey).catch(() => null);
-    await stopSandboxes(ticketKey, sandboxId).catch(() => {});
-    await registry.unregister(ticketKey).catch(() => {});
+    let sandboxId: string | null = null;
+    try {
+      sandboxId = await registry.getSandboxId(ticketKey);
+    } catch (err) {
+      logger.warn(
+        { ticketKey, error: (err as Error).message },
+        "slack_cancel_sandbox_lookup_failed",
+      );
+    }
+
+    const failures: string[] = [];
+    try {
+      await stopSandboxes(ticketKey, sandboxId);
+    } catch (err) {
+      failures.push(`stopSandboxes: ${(err as Error).message}`);
+      logger.error(
+        { ticketKey, sandboxId, error: (err as Error).message },
+        "slack_cancel_stop_sandboxes_failed",
+      );
+    }
+    try {
+      await registry.unregister(ticketKey);
+    } catch (err) {
+      failures.push(`registry.unregister: ${(err as Error).message}`);
+      logger.error(
+        { ticketKey, error: (err as Error).message },
+        "slack_cancel_unregister_failed",
+      );
+    }
+
+    if (failures.length > 0) {
+      return `${ticketKey} is mid-dispatch; failed to clear the claim (${failures.join("; ")}). Check logs and retry.`;
+    }
     return `${ticketKey} is mid-dispatch; cleared the claim. Try the cancel again in a moment if a real run shows up.`;
   }
 

--- a/src/lib/slack/handlers.ts
+++ b/src/lib/slack/handlers.ts
@@ -1,0 +1,60 @@
+import type { RunRegistryAdapter } from "../../adapters/run-registry/types.js";
+import { isClaimingSentinel } from "../dispatch.js";
+import { formatRunList, formatRunStatus } from "./format.js";
+
+export type CancelRunFn = (
+  ticketKey: string,
+  runId: string,
+  registry: RunRegistryAdapter,
+) => Promise<boolean>;
+
+export type StopTicketSandboxesFn = (
+  ticketKey: string,
+  sandboxId: string | null,
+) => Promise<unknown>;
+
+export async function handleList(
+  registry: RunRegistryAdapter,
+  jiraBaseUrl: string,
+): Promise<string> {
+  const all = await registry.listAll();
+  const live = all.filter((row) => !isClaimingSentinel(row.runId));
+  return formatRunList(live, jiraBaseUrl);
+}
+
+export async function handleStatus(
+  registry: RunRegistryAdapter,
+  ticketKey: string,
+  jiraBaseUrl: string,
+): Promise<string> {
+  const [runId, sandboxId] = await Promise.all([
+    registry.getRunId(ticketKey),
+    registry.getSandboxId(ticketKey),
+  ]);
+  return formatRunStatus(ticketKey, { runId, sandboxId }, jiraBaseUrl);
+}
+
+export async function handleCancel(
+  registry: RunRegistryAdapter,
+  ticketKey: string,
+  cancelRunFn: CancelRunFn,
+  stopSandboxes: StopTicketSandboxesFn,
+): Promise<string> {
+  const runId = await registry.getRunId(ticketKey);
+  if (!runId) return `No active run for ${ticketKey}.`;
+
+  if (isClaimingSentinel(runId)) {
+    // Mid-dispatch: dispatch.ts has called start() but not yet swapped in the
+    // real runId. We can't cancel a workflow whose id we don't know. Stop any
+    // sandbox that may have leaked and clear the entry so the next dispatch
+    // sees a clean slot — same shape as the jira webhook handles it.
+    const sandboxId = await registry.getSandboxId(ticketKey).catch(() => null);
+    await stopSandboxes(ticketKey, sandboxId).catch(() => {});
+    await registry.unregister(ticketKey).catch(() => {});
+    return `${ticketKey} is mid-dispatch; cleared the claim. Try the cancel again in a moment if a real run shows up.`;
+  }
+
+  const ok = await cancelRunFn(ticketKey, runId, registry);
+  if (ok) return `Cancelled ${ticketKey} (runId \`${runId}\`).`;
+  return `${ticketKey}: could not cancel run \`${runId}\` cleanly — sandbox + registry have been cleaned up.`;
+}

--- a/src/lib/slack/respond.ts
+++ b/src/lib/slack/respond.ts
@@ -18,15 +18,20 @@ export interface SlackResponsePayload {
  * has already been ack'd should not retry the user's request just because
  * Slack momentarily 5xx'd on the follow-up post.
  */
+const RESPONSE_URL_TIMEOUT_MS = 5000;
+
 export async function postToResponseUrl(
   responseUrl: string,
   payload: SlackResponsePayload,
 ): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RESPONSE_URL_TIMEOUT_MS);
   try {
     const res = await fetch(responseUrl, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(payload),
+      signal: controller.signal,
     });
     if (!res.ok) {
       logger.warn(
@@ -39,5 +44,7 @@ export async function postToResponseUrl(
       { error: (err as Error).message },
       "slack_response_url_post_error",
     );
+  } finally {
+    clearTimeout(timer);
   }
 }

--- a/src/lib/slack/respond.ts
+++ b/src/lib/slack/respond.ts
@@ -1,0 +1,43 @@
+import { logger } from "../logger.js";
+
+export interface SlackResponsePayload {
+  text: string;
+  /**
+   * Slack-specific reply target. `ephemeral` is only visible to the invoking
+   * user; `in_channel` is visible to everyone in the channel.
+   */
+  response_type?: "ephemeral" | "in_channel";
+  replace_original?: boolean;
+}
+
+/**
+ * POST a follow-up message to Slack's `response_url` from a slash command.
+ *
+ * Failures are logged and swallowed: the same philosophy the messaging
+ * adapter applies — "notifications never break flows". A slash command that
+ * has already been ack'd should not retry the user's request just because
+ * Slack momentarily 5xx'd on the follow-up post.
+ */
+export async function postToResponseUrl(
+  responseUrl: string,
+  payload: SlackResponsePayload,
+): Promise<void> {
+  try {
+    const res = await fetch(responseUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      logger.warn(
+        { status: res.status, statusText: res.statusText },
+        "slack_response_url_post_failed",
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      { error: (err as Error).message },
+      "slack_response_url_post_error",
+    );
+  }
+}

--- a/src/lib/slack/verify.test.ts
+++ b/src/lib/slack/verify.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { createHmac } from "node:crypto";
+import { verifySlackSignature } from "./verify.js";
+
+const SIGNING_SECRET = "shhhh-do-not-tell";
+
+function sign(rawBody: string, timestamp: string, secret = SIGNING_SECRET): string {
+  const mac = createHmac("sha256", secret)
+    .update(`v0:${timestamp}:${rawBody}`)
+    .digest("hex");
+  return `v0=${mac}`;
+}
+
+describe("verifySlackSignature", () => {
+  it("returns true for a valid signature within the replay window", () => {
+    const rawBody = "command=%2Fblazebot&text=list";
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = sign(rawBody, timestamp);
+
+    expect(
+      verifySlackSignature({
+        rawBody,
+        timestamp,
+        signature,
+        signingSecret: SIGNING_SECRET,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when the body has been tampered", () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = sign("original", timestamp);
+
+    expect(
+      verifySlackSignature({
+        rawBody: "tampered",
+        timestamp,
+        signature,
+        signingSecret: SIGNING_SECRET,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the timestamp is older than 5 minutes", () => {
+    const rawBody = "ok";
+    const tooOld = String(Math.floor(Date.now() / 1000) - 6 * 60);
+    const signature = sign(rawBody, tooOld);
+
+    expect(
+      verifySlackSignature({
+        rawBody,
+        timestamp: tooOld,
+        signature,
+        signingSecret: SIGNING_SECRET,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the timestamp is in the far future", () => {
+    const rawBody = "ok";
+    const tooNew = String(Math.floor(Date.now() / 1000) + 10 * 60);
+    const signature = sign(rawBody, tooNew);
+
+    expect(
+      verifySlackSignature({
+        rawBody,
+        timestamp: tooNew,
+        signature,
+        signingSecret: SIGNING_SECRET,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false on a length-mismatched signature without throwing", () => {
+    const rawBody = "ok";
+    const timestamp = String(Math.floor(Date.now() / 1000));
+
+    expect(() =>
+      verifySlackSignature({
+        rawBody,
+        timestamp,
+        signature: "v0=short",
+        signingSecret: SIGNING_SECRET,
+      }),
+    ).not.toThrow();
+    expect(
+      verifySlackSignature({
+        rawBody,
+        timestamp,
+        signature: "v0=short",
+        signingSecret: SIGNING_SECRET,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the signature is missing the v0= prefix", () => {
+    const rawBody = "ok";
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = sign(rawBody, timestamp).slice("v0=".length);
+
+    expect(
+      verifySlackSignature({
+        rawBody,
+        timestamp,
+        signature,
+        signingSecret: SIGNING_SECRET,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the timestamp is not a valid integer", () => {
+    expect(
+      verifySlackSignature({
+        rawBody: "ok",
+        timestamp: "not-a-number",
+        signature: "v0=deadbeef",
+        signingSecret: SIGNING_SECRET,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/slack/verify.ts
+++ b/src/lib/slack/verify.ts
@@ -1,0 +1,39 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const REPLAY_WINDOW_SECONDS = 60 * 5;
+const SIGNATURE_PREFIX = "v0=";
+
+export interface VerifySlackSignatureInput {
+  rawBody: string;
+  timestamp: string;
+  signature: string;
+  signingSecret: string;
+}
+
+/**
+ * Verify Slack's `x-slack-signature` HMAC, per
+ * https://api.slack.com/authentication/verifying-requests-from-slack.
+ *
+ * The 5-minute replay window protects against attackers replaying a captured
+ * (and otherwise valid) signed request long after Slack would have retried.
+ */
+export function verifySlackSignature(input: VerifySlackSignatureInput): boolean {
+  const { rawBody, timestamp, signature, signingSecret } = input;
+
+  if (!signature.startsWith(SIGNATURE_PREFIX)) return false;
+
+  const ts = Number.parseInt(timestamp, 10);
+  if (!Number.isFinite(ts)) return false;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (Math.abs(nowSeconds - ts) > REPLAY_WINDOW_SECONDS) return false;
+
+  const expected = createHmac("sha256", signingSecret)
+    .update(`v0:${timestamp}:${rawBody}`)
+    .digest("hex");
+  const expectedFull = SIGNATURE_PREFIX + expected;
+
+  const a = Buffer.from(signature);
+  const b = Buffer.from(expectedFull);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/src/routes/webhooks/slack.post.test.ts
+++ b/src/routes/webhooks/slack.post.test.ts
@@ -199,6 +199,7 @@ describe("POST /webhooks/slack", () => {
     await handler(makeRequest(body));
     await flushDeferred();
     expect(cancelRunFn).not.toHaveBeenCalled();
+    expect(postedToResponseUrl).toHaveLength(1);
     expect(postedToResponseUrl[0]!.payload.text).toContain("No active run for AWT-1");
   });
 
@@ -218,6 +219,7 @@ describe("POST /webhooks/slack", () => {
 
     expect(cancelRunFn).toHaveBeenCalledTimes(1);
     expect(cancelRunFn).toHaveBeenCalledWith("AWT-1", "run_a", runRegistry);
+    expect(postedToResponseUrl).toHaveLength(1);
     expect(postedToResponseUrl[0]!.payload.text).toContain("Cancelled AWT-1");
   });
 

--- a/src/routes/webhooks/slack.post.test.ts
+++ b/src/routes/webhooks/slack.post.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createApp, toWebHandler } from "h3";
+import { createHmac } from "node:crypto";
+
+const SIGNING_SECRET = "shhhh-do-not-tell";
+const JIRA_BASE_URL = "https://example.atlassian.net";
+
+// Mock env BEFORE importing anything that pulls it in transitively.
+vi.mock("../../../env.js", () => ({
+  env: {
+    SLACK_SIGNING_SECRET: SIGNING_SECRET,
+    SLACK_ALLOWED_USER_IDS: undefined as string | undefined,
+    JIRA_BASE_URL,
+  },
+}));
+
+// Adapters: only runRegistry matters for these tests.
+const runRegistry = {
+  claim: vi.fn(),
+  register: vi.fn(),
+  getRunId: vi.fn(),
+  unregister: vi.fn().mockResolvedValue(undefined),
+  listAll: vi.fn(),
+  registerSandbox: vi.fn(),
+  getSandboxId: vi.fn().mockResolvedValue(null),
+  getEntryCreatedAt: vi.fn(),
+  markFailed: vi.fn(),
+  isTicketFailed: vi.fn(),
+  listAllFailed: vi.fn(),
+  clearFailedMark: vi.fn(),
+};
+vi.mock("../../lib/adapters.js", () => ({
+  createAdapters: () => ({
+    runRegistry,
+    issueTracker: {},
+    vcs: {},
+    messaging: {},
+  }),
+}));
+
+const cancelRunFn = vi.fn();
+vi.mock("../../lib/cancel-run.js", () => ({
+  cancelRun: (...args: any[]) => cancelRunFn(...args),
+}));
+
+const stopTicketSandboxesFn = vi.fn();
+vi.mock("../../sandbox/stop-ticket-sandboxes.js", () => ({
+  stopTicketSandboxes: (...args: any[]) => stopTicketSandboxesFn(...args),
+}));
+
+let postedToResponseUrl: Array<{ url: string; payload: any }> = [];
+vi.mock("../../lib/slack/respond.js", () => ({
+  postToResponseUrl: vi.fn(async (url: string, payload: any) => {
+    postedToResponseUrl.push({ url, payload });
+  }),
+}));
+
+const slackHandler = (await import("./slack.post.js")).default;
+
+function makeApp() {
+  const app = createApp();
+  app.use("/", slackHandler);
+  return toWebHandler(app);
+}
+
+function sign(rawBody: string, timestamp: string): string {
+  const mac = createHmac("sha256", SIGNING_SECRET)
+    .update(`v0:${timestamp}:${rawBody}`)
+    .digest("hex");
+  return `v0=${mac}`;
+}
+
+function makeRequest(
+  body: string,
+  opts: { signed?: boolean; timestamp?: string } = {},
+): Request {
+  const timestamp = opts.timestamp ?? String(Math.floor(Date.now() / 1000));
+  const headers: Record<string, string> = {
+    "content-type": "application/x-www-form-urlencoded",
+  };
+  if (opts.signed !== false) {
+    headers["x-slack-request-timestamp"] = timestamp;
+    headers["x-slack-signature"] = sign(body, timestamp);
+  }
+  return new Request("http://localhost/", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+function form(fields: Record<string, string>): string {
+  return new URLSearchParams(fields).toString();
+}
+
+async function flushDeferred(): Promise<void> {
+  // event.waitUntil is not available on the bare h3 app, so the route falls
+  // back to fire-and-forget. Yield to the microtask queue so the deferred
+  // postToResponseUrl call lands before assertions.
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe("POST /webhooks/slack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    postedToResponseUrl = [];
+    runRegistry.listAll.mockResolvedValue([]);
+    runRegistry.getRunId.mockResolvedValue(null);
+    runRegistry.getSandboxId.mockResolvedValue(null);
+  });
+
+  it("returns 401 on a tampered body", async () => {
+    const handler = makeApp();
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const headers = {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-slack-request-timestamp": timestamp,
+      "x-slack-signature": sign("original", timestamp),
+    };
+    const res = await handler(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers,
+        body: "tampered",
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when signature headers are missing", async () => {
+    const handler = makeApp();
+    const res = await handler(makeRequest(form({ text: "list" }), { signed: false }));
+    expect(res.status).toBe(401);
+  });
+
+  it("acks /ai-workflow list within 200 and posts the formatted list to response_url", async () => {
+    runRegistry.listAll.mockResolvedValue([
+      { ticketKey: "AWT-1", runId: "run_real" },
+      { ticketKey: "AWT-2", runId: "claiming:1700000000000" },
+    ]);
+
+    const handler = makeApp();
+    const body = form({
+      command: "/ai-workflow",
+      text: "list",
+      user_id: "U999",
+      response_url: "https://hooks.slack.com/commands/T1/abc",
+    });
+    const res = await handler(makeRequest(body));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.response_type).toBe("ephemeral");
+    expect(json.text).toContain("Working on");
+
+    await flushDeferred();
+    expect(postedToResponseUrl).toHaveLength(1);
+    expect(postedToResponseUrl[0]!.url).toBe(
+      "https://hooks.slack.com/commands/T1/abc",
+    );
+    expect(postedToResponseUrl[0]!.payload.response_type).toBe("in_channel");
+    expect(postedToResponseUrl[0]!.payload.text).toContain("AWT-1");
+    expect(postedToResponseUrl[0]!.payload.text).toContain("run_real");
+    expect(postedToResponseUrl[0]!.payload.text).not.toContain("AWT-2");
+  });
+
+  it("returns ephemeral 'Not authorized.' when user is not in the allowlist", async () => {
+    const { env } = await import("../../../env.js");
+    (env as any).SLACK_ALLOWED_USER_IDS = "UALLOWED1,UALLOWED2";
+    try {
+      const handler = makeApp();
+      const body = form({
+        command: "/ai-workflow",
+        text: "list",
+        user_id: "UDENIED",
+        response_url: "https://hooks.slack.com/commands/T1/abc",
+      });
+      const res = await handler(makeRequest(body));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.response_type).toBe("ephemeral");
+      expect(json.text).toBe("Not authorized.");
+      await flushDeferred();
+      expect(postedToResponseUrl).toHaveLength(0);
+    } finally {
+      (env as any).SLACK_ALLOWED_USER_IDS = undefined;
+    }
+  });
+
+  it("/ai-workflow cancel AWT-1 with no entry posts 'No active run' to response_url", async () => {
+    runRegistry.getRunId.mockResolvedValue(null);
+    const handler = makeApp();
+    const body = form({
+      command: "/ai-workflow",
+      text: "cancel AWT-1",
+      user_id: "U1",
+      response_url: "https://hooks.slack.com/commands/T1/abc",
+    });
+    await handler(makeRequest(body));
+    await flushDeferred();
+    expect(cancelRunFn).not.toHaveBeenCalled();
+    expect(postedToResponseUrl[0]!.payload.text).toContain("No active run for AWT-1");
+  });
+
+  it("/ai-workflow cancel AWT-1 with a real entry calls cancelRun once with the right args", async () => {
+    runRegistry.getRunId.mockResolvedValue("run_a");
+    cancelRunFn.mockResolvedValue(true);
+
+    const handler = makeApp();
+    const body = form({
+      command: "/ai-workflow",
+      text: "cancel AWT-1",
+      user_id: "U1",
+      response_url: "https://hooks.slack.com/commands/T1/abc",
+    });
+    await handler(makeRequest(body));
+    await flushDeferred();
+
+    expect(cancelRunFn).toHaveBeenCalledTimes(1);
+    expect(cancelRunFn).toHaveBeenCalledWith("AWT-1", "run_a", runRegistry);
+    expect(postedToResponseUrl[0]!.payload.text).toContain("Cancelled AWT-1");
+  });
+
+  it("an empty /ai-workflow returns the help text synchronously", async () => {
+    const handler = makeApp();
+    const res = await handler(
+      makeRequest(
+        form({
+          command: "/ai-workflow",
+          text: "",
+          user_id: "U1",
+          response_url: "https://hooks.slack.com/commands/T1/abc",
+        }),
+      ),
+    );
+    const json = await res.json();
+    expect(json.response_type).toBe("ephemeral");
+    expect(json.text).toContain("Blazebot commands");
+  });
+});

--- a/src/routes/webhooks/slack.post.ts
+++ b/src/routes/webhooks/slack.post.ts
@@ -1,0 +1,162 @@
+import { defineEventHandler, readRawBody, getHeader, createError, type H3Event } from "h3";
+import { env } from "../../../env.js";
+import { createAdapters } from "../../lib/adapters.js";
+import { cancelRun } from "../../lib/cancel-run.js";
+import { logger } from "../../lib/logger.js";
+import { stopTicketSandboxes } from "../../sandbox/stop-ticket-sandboxes.js";
+import { parseCommand, type ParsedCommand } from "../../lib/slack/commands.js";
+import { HELP_TEXT } from "../../lib/slack/format.js";
+import {
+  handleCancel,
+  handleList,
+  handleStatus,
+} from "../../lib/slack/handlers.js";
+import { postToResponseUrl } from "../../lib/slack/respond.js";
+import { verifySlackSignature } from "../../lib/slack/verify.js";
+
+/**
+ * Slack slash command webhook.
+ *
+ * Configure in api.slack.com → Slash Commands:
+ *   Command:     /ai-workflow
+ *   Request URL: https://<your-domain>/webhooks/slack
+ *
+ * Auth: HMAC-SHA256 over `v0:${timestamp}:${rawBody}` (Slack signs every
+ * request when a Signing Secret is configured for the app).
+ *
+ * The 3s ack budget is critical: Slack drops requests that don't respond in
+ * time. We verify, parse, schedule the real work via `event.waitUntil`, and
+ * return immediately. Results are POSTed back to `response_url`.
+ */
+export default defineEventHandler(async (event) => {
+  const rawBody = (await readRawBody(event, "utf8")) ?? "";
+
+  verifyWebhookAuth(event, rawBody);
+
+  const fields = parseFormBody(rawBody);
+  const text = fields.get("text") ?? "";
+  const userId = fields.get("user_id") ?? "";
+  const responseUrl = fields.get("response_url") ?? "";
+  const command = fields.get("command") ?? "/ai-workflow";
+
+  if (!isUserAllowed(userId)) {
+    logger.info({ userId, command }, "slack_command_user_not_allowed");
+    return ephemeral("Not authorized.");
+  }
+
+  const parsed = parseCommand(text);
+
+  if (parsed.kind === "help" || parsed.kind === "unknown") {
+    logger.info({ userId, command, parsedKind: parsed.kind }, "slack_command_help_or_unknown");
+    return ephemeral(parsed.kind === "help" ? HELP_TEXT : `Unknown command. ${HELP_TEXT}`);
+  }
+
+  if (!responseUrl) {
+    // Without response_url we have no way to post the deferred result, so
+    // fail loud rather than silently dropping the user's request.
+    throw createError({ statusCode: 400, statusMessage: "Missing response_url" });
+  }
+
+  logger.info(
+    { userId, command, parsedKind: parsed.kind },
+    "slack_command_dispatching",
+  );
+
+  scheduleHandler(event, parsed, responseUrl);
+
+  return ephemeral(`Working on \`${command} ${text}\`…`);
+});
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+function verifyWebhookAuth(event: H3Event, rawBody: string): void {
+  const signature = getHeader(event, "x-slack-signature");
+  const timestamp = getHeader(event, "x-slack-request-timestamp");
+  if (!signature || !timestamp) {
+    throw createError({ statusCode: 401, statusMessage: "Missing Slack signature headers" });
+  }
+  const ok = verifySlackSignature({
+    rawBody,
+    timestamp,
+    signature,
+    signingSecret: env.SLACK_SIGNING_SECRET,
+  });
+  if (!ok) {
+    throw createError({ statusCode: 401, statusMessage: "Invalid Slack signature" });
+  }
+}
+
+function isUserAllowed(userId: string): boolean {
+  if (!env.SLACK_ALLOWED_USER_IDS) return true;
+  const allow = env.SLACK_ALLOWED_USER_IDS
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (allow.length === 0) return true;
+  return allow.includes(userId);
+}
+
+// ---------------------------------------------------------------------------
+// Body parsing
+// ---------------------------------------------------------------------------
+
+function parseFormBody(rawBody: string): URLSearchParams {
+  return new URLSearchParams(rawBody);
+}
+
+// ---------------------------------------------------------------------------
+// Response shaping
+// ---------------------------------------------------------------------------
+
+function ephemeral(text: string) {
+  return { response_type: "ephemeral" as const, text };
+}
+
+// ---------------------------------------------------------------------------
+// Deferred work
+// ---------------------------------------------------------------------------
+
+function scheduleHandler(
+  event: H3Event,
+  parsed: ParsedCommand,
+  responseUrl: string,
+): void {
+  const promise = runHandler(parsed, responseUrl);
+  // Nitro mounts waitUntil onto the event in its app entry. On platforms that
+  // support it (Vercel, Cloudflare) this lets the function keep working after
+  // the response is sent. On platforms without it, fall back to fire-and-
+  // forget — the slash command will still ack within 3s.
+  if (typeof event.waitUntil === "function") {
+    event.waitUntil(promise);
+    return;
+  }
+  promise.catch((err) =>
+    logger.error({ error: (err as Error).message }, "slack_handler_unhandled_error"),
+  );
+}
+
+async function runHandler(parsed: ParsedCommand, responseUrl: string): Promise<void> {
+  const text = await executeCommand(parsed);
+  await postToResponseUrl(responseUrl, {
+    response_type: "in_channel",
+    text,
+  });
+}
+
+async function executeCommand(parsed: ParsedCommand): Promise<string> {
+  const { runRegistry } = createAdapters();
+  switch (parsed.kind) {
+    case "list":
+      return handleList(runRegistry, env.JIRA_BASE_URL);
+    case "status":
+      return handleStatus(runRegistry, parsed.ticketKey, env.JIRA_BASE_URL);
+    case "cancel":
+      return handleCancel(runRegistry, parsed.ticketKey, cancelRun, stopTicketSandboxes);
+    case "help":
+    case "unknown":
+      // Already handled synchronously, but exhaustive for type-narrowing.
+      return HELP_TEXT;
+  }
+}

--- a/src/routes/webhooks/slack.post.ts
+++ b/src/routes/webhooks/slack.post.ts
@@ -123,18 +123,23 @@ function scheduleHandler(
   parsed: ParsedCommand,
   responseUrl: string,
 ): void {
-  const promise = runHandler(parsed, responseUrl);
+  // Always attach error logging *before* handing the promise off — otherwise an
+  // unhandled rejection inside the waitUntil-extended invocation disappears
+  // silently. The .catch returns void, so waitUntil still sees a settled
+  // promise and keeps the function alive for the original work.
+  const promise = runHandler(parsed, responseUrl).catch((err) =>
+    logger.error(
+      { error: (err as Error).message, parsedKind: parsed.kind },
+      "slack_handler_unhandled_error",
+    ),
+  );
   // Nitro mounts waitUntil onto the event in its app entry. On platforms that
   // support it (Vercel, Cloudflare) this lets the function keep working after
   // the response is sent. On platforms without it, fall back to fire-and-
   // forget — the slash command will still ack within 3s.
   if (typeof event.waitUntil === "function") {
     event.waitUntil(promise);
-    return;
   }
-  promise.catch((err) =>
-    logger.error({ error: (err as Error).message }, "slack_handler_unhandled_error"),
-  );
 }
 
 async function runHandler(parsed: ParsedCommand, responseUrl: string): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash-command support: /ai-workflow with subcommands list, status <KEY>, cancel <KEY>, plus inline help and clearer responses (ephemeral acknowledgements and posted results).

* **Documentation**
  * Updated Slack setup and registration steps; added required SLACK_SIGNING_SECRET and optional SLACK_ALLOWED_USER_IDS, smoke tests, and troubleshooting notes for slash-command registration and signing-secret rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->