### PR TITLE
Fix dashboard SSO OAuth state flow

### DIFF
--- a/apps/dashboard/app/api/auth/sso/start/route.test.ts
+++ b/apps/dashboard/app/api/auth/sso/start/route.test.ts
@@ -1,0 +1,17 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+test("SSO start redirects the browser to the worker start endpoint", async () => {
+  process.env.WORKER_BASE_URL = "https://worker.example.com";
+  const { GET } = await import("./route.ts");
+
+  const res = await GET(
+    new Request("https://dashboard.example.com/api/auth/sso/start?inviteId=invite_1"),
+  );
+
+  assert.equal(res.status, 307);
+  assert.equal(
+    res.headers.get("location"),
+    "https://worker.example.com/api/dashboard-auth/sso/start?inviteId=invite_1",
+  );
+});

--- a/apps/dashboard/app/api/auth/sso/start/route.ts
+++ b/apps/dashboard/app/api/auth/sso/start/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { fetchAuthWorker, readWorkerJson } from "@/lib/auth/worker";
+import { workerUrl } from "@/lib/auth/worker-core";
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
@@ -8,15 +8,9 @@ export async function GET(req: Request) {
   const workerPath = inviteId
     ? `/api/dashboard-auth/sso/start?inviteId=${encodeURIComponent(inviteId)}`
     : "/api/dashboard-auth/sso/start";
-  const res = await fetchAuthWorker(workerPath);
-  if (!res?.ok) {
+  try {
+    return NextResponse.redirect(workerUrl(process.env.WORKER_BASE_URL, workerPath));
+  } catch {
     return NextResponse.redirect(new URL("/login", req.url));
   }
-
-  const body = await readWorkerJson<{ url?: string }>(res);
-  if (!body.url) {
-    return NextResponse.redirect(new URL("/login", req.url));
-  }
-
-  return NextResponse.redirect(body.url);
 }

--- a/apps/worker/src/routes/api/dashboard-auth/sso/start.get.test.ts
+++ b/apps/worker/src/routes/api/dashboard-auth/sso/start.get.test.ts
@@ -26,7 +26,14 @@ const startRoute = (await import("./start.get.js")).default;
 beforeEach(() => {
   vi.clearAllMocks();
   state.authHandler.mockResolvedValue(
-    Response.json({ url: "https://idp.example.com/authorize" }),
+    Response.json(
+      { url: "https://idp.example.com/authorize" },
+      {
+        headers: {
+          "set-cookie": "better-auth.state=state-cookie; Path=/; HttpOnly",
+        },
+      },
+    ),
   );
 });
 
@@ -37,13 +44,12 @@ function handlerFor(route: Parameters<typeof eventHandler>[0]) {
 }
 
 describe("SSO start API", () => {
-  it("starts OIDC SSO against the fixed dashboard provider", async () => {
+  it("redirects to OIDC SSO and forwards Better Auth state cookies", async () => {
     const res = await handlerFor(startRoute)(new Request("http://localhost/"));
 
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({
-      url: "https://idp.example.com/authorize",
-    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://idp.example.com/authorize");
+    expect(res.headers.get("set-cookie")).toContain("better-auth.state=state-cookie");
 
     const request = state.authHandler.mock.calls[0]?.[0] as Request | undefined;
     expect(request?.url).toBe("https://worker.example.com/api/auth/sign-in/sso");
@@ -68,7 +74,7 @@ describe("SSO start API", () => {
       new Request("http://localhost/?inviteId=invite_1"),
     );
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(302);
     const request = state.authHandler.mock.calls[0]?.[0] as Request | undefined;
     await expect(request?.json()).resolves.toMatchObject({
       callbackURL:

--- a/apps/worker/src/routes/api/dashboard-auth/sso/start.get.ts
+++ b/apps/worker/src/routes/api/dashboard-auth/sso/start.get.ts
@@ -1,4 +1,12 @@
-import { createError, defineEventHandler, getQuery } from "h3";
+import {
+  appendResponseHeader,
+  createError,
+  defineEventHandler,
+  getQuery,
+  sendRedirect,
+  splitCookiesString,
+  type H3Event,
+} from "h3";
 
 import { env } from "../../../../../env.js";
 import { DASHBOARD_SSO_PROVIDER_ID } from "../../../../auth.js";
@@ -41,9 +49,23 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  return { url: body.url };
+  forwardSetCookieHeaders(event, res.headers);
+  return sendRedirect(event, body.url, 302);
 });
 
 function inviteIdFromQuery(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function forwardSetCookieHeaders(event: H3Event, headers: Headers) {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] })
+    .getSetCookie;
+  const cookies =
+    typeof getSetCookie === "function"
+      ? getSetCookie.call(headers)
+      : splitCookiesString(headers.get("set-cookie") ?? "");
+
+  for (const cookie of cookies) {
+    appendResponseHeader(event, "set-cookie", cookie);
+  }
 }


### PR DESCRIPTION
## Summary
- redirect dashboard SSO starts to the worker so the browser receives worker-domain OAuth state cookies
- make the worker SSO start route forward Better Auth state cookies and redirect to Google
- add focused route tests for the worker and dashboard start flow

## Validation
- apps/worker/node_modules/.bin/vitest run --config apps/worker/vitest.config.ts src/routes/api/dashboard-auth/sso/start.get.test.ts
- apps/worker/node_modules/.bin/tsx --test app/api/auth/sso/start/route.test.ts (from apps/dashboard)
- apps/worker/node_modules/.bin/tsc --noEmit --project apps/worker/tsconfig.json
- node_modules/.bin/tsc --noEmit --project apps/dashboard/tsconfig.json
- deployed production worker and dashboard from clean worktrees
- verified dashboard /api/auth/sso/start redirects to worker and worker /api/dashboard-auth/sso/start sets __Secure-better-auth.state before redirecting to Google

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - SSO sign-in now redirects the browser directly to the correct authentication flow instead of returning JSON.
  - Invite links continue to work during SSO start, with the invite ID preserved in the redirect.
  - Authentication cookies are now forwarded during the redirect, helping keep SSO sessions working reliably.
  - Failed SSO start requests now fall back to the login page instead of leaving users stuck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->