### PR TITLE
Use configured Jira transition IDs

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -80,7 +80,12 @@ ai-workflow authenticates to Jira as an **Atlassian service account** — a mach
    - `COLUMN_AI` — tickets assigned to the agent (default: `AI`)
    - `COLUMN_AI_REVIEW` — completed tickets pending human review (default: `AI Review`)
    - `COLUMN_BACKLOG` — tickets bounced back for clarification (default: `Backlog`)
-4. Generate a webhook secret to authenticate Jira → Vercel deliveries:
+4. Optional but recommended: capture stable Jira transition IDs for workflow moves:
+   - `JIRA_BACKLOG_TRANSITION_ID` — transition back to `COLUMN_BACKLOG`
+   - `JIRA_AI_REVIEW_TRANSITION_ID` — transition to `COLUMN_AI_REVIEW`
+
+   These avoid relying on localized transition display names. You can fetch IDs from `GET /rest/api/3/issue/<KEY>/transitions` while the ticket is in the source status.
+5. Generate a webhook secret to authenticate Jira → Vercel deliveries:
    ```bash
    openssl rand -hex 32
    ```
@@ -255,7 +260,8 @@ vercel env add JIRA_API_TOKEN production
 | Variable                                                                                           | Purpose                                                |
 | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
 | `JIRA_BASE_URL`, `JIRA_API_TOKEN`, `JIRA_PROJECT_KEY`                                              | Jira credentials (scoped service-account Bearer token) |
-| `COLUMN_AI`, `COLUMN_AI_REVIEW`, `COLUMN_BACKLOG`                                                  | Board columns                                          |
+| `COLUMN_AI`, `COLUMN_AI_REVIEW`, `COLUMN_BACKLOG`                                                  | Jira status/display names for polling, webhooks, and fallback transition lookup |
+| `JIRA_BACKLOG_TRANSITION_ID`, `JIRA_AI_REVIEW_TRANSITION_ID`                                       | Optional stable transition IDs for Jira moves; recommended when Jira localizes transition names |
 | `VCS_KIND`                                                                                         | `github` or `gitlab`                                   |
 | `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_INSTALLATION_ID`, `GITHUB_OWNER`, `GITHUB_REPO` | If `VCS_KIND=github` (GitHub App auth)                 |
 | `GITHUB_WEBHOOK_SECRET`                                                                            | If `VCS_KIND=github` — signs `pull_request` webhook deliveries for the post-PR gate. Required in **every** environment (Production, Preview, Development) because the webhook fires on preview deployments too. Generate: `openssl rand -hex 32`. |

--- a/apps/worker/env.test.ts
+++ b/apps/worker/env.test.ts
@@ -53,6 +53,18 @@ describe("env", () => {
     expect(env.JOB_TIMEOUT_MS).toBe(1800000);
   });
 
+  it("accepts optional Jira transition ids", async () => {
+    Object.assign(process.env, {
+      ...VALID_ENV,
+      JIRA_BACKLOG_TRANSITION_ID: "11",
+      JIRA_AI_REVIEW_TRANSITION_ID: "31",
+    });
+
+    const { env } = await import("./env.js");
+    expect(env.JIRA_BACKLOG_TRANSITION_ID).toBe("11");
+    expect(env.JIRA_AI_REVIEW_TRANSITION_ID).toBe("31");
+  });
+
   it("uses defaults for optional fields", async () => {
     const partial = { ...VALID_ENV };
     delete (partial as any).MAX_CONCURRENT_AGENTS;

--- a/apps/worker/env.ts
+++ b/apps/worker/env.ts
@@ -19,6 +19,8 @@ export const env = createEnv({
     COLUMN_AI: z.string().min(1),
     COLUMN_AI_REVIEW: z.string().min(1),
     COLUMN_BACKLOG: z.string().min(1),
+    JIRA_BACKLOG_TRANSITION_ID: z.string().min(1).optional(),
+    JIRA_AI_REVIEW_TRANSITION_ID: z.string().min(1).optional(),
 
     // VCS
     VCS_KIND: z.enum(["github", "gitlab"]).optional(),

--- a/apps/worker/src/adapters/issue-tracker/jira.test.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.test.ts
@@ -439,7 +439,7 @@ describe("JiraAdapter", () => {
       });
     });
 
-    it("matches default Jira workflow transitions when names are localized", async () => {
+    it("uses a configured transition id when Jira localizes names", async () => {
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -461,7 +461,10 @@ describe("JiraAdapter", () => {
         .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
 
       const adapter = jiraAdapter();
-      await adapter.moveTicket("10001", "To Do");
+      await adapter.moveTicket("10001", {
+        name: "To Do",
+        transitionId: "11",
+      });
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
       const transitionCall = mockFetch.mock.calls[1];

--- a/apps/worker/src/adapters/issue-tracker/jira.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.ts
@@ -1,6 +1,8 @@
 import {
   IssueTrackerNotFoundError,
   type IssueTrackerAdapter,
+  type IssueTrackerMoveTarget,
+  type IssueTrackerTransitionTarget,
   type TicketAttachment,
   type TicketContent,
   type TicketComment,
@@ -14,11 +16,6 @@ export interface JiraConfig {
 }
 
 const ATLASSIAN_API_ORIGIN = "https://api.atlassian.com";
-const DEFAULT_JIRA_STATUS_CATEGORY_BY_NAME = new Map([
-  ["to do", "new"],
-  ["in progress", "indeterminate"],
-  ["done", "done"],
-]);
 
 type JiraTransition = {
   id: string;
@@ -136,13 +133,17 @@ export class JiraAdapter implements IssueTrackerAdapter {
     };
   }
 
-  async moveTicket(id: string, column: string): Promise<void> {
+  async moveTicket(id: string, target: IssueTrackerMoveTarget): Promise<void> {
     const data = await this.request(`/rest/api/3/issue/${id}/transitions`);
     const transitions = data.transitions as JiraTransition[];
-    const transition = findTransition(transitions, column);
+    const transitionTarget = normalizeTransitionTarget(target);
+    const transition = findTransition(transitions, transitionTarget);
     if (!transition) {
+      const targetDescription = transitionTarget.transitionId
+        ? `${transitionTarget.name} (${transitionTarget.transitionId})`
+        : transitionTarget.name;
       throw new Error(
-        `No transition to "${column}" found for issue ${id}. Available: ${transitions.map((t) => t.name).join(", ")}`,
+        `No transition to "${targetDescription}" found for issue ${id}. Available: ${transitions.map((t) => `${t.name} (${t.id})`).join(", ")}`,
       );
     }
     await this.request(`/rest/api/3/issue/${id}/transitions`, {
@@ -272,21 +273,27 @@ export class JiraAdapter implements IssueTrackerAdapter {
   }
 }
 
-function findTransition(transitions: JiraTransition[], column: string) {
-  const normalizedColumn = column.toLowerCase();
+function normalizeTransitionTarget(
+  target: IssueTrackerMoveTarget,
+): IssueTrackerTransitionTarget {
+  return typeof target === "string" ? { name: target } : target;
+}
+
+function findTransition(
+  transitions: JiraTransition[],
+  target: IssueTrackerTransitionTarget,
+) {
+  if (target.transitionId) {
+    return transitions.find(
+      (transition) => String(transition.id) === target.transitionId,
+    );
+  }
+
+  const normalizedColumn = target.name.toLowerCase();
   const exact = transitions.find(
     (transition) => transition.name?.toLowerCase() === normalizedColumn,
   );
-  if (exact) return exact;
-
-  const categoryKey = DEFAULT_JIRA_STATUS_CATEGORY_BY_NAME.get(normalizedColumn);
-  if (!categoryKey) return undefined;
-
-  const categoryMatches = transitions.filter(
-    (transition) =>
-      transition.to?.statusCategory?.key?.toLowerCase() === categoryKey,
-  );
-  return categoryMatches.length === 1 ? categoryMatches[0] : undefined;
+  return exact;
 }
 
 function toAdfParagraphs(text: string) {

--- a/apps/worker/src/adapters/issue-tracker/types.ts
+++ b/apps/worker/src/adapters/issue-tracker/types.ts
@@ -36,13 +36,20 @@ export interface TicketAttachment {
   contentUrl?: string;
 }
 
+export interface IssueTrackerTransitionTarget {
+  name: string;
+  transitionId?: string;
+}
+
+export type IssueTrackerMoveTarget = string | IssueTrackerTransitionTarget;
+
 export interface IssueTrackerAdapter {
   /**
    * Fetch a single ticket by key/id.
    * Throws IssueTrackerNotFoundError (code: NOT_FOUND) when the ticket does not exist.
    */
   fetchTicket(id: string): Promise<TicketContent>;
-  moveTicket(id: string, column: string): Promise<void>;
+  moveTicket(id: string, target: IssueTrackerMoveTarget): Promise<void>;
   /**
    * Post a comment on a ticket.
    *

--- a/apps/worker/src/lib/cancel-run.ts
+++ b/apps/worker/src/lib/cancel-run.ts
@@ -1,7 +1,10 @@
 import { getRun } from "workflow/api";
 import { logger } from "./logger.js";
 import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
-import type { IssueTrackerAdapter } from "../adapters/issue-tracker/types.js";
+import type {
+  IssueTrackerAdapter,
+  IssueTrackerMoveTarget,
+} from "../adapters/issue-tracker/types.js";
 import { stopTicketSandboxes } from "../sandbox/stop-ticket-sandboxes.js";
 
 /**
@@ -18,7 +21,7 @@ export async function cancelRun(
   runId: string,
   runRegistry: RunRegistryAdapter,
   issueTracker?: IssueTrackerAdapter,
-  targetColumn?: string,
+  targetColumn?: IssueTrackerMoveTarget,
 ): Promise<boolean> {
   let cancelled = false;
   try {

--- a/apps/worker/src/lib/slack/handlers.ts
+++ b/apps/worker/src/lib/slack/handlers.ts
@@ -2,7 +2,10 @@ import type {
   RunRegistryAdapter,
   ThreadStore,
 } from "../../adapters/run-registry/types.js";
-import type { IssueTrackerAdapter } from "../../adapters/issue-tracker/types.js";
+import type {
+  IssueTrackerAdapter,
+  IssueTrackerMoveTarget,
+} from "../../adapters/issue-tracker/types.js";
 import { isClaimingSentinel } from "../dispatch.js";
 import { logger } from "../logger.js";
 import {
@@ -17,7 +20,7 @@ export type CancelRunFn = (
   runId: string,
   registry: RunRegistryAdapter,
   issueTracker?: IssueTrackerAdapter,
-  targetColumn?: string,
+  targetColumn?: IssueTrackerMoveTarget,
 ) => Promise<boolean>;
 
 export type StopTicketSandboxesFn = (
@@ -60,7 +63,7 @@ export async function handleCancel(
   cancelRunFn: CancelRunFn,
   stopSandboxes: StopTicketSandboxesFn,
   issueTracker?: IssueTrackerAdapter,
-  targetColumn?: string,
+  targetColumn?: IssueTrackerMoveTarget,
 ): Promise<string> {
   const runId = await registry.getRunId(ticketKey);
   if (!runId) return `No active run for ${ticketKey}.`;

--- a/apps/worker/src/routes/webhooks/slack.post.ts
+++ b/apps/worker/src/routes/webhooks/slack.post.ts
@@ -153,6 +153,9 @@ async function runHandler(parsed: ParsedCommand, responseUrl: string): Promise<v
 async function executeCommand(parsed: ParsedCommand): Promise<string> {
   const adapters = createAdapters();
   const { runRegistry, issueTracker } = adapters;
+  const backlogMoveTarget = env.JIRA_BACKLOG_TRANSITION_ID
+    ? { name: env.COLUMN_BACKLOG, transitionId: env.JIRA_BACKLOG_TRANSITION_ID }
+    : env.COLUMN_BACKLOG;
   switch (parsed.kind) {
     case "list":
       return handleList(runRegistry, env.JIRA_BASE_URL);
@@ -165,7 +168,7 @@ async function executeCommand(parsed: ParsedCommand): Promise<string> {
         cancelRun,
         stopTicketSandboxes,
         issueTracker,
-        env.COLUMN_BACKLOG,
+        backlogMoveTarget,
       );
     case "inspect":
       return handleInspect(runRegistry, parsed.ticketKey, env.JIRA_BASE_URL);

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -6,7 +6,10 @@ import type {
 } from "../sandbox/agents/types.js";
 import type { AgentKind } from "../sandbox/agents/index.js";
 import type { PRComment, CheckRunResult } from "../adapters/vcs/types.js";
-import type { TicketAttachment } from "../adapters/issue-tracker/types.js";
+import type {
+  IssueTrackerMoveTarget,
+  TicketAttachment,
+} from "../adapters/issue-tracker/types.js";
 import type { TicketEvent } from "../adapters/messaging/types.js";
 import type { DownloadedAttachment } from "../sandbox/attachments.js";
 import type { SelectedRepository } from "../adapters/vcs/repository-directory.js";
@@ -409,11 +412,11 @@ async function postPrLinksComment(
 }
 postPrLinksComment.maxRetries = 0;
 
-async function moveTicket(ticketId: string, column: string) {
+async function moveTicket(ticketId: string, target: IssueTrackerMoveTarget) {
   "use step";
   const { createStepAdapters } = await import("../lib/step-adapters.js");
   const { issueTracker } = createStepAdapters();
-  await issueTracker.moveTicket(ticketId, column);
+  await issueTracker.moveTicket(ticketId, target);
 }
 
 async function notifyTicket(ticketKey: string, event: TicketEvent) {
@@ -426,7 +429,7 @@ async function notifyTicket(ticketKey: string, event: TicketEvent) {
 async function postClarificationAndMoveBack(
   ticketId: string,
   questions: string[],
-  backlogColumn: string,
+  backlogTarget: IssueTrackerMoveTarget,
 ): Promise<string | null> {
   "use step";
   const { createStepAdapters } = await import("../lib/step-adapters.js");
@@ -448,7 +451,7 @@ async function postClarificationAndMoveBack(
       );
     }
   }
-  await issueTracker.moveTicket(ticketId, backlogColumn);
+  await issueTracker.moveTicket(ticketId, backlogTarget);
   return commentUrl;
 }
 
@@ -598,6 +601,14 @@ export async function agentWorkflow(ticketId: string) {
   const { publishWorkspaceChanges } = await import("./workspace-publication.js");
   const { formatUsageReport } = await import("../sandbox/usage.js");
   const { AGENT_SCHEMA, RESEARCH_SCHEMA, REVIEW_SCHEMA } = await import("../sandbox/agents/types.js");
+  const backlogMoveTarget = (): IssueTrackerMoveTarget =>
+    env.JIRA_BACKLOG_TRANSITION_ID
+      ? { name: env.COLUMN_BACKLOG, transitionId: env.JIRA_BACKLOG_TRANSITION_ID }
+      : env.COLUMN_BACKLOG;
+  const aiReviewMoveTarget = (): IssueTrackerMoveTarget =>
+    env.JIRA_AI_REVIEW_TRANSITION_ID
+      ? { name: env.COLUMN_AI_REVIEW, transitionId: env.JIRA_AI_REVIEW_TRANSITION_ID }
+      : env.COLUMN_AI_REVIEW;
 
   const ticket = await fetchAndValidateTicket(ticketId, env.COLUMN_AI);
   if (!ticket) return;
@@ -667,7 +678,7 @@ export async function agentWorkflow(ticketId: string) {
         const commentUrl = await postClarificationAndMoveBack(
           ticketId,
           questions.length > 0 ? questions : [preSandboxResult.message],
-          env.COLUMN_BACKLOG,
+          backlogMoveTarget(),
         );
         await notifyTicket(ticket.identifier, {
           kind: "needs_clarification",
@@ -678,7 +689,7 @@ export async function agentWorkflow(ticketId: string) {
         return;
       }
 
-      await moveTicket(ticketId, env.COLUMN_BACKLOG);
+      await moveTicket(ticketId, backlogMoveTarget());
       await notifyTicket(ticket.identifier, {
         kind: "failed",
         reason: `pre-sandbox: ${preSandboxResult.message}`,
@@ -693,7 +704,7 @@ export async function agentWorkflow(ticketId: string) {
       const commentUrl = await postClarificationAndMoveBack(
         ticketId,
         ["Which repository should this ticket modify?"],
-        env.COLUMN_BACKLOG,
+        backlogMoveTarget(),
       );
       await notifyTicket(ticket.identifier, {
         kind: "needs_clarification",
@@ -771,7 +782,7 @@ export async function agentWorkflow(ticketId: string) {
         // run as a cancellable orphan). Same reasoning at every terminal
         // path below.
         await unregisterRun(ticket.identifier);
-        await moveTicket(ticketId, env.COLUMN_BACKLOG);
+        await moveTicket(ticketId, backlogMoveTarget());
         await notifyTicket(ticket.identifier, {
           kind: "failed",
           phase: "research",
@@ -793,7 +804,7 @@ export async function agentWorkflow(ticketId: string) {
         const commentUrl = await postClarificationAndMoveBack(
           ticketId,
           questions.length > 0 ? questions : [research.body],
-          env.COLUMN_BACKLOG,
+          backlogMoveTarget(),
         );
         await notifyTicket(ticket.identifier, {
           kind: "needs_clarification",
@@ -806,7 +817,7 @@ export async function agentWorkflow(ticketId: string) {
 
       if (research.status === "failed") {
         await unregisterRun(ticket.identifier);
-        await moveTicket(ticketId, env.COLUMN_BACKLOG);
+        await moveTicket(ticketId, backlogMoveTarget());
         await notifyTicket(ticket.identifier, {
           kind: "failed",
           phase: "research",
@@ -857,7 +868,7 @@ export async function agentWorkflow(ticketId: string) {
         const commentUrl = await postClarificationAndMoveBack(
           ticketId,
           implOutput.questions ?? [],
-          env.COLUMN_BACKLOG,
+          backlogMoveTarget(),
         );
         await notifyTicket(ticket.identifier, {
           kind: "needs_clarification",
@@ -870,7 +881,7 @@ export async function agentWorkflow(ticketId: string) {
 
       if (implOutput.result === "failed") {
         await unregisterRun(ticket.identifier);
-        await moveTicket(ticketId, env.COLUMN_BACKLOG);
+        await moveTicket(ticketId, backlogMoveTarget());
         await notifyTicket(ticket.identifier, {
           kind: "failed",
           phase: "impl",
@@ -916,7 +927,7 @@ export async function agentWorkflow(ticketId: string) {
 
         if (reviewOutput.result === "failed") {
           await unregisterRun(ticket.identifier);
-          await moveTicket(ticketId, env.COLUMN_BACKLOG);
+          await moveTicket(ticketId, backlogMoveTarget());
           await notifyTicket(ticket.identifier, {
             kind: "failed",
             phase: "review",
@@ -963,7 +974,7 @@ export async function agentWorkflow(ticketId: string) {
             "Pull requests created before publication failed:",
           );
         }
-        await moveTicket(ticketId, env.COLUMN_BACKLOG);
+        await moveTicket(ticketId, backlogMoveTarget());
         await notifyTicket(ticket.identifier, {
           kind: "failed",
           phase: "push",
@@ -986,7 +997,7 @@ export async function agentWorkflow(ticketId: string) {
         pr: { url: primaryPr.url, number: primaryPr.id },
         usageReport,
       });
-      await moveTicket(ticketId, env.COLUMN_AI_REVIEW);
+      await moveTicket(ticketId, aiReviewMoveTarget());
       runOutcome = "success";
     } finally {
       await teardownSandbox(sandboxId);
@@ -998,7 +1009,7 @@ export async function agentWorkflow(ticketId: string) {
     // If the move then fails, markTicketFailed re-records a marker that
     // dispatch.isTicketFailed checks to keep the ticket from being re-picked.
     await unregisterRun(ticket.identifier).catch(() => {});
-    const moved = await moveTicket(ticketId, env.COLUMN_BACKLOG).then(() => true).catch(() => false);
+    const moved = await moveTicket(ticketId, backlogMoveTarget()).then(() => true).catch(() => false);
     await notifyTicket(ticket.identifier, {
       kind: "failed",
       reason: (err as Error).message ?? "unknown",

--- a/docs/ON-PREM-AWS.md
+++ b/docs/ON-PREM-AWS.md
@@ -354,7 +354,8 @@ Agent containers are immutable — new tasks always pull the latest image tag.
 | `SPOT_MAX_RETRIES`                                | Max Spot interruption retries before On-Demand fallback (default: 3) |
 | `EFS_FILESYSTEM_ID`                               | EFS filesystem ID for shared workspace                               |
 | `JOB_TIMEOUT_MS`                                  | Per-agent timeout (default: 1,800,000ms / 30min)                     |
-| `COLUMN_AI`, `COLUMN_AI_REVIEW`, `COLUMN_BACKLOG` | Jira column names                                                    |
+| `COLUMN_AI`, `COLUMN_AI_REVIEW`, `COLUMN_BACKLOG` | Jira status/display names                                            |
+| `JIRA_BACKLOG_TRANSITION_ID`, `JIRA_AI_REVIEW_TRANSITION_ID` | Optional stable Jira transition IDs for workflow moves               |
 
 ## Operations
 


### PR DESCRIPTION
## Summary
- remove the hardcoded default Jira status-name fallback from transition resolution
- add optional stable transition ID config for backlog and AI review moves
- keep existing COLUMN_* string behavior as a fallback for deployments that have not configured IDs

## Tests
- ./node_modules/.bin/vitest run src/adapters/issue-tracker/jira.test.ts env.test.ts src/lib/slack/handlers.test.ts src/routes/webhooks/slack.post.test.ts
- ./node_modules/.bin/tsc --noEmit
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more reliable Jira ticket moves using stable transition IDs when available.
  * Improved workflow handling so ticket moves can work even when Jira transition names are localized.

* **Bug Fixes**
  * Reduced failures when moving tickets between backlog and review states by falling back to configured column names.

* **Documentation**
  * Updated setup and deployment docs to explain the new optional Jira transition ID settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->