### PR TITLE
Handle localized Jira transitions

### DIFF
--- a/apps/worker/src/adapters/issue-tracker/jira.test.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.test.ts
@@ -438,6 +438,37 @@ describe("JiraAdapter", () => {
         transition: { id: "31" },
       });
     });
+
+    it("matches default Jira workflow transitions when names are localized", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            transitions: [
+              {
+                id: "11",
+                name: "待办",
+                to: { statusCategory: { key: "new" } },
+              },
+              {
+                id: "21",
+                name: "正在进行",
+                to: { statusCategory: { key: "indeterminate" } },
+              },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+
+      const adapter = jiraAdapter();
+      await adapter.moveTicket("10001", "To Do");
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const transitionCall = mockFetch.mock.calls[1];
+      expect(JSON.parse(transitionCall[1].body)).toEqual({
+        transition: { id: "11" },
+      });
+    });
   });
 
   describe("postComment", () => {

--- a/apps/worker/src/adapters/issue-tracker/jira.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.ts
@@ -14,6 +14,21 @@ export interface JiraConfig {
 }
 
 const ATLASSIAN_API_ORIGIN = "https://api.atlassian.com";
+const DEFAULT_JIRA_STATUS_CATEGORY_BY_NAME = new Map([
+  ["to do", "new"],
+  ["in progress", "indeterminate"],
+  ["done", "done"],
+]);
+
+type JiraTransition = {
+  id: string;
+  name?: string;
+  to?: {
+    statusCategory?: {
+      key?: string;
+    };
+  };
+};
 
 export class JiraAdapter implements IssueTrackerAdapter {
   private tenantOrigin: string;
@@ -123,12 +138,11 @@ export class JiraAdapter implements IssueTrackerAdapter {
 
   async moveTicket(id: string, column: string): Promise<void> {
     const data = await this.request(`/rest/api/3/issue/${id}/transitions`);
-    const transition = data.transitions.find(
-      (t: any) => t.name.toLowerCase() === column.toLowerCase(),
-    );
+    const transitions = data.transitions as JiraTransition[];
+    const transition = findTransition(transitions, column);
     if (!transition) {
       throw new Error(
-        `No transition to "${column}" found for issue ${id}. Available: ${data.transitions.map((t: any) => t.name).join(", ")}`,
+        `No transition to "${column}" found for issue ${id}. Available: ${transitions.map((t) => t.name).join(", ")}`,
       );
     }
     await this.request(`/rest/api/3/issue/${id}/transitions`, {
@@ -256,6 +270,23 @@ export class JiraAdapter implements IssueTrackerAdapter {
     }
     return this.selfAccountIdPromise;
   }
+}
+
+function findTransition(transitions: JiraTransition[], column: string) {
+  const normalizedColumn = column.toLowerCase();
+  const exact = transitions.find(
+    (transition) => transition.name?.toLowerCase() === normalizedColumn,
+  );
+  if (exact) return exact;
+
+  const categoryKey = DEFAULT_JIRA_STATUS_CATEGORY_BY_NAME.get(normalizedColumn);
+  if (!categoryKey) return undefined;
+
+  const categoryMatches = transitions.filter(
+    (transition) =>
+      transition.to?.statusCategory?.key?.toLowerCase() === categoryKey,
+  );
+  return categoryMatches.length === 1 ? categoryMatches[0] : undefined;
 }
 
 function toAdfParagraphs(text: string) {


### PR DESCRIPTION
## Summary
- keep Jira transition env values canonical, e.g. To Do
- preserve exact transition-name matching first
- fall back to Jira statusCategory for built-in To Do/In Progress/Done transitions when Jira localizes display names

## Tests
- ./node_modules/.bin/vitest run src/adapters/issue-tracker/jira.test.ts
- ./node_modules/.bin/tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ticket status changes so moves now match workflow transitions more reliably, including localized transition names.
  * Added smarter fallback matching when the exact transition name isn’t available, reducing failed ticket moves.
  * Error messages now list available transition options more clearly when no match is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->