### PR TITLE
Separate execution errors from workflow outcomes

### DIFF
--- a/apps/dashboard/lib/workflow-editor/run-statuses.test.ts
+++ b/apps/dashboard/lib/workflow-editor/run-statuses.test.ts
@@ -75,6 +75,23 @@ test("errors map contains only entries with an error", () => {
   assert.deepEqual(derived?.errors, { n3: "boom", n4: "why?" });
 });
 
+test("execution errors include their diagnostic id without exposing internal detail", () => {
+  const run = snapshot({
+    blockStatuses: {
+      n1: {
+        status: "fail",
+        error: "An external service could not complete this block.",
+        diagnosticId: "AIW-DIAG-run-1-n1-1",
+      },
+    },
+  });
+
+  assert.deepEqual(deriveRunStatuses(run, editor)?.errors, {
+    n1:
+      "An external service could not complete this block. Diagnostic ID: AIW-DIAG-run-1-n1-1",
+  });
+});
+
 test("empty blockStatuses yields empty maps", () => {
   const derived = deriveRunStatuses(snapshot({ blockStatuses: {} }), editor);
   assert.deepEqual(derived, { statuses: {}, errors: {} });

--- a/apps/dashboard/lib/workflow-editor/run-statuses.ts
+++ b/apps/dashboard/lib/workflow-editor/run-statuses.ts
@@ -17,7 +17,11 @@ export function deriveRunStatuses(
   const errors: Record<string, string> = {};
   for (const [nodeId, state] of Object.entries(run.blockStatuses)) {
     statuses[nodeId] = state.status;
-    if (state.error !== undefined) errors[nodeId] = state.error;
+    if (state.error !== undefined) {
+      errors[nodeId] = state.diagnosticId
+        ? `${state.error} Diagnostic ID: ${state.diagnosticId}`
+        : state.error;
+    }
   }
   return { statuses, errors };
 }

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -64,6 +64,8 @@ export interface Run {
 }
 
 /** Structured error as returned by the Workflow runtime for failed runs/steps. */
+export const EXECUTION_DIAGNOSTIC_PREFIX = "AIW-DIAG-";
+
 export interface RunError {
   message: string;
   stack?: string;
@@ -310,7 +312,7 @@ export interface WorkflowBlockContract {
   inputs: Record<string, WorkflowBlockInputContract>;
   additionalInputs: WorkflowBlockAdditionalInputContract[];
   output: {
-    /** Complete executor envelope, including failure and clarification output. */
+    /** Complete domain-output envelope, including clarification outcomes. */
     schema: WorkflowValueSchema;
     /** Fields guaranteed when execution continues through a normal output port. */
     bindingSchema: WorkflowValueSchema;
@@ -398,6 +400,8 @@ export type BlockRunStatus = "pending" | "running" | "ok" | "warn" | "fail";
 export interface BlockRunState {
   status: BlockRunStatus;
   error?: string;
+  /** Stable, user-safe correlation key for an execution error. */
+  diagnosticId?: string;
   attempt?: number;
   output?: BlockOutput;
 }

--- a/apps/worker/src/lib/overview/collect-run-detail.test.ts
+++ b/apps/worker/src/lib/overview/collect-run-detail.test.ts
@@ -127,6 +127,73 @@ describe("collectRunDetail", () => {
     expect(run.ticketTitle).toBe("");
     expect(run.ticketUrl).toBe("");
   });
+
+  it("drops the stack from diagnostic-coded execution errors", async () => {
+    const source = makeSource(
+      {
+        runId: "run_diag",
+        status: "failed",
+        error: {
+          message: "The block could not be completed.",
+          code: "AIW-DIAG-run_diag-engine-1",
+          stack: "provider secret stack",
+        },
+      },
+      [
+        step({
+          stepId: "provider-step",
+          status: "failed",
+          error: {
+            message: "provider secret detail",
+            stack: "provider secret stack",
+          },
+        }),
+      ],
+    );
+
+    const { run, steps } = await collectRunDetail({
+      world: source,
+      model: "m",
+      runId: "run_diag",
+    });
+
+    expect(run.error).toEqual({
+      message: "The block could not be completed.",
+      code: "AIW-DIAG-run_diag-engine-1",
+    });
+    expect(steps[0]?.error).toEqual({
+      message: "The block could not be completed.",
+      code: "AIW-DIAG-run_diag-engine-1",
+    });
+  });
+
+  it("recovers the diagnostic ID when the SDK replaces the thrown code", async () => {
+    const source = makeSource(
+      {
+        runId: "run_sdk_diag",
+        status: "failed",
+        error: {
+          message:
+            "The block could not be completed. Diagnostic ID: AIW-DIAG-run_sdk_diag-engine-1",
+          code: "USER_ERROR",
+          stack: "safe workflow stack",
+        },
+      },
+      [],
+    );
+
+    const { run } = await collectRunDetail({
+      world: source,
+      model: "m",
+      runId: "run_sdk_diag",
+    });
+
+    expect(run.error).toEqual({
+      message:
+        "The block could not be completed. Diagnostic ID: AIW-DIAG-run_sdk_diag-engine-1",
+      code: "AIW-DIAG-run_sdk_diag-engine-1",
+    });
+  });
 });
 
 describe("captureRunStepsBestEffort", () => {

--- a/apps/worker/src/lib/overview/collect-run-detail.ts
+++ b/apps/worker/src/lib/overview/collect-run-detail.ts
@@ -6,6 +6,7 @@ import type {
   RunStatus,
   StepStatus,
 } from "@shared/contracts";
+import { EXECUTION_DIAGNOSTIC_PREFIX } from "@shared/contracts";
 
 type WorkflowStatus =
   | "pending"
@@ -101,7 +102,26 @@ function stepLabel(stepName: string): string {
 function normalizeRunError(error: string | RunError | undefined): RunError | null {
   if (!error) return null;
   if (typeof error === "string") return { message: error };
+  const diagnosticId = error.code?.startsWith(EXECUTION_DIAGNOSTIC_PREFIX)
+    ? error.code
+    : error.message.match(/Diagnostic ID: (AIW-DIAG-[A-Za-z0-9._:-]+)/)?.[1];
+  if (diagnosticId) {
+    return { message: error.message, code: diagnosticId };
+  }
   return error;
+}
+
+export function sanitizeRunStepsForDiagnosticError(
+  steps: RunStep[] | null,
+  error: RunError | null,
+): RunStep[] | null {
+  if (!steps || !error?.code?.startsWith(EXECUTION_DIAGNOSTIC_PREFIX)) {
+    return steps;
+  }
+  const safeError = { message: error.message, code: error.code };
+  return steps.map((step) =>
+    step.error ? { ...step, error: safeError } : step,
+  );
 }
 
 export interface CollectRunDetailOptions {
@@ -137,8 +157,9 @@ export async function collectRunDetail(
 
   const runStart = (run.startedAt ?? run.createdAt).getTime();
   const { id, name } = mapWorkflow(run.workflowName);
+  const runError = normalizeRunError(run.error);
 
-  const steps: RunStep[] = stepsPage.data
+  const mappedSteps: RunStep[] = stepsPage.data
     .map((s): RunStep => {
       const start = (s.startedAt ?? s.createdAt).getTime();
       const durationMs =
@@ -160,6 +181,7 @@ export async function collectRunDetail(
       };
     })
     .sort((a, b) => a.startOffsetMs - b.startOffsetMs);
+  const steps = sanitizeRunStepsForDiagnosticError(mappedSteps, runError) ?? [];
 
   const startedAt = run.startedAt ?? run.createdAt;
   const durationSec =
@@ -187,7 +209,7 @@ export async function collectRunDetail(
     startedAt: run.startedAt?.toISOString() ?? null,
     completedAt: run.completedAt?.toISOString() ?? null,
     durationSec,
-    error: normalizeRunError(run.error),
+    error: runError,
     deploymentId: run.deploymentId ?? null,
   };
 

--- a/apps/worker/src/workflow-definition/block-registry.test.ts
+++ b/apps/worker/src/workflow-definition/block-registry.test.ts
@@ -41,11 +41,11 @@ describe("workflow block registry", () => {
     }
   });
 
-  it("accepts the normalized failed envelope for every executable action", () => {
+  it("does not advertise execution errors as normal action outputs", () => {
     const registry = buildWorkflowBlockRegistry(context);
     for (const [type, spec] of Object.entries(BLOCK_TYPE_SPECS)) {
       if (spec.category !== "action") continue;
-      expect(registry[type as WorkflowBlockType].output.statusVariants, type).toContain(
+      expect(registry[type as WorkflowBlockType].output.statusVariants, type).not.toContain(
         "failed",
       );
     }
@@ -129,7 +129,6 @@ describe("workflow block registry", () => {
     expect(registry.fix_agent.output.statusVariants).toEqual([
       "fixed",
       "needs_human_input",
-      "failed",
     ]);
     expect(registry.fix_agent.output.bindingSchema).toMatchObject({
       required: [

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -430,7 +430,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       [],
     ),
     normalOutputRequired: ["plan"],
-    statusVariants: ["ready", "needs_human_input", "failed"],
+    statusVariants: ["ready", "needs_human_input"],
   },
   implementation_agent: {
     presentation: presentation(
@@ -454,7 +454,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       suggestedAnswers: arrayType(stringType()),
     }),
     normalOutputRequired: ["workspaceId", "branches", "commits", "summary"],
-    statusVariants: ["implemented", "needs_human_input", "failed"],
+    statusVariants: ["implemented", "needs_human_input"],
   },
   review_agent: {
     presentation: presentation(
@@ -471,7 +471,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       feedback: stringType(),
     }),
     normalOutputRequired: ["findings", "decision"],
-    statusVariants: ["reviewed", "failed"],
+    statusVariants: ["reviewed"],
   },
   fix_agent: {
     presentation: presentation(
@@ -498,7 +498,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       "unresolvedConflicts",
       "summary",
     ],
-    statusVariants: ["fixed", "needs_human_input", "failed"],
+    statusVariants: ["fixed", "needs_human_input"],
   },
   generic_agent: {
     presentation: presentation(
@@ -520,7 +520,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       [],
     ),
     normalOutputRequired: ["body"],
-    statusVariants: ["completed", "needs_human_input", "failed"],
+    statusVariants: ["completed", "needs_human_input"],
   },
   prepare_workspace: {
     presentation: presentation(
@@ -538,7 +538,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       questions: arrayType(stringType()),
     }),
     normalOutputRequired: ["sandboxId", "repositories", "workspace"],
-    statusVariants: ["ok", "needs_human_input", "failed"],
+    statusVariants: ["ok", "needs_human_input"],
   },
   finalize_workspace: {
     presentation: presentation(
@@ -557,10 +557,9 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     ],
     output: statusOutput({
       repositories: arrayType(finalizedBranchType),
-      unmetChecks: arrayType(stringType()),
     }),
     normalOutputRequired: ["repositories"],
-    statusVariants: ["finalized", "failed"],
+    statusVariants: ["finalized"],
   },
   run_pre_pr_checks: {
     presentation: presentation(
@@ -577,7 +576,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       summary: stringType(),
     }),
     normalOutputRequired: ["ok", "fixCycles", "summary"],
-    statusVariants: ["ok", "failed"],
+    statusVariants: ["ok"],
   },
   run_checks: {
     presentation: presentation(
@@ -594,7 +593,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       failures: arrayType(unknownType()),
     }),
     normalOutputRequired: ["ok", "results", "failures"],
-    statusVariants: ["ok", "failed"],
+    statusVariants: ["ok"],
   },
   call_llm: {
     presentation: presentation(
@@ -607,7 +606,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     inputs: { prompt: input(stringType()), system: input(stringType(), false) },
     output: statusOutput({ output: stringType() }),
     normalOutputRequired: ["output"],
-    statusVariants: ["ok", "failed"],
+    statusVariants: ["ok"],
   },
   fetch_pr_context: {
     presentation: presentation(
@@ -620,7 +619,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     inputs: {},
     output: statusOutput({ contexts: arrayType(unknownType()) }),
     normalOutputRequired: ["contexts"],
-    statusVariants: ["ok", "failed"],
+    statusVariants: ["ok"],
   },
   open_pr: {
     presentation: presentation(
@@ -637,7 +636,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       prNumber: numberType(),
     }),
     normalOutputRequired: ["prs"],
-    statusVariants: ["ok", "failed"],
+    statusVariants: ["ok"],
   },
   update_ticket_status: {
     presentation: presentation(
@@ -650,7 +649,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     inputs: { target: input(stringType()) },
     output: statusOutput({ target: stringType() }),
     normalOutputRequired: ["target"],
-    statusVariants: ["ok", "failed"],
+    statusVariants: ["ok"],
   },
   post_ticket_comment: {
     presentation: presentation(
@@ -663,7 +662,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     inputs: { body: input(stringType()) },
     output: statusOutput({ commentUrl: nullableType(stringType()) }),
     normalOutputRequired: ["commentUrl"],
-    statusVariants: ["ok", "failed"],
+    statusVariants: ["ok"],
   },
   post_pr_comment: {
     presentation: presentation(
@@ -676,7 +675,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     inputs: { body: input(stringType()) },
     output: statusOutput({ comments: arrayType(unknownType()) }),
     normalOutputRequired: ["comments"],
-    statusVariants: ["ok", "failed"],
+    statusVariants: ["ok"],
   },
   send_slack_message: {
     presentation: presentation(
@@ -688,7 +687,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     defaults: { message: "" },
     inputs: { message: input(stringType()) },
     output: statusOutput(),
-    statusVariants: ["ok", "skipped", "failed"],
+    statusVariants: ["ok", "skipped"],
   },
   send_plan_approval: {
     presentation: presentation(
@@ -704,7 +703,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     },
     output: statusOutput({ approvalRequestId: stringType() }),
     normalOutputRequired: ["approvalRequestId"],
-    statusVariants: ["awaiting_approval", "failed"],
+    statusVariants: ["awaiting_approval"],
   },
   human_question: {
     presentation: presentation(
@@ -723,7 +722,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       suggestedAnswers: arrayType(stringType()),
       answer: stringType(),
     }),
-    statusVariants: ["needs_human_input", "answered", "failed"],
+    statusVariants: ["needs_human_input", "answered"],
   },
   arthur_injection_check: {
     presentation: presentation(
@@ -735,7 +734,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     defaults: {},
     inputs: { content: input(stringType()) },
     output: statusOutput({ findings: arrayType(unknownType()), reason: stringType() }),
-    statusVariants: ["ok", "flagged", "skipped", "failed"],
+    statusVariants: ["ok", "flagged", "skipped"],
   },
   branch: {
     presentation: presentation(
@@ -746,8 +745,8 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     ),
     defaults: { condition: "" },
     inputs: {},
-    output: statusOutput({ path: stringType(), reason: stringType(), error: stringType() }),
-    statusVariants: ["ok", "failed"],
+    output: statusOutput({ path: stringType(), reason: stringType() }),
+    statusVariants: ["ok"],
   },
   loop: {
     presentation: presentation(

--- a/apps/worker/src/workflow-definition/interpreter.test.ts
+++ b/apps/worker/src/workflow-definition/interpreter.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "@shared/contracts";
 import {
   buildRuntimeGraph,
+  executionError,
   executeGraph as executeGraphWithContractValidation,
   type BlockExecutionResult,
   type BlockExecutor,
@@ -233,10 +234,13 @@ describe("executeGraph output contracts", () => {
 
     expect(result.outcome).toBe("stopped");
     expect(rec.failures[0]).toMatchObject({ phase: "contract", nodeId: "comment" });
-    expect(rec.failures[0]?.reason).toContain("output.comments is required");
+    expect(rec.failures[0]?.reason).toBe(
+      "The block returned an invalid result. Diagnostic ID: AIW-DIAG-test-run-comment-1",
+    );
+    expect(result.executionError?.category).toBe("schema");
   });
 
-  it("does not require normal-only fields from an authored failure output", async () => {
+  it("does not validate normal output fields for an execution error", async () => {
     const graph = graphFrom(
       [
         node("trig", "trigger_ticket_ai"),
@@ -256,13 +260,15 @@ describe("executeGraph output contracts", () => {
       triggerOutput: { status: "fired", ticketKey: "AIW-103" },
       executeBlock: async (block) =>
         block.id === "comment"
-          ? { kind: "failed", output: { status: "failed" }, reason: "provider rejected" }
+          ? executionError("provider rejected", { category: "provider" })
           : { kind: "next", output: { status: "ok" } },
       hooks: rec.hooks,
     });
 
     expect(result.outcome).toBe("completed");
-    expect(rec.failures).toEqual([]);
+    expect(result.steps.comment).toBeUndefined();
+    expect(result.executionError?.category).toBe("provider");
+    expect(rec.failures).toHaveLength(1);
   });
 
   it("routes a thrown executor error through an authored failure edge", async () => {
@@ -294,12 +300,20 @@ describe("executeGraph output contracts", () => {
 
     expect(result.outcome).toBe("completed");
     expect(calls).toEqual(["comment", "recover"]);
-    expect(result.steps.comment?.output).toEqual({ status: "failed" });
+    expect(result.steps.comment).toBeUndefined();
     expect(rec.finishes.find((finish) => finish.nodeId === "comment")?.state).toMatchObject({
       status: "fail",
-      error: "provider rejected the comment",
+      error: "The block could not be completed.",
+      diagnosticId: "AIW-DIAG-test-run-comment-1",
     });
-    expect(rec.failures).toEqual([]);
+    expect(rec.failures).toEqual([
+      {
+        phase: "post_ticket_comment",
+        reason:
+          "The block could not be completed. Diagnostic ID: AIW-DIAG-test-run-comment-1",
+        nodeId: "comment",
+      },
+    ]);
   });
 
   it.each([
@@ -367,11 +381,12 @@ describe("executeGraph output contracts", () => {
     });
 
     expect(result.outcome).toBe("stopped");
-    expect(result.steps.comment?.output).toEqual({ status: "failed" });
+    expect(result.steps.comment).toBeUndefined();
     expect(rec.failures).toEqual([
       {
         phase: "post_ticket_comment",
-        reason: "provider rejected the comment",
+        reason:
+          "The block could not be completed. Diagnostic ID: AIW-DIAG-test-run-comment-1",
         nodeId: "comment",
       },
     ]);
@@ -601,7 +616,7 @@ describe("executeGraph branch", () => {
     expect(rec.failures[0].phase).toBe("branch");
     expect(rec.failures[0].nodeId).toBe("br");
     expect(rec.failures[0].reason).toBe(
-      "steps.trig.output.failures: expected boolean, got array",
+      "The workflow engine could not continue. Diagnostic ID: AIW-DIAG-test-run-br-1",
     );
     expect(finishStatuses(rec, "br")).toEqual(["fail"]);
     expect(result.steps.br).toBeUndefined();
@@ -836,7 +851,9 @@ describe("executeGraph loop", () => {
     });
 
     expect(result.outcome).toBe("stopped");
-    expect(rec.failures[0]?.reason).toMatch(/maximum of 2 block executions/);
+    expect(rec.failures[0]?.reason).toBe(
+      "The workflow engine could not continue. Diagnostic ID: AIW-DIAG-test-run-waiting-2",
+    );
   });
 });
 
@@ -855,7 +872,10 @@ describe("executeGraph failure port override", () => {
   it("continues along a wired failure edge and persists a fail state", async () => {
     const rec = makeRecorder();
     const { executor, calls } = makeExecutor({
-      checks: { kind: "failed", output: { status: "failed" }, reason: "lint broke", phase: "checks" },
+      checks: executionError("lint broke", {
+        category: "checks",
+        phase: "checks",
+      }),
     });
     const result = await executeGraph({
       graph: failGraph(true),
@@ -866,15 +886,74 @@ describe("executeGraph failure port override", () => {
     });
     expect(result.outcome).toBe("completed");
     expect(calls).toEqual(["checks", "recover"]);
-    expect(rec.failures).toEqual([]);
+    expect(rec.failures).toHaveLength(1);
     expect(finishStatuses(rec, "checks")).toEqual(["fail"]);
-    expect(rec.finishes[0].state.error).toBe("lint broke");
+    expect(rec.finishes[0].state.error).toBe("The checks could not be started.");
+    expect(result.steps.checks).toBeUndefined();
+    expect(result.executionError?.diagnosticId).toBe(
+      "AIW-DIAG-test-run-checks-1",
+    );
+  });
+
+  it("keeps the first error primary when cleanup also errors", async () => {
+    const rec = makeRecorder();
+    const { executor } = makeExecutor({
+      checks: executionError("provider rejected checks", {
+        category: "provider",
+        phase: "checks",
+      }),
+      recover: executionError("cleanup sandbox unavailable", {
+        category: "sandbox",
+        phase: "cleanup",
+      }),
+    });
+
+    const result = await executeGraph({
+      graph: failGraph(true),
+      entryTriggerId: "trig",
+      triggerOutput: { status: "ok" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+    });
+
+    expect(result.executionError).toMatchObject({
+      category: "provider",
+      diagnosticId: "AIW-DIAG-test-run-checks-1",
+      nodeId: "checks",
+    });
+    expect(rec.finishes).toEqual([
+      expect.objectContaining({
+        nodeId: "checks",
+        state: expect.objectContaining({
+          status: "fail",
+          diagnosticId: "AIW-DIAG-test-run-checks-1",
+        }),
+      }),
+      expect.objectContaining({
+        nodeId: "recover",
+        state: expect.objectContaining({
+          status: "fail",
+          diagnosticId: "AIW-DIAG-test-run-recover-1",
+        }),
+      }),
+    ]);
+    expect(rec.failures).toEqual([
+      {
+        phase: "checks",
+        reason:
+          "An external service could not complete this block. Diagnostic ID: AIW-DIAG-test-run-checks-1",
+        nodeId: "checks",
+      },
+    ]);
   });
 
   it("calls failureExit with the phase when no failure edge is wired", async () => {
     const rec = makeRecorder();
     const { executor } = makeExecutor({
-      checks: { kind: "failed", output: { status: "failed" }, reason: "lint broke", phase: "checks" },
+      checks: executionError("lint broke", {
+        category: "checks",
+        phase: "checks",
+      }),
     });
     const result = await executeGraph({
       graph: failGraph(false),
@@ -886,7 +965,9 @@ describe("executeGraph failure port override", () => {
     expect(result.outcome).toBe("stopped");
     expect(rec.failures).toHaveLength(1);
     expect(rec.failures[0].phase).toBe("checks");
-    expect(rec.failures[0].reason).toBe("lint broke");
+    expect(rec.failures[0].reason).toBe(
+      "The checks could not be started. Diagnostic ID: AIW-DIAG-test-run-checks-1",
+    );
   });
 });
 
@@ -1036,6 +1117,38 @@ describe("executeGraph terminate", () => {
       ]);
     },
   );
+
+  it("does not let a cleanup terminate replace or repeat the primary failure exit", async () => {
+    const graph = graphFrom(
+      [
+        node("trig", "trigger_ticket_ai"),
+        node("action", "post_ticket_comment", { body: "work" }),
+        node("term", "terminate", { terminalStatus: "failed", postComment: "cleanup" }),
+      ],
+      [
+        { from: "trig", to: "action" },
+        { from: "action", to: "term", fromPort: "failed" },
+      ],
+    );
+    const rec = makeRecorder();
+    const result = await executeGraph({
+      graph,
+      entryTriggerId: "trig",
+      triggerOutput: { status: "ok" },
+      executeBlock: async () =>
+        executionError("provider rejected the action", { category: "provider" }),
+      hooks: rec.hooks,
+    });
+
+    expect(result.executionError).toMatchObject({
+      category: "provider",
+      diagnosticId: "AIW-DIAG-test-run-action-1",
+    });
+    expect(rec.terminations).toEqual([]);
+    expect(rec.failures).toEqual([
+      expect.objectContaining({ nodeId: "action" }),
+    ]);
+  });
 });
 
 describe("executeGraph multi-trigger", () => {
@@ -1094,7 +1207,9 @@ describe("executeGraph execution cap", () => {
     expect(result.outcome).toBe("stopped");
     expect(rec.failures).toHaveLength(1);
     expect(rec.failures[0].phase).toBe("engine");
-    expect(rec.failures[0].reason).toContain("maximum of 5 block executions");
+    expect(rec.failures[0].reason).toBe(
+      "The workflow engine could not continue. Diagnostic ID: AIW-DIAG-test-run-body-3",
+    );
   });
 });
 
@@ -1171,7 +1286,8 @@ describe("executeGraph steps propagation", () => {
     expect(rec.failures).toEqual([
       {
         phase: "bindings",
-        reason: 'binding "trigger.missing" could not be resolved',
+        reason:
+          "A block input could not be resolved. Diagnostic ID: AIW-DIAG-test-run-target-1",
         nodeId: "target",
       },
     ]);
@@ -1263,18 +1379,26 @@ describe("executeGraph steps propagation", () => {
     expect(result.steps.a.output.value).toBe(42);
   });
 
-  it("throws when the entry trigger is missing from the graph", async () => {
+  it("normalizes a missing entry trigger through the execution-error path", async () => {
     const graph = graphFrom([node("trig", "trigger_ticket_ai")], []);
     const rec = makeRecorder();
     const { executor } = makeExecutor();
-    await expect(
-      executeGraph({
-        graph,
-        entryTriggerId: "ghost",
-        triggerOutput: { status: "ok" },
-        executeBlock: executor,
-        hooks: rec.hooks,
-      }),
-    ).rejects.toThrow(/entry trigger/);
+    const result = await executeGraph({
+      graph,
+      entryTriggerId: "ghost",
+      triggerOutput: { status: "ok" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+    });
+
+    expect(result.outcome).toBe("stopped");
+    expect(result.executionError).toMatchObject({
+      category: "engine",
+      diagnosticId: "AIW-DIAG-test-run-ghost-1",
+      nodeId: "ghost",
+    });
+    expect(rec.failures).toEqual([
+      expect.objectContaining({ phase: "engine", nodeId: "ghost" }),
+    ]);
   });
 });

--- a/apps/worker/src/workflow-definition/interpreter.ts
+++ b/apps/worker/src/workflow-definition/interpreter.ts
@@ -1,5 +1,6 @@
 import {
   BLOCK_TYPE_SPECS,
+  EXECUTION_DIAGNOSTIC_PREFIX,
   FAILURE_PORT,
   isTriggerBlockType,
   wirablePorts,
@@ -52,6 +53,97 @@ export function buildRuntimeGraph(
 /** Accumulated block outputs keyed by node id, readable by later condition evaluation. */
 export type StepsRecord = Record<string, { output: BlockOutput }>;
 
+export type ExecutionErrorCategory =
+  | "sandbox"
+  | "provider"
+  | "engine"
+  | "binding"
+  | "timeout"
+  | "parsing"
+  | "schema"
+  | "checks"
+  | "unknown";
+
+export interface BlockExecutionError {
+  category: ExecutionErrorCategory;
+  /** Safe text that may be persisted or shown to a user. */
+  message: string;
+  /** Internal context for correlated server logs. Never persist or expose it. */
+  detail?: string;
+  phase?: string;
+}
+
+export interface WorkflowExecutionErrorState
+  extends Omit<BlockExecutionError, "detail"> {
+  diagnosticId: string;
+  nodeId: string;
+  attempt: number;
+}
+
+const SAFE_EXECUTION_ERROR_MESSAGES: Record<ExecutionErrorCategory, string> = {
+  sandbox: "The workspace environment could not complete this block.",
+  provider: "An external service could not complete this block.",
+  engine: "The workflow engine could not continue.",
+  binding: "A block input could not be resolved.",
+  timeout: "The block timed out.",
+  parsing: "The block response could not be parsed.",
+  schema: "The block returned an invalid result.",
+  checks: "The checks could not be started.",
+  unknown: "The block could not be completed.",
+};
+
+export function executionError(
+  detail: string,
+  options: {
+    category?: ExecutionErrorCategory;
+    message?: string;
+    phase?: string;
+  } = {},
+): Extract<BlockExecutionResult, { kind: "execution_error" }> {
+  const category = options.category ?? "unknown";
+  return {
+    kind: "execution_error",
+    error: {
+      category,
+      message: options.message ?? SAFE_EXECUTION_ERROR_MESSAGES[category],
+      detail,
+      ...(options.phase ? { phase: options.phase } : {}),
+    },
+  };
+}
+
+export function formatExecutionErrorForUser(
+  error: Pick<WorkflowExecutionErrorState, "message" | "diagnosticId">,
+): string {
+  return `${error.message} Diagnostic ID: ${error.diagnosticId}`;
+}
+
+export function createWorkflowExecutionErrorState(
+  runId: string,
+  nodeId: string,
+  attempt: number,
+  error: BlockExecutionError,
+): WorkflowExecutionErrorState {
+  return {
+    category: error.category,
+    message: error.message,
+    ...(error.phase ? { phase: error.phase } : {}),
+    diagnosticId: `${EXECUTION_DIAGNOSTIC_PREFIX}${runId}-${nodeId}-${attempt}`,
+    nodeId,
+    attempt,
+  };
+}
+
+export class WorkflowExecutionError extends Error {
+  readonly code: string;
+
+  constructor(error: WorkflowExecutionErrorState) {
+    super(formatExecutionErrorForUser(error));
+    this.name = "WorkflowExecutionError";
+    this.code = error.diagnosticId;
+  }
+}
+
 /** Outcome an action block reports back to the engine. */
 export type BlockExecutionResult =
   | { kind: "next"; output: BlockOutput; port?: string }
@@ -61,7 +153,7 @@ export type BlockExecutionResult =
       questions: string[];
       suggestedAnswers?: string[];
     }
-  | { kind: "failed"; output: BlockOutput; reason: string; phase?: string }
+  | { kind: "execution_error"; error: BlockExecutionError; output?: never }
   | { kind: "ended"; output: BlockOutput };
 
 /** Runs a single action-category block and reports how the walk should proceed. */
@@ -118,6 +210,12 @@ export interface ExecuteGraphHooks {
   ): Promise<void>;
 }
 
+export interface ExecuteGraphResult {
+  outcome: "completed" | "stopped" | "ended";
+  steps: StepsRecord;
+  executionError?: WorkflowExecutionErrorState;
+}
+
 const ERROR_MAX_LENGTH = 500;
 const DEFAULT_MAX_TOTAL_EXECUTIONS = 200;
 
@@ -147,6 +245,7 @@ function contractViolation(node: WorkflowDefinitionNode, issues: string[]): stri
 
 /** Walk the graph from a trigger, driving action blocks through `executeBlock` and control blocks inline. */
 export async function executeGraph(opts: {
+  runId?: string;
   graph: RuntimeGraph;
   entryTriggerId: string;
   triggerOutput: BlockOutput;
@@ -160,36 +259,106 @@ export async function executeGraph(opts: {
   outputValidator?: BlockOutputValidator;
   /** Run-level control errors (for example a hard budget stop) must escape the
    * block failure graph. Ordinary executor/provider errors are normalized to
-   * the block's failed result so an authored failure edge can handle them. */
+   * execution errors so an authored failure edge can run cleanup. */
   shouldRethrowExecutionError?: (error: unknown) => boolean;
-}): Promise<{ outcome: "completed" | "stopped" | "ended"; steps: StepsRecord }> {
+}): Promise<ExecuteGraphResult> {
   const { graph, entryTriggerId, triggerOutput, executeBlock, hooks } = opts;
+  const runId = opts.runId ?? "test-run";
   const maxTotalExecutions = opts.maxTotalExecutions ?? DEFAULT_MAX_TOTAL_EXECUTIONS;
+  let primaryExecutionError: WorkflowExecutionErrorState | undefined;
+  let failureExitCalled = false;
+
+  const recordExecutionError = async (
+    nodeId: string,
+    attempt: number,
+    error: BlockExecutionError,
+  ): Promise<WorkflowExecutionErrorState> => {
+    const state = createWorkflowExecutionErrorState(
+      runId,
+      nodeId,
+      attempt,
+      error,
+    );
+    if (error.detail) {
+      console.error(
+        `[${state.diagnosticId}] workflow execution error in ${nodeId}: ${error.detail}`,
+      );
+    }
+    primaryExecutionError ??= state;
+    await hooks.onBlockFinish(nodeId, {
+      status: "fail",
+      attempt,
+      error: state.message,
+      diagnosticId: state.diagnosticId,
+    });
+    return state;
+  };
+  const finish = async (
+    outcome: ExecuteGraphResult["outcome"],
+  ): Promise<ExecuteGraphResult> => {
+    if (primaryExecutionError && !failureExitCalled) {
+      failureExitCalled = true;
+      await hooks.failureExit(
+        primaryExecutionError.phase ?? primaryExecutionError.category,
+        formatExecutionErrorForUser(primaryExecutionError),
+        primaryExecutionError.nodeId,
+      );
+    }
+    return {
+      outcome,
+      steps,
+      ...(primaryExecutionError
+        ? { executionError: primaryExecutionError }
+        : {}),
+    };
+  };
+
+  const steps: StepsRecord = Object.create(null) as StepsRecord;
+  for (const [nodeId, state] of Object.entries(opts.resume?.priorSteps ?? {})) {
+    steps[nodeId] = state;
+  }
 
   const entry = graph.nodes.get(entryTriggerId);
   if (!entry) {
-    throw new Error(`entry trigger "${entryTriggerId}" is not present in the graph`);
+    await recordExecutionError(
+      entryTriggerId,
+      1,
+      executionError(
+        `entry trigger "${entryTriggerId}" is not present in the graph`,
+        { category: "engine", phase: "engine" },
+      ).error,
+    );
+    return finish("stopped");
   }
 
   const resume = opts.resume;
   if (resume && !graph.nodes.has(resume.waitingNodeId)) {
-    throw new Error(
-      `clarification waiting node "${resume.waitingNodeId}" is not present in the graph`,
+    await recordExecutionError(
+      resume.waitingNodeId,
+      (resume.controlState?.attempts[resume.waitingNodeId] ?? 0) + 1,
+      executionError(
+        `clarification waiting node "${resume.waitingNodeId}" is not present in the graph`,
+        { category: "engine", phase: "engine" },
+      ).error,
     );
+    return finish("stopped");
   }
 
-  const steps: StepsRecord = Object.create(null) as StepsRecord;
-  for (const [nodeId, state] of Object.entries(resume?.priorSteps ?? {})) {
-    steps[nodeId] = state;
-  }
   const outputValidator = opts.outputValidator ?? defaultOutputValidator;
   // Stored runs and clarification checkpoints created before typed trigger
   // inputs may carry the legacy minimal envelope. Validate every field they do
   // carry, but reserve normal-output guarantees for new authored bindings.
   const triggerIssues = outputValidator(entry, triggerOutput, false);
   if (triggerIssues.length > 0) {
-    await hooks.failureExit("contract", contractViolation(entry, triggerIssues), entryTriggerId);
-    return { outcome: "stopped", steps };
+    await recordExecutionError(
+      entryTriggerId,
+      1,
+      executionError(contractViolation(entry, triggerIssues), {
+        category: "schema",
+        phase: "contract",
+      }).error,
+    );
+    return finish("stopped");
   }
   steps[entryTriggerId] = { output: triggerOutput };
   const attempts = new Map<string, number>(
@@ -211,18 +380,28 @@ export async function executeGraph(opts: {
 
     executions += 1;
     if (executions > maxTotalExecutions) {
-      await hooks.failureExit(
-        "engine",
-        `workflow exceeded the maximum of ${maxTotalExecutions} block executions`,
+      await recordExecutionError(
         id,
+        (attempts.get(id) ?? 0) + 1,
+        executionError(
+          `workflow exceeded the maximum of ${maxTotalExecutions} block executions`,
+          { category: "engine", phase: "engine" },
+        ).error,
       );
-      return { outcome: "stopped", steps };
+      return finish("stopped");
     }
 
     const node = graph.nodes.get(id);
     if (!node) {
-      await hooks.failureExit("engine", `workflow referenced an unknown block "${id}"`, id);
-      return { outcome: "stopped", steps };
+      await recordExecutionError(
+        id,
+        (attempts.get(id) ?? 0) + 1,
+        executionError(`workflow referenced an unknown block "${id}"`, {
+          category: "engine",
+          phase: "engine",
+        }).error,
+      );
+      return finish("stopped");
     }
 
     const resumingWaitingNode =
@@ -284,17 +463,27 @@ export async function executeGraph(opts: {
             // run fails here with the reason rather than taking an arbitrary port.
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
-            const output: BlockOutput = { status: "failed", error: message };
-            await hooks.onBlockFinish(id, { status: "fail", attempt, error: message, output });
-            await hooks.failureExit("branch", message, id);
-            return { outcome: "stopped", steps };
+            await recordExecutionError(
+              id,
+              attempt,
+              executionError(message, {
+                category: "engine",
+                phase: "branch",
+              }).error,
+            );
+            return finish("stopped");
           }
         } else {
           const message = parsed.error;
-          const output: BlockOutput = { status: "failed", error: message };
-          await hooks.onBlockFinish(id, { status: "fail", attempt, error: message, output });
-          await hooks.failureExit("branch", message, id);
-          return { outcome: "stopped", steps };
+          await recordExecutionError(
+            id,
+            attempt,
+            executionError(message, {
+              category: "engine",
+              phase: "branch",
+            }).error,
+          );
+          return finish("stopped");
         }
 
         const path = value ? "true" : "false";
@@ -339,7 +528,7 @@ export async function executeGraph(opts: {
           );
           if (answer === undefined) {
             await hooks.onBlockFinish(id, { status: "warn", attempt, error: message, output });
-            return { outcome: "stopped", steps };
+            return finish("stopped");
           }
           const answeredOutput: BlockOutput = {
             status: "exhausted",
@@ -359,6 +548,7 @@ export async function executeGraph(opts: {
         }
         const message = `loop "${id}" exhausted after ${maxAttempts} attempts`;
         await hooks.onBlockFinish(id, { status: "fail", attempt, error: message, output });
+        if (primaryExecutionError) return finish("stopped");
         await hooks.failureExit("loop", message, id);
         return { outcome: "stopped", steps };
       }
@@ -385,13 +575,15 @@ export async function executeGraph(opts: {
             output = { status: "done", answer };
             steps[id] = { output };
             await hooks.onBlockFinish(id, { status: "ok", attempt, output });
-            return { outcome: "completed", steps };
+            return finish("completed");
           }
         }
         const finishStatus = terminalStatus === "failed" ? "fail" : terminalStatus === "waiting_for_human" ? "warn" : "ok";
         await hooks.onBlockFinish(id, { status: finishStatus, attempt, output });
-        await hooks.terminate({ terminalStatus, postComment }, id, steps, controlState());
-        return { outcome: "stopped", steps };
+        if (!primaryExecutionError) {
+          await hooks.terminate({ terminalStatus, postComment }, id, steps, controlState());
+        }
+        return finish("stopped");
       }
     }
 
@@ -405,16 +597,15 @@ export async function executeGraph(opts: {
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      const output: BlockOutput = { status: "failed", error: message };
-      steps[id] = { output };
-      await hooks.onBlockFinish(id, {
-        status: "fail",
+      await recordExecutionError(
+        id,
         attempt,
-        output,
-        error: truncate(message),
-      });
-      await hooks.failureExit("bindings", truncate(message), id);
-      return { outcome: "stopped", steps };
+        executionError(truncate(message), {
+          category: "binding",
+          phase: "bindings",
+        }).error,
+      );
+      return finish("stopped");
     }
 
     const execution = resumingWaitingNode
@@ -426,39 +617,52 @@ export async function executeGraph(opts: {
       result = await executeBlock(node, steps, resolvedInputs, execution);
     } catch (error) {
       if (opts.shouldRethrowExecutionError?.(error)) throw error;
-      result = {
-        kind: "failed",
-        output: { status: "failed" },
-        reason: error instanceof Error ? error.message : String(error),
-        phase: node.type,
-      };
+      result = executionError(
+        error instanceof Error ? error.stack ?? error.message : String(error),
+        { phase: node.type },
+      );
     }
 
-    const requireNormalOutput =
-      result.kind === "ended" ||
-      (result.kind === "next" &&
-        (result.port ?? defaultPortOf(node)) !== FAILURE_PORT);
-    const outputIssues = outputValidator(node, result.output, requireNormalOutput);
-    if (outputIssues.length > 0) {
-      const message = contractViolation(node, outputIssues);
-      await hooks.onBlockFinish(id, { status: "fail", attempt, error: message });
-      await hooks.failureExit("contract", message, id);
-      return { outcome: "stopped", steps };
+    if (result.kind !== "execution_error") {
+      const outputIssues = outputValidator(
+        node,
+        result.output,
+        result.kind === "next" || result.kind === "ended",
+      );
+      if (outputIssues.length > 0) {
+        const message = contractViolation(node, outputIssues);
+        await recordExecutionError(
+          id,
+          attempt,
+          executionError(message, {
+            category: "schema",
+            phase: "contract",
+          }).error,
+        );
+        return finish("stopped");
+      }
     }
 
     if (result.kind === "next") {
       const output = result.output;
+      const port = result.port ?? defaultPortOf(node);
+      if (
+        port === undefined ||
+        port === FAILURE_PORT ||
+        !wirablePorts(node.type).includes(port)
+      ) {
+        await recordExecutionError(
+          id,
+          attempt,
+          executionError(
+            `block "${id}" returned an unknown port "${String(port)}"`,
+            { category: "engine", phase: "engine" },
+          ).error,
+        );
+        return finish("stopped");
+      }
       steps[id] = { output };
       await hooks.onBlockFinish(id, { status: "ok", attempt, output });
-      const port = result.port ?? defaultPortOf(node);
-      if (port === undefined || !wirablePorts(node.type).includes(port)) {
-        await hooks.failureExit(
-          "engine",
-          `block "${id}" returned an unknown port "${String(port)}"`,
-          id,
-        );
-        return { outcome: "stopped", steps };
-      }
       current = graph.outEdges.get(id)?.get(port);
       continue;
     }
@@ -476,7 +680,7 @@ export async function executeGraph(opts: {
       );
       if (answer === undefined) {
         await hooks.onBlockFinish(id, { status: "warn", attempt, output, error });
-        return { outcome: "stopped", steps };
+        return finish("stopped");
       }
       const answeredOutput: BlockOutput = { status: "answered", answer };
       steps[id] = { output: answeredOutput };
@@ -486,22 +690,14 @@ export async function executeGraph(opts: {
       continue;
     }
 
-    if (result.kind === "failed") {
-      const output = result.output;
-      steps[id] = { output };
-      await hooks.onBlockFinish(id, {
-        status: "fail",
-        attempt,
-        output,
-        error: truncate(result.reason),
-      });
+    if (result.kind === "execution_error") {
+      await recordExecutionError(id, attempt, result.error);
       const failureTarget = graph.outEdges.get(id)?.get(FAILURE_PORT);
       if (failureTarget !== undefined) {
         current = failureTarget;
         continue;
       }
-      await hooks.failureExit(result.phase ?? node.type, truncate(result.reason), id);
-      return { outcome: "stopped", steps };
+      return finish("stopped");
     }
 
     // result.kind === "ended": a block (e.g. send_plan_approval) parked the run
@@ -510,8 +706,8 @@ export async function executeGraph(opts: {
     const output = result.output;
     steps[id] = { output };
     await hooks.onBlockFinish(id, { status: "warn", attempt, output });
-    return { outcome: "ended", steps };
+    return finish("ended");
   }
 
-  return { outcome: "completed", steps };
+  return finish("completed");
 }

--- a/apps/worker/src/workflows/agent-clarification-telemetry.test.ts
+++ b/apps/worker/src/workflows/agent-clarification-telemetry.test.ts
@@ -15,6 +15,7 @@ vi.mock("../clarifications/store.js", () => ({
 }));
 vi.mock("../lib/overview/collect-run-detail.js", () => ({
   captureRunStepsBestEffort: (...args: unknown[]) => mocks.captureRunSteps(...args),
+  sanitizeRunStepsForDiagnosticError: (steps: unknown) => steps,
 }));
 vi.mock("workflow/runtime", () => ({ getWorld: () => ({ world: true }) }));
 
@@ -47,6 +48,7 @@ describe("clarification terminal telemetry", () => {
       },
       budgetFailure: null,
       pr: null,
+      executionError: null,
       awaitingClarificationId: "clarification-answered",
     } as never);
 

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -16,9 +16,14 @@ import type { DownloadedAttachment } from "../sandbox/attachments.js";
 import type { SelectedRepository } from "../adapters/vcs/repository-directory.js";
 import {
   buildRuntimeGraph,
+  createWorkflowExecutionErrorState,
+  executionError,
   executeGraph,
+  formatExecutionErrorForUser,
+  WorkflowExecutionError,
   type RuntimeGraph,
   type StepsRecord,
+  type WorkflowExecutionErrorState,
 } from "../workflow-definition/interpreter.js";
 import type {
   BlockExecutionContext,
@@ -384,18 +389,16 @@ export async function ensurePlanningAgentSandboxForBlock(
   model: string,
 ): Promise<
   | { kind: "ready"; sandboxId: string }
-  | Extract<BlockExecutionResult, { kind: "failed" }>
+  | Extract<BlockExecutionResult, { kind: "execution_error" }>
 > {
   try {
     return { kind: "ready", sandboxId: await ensureAgentSandbox(ctx, kind, model) };
   } catch (error) {
     if (isRunControlError(error)) throw error;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: error instanceof Error ? error.message : String(error),
+    return executionError(error instanceof Error ? error.message : String(error), {
+      category: "sandbox",
       phase: "research",
-    };
+    });
   }
 }
 
@@ -1150,6 +1153,7 @@ export async function recordRunTelemetryStep(payload: {
   totals: UsageTotals;
   budgetFailure: RunBudgetFailure | null;
   pr: { url: string; number: number } | null;
+  executionError: { message: string; code: string } | null;
 }) {
   "use step";
   const { getDb } = await import("../db/client.js");
@@ -1158,9 +1162,13 @@ export async function recordRunTelemetryStep(payload: {
   const collectRunDetailMod = await import(
     "../lib/overview/collect-run-detail.js"
   );
-  const steps = await collectRunDetailMod.captureRunStepsBestEffort(
+  const capturedSteps = await collectRunDetailMod.captureRunStepsBestEffort(
     getWorld() as unknown as import("../lib/overview/collect-run-detail.js").RunDetailSource,
     payload.runId,
+  );
+  const steps = collectRunDetailMod.sanitizeRunStepsForDiagnosticError(
+    capturedSteps,
+    payload.executionError,
   );
   const { totals } = payload;
   await recordRunUsage(getDb(), {
@@ -1240,13 +1248,22 @@ export async function agentWorkflow(input: string | AgentWorkflowInput) {
     if (!(await acknowledgePrTriggerDispatchStep(entry, workflowRunId))) return;
     await acknowledgePendingTriggerStep(entry);
   }
-  await agentWorkflowBody(entry, workflowRunId);
+  const result = await agentWorkflowBody(entry, workflowRunId);
+  if (result && typeof result === "object") {
+    throw new WorkflowExecutionError(result.error);
+  }
 }
 
 async function agentWorkflowBody(
   entry: AgentWorkflowInput,
   workflowRunId: string,
-): Promise<"success" | "failed" | "awaiting" | undefined> {
+): Promise<
+  | "success"
+  | "failed"
+  | "awaiting"
+  | { kind: "execution_error"; error: WorkflowExecutionErrorState }
+  | undefined
+> {
   const budgetStartedAtMs = await readRunBudgetClockStep();
 
   const { env } = await import("../../env.js");
@@ -1405,6 +1422,7 @@ async function agentWorkflowBody(
   // flips it to success). Every phase failure / timeout / thrown error keeps
   // "failed".
   let runOutcome: "success" | "failed" | "awaiting" = "failed";
+  let terminalExecutionError: WorkflowExecutionErrorState | null = null;
   let terminalBudgetFailure: RunBudgetFailure | null = null;
   // Seeded with the run default model once prepare_workspace provisions the
   // sandbox, then set to the implementation block's model once it runs.
@@ -1819,9 +1837,9 @@ async function agentWorkflowBody(
       };
 
       const noWorkspace = (type: WorkflowBlockType): BlockExecutionResult => ({
-        kind: "failed",
-        output: { status: "failed" },
-        reason: `no workspace: connect prepare_workspace before ${type}`,
+        ...executionError(`no workspace: connect prepare_workspace before ${type}`, {
+          category: "sandbox",
+        }),
       });
 
       const attachmentSandboxIds = new Set<string>();
@@ -1873,7 +1891,7 @@ async function agentWorkflowBody(
             const researchPhase = phaseKey("Research", state.attempt);
             const { kind, model } = resolveAgent(node.params);
             const provisioned = await ensurePlanningAgentSandboxForBlock(ctx, kind, model);
-            if (provisioned.kind === "failed") return provisioned;
+            if (provisioned.kind === "execution_error") return provisioned;
             const sandboxId = provisioned.sandboxId;
             await writeAttachmentsOnce(sandboxId);
             phaseModels[researchPhase] = model;
@@ -1906,7 +1924,10 @@ async function agentWorkflowBody(
               ctx.observeBudget,
             );
             if (!researchDone) {
-              return { kind: "failed", output: { status: "failed" }, reason: "phase timed out", phase: "research" };
+              return executionError("phase timed out", {
+                category: "timeout",
+                phase: "research",
+              });
             }
 
             const { raw: researchRaw, structured: researchStructured } =
@@ -1932,7 +1953,10 @@ async function agentWorkflowBody(
 
             if (research.status === "failed") {
               const reason = research.body.slice(0, 200);
-              return { kind: "failed", output: { status: "failed" }, reason, phase: "research" };
+              return executionError(reason, {
+                category: "provider",
+                phase: "research",
+              });
             }
 
             ctx.researchPlanMarkdown = research.body;
@@ -2005,16 +2029,17 @@ async function agentWorkflowBody(
 
             if (implOutput.result === "failed") {
               const reason = implOutput.error ?? "unknown";
-              return { kind: "failed", output: { status: "failed" }, reason, phase: "impl" };
+              return executionError(reason, {
+                category: implDone ? "provider" : "timeout",
+                phase: "impl",
+              });
             }
 
             if (!ctx.workspaceManifest) {
-              return {
-                kind: "failed",
-                output: { status: "failed" },
-                reason: "implementation workspace manifest is unavailable",
+              return executionError("implementation workspace manifest is unavailable", {
+                category: "sandbox",
                 phase: "impl",
-              };
+              });
             }
             try {
               const { inspectFixWorkspace } = await import("./blocks/fix-workspace-state.js");
@@ -2030,12 +2055,10 @@ async function agentWorkflowBody(
               };
             } catch (error) {
               if (isRunControlError(error)) throw error;
-              return {
-                kind: "failed",
-                output: { status: "failed" },
-                reason: `could not inspect implementation workspace: ${errorMessage(error)}`,
-                phase: "impl",
-              };
+              return executionError(
+                `could not inspect implementation workspace: ${errorMessage(error)}`,
+                { category: "sandbox", phase: "impl" },
+              );
             }
           }
 
@@ -2083,18 +2106,18 @@ async function agentWorkflowBody(
               ctx.recordUsage("Review", reviewUsage, model);
               reviewOutput = output;
             } else {
-              reviewOutput = { result: "failed", feedback: "", issues: [], error: "Review phase timed out" };
+              return executionError("Review phase timed out", {
+                category: "timeout",
+                phase: "review",
+              });
             }
 
             if (reviewOutput.result === "failed") {
               const reason = reviewOutput.error ?? "unknown";
-              const feedback = reviewOutput.feedback.trim();
-              return {
-                kind: "failed",
-                output: { status: "failed", ...(feedback ? { feedback } : {}) },
-                reason,
+              return executionError(reason, {
+                category: "provider",
                 phase: "review",
-              };
+              });
             }
 
             return {
@@ -2140,15 +2163,13 @@ async function agentWorkflowBody(
             );
             if (!prePrChecks.passed) {
               return {
-                kind: "failed",
+                kind: "next",
                 output: {
-                  status: "failed",
+                  status: "ok",
                   ok: false,
                   fixCycles: prePrChecks.fixCycles,
                   summary: prePrChecks.summary,
                 },
-                reason: prePrChecks.summary,
-                phase: "pre-pr-checks",
               };
             }
             return {
@@ -2165,12 +2186,10 @@ async function agentWorkflowBody(
           case "open_pr": {
             const repositories = resolvedInputs.repositories;
             if (!Array.isArray(repositories)) {
-              return {
-                kind: "failed",
-                output: { status: "failed" },
-                reason: "Open PR/MR requires successful Finalize repository metadata",
-                phase: "open-pr",
-              };
+              return executionError(
+                "Open PR/MR requires successful Finalize repository metadata",
+                { category: "binding", phase: "open-pr" },
+              );
             }
             const publication = await openPullRequestsForPublication({
               repositories: repositories as import("./workspace-publication.js").FinalizedBranch[],
@@ -2201,21 +2220,17 @@ async function agentWorkflowBody(
                   "Pull requests created before publication failed:",
                 );
               }
-              return {
-                kind: "failed",
-                output: { status: "failed" },
-                reason: publication.reason,
+              return executionError(publication.reason, {
+                category: "provider",
                 phase: "open-pr",
-              };
+              });
             }
 
             if (publication.status !== "published") {
-              return {
-                kind: "failed",
-                output: { status: "failed" },
-                reason: `Open PR/MR received unexpected publication status: ${publication.status}`,
-                phase: "open-pr",
-              };
+              return executionError(
+                `Open PR/MR received unexpected publication status: ${publication.status}`,
+                { category: "engine", phase: "open-pr" },
+              );
             }
 
             if (publication.prs.some((pr) => pr.isNew)) {
@@ -2293,6 +2308,7 @@ async function agentWorkflowBody(
       };
 
       const walk = await executeGraph({
+        runId: workflowRunId,
         graph,
         entryTriggerId: entryTrigger.id,
         triggerOutput,
@@ -2306,6 +2322,7 @@ async function agentWorkflowBody(
         shouldRethrowExecutionError: isRunControlError,
         maxTotalExecutions: 200,
       });
+      terminalExecutionError = walk.executionError ?? null;
       // "ended" is a clean awaiting stop (e.g. send_plan_approval parked the
       // run for human approval and already moved the ticket): a success, not a
       // failure. No ticket move here; the block owns that.
@@ -2316,6 +2333,7 @@ async function agentWorkflowBody(
       // because TS can't see the hook closures writing runOutcome and narrows
       // it to its "failed" initializer.
       if (
+        !terminalExecutionError &&
         (walk.outcome === "completed" || walk.outcome === "ended") &&
         (runOutcome as string) !== "awaiting"
       ) {
@@ -2336,13 +2354,37 @@ async function agentWorkflowBody(
       if (observation.check.status !== "ok") err = new RunBudgetError(observation.check);
     }
     terminalBudgetFailure = runBudgetFailureFromError(err);
+    const controlError = isRunControlError(err);
+    if (!controlError) {
+      const nodeId = currentBlockId ?? "engine";
+      const attempt = blockStatuses[nodeId]?.attempt ?? 1;
+      const blockError = executionError(errorMessage(err), {
+        category: currentBlockId ? "unknown" : "engine",
+        phase: currentBlockId ? undefined : "engine",
+      }).error;
+      const diagnostic = createWorkflowExecutionErrorState(
+        workflowRunId,
+        nodeId,
+        attempt,
+        blockError,
+      );
+      terminalExecutionError ??= diagnostic;
+      console.error(
+        `[${diagnostic.diagnosticId}] unhandled workflow execution error:`,
+        err,
+      );
+      err = new WorkflowExecutionError(terminalExecutionError);
+    }
     const { handleUnhandledWorkflowError } = await import("./workflow-failure-exit.js");
     await handleUnhandledWorkflowError(err, {
       recordBlockFailure: async (error) => {
         if (!currentBlockId) return;
         blockStatuses[currentBlockId] = {
           status: "fail",
-          error: truncateError(errorMessage(error)),
+          error: terminalExecutionError?.message ?? truncateError(errorMessage(error)),
+          ...(terminalExecutionError
+            ? { diagnosticId: terminalExecutionError.diagnosticId }
+            : {}),
         };
         await writeBlockStatuses();
       },
@@ -2382,7 +2424,7 @@ async function agentWorkflowBody(
         }
       },
     });
-    throw err;
+    if (controlError) throw err;
   } finally {
     // A launched phase with no parsed usage (timed out / errored before
     // collect) records as unknown, so computeUsageTotals reports
@@ -2414,6 +2456,12 @@ async function agentWorkflowBody(
       ),
       budgetFailure: terminalBudgetFailure,
       pr: prForTelemetry,
+      executionError: terminalExecutionError
+        ? {
+            message: formatExecutionErrorForUser(terminalExecutionError),
+            code: terminalExecutionError.diagnosticId,
+          }
+        : null,
     }).catch((err) => {
       console.error(
         `Run telemetry failed to persist for ${ticket.identifier} (run ${workflowRunId}):`,
@@ -2421,5 +2469,7 @@ async function agentWorkflowBody(
       );
     });
   }
-  return runOutcome;
+  return terminalExecutionError
+    ? { kind: "execution_error", error: terminalExecutionError }
+    : runOutcome;
 }

--- a/apps/worker/src/workflows/blocks/arthur-injection-check.test.ts
+++ b/apps/worker/src/workflows/blocks/arthur-injection-check.test.ts
@@ -105,7 +105,7 @@ describe("arthur_injection_check execute", () => {
     expect(mocks.validatePrompt).toHaveBeenCalledWith("task-1", "text");
   });
 
-  it("skips on client errors instead of failing the run", async () => {
+  it("returns an execution error without output on client failures", async () => {
     configureArthur();
     mocks.validatePrompt.mockRejectedValue(new Error("arthur 500"));
 
@@ -115,8 +115,14 @@ describe("arthur_injection_check execute", () => {
       makeCtx({ arthur: { taskId: "task-1" } }),
     );
 
-    expect(result.kind).toBe("next");
-    expect(result.output).toEqual({ status: "skipped", reason: "arthur 500" });
+    expect(result).toEqual({
+      kind: "execution_error",
+      error: {
+        category: "provider",
+        message: "An external service could not complete this block.",
+        detail: "arthur 500",
+      },
+    });
   });
 
   it.each(runControlErrorCases())("rethrows %s from Arthur validation", async (_label, error) => {

--- a/apps/worker/src/workflows/blocks/arthur-injection-check.ts
+++ b/apps/worker/src/workflows/blocks/arthur-injection-check.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { isRunControlError } from "../run-control-error.js";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 
 export const paramsSchema = z.object({}).strict();
 
@@ -33,7 +33,8 @@ blockArthurValidatePromptStep.maxRetries = 0;
  * validate_prompt. Content is either the resolved `content` input or the
  * ticket description plus comments. Every outcome is a
  * kind "next" output so graphs can branch on it: "ok", "flagged" (with
- * findings), or "skipped" (Arthur unconfigured, no task, or a client error).
+ * findings), or "skipped" (Arthur unconfigured or no task). Provider failures
+ * are execution errors and carry no bindable output.
  */
 export const execute: BlockExecuteFn = async (
   _block,
@@ -76,12 +77,8 @@ export const execute: BlockExecuteFn = async (
     };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "next",
-      output: {
-        status: "skipped",
-        reason: (err instanceof Error ? err.message : String(err)).slice(0, 300),
-      },
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
+    });
   }
 };

--- a/apps/worker/src/workflows/blocks/call-llm.test.ts
+++ b/apps/worker/src/workflows/blocks/call-llm.test.ts
@@ -44,7 +44,7 @@ describe("call_llm execute", () => {
     const result = await execute(makeNode("call_llm", { prompt: "hi" }, "llm-1"), {}, ctx);
 
     expect(result.kind).toBe("next");
-    expect(result.output).toEqual({ status: "ok", output: "answer" });
+    expect(result.output!).toEqual({ status: "ok", output: "answer" });
     expect(mocks.generateStructured).toHaveBeenCalledWith({
       provider: "claude",
       model: "claude-haiku-4-5",
@@ -207,7 +207,7 @@ describe("call_llm execute", () => {
       makeCtx(),
     );
 
-    expect(result.output).toEqual({ status: "ok", output: { answer: 42 } });
+    expect(result.output!).toEqual({ status: "ok", output: { answer: 42 } });
     expect(mocks.generateStructured).toHaveBeenCalledWith({
       model: "claude-opus-4",
       prompt: "hi",
@@ -240,8 +240,8 @@ describe("call_llm execute", () => {
       makeCtx(),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("invalid outputSchema");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("invalid outputSchema");
     expect(mocks.generateStructured).not.toHaveBeenCalled();
   });
 
@@ -251,8 +251,8 @@ describe("call_llm execute", () => {
 
     const result = await execute(makeNode("call_llm", { prompt: "hi" }), {}, ctx);
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("api down");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("api down");
     expect(ctx.markLaunched).toHaveBeenCalledWith("LLM blk");
     expect(ctx.recordUsage).toHaveBeenCalledWith("LLM blk", null, "claude-haiku-4-5");
   });
@@ -301,9 +301,12 @@ describe("call_llm execute", () => {
     const result = await execute(makeNode("call_llm", { prompt: "hi" }), {}, ctx);
 
     expect(result).toEqual({
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "provider timed out",
+      kind: "execution_error",
+      error: {
+        category: "provider",
+        message: "An external service could not complete this block.",
+        detail: "provider timed out",
+      },
     });
     expect(ctx.recordUsage).toHaveBeenCalledWith("LLM blk", null, "claude-haiku-4-5");
   });

--- a/apps/worker/src/workflows/blocks/call-llm.ts
+++ b/apps/worker/src/workflows/blocks/call-llm.ts
@@ -3,7 +3,7 @@ import type { JsonValue } from "@shared/contracts";
 import { validateBlockOutputForDefinition } from "../../workflow-definition/block-registry.js";
 import { RunBudgetError } from "../run-budget.js";
 import { isRunControlError } from "../run-control-error.js";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -90,7 +90,7 @@ export const execute: BlockExecuteFn = async (
     try {
       JSON.parse(schema);
     } catch {
-      return { kind: "failed", output: { status: "failed" }, reason: "invalid outputSchema" };
+      return executionError("invalid outputSchema", { category: "schema" });
     }
   }
 
@@ -101,7 +101,7 @@ export const execute: BlockExecuteFn = async (
         ? block.params.prompt
         : "";
   if (prompt.length === 0) {
-    return { kind: "failed", output: { status: "failed" }, reason: "call_llm requires a prompt" };
+    return executionError("call_llm requires a prompt", { category: "binding" });
   }
   // With an explicit model, pass it through and let generateStructured infer the
   // provider from the id unless one is set. Without a model, default to the run
@@ -152,11 +152,9 @@ export const execute: BlockExecuteFn = async (
 
     if (schema !== undefined) {
       if (!result.hasObject) {
-        return {
-          kind: "failed",
-          output: { status: "failed" },
-          reason: "LLM output did not match the requested schema",
-        };
+        return executionError("LLM output did not match the requested schema", {
+          category: "schema",
+        });
       }
       const output = { status: "ok", output: result.object as JsonValue } as const;
       if (
@@ -164,11 +162,9 @@ export const execute: BlockExecuteFn = async (
           requireNormalOutput: true,
         }).length > 0
       ) {
-        return {
-          kind: "failed",
-          output: { status: "failed" },
-          reason: "LLM output did not match the requested schema",
-        };
+        return executionError("LLM output did not match the requested schema", {
+          category: "schema",
+        });
       }
       return { kind: "next", output };
     }
@@ -189,10 +185,8 @@ export const execute: BlockExecuteFn = async (
         reason: `budget_exceeded: duration ${consumed} reached limit ${limit} during Call LLM`,
       });
     }
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
+    });
   }
 };

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
@@ -152,8 +152,8 @@ describe("fetch_pr_context execute", () => {
 
   it("fails when no repositories are in scope", async () => {
     const result = await execute(makeNode("fetch_pr_context"), {}, makeCtx());
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("no repositories in scope");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("no repositories in scope");
   });
 
   it.each(runControlErrorCases())("rethrows %s from context loading", async (_label, error) => {

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.ts
@@ -3,7 +3,7 @@ import type { SelectedRepository } from "../../adapters/vcs/repository-directory
 import type { SelectedRepositoryPromptContext } from "../../sandbox/context.js";
 import type { PrTriggerPayload } from "../agent-input.js";
 import { isRunControlError } from "../run-control-error.js";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 
 export const paramsSchema = z.object({}).strict();
 
@@ -83,11 +83,10 @@ export const execute: BlockExecuteFn = async (_block, _steps, ctx): Promise<Bloc
       repositories = await blockPrTriggerRepositoriesStep(ctx.ticket.identifier, ctx.entry.pr);
     }
     if (repositories.length === 0) {
-      return {
-        kind: "failed",
-        output: { status: "failed" },
-        reason: "no repositories in scope: run prepare_workspace first or use a PR trigger",
-      };
+      return executionError(
+        "no repositories in scope: run prepare_workspace first or use a PR trigger",
+        { category: "binding" },
+      );
     }
 
     const contexts = await blockFetchPrContextsStep(repositories);
@@ -110,10 +109,8 @@ export const execute: BlockExecuteFn = async (_block, _steps, ctx): Promise<Bloc
     };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
+    });
   }
 };

--- a/apps/worker/src/workflows/blocks/finalize-workspace.test.ts
+++ b/apps/worker/src/workflows/blocks/finalize-workspace.test.ts
@@ -71,7 +71,7 @@ describe("finalize_workspace execute", () => {
   it("ignores unrelated prior step records", async () => {
     const result = await execute(
       makeNode("finalize_workspace"),
-      { "checks-1": { output: { status: "failed", ok: false } } },
+      { "checks-1": { output: { status: "ok", ok: false } } },
       makeCtx({ selectedRepositories: [repo], workspaceManifest: trustedManifest }),
     );
     expect(result.kind).toBe("next");
@@ -85,9 +85,12 @@ describe("finalize_workspace execute", () => {
       { "checks.lint": "ok", "checks.test": "failed" },
     );
     expect(result).toEqual({
-      kind: "failed",
-      output: { status: "failed", unmetChecks: ["test"] },
-      reason: "required checks not satisfied: test",
+      kind: "execution_error",
+      error: {
+        category: "checks",
+        message: "The checks could not be started.",
+        detail: "required checks not satisfied: test",
+      },
     });
     expect(mocks.finalizeWorkspacePublication).not.toHaveBeenCalled();
   });
@@ -110,7 +113,7 @@ describe("finalize_workspace execute", () => {
       {},
       makeCtx({ sandboxId: null }),
     );
-    expect(result.kind).toBe("failed");
+    expect(result.kind).toBe("execution_error");
     expect(mocks.finalizeWorkspacePublication).not.toHaveBeenCalled();
   });
 
@@ -122,8 +125,8 @@ describe("finalize_workspace execute", () => {
     );
 
     expect(result).toEqual(expect.objectContaining({
-      kind: "failed",
-      reason: expect.stringContaining("trusted"),
+      kind: "execution_error",
+      error: expect.objectContaining({ detail: expect.stringContaining("trusted") }),
     }));
     expect(mocks.finalizeWorkspacePublication).not.toHaveBeenCalled();
   });
@@ -168,7 +171,7 @@ describe("finalize_workspace execute", () => {
         repositories: finalized.repositories,
       },
     });
-    expectOutputConformsToRegistry("finalize_workspace", result.output);
+    expectOutputConformsToRegistry("finalize_workspace", result.output!);
   });
 
   it("passes the exact triggering PR/MR source head into publication", async () => {
@@ -219,10 +222,13 @@ describe("finalize_workspace execute", () => {
     const result = await execute(makeNode("finalize_workspace"), {}, ctx);
 
     expect(result).toEqual({
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "lease rejected",
-      phase: "push",
+      kind: "execution_error",
+      error: {
+        category: "provider",
+        message: "An external service could not complete this block.",
+        detail: "lease rejected",
+        phase: "push",
+      },
     });
   });
 

--- a/apps/worker/src/workflows/blocks/finalize-workspace.ts
+++ b/apps/worker/src/workflows/blocks/finalize-workspace.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { isRunControlError } from "../run-control-error.js";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 
 export const paramsSchema = z.object({}).strict();
 
@@ -23,27 +23,22 @@ export const execute: BlockExecuteFn = async (
   );
   if (unmetChecks.size > 0) {
     const unmet = [...unmetChecks];
-    return {
-      kind: "failed",
-      output: { status: "failed", unmetChecks: unmet },
-      reason: `required checks not satisfied: ${unmet.join(", ")}`,
-    };
+    return executionError(`required checks not satisfied: ${unmet.join(", ")}`, {
+      category: "checks",
+    });
   }
 
   if (!ctx.sandboxId) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "no workspace: connect prepare_workspace before finalize_workspace",
-    };
+    return executionError(
+      "no workspace: connect prepare_workspace before finalize_workspace",
+      { category: "sandbox" },
+    );
   }
 
   if (!ctx.workspaceManifest) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "workspace has no manager-authored trusted manifest",
-    };
+    return executionError("workspace has no manager-authored trusted manifest", {
+      category: "sandbox",
+    });
   }
 
   try {
@@ -70,21 +65,17 @@ export const execute: BlockExecuteFn = async (
     ctx.publication = publication;
 
     if (publication.status === "failed") {
-      return {
-        kind: "failed",
-        output: { status: "failed" },
-        reason: publication.reason,
+      return executionError(publication.reason, {
+        category: "provider",
         phase: "push",
-      };
+      });
     }
 
     if (publication.status !== "finalized") {
-      return {
-        kind: "failed",
-        output: { status: "failed" },
-        reason: `Finalize Workspace received unexpected publication status: ${publication.status}`,
-        phase: "push",
-      };
+      return executionError(
+        `Finalize Workspace received unexpected publication status: ${publication.status}`,
+        { category: "engine", phase: "push" },
+      );
     }
 
     return {
@@ -103,11 +94,9 @@ export const execute: BlockExecuteFn = async (
     };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
       phase: "push",
-    };
+    });
   }
 };

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -178,7 +178,7 @@ describe("fix_agent execute", () => {
         summary: "patched",
       },
     });
-    expectOutputConformsToRegistry("fix_agent", result.output);
+    expectOutputConformsToRegistry("fix_agent", result.output!);
   });
 
   it("feeds pr_trigger failed checks and review into the fix context", async () => {
@@ -267,7 +267,7 @@ describe("fix_agent execute", () => {
         expect(result.questions).toEqual([
           "The Fix Agent needs more information. What should it use to continue?",
         ]);
-        expect(result.output.questions).toEqual(result.questions);
+        expect(result.output!.questions).toEqual(result.questions);
       }
     },
   );
@@ -341,21 +341,15 @@ describe("fix_agent execute", () => {
     });
   });
 
-  it("maps a failed agent result to kind failed", async () => {
+  it("maps a failed agent result to an execution error without output", async () => {
     mocks.parseAgentOutput.mockReturnValue({ result: "failed", error: "could not fix" });
 
     const result = await execute(makeNode("fix_agent"), {}, makeCtx());
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") {
-      expect(result.reason).toBe("could not fix");
-      expect(result.output).toEqual({
-        status: "failed",
-        workspaceId: "sbx-1",
-        commits: [],
-        resolvedConflicts: [],
-        unresolvedConflicts: [],
-      });
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toBe("could not fix");
+      expect(result.output).toBeUndefined();
     }
   });
 
@@ -365,7 +359,7 @@ describe("fix_agent execute", () => {
     await expect(execute(makeNode("fix_agent"), {}, makeCtx())).rejects.toBe(error);
   });
 
-  it("reports the post-termination workspace state when the phase times out", async () => {
+  it("returns a timeout execution error without publishing workspace output", async () => {
     mocks.pollPhaseUntilDone.mockResolvedValue(false);
     const before = {
       commits: [{ provider: "github" as const, repoPath: "acme/api", sha: "before123" }],
@@ -387,19 +381,14 @@ describe("fix_agent execute", () => {
     const result = await execute(makeNode("fix_agent"), {}, makeCtx());
 
     expect(result).toEqual({
-      kind: "failed",
-      output: {
-        status: "failed",
-        workspaceId: "sbx-1",
-        commits: after.commits,
-        resolvedConflicts: [
-          { provider: "github", repoPath: "acme/api", files: ["src/old.ts"] },
-        ],
-        unresolvedConflicts: after.unresolvedConflicts,
+      kind: "execution_error",
+      error: {
+        category: "timeout",
+        message: "The block timed out.",
+        detail: "fix phase timed out",
       },
-      reason: "fix phase timed out",
     });
-    expect(mocks.inspectFixWorkspace).toHaveBeenCalledTimes(2);
+    expect(mocks.inspectFixWorkspace).toHaveBeenCalledTimes(1);
     expect(mocks.collectPhase).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -16,7 +16,13 @@ import {
   resolvedFixConflicts,
   type FixWorkspaceState,
 } from "./fix-workspace-state.js";
-import { sanitizeBlockId, type BlockExecuteFn, type BlockExecutionResult, type EngineCtx } from "./types.js";
+import {
+  executionError,
+  sanitizeBlockId,
+  type BlockExecuteFn,
+  type BlockExecutionResult,
+  type EngineCtx,
+} from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -164,7 +170,7 @@ export const execute: BlockExecuteFn = async (
   const workspace = await ensureWorkspace(ctx, execution);
   if (workspace.kind !== "next") return workspace;
   if (!ctx.sandboxId) {
-    return { kind: "failed", output: { status: "failed" }, reason: "workspace was not attached" };
+    return executionError("workspace was not attached", { category: "sandbox" });
   }
   const sandboxId = ctx.sandboxId;
   const { kind, model } = resolveBlockAgent(block.params, ctx.runDefaultKind, ctx.defaults);
@@ -196,15 +202,7 @@ export const execute: BlockExecuteFn = async (
       ctx.observeBudget,
     );
     if (!done) {
-      // The shared poller's timeout contract (implemented with AIW-102) stops
-      // the detached command before returning false. Re-read afterward because
-      // the phase may still have committed work or partially resolved conflicts.
-      const after = await inspectFixWorkspace(sandboxId);
-      return {
-        kind: "failed",
-        output: workspaceStateOutput("failed", sandboxId, before, after),
-        reason: "fix phase timed out",
-      };
+      return executionError("fix phase timed out", { category: "timeout" });
     }
 
     const { collectPhase } = await import("../../sandbox/poll-agent.js");
@@ -235,11 +233,7 @@ export const execute: BlockExecuteFn = async (
       };
     }
     if (output.result === "failed") {
-      return {
-        kind: "failed",
-        output: workspaceStateOutput("failed", sandboxId, before, after),
-        reason: output.error ?? "unknown",
-      };
+      return executionError(output.error ?? "unknown", { category: "provider" });
     }
     if (after.unresolvedConflicts.length > 0) {
       const questions = [formatUnresolvedConflictQuestion(after)];
@@ -263,17 +257,9 @@ export const execute: BlockExecuteFn = async (
     };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: {
-        status: "failed",
-        workspaceId: sandboxId,
-        commits: [],
-        resolvedConflicts: [],
-        unresolvedConflicts: [],
-      },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
+    });
   }
 };
 
@@ -290,18 +276,6 @@ function workspaceStateFields(
     commits: after.commits,
     resolvedConflicts: resolvedFixConflicts(before, after),
     unresolvedConflicts: after.unresolvedConflicts,
-  };
-}
-
-function workspaceStateOutput(
-  status: "fixed" | "failed",
-  sandboxId: string,
-  before: FixWorkspaceState,
-  after: FixWorkspaceState,
-) {
-  return {
-    status,
-    ...workspaceStateFields(sandboxId, before, after),
   };
 }
 

--- a/apps/worker/src/workflows/blocks/generic-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/generic-agent.test.ts
@@ -92,8 +92,8 @@ describe("generic_agent execute", () => {
       makeCtx(),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("invalid outputSchema");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("invalid outputSchema");
     expect(mocks.sandboxGet).not.toHaveBeenCalled();
   });
 
@@ -103,8 +103,8 @@ describe("generic_agent execute", () => {
       {},
       makeCtx({ sandboxId: null }),
     );
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("no workspace");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("no workspace");
   });
 
   it("uses an agent-only scratch sandbox in none mode", async () => {
@@ -173,7 +173,7 @@ describe("generic_agent execute", () => {
     expect(result.kind).toBe("next");
   });
 
-  it("maps agent-only scratch provisioning failures to a failed block", async () => {
+  it("maps agent-only scratch provisioning failures to an execution error", async () => {
     mocks.ensureAgentSandbox.mockRejectedValueOnce(new Error("sandbox unavailable"));
 
     const result = await execute(
@@ -183,9 +183,12 @@ describe("generic_agent execute", () => {
     );
 
     expect(result).toEqual({
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "sandbox unavailable",
+      kind: "execution_error",
+      error: {
+        category: "sandbox",
+        message: "The workspace environment could not complete this block.",
+        detail: "sandbox unavailable",
+      },
     });
   });
 
@@ -348,8 +351,8 @@ describe("generic_agent execute", () => {
 
     const result = await execute(makeNode("generic_agent", { prompt: "p" }), {}, makeCtx());
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("broke");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("broke");
   });
 
   it("returns custom-schema fields at the top level with a compatibility data alias", async () => {
@@ -389,9 +392,9 @@ describe("generic_agent execute", () => {
       makeCtx(),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") {
-      expect(result.reason).toBe("agent output did not match the requested schema");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toBe("agent output did not match the requested schema");
     }
   });
 
@@ -405,9 +408,13 @@ describe("generic_agent execute", () => {
     const result = await execute(node, {}, makeCtx());
 
     expect(result).toEqual({
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "invalid outputSchema: outputSchema must declare an object for Generic Agent.",
+      kind: "execution_error",
+      error: {
+        category: "schema",
+        message: "The block returned an invalid result.",
+        detail:
+          "invalid outputSchema: outputSchema must declare an object for Generic Agent.",
+      },
     });
   });
 
@@ -420,9 +427,9 @@ describe("generic_agent execute", () => {
       makeCtx(),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") {
-      expect(result.reason).toBe("agent output did not match the requested schema");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toBe("agent output did not match the requested schema");
     }
   });
 
@@ -448,7 +455,7 @@ describe("generic_agent execute", () => {
 
     const result = await execute(makeNode("generic_agent", { prompt: "p" }), {}, makeCtx());
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("agent phase timed out");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("agent phase timed out");
   }, 15000);
 });

--- a/apps/worker/src/workflows/blocks/generic-agent.ts
+++ b/apps/worker/src/workflows/blocks/generic-agent.ts
@@ -10,7 +10,12 @@ import { resolveBlockAgent } from "../../workflow-definition/resolve-agent.js";
 import { ensureAgentSandbox } from "./agent-sandbox.js";
 import { isRunControlError } from "../run-control-error.js";
 import { pollPhaseUntilDone } from "./poll-phase.js";
-import { sanitizeBlockId, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
+import {
+  executionError,
+  sanitizeBlockId,
+  type BlockExecuteFn,
+  type BlockExecutionResult,
+} from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -138,7 +143,7 @@ async function blockGenericAgentParseStep(
  * generic_agent: run a free-form agent phase on the attached workspace. The
  * prompt param is written verbatim as the phase input file. Without an
  * outputSchema param the phase uses GENERIC_SCHEMA and its status maps to
- * next / needs_human_input / failed; with a custom schema the parsed object is
+ * next / needs_human_input / execution_error; with a custom schema the parsed object is
  * returned at the top level with the reserved runtime status plus a compatibility
  * `data` alias. The outputSchema string is validated before anything reaches
  * the agent CLI.
@@ -158,15 +163,13 @@ export const execute: BlockExecuteFn = async (
     try {
       JSON.parse(customSchema);
     } catch {
-      return { kind: "failed", output: { status: "failed" }, reason: "invalid outputSchema" };
+      return executionError("invalid outputSchema", { category: "schema" });
     }
     const definitionIssue = workflowBlockDefinitionIssue(block.type, block.params);
     if (definitionIssue) {
-      return {
-        kind: "failed",
-        output: { status: "failed" },
-        reason: `invalid outputSchema: ${definitionIssue}`,
-      };
+      return executionError(`invalid outputSchema: ${definitionIssue}`, {
+        category: "schema",
+      });
     }
   }
 
@@ -183,21 +186,17 @@ export const execute: BlockExecuteFn = async (
         : ctx.sandboxId;
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "sandbox",
+    });
   }
   if (!sandboxId) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason:
+    return executionError(
         workspaceMode === "read_write"
           ? "no workspace: connect prepare_workspace before generic_agent"
           : "could not provision an agent-only sandbox for generic_agent",
-    };
+      { category: "sandbox" },
+    );
   }
   const basePrompt =
     typeof resolvedInputs.prompt === "string"
@@ -209,7 +208,9 @@ export const execute: BlockExecuteFn = async (
     ? `${basePrompt}\n\nHuman clarification answer:\n${execution.clarificationAnswer}`
     : basePrompt;
   if (prompt.length === 0) {
-    return { kind: "failed", output: { status: "failed" }, reason: "generic_agent requires a prompt" };
+    return executionError("generic_agent requires a prompt", {
+      category: "binding",
+    });
   }
 
   // Artifact phase must be shell/file-safe (drives /tmp paths); telemetry label
@@ -246,7 +247,7 @@ export const execute: BlockExecuteFn = async (
       ctx.observeBudget,
     );
     if (!done) {
-      return { kind: "failed", output: { status: "failed" }, reason: "agent phase timed out" };
+      return executionError("agent phase timed out", { category: "timeout" });
     }
 
     const { collectPhase } = await import("../../sandbox/poll-agent.js");
@@ -256,18 +257,14 @@ export const execute: BlockExecuteFn = async (
 
     if (customSchema !== undefined) {
       if (object === undefined) {
-        return {
-          kind: "failed",
-          output: { status: "failed" },
-          reason: "agent output did not match the requested schema",
-        };
+        return executionError("agent output did not match the requested schema", {
+          category: "schema",
+        });
       }
       if (object === null || typeof object !== "object" || Array.isArray(object)) {
-        return {
-          kind: "failed",
-          output: { status: "failed" },
-          reason: "agent output did not match the requested schema",
-        };
+        return executionError("agent output did not match the requested schema", {
+          category: "schema",
+        });
       }
       const data = object as Record<string, JsonValue>;
       const output = { ...data, status: "completed", data } as const;
@@ -276,22 +273,18 @@ export const execute: BlockExecuteFn = async (
           requireNormalOutput: true,
         }).length > 0
       ) {
-        return {
-          kind: "failed",
-          output: { status: "failed" },
-          reason: "agent output did not match the requested schema",
-        };
+        return executionError("agent output did not match the requested schema", {
+          category: "schema",
+        });
       }
       return { kind: "next", output };
     }
 
     const parsed = genericOutputSchema.safeParse(object);
     if (!parsed.success) {
-      return {
-        kind: "failed",
-        output: { status: "failed" },
-        reason: "agent output was not structured JSON",
-      };
+      return executionError("agent output was not structured JSON", {
+        category: "parsing",
+      });
     }
     if (parsed.data.status === "needs_input") {
       const listed = (parsed.data.questions ?? []).filter((q) => q.trim().length > 0);
@@ -311,11 +304,10 @@ export const execute: BlockExecuteFn = async (
       };
     }
     if (parsed.data.status === "failed") {
-      return {
-        kind: "failed",
-        output: { status: "failed" },
-        reason: parsed.data.error ?? parsed.data.body.slice(0, 500),
-      };
+      return executionError(
+        parsed.data.error ?? parsed.data.body.slice(0, 500),
+        { category: "provider" },
+      );
     }
     return {
       kind: "next",
@@ -326,10 +318,8 @@ export const execute: BlockExecuteFn = async (
     };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
+    });
   }
 };

--- a/apps/worker/src/workflows/blocks/human-question.test.ts
+++ b/apps/worker/src/workflows/blocks/human-question.test.ts
@@ -63,9 +63,9 @@ describe("human_question execute", () => {
   it("fails with a clear reason when nothing is derivable", async () => {
     const steps: StepsRecord = { a: { output: { status: "ok" } } };
     const result = await execute(makeNode("human_question"), steps, makeCtx());
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") {
-      expect(result.reason).toContain("human_question has no questions");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("human_question has no questions");
     }
   });
 

--- a/apps/worker/src/workflows/blocks/human-question.ts
+++ b/apps/worker/src/workflows/blocks/human-question.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -67,12 +67,10 @@ export const execute: BlockExecuteFn = async (
   }
 
   if (questions.length === 0) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason:
-        "human_question has no questions: set the questions param or place it after a block that produces questions",
-    };
+    return executionError(
+      "human_question has no questions: set the questions param or place it after a block that produces questions",
+      { category: "binding" },
+    );
   }
 
   return {

--- a/apps/worker/src/workflows/blocks/io-blocks.edge.test.ts
+++ b/apps/worker/src/workflows/blocks/io-blocks.edge.test.ts
@@ -404,8 +404,8 @@ describe("post_ticket_comment edge cases", () => {
       makeCtx(),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("requires a body");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("requires a body");
     expect(mocks.postComment).not.toHaveBeenCalled();
   });
 
@@ -488,9 +488,9 @@ describe("post_pr_comment edge cases", () => {
       makeCtx({ publication: singlePublication() }),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") {
-      expect(result.reason).toContain("not in AGENT_ALLOWED_REPOS");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("not in AGENT_ALLOWED_REPOS");
     }
     expect(mocks.createRepositoryVCS).not.toHaveBeenCalled();
   });
@@ -553,8 +553,8 @@ describe("post_pr_comment edge cases", () => {
       }),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("identity is incomplete");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("identity is incomplete");
     expect(mocks.createRepositoryVCS).not.toHaveBeenCalled();
   });
 
@@ -567,8 +567,8 @@ describe("post_pr_comment edge cases", () => {
       makeCtx({ publication: incomplete }),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("identity is incomplete");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("identity is incomplete");
     expect(mocks.createRepositoryVCS).not.toHaveBeenCalled();
   });
 
@@ -579,8 +579,8 @@ describe("post_pr_comment edge cases", () => {
       makeCtx({ publication: publication() }),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("requires a body");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("requires a body");
     expect(mocks.createRepositoryVCS).not.toHaveBeenCalled();
   });
 });
@@ -662,8 +662,8 @@ describe("run_checks edge cases", () => {
     const result = await executeRunChecks(makeNode("run_checks"), {}, makeCtx());
 
     expect(result.kind).toBe("next");
-    expect(result.output.ok).toBe(true);
-    expect(result.output.failures).toEqual([]);
+    expect(result.output!.ok).toBe(true);
+    expect(result.output!.failures).toEqual([]);
   });
 
   it("fails when the workspace manifest is missing", async () => {
@@ -675,8 +675,8 @@ describe("run_checks edge cases", () => {
       makeCtx(),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("Workspace manifest not found");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("Workspace manifest not found");
   });
 
   it("routes an empty commands array to the configured pre-PR-checks path", async () => {
@@ -704,7 +704,7 @@ describe("run_checks edge cases", () => {
     );
 
     expect(result.kind).toBe("next");
-    expect(result.output.results).toEqual([
+    expect(result.output!.results).toEqual([
       { repo: "github:acme/api", command: "pnpm lint", exitCode: 0 },
       { repo: "github:acme/web", command: "pnpm lint", exitCode: 0 },
     ]);
@@ -747,10 +747,10 @@ describe("finalize_workspace edge cases", () => {
       makeCtx({ selectedRepositories: [repo], workspaceManifest }),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") {
-      expect(result.reason).toBe("boom");
-      expect(result.phase).toBe("push");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toBe("boom");
+      expect(result.error.phase).toBe("push");
     }
   });
 
@@ -768,7 +768,7 @@ describe("finalize_workspace edge cases", () => {
       makeCtx({ selectedRepositories: [repo], workspaceManifest }),
     );
 
-    expect(result.kind).toBe("failed");
+    expect(result.kind).toBe("execution_error");
     expect(mocks.postComment).not.toHaveBeenCalled();
   });
 
@@ -828,9 +828,9 @@ describe("fetch_pr_context edge cases", () => {
       makeCtx({ selectedRepositories: [repoWithPr] }),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") {
-      expect(result.reason).toContain("not in AGENT_ALLOWED_REPOS");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("not in AGENT_ALLOWED_REPOS");
     }
     expect(mocks.createRepositoryVCS).not.toHaveBeenCalled();
   });
@@ -878,8 +878,8 @@ describe("fetch_pr_context edge cases", () => {
       makeCtx({ selectedRepositories: [repoWithPr] }),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("github 500");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("github 500");
   });
 
   it("returns full context for a repo with a PR and empty context for one without", async () => {

--- a/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
@@ -151,7 +151,7 @@ describe("post_pr_comment execute", () => {
     );
     expect(result.kind).toBe("next");
     if (result.kind === "next") {
-      expect(result.output.comments).toHaveLength(2);
+      expect(result.output!.comments).toHaveLength(2);
     }
   });
 
@@ -225,8 +225,8 @@ describe("post_pr_comment execute", () => {
         }),
       );
 
-      expect(result.kind).toBe("failed");
-      if (result.kind === "failed") expect(result.reason).toContain(expectedReason);
+      expect(result.kind).toBe("execution_error");
+      if (result.kind === "execution_error") expect(result.error.detail).toContain(expectedReason);
       expect(postPRComment).not.toHaveBeenCalled();
     },
   );
@@ -259,8 +259,8 @@ describe("post_pr_comment execute", () => {
         makeCtx({ publication: publication() }),
       );
 
-      expect(result.kind).toBe("failed");
-      if (result.kind === "failed") expect(result.reason).toContain(expectedReason);
+      expect(result.kind).toBe("execution_error");
+      if (result.kind === "execution_error") expect(result.error.detail).toContain(expectedReason);
       expect(postPRComment).not.toHaveBeenCalled();
     },
   );
@@ -298,7 +298,7 @@ describe("post_pr_comment execute", () => {
     expect(postPRComment).toHaveBeenCalledWith(7, "merged");
   });
 
-  it("returns failed with partial comments when one target errors", async () => {
+  it("returns an execution error without publishing partial comments", async () => {
     const postPRComment = vi
       .fn()
       .mockResolvedValueOnce({ url: "https://pr/comment" })
@@ -311,19 +311,17 @@ describe("post_pr_comment execute", () => {
       makeCtx({ publication: publication() }),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") {
-      expect(result.reason).toContain("gitlab down");
-      expect(result.output.comments).toEqual([
-        { provider: "github", repoPath: "acme/api", prId: 7, url: "https://pr/comment" },
-      ]);
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("gitlab down");
+      expect(result.output).toBeUndefined();
     }
   });
 
   it("fails when no pull request is in scope", async () => {
     const result = await execute(makeNode("post_pr_comment", { body: "hi" }), {}, makeCtx());
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("no pull request in scope");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("no pull request in scope");
   });
 
   it.each(runControlErrorCases())(

--- a/apps/worker/src/workflows/blocks/post-pr-comment.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.ts
@@ -3,7 +3,12 @@ import type { VcsProvider } from "../../adapters/vcs/repository-directory.js";
 import type { PullRequestHead } from "../../adapters/vcs/types.js";
 import type { ActiveRunOwner } from "../../lib/active-run-owner.js";
 import { isRunControlError } from "../run-control-error.js";
-import type { BlockExecuteFn, BlockExecutionResult, EngineCtx } from "./types.js";
+import {
+  executionError,
+  type BlockExecuteFn,
+  type BlockExecutionResult,
+  type EngineCtx,
+} from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -100,8 +105,8 @@ function assertCurrentPrCommentTarget(
  * post_pr_comment: comment on the run's pull requests. The PR set comes from
  * ctx.publication when the workspace was published, otherwise from the
  * pr_trigger entry payload. target "primary" comments only the first PR;
- * "all" comments every PR. Partial failures return kind "failed" with the
- * comments that did land in the output.
+ * "all" comments every PR. Partial provider failures are execution errors;
+ * successful partial results are not published as normal block output.
  */
 export const execute: BlockExecuteFn = async (
   block,
@@ -116,11 +121,9 @@ export const execute: BlockExecuteFn = async (
         ? block.params.body.trim()
         : "";
   if (body.length === 0) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "post_pr_comment requires a body",
-    };
+    return executionError("post_pr_comment requires a body", {
+      category: "binding",
+    });
   }
 
   let prs: PrCommentTarget[] = [];
@@ -131,13 +134,11 @@ export const execute: BlockExecuteFn = async (
           repository.provider === pr.provider && repository.repoPath === pr.repoPath,
       );
       if (!finalized?.defaultBranch) {
-        return {
-          kind: "failed",
-          output: { status: "failed" },
-          reason:
-            `publication identity is incomplete for ${pr.provider}:${pr.repoPath}#${pr.id}: ` +
+        return executionError(
+          `publication identity is incomplete for ${pr.provider}:${pr.repoPath}#${pr.id}: ` +
             "missing finalized head or target branch",
-        };
+          { category: "binding" },
+        );
       }
       prs.push({
         provider: pr.provider,
@@ -161,11 +162,10 @@ export const execute: BlockExecuteFn = async (
     ];
   }
   if (prs.length === 0) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "no pull request in scope: publish the workspace first or use a PR trigger",
-    };
+    return executionError(
+      "no pull request in scope: publish the workspace first or use a PR trigger",
+      { category: "binding" },
+    );
   }
 
   const target = block.params.target === "all" ? "all" : "primary";
@@ -178,19 +178,15 @@ export const execute: BlockExecuteFn = async (
       runId: ctx.runId,
     });
     if (errors.length > 0) {
-      return {
-        kind: "failed",
-        output: { status: "failed", comments },
-        reason: errors.join("; ").slice(0, 500),
-      };
+      return executionError(errors.join("; ").slice(0, 500), {
+        category: "provider",
+      });
     }
     return { kind: "next", output: { status: "ok", comments } };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
+    });
   }
 };

--- a/apps/worker/src/workflows/blocks/post-ticket-comment.test.ts
+++ b/apps/worker/src/workflows/blocks/post-ticket-comment.test.ts
@@ -75,7 +75,7 @@ describe("post_ticket_comment execute", () => {
 
   it("fails when the body param is missing", async () => {
     const result = await execute(makeNode("post_ticket_comment"), {}, makeCtx());
-    expect(result.kind).toBe("failed");
+    expect(result.kind).toBe("execution_error");
     expect(mocks.postComment).not.toHaveBeenCalled();
   });
 
@@ -89,7 +89,7 @@ describe("post_ticket_comment execute", () => {
     );
 
     expect(result).toEqual({ kind: "next", output: { status: "ok", commentUrl: null } });
-    expectOutputConformsToRegistry("post_ticket_comment", result.output);
+    expectOutputConformsToRegistry("post_ticket_comment", result.output!);
   });
 
   it("maps tracker errors to a failed result", async () => {
@@ -101,8 +101,8 @@ describe("post_ticket_comment execute", () => {
       makeCtx(),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("jira down");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("jira down");
   });
 
   it.each(runControlErrorCases())(

--- a/apps/worker/src/workflows/blocks/post-ticket-comment.ts
+++ b/apps/worker/src/workflows/blocks/post-ticket-comment.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ActiveRunOwner } from "../../lib/active-run-owner.js";
 import { isRunControlError } from "../run-control-error.js";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -41,11 +41,9 @@ export const execute: BlockExecuteFn = async (
         ? block.params.body.trim()
         : "";
   if (body.length === 0) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "post_ticket_comment requires a body",
-    };
+    return executionError("post_ticket_comment requires a body", {
+      category: "binding",
+    });
   }
 
   try {
@@ -57,10 +55,8 @@ export const execute: BlockExecuteFn = async (
     return { kind: "next", output: { status: "ok", commentUrl } };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
+    });
   }
 };

--- a/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
@@ -155,7 +155,7 @@ describe("prepare_workspace execute", () => {
         workspace: { id: "sbx-9", repositories: ["github:acme/api"] },
       },
     });
-    expectOutputConformsToRegistry("prepare_workspace", result.output);
+    expectOutputConformsToRegistry("prepare_workspace", result.output!);
   });
 
   it("passes the clarification answer back into pre-sandbox repository selection", async () => {
@@ -327,8 +327,8 @@ describe("prepare_workspace execute", () => {
     const ctx = makeCtx({ sandboxId: null, sandboxIds: new Set<string>() });
     const result = await execute(makeNode("prepare_workspace"), {}, ctx);
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("registry write failed");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("registry write failed");
     expect(ctx.sandboxId).toBeNull();
     expect([...ctx.sandboxIds]).toEqual([]);
   });
@@ -360,8 +360,8 @@ describe("prepare_workspace execute", () => {
 
     const result = await execute(makeNode("prepare_workspace"), {}, makeCtx({ sandboxId: null }));
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("pre-sandbox: step exploded");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("pre-sandbox: step exploded");
   });
 
   it("asks for a repository when none is selectable", async () => {
@@ -450,8 +450,8 @@ describe("prepare_workspace execute", () => {
 
     const result = await execute(makeNode("prepare_workspace"), {}, makeCtx({ sandboxId: null }));
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("no capacity");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("no capacity");
   });
 
   it.each(runControlErrorCases())("rethrows %s from provisioning", async (_label, error) => {

--- a/apps/worker/src/workflows/blocks/prepare-workspace.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.ts
@@ -10,7 +10,7 @@ import type {
 import { resolveBlockAgent } from "../../workflow-definition/resolve-agent.js";
 import { isRunControlError } from "../run-control-error.js";
 import { blockFetchPrContextsStep, blockPrTriggerRepositoriesStep } from "./fetch-pr-context.js";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 import type { BlockExecutionContext } from "../../workflow-definition/interpreter.js";
 
 export const paramsSchema = z.object({}).strict();
@@ -233,11 +233,9 @@ export async function ensureWorkspace(
       };
     } catch (err) {
       if (isRunControlError(err)) throw err;
-      return {
-        kind: "failed",
-        output: { status: "failed" },
-        reason: err instanceof Error ? err.message : String(err),
-      };
+      return executionError(err instanceof Error ? err.message : String(err), {
+        category: "sandbox",
+      });
     }
   }
 
@@ -275,11 +273,9 @@ export async function ensureWorkspace(
             questions,
           };
         }
-        return {
-          kind: "failed",
-          output: { status: "failed" },
-          reason: `pre-sandbox: ${preSandbox.message}`,
-        };
+        return executionError(`pre-sandbox: ${preSandbox.message}`, {
+          category: "sandbox",
+        });
       }
       if (preSandbox.promptAdditions) {
         ctx.preSandboxAdditions = preSandbox.promptAdditions;
@@ -360,11 +356,9 @@ export async function ensureWorkspace(
     };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "sandbox",
+    });
   }
 }
 

--- a/apps/worker/src/workflows/blocks/run-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.test.ts
@@ -70,8 +70,8 @@ describe("run_checks execute", () => {
 
   it("fails when no workspace is attached", async () => {
     const result = await execute(makeNode("run_checks"), {}, makeCtx({ sandboxId: null }));
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toContain("no workspace");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toContain("no workspace");
   });
 
   it("returns kind next with ok false when explicit commands fail", async () => {
@@ -86,7 +86,7 @@ describe("run_checks execute", () => {
     );
 
     expect(result.kind).toBe("next");
-    expect(result.output).toEqual({
+    expect(result.output!).toEqual({
       status: "ok",
       ok: false,
       results: [
@@ -114,8 +114,8 @@ describe("run_checks execute", () => {
     );
 
     expect(result.kind).toBe("next");
-    expect(result.output.ok).toBe(true);
-    expect(result.output.failures).toEqual([]);
+    expect(result.output!.ok).toBe(true);
+    expect(result.output!.failures).toEqual([]);
   });
 
   it("aborts explicit commands at the remaining duration and starts no later command", async () => {
@@ -192,8 +192,8 @@ describe("run_checks execute", () => {
       1_800_000,
     );
     expect(result.kind).toBe("next");
-    expect(result.output.ok).toBe(false);
-    expect(result.output.failures).toEqual([
+    expect(result.output!.ok).toBe(false);
+    expect(result.output!.failures).toEqual([
       { repo: "github:acme/api", command: "pnpm lint", exitCode: 1, output: "lint output" },
     ]);
   });
@@ -245,8 +245,8 @@ describe("run_checks execute", () => {
       makeCtx(),
     );
 
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("sandbox gone");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("sandbox gone");
   });
 
   it.each(runControlErrorCases())("rethrows %s from checks", async (_label, error) => {

--- a/apps/worker/src/workflows/blocks/run-checks.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.ts
@@ -6,7 +6,7 @@ import {
   isDurationAbortError,
 } from "../run-budget.js";
 import { isRunControlError } from "../run-control-error.js";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -113,16 +113,15 @@ blockRunChecksConfiguredStep.maxRetries = 0;
  * command in every workspace repository; without it it runs the dashboard's
  * pre-PR-checks config once (no fix cycles). Failing checks are a normal
  * branchable outcome: the block returns kind "next" with { status: "ok",
- * ok: false } when checks ran and failed, reserving kind "failed" for
+ * ok: false } when checks ran and failed, reserving kind "execution_error" for
  * infrastructure errors (checks could not run at all).
  */
 export const execute: BlockExecuteFn = async (block, _steps, ctx): Promise<BlockExecutionResult> => {
   if (!ctx.sandboxId) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "no workspace: connect prepare_workspace before run_checks",
-    };
+    return executionError(
+      "no workspace: connect prepare_workspace before run_checks",
+      { category: "sandbox" },
+    );
   }
   const commands = Array.isArray(block.params.commands)
     ? block.params.commands.filter((c): c is string => typeof c === "string")
@@ -157,10 +156,8 @@ export const execute: BlockExecuteFn = async (block, _steps, ctx): Promise<Block
     if (isDurationAbortError(err)) {
       throw new RunBudgetError(durationBudgetFailure(after, "Run checks"));
     }
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "checks",
+    });
   }
 };

--- a/apps/worker/src/workflows/blocks/send-plan-approval.test.ts
+++ b/apps/worker/src/workflows/blocks/send-plan-approval.test.ts
@@ -67,8 +67,8 @@ describe("send_plan_approval execute", () => {
       {},
       makeCtx({ researchPlanMarkdown: "" }),
     );
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("no plan available");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("no plan available");
     expect(mocks.createApprovalRequest).not.toHaveBeenCalled();
   });
 
@@ -78,8 +78,8 @@ describe("send_plan_approval execute", () => {
       {},
       makeCtx({ researchPlanMarkdown: "# Plan", definitionId: null }),
     );
-    expect(result.kind).toBe("failed");
-    if (result.kind === "failed") expect(result.reason).toBe("approval requires a stored definition");
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") expect(result.error.detail).toBe("approval requires a stored definition");
   });
 
   it("stores the plan, mirrors a comment, notifies, parks the ticket, and ends while retaining ownership", async () => {

--- a/apps/worker/src/workflows/blocks/send-plan-approval.ts
+++ b/apps/worker/src/workflows/blocks/send-plan-approval.ts
@@ -3,7 +3,7 @@ import type { IssueTrackerMoveTarget } from "../../adapters/issue-tracker/types.
 import type { ActiveRunOwner } from "../../lib/active-run-owner.js";
 import type { TicketTransitionOwner } from "../../lib/ticket-transition.js";
 import { isRunControlError } from "../run-control-error.js";
-import type { BlockExecuteFn, BlockExecutionResult } from "./types.js";
+import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -138,15 +138,13 @@ export const execute: BlockExecuteFn = async (
       ? resolvedInputs.plan
       : ctx.researchPlanMarkdown;
   if (markdown.trim().length === 0) {
-    return { kind: "failed", output: { status: "failed" }, reason: "no plan available" };
+    return executionError("no plan available", { category: "binding" });
   }
 
   if (ctx.definitionId === null) {
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: "approval requires a stored definition",
-    };
+    return executionError("approval requires a stored definition", {
+      category: "binding",
+    });
   }
 
   const rawAssumptions = resolvedInputs?.assumptions;
@@ -174,11 +172,9 @@ export const execute: BlockExecuteFn = async (
     });
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    return {
-      kind: "failed",
-      output: { status: "failed" },
-      reason: err instanceof Error ? err.message : String(err),
-    };
+    return executionError(err instanceof Error ? err.message : String(err), {
+      category: "provider",
+    });
   }
 
   if (block.params.mirrorComment !== false) {

--- a/apps/worker/src/workflows/blocks/types.ts
+++ b/apps/worker/src/workflows/blocks/types.ts
@@ -116,6 +116,7 @@ export type {
   BlockExecutionResult,
   StepsRecord,
 } from "../../workflow-definition/interpreter.js";
+export { executionError } from "../../workflow-definition/interpreter.js";
 
 /** Executor signature every block module in this directory exports. */
 export type BlockExecuteFn = (

--- a/apps/worker/src/workflows/planning-agent-provisioning.test.ts
+++ b/apps/worker/src/workflows/planning-agent-provisioning.test.ts
@@ -44,7 +44,7 @@ describe("planning agent scratch provisioning", () => {
           "claude",
           "claude-model",
         );
-        if (provisioned.kind === "failed") return provisioned;
+        if (provisioned.kind === "execution_error") return provisioned;
       }
       return { kind: "next", output: { status: "ok" } };
     };
@@ -80,8 +80,13 @@ describe("planning agent scratch provisioning", () => {
 
     expect(result.outcome).toBe("completed");
     expect(calls).toEqual(["plan", "recover"]);
-    expect(result.steps.plan.output).toEqual({ status: "failed" });
-    expect(failures).toEqual([]);
+    expect(result.steps.plan).toBeUndefined();
+    expect(result.executionError?.diagnosticId).toBe(
+      "AIW-DIAG-test-run-plan-1",
+    );
+    expect(failures).toEqual([
+      "The workspace environment could not complete this block. Diagnostic ID: AIW-DIAG-test-run-plan-1",
+    ]);
   });
 
   it.each(runControlErrorCases())(

--- a/apps/worker/src/workflows/run-telemetry-integration.test.ts
+++ b/apps/worker/src/workflows/run-telemetry-integration.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { eq } from "drizzle-orm";
 import {
   buildRuntimeGraph,
+  executionError,
   executeGraph,
   type BlockExecutionResult,
   type BlockExecutor,
   type ExecuteGraphHooks,
+  type WorkflowExecutionErrorState,
 } from "../workflow-definition/interpreter.js";
 import { recordBlockStatuses, recordRunUsage } from "../lib/telemetry/run-telemetry.js";
 import { entryOwnsClarificationThread } from "./agent.js";
@@ -98,6 +100,7 @@ interface RunFixture {
 interface RunResult {
   outcome: "completed" | "stopped" | "ended";
   runOutcome: "success" | "failed" | "awaiting";
+  executionError?: WorkflowExecutionErrorState;
   /** block_statuses read back from the DB after every persisted write. */
   persistedSnapshots: Array<Record<string, BlockRunState>>;
 }
@@ -226,8 +229,10 @@ async function runWorkflowAgainstDb(db: Db, fx: RunFixture): Promise<RunResult> 
   const triggerOutput: BlockOutput = { status: "fired", ticketKey: TICKET.identifier };
 
   let outcome: "completed" | "stopped" | "ended" = "stopped";
+  let terminalExecutionError: WorkflowExecutionErrorState | undefined;
   try {
     const walk = await executeGraph({
+      runId: fx.runId,
       graph,
       entryTriggerId: entryTrigger.id,
       triggerOutput,
@@ -237,10 +242,12 @@ async function runWorkflowAgainstDb(db: Db, fx: RunFixture): Promise<RunResult> 
       outputValidator: () => [],
     });
     outcome = walk.outcome;
+    terminalExecutionError = walk.executionError;
     // Mirror agent.ts: never promote a clarification park (awaiting) to success.
     // `as string` because TS narrows runOutcome to its "failed" initializer (it
     // can't see the hook closures writing it).
     if (
+      !terminalExecutionError &&
       (walk.outcome === "completed" || walk.outcome === "ended") &&
       (runOutcome as string) !== "awaiting"
     ) {
@@ -286,7 +293,14 @@ async function runWorkflowAgainstDb(db: Db, fx: RunFixture): Promise<RunResult> 
     } as Parameters<typeof recordRunUsage>[1]);
   }
 
-  return { outcome, runOutcome, persistedSnapshots };
+  return {
+    outcome,
+    runOutcome,
+    persistedSnapshots,
+    ...(terminalExecutionError
+      ? { executionError: terminalExecutionError }
+      : {}),
+  };
 }
 
 let db: Db;
@@ -522,12 +536,10 @@ describe("run telemetry integration (executeGraph -> pglite)", () => {
           usage: { phase: "Research", usage: claudeUsage(0.5), model: "claude-opus" },
         },
         impl: {
-          result: {
-            kind: "failed",
-            output: { status: "failed" },
-            reason: "impl blew up",
+          result: executionError("impl blew up", {
+            category: "provider",
             phase: "impl",
-          },
+          }),
           usage: { phase: "Impl", usage: claudeUsage(1.0), model: "claude-sonnet" },
           activeModel: "claude-sonnet",
         },
@@ -542,7 +554,13 @@ describe("run telemetry integration (executeGraph -> pglite)", () => {
     expect(persisted.prep.status).toBe("ok");
     expect(persisted.plan.status).toBe("ok");
     expect(persisted.impl.status).toBe("fail");
-    expect(persisted.impl.error).toBe("impl blew up");
+    expect(persisted.impl.error).toBe(
+      "An external service could not complete this block.",
+    );
+    expect(persisted.impl.diagnosticId).toBe(
+      "AIW-DIAG-wrun_fail-impl-1",
+    );
+    expect(persisted.impl.output).toBeUndefined();
     expect(persisted.pr).toEqual({ status: "pending" });
 
     // Run is failed, yet cost/usage from the phases that ran is still recorded.
@@ -555,7 +573,7 @@ describe("run telemetry integration (executeGraph -> pglite)", () => {
     expect(r.completedAt).not.toBeNull();
   });
 
-  it("failed block routed through a wired failure edge: fail persisted but run completes as success", async () => {
+  it("keeps an execution error sticky after a wired cleanup edge completes", async () => {
     const nodes = [
       node("trig", "trigger_ticket_ai"),
       node("prep", "prepare_workspace"),
@@ -576,29 +594,30 @@ describe("run telemetry integration (executeGraph -> pglite)", () => {
       scripts: {
         prep: { result: { kind: "next", output: { status: "ok" } }, activeModel: "claude-default" },
         checks: {
-          result: {
-            kind: "failed",
-            output: { status: "failed" },
-            reason: "lint broke",
+          result: executionError("lint broke", {
+            category: "checks",
             phase: "checks",
-          },
+          }),
         },
         recover: { result: { kind: "next", output: { status: "ok" } } },
       },
     });
 
     expect(result.outcome).toBe("completed");
-    expect(result.runOutcome).toBe("success");
+    expect(result.runOutcome).toBe("failed");
+    expect(result.executionError?.diagnosticId).toBe(
+      "AIW-DIAG-wrun_recover-checks-1",
+    );
 
     const r = await runRow("wrun_recover");
     const persisted = r.blockStatuses as Record<string, BlockRunState>;
     expect(persisted.prep.status).toBe("ok");
     expect(persisted.checks.status).toBe("fail");
-    expect(persisted.checks.error).toBe("lint broke");
+    expect(persisted.checks.error).toBe("The checks could not be started.");
+    expect(persisted.checks.output).toBeUndefined();
     expect(persisted.recover.status).toBe("ok");
 
-    // A recovered failure edge leaves the run itself successful.
-    expect(r.status).toBe("success");
+    expect(r.status).toBe("failed");
   });
 
   it("persists a budget failure and never executes the downstream side effect", async () => {

--- a/apps/worker/src/workflows/workflow-failure-exit.test.ts
+++ b/apps/worker/src/workflows/workflow-failure-exit.test.ts
@@ -28,6 +28,24 @@ describe("handleWorkflowFailureExit", () => {
 
     expect(order).toEqual(["log", "move", "notify"]);
   });
+
+  it("attempts each ordinary failure side effect once without replacing the primary error", async () => {
+    const logFailure = vi.fn().mockRejectedValue(new Error("log unavailable"));
+    const moveTicket = vi.fn().mockRejectedValue(new Error("Jira unavailable"));
+    const notifyTicket = vi.fn().mockRejectedValue(new Error("Slack unavailable"));
+
+    await expect(
+      handleWorkflowFailureExit("PROJ-1", {
+        logFailure,
+        moveTicket,
+        notifyTicket,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(logFailure).toHaveBeenCalledOnce();
+    expect(moveTicket).toHaveBeenCalledOnce();
+    expect(notifyTicket).toHaveBeenCalledOnce();
+  });
 });
 
 describe("handleUnhandledWorkflowError", () => {

--- a/apps/worker/src/workflows/workflow-failure-exit.ts
+++ b/apps/worker/src/workflows/workflow-failure-exit.ts
@@ -19,10 +19,19 @@ export async function handleWorkflowFailureExit(
   ticketKey: string | undefined,
   deps: WorkflowFailureExitDeps,
 ): Promise<void> {
-  await deps.logFailure();
+  const runOnce = async (label: string, task: () => Promise<void>) => {
+    try {
+      await task();
+    } catch (error) {
+      if (isRunControlError(error)) throw error;
+      console.error(`Workflow failure ${label} failed:`, error);
+    }
+  };
+
+  await runOnce("logging", deps.logFailure);
   if (!ticketKey) return;
-  await deps.moveTicket();
-  await deps.notifyTicket();
+  await runOnce("ticket parking", deps.moveTicket);
+  await runOnce("notification", deps.notifyTicket);
 }
 
 /**

--- a/apps/worker/workflow-sdk-tests/run-control-workflow-sdk.test.ts
+++ b/apps/worker/workflow-sdk-tests/run-control-workflow-sdk.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { start } from "workflow/api";
+import { WorkflowRunFailedError } from "workflow/errors";
+import { parseStepName } from "workflow/observability";
+import { getWorld } from "workflow/runtime";
 import { ACTIVE_RUN_OWNER_ERROR_SENTINEL } from "../src/lib/run-control-errors.js";
-import { probeRunControlStepBoundary } from "../workflow-test-fixtures/run-control/workflow.js";
+import {
+  probeRunControlStepBoundary,
+  probeStickyExecutionFailure,
+} from "../workflow-test-fixtures/run-control/workflow.js";
 
 describe("installed Workflow step failure boundary", () => {
   it.each(["owner_no_retries", "owner_default_retries"] as const)(
@@ -48,5 +54,37 @@ describe("installed Workflow step failure boundary", () => {
     expect(result.message).toContain(
       "failed after 3 retries: ordinary failure attempt=4",
     );
+  });
+
+  it("completes cleanup before reporting a safe failed workflow trace", async () => {
+    const run = await start(probeStickyExecutionFailure, []);
+
+    let failure: unknown;
+    try {
+      await run.returnValue;
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(WorkflowRunFailedError.is(failure)).toBe(true);
+    if (!WorkflowRunFailedError.is(failure)) throw failure;
+    expect(failure.cause.message).toBe(
+      "An external service could not complete this block. Diagnostic ID: AIW-DIAG-sdk-run-provider-1",
+    );
+    // The Workflow SDK owns this classification code. The application-level
+    // diagnostic code remains in the safe message and is recovered by the run
+    // detail collector rather than exposing this SDK stack to the dashboard.
+    expect(failure.cause.code).toBe("USER_ERROR");
+    expect(JSON.stringify(failure.cause)).not.toContain("provider secret detail");
+    expect(await run.status).toBe("failed");
+
+    const steps = await getWorld().steps.list({
+      runId: run.runId,
+      resolveData: "none",
+    });
+    const cleanup = steps.data.find(
+      (step) => parseStepName(step.stepName)?.shortName === "deterministicCleanupStep",
+    );
+    expect(cleanup?.status).toBe("completed");
   });
 });

--- a/apps/worker/workflow-test-fixtures/run-control/workflow.ts
+++ b/apps/worker/workflow-test-fixtures/run-control/workflow.ts
@@ -1,6 +1,7 @@
 import { getStepMetadata } from "workflow";
 import { ActiveRunOwnerError } from "../../src/lib/run-control-errors.js";
 import { isRunControlError } from "../../src/workflows/run-control-error.js";
+import { WorkflowExecutionError } from "../../src/workflow-definition/interpreter.js";
 import {
   RunBudgetError,
   runBudgetFailureFromError,
@@ -40,6 +41,16 @@ async function failOrdinaryWithDefaultRetries(): Promise<never> {
   throw new Error(`ordinary failure attempt=${getStepMetadata().attempt}`);
 }
 
+async function failProviderWithoutRetries(): Promise<never> {
+  "use step";
+  throw new Error("provider secret detail");
+}
+failProviderWithoutRetries.maxRetries = 0;
+
+async function deterministicCleanupStep(): Promise<void> {
+  "use step";
+}
+
 export async function probeRunControlStepBoundary(kind: ProbeKind) {
   "use workflow";
   try {
@@ -63,5 +74,21 @@ export async function probeRunControlStepBoundary(kind: ProbeKind) {
       hasFailureProperty:
         typeof error === "object" && error !== null && "failure" in error,
     };
+  }
+}
+
+export async function probeStickyExecutionFailure() {
+  "use workflow";
+  try {
+    await failProviderWithoutRetries();
+  } catch {
+    await deterministicCleanupStep();
+    throw new WorkflowExecutionError({
+      category: "provider",
+      message: "An external service could not complete this block.",
+      diagnosticId: "AIW-DIAG-sdk-run-provider-1",
+      nodeId: "provider",
+      attempt: 1,
+    });
   }
 }

--- a/docs/testing/block-reference.md
+++ b/docs/testing/block-reference.md
@@ -13,6 +13,7 @@ Current reference for the 28 server-owned workflow block contracts in nine group
 - Moving nodes changes layout only. It does not change the semantic draft or deployed version.
 - Specialized Implementation, Review, and Fix agents prepare or resume their workspace automatically. Planning is workspace-free. Explicit Prepare is available for modular/custom graphs; Generic Agent requires it only when `workspaceMode` reads or mutates repositories.
 - Any agent may return `needs_human_input`. The runtime creates a pinned checkpoint/snapshot continuation and reruns only the waiting agent after an answer; authors do not need to recreate that behavior with a Human Question block.
+- Execution errors are not block outputs. The errored block is excluded from `steps`, receives a safe message plus diagnostic ID, and may route through its existing `failed` port for deterministic cleanup. Cleanup cannot turn the run back into success.
 - Finalize is the sole push boundary. Open PR/MR consumes Finalize's durable `publicationAttemptId`; it never pushes workspace changes. The active-run claim remains held through every downstream block.
 
 ## Catalog summary
@@ -25,26 +26,26 @@ Current reference for the 28 server-owned workflow block contracts in nine group
 | `trigger_pr_checks_failed` | Trigger | `providers`, `scope`, exact `checkNames`, GitHub App slugs, GitLab pipeline sources | `fired` | Starts from an allowlisted external CI failure on the current head. |
 | `trigger_pr_review` | Trigger | `providers`, `scope`, non-empty `on[]` | `fired` | Starts from selected GitHub review states or external GitLab comments. |
 | `trigger_pr_merged` | Trigger | `providers`, `scope` | `fired` | Starts after an allowed PR/MR merge and carries merge metadata. |
-| `planning_agent` | Agents | optional provider/model | `ready`, `needs_human_input`, `failed` | Produces a plan or clarification questions without requiring a workspace. |
-| `implementation_agent` | Agents | optional provider/model | `implemented`, `needs_human_input`, `failed` | Implements in an implicitly prepared/resumed managed workspace. |
-| `review_agent` | Agents | optional provider/model | `reviewed`, `failed` | Reviews the current workspace diff before publication. |
-| `fix_agent` | Agents | optional provider/model/instructions/max minutes | `fixed`, `needs_human_input`, `failed` | Applies CI, review, or merge-conflict remediation. `fixed` is its built-in publication classification. |
-| `generic_agent` | Agents | prompt, optional declared object schema and `workspaceMode` | `completed`, `needs_human_input`, `failed` | Configurable escape hatch; custom classification is a declared field plus Branch. |
-| `prepare_workspace` | Workspace | none | `ok`, `needs_human_input`, `failed` | Explicitly selects repositories and creates/reuses a workspace for modular graphs. |
-| `finalize_workspace` | Workspace | optional `checks.<id>` bindings | `finalized`, `failed` | Preflights all repositories, pushes committed changes, and records the durable publication attempt. It does not open PRs. |
-| `branch` | Control | restricted `condition` | `ok`, `failed` | Chooses `true` or `false` using parsed expressions over prior outputs. |
+| `planning_agent` | Agents | optional provider/model | `ready`, `needs_human_input` | Produces a plan or clarification questions without requiring a workspace. |
+| `implementation_agent` | Agents | optional provider/model | `implemented`, `needs_human_input` | Implements in an implicitly prepared/resumed managed workspace. |
+| `review_agent` | Agents | optional provider/model | `reviewed` | Reviews the current workspace diff before publication. |
+| `fix_agent` | Agents | optional provider/model/instructions/max minutes | `fixed`, `needs_human_input` | Applies CI, review, or merge-conflict remediation. `fixed` is its built-in publication classification. |
+| `generic_agent` | Agents | prompt, optional declared object schema and `workspaceMode` | `completed`, `needs_human_input` | Configurable escape hatch; custom classification is a declared field plus Branch. |
+| `prepare_workspace` | Workspace | none | `ok`, `needs_human_input` | Explicitly selects repositories and creates/reuses a workspace for modular graphs. |
+| `finalize_workspace` | Workspace | optional `checks.<id>` bindings | `finalized` | Preflights all repositories, pushes committed changes, and records the durable publication attempt. It does not open PRs. |
+| `branch` | Control | restricted `condition` | `ok` | Chooses `true` or `false` using parsed expressions over prior outputs. |
 | `loop` | Control | `maxAttempts`, `onExhaust` | `ok`, `exhausted` | Bounds the single permitted re-entry point for a cycle. |
 | `terminate` | Control | terminal status | `waiting_for_human`, `failed`, `skipped`, `done` | Stops the path with an explicit terminal outcome. |
-| `post_ticket_comment` | Ticket | body input/param | `ok`, `failed` | Posts questions, plans, or status to the real ticket. |
+| `post_ticket_comment` | Ticket | body input/param | `ok` | Posts questions, plans, or status to the real ticket. |
 | `update_ticket_status` | Ticket | target input/param | `ok` | Moves the real ticket to a configured/discovered provider status. |
-| `fetch_pr_context` | VCS | none | `ok`, `failed` | Loads PR/MR comments, checks, conflicts, and normalized remediation context. |
-| `open_pr` | VCS | required `publicationAttemptId` binding | `ok`, `failed` | Creates/reuses PRs/MRs from a successful Finalize output; no pushing. |
-| `post_pr_comment` | VCS | body input/param | `ok`, `failed` | Posts a summary or response to the selected PRs/MRs. |
-| `send_plan_approval` | Human | required plan; optional assumptions | `awaiting_approval`, `failed` | Creates a durable approval item and ends that path. |
-| `human_question` | Human | questions; optional suggested answers | `needs_human_input`, `answered`, `failed` | Explicit authoring primitive for a scoped question; agent clarification does not require it. |
-| `run_pre_pr_checks` | Utility | `maxFixCycles` | `ok`, `failed` | Existing bounded pre-PR validation/fix gate before publication. |
-| `run_checks` | Utility | optional commands | `ok`, `failed` | Runs configured/explicit commands and exposes branchable aggregate/results/failures. |
-| `call_llm` | Utility | prompt; optional system/provider/model/output schema | `ok`, `failed` | Focused non-agent LLM transform with an optional declared output contract. |
+| `fetch_pr_context` | VCS | none | `ok` | Loads PR/MR comments, checks, conflicts, and normalized remediation context. |
+| `open_pr` | VCS | required `publicationAttemptId` binding | `ok` | Creates/reuses PRs/MRs from a successful Finalize output; no pushing. |
+| `post_pr_comment` | VCS | body input/param | `ok` | Posts a summary or response to the selected PRs/MRs. |
+| `send_plan_approval` | Human | required plan; optional assumptions | `awaiting_approval` | Creates a durable approval item and ends that path. |
+| `human_question` | Human | questions; optional suggested answers | `needs_human_input`, `answered` | Explicit authoring primitive for a scoped question; agent clarification does not require it. |
+| `run_pre_pr_checks` | Utility | `maxFixCycles` | `ok` | Existing bounded pre-PR validation/fix gate before publication. Command failures are exposed as `ok: false`. |
+| `run_checks` | Utility | optional commands | `ok` | Runs configured/explicit commands and exposes branchable aggregate/results/failures. Command failures are exposed as `ok: false`. |
+| `call_llm` | Utility | prompt; optional system/provider/model/output schema | `ok` | Focused non-agent LLM transform with an optional declared output contract. |
 | `send_slack_message` | Utility | message input/param | `ok`, `skipped` | Sends a milestone to the configured channel or skips when there is nothing applicable to send. |
 | `arthur_injection_check` | Arthur | optional content input | `ok`, `flagged`, `skipped` | Optional prompt-injection scan; unavailable when Arthur is not configured. |
 
@@ -106,7 +107,7 @@ PR checks failed ─┐
 PR review ────────┘
 ```
 
-There is no explicit Prepare or readiness Branch. `fixed` follows Fix's normal output; `needs_human_input` creates a pinned continuation; `failed` follows failure policy.
+There is no explicit Prepare or readiness Branch. `fixed` follows Fix's normal output; `needs_human_input` creates a pinned continuation. Execution errors can follow an authored `failed` cleanup edge, but they never produce a bindable block output and the run remains failed.
 
 ### Pinned clarification
 

--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -890,7 +890,7 @@
           ],
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("string", "plan")],
           optionalOutputs: typedPaths("string[]", "questions", "suggestedAnswers"),
-          statuses: ["ready", "needs_human_input", "failed"],
+          statuses: ["ready", "needs_human_input"],
         }),
         implementation_agent: runtimeContract(["provider", "model", "prompt"], {
           optionalInputs: [...typedPaths("object", "ticket"), ...typedPaths("string", "plan")],
@@ -903,7 +903,7 @@
             ...typedPaths("unknown", "verification"),
             ...typedPaths("string[]", "questions", "suggestedAnswers"),
           ],
-          statuses: ["implemented", "needs_human_input", "failed"],
+          statuses: ["implemented", "needs_human_input"],
         }),
         review_agent: runtimeContract(["provider", "model", "prompt"], {
           requiredOutputs: [
@@ -912,7 +912,7 @@
             ...typedPaths("string", "decision"),
           ],
           optionalOutputs: typedPaths("string", "feedback"),
-          statuses: ["reviewed", "failed"],
+          statuses: ["reviewed"],
         }),
         fix_agent: runtimeContract(["provider", "model", "instructions", "maxMinutes"], {
           requiredOutputs: [
@@ -921,7 +921,7 @@
             ...typedPaths("object[]", "commits", "resolvedConflicts", "unresolvedConflicts"),
           ],
           optionalOutputs: typedPaths("string[]", "questions", "suggestedAnswers"),
-          statuses: ["fixed", "needs_human_input", "failed"],
+          statuses: ["fixed", "needs_human_input"],
         }),
         generic_agent: runtimeContract(
           ["provider", "model", "prompt", "outputSchema", "workspaceMode"],
@@ -929,7 +929,7 @@
             optionalInputs: typedPaths("string", "prompt"),
             requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("string", "body")],
             optionalOutputs: typedPaths("string[]", "questions", "suggestedAnswers"),
-            statuses: ["completed", "needs_human_input", "failed"],
+            statuses: ["completed", "needs_human_input"],
           },
           [
             runtimeProbe(
@@ -949,7 +949,7 @@
                   ...typedPaths("object", "data"),
                 ],
                 optionalOutputs: typedPaths("number", "confidence", "data.confidence"),
-                statuses: ["completed", "needs_human_input", "failed"],
+                statuses: ["completed", "needs_human_input"],
               },
             ),
           ],
@@ -964,7 +964,7 @@
           optionalOutputs: [
             ...typedPaths("string[]", "workspace.repositories", "questions"),
           ],
-          statuses: ["ok", "needs_human_input", "failed"],
+          statuses: ["ok", "needs_human_input"],
         }),
         finalize_workspace: runtimeContract([], {
           additionalInputs: [{
@@ -976,8 +976,7 @@
             ...STATUS_OUTPUT,
             ...typedPaths("object[]", "repositories"),
           ],
-          optionalOutputs: typedPaths("string[]", "unmetChecks"),
-          statuses: ["finalized", "failed"],
+          statuses: ["finalized"],
         }),
         run_pre_pr_checks: runtimeContract(["maxFixCycles"], {
           requiredOutputs: [
@@ -986,7 +985,7 @@
             ...typedPaths("number", "fixCycles"),
             ...typedPaths("string", "summary"),
           ],
-          statuses: ["ok", "failed"],
+          statuses: ["ok"],
         }),
         run_checks: runtimeContract(["commands"], {
           requiredOutputs: [
@@ -994,14 +993,14 @@
             ...typedPaths("boolean", "ok"),
             ...typedPaths("unknown[]", "results", "failures"),
           ],
-          statuses: ["ok", "failed"],
+          statuses: ["ok"],
         }),
         call_llm: runtimeContract(
           ["prompt", "system", "model", "provider", "outputSchema"],
           {
             optionalInputs: typedPaths("string", "prompt", "system"),
             requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("string", "output")],
-            statuses: ["ok", "failed"],
+            statuses: ["ok"],
           },
           [
             runtimeProbe(
@@ -1018,14 +1017,14 @@
                   ...typedPaths("string", "output.summary"),
                 ],
                 optionalOutputs: typedPaths("number", "output.score"),
-                statuses: ["ok", "failed"],
+                statuses: ["ok"],
               },
             ),
           ],
         ),
         fetch_pr_context: runtimeContract([], {
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("unknown[]", "contexts")],
-          statuses: ["ok", "failed"],
+          statuses: ["ok"],
         }),
         open_pr: runtimeContract([], {
           requiredInputs: typedPaths("object[]", "repositories"),
@@ -1034,12 +1033,12 @@
             ...typedPaths("string", "prUrl"),
             ...typedPaths("number", "prNumber"),
           ],
-          statuses: ["ok", "failed"],
+          statuses: ["ok"],
         }),
         update_ticket_status: runtimeContract(["target"], {
           optionalInputs: typedPaths("string", "target"),
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("string", "target")],
-          statuses: ["ok", "failed"],
+          statuses: ["ok"],
         }),
         post_ticket_comment: runtimeContract(["body"], {
           optionalInputs: typedPaths("string", "body"),
@@ -1047,17 +1046,17 @@
             ...STATUS_OUTPUT,
             ...typedPaths("string | null", "commentUrl"),
           ],
-          statuses: ["ok", "failed"],
+          statuses: ["ok"],
         }),
         post_pr_comment: runtimeContract(["body", "target"], {
           optionalInputs: typedPaths("string", "body"),
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("unknown[]", "comments")],
-          statuses: ["ok", "failed"],
+          statuses: ["ok"],
         }),
         send_slack_message: runtimeContract(["message"], {
           optionalInputs: typedPaths("string", "message"),
           requiredOutputs: STATUS_OUTPUT,
-          statuses: ["ok", "skipped", "failed"],
+          statuses: ["ok", "skipped"],
         }),
         send_plan_approval: runtimeContract(["mirrorComment"], {
           requiredInputs: typedPaths("string", "plan"),
@@ -1066,7 +1065,7 @@
             ...STATUS_OUTPUT,
             ...typedPaths("string", "approvalRequestId"),
           ],
-          statuses: ["awaiting_approval", "failed"],
+          statuses: ["awaiting_approval"],
         }),
         human_question: runtimeContract(["questions", "suggestedAnswers"], {
           optionalInputs: typedPaths("string[]", "questions", "suggestedAnswers"),
@@ -1075,7 +1074,7 @@
             ...typedPaths("string[]", "questions", "suggestedAnswers"),
             ...typedPaths("string", "answer"),
           ],
-          statuses: ["needs_human_input", "answered", "failed"],
+          statuses: ["needs_human_input", "answered"],
         }),
         arthur_injection_check: runtimeContract([], {
           optionalInputs: typedPaths("string", "content"),
@@ -1084,12 +1083,12 @@
             ...typedPaths("unknown[]", "findings"),
             ...typedPaths("string", "reason"),
           ],
-          statuses: ["ok", "flagged", "skipped", "failed"],
+          statuses: ["ok", "flagged", "skipped"],
         }),
         branch: runtimeContract(["condition"], {
           requiredOutputs: STATUS_OUTPUT,
-          optionalOutputs: typedPaths("string", "path", "reason", "error"),
-          statuses: ["ok", "failed"],
+          optionalOutputs: typedPaths("string", "path", "reason"),
+          statuses: ["ok"],
         }),
         loop: runtimeContract(["maxAttempts", "onExhaust"], {
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("number", "attempt")],
@@ -1182,7 +1181,7 @@
           group: "agent",
           title: "Fix Agent",
           blurb: "Repair pass scoped to structured failures, review feedback, or current merge conflicts.",
-          note: "Reuses an upstream prepared workspace when present; otherwise prepares or resumes the target workspace automatically. Accepted PR head, failures, ticket, and workspace context are carried by the run rather than authored as bindings. status: fixed is the specialized agent's built-in readiness classification and continues to Finalize workspace; it is not a CI verdict or permission to bypass publication guards. needs_human_input creates the runtime clarification checkpoint; failed follows default failure policy. Use Generic Agent + Branch for a custom classification. Merge conflicts are auto-resolved only when the agent can produce a clean committed tree. Before publication, the runtime re-reads the accepted PR head and refuses to overwrite a different SHA; provider CI remains authoritative for correctness."
+          note: "Reuses an upstream prepared workspace when present; otherwise prepares or resumes the target workspace automatically. Accepted PR head, failures, ticket, and workspace context are carried by the run rather than authored as bindings. status: fixed is the specialized agent's built-in readiness classification and continues to Finalize workspace; it is not a CI verdict or permission to bypass publication guards. needs_human_input creates the runtime clarification checkpoint; execution errors follow the failed cleanup port when authored and keep the run failed. Use Generic Agent + Branch for a custom classification. Merge conflicts are auto-resolved only when the agent can produce a clean committed tree. Before publication, the runtime re-reads the accepted PR head and refuses to overwrite a different SHA; provider CI remains authoritative for correctness."
         },
         "agent.generic": {
           runtimeType: "generic_agent",
@@ -1190,7 +1189,7 @@
           group: "agent",
           title: "Generic Agent",
           blurb: "Prompted agent with a declared output schema. Must attach a workspace to touch code.",
-          note: "The escape hatch: everything the specialized agents do can be rebuilt from Generic Agent + workspace + control blocks. Non-code uses such as planning need no workspace; repository-reading or mutating configurations require an upstream Prepare workspace binding. For custom routing, use a declared classification field in the output schema and evaluate it with Branch; the runtime status remains reserved for completed, needs_human_input, and failed."
+          note: "The escape hatch: everything the specialized agents do can be rebuilt from Generic Agent + workspace + control blocks. Non-code uses such as planning need no workspace; repository-reading or mutating configurations require an upstream Prepare workspace binding. For custom routing, use a declared classification field in the output schema and evaluate it with Branch; execution errors have no output and use the failed cleanup port rather than a status field."
         },
 
         "ws.prepare": {
@@ -1458,7 +1457,7 @@
             },
             {
               head: "Failure has a default path",
-              body: "Any block can end <code>status: \"failed\"</code>. Unless an explicit failure edge overrides it, the runtime applies the default policy: terminate the run, move the ticket to the configured column, notify the channel. Run-control stops — cancellation, budget exhaustion, or loss of the exact active owner — are not block failures and cannot be routed around by a failure edge. Graphs draw the happy path — no <code>if err != nil</code> ladders."
+              body: "Any block can encounter an execution error. The errored block has no bindable output and the run stays failed even when an explicit <code>failed</code> edge runs deterministic cleanup. Without that edge, the runtime terminates the graph path. After cleanup it moves the ticket to the configured column and notifies the channel once. Run-control stops — cancellation, budget exhaustion, or loss of the exact active owner — are not block execution errors and cannot be routed around by a failure edge. Graphs draw the happy path — no <code>if err != nil</code> ladders."
             },
             {
               head: "Runs serialize per subject",
@@ -1626,7 +1625,7 @@
             },
             { x: 1130, y: 760, w: 650,
               head: "Publish safety is not validation",
-              body: "The specialized Fix Agent initializes its workspace when necessary and classifies its result. <code>fixed</code> continues directly to Finalize workspace; <code>needs_human_input</code> suspends the same Workflow run on a durable hook and <code>failed</code> follows default failure policy. Authors who need custom classification declare it through Generic Agent and route it with control blocks. Finalization only protects the write: current source SHA, clean committed tree, and a branch allowed by the selected PR-ownership policy. It does not decide whether the PR passes. Finalize preflights every repository, pushes with exact leases, and emits finalized branch metadata directly to Open PR/MR. Workflow owns retries; an exact target already present is a safe replay, while remote drift is terminal. Open PR/MR revalidates the exact branch, source PR, and created or recovered PR before recording ownership. The Fix Agent may safely resolve a merge conflict; unresolved conflicts suspend on the same human-input hook. A multi-repository preflight failure creates no partial push and cannot be reported as success. Terminal cleanup destroys the live sandbox; clarification snapshots are restored by the same run and removed after use or expiry."
+              body: "The specialized Fix Agent initializes its workspace when necessary and classifies its result. <code>fixed</code> continues directly to Finalize workspace; <code>needs_human_input</code> suspends the same Workflow run on a durable hook. Execution errors have no output, may follow the <code>failed</code> cleanup port, and keep the run failed. Authors who need custom classification declare it through Generic Agent and route it with control blocks. Finalization only protects the write: current source SHA, clean committed tree, and a branch allowed by the selected PR-ownership policy. It does not decide whether the PR passes. Finalize preflights every repository, pushes with exact leases, and emits finalized branch metadata directly to Open PR/MR. Workflow owns retries; an exact target already present is a safe replay, while remote drift is terminal. Open PR/MR revalidates the exact branch, source PR, and created or recovered PR before recording ownership. The Fix Agent may safely resolve a merge conflict; unresolved conflicts suspend on the same human-input hook. A multi-repository preflight failure creates no partial push and cannot be reported as success. Terminal cleanup destroys the live sandbox; clarification snapshots are restored by the same run and removed after use or expiry."
             }
           ]
         },


### PR DESCRIPTION
## What changed

- replaces block `failed` results with categorized execution errors that never carry bindable output
- preserves domain-negative review/check outputs, including `request_changes` and `ok: false`
- latches the first execution error across authored cleanup paths and emits deterministic `AIW-DIAG-<run>-<node>-<attempt>` IDs
- completes ticket failure handling, sandbox teardown, and durable telemetry before the outer Workflow trace fails
- removes `failed` from normal block status contracts while retaining explicit `terminate failed`
- exposes only safe diagnostic messages/codes in run detail and block tooltips, scrubbing provider stacks from live and persisted traces
- keeps run-control, awaiting-human, cancellation, budget, loop, terminate, and success behavior distinct

## Why

Negative workflow outcomes were represented with the same `failed` envelope as infrastructure/provider/runtime errors. That made nonexistent error outputs bindable, allowed cleanup success to promote a run, and could leave Workflow's own trace completed even though durable telemetry reported failure.

## Compatibility

This updates Workflow Definition v1 in place. There is no v2 adapter, migration flow, or database migration.

Base: `fc46b0b8efdc444bdfd80624d199385fc73fe17c`
Head: `774f154bafa26feefe4cabc325e43a7b1a74b248`

## Verification

- `corepack pnpm --filter @shared/contracts build`
- `corepack pnpm --filter @shared/conditions build`
- worker TypeScript: passed
- dashboard TypeScript: passed
- worker Vitest: 172 files, 2,060 tests passed
- dashboard tests: 303 tests passed
- `corepack pnpm --filter worker test:workflow-sdk`: 2 files, 7 tests passed
- `git diff --check`: passed

Jira: [AIW-105](https://blazity.atlassian.net/browse/AIW-105)

[AIW-105]: https://blazity.atlassian.net/browse/AIW-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured execution errors with diagnostic IDs and clearer error categories.
  * Workflow failures now provide safer, user-facing messages while preserving diagnostic context.
  * Cleanup paths can complete without masking the original failed run.

* **Bug Fixes**
  * Prevented sensitive stack traces and provider details from appearing in run and step results.
  * Improved failure handling so secondary cleanup errors do not replace the primary failure.

* **Documentation**
  * Updated workflow status and error-handling guidance to reflect the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->