### PR TITLE
fix(worker): keep failed runs failed + explain block failures (AIW-142, AIW-143)

### DIFF
--- a/apps/worker/src/db/queries/runs-read.test.ts
+++ b/apps/worker/src/db/queries/runs-read.test.ts
@@ -11,6 +11,7 @@ import {
   workflowAgg,
   costAgg,
   listRunsForTicket,
+  isRunRecordedFailed,
 } from "./runs-read.js";
 
 const NOW = new Date("2026-06-16T12:00:00.000Z");
@@ -307,5 +308,25 @@ describe("listRunsForTicket", () => {
     expect(res.runs).toEqual([]);
     expect(res.totals.runCount).toBe(0);
     expect(res.ticket).toBeNull();
+  });
+});
+
+describe("isRunRecordedFailed", () => {
+  it("is true only for a run whose recorded status is failed", async () => {
+    await seed({ runId: "wrun_failed", status: "failed" });
+    expect(await isRunRecordedFailed(db, "wrun_failed")).toBe(true);
+  });
+
+  it("is false for non-failed statuses", async () => {
+    await seed({ runId: "wrun_running", status: "running" });
+    await seed({ runId: "wrun_success", status: "success" });
+    await seed({ runId: "wrun_blocked", status: "blocked" });
+    expect(await isRunRecordedFailed(db, "wrun_running")).toBe(false);
+    expect(await isRunRecordedFailed(db, "wrun_success")).toBe(false);
+    expect(await isRunRecordedFailed(db, "wrun_blocked")).toBe(false);
+  });
+
+  it("is false for a missing run", async () => {
+    expect(await isRunRecordedFailed(db, "wrun_missing")).toBe(false);
   });
 });

--- a/apps/worker/src/db/queries/runs-read.ts
+++ b/apps/worker/src/db/queries/runs-read.ts
@@ -85,6 +85,22 @@ function searchCondition(q: string): SQL {
   return sql`(${workflowRuns.ticketKey} ilike ${pat} or ${workflowRuns.ticketTitle} ilike ${pat})`;
 }
 
+/**
+ * True when the run has already recorded a terminal "failed" outcome. The Jira
+ * webhook consults this before cancelling a run whose ticket left the AI
+ * column: the bot's own failure handling moves a failed ticket to the backlog,
+ * which fires that webhook, and cancelling would overwrite the run's genuine
+ * failure with a "cancelled" status the errors KPI never counts.
+ */
+export async function isRunRecordedFailed(db: Db, runId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ status: workflowRuns.status })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, runId))
+    .limit(1);
+  return row?.status === "failed";
+}
+
 const RUN_STATUSES = new Set<RunStatus>([
   "success",
   "running",

--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -10,6 +10,7 @@ import {
   recordBlockStatuses,
   resolveAwaitingRun,
   resolveAwaitingRunsForTicket,
+  markRunFailedOnSelfMove,
   type RunSnapshot,
   type RunUsage,
   type RunBlockStatusWrite,
@@ -373,6 +374,34 @@ describe("recordBlockStatuses", () => {
     expect(r.status).toBe("running");
     expect(r.ticketTitle).toBe("Add login");
     expect(r.sandboxId).toBe("sbx_1");
+  });
+});
+
+describe("markRunFailedOnSelfMove", () => {
+  it("advances an in-flight 'running' row to 'failed'", async () => {
+    await recordBlockStatuses(db, blockWrite()); // inserts status 'running'
+    await markRunFailedOnSelfMove(db, "wrun_1");
+    expect((await row("wrun_1")).status).toBe("failed");
+  });
+
+  it("never downgrades an already-frozen outcome", async () => {
+    for (const frozen of ["success", "blocked", "awaiting"] as const) {
+      const runId = `wrun_${frozen}`;
+      await db.insert(workflowRuns).values({
+        runId,
+        subjectKey: "ticket:jira:PROJ-1",
+        workflowId: "wf_agent",
+        workflowName: "Agent",
+        status: frozen,
+      });
+      await markRunFailedOnSelfMove(db, runId);
+      expect((await row(runId)).status).toBe(frozen);
+    }
+  });
+
+  it("is a no-op for a missing run", async () => {
+    await markRunFailedOnSelfMove(db, "wrun_missing");
+    expect(await row("wrun_missing")).toBeUndefined();
   });
 });
 

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne, sql } from "drizzle-orm";
+import { and, eq, ne, notInArray, sql } from "drizzle-orm";
 import type { Db } from "../../db/client.js";
 import { workflowRuns } from "../../db/schema.js";
 import type {
@@ -277,6 +277,29 @@ export async function recordBlockStatuses(
         updatedAt: sql`now()`,
       },
     });
+}
+
+/**
+ * Commits a run's authoritative "failed" status the moment its own
+ * failure-handling backlog move is about to fire a Jira webhook. The bot moving
+ * a failed ticket out of the AI column triggers the "ticket left the AI column"
+ * webhook, which would otherwise race in and cancel this still-finalizing run,
+ * flipping its world status to "cancelled" (stored as "blocked"), a genuine
+ * failure the errors KPI never counts. Recording "failed" first makes the
+ * outcome durable before that self-triggered cancel can land: the cron never
+ * downgrades a frozen status, so the run stays "failed". Guarded to only
+ * advance an in-flight row and never clobber an already-frozen outcome.
+ */
+export async function markRunFailedOnSelfMove(db: Db, runId: string): Promise<void> {
+  await db
+    .update(workflowRuns)
+    .set({ status: "failed", updatedAt: sql`now()` })
+    .where(
+      and(
+        eq(workflowRuns.runId, runId),
+        notInArray(workflowRuns.status, ["success", "failed", "blocked", "awaiting"]),
+      ),
+    );
 }
 
 /**

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -12,12 +12,17 @@ const state = vi.hoisted(() => ({
   createAdapters: vi.fn(),
   dispatch: vi.fn(),
   cancel: vi.fn(),
+  isRunRecordedFailed: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({ env: state.env }));
 vi.mock("../../lib/adapters.js", () => ({ createAdapters: state.createAdapters }));
 vi.mock("../../lib/dispatch.js", () => ({ dispatchTicket: state.dispatch }));
 vi.mock("../../lib/cancel-run.js", () => ({ cancelRun: state.cancel }));
+vi.mock("../../db/client.js", () => ({ getDb: () => ({}) }));
+vi.mock("../../db/queries/runs-read.js", () => ({
+  isRunRecordedFailed: state.isRunRecordedFailed,
+}));
 
 const handler = (await import("./jira.post.js")).default;
 
@@ -91,6 +96,7 @@ describe("POST /webhooks/jira", () => {
     state.env.JIRA_WEBHOOK_SECRET = "secret";
     state.cancel.mockResolvedValue(true);
     state.dispatch.mockResolvedValue({ started: false, reason: "not_applicable" });
+    state.isRunRecordedFailed.mockResolvedValue(false);
   });
 
   it("rejects unauthenticated configuration", async () => {
@@ -128,6 +134,25 @@ describe("POST /webhooks/jira", () => {
       connected.runRegistry,
       connected.issueTracker,
     );
+  });
+
+  it("does not cancel a run whose failure is already recorded (its own backlog move)", async () => {
+    // The bot's failure handling moved the ticket to the backlog, firing this
+    // webhook. The run already recorded 'failed', so cancelling would overwrite
+    // that with a 'cancelled' status the errors KPI never counts.
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.isRunRecordedFailed.mockResolvedValue(true);
+
+    const response = await app()(request({ actor: "human-account" }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ignored",
+      reason: "run_already_failed",
+      ticketKey: "PROJ-42",
+    });
+    expect(state.isRunRecordedFailed).toHaveBeenCalledWith(expect.anything(), "run-1");
+    expect(state.cancel).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -2,6 +2,8 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { defineEventHandler, readRawBody, getHeader, createError } from "h3";
 import { env } from "../../../env.js";
 import { IssueTrackerNotFoundError } from "../../adapters/issue-tracker/types.js";
+import { getDb } from "../../db/client.js";
+import { isRunRecordedFailed } from "../../db/queries/runs-read.js";
 import { createAdapters } from "../../lib/adapters.js";
 import { cancelRun } from "../../lib/cancel-run.js";
 import { dispatchTicket } from "../../lib/dispatch.js";
@@ -185,6 +187,24 @@ export default defineEventHandler(async (event) => {
         ticketKey,
         reason: result.reason,
       };
+    }
+
+    // The bot's OWN failure handling moves a failed run's ticket to the
+    // backlog, which fires this exact webhook. Refuse to cancel a run whose
+    // failure is already recorded: cancelling would overwrite its "failed"
+    // outcome with a "cancelled" world status the errors KPI never counts. A
+    // human abort still cancels, because a live run is never recorded "failed".
+    const subjectKey = ticketSubjectKey("jira", ticketKey);
+    const activeRun = await adapters.runRegistry.get(subjectKey).catch(() => null);
+    if (
+      activeRun?.runId &&
+      (await isRunRecordedFailed(getDb(), activeRun.runId).catch(() => false))
+    ) {
+      logger.info(
+        { ticketKey, runId: activeRun.runId, payloadStatus: ticketStatus },
+        "webhook_skip_cancel_run_already_failed",
+      );
+      return { status: "ignored", reason: "run_already_failed", ticketKey };
     }
 
     const cancellation = await cancelTrackedRun(

--- a/apps/worker/src/workflow-definition/failure-message.test.ts
+++ b/apps/worker/src/workflow-definition/failure-message.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyProviderFailure,
+  deriveFailureMessage,
+  sanitizeDetail,
+} from "./failure-message.js";
+
+describe("classifyProviderFailure", () => {
+  it("maps the credit/billing cause, including the real Anthropic wording", () => {
+    const billing =
+      "The AI provider rejected the request: the account credit or billing balance is too low.";
+    expect(classifyProviderFailure("Credit balance is too low")).toBe(billing);
+    expect(
+      classifyProviderFailure("Your account has insufficient credits remaining"),
+    ).toBe(billing);
+    expect(classifyProviderFailure("billing account is past due")).toBe(billing);
+  });
+
+  it("maps rate-limit causes", () => {
+    const msg = "The AI provider rate-limited the request. Please retry shortly.";
+    expect(classifyProviderFailure("429 Too Many Requests")).toBe(msg);
+    expect(classifyProviderFailure("rate limit exceeded")).toBe(msg);
+    expect(classifyProviderFailure("rate_limit_error")).toBe(msg);
+  });
+
+  it("maps auth causes", () => {
+    const msg =
+      "The AI provider rejected the credentials (authentication failed). Check the API key.";
+    expect(classifyProviderFailure("401 Unauthorized")).toBe(msg);
+    expect(classifyProviderFailure("authentication_error")).toBe(msg);
+    expect(classifyProviderFailure("invalid x-api-key header")).toBe(msg);
+    expect(classifyProviderFailure("permission denied")).toBe(msg);
+  });
+
+  it("maps model access/not-found causes", () => {
+    const msg = "The requested AI model is unavailable or access is denied.";
+    expect(classifyProviderFailure("model not found")).toBe(msg);
+    expect(classifyProviderFailure("the model does not exist")).toBe(msg);
+    expect(classifyProviderFailure("model access is not allowed")).toBe(msg);
+  });
+
+  it("maps overloaded causes", () => {
+    const msg = "The AI provider is overloaded. Please retry shortly.";
+    expect(classifyProviderFailure("529 overloaded_error")).toBe(msg);
+    expect(classifyProviderFailure("Overloaded")).toBe(msg);
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(classifyProviderFailure("the socket hung up")).toBeUndefined();
+  });
+});
+
+describe("sanitizeDetail", () => {
+  it("redacts Anthropic and OpenAI style keys", () => {
+    const out = sanitizeDetail(
+      "auth failed with sk-ant-api03-abcDEF1234567890_-token and sk-abcdefghijklmnopqrstuvwxyz0123456789",
+    );
+    expect(out).not.toMatch(/sk-ant-api03/);
+    expect(out).not.toMatch(/abcdefghijklmnopqrstuvwxyz0123456789/);
+    expect(out).toContain("[redacted]");
+  });
+
+  it("redacts GitLab, GitHub and Google secret prefixes", () => {
+    expect(sanitizeDetail("token glpat-notarealtoken")).not.toContain(
+      "glpat-notarealtoken",
+    );
+    expect(sanitizeDetail("token ghp_abcdefghij1234567890ABCDEFGH")).not.toContain(
+      "ghp_abcdefghij1234567890ABCDEFGH",
+    );
+    expect(sanitizeDetail("client GOCSPX-abcd1234efgh5678")).not.toContain(
+      "GOCSPX-abcd1234efgh5678",
+    );
+  });
+
+  it("redacts Bearer tokens while keeping the label", () => {
+    const out = sanitizeDetail("Authorization: Bearer abcdef.ghijkl-mnop_qrstuv");
+    expect(out).toContain("Bearer [redacted]");
+    expect(out).not.toContain("abcdef.ghijkl-mnop_qrstuv");
+  });
+
+  it("redacts credentials in URLs but keeps the host", () => {
+    const out = sanitizeDetail(
+      "clone failed: https://admin:s3cr3tPassw0rd@internal.example.com/repo.git",
+    );
+    expect(out).not.toContain("s3cr3tPassw0rd");
+    expect(out).not.toContain("admin:");
+    expect(out).toContain("[redacted]@internal.example.com");
+  });
+
+  it("redacts email addresses", () => {
+    const out = sanitizeDetail("notified ops.team@blazity.com about the failure");
+    expect(out).not.toContain("ops.team@blazity.com");
+    expect(out).toContain("[redacted]");
+  });
+
+  it("redacts long hex and base64-ish runs", () => {
+    const hex = "a".repeat(40);
+    const token = "Ab9_".repeat(12); // 48 base64url-ish chars
+    expect(sanitizeDetail(`digest ${hex}`)).not.toContain(hex);
+    expect(sanitizeDetail(`token ${token}`)).not.toContain(token);
+  });
+
+  it("strips stack-trace frames", () => {
+    const detail =
+      "Error: boom\n    at Object.<anonymous> (/Users/x/app/file.ts:12:5)\n    at run (/Users/x/app/run.ts:3:1)";
+    expect(sanitizeDetail(detail)).toBe("Error: boom");
+  });
+
+  it("collapses whitespace and truncates to the cap", () => {
+    const long = "word ".repeat(60); // 300 chars before trim
+    const out = sanitizeDetail(long);
+    expect(out.length).toBeLessThanOrEqual(120);
+    expect(out).not.toContain("\n");
+    expect(out).not.toMatch(/\s{2,}/);
+  });
+
+  it("returns an empty string for empty or whitespace-only detail", () => {
+    expect(sanitizeDetail("")).toBe("");
+    expect(sanitizeDetail("   \n\t  ")).toBe("");
+  });
+});
+
+describe("deriveFailureMessage", () => {
+  const providerGeneric = "An external service could not complete this block.";
+
+  it("uses the curated message for a known provider cause", () => {
+    expect(
+      deriveFailureMessage({
+        category: "provider",
+        detail: "Credit balance is too low",
+        genericMessage: providerGeneric,
+      }),
+    ).toBe(
+      "The AI provider rejected the request: the account credit or billing balance is too low.",
+    );
+  });
+
+  it("appends a sanitized snippet for an unknown provider cause", () => {
+    expect(
+      deriveFailureMessage({
+        category: "provider",
+        detail: "the upstream socket hung up",
+        genericMessage: providerGeneric,
+      }),
+    ).toBe(`${providerGeneric} (the upstream socket hung up)`);
+  });
+
+  it("appends a sanitized snippet for non-provider categories (no curated match)", () => {
+    expect(
+      deriveFailureMessage({
+        category: "checks",
+        detail: "lint broke on 3 files",
+        genericMessage: "The checks could not be started.",
+      }),
+    ).toBe("The checks could not be started. (lint broke on 3 files)");
+  });
+
+  it("does not apply curated provider matches to other categories", () => {
+    // "401" would be a provider auth cause, but for a binding failure it must
+    // fall through to the sanitized snippet, not the auth message.
+    const generic = "A block input could not be resolved.";
+    expect(
+      deriveFailureMessage({
+        category: "binding",
+        detail: "returned 401 rows",
+        genericMessage: generic,
+      }),
+    ).toBe(`${generic} (returned 401 rows)`);
+  });
+
+  it("returns just the generic text (no dangling parens) when detail is empty", () => {
+    expect(
+      deriveFailureMessage({
+        category: "provider",
+        detail: "   ",
+        genericMessage: providerGeneric,
+      }),
+    ).toBe(providerGeneric);
+  });
+});

--- a/apps/worker/src/workflow-definition/failure-message.ts
+++ b/apps/worker/src/workflow-definition/failure-message.ts
@@ -1,0 +1,114 @@
+import type { ExecutionErrorCategory } from "./interpreter.js";
+
+/** Longest single-line snippet of raw `detail` we append to a user-facing
+ * failure message. Keeps Slack messages and Jira comments compact. */
+const SNIPPET_MAX_LENGTH = 120;
+
+const REDACTED = "[redacted]";
+
+/** Curated (pattern, message) rules for provider-category failures. The first
+ * match wins, so order them from the most to the least specific cause. Each
+ * message names the cause and the fix without echoing the raw provider
+ * payload, so it is safe for Slack and client-visible Jira comments. */
+const PROVIDER_CAUSES: Array<{ pattern: RegExp; message: string }> = [
+  {
+    pattern: /credit balance|billing|insufficient.*(credit|quota|funds)/i,
+    message:
+      "The AI provider rejected the request: the account credit or billing balance is too low.",
+  },
+  {
+    pattern: /rate.?limit|429|too many requests/i,
+    message: "The AI provider rate-limited the request. Please retry shortly.",
+  },
+  {
+    pattern:
+      /401|unauthorized|authentication|invalid.*(api.?key|x-api-key)|permission denied/i,
+    message:
+      "The AI provider rejected the credentials (authentication failed). Check the API key.",
+  },
+  {
+    pattern: /model.*(not found|does not exist|access|not allowed)/i,
+    message: "The requested AI model is unavailable or access is denied.",
+  },
+  {
+    pattern: /529|overloaded/i,
+    message: "The AI provider is overloaded. Please retry shortly.",
+  },
+];
+
+/** Match `detail` against the curated provider causes, returning the safe
+ * message for the first hit, or undefined when nothing matches. */
+export function classifyProviderFailure(detail: string): string | undefined {
+  for (const { pattern, message } of PROVIDER_CAUSES) {
+    if (pattern.test(detail)) return message;
+  }
+  return undefined;
+}
+
+/** Drop stack-trace frames ("at fn (file:line:col)") that would leak internal
+ * paths and add no operator value. */
+function stripStackFrames(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => !/^\s*at\s+.+/.test(line))
+    .join("\n");
+}
+
+/** Ordered redactions removing each class of secret/PII before a snippet of
+ * raw detail can be surfaced. */
+function redactSecrets(text: string): string {
+  return (
+    text
+      // Credentialed URLs: keep the scheme + host, drop the user:pass segment.
+      .replace(
+        /([a-z][a-z0-9+.-]*:\/\/)[^\s/:@]+:[^\s/:@]+@/gi,
+        `$1${REDACTED}@`,
+      )
+      // Bearer tokens.
+      .replace(/\bBearer\s+[A-Za-z0-9._-]{8,}/gi, `Bearer ${REDACTED}`)
+      // Known provider key / token prefixes (sk-ant before sk- so the longer
+      // Anthropic prefix wins).
+      .replace(/\bsk-ant-[A-Za-z0-9_-]{8,}/gi, REDACTED)
+      .replace(/\bsk-[A-Za-z0-9_-]{16,}/gi, REDACTED)
+      .replace(/\bglpat-[A-Za-z0-9_-]{8,}/gi, REDACTED)
+      .replace(/\bgh[posur]_[A-Za-z0-9]{16,}/gi, REDACTED)
+      .replace(/\bGOCSPX-[A-Za-z0-9_-]{8,}/gi, REDACTED)
+      // Email addresses.
+      .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, REDACTED)
+      // Long hex runs (hashes) and base64 / token-ish runs.
+      .replace(/[A-Fa-f0-9]{32,}/g, REDACTED)
+      .replace(/[A-Za-z0-9_-]{40,}/g, REDACTED)
+  );
+}
+
+/** Turn any raw `detail` into a snippet safe to show a user: strip stack
+ * frames, redact secrets/PII, collapse whitespace to single spaces, and cap
+ * the length. Empty or whitespace-only detail yields an empty string. */
+export function sanitizeDetail(detail: string): string {
+  if (!detail || !detail.trim()) return "";
+  const redacted = redactSecrets(stripStackFrames(detail));
+  const collapsed = redacted.replace(/\s+/g, " ").trim();
+  if (!collapsed) return "";
+  return collapsed.length > SNIPPET_MAX_LENGTH
+    ? collapsed.slice(0, SNIPPET_MAX_LENGTH).trimEnd()
+    : collapsed;
+}
+
+/** Derive the user-facing failure message for a block error when the caller
+ * did not supply an explicit safe message. Provider failures try the curated
+ * causes first; otherwise (and for every other category) a sanitized snippet
+ * of `detail` is appended to the generic per-category text so the message
+ * explains *why* without leaking secrets. */
+export function deriveFailureMessage(params: {
+  category: ExecutionErrorCategory;
+  detail: string;
+  genericMessage: string;
+}): string {
+  const { category, detail, genericMessage } = params;
+  if (category === "provider") {
+    const curated = classifyProviderFailure(detail);
+    if (curated) return curated;
+  }
+  const snippet = sanitizeDetail(detail);
+  return snippet ? `${genericMessage} (${snippet})` : genericMessage;
+}

--- a/apps/worker/src/workflow-definition/interpreter.test.ts
+++ b/apps/worker/src/workflow-definition/interpreter.test.ts
@@ -235,7 +235,7 @@ describe("executeGraph output contracts", () => {
     expect(result.outcome).toBe("stopped");
     expect(rec.failures[0]).toMatchObject({ phase: "contract", nodeId: "comment" });
     expect(rec.failures[0]?.reason).toBe(
-      "The block returned an invalid result. Diagnostic ID: AIW-DIAG-test-run-comment-1",
+      'The block returned an invalid result. (block "comment" (post_pr_comment) returned output that violates its contract: output.comments is required.) Diagnostic ID: AIW-DIAG-test-run-comment-1',
     );
     expect(result.executionError?.category).toBe("schema");
   });
@@ -303,14 +303,14 @@ describe("executeGraph output contracts", () => {
     expect(result.steps.comment).toBeUndefined();
     expect(rec.finishes.find((finish) => finish.nodeId === "comment")?.state).toMatchObject({
       status: "fail",
-      error: "The block could not be completed.",
+      error: "The block could not be completed. (Error: provider rejected the comment)",
       diagnosticId: "AIW-DIAG-test-run-comment-1",
     });
     expect(rec.failures).toEqual([
       {
         phase: "post_ticket_comment",
         reason:
-          "The block could not be completed. Diagnostic ID: AIW-DIAG-test-run-comment-1",
+          "The block could not be completed. (Error: provider rejected the comment) Diagnostic ID: AIW-DIAG-test-run-comment-1",
         nodeId: "comment",
       },
     ]);
@@ -386,7 +386,7 @@ describe("executeGraph output contracts", () => {
       {
         phase: "post_ticket_comment",
         reason:
-          "The block could not be completed. Diagnostic ID: AIW-DIAG-test-run-comment-1",
+          "The block could not be completed. (Error: provider rejected the comment) Diagnostic ID: AIW-DIAG-test-run-comment-1",
         nodeId: "comment",
       },
     ]);
@@ -616,7 +616,7 @@ describe("executeGraph branch", () => {
     expect(rec.failures[0].phase).toBe("branch");
     expect(rec.failures[0].nodeId).toBe("br");
     expect(rec.failures[0].reason).toBe(
-      "The workflow engine could not continue. Diagnostic ID: AIW-DIAG-test-run-br-1",
+      "The workflow engine could not continue. (steps.trig.output.failures: expected boolean, got array) Diagnostic ID: AIW-DIAG-test-run-br-1",
     );
     expect(finishStatuses(rec, "br")).toEqual(["fail"]);
     expect(result.steps.br).toBeUndefined();
@@ -852,7 +852,7 @@ describe("executeGraph loop", () => {
 
     expect(result.outcome).toBe("stopped");
     expect(rec.failures[0]?.reason).toBe(
-      "The workflow engine could not continue. Diagnostic ID: AIW-DIAG-test-run-waiting-2",
+      "The workflow engine could not continue. (workflow exceeded the maximum of 2 block executions) Diagnostic ID: AIW-DIAG-test-run-waiting-2",
     );
   });
 });
@@ -888,7 +888,7 @@ describe("executeGraph failure port override", () => {
     expect(calls).toEqual(["checks", "recover"]);
     expect(rec.failures).toHaveLength(1);
     expect(finishStatuses(rec, "checks")).toEqual(["fail"]);
-    expect(rec.finishes[0].state.error).toBe("The checks could not be started.");
+    expect(rec.finishes[0].state.error).toBe("The checks could not be started. (lint broke)");
     expect(result.steps.checks).toBeUndefined();
     expect(result.executionError?.diagnosticId).toBe(
       "AIW-DIAG-test-run-checks-1",
@@ -941,7 +941,7 @@ describe("executeGraph failure port override", () => {
       {
         phase: "checks",
         reason:
-          "An external service could not complete this block. Diagnostic ID: AIW-DIAG-test-run-checks-1",
+          "An external service could not complete this block. (provider rejected checks) Diagnostic ID: AIW-DIAG-test-run-checks-1",
         nodeId: "checks",
       },
     ]);
@@ -966,7 +966,7 @@ describe("executeGraph failure port override", () => {
     expect(rec.failures).toHaveLength(1);
     expect(rec.failures[0].phase).toBe("checks");
     expect(rec.failures[0].reason).toBe(
-      "The checks could not be started. Diagnostic ID: AIW-DIAG-test-run-checks-1",
+      "The checks could not be started. (lint broke) Diagnostic ID: AIW-DIAG-test-run-checks-1",
     );
   });
 });
@@ -1151,6 +1151,42 @@ describe("executeGraph terminate", () => {
   });
 });
 
+describe("executionError message derivation", () => {
+  it("keeps an explicit safe message and ignores the detail", () => {
+    const { error } = executionError("Credit balance is too low", {
+      category: "provider",
+      message: "A curated caller message.",
+    });
+    expect(error.message).toBe("A curated caller message.");
+    expect(error.detail).toBe("Credit balance is too low");
+  });
+
+  it("derives the curated billing message for a provider credit failure", () => {
+    const { error } = executionError("Credit balance is too low", {
+      category: "provider",
+    });
+    expect(error.message).toBe(
+      "The AI provider rejected the request: the account credit or billing balance is too low.",
+    );
+    // detail is untouched so server logs still see the raw cause.
+    expect(error.detail).toBe("Credit balance is too low");
+  });
+
+  it("appends a sanitized snippet for an unknown provider cause", () => {
+    const { error } = executionError("the upstream socket hung up", {
+      category: "provider",
+    });
+    expect(error.message).toBe(
+      "An external service could not complete this block. (the upstream socket hung up)",
+    );
+  });
+
+  it("falls back to the plain generic text when detail is empty", () => {
+    const { error } = executionError("   ", { category: "provider" });
+    expect(error.message).toBe("An external service could not complete this block.");
+  });
+});
+
 describe("executeGraph multi-trigger", () => {
   it("walks only the entry trigger's chain", async () => {
     const graph = graphFrom(
@@ -1208,7 +1244,7 @@ describe("executeGraph execution cap", () => {
     expect(rec.failures).toHaveLength(1);
     expect(rec.failures[0].phase).toBe("engine");
     expect(rec.failures[0].reason).toBe(
-      "The workflow engine could not continue. Diagnostic ID: AIW-DIAG-test-run-body-3",
+      "The workflow engine could not continue. (workflow exceeded the maximum of 5 block executions) Diagnostic ID: AIW-DIAG-test-run-body-3",
     );
   });
 });
@@ -1287,7 +1323,7 @@ describe("executeGraph steps propagation", () => {
       {
         phase: "bindings",
         reason:
-          "A block input could not be resolved. Diagnostic ID: AIW-DIAG-test-run-target-1",
+          'A block input could not be resolved. (binding "trigger.missing" could not be resolved) Diagnostic ID: AIW-DIAG-test-run-target-1',
         nodeId: "target",
       },
     ]);

--- a/apps/worker/src/workflow-definition/interpreter.ts
+++ b/apps/worker/src/workflow-definition/interpreter.ts
@@ -17,6 +17,7 @@ import {
   type WorkflowRunBindingValues,
 } from "./bindings.js";
 import { validateBlockOutputForDefinition } from "./block-registry.js";
+import { deriveFailureMessage } from "./failure-message.js";
 
 /** Resolved graph shape the walker consumes: node lookup, per-port targets, and triggers. */
 export interface RuntimeGraph {
@@ -105,7 +106,13 @@ export function executionError(
     kind: "execution_error",
     error: {
       category,
-      message: options.message ?? SAFE_EXECUTION_ERROR_MESSAGES[category],
+      message:
+        options.message ??
+        deriveFailureMessage({
+          category,
+          detail,
+          genericMessage: SAFE_EXECUTION_ERROR_MESSAGES[category],
+        }),
       detail,
       ...(options.phase ? { phase: options.phase } : {}),
     },

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -879,6 +879,19 @@ async function logPhaseFailure(
 }
 logPhaseFailure.maxRetries = 0;
 
+/**
+ * Records the run's "failed" status before its failure-handling backlog move
+ * fires the self-triggered "ticket left the AI column" webhook, so that webhook
+ * cannot cancel the run out of a genuine failure. See markRunFailedOnSelfMove.
+ */
+async function markRunFailedOnSelfMoveStep(runId: string): Promise<void> {
+  "use step";
+  const { getDb } = await import("../db/client.js");
+  const { markRunFailedOnSelfMove } = await import("../lib/telemetry/run-telemetry.js");
+  await markRunFailedOnSelfMove(getDb(), runId);
+}
+markRunFailedOnSelfMoveStep.maxRetries = 0;
+
 export function clarificationExitDisposition(providerParked: boolean): {
   outcome: "awaiting";
   notify: boolean;
@@ -1786,6 +1799,14 @@ async function agentWorkflowBody(
       const clarificationExit = awaitClarification;
 
       const failureExit = async (phase: string, reason: string): Promise<void> => {
+        // Commit the run's "failed" status BEFORE the backlog move below fires a
+        // Jira webhook. That self-triggered "ticket left the AI column" event
+        // would otherwise race in and cancel this still-finalizing run,
+        // overwriting a genuine failure with a "cancelled"/"blocked" status the
+        // errors KPI never counts. The cron never downgrades a frozen status, so
+        // recording "failed" first keeps the outcome correct even if the cancel
+        // still lands.
+        await markRunFailedOnSelfMoveStep(workflowRunId);
         const usageReport = usageReportOrUndefined();
         const knownPhase = FAILURE_PHASES.has(phase) ? (phase as NotifyPhase) : undefined;
         const { handleWorkflowFailureExit } = await import("./workflow-failure-exit.js");

--- a/apps/worker/src/workflows/blocks/arthur-injection-check.test.ts
+++ b/apps/worker/src/workflows/blocks/arthur-injection-check.test.ts
@@ -119,7 +119,7 @@ describe("arthur_injection_check execute", () => {
       kind: "execution_error",
       error: {
         category: "provider",
-        message: "An external service could not complete this block.",
+        message: "An external service could not complete this block. (arthur 500)",
         detail: "arthur 500",
       },
     });

--- a/apps/worker/src/workflows/blocks/call-llm.test.ts
+++ b/apps/worker/src/workflows/blocks/call-llm.test.ts
@@ -304,7 +304,7 @@ describe("call_llm execute", () => {
       kind: "execution_error",
       error: {
         category: "provider",
-        message: "An external service could not complete this block.",
+        message: "An external service could not complete this block. (provider timed out)",
         detail: "provider timed out",
       },
     });

--- a/apps/worker/src/workflows/blocks/finalize-workspace.test.ts
+++ b/apps/worker/src/workflows/blocks/finalize-workspace.test.ts
@@ -88,7 +88,7 @@ describe("finalize_workspace execute", () => {
       kind: "execution_error",
       error: {
         category: "checks",
-        message: "The checks could not be started.",
+        message: "The checks could not be started. (required checks not satisfied: test)",
         detail: "required checks not satisfied: test",
       },
     });
@@ -225,7 +225,7 @@ describe("finalize_workspace execute", () => {
       kind: "execution_error",
       error: {
         category: "provider",
-        message: "An external service could not complete this block.",
+        message: "An external service could not complete this block. (lease rejected)",
         detail: "lease rejected",
         phase: "push",
       },

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -384,7 +384,7 @@ describe("fix_agent execute", () => {
       kind: "execution_error",
       error: {
         category: "timeout",
-        message: "The block timed out.",
+        message: "The block timed out. (fix phase timed out)",
         detail: "fix phase timed out",
       },
     });

--- a/apps/worker/src/workflows/blocks/generic-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/generic-agent.test.ts
@@ -186,7 +186,7 @@ describe("generic_agent execute", () => {
       kind: "execution_error",
       error: {
         category: "sandbox",
-        message: "The workspace environment could not complete this block.",
+        message: "The workspace environment could not complete this block. (sandbox unavailable)",
         detail: "sandbox unavailable",
       },
     });
@@ -411,7 +411,8 @@ describe("generic_agent execute", () => {
       kind: "execution_error",
       error: {
         category: "schema",
-        message: "The block returned an invalid result.",
+        message:
+          "The block returned an invalid result. (invalid outputSchema: outputSchema must declare an object for Generic Agent.)",
         detail:
           "invalid outputSchema: outputSchema must declare an object for Generic Agent.",
       },

--- a/apps/worker/src/workflows/planning-agent-provisioning.test.ts
+++ b/apps/worker/src/workflows/planning-agent-provisioning.test.ts
@@ -85,7 +85,7 @@ describe("planning agent scratch provisioning", () => {
       "AIW-DIAG-test-run-plan-1",
     );
     expect(failures).toEqual([
-      "The workspace environment could not complete this block. Diagnostic ID: AIW-DIAG-test-run-plan-1",
+      "The workspace environment could not complete this block. (registry unavailable) Diagnostic ID: AIW-DIAG-test-run-plan-1",
     ]);
   });
 

--- a/apps/worker/src/workflows/run-telemetry-integration.test.ts
+++ b/apps/worker/src/workflows/run-telemetry-integration.test.ts
@@ -555,7 +555,7 @@ describe("run telemetry integration (executeGraph -> pglite)", () => {
     expect(persisted.plan.status).toBe("ok");
     expect(persisted.impl.status).toBe("fail");
     expect(persisted.impl.error).toBe(
-      "An external service could not complete this block.",
+      "An external service could not complete this block. (impl blew up)",
     );
     expect(persisted.impl.diagnosticId).toBe(
       "AIW-DIAG-wrun_fail-impl-1",
@@ -613,7 +613,7 @@ describe("run telemetry integration (executeGraph -> pglite)", () => {
     const persisted = r.blockStatuses as Record<string, BlockRunState>;
     expect(persisted.prep.status).toBe("ok");
     expect(persisted.checks.status).toBe("fail");
-    expect(persisted.checks.error).toBe("The checks could not be started.");
+    expect(persisted.checks.error).toBe("The checks could not be started. (lint broke)");
     expect(persisted.checks.output).toBeUndefined();
     expect(persisted.recover.status).toBe("ok");
 


### PR DESCRIPTION
## Summary

Two related worker fixes surfaced while diagnosing failures on the Arthur deployment.

### AIW-142 — failed runs miscounted as cancelled

When a block fails, the failure handler moves the Jira ticket to the backlog column. The resulting "ticket left the AI column" webhook raced in and cancelled the still-finalizing run, so its terminal status became `cancelled` (stored as `blocked`) instead of `failed`, and the errors KPI never counted it (a real failure showed as 0 errors on the dashboard).

Fix: record the run's `failed` status **before** the self-move fires the webhook, and skip the cancel guard for a run whose failure is already recorded. Human aborts of live runs still cancel (a live run is never recorded `failed`).

### AIW-143 — clearer block failure messages

User-facing failure messages were the generic per-category text; the real cause (e.g. "Credit balance is too low") lived only in logs. `executionError` now derives a curated, sanitized message from the failure `detail`:
- Provider causes mapped to clear, safe messages: credit/billing, rate limit, auth/invalid key, model access, overloaded.
- Sanitized, truncated fallback for anything else (secrets/tokens/credentialed URLs/emails/hashes redacted, stack frames stripped, capped at 120 chars).

`detail` and the Diagnostic ID are unchanged; an explicit caller-supplied message still wins.

## Verification

- Targeted + touched test files pass; full `apps/worker` suite: 2104 passed, 1 failed. The single failure is `apps/worker/src/db/queries/workflow-owned-branches.test.ts`, which is pre-existing on `main` (verified) and unrelated to this change.
- `tsc --noEmit` clean.

## Reviewer notes

- AIW-142 covers the `failureExit` path (research/impl/review/push). The separate `terminate("failed")` backlog move and clarification parks still rely on the best-effort Jira actor echo-suppression; can be extended in a follow-up if desired.
- AIW-143 fallback also appends a sanitized snippet to non-provider categories (engine/schema/binding/timeout/checks/sandbox). This is intentional (explain *why* across the board), but worth confirming the sanitized internal reasons are acceptable in client-visible messages.

Refs AIW-142, AIW-143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved execution failure messages with clearer provider-specific guidance and relevant, sanitized details.
  * Added protection against self-triggered workflow updates overwriting recorded failures.
  * Webhook handling now ignores cancellation when a run has already failed.

* **Bug Fixes**
  * Preserved terminal run outcomes during cancellation races.
  * Prevented sensitive information from appearing in failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->