### PR TITLE
feat(workflow): generate PR title and description from editable templates with Jira link

### DIFF
--- a/apps/dashboard/components/cockpit/flow-editor/blocks.ts
+++ b/apps/dashboard/components/cockpit/flow-editor/blocks.ts
@@ -90,6 +90,10 @@ export function nodeSummary(node: FlowNodeDef, options: WorkflowEditorOptions): 
       const body = str(node.params.body);
       return body !== "" ? truncate(body) : null;
     }
+    case "open_pr": {
+      const title = str(node.params.title);
+      return title !== "" ? truncate(title) : null;
+    }
     case "update_ticket_status": {
       const target = node.params.target;
       const label = options.ticketStatusTargets.find((t) => t.value === target)?.label;

--- a/apps/dashboard/components/cockpit/flow-editor/config-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/config-fields.tsx
@@ -9,7 +9,7 @@ import type {
   WorkflowEditorOptions,
   WorkflowParamValue,
 } from "@shared/contracts";
-import { DEFAULT_PROMPT_NAME_BY_AGENT } from "@shared/contracts";
+import { DEFAULT_OPEN_PR_TITLE, DEFAULT_PROMPT_NAME_BY_AGENT } from "@shared/contracts";
 import { parseCondition } from "@shared/conditions";
 import {
   arrayToLines,
@@ -691,7 +691,28 @@ export function ConfigFields({
     case "fetch_pr_context":
       return <ConfigNote>Loads the pull request diff, files and metadata for downstream steps.</ConfigNote>;
     case "open_pr":
-      return <ConfigNote>Opens a pull request with the agent&apos;s changes on the ticket branch.</ConfigNote>;
+      return (
+        <>
+          <ConfigField label="Title">
+            <TextInput
+              value={str(node.params.title)}
+              disabled={!canEdit}
+              placeholder={DEFAULT_OPEN_PR_TITLE}
+              onChange={(v) => onChange("params.title", v)}
+            />
+          </ConfigField>
+          <ConfigField label="Description">
+            <RichTextField
+              value={str(node.params.body)}
+              disabled={!canEdit}
+              onChange={(v) => onChange("params.body", v)}
+            />
+          </ConfigField>
+          <ConfigNote>
+            {"Templates for the pull request opened on the ticket branch. Variables like {{ticket_key}}, {{ticket_title}}, {{ticket_url}} (issue tracker link) and {{change_summary}} (what the agent changed) are substituted at run time. Leave a field empty to use the default."}
+          </ConfigNote>
+        </>
+      );
     case "update_ticket_status":
       return (
         <ConfigField label="Target status">

--- a/apps/shared/contracts/prompt-variables.ts
+++ b/apps/shared/contracts/prompt-variables.ts
@@ -9,9 +9,11 @@ export interface PromptVariableSpec {
 export const PROMPT_VARIABLES = [
   { name: "ticket_key", description: "Ticket identifier, e.g. ABC-123." },
   { name: "ticket_title", description: "Ticket title." },
+  { name: "ticket_url", description: "URL of the ticket in the issue tracker; empty for non-ticket runs." },
   { name: "ticket_description", description: "Ticket description (markdown)." },
   { name: "ticket_acceptance_criteria", description: "Acceptance criteria; empty when none." },
   { name: "ticket_labels", description: "Comma-separated ticket labels." },
+  { name: "change_summary", description: "Summary of what the agent changed, from the implementation phase; empty before it runs." },
   { name: "branch_name", description: "Work branch for this run." },
   { name: "run_id", description: "Durable workflow run id." },
   { name: "plan_markdown", description: "Plan produced by the planning agent (or the approved plan); empty before planning." },
@@ -22,3 +24,14 @@ export const PROMPT_VARIABLES = [
 ] as const satisfies readonly PromptVariableSpec[];
 
 export type PromptVariableName = (typeof PROMPT_VARIABLES)[number]["name"];
+
+/** Default {{variable}} templates for the open_pr block's title and body. New
+ *  blocks are seeded with these (block registry defaults); a deployed definition
+ *  authored before these fields existed falls back to them at run time. Editable
+ *  per-block in the flow editor. The title carries the ticket key for tracking;
+ *  the body opens with the ticket link and the agent's change summary. */
+export const DEFAULT_OPEN_PR_TITLE = "[{{ticket_key}}] {{ticket_title}}";
+export const DEFAULT_OPEN_PR_BODY = `**Ticket:** [{{ticket_key}}]({{ticket_url}})
+
+## What changed
+{{change_summary}}`;

--- a/apps/shared/contracts/workflow-graph.ts
+++ b/apps/shared/contracts/workflow-graph.ts
@@ -93,7 +93,7 @@ export const BLOCK_PARAM_KEYS: Record<WorkflowBlockType, readonly string[]> = {
   run_checks: ["commands"],
   call_llm: ["prompt", "system", "model", "provider", "outputSchema"],
   fetch_pr_context: [],
-  open_pr: [],
+  open_pr: ["title", "body"],
   update_ticket_status: ["target"],
   post_ticket_comment: ["body"],
   post_pr_comment: ["body", "target"],

--- a/apps/worker/src/workflow-definition/block-registry.test.ts
+++ b/apps/worker/src/workflow-definition/block-registry.test.ts
@@ -90,6 +90,8 @@ describe("workflow block registry", () => {
         required: true,
         schema: expect.objectContaining({ type: "array" }),
       },
+      title: { required: false, schema: { type: "string" } },
+      body: { required: false, schema: { type: "string" } },
     });
     expect(registry.planning_agent.inputs).toEqual({
       ticket: { required: false, schema: expect.objectContaining({ type: "object" }) },

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -1,5 +1,7 @@
 import {
   BLOCK_TYPE_SPECS,
+  DEFAULT_OPEN_PR_BODY,
+  DEFAULT_OPEN_PR_TITLE,
   isWorkflowAddressablePathSegment,
   type BlockOutput,
   type VcsProviderKind,
@@ -628,8 +630,12 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       "Creates or reuses pull or merge requests from a successful Finalize output.",
       "⇪",
     ),
-    defaults: {},
-    inputs: { repositories: input(arrayType(finalizedBranchType), true) },
+    defaults: { title: DEFAULT_OPEN_PR_TITLE, body: DEFAULT_OPEN_PR_BODY },
+    inputs: {
+      repositories: input(arrayType(finalizedBranchType), true),
+      title: input(stringType(), false),
+      body: input(stringType(), false),
+    },
     output: statusOutput({
       prs: arrayType(workflowPrRefType),
       prUrl: stringType(),

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -43,6 +43,7 @@ import {
   buildPromptVariables,
   substituteNodePromptParams,
   substitutePromptVariables,
+  type PromptVariableValues,
 } from "./prompt-vars.js";
 import type { HumanDecision } from "../lib/human-decisions-memory.js";
 import type { WorkspacePublicationResult } from "./workspace-publication.js";
@@ -83,7 +84,12 @@ import { execute as executePostPrComment } from "./blocks/post-pr-comment.js";
 import { execute as executeHumanQuestion } from "./blocks/human-question.js";
 import { execute as executeArthurInjectionCheck } from "./blocks/arthur-injection-check.js";
 import { execute as executeSendPlanApproval } from "./blocks/send-plan-approval.js";
-import { BLOCK_TYPE_SPECS, isTriggerBlockType } from "@shared/contracts";
+import {
+  BLOCK_TYPE_SPECS,
+  DEFAULT_OPEN_PR_BODY,
+  DEFAULT_OPEN_PR_TITLE,
+  isTriggerBlockType,
+} from "@shared/contracts";
 import type {
   BlockOutput,
   BlockRunState,
@@ -336,6 +342,52 @@ export function resolveTicketStatusInput(
     throw new Error("Update Ticket Status requires a non-empty status target.");
   }
   return target.trim();
+}
+
+/** The implementation block's own account of what it changed, read from the
+ *  durable step outputs so it survives workflow replay (the implementation case
+ *  may be skipped on resume, yet its output persists in `steps`). Backs
+ *  {{change_summary}} for the open_pr description; empty until an
+ *  implementation_agent block has produced a summary. */
+export function implementationChangeSummary(
+  steps: StepsRecord,
+  nodes: WorkflowDefinitionNode[],
+): string {
+  for (const node of nodes) {
+    if (node.type !== "implementation_agent") continue;
+    const summary = steps[node.id]?.output?.summary;
+    if (typeof summary === "string" && summary.trim() !== "") return summary;
+  }
+  return "";
+}
+
+/** open_pr title: a binding wins, else the authored (already {{var}}-substituted)
+ *  template param, else the default template resolved against `vars`. */
+export function resolveOpenPrTitle(
+  params: Record<string, unknown>,
+  resolvedInputs: Record<string, unknown>,
+  vars: PromptVariableValues,
+): string {
+  const bound = typeof resolvedInputs.title === "string" ? resolvedInputs.title.trim() : "";
+  if (bound !== "") return bound;
+  const authored = typeof params.title === "string" ? params.title.trim() : "";
+  if (authored !== "") return authored;
+  return substitutePromptVariables(DEFAULT_OPEN_PR_TITLE, vars).trim();
+}
+
+/** open_pr body: same precedence as the title. Whitespace is preserved for the
+ *  authored/bound value so markdown structure survives; only emptiness decides
+ *  the fallback. */
+export function resolveOpenPrBody(
+  params: Record<string, unknown>,
+  resolvedInputs: Record<string, unknown>,
+  vars: PromptVariableValues,
+): string {
+  const bound = typeof resolvedInputs.body === "string" ? resolvedInputs.body : "";
+  if (bound.trim() !== "") return bound;
+  const authored = typeof params.body === "string" ? params.body : "";
+  if (authored.trim() !== "") return authored;
+  return substitutePromptVariables(DEFAULT_OPEN_PR_BODY, vars);
 }
 
 function publicationPrForTelemetry(
@@ -1539,6 +1591,10 @@ async function agentWorkflowBody(
       definitionNodes: plan.nodes,
       entry,
       ticket,
+      ticketUrl: entry.ticketKey
+        ? `${env.JIRA_BASE_URL.replace(/\/+$/, "")}/browse/${ticket.identifier}`
+        : "",
+      changeSummary: "",
       ...(clarificationHistory && clarificationHistory.length > 0
         ? { clarifications: clarificationHistory }
         : {}),
@@ -1865,6 +1921,10 @@ async function agentWorkflowBody(
         resolvedInputs,
         execution,
       ): Promise<BlockExecutionResult> => {
+        // Refresh {{change_summary}} from the implementation block's durable
+        // output before substituting, so open_pr's description reflects what the
+        // agent changed even on a resumed run where the impl case was skipped.
+        ctx.changeSummary = implementationChangeSummary(steps, ctx.definitionNodes);
         // Substitute {{variables}} into prompt-bearing params per execution: the
         // run context (research plan, publication, selected repos) mutates
         // mid-run, so each block sees the values current at its turn.
@@ -2191,13 +2251,20 @@ async function agentWorkflowBody(
                 { category: "binding", phase: "open-pr" },
               );
             }
+            // node.params.title/body are already {{var}}-substituted (executeBlock).
+            // ticket.title is the last-resort title if a template resolves empty.
+            const prVars = buildPromptVariables(ctx);
+            const prTitle =
+              resolveOpenPrTitle(node.params, resolvedInputs, prVars) || ticket.title;
+            const prBody = resolveOpenPrBody(node.params, resolvedInputs, prVars);
             const publication = await openPullRequestsForPublication({
               repositories: repositories as import("./workspace-publication.js").FinalizedBranch[],
               runId: ctx.runId,
               subjectKey: transitionOwner.subjectKey,
               ownerToken: transitionOwner.ownerToken,
               ticketKey: ticket.identifier,
-              title: ticket.title,
+              title: prTitle,
+              body: prBody,
               sourcePullRequest:
                 ctx.entry.kind === "pr_trigger"
                   ? {

--- a/apps/worker/src/workflows/block-executors.test.ts
+++ b/apps/worker/src/workflows/block-executors.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { BLOCK_TYPE_SPECS } from "@shared/contracts";
-import type { WorkflowBlockType } from "@shared/contracts";
+import type { WorkflowBlockType, WorkflowDefinitionNode } from "@shared/contracts";
 import {
   blockTypesMissingExecutor,
+  implementationChangeSummary,
   planningClarificationResult,
+  resolveOpenPrBody,
+  resolveOpenPrTitle,
   resolveSlackMessageInput,
   resolveTicketStatusInput,
 } from "./agent.js";
@@ -48,5 +51,59 @@ describe("block executor exhaustiveness", () => {
       "backlog",
     );
     expect(resolveTicketStatusInput({ target: "10042" }, {})).toBe("10042");
+  });
+});
+
+describe("open_pr title and body resolution", () => {
+  const vars = {
+    ticket_key: "AIW-117",
+    ticket_title: "Updates to the generated PR",
+    ticket_url: "https://jira.example.com/browse/AIW-117",
+    change_summary: "Added templated PR title and body.",
+  };
+
+  it("prefers a bound input over the authored template and the default", () => {
+    expect(resolveOpenPrTitle({ title: "authored" }, { title: "bound" }, vars)).toBe("bound");
+    expect(resolveOpenPrBody({ body: "authored" }, { body: "bound body" }, vars)).toBe(
+      "bound body",
+    );
+  });
+
+  it("uses the authored (already-substituted) param when nothing is bound", () => {
+    expect(resolveOpenPrTitle({ title: "[AIW-117] X" }, {}, vars)).toBe("[AIW-117] X");
+    expect(resolveOpenPrBody({ body: "changed things" }, {}, vars)).toBe("changed things");
+  });
+
+  it("falls back to the default template resolved against the variables", () => {
+    expect(resolveOpenPrTitle({}, {}, vars)).toBe("[AIW-117] Updates to the generated PR");
+    expect(resolveOpenPrBody({}, {}, vars)).toBe(
+      "**Ticket:** [AIW-117](https://jira.example.com/browse/AIW-117)\n\n## What changed\nAdded templated PR title and body.",
+    );
+  });
+
+  it("treats a blank authored value as empty and falls back to the default", () => {
+    expect(resolveOpenPrTitle({ title: "   " }, { title: "" }, vars)).toBe(
+      "[AIW-117] Updates to the generated PR",
+    );
+  });
+});
+
+describe("implementationChangeSummary", () => {
+  const nodes: WorkflowDefinitionNode[] = [
+    { id: "impl", type: "implementation_agent", x: 0, y: 0, params: {}, inputs: {} },
+  ];
+
+  it("reads the implementation block summary from the durable steps", () => {
+    const steps = {
+      impl: { output: { status: "implemented", summary: "Did the work." } },
+    };
+    expect(implementationChangeSummary(steps, nodes)).toBe("Did the work.");
+  });
+
+  it("returns empty when no implementation output carries a summary yet", () => {
+    expect(implementationChangeSummary({}, nodes)).toBe("");
+    expect(
+      implementationChangeSummary({ impl: { output: { status: "implemented" } } }, nodes),
+    ).toBe("");
   });
 });

--- a/apps/worker/src/workflows/blocks/test-support.ts
+++ b/apps/worker/src/workflows/blocks/test-support.ts
@@ -107,6 +107,8 @@ export function makeCtx(overrides: Partial<EngineCtx> = {}): EngineCtx {
       trackerStatus: "AI",
       attachments: [],
     },
+    ticketUrl: "https://jira.example.com/browse/AWT-1",
+    changeSummary: "",
     branchName: "blazebot/awt-1",
     sandboxId: "sbx-1",
     workspaceManifest: null,

--- a/apps/worker/src/workflows/blocks/types.ts
+++ b/apps/worker/src/workflows/blocks/types.ts
@@ -49,6 +49,14 @@ export interface EngineCtx {
   /** What started this run. */
   entry: AgentWorkflowInput;
   ticket: TicketContent;
+  /** Ticket URL in the issue tracker (JIRA_BASE_URL/browse/<key>); empty when the
+   *  run has no ticket. Backs the {{ticket_url}} prompt variable so open_pr and
+   *  comment templates can link back to the ticket. */
+  ticketUrl: string;
+  /** Summary of what the agent changed, carried from the implementation phase.
+   *  Backs {{change_summary}} for the open_pr description; empty until the
+   *  implementation phase produces one. */
+  changeSummary: string;
   /** Answered Q&A history for the ticket, injected into fix-phase context so a
    *  resumed run sees what a human already answered; absent when there is none. */
   clarifications?: Array<{

--- a/apps/worker/src/workflows/prompt-vars.test.ts
+++ b/apps/worker/src/workflows/prompt-vars.test.ts
@@ -83,9 +83,11 @@ function makeSource(overrides: Partial<Source> = {}): Source {
   return {
     runId: "run_abc",
     ticket: baseTicket,
+    ticketUrl: "",
     branchName: "ai/abc-123",
     entry: ticketEntry,
     researchPlanMarkdown: "",
+    changeSummary: "",
     publication: null,
     selectedRepositories: [],
     ...overrides,
@@ -101,20 +103,24 @@ describe("buildPromptVariables", () => {
     expect(Object.keys(vars).sort()).toEqual(PROMPT_VARIABLES.map((v) => v.name).sort());
   });
 
-  it("resolves all twelve variables from a stubbed context", () => {
+  it("resolves every variable from a stubbed context", () => {
     const vars = buildPromptVariables(
       makeSource({
         entry: prEntry,
+        ticketUrl: "https://jira.example.com/browse/ABC-123",
         researchPlanMarkdown: "1. Do the thing",
+        changeSummary: "Added a theme toggle that persists.",
       }),
     );
 
     expect(vars).toEqual({
       ticket_key: "ABC-123",
       ticket_title: "Add dark mode",
+      ticket_url: "https://jira.example.com/browse/ABC-123",
       ticket_description: "Users want a dark theme.",
       ticket_acceptance_criteria: "Toggle persists across reloads.",
       ticket_labels: "frontend, ui",
+      change_summary: "Added a theme toggle that persists.",
       branch_name: "ai/abc-123",
       run_id: "run_abc",
       plan_markdown: "1. Do the thing",
@@ -243,8 +249,18 @@ describe("substituteNodePromptParams", () => {
     expect(result.promptRefs).toBe(node.promptRefs);
   });
 
+  it("substitutes into open_pr title and body params", () => {
+    const node = makeNode("open_pr", {
+      title: "PR: {{ticket_title}}",
+      body: "Changed {{ticket_title}}",
+    });
+    const result = substituteNodePromptParams(node, vars);
+    expect(result.params.title).toBe("PR: Add dark mode");
+    expect(result.params.body).toBe("Changed Add dark mode");
+  });
+
   it("returns the identical node for a block type with no variable params", () => {
-    const node = makeNode("open_pr", { prompt: "{{ticket_title}}" });
+    const node = makeNode("finalize_workspace", { prompt: "{{ticket_title}}" });
     expect(substituteNodePromptParams(node, vars)).toBe(node);
   });
 

--- a/apps/worker/src/workflows/prompt-vars.ts
+++ b/apps/worker/src/workflows/prompt-vars.ts
@@ -18,6 +18,7 @@ export const VARIABLE_PARAM_KEYS: Partial<Record<WorkflowBlockType, readonly str
   fix_agent: ["instructions"],
   post_ticket_comment: ["body"],
   post_pr_comment: ["body"],
+  open_pr: ["title", "body"],
   send_slack_message: ["message"],
   human_question: ["questions"],
   terminate: ["postComment"],
@@ -36,9 +37,11 @@ type PromptVariableSource = Pick<
   EngineCtx,
   | "runId"
   | "ticket"
+  | "ticketUrl"
   | "branchName"
   | "entry"
   | "researchPlanMarkdown"
+  | "changeSummary"
   | "publication"
   | "selectedRepositories"
 >;
@@ -64,9 +67,11 @@ export function buildPromptVariables(ctx: PromptVariableSource): PromptVariableV
   return {
     ticket_key: ticket.identifier,
     ticket_title: ticket.title,
+    ticket_url: ctx.ticketUrl,
     ticket_description: ticket.description,
     ticket_acceptance_criteria: ticket.acceptanceCriteria ?? "",
     ticket_labels: ticket.labels.join(", "),
+    change_summary: ctx.changeSummary,
     branch_name: ctx.branchName,
     run_id: ctx.runId,
     plan_markdown: ctx.researchPlanMarkdown ?? "",

--- a/apps/worker/src/workflows/repository-prs.test.ts
+++ b/apps/worker/src/workflows/repository-prs.test.ts
@@ -349,11 +349,18 @@ describe("durable publication PR phases", () => {
         workflowOwnedBranch: { branchName: "blazebot/aiw-100" },
       },
       title: "Safe publication",
+      body: "## What changed\nThings.",
       owner: durableOwner,
     });
 
     expect(order).toEqual(["reconcile", "owner-fence", "create"]);
     expect(mocks.assertActiveRunOwner).toHaveBeenCalledWith({ db: true }, durableOwner);
+    // The resolved title and body are handed to the provider verbatim.
+    expect(createPR).toHaveBeenCalledWith(
+      "blazebot/aiw-100",
+      "Safe publication",
+      "## What changed\nThings.",
+    );
   });
 
   it("does not create a provider PR when cancellation wins after reconciliation", async () => {
@@ -378,6 +385,7 @@ describe("durable publication PR phases", () => {
           workflowOwnedBranch: { branchName: "blazebot/aiw-100" },
         },
         title: "Safe publication",
+        body: "## What changed\nThings.",
         owner: durableOwner,
       }),
     ).rejects.toBe(ownerLoss);
@@ -405,6 +413,7 @@ describe("durable publication PR phases", () => {
         workflowOwnedBranch: { branchName: "blazebot/aiw-100" },
       },
       title: "Safe publication",
+      body: "## What changed\nThings.",
       owner: durableOwner,
     });
 
@@ -438,6 +447,7 @@ describe("durable publication PR phases", () => {
           workflowOwnedBranch: { branchName: "blazebot/aiw-100" },
         },
         title: "Safe publication",
+        body: "## What changed\nThings.",
         owner: durableOwner,
       }),
     ).resolves.toEqual({

--- a/apps/worker/src/workflows/repository-prs.ts
+++ b/apps/worker/src/workflows/repository-prs.ts
@@ -44,6 +44,7 @@ export async function createOrFindWorkflowOwnedPullRequest(input: {
   branchName: string;
   repository: SelectedRepository;
   title: string;
+  body: string;
   owner: ActiveRunOwner;
 }): Promise<WorkflowPrLink> {
   "use step";
@@ -198,6 +199,7 @@ async function resolveWorkflowOwnedPullRequest(
     branchName: string;
     repository: SelectedRepository;
     title: string;
+    body?: string;
   },
   createVcs: (input: {
     provider: SelectedRepository["provider"];
@@ -233,6 +235,7 @@ async function resolveWorkflowOwnedPullRequest(
     vcs,
     branchName,
     input.title,
+    input.body ?? "",
     assertProviderMutation,
   );
   return {
@@ -249,6 +252,7 @@ async function createOrFindPullRequest(
   vcs: VCSAdapter,
   branchName: string,
   title: string,
+  body: string,
   assertProviderMutation?: () => Promise<void>,
 ): Promise<{ pr: PullRequest; isNew: boolean }> {
   const beforeCreate = await vcs.findPR(branchName);
@@ -256,7 +260,7 @@ async function createOrFindPullRequest(
 
   try {
     await assertProviderMutation?.();
-    return { pr: await vcs.createPR(branchName, title, ""), isNew: true };
+    return { pr: await vcs.createPR(branchName, title, body), isNew: true };
   } catch (err) {
     if (isRunControlError(err)) throw err;
     // Creation can succeed remotely and still time out before the response

--- a/apps/worker/src/workflows/slack-message-variables.test.ts
+++ b/apps/worker/src/workflows/slack-message-variables.test.ts
@@ -56,9 +56,11 @@ function makeSource(overrides: Partial<Source> = {}): Source {
   return {
     runId: "run_awt42",
     ticket,
+    ticketUrl: "",
     branchName: "ai/awt-42",
     entry: ticketEntry,
     researchPlanMarkdown: "",
+    changeSummary: "",
     publication: publishedPr,
     selectedRepositories: [],
     ...overrides,

--- a/apps/worker/src/workflows/workspace-publication.test.ts
+++ b/apps/worker/src/workflows/workspace-publication.test.ts
@@ -138,6 +138,7 @@ describe("workspace publication", () => {
     const result = await openPullRequestsForPublication({
       ...common,
       title: "Implement the ticket",
+      body: "## What changed\nImplemented the ticket.",
       repositories: [finalized],
     });
 
@@ -158,6 +159,7 @@ describe("workspace publication", () => {
     const result = await openPullRequestsForPublication({
       ...common,
       title: "Implement the ticket",
+      body: "## What changed\nImplemented the ticket.",
       repositories: [finalized],
     });
 
@@ -172,6 +174,7 @@ describe("workspace publication", () => {
     const result = await openPullRequestsForPublication({
       ...common,
       title: "Implement the ticket",
+      body: "## What changed\nImplemented the ticket.",
       repositories: [finalized],
     });
 
@@ -191,6 +194,7 @@ describe("workspace publication", () => {
     const result = await openPullRequestsForPublication({
       ...common,
       title: "Fix review",
+      body: "## What changed\nAddressed the review.",
       repositories: [finalized],
       sourcePullRequest: {
         provider: "github",

--- a/apps/worker/src/workflows/workspace-publication.ts
+++ b/apps/worker/src/workflows/workspace-publication.ts
@@ -121,6 +121,7 @@ export async function openPullRequestsForPublication(input: {
   ownerToken: string;
   ticketKey: string;
   title: string;
+  body: string;
   sourcePullRequest?: SourcePullRequestIdentity;
 }): Promise<WorkspacePublicationResult> {
   if (input.repositories.length === 0) {
@@ -182,6 +183,7 @@ export async function openPullRequestsForPublication(input: {
           branchName: repository.branchName,
           repository: selected,
           title: input.title,
+          body: input.body,
           owner: {
             subjectKey: input.subjectKey,
             ownerToken: input.ownerToken,

--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -1026,8 +1026,9 @@
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("unknown[]", "contexts")],
           statuses: ["ok"],
         }),
-        open_pr: runtimeContract([], {
+        open_pr: runtimeContract(["title", "body"], {
           requiredInputs: typedPaths("object[]", "repositories"),
+          optionalInputs: typedPaths("string", "title", "body"),
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("object[]", "prs")],
           optionalOutputs: [
             ...typedPaths("string", "prUrl"),


### PR DESCRIPTION
## Summary

The `open_pr` block now generates the pull/merge request **title** and **description** from editable `{{variable}}` templates, instead of using the raw ticket title and an empty body.

- **Link the PR to the Jira ticket** — new `{{ticket_url}}` variable (`JIRA_BASE_URL/browse/<key>`); the default description opens with the ticket link.
- **Fill in the PR description** — the body is templated and includes `{{change_summary}}`, the implementation agent's own account of what it changed (no extra LLM call). Previously the body was hardcoded empty.
- **Descriptive title with ticket number** — default title `[{{ticket_key}}] {{ticket_title}}`.

Both fields are editable per-block in the flow editor (rich-text with variable highlighting) and are bindable, so an upstream `call_llm` step can generate the title/body if a team prefers an LLM-written title.

## Default templates

Title:
```
[{{ticket_key}}] {{ticket_title}}
```
Description:
```
**Ticket:** [{{ticket_key}}]({{ticket_url}})

## What changed
{{change_summary}}
```

## Behavior notes

- **Backward compatible:** deployed definitions whose `open_pr` block has no title/body params fall back to the default templates at run time (registry defaults only seed new editor blocks).
- **Write-once:** the description is set only at PR creation; re-runs reuse the existing PR untouched.
- **Replay-safe:** `{{change_summary}}` is derived from the implementation block's durable step output, so it survives workflow resume.

## Implementation

- New prompt variables `{{ticket_url}}` and `{{change_summary}}`; `open_pr` title/body added to variable substitution.
- `EngineCtx` carries `ticketUrl` and `changeSummary`; the body is threaded through `openPullRequestsForPublication` → `repository-prs` → `vcs.createPR(branch, title, body)` (previously dropped).
- `open_pr` gains editable Title/Description fields and optional bindable `title`/`body` inputs; block catalog kept in sync.

## Testing

- `pnpm --filter worker typecheck` and dashboard typecheck: pass.
- Worker unit tests (prompt-vars, repository-prs, workspace-publication, block-registry, block-catalog-sync, block-executors, io-blocks) and dashboard workflow-editor tests: pass.
- New unit tests for `resolveOpenPrTitle` / `resolveOpenPrBody` / `implementationChangeSummary` and `{{ticket_url}}`/`{{change_summary}}` substitution.

## Ticket

AIW-117 (subtask of AIW-40).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable pull request titles and descriptions to the workflow editor.
  - Supports template variables for ticket details, labels, links, and change summaries.
  - Pull requests now use configured titles and descriptions, with sensible defaults when fields are blank.

- **Documentation**
  - Updated workflow contract documentation to reflect the new pull request options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->