### PR TITLE
fix(worker): review hardening for failed-run guard and failure messages

### DIFF
--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -399,6 +399,18 @@ describe("markRunFailedOnSelfMove", () => {
     }
   });
 
+  it("marks a null-status (in-flight) row as failed", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_null",
+      subjectKey: "ticket:jira:PROJ-2",
+      workflowId: "wf_agent",
+      workflowName: "Agent",
+      // status omitted -> stored NULL; must be treated as in-flight, not skipped
+    });
+    await markRunFailedOnSelfMove(db, "wrun_null");
+    expect((await row("wrun_null")).status).toBe("failed");
+  });
+
   it("is a no-op for a missing run", async () => {
     await markRunFailedOnSelfMove(db, "wrun_missing");
     expect(await row("wrun_missing")).toBeUndefined();

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -1,4 +1,4 @@
-import { and, eq, ne, notInArray, sql } from "drizzle-orm";
+import { and, eq, isNull, ne, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "../../db/client.js";
 import { workflowRuns } from "../../db/schema.js";
 import type {
@@ -297,7 +297,13 @@ export async function markRunFailedOnSelfMove(db: Db, runId: string): Promise<vo
     .where(
       and(
         eq(workflowRuns.runId, runId),
-        notInArray(workflowRuns.status, ["success", "failed", "blocked", "awaiting"]),
+        // A NULL status is an in-flight row too: `status NOT IN (...)` is NULL
+        // (not true) for NULL, so without this a null-status run would be
+        // skipped and its failure lost.
+        or(
+          isNull(workflowRuns.status),
+          notInArray(workflowRuns.status, ["success", "failed", "blocked", "awaiting"]),
+        ),
       ),
     );
 }

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -155,6 +155,19 @@ describe("POST /webhooks/jira", () => {
     expect(state.cancel).not.toHaveBeenCalled();
   });
 
+  it("surfaces a retryable error when the failed-status lookup fails (does not cancel)", async () => {
+    // A transient lookup failure must not be read as "not failed": guessing
+    // would cancel a genuinely failed run. Return a retryable 503 instead.
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.isRunRecordedFailed.mockRejectedValue(new Error("db down"));
+
+    const response = await app()(request({ actor: "human-account" }));
+
+    expect(response.status).toBe(503);
+    expect(state.cancel).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["missing actor", null],
     ["different actor", "another-account"],

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -196,15 +196,30 @@ export default defineEventHandler(async (event) => {
     // human abort still cancels, because a live run is never recorded "failed".
     const subjectKey = ticketSubjectKey("jira", ticketKey);
     const activeRun = await adapters.runRegistry.get(subjectKey).catch(() => null);
-    if (
-      activeRun?.runId &&
-      (await isRunRecordedFailed(getDb(), activeRun.runId).catch(() => false))
-    ) {
-      logger.info(
-        { ticketKey, runId: activeRun.runId, payloadStatus: ticketStatus },
-        "webhook_skip_cancel_run_already_failed",
-      );
-      return { status: "ignored", reason: "run_already_failed", ticketKey };
+    if (activeRun?.runId) {
+      let recordedFailed: boolean;
+      try {
+        recordedFailed = await isRunRecordedFailed(getDb(), activeRun.runId);
+      } catch (lookupError) {
+        // Do not guess on a lookup failure: treating it as "not failed" would let
+        // this self-triggered webhook cancel a genuinely failed run (the exact
+        // masking bug). Surface a retryable error so the webhook is redelivered.
+        logger.warn(
+          { ticketKey, runId: activeRun.runId, err: String(lookupError) },
+          "webhook_run_failed_lookup_failed",
+        );
+        throw createError({
+          statusCode: 503,
+          statusMessage: "Run status lookup failed",
+        });
+      }
+      if (recordedFailed) {
+        logger.info(
+          { ticketKey, runId: activeRun.runId, payloadStatus: ticketStatus },
+          "webhook_skip_cancel_run_already_failed",
+        );
+        return { status: "ignored", reason: "run_already_failed", ticketKey };
+      }
     }
 
     const cancellation = await cancelTrackedRun(

--- a/apps/worker/src/workflow-definition/failure-message.test.ts
+++ b/apps/worker/src/workflow-definition/failure-message.test.ts
@@ -48,6 +48,13 @@ describe("classifyProviderFailure", () => {
   it("returns undefined when nothing matches", () => {
     expect(classifyProviderFailure("the socket hung up")).toBeUndefined();
   });
+
+  it("does not match status codes embedded in larger numbers or 'rate-limiter'", () => {
+    expect(classifyProviderFailure("processed 4013 items")).toBeUndefined();
+    expect(classifyProviderFailure("processed 14290 tokens")).toBeUndefined();
+    expect(classifyProviderFailure("elapsed 5290 ms")).toBeUndefined();
+    expect(classifyProviderFailure("our rate-limiter dropped it")).toBeUndefined();
+  });
 });
 
 describe("sanitizeDetail", () => {
@@ -78,6 +85,13 @@ describe("sanitizeDetail", () => {
     expect(out).not.toContain("abcdef.ghijkl-mnop_qrstuv");
   });
 
+  it("strips a leading generic error-class prefix", () => {
+    expect(sanitizeDetail("TypeError: cannot read x of undefined")).toBe(
+      "cannot read x of undefined",
+    );
+    expect(sanitizeDetail("Error: boom")).toBe("boom");
+  });
+
   it("redacts credentials in URLs but keeps the host", () => {
     const out = sanitizeDetail(
       "clone failed: https://admin:s3cr3tPassw0rd@internal.example.com/repo.git",
@@ -103,7 +117,7 @@ describe("sanitizeDetail", () => {
   it("strips stack-trace frames", () => {
     const detail =
       "Error: boom\n    at Object.<anonymous> (/Users/x/app/file.ts:12:5)\n    at run (/Users/x/app/run.ts:3:1)";
-    expect(sanitizeDetail(detail)).toBe("Error: boom");
+    expect(sanitizeDetail(detail)).toBe("boom");
   });
 
   it("collapses whitespace and truncates to the cap", () => {

--- a/apps/worker/src/workflow-definition/failure-message.ts
+++ b/apps/worker/src/workflow-definition/failure-message.ts
@@ -17,12 +17,12 @@ const PROVIDER_CAUSES: Array<{ pattern: RegExp; message: string }> = [
       "The AI provider rejected the request: the account credit or billing balance is too low.",
   },
   {
-    pattern: /rate.?limit|429|too many requests/i,
+    pattern: /rate.?limit(?!er)|\b429\b|too many requests/i,
     message: "The AI provider rate-limited the request. Please retry shortly.",
   },
   {
     pattern:
-      /401|unauthorized|authentication|invalid.*(api.?key|x-api-key)|permission denied/i,
+      /\b401\b|unauthorized|authentication|invalid.*(api.?key|x-api-key)|permission denied/i,
     message:
       "The AI provider rejected the credentials (authentication failed). Check the API key.",
   },
@@ -31,7 +31,7 @@ const PROVIDER_CAUSES: Array<{ pattern: RegExp; message: string }> = [
     message: "The requested AI model is unavailable or access is denied.",
   },
   {
-    pattern: /529|overloaded/i,
+    pattern: /\b529\b|overloaded/i,
     message: "The AI provider is overloaded. Please retry shortly.",
   },
 ];
@@ -86,7 +86,13 @@ function redactSecrets(text: string): string {
  * the length. Empty or whitespace-only detail yields an empty string. */
 export function sanitizeDetail(detail: string): string {
   if (!detail || !detail.trim()) return "";
-  const redacted = redactSecrets(stripStackFrames(detail));
+  // Drop a leading generic JS error-class prefix ("Error:", "TypeError:", ...)
+  // so the snippet leads with the actual cause, not the error class name.
+  const withoutErrorClass = stripStackFrames(detail).replace(
+    /^\s*(?:[A-Za-z_$][\w$]*)?Error:\s*/,
+    "",
+  );
+  const redacted = redactSecrets(withoutErrorClass);
   const collapsed = redacted.replace(/\s+/g, " ").trim();
   if (!collapsed) return "";
   return collapsed.length > SNIPPET_MAX_LENGTH

--- a/apps/worker/src/workflow-definition/interpreter.test.ts
+++ b/apps/worker/src/workflow-definition/interpreter.test.ts
@@ -303,14 +303,14 @@ describe("executeGraph output contracts", () => {
     expect(result.steps.comment).toBeUndefined();
     expect(rec.finishes.find((finish) => finish.nodeId === "comment")?.state).toMatchObject({
       status: "fail",
-      error: "The block could not be completed. (Error: provider rejected the comment)",
+      error: "The block could not be completed. (provider rejected the comment)",
       diagnosticId: "AIW-DIAG-test-run-comment-1",
     });
     expect(rec.failures).toEqual([
       {
         phase: "post_ticket_comment",
         reason:
-          "The block could not be completed. (Error: provider rejected the comment) Diagnostic ID: AIW-DIAG-test-run-comment-1",
+          "The block could not be completed. (provider rejected the comment) Diagnostic ID: AIW-DIAG-test-run-comment-1",
         nodeId: "comment",
       },
     ]);
@@ -386,7 +386,7 @@ describe("executeGraph output contracts", () => {
       {
         phase: "post_ticket_comment",
         reason:
-          "The block could not be completed. (Error: provider rejected the comment) Diagnostic ID: AIW-DIAG-test-run-comment-1",
+          "The block could not be completed. (provider rejected the comment) Diagnostic ID: AIW-DIAG-test-run-comment-1",
         nodeId: "comment",
       },
     ]);

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -1848,6 +1848,9 @@ async function agentWorkflowBody(
           runOutcome = "failed";
           return;
         }
+        // Persist "failed" before this backlog move fires the self-triggered
+        // "ticket left the AI column" webhook (same race as failureExit).
+        await markRunFailedOnSelfMoveStep(workflowRunId);
         await moveTicketStep(ticketId, backlogMoveTarget(), transitionOwner);
         await notifyTicket(ticket.identifier, {
           kind: "failed",
@@ -2441,6 +2444,9 @@ async function agentWorkflowBody(
         console.error(`Workflow failed for ${ticket.identifier}:`, error);
         if (!entry.ticketKey) return;
 
+        // Persist "failed" before this backlog move fires the self-triggered
+        // "ticket left the AI column" webhook (same race as failureExit).
+        await markRunFailedOnSelfMoveStep(workflowRunId);
         let moved = false;
         try {
           await moveTicketStep(


### PR DESCRIPTION
Follow-up to #132 (merged), which landed the core AIW-142 / AIW-143 changes. These are the code-review fixes that came after that merge:

- `markRunFailedOnSelfMove`: treat a NULL status as in-flight (`or(isNull(...), notInArray(...))`) so a null-status run's failure is not skipped.
- Jira webhook cancel guard: a failed-status lookup error now surfaces a retryable 503 instead of being read as "not failed" (which could cancel a genuinely failed run). Cancel only when the query succeeds and confirms not-failed.
- `failure-message` provider regexes: standalone status codes only (`\\b401\\b`, `\\b429\\b`, `\\b529\\b`) and `rate.?limit(?!er)`, to avoid matches inside larger numbers or `rate-limiter`.
- Persist `failed` before the backlog move in the `terminate` and `applyDefaultFailure` paths too (not only `failureExit`).
- `sanitizeDetail`: strip a leading generic error-class prefix (`Error:` / `TypeError:`).

Tests added/updated. Full `apps/worker` suite: 173/174 passed (the 1 failure is the pre-existing, unrelated `workflow-owned-branches.test.ts`, also fails on main). `tsc --noEmit` clean.

Refs AIW-142, AIW-143