### PR TITLE
feat(workflow): rich text prose fields with variables and Slack send-mode

### DIFF
--- a/apps/dashboard/components/cockpit/flow-editor/config-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/config-fields.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/workflow-editor/params";
 import { Listbox } from "@/components/cockpit/listbox";
 import { PromptField } from "./prompt-field";
+import { PromptEditor } from "@/components/cockpit/prompt-editor/prompt-editor";
 
 /** The inspector change callback. Widened past WorkflowParamValue so PromptField
  *  can set/clear provenance refs under `promptRefs.<paramKey>` paths too. */
@@ -132,6 +133,31 @@ function TextArea({
       rows={3}
       onChange={(e) => onChange(e.target.value)}
       className={mono ? monoTextareaCls : textareaCls}
+    />
+  );
+}
+
+/** Rich text (Tiptap) surface for prose params: Slack messages, comment bodies.
+ *  Reuses the prompt editor so these fields match the Prompt Library editor and
+ *  get {{variable}} insertion + highlighting for free. Markdown is the stored
+ *  value; the worker substitutes {{variables}} at runtime per VARIABLE_PARAM_KEYS. */
+function RichTextField({
+  value,
+  disabled,
+  minHeightClass,
+  onChange,
+}: {
+  value: string;
+  disabled: boolean;
+  minHeightClass?: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <PromptEditor
+      value={value}
+      disabled={disabled}
+      minHeightClass={minHeightClass ?? "min-h-[96px]"}
+      onChange={onChange}
     />
   );
 }
@@ -681,14 +707,22 @@ export function ConfigFields({
     case "post_ticket_comment":
       return (
         <ConfigField label="Body">
-          <TextArea value={str(node.params.body)} disabled={!canEdit} onChange={(v) => onChange("params.body", v)} />
+          <RichTextField
+            value={str(node.params.body)}
+            disabled={!canEdit}
+            onChange={(v) => onChange("params.body", v)}
+          />
         </ConfigField>
       );
     case "post_pr_comment":
       return (
         <>
           <ConfigField label="Body">
-            <TextArea value={str(node.params.body)} disabled={!canEdit} onChange={(v) => onChange("params.body", v)} />
+            <RichTextField
+              value={str(node.params.body)}
+              disabled={!canEdit}
+              onChange={(v) => onChange("params.body", v)}
+            />
           </ConfigField>
           <ConfigField label="Target">
             <Listbox
@@ -704,12 +738,37 @@ export function ConfigFields({
           </ConfigField>
         </>
       );
-    case "send_slack_message":
+    case "send_slack_message": {
+      const sendOn = str(node.params.sendOn) === "always" ? "always" : "pr_ready";
       return (
-        <ConfigField label="Message">
-          <TextInput value={str(node.params.message)} disabled={!canEdit} onChange={(v) => onChange("params.message", v)} />
-        </ConfigField>
+        <>
+          <ConfigField label="When to send">
+            <Listbox
+              options={[
+                { value: "pr_ready", label: "Only when a PR is ready" },
+                { value: "always", label: "Always (standalone message)" },
+              ]}
+              value={sendOn}
+              disabled={!canEdit}
+              ariaLabel="When to send"
+              onChange={(v) => onChange("params.sendOn", v)}
+            />
+          </ConfigField>
+          <ConfigField label="Message">
+            <RichTextField
+              value={str(node.params.message)}
+              disabled={!canEdit}
+              onChange={(v) => onChange("params.message", v)}
+            />
+          </ConfigField>
+          <ConfigNote>
+            {sendOn === "always"
+              ? "Posts your message as a standalone note in the ticket thread whenever this block runs. Add {{pr_url}} if you want a PR link."
+              : "Appends your message under the PR ready card, only after a pull request is published."}
+          </ConfigNote>
+        </>
       );
+    }
     case "human_question":
       return (
         <ConfigField label="Questions">
@@ -800,7 +859,11 @@ export function ConfigFields({
             />
           </ConfigField>
           <ConfigField label="Post comment">
-            <TextArea value={str(node.params.postComment)} disabled={!canEdit} onChange={(v) => onChange("params.postComment", v)} />
+            <RichTextField
+              value={str(node.params.postComment)}
+              disabled={!canEdit}
+              onChange={(v) => onChange("params.postComment", v)}
+            />
           </ConfigField>
         </>
       );

--- a/apps/dashboard/components/cockpit/prompt-editor/prompt-editor.tsx
+++ b/apps/dashboard/components/cockpit/prompt-editor/prompt-editor.tsx
@@ -255,8 +255,9 @@ export function PromptEditor({ value, onChange, syncRequest, disabled, minHeight
         fill ? "h-full min-h-0" : ""
       }`}
     >
-      {/* Toolbar (pinned) */}
-      <div className="flex shrink-0 items-center gap-0.5 border-b border-neutral-200 px-1.5 py-1">
+      {/* Toolbar (pinned). Wraps to a second row in narrow hosts (e.g. the flow
+          inspector) so buttons never overlap; stays single-line where it fits. */}
+      <div className="flex flex-wrap shrink-0 items-center gap-y-1 gap-x-0.5 border-b border-neutral-200 px-1.5 py-1">
         {!raw &&
           actions.map((a) => (
             <span key={a.key} className="flex items-center">

--- a/apps/shared/contracts/workflow-graph.ts
+++ b/apps/shared/contracts/workflow-graph.ts
@@ -97,7 +97,7 @@ export const BLOCK_PARAM_KEYS: Record<WorkflowBlockType, readonly string[]> = {
   update_ticket_status: ["target"],
   post_ticket_comment: ["body"],
   post_pr_comment: ["body", "target"],
-  send_slack_message: ["message"],
+  send_slack_message: ["message", "sendOn"],
   send_plan_approval: ["mirrorComment"],
   human_question: ["questions", "suggestedAnswers"],
   arthur_injection_check: [],

--- a/apps/worker/src/adapters/messaging/chatsdk.test.ts
+++ b/apps/worker/src/adapters/messaging/chatsdk.test.ts
@@ -236,4 +236,33 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
       `:no_entry: Task ${JIRA_LINK} canceled: left AI column`,
     );
   });
+
+  it("note — posts the raw message as a thread reply WITHOUT editing the top-level status", async () => {
+    const store = createThreadStore();
+    store.getParent.mockResolvedValueOnce("1700000000.000111");
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", {
+      kind: "note",
+      text: "Deploy to staging is done",
+    });
+
+    // A standalone message never overwrites the status line or re-anchors the parent.
+    expect(mockEditMessage).not.toHaveBeenCalled();
+    expect(mockChannelPost).not.toHaveBeenCalled();
+    expect(store.setParent).not.toHaveBeenCalled();
+    // Just the user's message, no system head/emoji.
+    expect(mockThreadPost).toHaveBeenCalledWith("Deploy to staging is done");
+  });
+
+  it("note — falls back to a top-level post when no thread parent exists yet", async () => {
+    const store = createThreadStore(); // getParent resolves null
+    const adapter = createAdapter(store);
+
+    await adapter.notifyForTicket("AWT-42", { kind: "note", text: "Heads up" });
+
+    expect(mockEditMessage).not.toHaveBeenCalled();
+    expect(mockThreadPost).not.toHaveBeenCalled();
+    expect(mockChannelPost).toHaveBeenCalledWith("Heads up");
+  });
 });

--- a/apps/worker/src/adapters/messaging/chatsdk.ts
+++ b/apps/worker/src/adapters/messaging/chatsdk.ts
@@ -77,6 +77,36 @@ export class ChatSDKAdapter implements MessagingAdapter {
     ticketKey: string,
     event: TicketEvent,
   ): Promise<void> {
+    if (event.kind === "note") {
+      // A note is a standalone message from a send_slack_message block in "always"
+      // mode. Post it as a thread reply under the existing status parent WITHOUT
+      // editing the top-level status line — a mid-run message must not overwrite the
+      // "in progress"/"PR ready" status. Falls back to top-level if no parent exists.
+      const parent = await this.threadStore.getParent(ticketKey).catch((err) => {
+        logger.warn(
+          { ticketKey, error: (err as Error).message },
+          "thread_parent_lookup_failed",
+        );
+        return null;
+      });
+      await this.postDetail(
+        ticketKey,
+        parent,
+        formatTicketEvent(event, ticketKey, this.jiraBaseUrl),
+        event.kind,
+      );
+      logger.info(
+        {
+          ticketKey,
+          eventKind: event.kind,
+          threadParentId: parent,
+          channelId: this.channelId,
+        },
+        "notification_sent",
+      );
+      return;
+    }
+
     const status = formatTicketStatus(event, ticketKey, this.jiraBaseUrl);
     const detail = formatTicketEvent(event, ticketKey, this.jiraBaseUrl);
 

--- a/apps/worker/src/adapters/messaging/format.test.ts
+++ b/apps/worker/src/adapters/messaging/format.test.ts
@@ -300,6 +300,16 @@ describe("formatTicketEvent", () => {
     expect(text).not.toContain("<!channel>");
     expect(text).toContain(`Ship it <${ZWSP}!channel>`);
   });
+
+  it("note: returns just the message with no system head, defanging broadcasts", () => {
+    expect(
+      formatTicketEvent({ kind: "note", text: "Deploy done for AWT-42" }, KEY, JIRA),
+    ).toBe("Deploy done for AWT-42");
+    // No "Task <link>" head or emoji is prefixed to a standalone message.
+    expect(
+      formatTicketEvent({ kind: "note", text: "Ship it <!channel>" }, KEY, JIRA),
+    ).toBe(`Ship it <${ZWSP}!channel>`);
+  });
 });
 
 describe("neutralizeSlackBroadcasts", () => {

--- a/apps/worker/src/adapters/messaging/format.ts
+++ b/apps/worker/src/adapters/messaging/format.ts
@@ -14,6 +14,7 @@ const EVENT_EMOJI: Record<TicketEvent["kind"], string> = {
   failed: ":warning:",
   plan_approval_requested: ":memo:",
   canceled: ":no_entry:",
+  note: ":speech_balloon:",
 };
 
 /**
@@ -48,6 +49,10 @@ export function formatTicketStatus(
       return `${head} plan awaiting approval`;
     case "canceled":
       return `${head} canceled`;
+    case "note":
+      // Notes never edit the top-level status; chatsdk's note branch posts the
+      // detail directly and never calls this. Present only for switch exhaustiveness.
+      return "";
   }
 }
 
@@ -113,6 +118,12 @@ export function formatTicketEvent(
 
     case "canceled":
       return `${head} canceled: ${event.reason}`;
+
+    case "note":
+      // A note carries only the user's own message (already {{variable}}-substituted).
+      // No system head/emoji so it reads as a plain message; defang broadcast tokens
+      // so ticket-derived text can't ping the whole channel.
+      return neutralizeSlackBroadcasts(event.text);
   }
 }
 

--- a/apps/worker/src/adapters/messaging/types.ts
+++ b/apps/worker/src/adapters/messaging/types.ts
@@ -35,7 +35,16 @@ export type TicketEvent =
       /** Short excerpt of the proposed plan. Not rendered in the Slack copy. */
       planPreview?: string;
     }
-  | { kind: "canceled"; reason: string };
+  | { kind: "canceled"; reason: string }
+  | {
+      /**
+       * Free-form message from a `send_slack_message` block in "always" mode.
+       * Posted as a thread reply under the ticket status without touching the
+       * top-level status line (see chatsdk `notifyForTicket`).
+       */
+      kind: "note";
+      text: string;
+    };
 
 export interface MessagingAdapter {
   /**

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -685,7 +685,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       "Notifies the configured Slack channel about a workflow milestone.",
       "✉",
     ),
-    defaults: { message: "" },
+    defaults: { message: "", sendOn: "pr_ready" },
     inputs: { message: input(stringType()) },
     output: statusOutput(),
     statusVariants: ["ok", "skipped", "failed"],

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -242,7 +242,12 @@ const sendSlackMessageNode = z
   .object({
     ...baseNodeFields,
     type: z.literal("send_slack_message"),
-    params: z.object({ message: z.string().trim().max(2000).optional() }).strict(),
+    params: z
+      .object({
+        message: z.string().trim().max(2000).optional(),
+        sendOn: z.enum(["pr_ready", "always"]).optional(),
+      })
+      .strict(),
   })
   .strict();
 

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -2228,11 +2228,24 @@ async function agentWorkflowBody(
           }
 
           case "send_slack_message": {
+            // node.params.message is already {{variable}}-substituted (executeBlock).
+            const message = resolveSlackMessageInput(node.params, resolvedInputs);
+            const sendOn = node.params.sendOn === "always" ? "always" : "pr_ready";
+
+            if (sendOn === "always") {
+              // Standalone message: post it as a thread note whenever this block
+              // runs, independent of any PR. Empty message is a no-op.
+              if (!message) return { kind: "next", output: { status: "skipped" } };
+              await notifyTicket(ticket.identifier, { kind: "note", text: message }, transitionOwner);
+              return { kind: "next", output: { status: "ok" } };
+            }
+
+            // Default "pr_ready": ride along with the PR-ready card, only once a PR
+            // has been published.
             const publication = ctx.publication;
             if (publication?.status === "published") {
               const primaryPr = publication.prs[0]!;
               const usageReport = formatUsageReport(phaseUsages, priceLookup, activeModel, phaseModels);
-              const message = resolveSlackMessageInput(node.params, resolvedInputs);
               await notifyTicket(ticket.identifier, {
                 kind: "pr_ready",
                 pr: { url: primaryPr.url, number: primaryPr.id },

--- a/apps/worker/src/workflows/slack-message-variables.test.ts
+++ b/apps/worker/src/workflows/slack-message-variables.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { buildPromptVariables, substituteNodePromptParams } from "./prompt-vars.js";
+import { resolveSlackMessageInput } from "./agent.js";
+import { formatTicketEvent } from "../adapters/messaging/format.js";
+import type { WorkflowDefinitionNode } from "@shared/contracts";
+import type { AgentWorkflowInput } from "./agent-input.js";
+import type { WorkspacePublicationResult } from "./workspace-publication.js";
+
+// End-to-end proof of what a `send_slack_message` block actually sends once its
+// {{variables}} are substituted. It stitches the real runtime steps in order:
+//   1. buildPromptVariables(ctx)           -> the {{name}} -> value map
+//   2. substituteNodePromptParams(node)    -> node.params.message with vars resolved
+//                                             (this is what executeBlock does at agent.ts:1864)
+//   3. resolveSlackMessageInput(params)    -> the string the handler passes as extraText
+//   4. formatTicketEvent(pr_ready)         -> the final Slack-mrkdwn text posted in-thread
+//
+// Note: send_slack_message piggybacks on the "PR ready" notification and only
+// fires when a PR has been published; the message is appended after that card.
+
+type Source = Parameters<typeof buildPromptVariables>[0];
+
+const ticket = {
+  id: "10042",
+  identifier: "AWT-42",
+  title: "Add rate limiting",
+  description: "Throttle the public API.",
+  acceptanceCriteria: "429 after 100 req/min.",
+  comments: [],
+  labels: ["backend", "api"],
+  trackerStatus: "AI",
+  attachments: [],
+};
+
+const ticketEntry: AgentWorkflowInput = {
+  kind: "ticket",
+  subjectKey: "jira:AWT-42",
+  ticketKey: "AWT-42",
+  ownerToken: "owner-token",
+};
+
+const publishedPr = {
+  status: "published",
+  prs: [
+    {
+      provider: "github",
+      repoPath: "acme/api",
+      id: 128,
+      url: "https://github.com/acme/api/pull/128",
+      branch: "ai/awt-42",
+      isNew: true,
+    },
+  ],
+} as unknown as WorkspacePublicationResult;
+
+function makeSource(overrides: Partial<Source> = {}): Source {
+  return {
+    runId: "run_awt42",
+    ticket,
+    branchName: "ai/awt-42",
+    entry: ticketEntry,
+    researchPlanMarkdown: "",
+    publication: publishedPr,
+    selectedRepositories: [],
+    ...overrides,
+  };
+}
+
+const slackNode = (message: string): WorkflowDefinitionNode => ({
+  id: "slack1",
+  type: "send_slack_message",
+  x: 0,
+  y: 0,
+  params: { message },
+  inputs: {},
+});
+
+/** Run steps 1-3: what the substituted `message` param becomes at send time. */
+function resolveSentMessage(rawMessage: string, source: Source = makeSource()): string {
+  const substituted = substituteNodePromptParams(slackNode(rawMessage), buildPromptVariables(source));
+  return resolveSlackMessageInput(substituted.params, {});
+}
+
+describe("send_slack_message: what actually goes to Slack", () => {
+  it("substitutes every {{variable}} in the message the user typed", () => {
+    const sent = resolveSentMessage(
+      ":rocket: {{ticket_key}}: {{ticket_title}} shipped to {{pr_url}} on branch {{branch_name}}",
+    );
+    expect(sent).toBe(
+      ":rocket: AWT-42: Add rate limiting shipped to https://github.com/acme/api/pull/128 on branch ai/awt-42",
+    );
+  });
+
+  it("appends the resolved message under the system 'PR ready' line in the final Slack text", () => {
+    const sent = resolveSentMessage("Heads up team: {{ticket_key}} ({{ticket_title}}) is ready");
+    const slackText = formatTicketEvent(
+      {
+        kind: "pr_ready",
+        pr: { url: "https://github.com/acme/api/pull/128", number: 128 },
+        usageReport: "",
+        extraText: sent,
+      },
+      "AWT-42",
+      "https://acme.atlassian.net",
+    );
+    // The user's substituted line is present verbatim...
+    expect(slackText).toContain("Heads up team: AWT-42 (Add rate limiting) is ready");
+    // ...appended after our own system-built PR-ready copy + link.
+    expect(slackText).toContain("PR ready for review");
+    expect(slackText).toContain("<https://github.com/acme/api/pull/128|#128>");
+    expect(slackText.indexOf("PR ready for review")).toBeLessThan(
+      slackText.indexOf("Heads up team"),
+    );
+  });
+
+  it("resolves a variable with no value to empty string, never the text 'undefined'", () => {
+    // pr_title has no source on a ticket-triggered run (only the opened PR backs
+    // pr_number/pr_url), so it collapses to "" rather than leaking "undefined".
+    const sent = resolveSentMessage("Title: [{{pr_title}}] done", makeSource({ entry: ticketEntry }));
+    expect(sent).toBe("Title: [] done");
+    expect(sent).not.toContain("undefined");
+  });
+
+  it("leaves an unknown/misspelled token verbatim so the typo stays visible", () => {
+    const sent = resolveSentMessage("Ping {{ticket_ky}} now");
+    expect(sent).toBe("Ping {{ticket_ky}} now");
+  });
+});
+
+describe('send_slack_message "always" mode: standalone note', () => {
+  const slackNodeWithMode = (
+    message: string,
+    sendOn: string,
+  ): WorkflowDefinitionNode => ({
+    id: "slack1",
+    type: "send_slack_message",
+    x: 0,
+    y: 0,
+    params: { message, sendOn },
+    inputs: {},
+  });
+
+  it("substitutes the message and leaves the sendOn config param untouched", () => {
+    const node = slackNodeWithMode("{{ticket_key}}: {{ticket_title}}", "always");
+    const substituted = substituteNodePromptParams(node, buildPromptVariables(makeSource()));
+    // sendOn is config, not a {{variable}} param — it must round-trip unchanged.
+    expect(substituted.params.sendOn).toBe("always");
+    expect(resolveSlackMessageInput(substituted.params, {})).toBe("AWT-42: Add rate limiting");
+  });
+
+  it("formats the substituted message as a bare note (no PR-ready card, no head)", () => {
+    const sent = resolveSentMessage("Team: {{ticket_key}} ({{ticket_title}}) is ready");
+    const slackText = formatTicketEvent({ kind: "note", text: sent }, "AWT-42", "https://acme.atlassian.net");
+    // A note is exactly the user's substituted message — nothing prepended.
+    expect(slackText).toBe("Team: AWT-42 (Add rate limiting) is ready");
+    expect(slackText).not.toContain("PR ready for review");
+  });
+});

--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -1054,7 +1054,7 @@
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("unknown[]", "comments")],
           statuses: ["ok", "failed"],
         }),
-        send_slack_message: runtimeContract(["message"], {
+        send_slack_message: runtimeContract(["message", "sendOn"], {
           optionalInputs: typedPaths("string", "message"),
           requiredOutputs: STATUS_OUTPUT,
           statuses: ["ok", "skipped", "failed"],


### PR DESCRIPTION
## What and why

Two related changes to the workflow editor, consistent with the Prompt Library.

### 1. Rich text editor for node prose fields
Action text fields were plain `input`/`textarea`. They now use the same TipTap editor as the Prompt Library (`PromptEditor`), with a toolbar, `{{variable}}` insertion (a `+ Variable` button and a right-click menu) and highlighting. Affected fields:
- Send Slack message → Message
- Post ticket comment → Body
- Post PR comment → Body
- Terminate → Post comment

All four already substitute `{{variables}}` at runtime (`VARIABLE_PARAM_KEYS`), so this was a frontend-only change. The toolbar now wraps in the narrow inspector panel (`flex-wrap`) so buttons no longer overlap.

### 2. Slack block send mode (`sendOn`)
The `send_slack_message` block only sent when a PR was published (appending the message to the "PR ready" card). New **"When to send"** selector:
- **Only when a PR is ready** (default, preserves current behavior),
- **Always (standalone message)** — posts the message as a standalone note in the ticket thread, independent of any PR.

"Always" mode uses a new `note` messaging event that posts the text as a thread reply without overwriting the top-level status. Use `{{pr_url}}` for a PR link in this mode.

## Technical notes
- Contract/validation: `sendOn` added to `BLOCK_PARAM_KEYS` (serialization allowlist), the zod schema, registry defaults, and the docs catalog (pinned by the bijection test).
- Messaging: new `kind: "note"` in `TicketEvent`, handled in `format.ts` and `chatsdk.ts` (a branch that skips the status edit).
- The `send_slack_message` handler branches on `sendOn`.

## Note
In "always" mode this block no longer sends the automatic "PR ready + link" card (it was the sole emitter); that is an intentional mode choice. The default "pr_ready" changes nothing for existing workflows.

## Tests
- Worker + dashboard typecheck: clean.
- New/extended tests: `format.test.ts` (note), `chatsdk.test.ts` (note without status edit), `slack-message-variables.test.ts` (end-to-end substitution + always mode), `block-catalog-sync` / `block-registry` (new param).
- Dashboard `serialize.test` confirms `sendOn` round-trips.
