### PR TITLE
fix(worker): stored definitions crash with zod 4 in the nitro bundle

### DIFF
--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -362,7 +362,10 @@ const storedWorkflowNode = z
     name: z.string().optional(),
     x: coordinate,
     y: coordinate,
-    params: z.record(storedWorkflowParamValue),
+    // Two-arg record: the nitro bundle resolves bare "zod" to zod 4, where a
+    // single-arg record means record(KEY) with an undefined value schema that
+    // only crashes at parse time (500 on every stored-definition read).
+    params: z.record(z.string(), storedWorkflowParamValue),
     inputs: z.record(bindingInputName, bindingSource).optional(),
   })
   .passthrough();


### PR DESCRIPTION
Production's `GET /api/v1/workflow-definitions/:id` returns 500 (`TypeError: Cannot read properties of undefined (reading '_zod')`) since the nitro bundle started resolving bare `zod` to 4.3.6 (transitive dep). In zod 4, single-arg `z.record(value)` is interpreted as `record(key)` with an undefined value schema, which only crashes at parse time, so every stored-definition read (dashboard editor) 500s.

Fix: make the record explicit two-arg (`z.record(z.string(), storedWorkflowParamValue)`), valid under both zod 3 and zod 4.

Evidence: runtime logs of dpl ai-workflow-fpmbt0hhr (production) and the ai-workflow-demo env show the identical stack in `.nitro/zod@4.3.6/v4/core/schemas.js`; the demo env stopped 500ing after this exact change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow validation reliability by preventing runtime parsing failures for stored workflow parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->