### PR TITLE
Improve workflow templates and editor UX

### DIFF
--- a/apps/dashboard/app/editor-data.tsx
+++ b/apps/dashboard/app/editor-data.tsx
@@ -30,6 +30,16 @@ export async function EditorData() {
     return (
       <WorkflowEditorScreen
         definitions={list.definitions}
+        templates={
+          list.templates ?? [
+            {
+              id: "ticket-workflow",
+              name: "Ticket workflow",
+              description: "The current production delivery workflow.",
+              definition: list.defaultDefinition,
+            },
+          ]
+        }
         initialDetail={initialDetail}
         defaultDefinition={list.defaultDefinition}
         options={list.options}

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
@@ -156,7 +156,9 @@ const FlowNode = React.memo(function FlowNode({
         if (canEdit && !locked) onDelete(node.id);
       }}
       onClick={(e) => { e.stopPropagation(); onSelect(node.id); }}
-      className={`absolute rounded-sm select-none transition-[box-shadow,border-color] duration-[120ms] bg-panel ${
+      role="group"
+      aria-label={`${cat.label}: ${node.name || cat.label}`}
+      className={`absolute rounded-[4px] select-none transition-[box-shadow,border-color] duration-[120ms] bg-panel ${
         canEdit ? "cursor-grab" : "cursor-pointer"
       } ${
         running
@@ -171,16 +173,15 @@ const FlowNode = React.memo(function FlowNode({
       }}
     >
       <div
-        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-t-[3px] font-mono text-[9px] font-semibold tracking-[0.06em] uppercase border-b"
+        className="flex h-8 min-w-0 items-center gap-2 overflow-hidden rounded-t-[3px] border-b px-2.5 font-mono text-[8px] font-semibold uppercase tracking-[0.06em]"
         style={{ background: cat.softColor, borderBottomColor: cat.softColor, color: cat.color }}
       >
         <span
-          className="w-4 h-4 rounded-xs text-white inline-flex items-center justify-center text-[10px] font-bold"
+          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-[2px] text-[9px] font-bold text-white"
           style={{ background: cat.color }}
         >{cat.glyph}</span>
-        {cat.label}
-        <span className="ml-auto font-mono text-[9px] text-neutral-500">{node.id}</span>
-        {locked && <span title="Anchor step, can't be removed" className="text-[9px] leading-none" aria-hidden>🔒</span>}
+        <span className="min-w-0 truncate">{cat.label}</span>
+        {locked && <span title="Anchor step, can't be removed" className="ml-auto shrink-0 text-[9px] leading-none" aria-hidden>🔒</span>}
         {runStatus && (
           <span
             title={
@@ -188,16 +189,14 @@ const FlowNode = React.memo(function FlowNode({
                 ? `last run: ${runStatus} (${runError})`
                 : "last run: " + runStatus
             }
-            className={`w-1.5 h-1.5 rounded-full ${runStatus === "running" ? "animate-pulse" : ""}`}
+            className={`h-1.5 w-1.5 shrink-0 rounded-full ${locked ? "" : "ml-auto"} ${runStatus === "running" ? "animate-pulse" : ""}`}
             style={{ background: RUN_STATUS_COLORS[runStatus] }}
           />
         )}
       </div>
-      <div className="px-2.5 py-2 flex flex-col gap-0.5">
+      <div className="flex min-w-0 flex-col px-2.5 py-2">
         <div className={`font-body text-[13px] font-semibold leading-[1.2] text-coal ${CONNECTED_CARD_TEXT_CLASS}`}>{node.name || cat.label}</div>
-        {summary && (
-          <div className={`font-mono text-[10px] text-neutral-700 ${CONNECTED_CARD_TEXT_CLASS}`}>{summary}</div>
-        )}
+        <div className={`mt-1 font-mono text-[9px] leading-[1.2] text-neutral-500 ${CONNECTED_CARD_TEXT_CLASS}`}>{summary ?? node.id}</div>
       </div>
 
       {!isTriggerBlockType(node.type) && (

--- a/apps/dashboard/components/cockpit/flow-editor/ports.ts
+++ b/apps/dashboard/components/cockpit/flow-editor/ports.ts
@@ -1,7 +1,9 @@
 import type { FlowNodeDef } from "@/lib/flows";
 
-export const NODE_W = 168;
-export const NODE_H = 84;
+// Match the original editor's card footprint. The smaller PR #118 dimensions
+// forced long block labels and ids to wrap inside a fixed-height card.
+export const NODE_W = 190;
+export const NODE_H = 94;
 
 export interface Point { x: number; y: number; }
 

--- a/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
@@ -10,6 +10,7 @@ import {
   type WorkflowDefinitionLayoutResponse,
   type WorkflowDefinitionMeta,
   type WorkflowDefinitionNode,
+  type WorkflowDefinitionTemplate,
   type WorkflowDefinitionSaveResponse,
   type WorkflowDefinitionValidationResponse,
   type WorkflowDefinitionVersion,
@@ -77,6 +78,7 @@ const headerButtonClass =
 
 export function WorkflowEditorScreen({
   definitions,
+  templates,
   initialDetail,
   defaultDefinition,
   options,
@@ -84,6 +86,7 @@ export function WorkflowEditorScreen({
   canEdit,
 }: {
   definitions: WorkflowDefinitionMeta[];
+  templates: WorkflowDefinitionTemplate[];
   initialDetail: WorkflowDefinitionDetailResponse;
   defaultDefinition: WorkflowDefinition;
   options: WorkflowEditorOptions;
@@ -113,7 +116,7 @@ export function WorkflowEditorScreen({
   const [rowError, setRowError] = useState<{ id: number; message: string } | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
-  const [newSource, setNewSource] = useState("default");
+  const [newSource, setNewSource] = useState(`template:${templates[0]?.id ?? "ticket-workflow"}`);
   const [validation, setValidation] = useState<{
     key: string | null;
     state: WorkflowValidationState;
@@ -504,9 +507,9 @@ export function WorkflowEditorScreen({
     setCreateError(null);
     try {
       const source =
-        newSource === "default"
-          ? { kind: "default" as const }
-          : { kind: "duplicate" as const, definitionId: Number(newSource) };
+        newSource.startsWith("template:")
+          ? { kind: "template" as const, templateId: newSource.slice("template:".length) }
+          : { kind: "duplicate" as const, definitionId: Number(newSource.slice("duplicate:".length)) };
       const res = await fetch("/api/workflow-definitions", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -519,7 +522,7 @@ export function WorkflowEditorScreen({
       const detail = (await res.json()) as WorkflowDefinitionDetailResponse;
       setMetas((prev) => [...prev, detail.meta]);
       setNewName("");
-      setNewSource("default");
+      setNewSource(`template:${templates[0]?.id ?? "ticket-workflow"}`);
       await requestSwitch(detail.meta.id);
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : "Unable to create definition");
@@ -532,6 +535,9 @@ export function WorkflowEditorScreen({
     `rounded-full border px-2 py-0.5 font-mono text-[10px] font-semibold tracking-[0.04em] uppercase ${
       enabled ? "border-mariner text-mariner" : "border-neutral-200 text-neutral-600"
     }`;
+
+  const triggerLabel = (type: WorkflowDefinitionMeta["triggerTypes"][number]) =>
+    options.blockRegistry[type]?.presentation.label ?? type;
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -602,27 +608,16 @@ export function WorkflowEditorScreen({
                   {busy === "deploy" ? "Deploying…" : "Deploy"}
                 </button>
               )}
-              <div className="w-[190px]">
-                <Listbox
-                  options={metas.map((m) => ({
-                    value: String(m.id),
-                    label: m.name,
-                    hint: m.enabled ? "enabled" : "disabled",
-                  }))}
-                  value={String(selectedId)}
-                  onChange={(v) => void requestSwitch(Number(v))}
-                  disabled={busy !== null}
-                  ariaLabel="Workflow definition"
-                />
-              </div>
               <button
                 onClick={() => {
                   setDefsOpen((o) => !o);
                   setHistoryOpen(false);
                 }}
-                className={headerButtonClass}
+                className={`${headerButtonClass} min-w-[190px] max-w-[260px] flex items-center justify-between gap-3 normal-case tracking-normal`}
+                aria-expanded={defsOpen}
               >
-                Definitions ({metas.length})
+                <span className="truncate">{selectedMeta?.name ?? "Workflows"}</span>
+                <span className="text-neutral-500 shrink-0">{metas.length} ▾</span>
               </button>
               <button
                 onClick={() => {
@@ -641,9 +636,14 @@ export function WorkflowEditorScreen({
           fitSignal={fitSignal}
         />
         {defsOpen && (
-          <div className="absolute right-4 top-[56px] z-[60] w-[420px] max-h-[60vh] overflow-y-auto bg-panel border border-neutral-200 rounded-[4px] shadow-[0_12px_28px_-8px_rgba(24,27,32,0.22),0_2px_6px_rgba(24,27,32,0.08)] px-4 py-3">
+          <div className="absolute right-4 top-[56px] z-[60] w-[440px] max-h-[70vh] overflow-y-auto bg-panel border border-neutral-200 rounded-[4px] shadow-[0_12px_28px_-8px_rgba(24,27,32,0.22),0_2px_6px_rgba(24,27,32,0.08)] px-4 py-3">
             <div className="flex items-center justify-between mb-1">
-              <h2 className="font-body text-[14px] font-semibold text-neutral-900">Definitions</h2>
+              <div>
+                <h2 className="font-body text-[14px] font-semibold text-neutral-900">Workflows</h2>
+                <p className="mt-0.5 font-body text-[11px] text-neutral-500">
+                  Switch, activate, rename, or create workflows here.
+                </p>
+              </div>
               <button
                 onClick={() => setDefsOpen(false)}
                 className="appearance-none border-none bg-transparent font-body text-[12px] text-neutral-500 cursor-pointer"
@@ -652,9 +652,58 @@ export function WorkflowEditorScreen({
               </button>
             </div>
             {metas.map((m) => (
-              <div key={m.id} className="border-b border-neutral-100 py-2">
-                <div className="flex items-center gap-3 font-body text-[12px] text-neutral-700">
+              <div
+                key={m.id}
+                className={`border-b border-neutral-100 py-2.5 ${m.id === selectedId ? "bg-app-bg -mx-2 px-2" : ""}`}
+              >
+                <div className="flex items-start gap-3 font-body text-[12px] text-neutral-700">
+                  <button
+                    onClick={() => {
+                      void requestSwitch(m.id);
+                      setDefsOpen(false);
+                    }}
+                    disabled={busy !== null || m.id === selectedId}
+                    className="appearance-none min-w-0 flex-1 border-none bg-transparent p-0 text-left cursor-pointer disabled:cursor-default"
+                  >
+                    <span className="flex items-center gap-2 text-neutral-900 font-semibold">
+                      <span className="truncate">{m.name}</span>
+                      {m.id === selectedId && (
+                        <span className="font-mono text-[9px] uppercase tracking-[0.05em] text-mariner">
+                          Current
+                        </span>
+                      )}
+                    </span>
+                    <span className="mt-1 flex flex-wrap gap-1">
+                      {m.triggerTypes.length === 0 ? (
+                        <span className="text-[11px] text-neutral-500">No active triggers</span>
+                      ) : (
+                        m.triggerTypes.map((trigger) => (
+                          <span
+                            key={trigger}
+                            className="rounded-[3px] border border-neutral-200 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.04em] text-neutral-600"
+                          >
+                            {triggerLabel(trigger)}
+                          </span>
+                        ))
+                      )}
+                    </span>
+                  </button>
                   {canEdit ? (
+                    <button
+                      onClick={() => void patchDefinition(m.id, { enabled: !m.enabled })}
+                      disabled={busy !== null}
+                      className={`appearance-none cursor-pointer bg-transparent disabled:opacity-40 ${enabledPillClass(m.enabled)}`}
+                    >
+                      {m.enabled ? "Enabled" : "Disabled"}
+                    </button>
+                  ) : (
+                    <span className={enabledPillClass(m.enabled)}>
+                      {m.enabled ? "Enabled" : "Disabled"}
+                    </span>
+                  )}
+                </div>
+                {canEdit && (
+                  <div className="mt-2 flex items-center gap-2 pl-0 font-body text-[12px] text-neutral-700">
                     <input
                       key={`${m.id}-${m.name}`}
                       defaultValue={m.name}
@@ -670,26 +719,9 @@ export function WorkflowEditorScreen({
                           e.currentTarget.value = m.name;
                         }
                       }}
-                      className="w-[150px] border border-neutral-200 bg-panel rounded-[3px] px-1.5 py-0.5 font-body text-[12px] text-neutral-900"
+                      className="flex-1 min-w-0 border border-neutral-200 bg-panel rounded-[3px] px-1.5 py-0.5 font-body text-[12px] text-neutral-900"
                     />
-                  ) : (
-                    <span className="text-neutral-900">{m.name}</span>
-                  )}
-                  {canEdit ? (
-                    <button
-                      onClick={() => void patchDefinition(m.id, { enabled: !m.enabled })}
-                      disabled={busy !== null}
-                      className={`appearance-none cursor-pointer bg-transparent disabled:opacity-40 ${enabledPillClass(m.enabled)}`}
-                    >
-                      {m.enabled ? "Enabled" : "Disabled"}
-                    </button>
-                  ) : (
-                    <span className={enabledPillClass(m.enabled)}>
-                      {m.enabled ? "Enabled" : "Disabled"}
-                    </span>
-                  )}
-                  {canEdit && (
-                    <span className="ml-auto">
+                    <span className="shrink-0">
                       {confirmDelete === m.id ? (
                         <>
                           <button
@@ -717,8 +749,8 @@ export function WorkflowEditorScreen({
                         </button>
                       )}
                     </span>
-                  )}
-                </div>
+                  </div>
+                )}
                 {rowError?.id === m.id && (
                   <div className="mt-1 font-body text-[11px] text-red-600">{rowError.message}</div>
                 )}
@@ -727,29 +759,33 @@ export function WorkflowEditorScreen({
             {canEdit && (
               <div className="pt-3">
                 <div className="font-body text-[12px] font-semibold text-neutral-900 mb-2">
-                  New definition
+                  New workflow
                 </div>
                 <div className="flex items-center gap-2">
                   <input
                     value={newName}
                     onChange={(e) => setNewName(e.target.value)}
                     placeholder="Name"
-                    aria-label="New definition name"
+                    aria-label="New workflow name"
                     className="flex-1 min-w-0 border border-neutral-200 bg-panel rounded-[3px] px-1.5 py-1 font-body text-[12px] text-neutral-900"
                   />
                   <div className="w-[160px]">
                     <Listbox
                       options={[
-                        { value: "default", label: "Built-in default" },
+                        ...templates.map((template) => ({
+                          value: `template:${template.id}`,
+                          label: template.name,
+                          hint: "template",
+                        })),
                         ...metas.map((m) => ({
-                          value: String(m.id),
+                          value: `duplicate:${m.id}`,
                           label: `Duplicate: ${m.name}`,
                         })),
                       ]}
                       value={newSource}
                       onChange={setNewSource}
                       disabled={busy !== null}
-                      ariaLabel="New definition source"
+                      ariaLabel="New workflow source"
                     />
                   </div>
                   <button

--- a/apps/shared/contracts/api.ts
+++ b/apps/shared/contracts/api.ts
@@ -206,8 +206,16 @@ export interface WorkflowDefinitionMeta {
   updatedAt: string;
 }
 
+export interface WorkflowDefinitionTemplate {
+  id: string;
+  name: string;
+  description: string;
+  definition: WorkflowDefinition;
+}
+
 export interface WorkflowDefinitionsResponse {
   definitions: WorkflowDefinitionMeta[];
+  templates: WorkflowDefinitionTemplate[];
   defaultDefinition: WorkflowDefinition;
   options: WorkflowEditorOptions;
 }

--- a/apps/worker/scripts/db-migrate.ts
+++ b/apps/worker/scripts/db-migrate.ts
@@ -23,6 +23,10 @@ config({ path: [".env.local", ".env"], quiet: true });
 
 import { execSync } from "node:child_process";
 import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import type { Db } from "../src/db/client.js";
+import * as schema from "../src/db/schema.js";
+import { seedWorkflowDefinitionTemplates } from "../src/workflow-definition/template-seed.js";
 
 const url = process.env.DATABASE_URL;
 if (!url) {
@@ -61,4 +65,12 @@ if (marker.endpoint_host !== host) {
   process.exitCode = 1;
 } else {
   console.log(`[db-migrate] OK — branch claimed by '${vercelEnv}'.`);
+}
+
+if (process.exitCode !== 1) {
+  const db = drizzle({ client: sql, schema }) as unknown as Db;
+  await seedWorkflowDefinitionTemplates(db, {
+    includeReview: process.env.ENABLE_REVIEW_PHASE === "true",
+  });
+  console.log("[db-migrate] Workflow templates are ready.");
 }

--- a/apps/worker/src/routes/api/v1/workflow-definitions.get.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.get.ts
@@ -4,6 +4,7 @@ import { env } from "../../../../env.js";
 import { getDb } from "../../../db/client.js";
 import { requireDashboardActor, toHttpError } from "../../../lib/auth/request-context.js";
 import { defaultWorkflowDefinition } from "../../../workflow-definition/default.js";
+import { workflowDefinitionTemplates } from "../../../workflow-definition/templates.js";
 import {
   buildWorkflowEditorOptions,
   fetchAvailableModels,
@@ -63,6 +64,7 @@ export default defineEventHandler(
       ]);
       return {
         definitions,
+        templates: workflowDefinitionTemplates({ includeReview: env.ENABLE_REVIEW_PHASE }),
         defaultDefinition: defaultWorkflowDefinition({ includeReview: env.ENABLE_REVIEW_PHASE }),
         options: buildWorkflowEditorOptions(models, ticketStatuses),
       };

--- a/apps/worker/src/routes/api/v1/workflow-definitions.post.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.post.ts
@@ -5,6 +5,7 @@ import { getDb } from "../../../db/client.js";
 import { requireDashboardActor } from "../../../lib/auth/request-context.js";
 import { dashboardUserLabel } from "../../../pre-pr-checks/store.js";
 import { defaultWorkflowDefinition } from "../../../workflow-definition/default.js";
+import { workflowDefinitionTemplate } from "../../../workflow-definition/templates.js";
 import {
   createWorkflowDefinitionDraft,
   getCurrentWorkflowDefinitionVersion,
@@ -18,7 +19,10 @@ import {
   toWorkflowDefinitionHttpError,
 } from "./workflow-definitions.get.js";
 
-type CreateSource = { kind: "default" } | { kind: "duplicate"; definitionId: number };
+type CreateSource =
+  | { kind: "default" }
+  | { kind: "template"; templateId: string }
+  | { kind: "duplicate"; definitionId: number };
 
 interface CreateBody {
   name?: unknown;
@@ -29,6 +33,12 @@ function parseSource(source: unknown): CreateSource {
   if (source && typeof source === "object") {
     const kind = (source as { kind?: unknown }).kind;
     if (kind === "default") return { kind: "default" };
+    if (kind === "template") {
+      const templateId = (source as { templateId?: unknown }).templateId;
+      if (typeof templateId === "string" && templateId.length > 0) {
+        return { kind: "template", templateId };
+      }
+    }
     if (kind === "duplicate") {
       const definitionId = (source as { definitionId?: unknown }).definitionId;
       if (typeof definitionId === "number" && Number.isInteger(definitionId) && definitionId > 0) {
@@ -61,6 +71,14 @@ export default defineEventHandler(
         const draft = await getWorkflowDefinitionDraft(dbHandle, source.definitionId);
         const deployed = await getDeployedWorkflowDefinitionVersion(dbHandle, source.definitionId);
         seed = draft?.draft ?? deployed?.definition ?? defaultWorkflowDefinition({ includeReview: env.ENABLE_REVIEW_PHASE });
+      } else if (source.kind === "template") {
+        const template = workflowDefinitionTemplate(source.templateId, {
+          includeReview: env.ENABLE_REVIEW_PHASE,
+        });
+        if (!template) {
+          throw createError({ statusCode: 400, statusMessage: "Unknown template" });
+        }
+        seed = template.definition;
       } else {
         seed = defaultWorkflowDefinition({ includeReview: env.ENABLE_REVIEW_PHASE });
       }

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -213,6 +213,12 @@ describe("GET /api/v1/workflow-definitions", () => {
       currentVersion: null,
     });
     expect(body.defaultDefinition.schemaVersion).toBe(1);
+    expect(body.templates.map((template: { name: string }) => template.name)).toEqual([
+      "Ticket workflow",
+      "Human-approved plan",
+      "Review & fix after PR",
+      "Fully modular",
+    ]);
     expect(body.options.agentKind).toBe("claude");
     expect(body.options.defaultModel).toBe("claude-test-default");
     expect(body.options.blockRegistry.trigger_ticket_ai.type).toBe("trigger_ticket_ai");
@@ -229,6 +235,34 @@ describe("GET /api/v1/workflow-definitions", () => {
 });
 
 describe("POST /api/v1/workflow-definitions", () => {
+  it("creates a disabled definition from a named template", async () => {
+    const res = await handlerFor(definitionsPost)(
+      jsonRequest("POST", {
+        name: "Approved delivery",
+        source: { kind: "template", templateId: "human-approved-plan" },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meta).toMatchObject({ name: "Approved delivery", enabled: false });
+    expect(body.draft.nodes.some((node: { type: string }) => node.type === "send_plan_approval")).toBe(
+      true,
+    );
+    expect(body.draft.nodes.some((node: { type: string }) => node.type === "review_agent")).toBe(
+      false,
+    );
+  });
+
+  it("rejects an unknown template", async () => {
+    const res = await handlerFor(definitionsPost)(
+      jsonRequest("POST", {
+        name: "Unknown template",
+        source: { kind: "template", templateId: "missing" },
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("creates a disabled definition seeded from the built-in default", async () => {
     const res = await handlerFor(definitionsPost)(
       jsonRequest("POST", { name: "Second flow", source: { kind: "default" } }),

--- a/apps/worker/src/workflow-definition/schema.test.ts
+++ b/apps/worker/src/workflow-definition/schema.test.ts
@@ -13,6 +13,7 @@ import {
   planApprovalDefinition,
   prReviewFixDefinition,
 } from "./graph-fixtures.js";
+import { workflowDefinitionTemplates } from "./templates.js";
 import {
   ANY_SCOPE_BLOCK_POLICY,
   upgradeStoredWorkflowDefinition,
@@ -883,6 +884,21 @@ describe("workflowDefinitionSchema block-executor node types", () => {
 });
 
 describe("validateWorkflowGraph fixtures", () => {
+  it("ships four deployable starter templates with the production ticket workflow first", () => {
+    const templates = workflowDefinitionTemplates({ includeReview: true });
+    expect(templates.map((template) => template.name)).toEqual([
+      "Ticket workflow",
+      "Human-approved plan",
+      "Review & fix after PR",
+      "Fully modular",
+    ]);
+    expect(templates[0].definition.nodes.some((node) => node.type === "review_agent")).toBe(true);
+    for (const template of templates) {
+      expect(workflowDefinitionSchema.safeParse(template.definition).success).toBe(true);
+      expect(validateWorkflowDefinitionForDeployment(template.definition, registryContext)).toEqual([]);
+    }
+  });
+
   it("accepts the linear pipeline fixture", () => {
     const def = linearPipelineDefinition();
     expect(workflowDefinitionSchema.safeParse(def).success).toBe(true);

--- a/apps/worker/src/workflow-definition/store.test.ts
+++ b/apps/worker/src/workflow-definition/store.test.ts
@@ -50,6 +50,7 @@ import {
   WorkflowDefinitionStoreError,
   type WorkflowDefinitionActor,
 } from "./store.js";
+import { seedWorkflowDefinitionTemplates } from "./template-seed.js";
 
 const ADMIN: WorkflowDefinitionActor = { role: "admin", id: "u_admin", label: "Admin" };
 const MEMBER: WorkflowDefinitionActor = { role: "member", id: "u_member", label: "Member" };
@@ -137,6 +138,29 @@ describe("migration seed", () => {
       createdById: "system",
       createdByLabel: "System migration",
     });
+  });
+});
+
+describe("starter template seed", () => {
+  it("adds the three disabled starter workflows exactly once", async () => {
+    await seedWorkflowDefinitionTemplates(db, { includeReview: true });
+    await seedWorkflowDefinitionTemplates(db, { includeReview: true });
+
+    const defs = await listWorkflowDefinitions(db);
+    expect(defs.map((definition) => definition.name)).toEqual([
+      "Ticket workflow",
+      "Human-approved plan",
+      "Review & fix after PR",
+      "Fully modular",
+    ]);
+    expect(defs.map((definition) => definition.enabled)).toEqual([true, false, false, false]);
+    expect(defs.slice(1).map((definition) => definition.draftRevision)).toEqual([1, 1, 1]);
+    expect(defs.slice(1).map((definition) => definition.deployedVersion)).toEqual([1, 1, 1]);
+    expect(defs.slice(1).map((definition) => definition.triggerTypes)).toEqual([
+      ["trigger_ticket_ai", "trigger_plan_approved"],
+      ["trigger_pr_checks_failed", "trigger_pr_review"],
+      ["trigger_ticket_ai"],
+    ]);
   });
 });
 

--- a/apps/worker/src/workflow-definition/template-seed.ts
+++ b/apps/worker/src/workflow-definition/template-seed.ts
@@ -1,0 +1,80 @@
+import { isTriggerBlockType } from "@shared/contracts";
+import { and, eq, isNull, or } from "drizzle-orm";
+import type { Db } from "../db/client.js";
+import { workflowDefinitions, workflowDefinitionVersions } from "../db/schema.js";
+import { canonicalizeWorkflowDefinition, extractWorkflowDefinitionLayout } from "./layout.js";
+import { workflowDefinitionTemplates } from "./templates.js";
+
+/**
+ * Adds the three optional starter workflows once. The ticket workflow is
+ * created by migration 0013 and deliberately remains the only enabled one.
+ * The system marker survives renames and archives, so deleting a starter does
+ * not cause it to reappear on the next deployment.
+ */
+export async function seedWorkflowDefinitionTemplates(
+  db: Db,
+  options: { includeReview: boolean },
+): Promise<void> {
+  for (const template of workflowDefinitionTemplates(options).slice(1)) {
+    const marker = `System template:${template.id}`;
+    const findExisting = () =>
+      db
+        .select({ id: workflowDefinitions.id })
+        .from(workflowDefinitions)
+        .where(
+          or(
+            eq(workflowDefinitions.createdByLabel, marker),
+            and(eq(workflowDefinitions.name, template.name), isNull(workflowDefinitions.archivedAt)),
+          ),
+        )
+        .limit(1);
+    const existing = await findExisting();
+    if (existing.length > 0) continue;
+
+    let definitionId: number;
+    try {
+      const created = await db
+        .insert(workflowDefinitions)
+        .values({
+          name: template.name,
+          enabled: false,
+          triggerTypes: [],
+          layout: extractWorkflowDefinitionLayout(template.definition),
+          layoutRevision: 1,
+          createdById: "system",
+          createdByLabel: marker,
+        })
+        .returning({ id: workflowDefinitions.id });
+      definitionId = created[0]!.id;
+    } catch (error) {
+      if ((await findExisting()).length > 0) continue;
+      throw error;
+    }
+
+    try {
+      await db.insert(workflowDefinitionVersions).values({
+        definitionId,
+        version: 1,
+        definition: canonicalizeWorkflowDefinition(template.definition),
+        createdById: "system",
+        createdByLabel: marker,
+        restoredFromVersion: null,
+      });
+      await db
+        .update(workflowDefinitions)
+        .set({
+          deployedVersion: 1,
+          triggerTypes: template.definition.nodes
+            .map((node) => node.type)
+            .filter(isTriggerBlockType),
+        })
+        .where(eq(workflowDefinitions.id, definitionId));
+    } catch (error) {
+      await db
+        .delete(workflowDefinitionVersions)
+        .where(eq(workflowDefinitionVersions.definitionId, definitionId));
+      await db.delete(workflowDefinitions).where(eq(workflowDefinitions.id, definitionId));
+      throw error;
+    }
+  }
+}

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -1,0 +1,148 @@
+import type {
+  WorkflowDefinition,
+  WorkflowDefinitionEdge,
+  WorkflowDefinitionNode,
+  WorkflowDefinitionTemplate,
+} from "@shared/contracts";
+import { defaultWorkflowDefinition } from "./default.js";
+import {
+  buildEdge,
+  buildNode,
+  planApprovalDefinition,
+  prReviewFixDefinition,
+} from "./graph-fixtures.js";
+
+export const DEFAULT_WORKFLOW_TEMPLATE_ID = "ticket-workflow";
+
+function fullyModularDefinition(): WorkflowDefinition {
+  const planningOutput = JSON.stringify({
+    type: "object",
+    properties: { plan: { type: "string" } },
+    required: ["plan"],
+    additionalProperties: false,
+  });
+  const implementationOutput = JSON.stringify({
+    type: "object",
+    properties: { summary: { type: "string" } },
+    required: ["summary"],
+    additionalProperties: false,
+  });
+  const nodes: WorkflowDefinitionNode[] = [
+    buildNode({ id: "trigger", type: "trigger_ticket_ai", name: "Ticket assigned to AI" }, 0),
+    buildNode(
+      {
+        id: "planning",
+        type: "generic_agent",
+        name: "Generic agent — planning",
+        params: {
+          prompt: "Produce an implementation plan for this ticket.",
+          outputSchema: planningOutput,
+          workspaceMode: "none",
+        },
+      },
+      1,
+    ),
+    buildNode({ id: "prepare", type: "prepare_workspace", name: "Prepare workspace" }, 2),
+    buildNode(
+      {
+        id: "implementation",
+        type: "generic_agent",
+        name: "Generic agent — implementation",
+        params: { outputSchema: implementationOutput, workspaceMode: "read_write" },
+        inputs: { prompt: "steps.planning.output.plan" },
+      },
+      3,
+    ),
+    buildNode({ id: "checks", type: "run_checks", name: "Run checks" }, 4),
+    buildNode(
+      {
+        id: "checks_ok",
+        type: "branch",
+        name: "All checks pass?",
+        params: { condition: "steps.checks.output.ok" },
+      },
+      5,
+    ),
+    buildNode(
+      { id: "retry", type: "loop", name: "Retry fixes", params: { maxAttempts: 3, onExhaust: "fail" } },
+      5,
+      1,
+    ),
+    buildNode({ id: "fix", type: "fix_agent", name: "Fix agent" }, 4, 1),
+    buildNode({ id: "finalize", type: "finalize_workspace", name: "Finalize workspace" }, 6),
+    buildNode(
+      {
+        id: "open_pr",
+        type: "open_pr",
+        name: "Open pull request",
+        inputs: { repositories: "steps.finalize.output.repositories" },
+      },
+      7,
+    ),
+  ];
+  const edges: WorkflowDefinitionEdge[] = [
+    buildEdge("trigger", "planning"),
+    buildEdge("planning", "prepare"),
+    buildEdge("prepare", "implementation"),
+    buildEdge("implementation", "checks"),
+    buildEdge("checks", "checks_ok"),
+    buildEdge("checks_ok", "finalize", "true"),
+    buildEdge("checks_ok", "retry", "false"),
+    buildEdge("retry", "fix", "continue"),
+    buildEdge("fix", "checks"),
+    buildEdge("finalize", "open_pr"),
+  ];
+  return { schemaVersion: 1, nodes, edges };
+}
+
+function reviewFixAfterPrDefinition(): WorkflowDefinition {
+  const definition = prReviewFixDefinition();
+  return {
+    ...definition,
+    nodes: definition.nodes.map((node) =>
+      node.type === "trigger_pr_checks_failed"
+        ? { ...node, params: { ...node.params, checkNames: ["CI"] } }
+        : node,
+    ),
+  };
+}
+
+export function workflowDefinitionTemplates({
+  includeReview,
+}: {
+  includeReview: boolean;
+}): WorkflowDefinitionTemplate[] {
+  return [
+    {
+      id: DEFAULT_WORKFLOW_TEMPLATE_ID,
+      name: "Ticket workflow",
+      description: "The current production delivery flow from ticket assignment through PR publication.",
+      definition: defaultWorkflowDefinition({ includeReview }),
+    },
+    {
+      id: "human-approved-plan",
+      name: "Human-approved plan",
+      description: "Plans first, waits for approval, then implements the approved plan.",
+      definition: planApprovalDefinition(),
+    },
+    {
+      id: "review-fix-after-pr",
+      name: "Review & fix after PR",
+      description: "Responds to failed checks or requested changes on workflow-owned pull requests.",
+      definition: reviewFixAfterPrDefinition(),
+    },
+    {
+      id: "fully-modular",
+      name: "Fully modular",
+      description: "Builds delivery from generic agents, workspace, checks, branch, and loop blocks.",
+      definition: fullyModularDefinition(),
+    },
+  ];
+}
+
+export function workflowDefinitionTemplate(
+  id: string,
+  options: { includeReview: boolean },
+): WorkflowDefinitionTemplate | null {
+  return workflowDefinitionTemplates(options).find((template) => template.id === id) ?? null;
+}


### PR DESCRIPTION
## What changed

- ship four canonical workflow templates:
  - Ticket workflow
  - Human-approved plan
  - Review & fix after PR
  - Fully modular
- seed the three optional templates as disabled, deployed definitions while preserving the current production-mirroring ticket workflow as the enabled default
- support creating definitions from named templates
- combine workflow switching and definition management into one workflow manager
- restore the pre-PR #118 node-card footprint and truncation behavior so long labels and summaries cannot overflow
- keep existing trigger ownership enforcement, failure ports, runtime badges, and connection interactions

## Why

PR #118 left the editor with only one initial workflow and split workflow selection from workflow management. Its smaller node cards also placed the internal block id beside the block label in an unfixed header, causing long trigger names to wrap and push content outside the card.

This follow-up restores the intended four starting workflows, provides one place to manage them, and fixes the canvas regression without changing execution ownership rules.

## Validation

- dashboard TypeScript check
- worker TypeScript check
- 43 focused dashboard workflow editor tests
- deploy-grade validation for all four templates
- idempotent starter-template seed test
- local browser verification of workflow switching and the Review & fix after PR canvas
- verified node text stays within card bounds while connection handles remain available
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added starter workflow templates for creating new workflows.
  - Added template-based workflow creation and duplication options.
  - Updated the workflow menu with trigger labels, workflow counts, and enable/disable controls.
  - Improved workflow node accessibility, layout, and status presentation.
  - Automatically makes starter templates available during setup.

- **Bug Fixes**
  - Workflow nodes now consistently display a descriptive summary or identifier.
  - Added validation and clear errors for unavailable templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->