### PR TITLE
Address auth follow-up review comments

### DIFF
--- a/apps/dashboard/app/api/auth/sso/start/route.ts
+++ b/apps/dashboard/app/api/auth/sso/start/route.ts
@@ -3,7 +3,12 @@ import { NextResponse } from "next/server";
 import { fetchAuthWorker, readWorkerJson } from "@/lib/auth/worker";
 
 export async function GET(req: Request) {
-  const res = await fetchAuthWorker("/api/dashboard-auth/sso/start");
+  const url = new URL(req.url);
+  const inviteId = url.searchParams.get("inviteId")?.trim();
+  const workerPath = inviteId
+    ? `/api/dashboard-auth/sso/start?inviteId=${encodeURIComponent(inviteId)}`
+    : "/api/dashboard-auth/sso/start";
+  const res = await fetchAuthWorker(workerPath);
   if (!res?.ok) {
     return NextResponse.redirect(new URL("/login", req.url));
   }

--- a/apps/dashboard/app/api/auth/sso/status/route.ts
+++ b/apps/dashboard/app/api/auth/sso/status/route.ts
@@ -5,7 +5,7 @@ import { fetchAuthWorker, readWorkerJson } from "@/lib/auth/worker";
 export async function GET() {
   const res = await fetchAuthWorker("/api/dashboard-auth/sso/status");
   if (!res?.ok) {
-    return NextResponse.json({ enabled: false });
+    return NextResponse.json({ enabled: null }, { status: 502 });
   }
 
   const body = await readWorkerJson<{ enabled?: unknown }>(res);

--- a/apps/dashboard/app/invite/accept/invite-accept-form.tsx
+++ b/apps/dashboard/app/invite/accept/invite-accept-form.tsx
@@ -235,7 +235,9 @@ export default function InviteAcceptForm({ inviteId }: { inviteId: string }) {
               <AuthButton
                 type="button"
                 onClick={() => {
-                  window.location.assign("/api/auth/sso/start");
+                  window.location.assign(
+                    `/api/auth/sso/start?inviteId=${encodeURIComponent(inviteId)}`,
+                  );
                 }}
               >
                 Continue with SSO

--- a/apps/dashboard/app/login/page.tsx
+++ b/apps/dashboard/app/login/page.tsx
@@ -19,7 +19,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
-  const [ssoEnabled, setSsoEnabled] = useState(false);
+  const [ssoEnabled, setSsoEnabled] = useState<boolean | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -27,10 +27,12 @@ export default function LoginPage() {
     fetch("/api/auth/sso/status", { cache: "no-store" })
       .then((res) => (res.ok ? res.json() : null))
       .then((body: { enabled?: unknown } | null) => {
-        if (!cancelled) setSsoEnabled(body?.enabled === true);
+        if (!cancelled) {
+          setSsoEnabled(typeof body?.enabled === "boolean" ? body.enabled : null);
+        }
       })
       .catch(() => {
-        if (!cancelled) setSsoEnabled(false);
+        if (!cancelled) setSsoEnabled(null);
       });
 
     return () => {
@@ -73,7 +75,7 @@ export default function LoginPage() {
         <AuthFormShell title="Sign in" subtitle="Welcome back to AI Workflow.">
           {error ? <AuthBanner tone="error">{error}</AuthBanner> : null}
 
-          {ssoEnabled ? (
+          {ssoEnabled !== false ? (
             <>
               <AuthButton
                 type="button"

--- a/apps/dashboard/components/cockpit/screens/users.tsx
+++ b/apps/dashboard/components/cockpit/screens/users.tsx
@@ -42,9 +42,13 @@ export function UsersScreen({
   initialUsers: DashboardUserRow[];
   initialInvites: DashboardInviteRow[];
 }) {
+  const initialUsersKey = snapshotKey(initialUsers);
+  const initialInvitesKey = snapshotKey(initialInvites);
   const [tab, setTab] = useState<"members" | "invites">("members");
   const [users, setUsers] = useState(initialUsers);
   const [invites, setInvites] = useState(initialInvites);
+  const [appliedUsersKey, setAppliedUsersKey] = useState(initialUsersKey);
+  const [appliedInvitesKey, setAppliedInvitesKey] = useState(initialInvitesKey);
   const [inviteOpen, setInviteOpen] = useState(false);
   const [roleChange, setRoleChange] = useState<{
     user: DashboardUserRow;
@@ -54,12 +58,16 @@ export function UsersScreen({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (initialUsersKey === appliedUsersKey) return;
     setUsers(initialUsers);
-  }, [initialUsers]);
+    setAppliedUsersKey(initialUsersKey);
+  }, [initialUsers, initialUsersKey, appliedUsersKey]);
 
   useEffect(() => {
+    if (initialInvitesKey === appliedInvitesKey) return;
     setInvites(initialInvites);
-  }, [initialInvites]);
+    setAppliedInvitesKey(initialInvitesKey);
+  }, [initialInvites, initialInvitesKey, appliedInvitesKey]);
 
   async function changeRole(user: DashboardUserRow, nextRole: "admin" | "member") {
     setBusyId(user.id);
@@ -203,6 +211,10 @@ export function UsersScreen({
       ) : null}
     </div>
   );
+}
+
+function snapshotKey(rows: unknown[]): string {
+  return JSON.stringify(rows);
 }
 
 export function NotAuthorizedScreen() {

--- a/apps/dashboard/lib/api/proxy.ts
+++ b/apps/dashboard/lib/api/proxy.ts
@@ -1,16 +1,8 @@
 import "server-only";
 import { cookies } from "next/headers";
+import { workerUrl } from "@/lib/auth/worker-core";
 
-const BASE = process.env.WORKER_BASE_URL;
 const FETCH_TIMEOUT_MS = 10_000;
-
-function workerUrl(path: string): string {
-  if (!BASE) {
-    throw new Error("WORKER_BASE_URL is required for dashboard API proxying");
-  }
-
-  return `${BASE}${path}`;
-}
 
 export async function proxyWorker(path: string, init: RequestInit = {}): Promise<Response> {
   const jar = await cookies();
@@ -18,7 +10,7 @@ export async function proxyWorker(path: string, init: RequestInit = {}): Promise
   const headers = new Headers(init.headers);
   if (session) headers.set("authorization", `Bearer ${session}`);
 
-  return fetch(workerUrl(path), {
+  return fetch(workerUrl(process.env.WORKER_BASE_URL, path), {
     ...init,
     headers,
     cache: "no-store",

--- a/apps/dashboard/lib/api/server.ts
+++ b/apps/dashboard/lib/api/server.ts
@@ -3,17 +3,9 @@ import "server-only";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { ForbiddenError, UnauthorizedError } from "@/lib/auth/errors";
+import { workerUrl } from "@/lib/auth/worker-core";
 
-const BASE = process.env.WORKER_BASE_URL;
 const FETCH_TIMEOUT_MS = 10_000;
-
-function workerUrl(path: string): string {
-  if (!BASE) {
-    throw new Error("WORKER_BASE_URL is required for dashboard server API calls");
-  }
-
-  return `${BASE}${path}`;
-}
 
 /** Append a query string, skipping empty/undefined values. */
 export function withQuery(
@@ -40,7 +32,7 @@ export function withQuery(
 export async function getJSON<T>(path: string): Promise<T> {
   const jar = await cookies();
   const session = jar.get("ba_session")?.value;
-  const res = await fetch(workerUrl(path), {
+  const res = await fetch(workerUrl(process.env.WORKER_BASE_URL, path), {
     cache: "no-store",
     headers: session ? { Authorization: `Bearer ${session}` } : undefined,
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),

--- a/apps/dashboard/lib/auth/worker-core.ts
+++ b/apps/dashboard/lib/auth/worker-core.ts
@@ -1,8 +1,8 @@
 const WORKER_TIMEOUT_MS = 10_000;
 
-function workerUrl(base: string | undefined, path: string): string {
+export function workerUrl(base: string | undefined, path: string): string {
   if (!base) {
-    throw new Error("WORKER_BASE_URL is required for dashboard auth requests");
+    throw new Error("WORKER_BASE_URL is required for dashboard worker requests");
   }
 
   return `${base}${path}`;

--- a/apps/worker/src/auth.test.ts
+++ b/apps/worker/src/auth.test.ts
@@ -115,6 +115,39 @@ describe("seedAuthUser", () => {
     });
     expect(tokenFrom(signIn)).toBeTruthy();
   });
+
+  it("resolves concurrent credential linking for an existing SSO-only owner", async () => {
+    const { auth, db } = await freshAuthContext();
+    const ctx = await auth.$context;
+    const created = await ctx.internalAdapter.createUser({
+      email: "owner@example.com",
+      name: "Owner",
+      emailVerified: true,
+    });
+    await ctx.internalAdapter.linkAccount({
+      userId: created.id,
+      providerId: DASHBOARD_SSO_PROVIDER_ID,
+      accountId: "sso-subject",
+    });
+
+    await expect(
+      Promise.all([
+        seedAuthUser(auth, { email: "owner@example.com", password: "password123" }),
+        seedAuthUser(auth, { email: "owner@example.com", password: "password123" }),
+      ]),
+    ).resolves.toHaveLength(2);
+
+    const credentials = await db
+      .select()
+      .from(account)
+      .where(
+        and(
+          eq(account.userId, created.id),
+          eq(account.providerId, "credential"),
+        ),
+      );
+    expect(credentials).toHaveLength(1);
+  });
 });
 
 describe("bootstrapDashboardAuth", () => {

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -128,6 +128,9 @@ export function createAuth(db: Db, options: AuthOptions) {
 }
 
 export type Auth = ReturnType<typeof createAuth>;
+type AuthContext = Awaited<Auth["$context"]>;
+
+const AUTH_SEED_MAX_ATTEMPTS = 3;
 
 export async function userHasCredentialAccount(db: Db, userId: string): Promise<boolean> {
   const [credential] = await db
@@ -188,29 +191,32 @@ export async function seedAuthUser(
 ): Promise<{ created: boolean; updated: boolean }> {
   const email = creds.email.trim().toLowerCase();
   const ctx = await auth.$context;
+  return retryOnUniqueViolation(() => seedAuthUserOnce(ctx, { ...creds, email }));
+}
+
+async function seedAuthUserOnce(
+  ctx: AuthContext,
+  creds: { email: string; password: string; name?: string },
+): Promise<{ created: boolean; updated: boolean }> {
+  const email = creds.email;
   const existing = await ctx.internalAdapter.findUserByEmail(email, {
     includeAccounts: true,
   });
 
   if (!existing) {
     const hash = await ctx.password.hash(creds.password);
-    try {
-      const created = await ctx.internalAdapter.createUser({
-        email,
-        name: creds.name ?? email,
-        emailVerified: true,
-      });
-      await ctx.internalAdapter.linkAccount({
-        userId: created.id,
-        providerId: "credential",
-        accountId: created.id,
-        password: hash,
-      });
-      return { created: true, updated: false };
-    } catch (error) {
-      if (!isUniqueViolation(error)) throw error;
-      return seedAuthUser(auth, { ...creds, email });
-    }
+    const created = await ctx.internalAdapter.createUser({
+      email,
+      name: creds.name ?? email,
+      emailVerified: true,
+    });
+    await ctx.internalAdapter.linkAccount({
+      userId: created.id,
+      providerId: "credential",
+      accountId: created.id,
+      password: hash,
+    });
+    return { created: true, updated: false };
   }
 
   const credential = existing.accounts.find((a) => a.providerId === "credential");
@@ -234,6 +240,20 @@ export async function seedAuthUser(
   }
 
   return { created: false, updated: false };
+}
+
+async function retryOnUniqueViolation<T>(operation: () => Promise<T>): Promise<T> {
+  for (let attempt = 0; attempt < AUTH_SEED_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!isUniqueViolation(error) || attempt === AUTH_SEED_MAX_ATTEMPTS - 1) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error("Unreachable auth seed retry state");
 }
 
 /**
@@ -425,7 +445,10 @@ function isUniqueViolation(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const maybeCode = (error as { code?: unknown }).code;
   if (maybeCode === "23505") return true;
-  return error instanceof Error && /duplicate key|unique constraint/i.test(error.message);
+  if (error instanceof Error && /duplicate key|unique constraint/i.test(error.message)) {
+    return true;
+  }
+  return isUniqueViolation((error as { cause?: unknown }).cause);
 }
 
 /**

--- a/apps/worker/src/lib/auth/invite-acceptance.test.ts
+++ b/apps/worker/src/lib/auth/invite-acceptance.test.ts
@@ -11,6 +11,7 @@ import { account, invitation, member, organization, user } from "../../db/schema
 import { createTestDb } from "../../db/test-db.js";
 import type { DashboardRole } from "./roles.js";
 import {
+  acceptDashboardSsoInvite,
   acceptDashboardInvite,
   getDashboardInviteAcceptanceState,
 } from "./invite-acceptance.js";
@@ -236,6 +237,72 @@ describe("acceptDashboardInvite", () => {
       .select({ role: member.role })
       .from(member)
       .where(eq(member.userId, result.user.id));
+    expect(membership).toEqual({ role: "admin" });
+  });
+
+  it("does not demote an existing owner when accepting a lower-role invite", async () => {
+    const { db, auth } = await setupInvite("existing@example.com", "member");
+    await seedAuthUser(auth, {
+      email: "existing@example.com",
+      password: "password123",
+      name: "Existing",
+    });
+    const [existingUser] = await db
+      .select({ id: user.id })
+      .from(user)
+      .where(eq(user.email, "existing@example.com"));
+    await db.insert(member).values({
+      id: "member_existing",
+      organizationId: "org_aiw",
+      userId: existingUser.id,
+      role: "owner",
+    });
+
+    await acceptDashboardInvite(db, auth, {
+      organizationSlug: "ai-workflow",
+      inviteId: "invite_1",
+      password: "password123",
+      now: new Date("2026-06-26T00:00:00.000Z"),
+    });
+
+    const [membership] = await db
+      .select({ role: member.role })
+      .from(member)
+      .where(eq(member.userId, existingUser.id));
+    expect(membership).toEqual({ role: "owner" });
+  });
+
+  it("accepts an SSO-only invite for the authenticated SSO user", async () => {
+    const { db, auth } = await setupInvite("sso@example.com", "admin");
+    const ctx = await auth.$context;
+    const ssoUser = await ctx.internalAdapter.createUser({
+      email: "sso@example.com",
+      name: "SSO User",
+      emailVerified: true,
+    });
+    await ctx.internalAdapter.linkAccount({
+      userId: ssoUser.id,
+      providerId: DASHBOARD_SSO_PROVIDER_ID,
+      accountId: "sso-subject",
+    });
+
+    await acceptDashboardSsoInvite(db, auth, {
+      organizationSlug: "ai-workflow",
+      inviteId: "invite_1",
+      user: { id: ssoUser.id, email: "sso@example.com" },
+      now: new Date("2026-06-26T00:00:00.000Z"),
+    });
+
+    const [accepted] = await db
+      .select({ status: invitation.status })
+      .from(invitation)
+      .where(eq(invitation.id, "invite_1"));
+    expect(accepted).toEqual({ status: "accepted" });
+
+    const [membership] = await db
+      .select({ role: member.role })
+      .from(member)
+      .where(eq(member.userId, ssoUser.id));
     expect(membership).toEqual({ role: "admin" });
   });
 

--- a/apps/worker/src/lib/auth/invite-acceptance.ts
+++ b/apps/worker/src/lib/auth/invite-acceptance.ts
@@ -51,6 +51,16 @@ export type AcceptDashboardInviteResult = {
   };
 };
 
+export type AcceptDashboardSsoInviteInput = {
+  organizationSlug: string;
+  inviteId: string;
+  user: {
+    id: string;
+    email: string;
+  };
+  now?: Date;
+};
+
 export type DashboardInviteAcceptanceState = {
   inviteId: string;
   email: string;
@@ -166,6 +176,39 @@ export async function acceptDashboardInvite(
   };
 }
 
+export async function acceptDashboardSsoInvite(
+  db: Db,
+  _auth: Auth,
+  input: AcceptDashboardSsoInviteInput,
+): Promise<void> {
+  const now = input.now ?? new Date();
+  const org = await requireOrganization(db, input.organizationSlug);
+  const invite = await requirePendingInvite(db, org.id, input.inviteId, now);
+  if (normalizeEmail(invite.email) !== normalizeEmail(input.user.email)) {
+    throw new DashboardAuthError(403, "Invite does not match signed-in user");
+  }
+
+  await db.transaction(async (tx) => {
+    const currentInvite = await requirePendingInvite(tx, org.id, invite.id, now);
+    if (normalizeEmail(currentInvite.email) !== normalizeEmail(input.user.email)) {
+      throw new DashboardAuthError(403, "Invite does not match signed-in user");
+    }
+    await ensureInviteMembership(tx, {
+      organizationId: org.id,
+      userId: input.user.id,
+      role: requireInviteRole(currentInvite.role),
+    });
+    const [accepted] = await tx
+      .update(invitation)
+      .set({ status: "accepted" })
+      .where(and(eq(invitation.id, currentInvite.id), eq(invitation.status, "pending")))
+      .returning({ id: invitation.id });
+    if (!accepted) {
+      throw new DashboardAuthError(409, "Invite is no longer pending");
+    }
+  });
+}
+
 function requireInviteRole(role: string): DashboardRole {
   if (role === "owner" || role === "admin" || role === "member") return role;
   throw new DashboardAuthError(500, "Invalid invite role");
@@ -265,7 +308,7 @@ async function ensureInviteMembership(
     )
     .limit(1);
   if (existing) {
-    if (existing.role !== input.role) {
+    if (roleRank(input.role) > roleRank(existing.role)) {
       await db
         .update(memberTable)
         .set({ role: input.role })
@@ -280,6 +323,17 @@ async function ensureInviteMembership(
     userId: input.userId,
     role: input.role,
   });
+}
+
+function roleRank(role: string): number {
+  if (role === "owner") return 3;
+  if (role === "admin") return 2;
+  if (role === "member") return 1;
+  return 0;
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
 }
 
 function sessionTokenFromSignIn(signIn: { headers: Headers; response: unknown }): string {

--- a/apps/worker/src/lib/email/invite-delivery.test.ts
+++ b/apps/worker/src/lib/email/invite-delivery.test.ts
@@ -178,7 +178,7 @@ describe("invite delivery helpers", () => {
     });
   });
 
-  it("maps accepted and delivered events to sent status", async () => {
+  it("does not overwrite terminal failures with later delivered events", async () => {
     await createInviteEmailDelivery(db, {
       id: "delivery_acme",
       invitationId: "invite_acme",
@@ -192,11 +192,11 @@ describe("invite delivery helpers", () => {
         type: "email.delivered",
         data: { email_id: "email_123" },
       }),
-    ).resolves.toEqual({ handled: true, updated: true });
+    ).resolves.toEqual({ handled: true, updated: false });
 
     await expect(findDelivery("email_123")).resolves.toMatchObject({
-      status: "sent",
-      error: null,
+      status: "failed",
+      error: "Previous temporary failure",
     });
   });
 });

--- a/apps/worker/src/lib/email/invite-delivery.ts
+++ b/apps/worker/src/lib/email/invite-delivery.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, notInArray } from "drizzle-orm";
 import type { Db } from "../../db/client.js";
 import { inviteEmailDelivery } from "../../db/schema.js";
 
@@ -89,10 +89,19 @@ export async function updateInviteEmailDeliveryByResendId(
       error: input.error ?? null,
       updatedAt: new Date(),
     })
-    .where(eq(inviteEmailDelivery.resendEmailId, input.resendEmailId))
+    .where(deliveryUpdateWhere(input))
     .returning({ id: inviteEmailDelivery.id });
 
   return !!row;
+}
+
+function deliveryUpdateWhere(input: UpdateInviteEmailDeliveryInput) {
+  const byResendId = eq(inviteEmailDelivery.resendEmailId, input.resendEmailId);
+  if (input.status !== "sent") return byResendId;
+  return and(
+    byResendId,
+    notInArray(inviteEmailDelivery.status, ["bounced", "failed"]),
+  );
 }
 
 export async function updateInviteEmailDeliveryById(

--- a/apps/worker/src/routes/api/dashboard-auth/sso/complete.get.ts
+++ b/apps/worker/src/routes/api/dashboard-auth/sso/complete.get.ts
@@ -1,7 +1,9 @@
-import { defineEventHandler, sendRedirect, toWebRequest } from "h3";
+import { defineEventHandler, getQuery, sendRedirect, toWebRequest } from "h3";
 
 import { env } from "../../../../../env.js";
 import { auth } from "../../../../auth-instance.js";
+import { getDb } from "../../../../db/client.js";
+import { acceptDashboardSsoInvite } from "../../../../lib/auth/invite-acceptance.js";
 import { createDashboardSsoHandoff } from "../../../../lib/auth/sso-handoff.js";
 
 export default defineEventHandler(async (event) => {
@@ -11,8 +13,21 @@ export default defineEventHandler(async (event) => {
     return sendRedirect(event, `${dashboardOrigin}/login`, 302);
   }
 
+  const inviteId = inviteIdFromQuery(getQuery(event).inviteId);
+  if (inviteId) {
+    await acceptDashboardSsoInvite(getDb(), auth, {
+      organizationSlug: env.DASHBOARD_ORG_SLUG,
+      inviteId,
+      user: { id: session.user.id, email: session.user.email },
+    });
+  }
+
   const handoffToken = await createDashboardSsoHandoff(auth, session.session.token);
   const redirectUrl = new URL("/api/auth/sso/complete", dashboardOrigin);
   redirectUrl.searchParams.set("token", handoffToken);
   return sendRedirect(event, redirectUrl.href, 302);
 });
+
+function inviteIdFromQuery(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}

--- a/apps/worker/src/routes/api/dashboard-auth/sso/consume.post.test.ts
+++ b/apps/worker/src/routes/api/dashboard-auth/sso/consume.post.test.ts
@@ -49,4 +49,17 @@ describe("SSO consume API", () => {
     expect(res.status).toBe(400);
     expect(state.consume).not.toHaveBeenCalled();
   });
+
+  it("returns 400 when the token is blank after trimming", async () => {
+    const res = await handlerFor(consumeRoute)(
+      new Request("http://localhost/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: "   " }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(state.consume).not.toHaveBeenCalled();
+  });
 });

--- a/apps/worker/src/routes/api/dashboard-auth/sso/start.get.test.ts
+++ b/apps/worker/src/routes/api/dashboard-auth/sso/start.get.test.ts
@@ -62,4 +62,25 @@ describe("SSO start API", () => {
 
     expect(res.status).toBe(502);
   });
+
+  it("preserves invite context in the SSO callback URL", async () => {
+    const res = await handlerFor(startRoute)(
+      new Request("http://localhost/?inviteId=invite_1"),
+    );
+
+    expect(res.status).toBe(200);
+    const request = state.authHandler.mock.calls[0]?.[0] as Request | undefined;
+    await expect(request?.json()).resolves.toMatchObject({
+      callbackURL:
+        "https://worker.example.com/api/dashboard-auth/sso/complete?inviteId=invite_1",
+    });
+  });
+
+  it("rejects non-string SSO redirect URLs from Better Auth", async () => {
+    state.authHandler.mockResolvedValueOnce(Response.json({ url: 123 }));
+
+    const res = await handlerFor(startRoute)(new Request("http://localhost/"));
+
+    expect(res.status).toBe(502);
+  });
 });

--- a/apps/worker/src/routes/api/dashboard-auth/sso/start.get.ts
+++ b/apps/worker/src/routes/api/dashboard-auth/sso/start.get.ts
@@ -1,12 +1,16 @@
-import { createError, defineEventHandler } from "h3";
+import { createError, defineEventHandler, getQuery } from "h3";
 
 import { env } from "../../../../../env.js";
 import { DASHBOARD_SSO_PROVIDER_ID } from "../../../../auth.js";
 import { auth } from "../../../../auth-instance.js";
 
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
   const workerOrigin = env.BETTER_AUTH_URL.replace(/\/$/, "");
   const dashboardOrigin = env.DASHBOARD_ORIGIN.replace(/\/$/, "");
+  const inviteId = inviteIdFromQuery(getQuery(event).inviteId);
+  const callbackUrl = new URL("/api/dashboard-auth/sso/complete", workerOrigin);
+  if (inviteId) callbackUrl.searchParams.set("inviteId", inviteId);
+
   const res = await auth.handler(
     new Request(`${workerOrigin}/api/auth/sign-in/sso`, {
       method: "POST",
@@ -14,7 +18,7 @@ export default defineEventHandler(async () => {
       body: JSON.stringify({
         providerId: DASHBOARD_SSO_PROVIDER_ID,
         providerType: "oidc",
-        callbackURL: `${workerOrigin}/api/dashboard-auth/sso/complete`,
+        callbackURL: callbackUrl.href,
         errorCallbackURL: `${dashboardOrigin}/login`,
       }),
     }),
@@ -30,7 +34,7 @@ export default defineEventHandler(async () => {
       statusMessage: body.message ?? "SSO is not configured",
     });
   }
-  if (!body.url) {
+  if (typeof body.url !== "string" || !body.url) {
     throw createError({
       statusCode: 502,
       statusMessage: body.message ?? "SSO is not configured",
@@ -39,3 +43,7 @@ export default defineEventHandler(async () => {
 
   return { url: body.url };
 });
+
+function inviteIdFromQuery(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}


### PR DESCRIPTION
## Summary
- preserve invite context through SSO start/complete and accept SSO-only invites after callback
- make auth seeding unique-conflict retries bounded and cover existing-user credential races
- prevent invite role downgrades and terminal email delivery status regressions
- keep SSO login visibility in an unknown state on status errors and reuse the shared worker URL helper

## Validation
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/tsc --noEmit (worker)
- ./node_modules/.bin/tsc --noEmit (dashboard)
- env NEXT_TELEMETRY_DISABLED=1 ./node_modules/.bin/next build (dashboard)