### PR TITLE
fix(worker): surface PR review feedback to agents on AI-column runs

### DIFF
--- a/apps/shared/contracts/prompt-variables.ts
+++ b/apps/shared/contracts/prompt-variables.ts
@@ -19,6 +19,7 @@ export const PROMPT_VARIABLES = [
   { name: "pr_url", description: "PR URL that triggered the run, or the PR opened by it; empty before either exists." },
   { name: "pr_title", description: "Title of the triggering PR; empty for non-PR runs." },
   { name: "repo_path", description: "Repository path (owner/repo) of the triggering PR, else the first selected repository." },
+  { name: "pr_review_feedback", description: "Human PR review feedback on the workflow-owned PR (review summaries, inline and conversation comments); empty when there is none." },
 ] as const satisfies readonly PromptVariableSpec[];
 
 export type PromptVariableName = (typeof PROMPT_VARIABLES)[number]["name"];

--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -15,6 +15,8 @@ const mockOctokit = {
     create: vi.fn(),
     list: vi.fn(),
     get: vi.fn(),
+    listReviewComments: vi.fn(),
+    listReviews: vi.fn(),
   },
   issues: {
     listComments: vi.fn(),
@@ -300,6 +302,55 @@ describe("GitHubAdapter", () => {
       expect(result).toEqual({
         url: "https://github.com/test-org/test-repo/pull/42#issuecomment-1",
       });
+    });
+  });
+
+  describe("getPRComments", () => {
+    it("includes inline comments, issue comments, and review summary bodies", async () => {
+      mockOctokit.pulls.listReviewComments.mockResolvedValueOnce({
+        data: [
+          {
+            user: { login: "reviewer" },
+            body: "rename this",
+            reactions: { total_count: 0 },
+            path: "src/a.ts",
+            line: 12,
+            start_line: null,
+          },
+        ],
+      });
+      mockOctokit.issues.listComments.mockResolvedValueOnce({
+        data: [{ user: { login: "reviewer" }, body: "general note", reactions: { total_count: 1 } }],
+      });
+      mockOctokit.pulls.listReviews.mockResolvedValueOnce({
+        data: [
+          { user: { login: "reviewer" }, state: "CHANGES_REQUESTED", body: "please fix the null check" },
+          // Approvals/dismissals with no summary text must not pollute the prompt.
+          { user: { login: "reviewer" }, state: "APPROVED", body: "" },
+        ],
+      });
+
+      const adapter = ghAdapter();
+      const comments = await adapter.getPRComments(42);
+
+      expect(mockOctokit.pulls.listReviews).toHaveBeenCalledWith({
+        owner: "test-org",
+        repo: "test-repo",
+        pull_number: 42,
+      });
+      expect(comments).toContainEqual(
+        expect.objectContaining({ filePath: "src/a.ts", body: "rename this", endLine: 12 }),
+      );
+      expect(comments).toContainEqual(
+        expect.objectContaining({ body: "general note", liked: true }),
+      );
+      expect(comments).toContainEqual({
+        author: "reviewer",
+        body: "[Review: changes requested] please fix the null check",
+        liked: false,
+      });
+      // The empty-body approval is filtered out.
+      expect(comments).toHaveLength(3);
     });
   });
 

--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -306,38 +306,43 @@ describe("GitHubAdapter", () => {
   });
 
   describe("getPRComments", () => {
-    it("includes inline comments, issue comments, and review summary bodies", async () => {
-      mockOctokit.pulls.listReviewComments.mockResolvedValueOnce({
-        data: [
-          {
-            user: { login: "reviewer" },
-            body: "rename this",
-            reactions: { total_count: 0 },
-            path: "src/a.ts",
-            line: 12,
-            start_line: null,
-          },
-        ],
-      });
-      mockOctokit.issues.listComments.mockResolvedValueOnce({
-        data: [{ user: { login: "reviewer" }, body: "general note", reactions: { total_count: 1 } }],
-      });
-      mockOctokit.pulls.listReviews.mockResolvedValueOnce({
-        data: [
-          { user: { login: "reviewer" }, state: "CHANGES_REQUESTED", body: "please fix the null check" },
-          // Approvals/dismissals with no summary text must not pollute the prompt.
-          { user: { login: "reviewer" }, state: "APPROVED", body: "" },
-        ],
+    it("paginates and includes inline comments, issue comments, and review summary bodies", async () => {
+      const reviewComments = [
+        {
+          user: { login: "reviewer" },
+          body: "rename this",
+          reactions: { total_count: 0 },
+          path: "src/a.ts",
+          line: 12,
+          start_line: null,
+        },
+      ];
+      const issueComments = [
+        { user: { login: "reviewer" }, body: "general note", reactions: { total_count: 1 } },
+      ];
+      const reviews = [
+        { user: { login: "reviewer" }, state: "CHANGES_REQUESTED", body: "please fix the null check" },
+        // Approvals/dismissals with no summary text must not pollute the prompt.
+        { user: { login: "reviewer" }, state: "APPROVED", body: "" },
+      ];
+      // paginate() follows every page; the adapter must read all three lists
+      // through it, not a single first page.
+      mockOctokit.paginate.mockImplementation(async (endpoint: unknown) => {
+        if (endpoint === mockOctokit.pulls.listReviewComments) return reviewComments;
+        if (endpoint === mockOctokit.issues.listComments) return issueComments;
+        if (endpoint === mockOctokit.pulls.listReviews) return reviews;
+        return [];
       });
 
       const adapter = ghAdapter();
       const comments = await adapter.getPRComments(42);
 
-      expect(mockOctokit.pulls.listReviews).toHaveBeenCalledWith({
-        owner: "test-org",
-        repo: "test-repo",
-        pull_number: 42,
-      });
+      // Regression: review summaries (and inline/issue comments) are paginated so
+      // feedback past the first page is never dropped.
+      expect(mockOctokit.paginate).toHaveBeenCalledWith(
+        mockOctokit.pulls.listReviews,
+        expect.objectContaining({ pull_number: 42, per_page: 100 }),
+      );
       expect(comments).toContainEqual(
         expect.objectContaining({ filePath: "src/a.ts", body: "rename this", endLine: 12 }),
       );

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -225,22 +225,25 @@ export class GitHubAdapter
   }
 
   async getPRComments(prId: number): Promise<PRComment[]> {
-    const { data: reviewComments } =
-      await this.octokit.pulls.listReviewComments({
-        ...this.ownerRepo,
-        pull_number: prId,
-      });
-    const { data: issueComments } = await this.octokit.issues.listComments({
+    // Paginate all three: a PR with many comments/reviews would otherwise drop
+    // feedback past the first page (default 30), silently starving the agent.
+    const reviewComments = await this.octokit.paginate(
+      this.octokit.pulls.listReviewComments,
+      { ...this.ownerRepo, pull_number: prId, per_page: 100 },
+    );
+    const issueComments = await this.octokit.paginate(this.octokit.issues.listComments, {
       ...this.ownerRepo,
       issue_number: prId,
+      per_page: 100,
     });
     // The review's own summary body ("Request Changes" / "Comment" text typed in
     // the main review box) lives on the review object, not on listReviewComments
     // (those are only the line-anchored inline notes). Without this, a review
     // carrying only a summary is invisible to the agent.
-    const { data: reviews } = await this.octokit.pulls.listReviews({
+    const reviews = await this.octokit.paginate(this.octokit.pulls.listReviews, {
       ...this.ownerRepo,
       pull_number: prId,
+      per_page: 100,
     });
 
     const comments: PRComment[] = [

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -234,6 +234,14 @@ export class GitHubAdapter
       ...this.ownerRepo,
       issue_number: prId,
     });
+    // The review's own summary body ("Request Changes" / "Comment" text typed in
+    // the main review box) lives on the review object, not on listReviewComments
+    // (those are only the line-anchored inline notes). Without this, a review
+    // carrying only a summary is invisible to the agent.
+    const { data: reviews } = await this.octokit.pulls.listReviews({
+      ...this.ownerRepo,
+      pull_number: prId,
+    });
 
     const comments: PRComment[] = [
       ...reviewComments.map((c) => ({
@@ -249,6 +257,13 @@ export class GitHubAdapter
         body: c.body ?? "",
         liked: (c.reactions?.total_count ?? 0) > 0,
       })),
+      ...reviews
+        .filter((r) => (r.body ?? "").trim().length > 0)
+        .map((r) => ({
+          author: r.user?.login ?? "unknown",
+          body: `[Review: ${formatReviewState(r.state)}] ${r.body}`,
+          liked: false,
+        })),
     ];
     return comments;
   }
@@ -452,6 +467,19 @@ export class GitHubAdapter
         },
       });
     }
+  }
+}
+
+function formatReviewState(state: string | null | undefined): string {
+  switch (state) {
+    case "CHANGES_REQUESTED":
+      return "changes requested";
+    case "APPROVED":
+      return "approved";
+    case "COMMENTED":
+      return "comment";
+    default:
+      return (state ?? "review").toLowerCase();
   }
 }
 

--- a/apps/worker/src/sandbox/context.test.ts
+++ b/apps/worker/src/sandbox/context.test.ts
@@ -225,6 +225,65 @@ describe("assembleImplementationContext (new)", () => {
     expect(result).toContain("You are an implementation agent...");
   });
 
+  it("surfaces PR review feedback when re-run against an existing PR", () => {
+    const result = assembleImplementationContext({
+      ticket: {
+        identifier: "TEST-9",
+        title: "Add login page",
+        description: "Build a login page",
+        acceptanceCriteria: "User can log in",
+        comments: [],
+      },
+      prompt: "You are an implementation agent...",
+      researchPlanMarkdown: "plan",
+      repositoryContexts: [
+        {
+          repository: {
+            provider: "github",
+            repoPath: "acme/api",
+            defaultBranch: "main",
+            selectedRationale: "workflow-owned branch for this ticket",
+          },
+          prComments: [
+            { author: "Bob", body: "[Review: changes requested] fix the null check", liked: false },
+          ],
+          checkResults: [],
+          hasConflicts: false,
+        },
+      ],
+    });
+
+    expect(result).toContain("## PR Review Feedback: github:acme/api");
+    expect(result).toContain("fix the null check");
+  });
+
+  it("omits PR review feedback when repositoryContexts are absent or empty", () => {
+    const base = {
+      ticket: { identifier: "X", title: "t", description: "d", acceptanceCriteria: "a", comments: [] },
+      prompt: "p",
+      researchPlanMarkdown: "plan",
+    };
+    expect(assembleImplementationContext(base)).not.toContain("## PR Review Feedback");
+    expect(
+      assembleImplementationContext({
+        ...base,
+        repositoryContexts: [
+          {
+            repository: {
+              provider: "github",
+              repoPath: "acme/api",
+              defaultBranch: "main",
+              selectedRationale: "workflow-owned branch for this ticket",
+            },
+            prComments: [],
+            checkResults: [],
+            hasConflicts: false,
+          },
+        ],
+      }),
+    ).not.toContain("## PR Review Feedback");
+  });
+
   it("renders attachments index when attachments are provided", () => {
     const result = assembleImplementationContext({
       ticket: {

--- a/apps/worker/src/sandbox/context.ts
+++ b/apps/worker/src/sandbox/context.ts
@@ -50,6 +50,7 @@ export interface ImplementationContextInput {
   attachments?: DownloadedAttachment[];
   preSandboxAdditions?: PreSandboxPromptAddition[];
   selectedRepositories?: SelectedRepository[];
+  repositoryContexts?: SelectedRepositoryPromptContext[];
 }
 
 export interface ReviewContextInput {
@@ -106,10 +107,14 @@ ${branchName}
 }
 
 export function assembleImplementationContext(input: ImplementationContextInput): string {
-  const { ticket, prompt, researchPlanMarkdown, attachments, preSandboxAdditions, selectedRepositories } = input;
+  const { ticket, prompt, researchPlanMarkdown, attachments, preSandboxAdditions, selectedRepositories, repositoryContexts } = input;
   const attachmentsSection = renderAttachmentsSection(attachments);
   const preSandboxSection = renderPreSandboxAdditions(preSandboxAdditions);
   const selectedRepositoriesSection = renderSelectedRepositories(selectedRepositories);
+  // On a re-run against an existing workflow-owned PR this surfaces the human PR
+  // review feedback (comments, failing checks, conflicts) so the implementation
+  // agent actually addresses it. Empty on the first run, so the section vanishes.
+  const repositoryContextSection = renderRepositoryContexts(repositoryContexts);
   const clarificationsSection = renderClarificationsSection(ticket.clarifications);
   return `# Requirements
 
@@ -128,7 +133,7 @@ ${clarificationsSection}
 ## Research & Plan
 
 ${researchPlanMarkdown}
-${selectedRepositoriesSection}
+${repositoryContextSection}${selectedRepositoriesSection}
 ${preSandboxSection}
 
 ---
@@ -285,7 +290,7 @@ function renderClarificationsSection(
   return `${header}${CLARIFICATIONS_TRUNCATION_NOTE}${kept.join(separator)}${footer}`;
 }
 
-function formatPRComments(comments: PRComment[]): string {
+export function formatPRComments(comments: PRComment[]): string {
   if (comments.length === 0) return "No review feedback.";
 
   const lineCoupled = comments

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -1989,6 +1989,7 @@ async function agentWorkflowBody(
               attachments: downloadedAttachments,
               preSandboxAdditions: ctx.preSandboxAdditions.implementation,
               selectedRepositories: ctx.selectedRepositories,
+              repositoryContexts: ctx.repositoryContexts,
             });
 
             const implCommandId = await writeAndStartPhase(

--- a/apps/worker/src/workflows/prompt-vars.test.ts
+++ b/apps/worker/src/workflows/prompt-vars.test.ts
@@ -149,7 +149,39 @@ describe("buildPromptVariables", () => {
         ],
       }),
     );
+    expect(vars.pr_review_feedback).toContain("### github:acme/api");
     expect(vars.pr_review_feedback).toContain("fix the null check");
+  });
+
+  it("keeps each repository's feedback under its own heading in multi-repo runs", () => {
+    const context = (repoPath: string, body: string) => ({
+      repository: {
+        provider: "github" as const,
+        repoPath,
+        defaultBranch: "main",
+        selectedRationale: "workflow-owned branch for this ticket",
+      },
+      prComments: [{ author: "reviewer", body, liked: false }],
+      checkResults: [],
+      hasConflicts: false,
+    });
+    const vars = buildPromptVariables(
+      makeSource({
+        repositoryContexts: [
+          context("acme/api", "fix the api null check"),
+          context("acme/web", "fix the web button copy"),
+        ],
+      }),
+    );
+    // Repo identity is preserved so same-path comments never get conflated.
+    expect(vars.pr_review_feedback).toContain("### github:acme/api");
+    expect(vars.pr_review_feedback).toContain("fix the api null check");
+    expect(vars.pr_review_feedback).toContain("### github:acme/web");
+    expect(vars.pr_review_feedback).toContain("fix the web button copy");
+    // api heading precedes web's (order follows repositoryContexts).
+    expect(vars.pr_review_feedback!.indexOf("acme/api")).toBeLessThan(
+      vars.pr_review_feedback!.indexOf("acme/web"),
+    );
   });
 
   it("leaves pr variables empty on a ticket-triggered run", () => {

--- a/apps/worker/src/workflows/prompt-vars.test.ts
+++ b/apps/worker/src/workflows/prompt-vars.test.ts
@@ -88,6 +88,7 @@ function makeSource(overrides: Partial<Source> = {}): Source {
     researchPlanMarkdown: "",
     publication: null,
     selectedRepositories: [],
+    repositoryContexts: [],
     ...overrides,
   };
 }
@@ -101,7 +102,7 @@ describe("buildPromptVariables", () => {
     expect(Object.keys(vars).sort()).toEqual(PROMPT_VARIABLES.map((v) => v.name).sort());
   });
 
-  it("resolves all twelve variables from a stubbed context", () => {
+  it("resolves all variables from a stubbed context", () => {
     const vars = buildPromptVariables(
       makeSource({
         entry: prEntry,
@@ -122,7 +123,33 @@ describe("buildPromptVariables", () => {
       pr_url: "https://github.com/acme/api/pull/77",
       pr_title: "Implement dark mode",
       repo_path: "acme/api",
+      pr_review_feedback: "",
     });
+  });
+
+  it("renders pr_review_feedback from workflow-owned PR comments, empty when none", () => {
+    expect(buildPromptVariables(makeSource()).pr_review_feedback).toBe("");
+
+    const vars = buildPromptVariables(
+      makeSource({
+        repositoryContexts: [
+          {
+            repository: {
+              provider: "github",
+              repoPath: "acme/api",
+              defaultBranch: "main",
+              selectedRationale: "workflow-owned branch for this ticket",
+            },
+            prComments: [
+              { author: "reviewer", body: "[Review: changes requested] fix the null check", liked: false },
+            ],
+            checkResults: [],
+            hasConflicts: false,
+          },
+        ],
+      }),
+    );
+    expect(vars.pr_review_feedback).toContain("fix the null check");
   });
 
   it("leaves pr variables empty on a ticket-triggered run", () => {

--- a/apps/worker/src/workflows/prompt-vars.ts
+++ b/apps/worker/src/workflows/prompt-vars.ts
@@ -51,11 +51,17 @@ type PromptVariableSource = Pick<
 export function buildPromptVariables(ctx: PromptVariableSource): PromptVariableValues {
   const { entry, ticket, publication, selectedRepositories, repositoryContexts } = ctx;
   const prEntry = entry.kind === "pr_trigger" ? entry.pr : null;
-  // Human PR review feedback for {{pr_review_feedback}}: flatten every
-  // workflow-owned repo's comments (same source and formatter the fix/impl
-  // context envelopes use). Empty string when there is no feedback yet.
-  const prComments = repositoryContexts.flatMap((context) => context.prComments);
-  const prReviewFeedback = prComments.length > 0 ? formatPRComments(prComments) : "";
+  // Human PR review feedback for {{pr_review_feedback}}: one block per
+  // workflow-owned repo, each under its own `provider:repoPath` heading so a
+  // multi-repo run never conflates same-path comments across checkouts. Same
+  // formatter the fix/impl context envelopes use. Empty when no feedback yet.
+  const prReviewFeedback = repositoryContexts
+    .filter((context) => context.prComments.length > 0)
+    .map(
+      (context) =>
+        `### ${context.repository.provider}:${context.repository.repoPath}\n${formatPRComments(context.prComments)}`,
+    )
+    .join("\n\n");
   // The PR this run opened (open_pr / finalize_workspace) once publication lands.
   const openedPr = publication?.prs[0];
 

--- a/apps/worker/src/workflows/prompt-vars.ts
+++ b/apps/worker/src/workflows/prompt-vars.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowParamValue,
 } from "@shared/contracts";
 import type { EngineCtx } from "./blocks/types.js";
+import { formatPRComments } from "../sandbox/context.js";
 
 /** Which string/string[] params of each block type receive {{var}} substitution.
  *  Deliberately excludes machine-shaped params (branch.condition, outputSchema,
@@ -41,14 +42,20 @@ type PromptVariableSource = Pick<
   | "researchPlanMarkdown"
   | "publication"
   | "selectedRepositories"
+  | "repositoryContexts"
 >;
 
 /** Snapshot every prompt variable for the current point of the run. Called per
  *  block execution because researchPlanMarkdown / publication / selectedRepositories
  *  mutate mid-run. */
 export function buildPromptVariables(ctx: PromptVariableSource): PromptVariableValues {
-  const { entry, ticket, publication, selectedRepositories } = ctx;
+  const { entry, ticket, publication, selectedRepositories, repositoryContexts } = ctx;
   const prEntry = entry.kind === "pr_trigger" ? entry.pr : null;
+  // Human PR review feedback for {{pr_review_feedback}}: flatten every
+  // workflow-owned repo's comments (same source and formatter the fix/impl
+  // context envelopes use). Empty string when there is no feedback yet.
+  const prComments = repositoryContexts.flatMap((context) => context.prComments);
+  const prReviewFeedback = prComments.length > 0 ? formatPRComments(prComments) : "";
   // The PR this run opened (open_pr / finalize_workspace) once publication lands.
   const openedPr = publication?.prs[0];
 
@@ -74,6 +81,7 @@ export function buildPromptVariables(ctx: PromptVariableSource): PromptVariableV
     pr_url: prUrl,
     pr_title: prTitle,
     repo_path: repoPath,
+    pr_review_feedback: prReviewFeedback,
   };
 }
 

--- a/apps/worker/src/workflows/slack-message-variables.test.ts
+++ b/apps/worker/src/workflows/slack-message-variables.test.ts
@@ -61,6 +61,7 @@ function makeSource(overrides: Partial<Source> = {}): Source {
     researchPlanMarkdown: "",
     publication: publishedPr,
     selectedRepositories: [],
+    repositoryContexts: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Problem

When a human leaves review feedback on a workflow-owned PR and moves the ticket back to the AI column, the run fires but the agent never acts on the feedback: it re-plans and re-implements against a branch that already has the work, producing no code change. The bot behaves as if it has no access to the PR discussion. This affects both plain comments and "Request Changes" reviews, and blocks the human-in-the-loop review step.

## Root cause

Two independent gaps on the ticket (AI-column) trigger path:

1. **PR feedback never reaches the implementing agent.** The default ticket workflow fetches PR comments into `ctx.repositoryContexts` during workspace prep, but `assembleImplementationContext` did not render them, and the planning agent runs before prep (so its `repositoryContexts` is still empty). The feedback was fetched and then dropped.
2. **Review summary bodies were not fetched.** `GitHubAdapter.getPRComments` read inline review comments (`listReviewComments`) and PR conversation comments (`issues.listComments`) but not `pulls.listReviews`, so a "Request Changes" whose text lives only in the main review box was invisible.

Note: the `liked` field (reactions) only annotates comments in the prompt; it does not filter them. Nothing gates comments behind a reaction.

## Changes

- `github.ts`: `getPRComments` now also fetches `pulls.listReviews` and includes non-empty review bodies, tagged with the review state (e.g. `[Review: changes requested] ...`).
- `context.ts`: `assembleImplementationContext` renders the existing "PR Review Feedback" section (reusing `renderRepositoryContexts`); empty on first runs, so no change to the normal flow.
- `agent.ts`: pass `ctx.repositoryContexts` into the implementation context.
- New prompt variable `{{pr_review_feedback}}` (`prompt-variables.ts` + `prompt-vars.ts`) so library-authored prompts and `generic_agent` can place the feedback explicitly. Sourced from the same `repositoryContexts` / `formatPRComments`.

## Scope

Targets the "move ticket to AI column" trigger (the intended design), independent of GitHub App review-webhook wiring. The `generic_agent` path is covered via the new variable; the `fix_agent` path already surfaced feedback via `assembleFixContext`.

## Testing

- Unit tests added for review-body fetching, implementation-context rendering, and the new variable; full worker unit suite and typecheck pass.
- Pending: real end-to-end smoke on a live tenant — leave a plain comment and a "Request Changes" review on a workflow-owned PR, move the ticket to the AI column, and confirm the run produces an actual code change addressing the feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for incorporating human pull request review feedback into implementation workflows.
  - GitHub review summaries, inline comments, and issue comments are now collected and combined.
  - Added the `pr_review_feedback` prompt variable, which provides formatted feedback when available and remains empty otherwise.
  - Review statuses such as approved or changes requested are displayed alongside feedback.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->