### PR TITLE
Backport users API hotfix to dev

### DIFF
--- a/apps/worker/src/routes/api/v1/users.get.ts
+++ b/apps/worker/src/routes/api/v1/users.get.ts
@@ -12,11 +12,11 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 403, statusMessage: "Forbidden" });
     }
 
-    const members = await listDashboardUsers(getDb(), {
+    const users = await listDashboardUsers(getDb(), {
       organizationSlug: env.DASHBOARD_ORG_SLUG,
       actorRole: actor.role,
     });
-    return { members };
+    return { users };
   } catch (error) {
     toHttpError(error);
   }

--- a/apps/worker/src/routes/api/v1/users.test.ts
+++ b/apps/worker/src/routes/api/v1/users.test.ts
@@ -126,7 +126,7 @@ describe("users API", () => {
 
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.members).toEqual(
+    expect(json.users).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: "user_owner",


### PR DESCRIPTION
## Summary
- Cherry-pick the production users API hotfix onto dev.
- Keep worker /api/v1/users aligned with the dashboard users page by returning the users payload.

## Root cause
Main hotfix PR #102 fixed a production /users client crash caused by the worker returning members while the dashboard reads users.

## Validation
- apps/worker: vitest run src/routes/api/v1/users.test.ts
- apps/worker: tsc --noEmit