### PR TITLE
Fix production users page crash

### DIFF
--- a/apps/worker/src/routes/api/v1/users.get.ts
+++ b/apps/worker/src/routes/api/v1/users.get.ts
@@ -12,11 +12,11 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 403, statusMessage: "Forbidden" });
     }
 
-    const members = await listDashboardUsers(getDb(), {
+    const users = await listDashboardUsers(getDb(), {
       organizationSlug: env.DASHBOARD_ORG_SLUG,
       actorRole: actor.role,
     });
-    return { members };
+    return { users };
   } catch (error) {
     toHttpError(error);
   }

--- a/apps/worker/src/routes/api/v1/users.test.ts
+++ b/apps/worker/src/routes/api/v1/users.test.ts
@@ -126,7 +126,7 @@ describe("users API", () => {
 
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.members).toEqual(
+    expect(json.users).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: "user_owner",


### PR DESCRIPTION
## Summary
- Fix /api/v1/users to return the dashboard-facing users payload instead of members.
- Update the worker route test to assert the response shape consumed by the dashboard users page.

## Root cause
The production dashboard calls /api/v1/users and reads response.users. The worker route returned response.members, so initialUsers became undefined and the client Users screen crashed while reading users.length.

## Validation
- apps/worker: vitest run src/routes/api/v1/users.test.ts
- apps/worker: tsc --noEmit
- apps/dashboard: tsc --noEmit
- apps/dashboard: NEXT_TELEMETRY_DISABLED=1 next build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The users API now returns the user list under `users` instead of `members`, matching the updated response shape.
  * Updated related test coverage to verify the new response field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->