### PR TITLE
[AIW-106] Pin agent CLI protocols and preserve structured-output diagnostics

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest",
     "typecheck": "pnpm build:shared && tsc --noEmit",
     "validate:pre-sandbox": "tsx scripts/validate-pre-sandbox-config.ts",
+    "capture:agent-protocol-fixtures": "tsx scripts/capture-agent-protocol-fixtures.ts",
     "build:arthur-tracer": "node scripts/build-arthur-tracer.mjs",
     "test:e2e": "pnpm test:e2e:agent && pnpm test:e2e:orchestration && pnpm test:e2e:capacity",
     "test:e2e:agent": "pnpm build:shared && vitest run --config e2e/vitest.e2e.config.ts --project agent",

--- a/apps/worker/scripts/capture-agent-protocol-fixtures.ts
+++ b/apps/worker/scripts/capture-agent-protocol-fixtures.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { config as loadEnv } from "dotenv";
+import { Sandbox } from "@vercel/sandbox";
+import { createAgentAdapter, type AgentKind } from "../src/sandbox/agents/index.js";
+import { AGENT_SCHEMA, type CollectedPhaseArtifacts } from "../src/sandbox/agents/types.js";
+import { getSandboxCredentials } from "../src/sandbox/credentials.js";
+
+const args = process.argv.slice(2);
+const requestedProvider = option("--provider") ?? "all";
+const envFile = option("--env-file");
+const shouldWrite = args.includes("--write");
+if (envFile) loadEnv({ path: envFile, quiet: true });
+
+const providers: AgentKind[] = requestedProvider === "all"
+  ? ["claude", "codex"]
+  : requestedProvider === "claude" || requestedProvider === "codex"
+    ? [requestedProvider]
+    : fail("--provider must be claude, codex, or all");
+
+const fixtureRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "src",
+  "sandbox",
+  "agents",
+  "fixtures",
+);
+
+for (const provider of providers) {
+  await captureProvider(provider);
+}
+
+async function captureProvider(provider: AgentKind): Promise<void> {
+  const adapter = createAgentAdapter(provider);
+  const apiKey = provider === "claude"
+    ? process.env.ANTHROPIC_API_KEY
+    : process.env.CODEX_API_KEY;
+  if (!apiKey) {
+    fail(
+      provider === "claude"
+        ? "ANTHROPIC_API_KEY is required for Claude fixture capture"
+        : "CODEX_API_KEY is required for Codex fixture capture; OAuth provisioning is outside AIW-106",
+    );
+  }
+
+  const sandbox = await Sandbox.create({
+    ...getSandboxCredentials(),
+    runtime: "node24",
+    timeout: 15 * 60 * 1000,
+  });
+  try {
+    await adapter.install(sandbox);
+    await adapter.configure(sandbox, {
+      anthropicApiKey: provider === "claude" ? apiKey : undefined,
+      codexApiKey: provider === "codex" ? apiKey : undefined,
+      model: provider === "claude"
+        ? process.env.CLAUDE_MODEL ?? "claude-sonnet-4-6"
+        : process.env.CODEX_MODEL ?? "gpt-5.3-codex",
+    });
+
+    const structured = await invoke({
+      sandbox,
+      provider,
+      model: provider === "claude"
+        ? process.env.CLAUDE_MODEL ?? "claude-sonnet-4-6"
+        : process.env.CODEX_MODEL ?? "gpt-5.3-codex",
+      phase: "fixture-structured",
+      prompt:
+        "Return the requested structured result with result=implemented, summary=sanitized fixture, and every nullable field set to null. Do not inspect the environment.",
+      schema: AGENT_SCHEMA,
+    });
+    const freeform = await invoke({
+      sandbox,
+      provider,
+      model: provider === "claude"
+        ? process.env.CLAUDE_MODEL ?? "claude-sonnet-4-6"
+        : process.env.CODEX_MODEL ?? "gpt-5.3-codex",
+      phase: "fixture-freeform",
+      prompt: "Reply with exactly: fixture complete",
+    });
+
+    const structuredValidation = adapter.parseAgentOutputProtocol(
+      structured,
+      "fixture-structured",
+    );
+    if (!structuredValidation.ok) {
+      throw new Error(
+        `structured fixture capture failed protocol validation: ${structuredValidation.diagnostic.failureKind}`,
+      );
+    }
+    const freeformValidation = adapter.validateFreeformProtocol(
+      freeform,
+      "fixture-freeform",
+    );
+    if (!freeformValidation.ok) {
+      throw new Error(
+        `freeform fixture capture failed protocol validation: ${freeformValidation.diagnostic.failureKind}`,
+      );
+    }
+
+    const structuredFixture = fixtureDocument(adapter.cliSpec, structured);
+    const freeformFixture = fixtureDocument(adapter.cliSpec, freeform);
+    assertSecretFree(structuredFixture);
+    assertSecretFree(freeformFixture);
+
+    if (shouldWrite) {
+      const target = join(fixtureRoot, provider, adapter.cliSpec.version);
+      await mkdir(target, { recursive: true });
+      await writeFile(
+        join(target, "structured-success.json"),
+        `${JSON.stringify(structuredFixture, null, 2)}\n`,
+      );
+      await writeFile(
+        join(target, "freeform-success.json"),
+        `${JSON.stringify(freeformFixture, null, 2)}\n`,
+      );
+    }
+
+    console.log(JSON.stringify({
+      provider,
+      package: adapter.cliSpec.packageName,
+      version: adapter.cliSpec.version,
+      protocol: adapter.cliSpec.protocol,
+      structured: artifactSummary(structured),
+      freeform: artifactSummary(freeform),
+      wroteFixtures: shouldWrite,
+    }));
+  } finally {
+    await sandbox.stop();
+  }
+}
+
+async function invoke(input: {
+  sandbox: Awaited<ReturnType<typeof Sandbox.create>>;
+  provider: AgentKind;
+  model: string;
+  phase: string;
+  prompt: string;
+  schema?: string;
+}): Promise<CollectedPhaseArtifacts> {
+  const adapter = createAgentAdapter(input.provider);
+  const paths = adapter.artifactPaths(input.phase);
+  const script = adapter.buildPhaseScript({
+    phase: input.phase,
+    model: input.model,
+    paths,
+    ...(input.schema ? { jsonSchema: input.schema } : {}),
+  });
+  await input.sandbox.writeFiles([
+    { path: paths.input, content: Buffer.from(input.prompt) },
+    { path: paths.wrapper, content: Buffer.from(script) },
+  ]);
+  const chmod = await input.sandbox.runCommand("chmod", ["+x", paths.wrapper]);
+  if (chmod.exitCode !== 0) throw new Error("fixture wrapper chmod failed");
+  await input.sandbox.runCommand({
+    cmd: "bash",
+    args: [paths.wrapper],
+    cwd: "/vercel/sandbox",
+  });
+  const read = async (path: string): Promise<string> => {
+    const result = await input.sandbox.runCommand("cat", [path]);
+    return result.exitCode === 0 ? (await result.stdout()).trim() : "";
+  };
+  const stdout = await read(paths.stdout);
+  const stderr = await read(paths.stderr);
+  const structuredOutput = paths.structuredOutput
+    ? (await read(paths.structuredOutput)) || null
+    : null;
+  const exitCodeText = await read(paths.exitCode);
+  return {
+    stdout,
+    stderr,
+    structuredOutput,
+    exitCode: /^-?\d+$/.test(exitCodeText) ? Number(exitCodeText) : null,
+  };
+}
+
+function fixtureDocument(
+  spec: ReturnType<typeof createAgentAdapter>["cliSpec"],
+  artifacts: CollectedPhaseArtifacts,
+) {
+  return {
+    package: spec.packageName,
+    version: spec.version,
+    protocol: spec.protocol,
+    provenance: "captured in a disposable Vercel Sandbox and normalized",
+    artifacts: normalizeArtifacts(artifacts),
+  };
+}
+
+function normalizeArtifacts(artifacts: CollectedPhaseArtifacts): CollectedPhaseArtifacts {
+  return {
+    stdout: normalizeProtocolText(artifacts.stdout),
+    stderr: redact(artifacts.stderr),
+    structuredOutput: artifacts.structuredOutput === null
+      ? null
+      : normalizeStructuredOutput(artifacts.structuredOutput),
+    exitCode: artifacts.exitCode,
+  };
+}
+
+function normalizeProtocolText(value: string): string {
+  return value.split("\n").map((line) => {
+    try {
+      return JSON.stringify(normalizeValue(JSON.parse(line)));
+    } catch {
+      return redact(line);
+    }
+  }).join("\n");
+}
+
+function normalizeStructuredOutput(value: string): string {
+  try {
+    return JSON.stringify(normalizeValue(JSON.parse(value)));
+  } catch {
+    return "[sanitized freeform response]";
+  }
+}
+
+function normalizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeValue);
+  if (!value || typeof value !== "object") return value;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (["id", "thread_id", "session_id", "uuid", "timestamp", "cwd"].includes(key)) {
+      normalized[key] = "normalized";
+    } else if (key === "result" && typeof entry === "string") {
+      normalized[key] = [
+        "implemented",
+        "clarification_needed",
+        "failed",
+        "approved",
+        "fixture complete",
+      ].includes(entry.trim())
+        ? entry.trim()
+        : "[sanitized response]";
+    } else if (key === "text" && typeof entry === "string") {
+      normalized[key] = entry.trim() === "fixture complete"
+        ? "fixture complete"
+        : "[sanitized response]";
+    } else {
+      normalized[key] = normalizeValue(entry);
+    }
+  }
+  return normalized;
+}
+
+function redact(value: string): string {
+  let result = value;
+  for (const [key, secret] of Object.entries(process.env)) {
+    if (secret && secret.length >= 8 && /(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)/i.test(key)) {
+      result = result.split(secret).join("[REDACTED]");
+    }
+  }
+  return result
+    .replace(/\b(?:sk-ant-[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+|glpat-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
+    .replace(/\b(Bearer\s+)[^\s,;]+/gi, "$1[REDACTED]");
+}
+
+function assertSecretFree(value: unknown): void {
+  const serialized = JSON.stringify(value);
+  const configuredSecrets = Object.entries(process.env)
+    .filter(([key, secret]) =>
+      secret && secret.length >= 8 && /(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)/i.test(key),
+    )
+    .map(([, secret]) => secret as string);
+  const leakedConfiguredSecret = configuredSecrets.some((secret) => serialized.includes(secret));
+  const leakedTokenPattern = /\b(?:sk-ant-|sk-[A-Za-z0-9_-]{16,}|gh[pousr]_|github_pat_|glpat-|Bearer\s+(?!\[REDACTED\]))/i
+    .test(serialized);
+  if (leakedConfiguredSecret || leakedTokenPattern) {
+    throw new Error("fixture secret scan failed; refusing to write protocol fixtures");
+  }
+}
+
+function artifactSummary(artifacts: CollectedPhaseArtifacts) {
+  const hash = (value: string) => createHash("sha256").update(value).digest("hex");
+  return {
+    exitCode: artifacts.exitCode,
+    stdoutBytes: Buffer.byteLength(artifacts.stdout),
+    stderrBytes: Buffer.byteLength(artifacts.stderr),
+    structuredOutputBytes: Buffer.byteLength(artifacts.structuredOutput ?? ""),
+    stdoutSha256: hash(artifacts.stdout),
+    stderrSha256: hash(artifacts.stderr),
+    structuredOutputSha256: artifacts.structuredOutput === null
+      ? null
+      : hash(artifacts.structuredOutput),
+  };
+}
+
+function option(name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function fail(message: string): never {
+  throw new Error(message);
+}

--- a/apps/worker/scripts/capture-agent-protocol-fixtures.ts
+++ b/apps/worker/scripts/capture-agent-protocol-fixtures.ts
@@ -186,7 +186,7 @@ function fixtureDocument(
     package: spec.packageName,
     version: spec.version,
     protocol: spec.protocol,
-    provenance: "captured in a disposable Vercel Sandbox and normalized",
+    provenance: "captured locally in a disposable Vercel Sandbox and normalized",
     artifacts: normalizeArtifacts(artifacts),
   };
 }

--- a/apps/worker/src/db/queries/workflow-owned-branches.test.ts
+++ b/apps/worker/src/db/queries/workflow-owned-branches.test.ts
@@ -229,6 +229,7 @@ describe("workflow-owned branch records", () => {
         repoPath: "acme/web",
         branchName: "blazebot/aiw-45",
         publishedHeadSha: "new-head",
+        targetBranch: "main",
       },
     ]);
     await expect(

--- a/apps/worker/src/pre-pr-checks/runner.test.ts
+++ b/apps/worker/src/pre-pr-checks/runner.test.ts
@@ -106,6 +106,8 @@ describe("runPrePrChecksWithFixes", () => {
   it("sends failed check logs back to the agent and retries", async () => {
     let checkRuns = 0;
     mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "claude");
+      if (artifact) return artifact;
       if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
         return commandResult(0, JSON.stringify(manifest));
       }
@@ -125,13 +127,21 @@ describe("runPrePrChecksWithFixes", () => {
 
     expect(result.passed).toBe(true);
     expect(result.fixCycles).toBe(1);
-    expect(mockWriteFiles).toHaveBeenCalledWith([
-      {
-        path: "/tmp/pre-pr-checks-fix-prompt.txt",
-        content: expect.any(Buffer),
-      },
-    ]);
-    const prompt = mockWriteFiles.mock.calls[0][0][0].content.toString();
+    expect(mockWriteFiles).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        {
+          path: "/tmp/pre-pr-fix-1-requirements.md",
+          content: expect.any(Buffer),
+        },
+        {
+          path: "/tmp/pre-pr-fix-1-wrapper.sh",
+          content: expect.any(Buffer),
+        },
+      ]),
+    );
+    const prompt = mockWriteFiles.mock.calls[0][0]
+      .find((file: { path: string; content: Buffer }) => file.path.endsWith("requirements.md"))
+      .content.toString();
     expect(prompt).toContain("github:acme/web");
     expect(prompt).toContain("Type error on line 12");
   });
@@ -152,11 +162,10 @@ describe("runPrePrChecksWithFixes", () => {
       },
     });
     mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "claude", claudeOutput);
+      if (artifact) return artifact;
       if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
         return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "cat" && args[0] === "/tmp/pre-pr-checks-fix-stdout.txt") {
-        return commandResult(0, claudeOutput);
       }
       if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
         return commandResult(0, "web-head");
@@ -186,25 +195,20 @@ describe("runPrePrChecksWithFixes", () => {
         num_turns: 2,
       },
     ]);
-    const fixerCall = mockRunCommand.mock.calls.find(
-      ([command]) =>
-        typeof command === "object" &&
-        command !== null &&
-        (command as { args?: string[] }).args?.some((arg) => arg.includes("claude --print")),
-    );
-    expect((fixerCall?.[0] as { args: string[] }).args.join(" ")).toContain(
-      "--output-format json",
-    );
+    const wrapper = mockWriteFiles.mock.calls[0][0]
+      .find((file: { path: string; content: Buffer }) => file.path.endsWith("wrapper.sh"))
+      .content.toString();
+    expect(wrapper).toContain("claude");
+    expect(wrapper).toContain("--output-format json");
   });
 
   it("returns null usage for a launched fix cycle whose CLI output has no usage", async () => {
     let checkRuns = 0;
     mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex");
+      if (artifact) return artifact;
       if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
         return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "cat" && args[0] === "/tmp/pre-pr-checks-fix-stdout.txt") {
-        return commandResult(0, "");
       }
       if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
         return commandResult(0, "web-head");
@@ -229,21 +233,101 @@ describe("runPrePrChecksWithFixes", () => {
     expect(result.fixCycleUsages).toEqual([null]);
   });
 
-  it("stops before another check or fixer when the first fix cycle exceeds the token cap", async () => {
+  it("returns an execution failure when the repair process exits nonzero", async () => {
     let checkRuns = 0;
-    const oneRepoConfig: PrePrCheckConfig = { repositories: [config.repositories[0]!] };
     mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex", undefined, 7);
+      if (artifact) return artifact;
       if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
         return commandResult(0, JSON.stringify(manifest));
       }
-      if (cmd === "cat" && args[0] === "/tmp/pre-pr-checks-fix-stdout.txt") {
-        return commandResult(
-          0,
-          JSON.stringify({
-            type: "turn.completed",
-            usage: { input_tokens: 10, cached_input_tokens: 2, output_tokens: 3 },
-          }),
-        );
+      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
+        return commandResult(0, "web-head");
+      }
+      if (isConfiguredCheck(cmd)) {
+        checkRuns++;
+        return commandResult(1, "", "still failing");
+      }
+      return commandResult(0, "");
+    });
+
+    const result = await runPrePrChecksWithFixes(
+      "sbx-test-123",
+      { repositories: [config.repositories[0]!] },
+      "codex",
+      "gpt-5",
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.fixCycles).toBe(1);
+    expect(result.agentFailure).toMatchObject({
+      category: "provider",
+      diagnostic: { failureKind: "cli_exit", exitCode: 7 },
+    });
+    expect(checkRuns).toBe(1);
+  });
+
+  it("keeps valid repair usage when malformed protocol output becomes an execution failure", async () => {
+    let checkRuns = 0;
+    const malformedWithUsage = [
+      JSON.stringify({ type: "thread.started", thread_id: "normalized" }),
+      "{malformed",
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 10, cached_input_tokens: 2, output_tokens: 3 },
+      }),
+    ].join("\n");
+    mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex", malformedWithUsage);
+      if (artifact) return artifact;
+      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+        return commandResult(0, JSON.stringify(manifest));
+      }
+      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
+        return commandResult(0, "web-head");
+      }
+      if (isConfiguredCheck(cmd)) {
+        checkRuns++;
+        return commandResult(1, "", "still failing");
+      }
+      return commandResult(0, "");
+    });
+
+    const result = await runPrePrChecksWithFixes(
+      "sbx-test-123",
+      { repositories: [config.repositories[0]!] },
+      "codex",
+      "gpt-5",
+    );
+
+    expect(result.agentFailure).toMatchObject({
+      category: "parsing",
+      diagnostic: { failureKind: "invalid_json" },
+    });
+    expect(result.fixCycleUsages).toEqual([
+      {
+        cost_usd: null,
+        tokens: { input: 8, cached_input: 2, output: 3 },
+        duration_ms: 0,
+        duration_api_ms: 0,
+        num_turns: 1,
+      },
+    ]);
+    expect(checkRuns).toBe(1);
+  });
+
+  it("stops before another check or fixer when the first fix cycle exceeds the token cap", async () => {
+    let checkRuns = 0;
+    const oneRepoConfig: PrePrCheckConfig = { repositories: [config.repositories[0]!] };
+    const codexOutput = JSON.stringify({
+      type: "turn.completed",
+      usage: { input_tokens: 10, cached_input_tokens: 2, output_tokens: 3 },
+    });
+    mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex", codexOutput);
+      if (artifact) return artifact;
+      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+        return commandResult(0, JSON.stringify(manifest));
       }
       if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
         return commandResult(0, "web-head");
@@ -285,11 +369,10 @@ describe("runPrePrChecksWithFixes", () => {
     let checkRuns = 0;
     const oneRepoConfig: PrePrCheckConfig = { repositories: [config.repositories[0]!] };
     mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex");
+      if (artifact) return artifact;
       if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
         return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "cat" && args[0] === "/tmp/pre-pr-checks-fix-stdout.txt") {
-        return commandResult(0, "");
       }
       if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
         return commandResult(0, "web-head");
@@ -327,6 +410,8 @@ describe("runPrePrChecksWithFixes", () => {
 
   it("fails after three unsuccessful fix cycles", async () => {
     mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex");
+      if (artifact) return artifact;
       if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
         return commandResult(0, JSON.stringify(manifest));
       }
@@ -348,6 +433,8 @@ describe("runPrePrChecksWithFixes", () => {
 
   it("caps fix cycles at a caller-supplied maxFixCycles", async () => {
     mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex");
+      if (artifact) return artifact;
       if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
         return commandResult(0, JSON.stringify(manifest));
       }
@@ -419,6 +506,25 @@ function commandResult(exitCode: number, stdout = "", stderr = "") {
     stdout: vi.fn().mockResolvedValue(stdout),
     stderr: vi.fn().mockResolvedValue(stderr),
   };
+}
+
+function phaseArtifactCommand(
+  cmd: unknown,
+  args: unknown,
+  provider: "claude" | "codex",
+  stdout = provider === "claude"
+    ? JSON.stringify({ type: "result", subtype: "success", is_error: false })
+    : JSON.stringify({ type: "turn.completed" }),
+  phaseExitCode = 0,
+) {
+  if (cmd !== "cat" || !Array.isArray(args) || typeof args[0] !== "string") return null;
+  const path = args[0];
+  if (!path.startsWith("/tmp/pre-pr-fix-")) return null;
+  if (path.endsWith("-stdout.txt")) return commandResult(0, stdout);
+  if (path.endsWith("-stderr.txt")) return commandResult(0, "");
+  if (path.endsWith("-exit-code")) return commandResult(0, String(phaseExitCode));
+  if (path.endsWith("-result.json")) return commandResult(0, "repair complete");
+  return null;
 }
 
 function isConfiguredCheck(cmd: unknown): boolean {

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -7,7 +7,12 @@ import {
   type WorkspaceRepo,
 } from "../sandbox/repo-workspace.js";
 import type { PrePrCheckConfig } from "./config.js";
-import type { PhaseUsage } from "../sandbox/agents/types.js";
+import type {
+  AgentProtocolResult,
+  CollectedPhaseArtifacts,
+  PhaseArtifactPaths,
+  PhaseUsage,
+} from "../sandbox/agents/types.js";
 import type { TokenPrice } from "../sandbox/agents/pricing.js";
 import {
   checkRunBudget,
@@ -36,6 +41,8 @@ export interface PrePrCheckRunResult {
   budgetFailure: RunBudgetFailure | null;
   failures: PrePrCheckFailure[];
   summary: string;
+  /** Runtime/protocol failure from a launched repair agent. */
+  agentFailure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
 }
 
 export interface PrePrFixBudgetContext {
@@ -96,10 +103,26 @@ export async function runPrePrChecksWithFixes(
 
   while (!result.passed && fixCycles < maxFixCycles) {
     fixCycles++;
-    const usage = await runFixAgent(sandbox, result, agentKind, model, signal);
-    fixCycleUsages.push(usage);
+    const fixer = await runFixAgent(
+      sandbox,
+      result,
+      agentKind,
+      model,
+      fixCycles,
+      signal,
+    );
+    fixCycleUsages.push(fixer.usage);
+    if (fixer.failure) {
+      return {
+        ...result,
+        fixCycles,
+        fixCycleUsages,
+        budgetFailure: null,
+        agentFailure: fixer.failure,
+      };
+    }
     if (budget && budgetState) {
-      budgetState = recordBudgetUsage(budgetState, usage, budget.price);
+      budgetState = recordBudgetUsage(budgetState, fixer.usage, budget.price);
       const check = checkRunBudget(budgetState, budget.limits);
       if (check.status !== "ok") {
         return { ...result, fixCycles, fixCycleUsages, budgetFailure: check };
@@ -201,37 +224,108 @@ async function runFixAgent(
   failedRun: PrePrCheckRunResult,
   agentKind: "claude" | "codex",
   model: string,
+  fixCycle: number,
   signal?: AbortSignal,
-): Promise<PhaseUsage | null> {
-  const { logger } = await import("../lib/logger.js");
+): Promise<{
+  usage: PhaseUsage | null;
+  failure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
+}> {
+  const { createAgentAdapter } = await import("../sandbox/agents/index.js");
+  const adapter = createAgentAdapter(agentKind);
+  const phase = `pre-pr-fix-${fixCycle}`;
+  const paths = adapter.artifactPaths(phase);
+  const script = adapter.buildPhaseScript({ phase, model, paths });
   await sandbox.writeFiles([
     {
-      path: "/tmp/pre-pr-checks-fix-prompt.txt",
+      path: paths.input,
       content: Buffer.from(buildFixPrompt(failedRun)),
     },
+    { path: paths.wrapper, content: Buffer.from(script) },
   ]);
-
-  const cli =
-    agentKind === "codex"
-      ? `codex exec --model "${model}" --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json -`
-      : `claude --print --output-format json --model '${model}' --dangerously-skip-permissions`;
-
-  await sandbox.runCommand({
-    cmd: "bash",
-    args: [
-      "-c",
-      `cd /vercel/sandbox || exit 1; if [ -f /tmp/agent-env.sh ]; then source /tmp/agent-env.sh; fi; cat /tmp/pre-pr-checks-fix-prompt.txt | ${cli} > /tmp/pre-pr-checks-fix-stdout.txt 2>/tmp/pre-pr-checks-fix-stderr.txt || true`,
-    ],
-    ...(signal ? { signal } : {}),
-  });
-
-  const fixOut = await sandbox.runCommand("cat", ["/tmp/pre-pr-checks-fix-stdout.txt"]);
-  const fixLog = (await fixOut.stdout()).trim();
-  if (fixLog) {
-    logger.info({ output: fixLog.slice(0, 500) }, "pre_pr_checks_fix_agent_output");
+  const chmod = await sandbox.runCommand("chmod", ["+x", paths.wrapper]);
+  if (chmod.exitCode !== 0) {
+    const { protocolFailure } = await import("../sandbox/agents/protocol.js");
+    const artifacts = await collectPhaseFromSandbox(sandbox, paths);
+    const failure = protocolFailure({
+      spec: adapter.cliSpec,
+      phase,
+      artifacts,
+      failureKind: "setup_failed",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      detail: "The Pre-PR repair wrapper could not be made executable.",
+    });
+    if (failure.ok) throw new Error("unreachable");
+    return { usage: null, failure };
   }
-  const { createAgentAdapter } = await import("../sandbox/agents/index.js");
-  return createAgentAdapter(agentKind).extractUsage(fixLog, null);
+  let launch: SandboxCommandResult;
+  try {
+    launch = await sandbox.runCommand({
+      cmd: "bash",
+      args: [paths.wrapper],
+      cwd: "/vercel/sandbox",
+      ...(signal ? { signal } : {}),
+    });
+  } catch (error) {
+    if (
+      error instanceof DOMException ||
+      (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
+    ) {
+      throw error;
+    }
+    const { protocolFailure } = await import("../sandbox/agents/protocol.js");
+    const failure = protocolFailure({
+      spec: adapter.cliSpec,
+      phase,
+      artifacts: { stdout: "", stderr: "", structuredOutput: null, exitCode: null },
+      failureKind: "provider_error",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      detail: "The Pre-PR repair process could not be launched.",
+    });
+    if (failure.ok) throw new Error("unreachable");
+    return { usage: null, failure };
+  }
+  if (launch.exitCode !== 0) {
+    const { commandProtocolFailure } = await import("../sandbox/agents/protocol.js");
+    return {
+      usage: null,
+      failure: await commandProtocolFailure({
+        spec: adapter.cliSpec,
+        phase,
+        result: launch,
+        failureKind: "cli_exit",
+        message: "The current agent phase could not be completed.",
+        detail: "The Pre-PR repair process could not be launched.",
+      }),
+    };
+  }
+  const artifacts = await collectPhaseFromSandbox(sandbox, paths);
+  const usage = adapter.extractUsage(artifacts.stdout, artifacts.structuredOutput);
+  const protocol = adapter.validateFreeformProtocol(artifacts, phase);
+  return protocol.ok ? { usage } : { usage, failure: protocol };
+}
+
+async function collectPhaseFromSandbox(
+  sandbox: SandboxSession,
+  paths: PhaseArtifactPaths,
+): Promise<CollectedPhaseArtifacts> {
+  const read = async (path: string): Promise<string> => {
+    const result = await sandbox.runCommand("cat", [path]);
+    return result.exitCode === 0 ? (await result.stdout()).trim() : "";
+  };
+  const stdout = await read(paths.stdout);
+  const stderr = await read(paths.stderr);
+  const structuredOutput = paths.structuredOutput
+    ? (await read(paths.structuredOutput)) || null
+    : null;
+  const exitCodeText = await read(paths.exitCode);
+  return {
+    stdout,
+    stderr,
+    structuredOutput,
+    exitCode: /^-?\d+$/.test(exitCodeText) ? Number(exitCodeText) : null,
+  };
 }
 
 function buildFixPrompt(failedRun: PrePrCheckRunResult): string {

--- a/apps/worker/src/sandbox/agents/claude.test.ts
+++ b/apps/worker/src/sandbox/agents/claude.test.ts
@@ -5,6 +5,20 @@ import { AGENT_SCHEMA, GENERIC_SCHEMA, RESEARCH_SCHEMA, REVIEW_SCHEMA } from "./
 
 const adapter = new ClaudeAgentAdapter();
 
+describe.each([
+  ["valid JSON events without a terminal result", '{"type":"assistant"}', "protocol_mismatch"],
+  ["non-JSON output", "not json", "invalid_json"],
+  ["empty output", "", "missing_result"],
+] as const)("ClaudeAgentAdapter.validateFreeformProtocol: %s", (_case, stdout, failureKind) => {
+  it(`reports ${failureKind}`, () => {
+    const result = adapter.validateFreeformProtocol(
+      { stdout, stderr: "", structuredOutput: null, exitCode: 0 },
+      "pre-pr-fix-1",
+    );
+    expect(result).toMatchObject({ ok: false, diagnostic: { failureKind } });
+  });
+});
+
 describe("ClaudeAgentAdapter.parseAgentOutput", () => {
   it("parses implemented result", () => {
     const raw = JSON.stringify({ result: "implemented", summary: "done" });

--- a/apps/worker/src/sandbox/agents/claude.test.ts
+++ b/apps/worker/src/sandbox/agents/claude.test.ts
@@ -401,6 +401,7 @@ describe("ClaudeAgentAdapter.artifactPaths", () => {
       input: "/tmp/research-requirements.md",
       stdout: "/tmp/research-stdout.txt",
       stderr: "/tmp/research-stderr.txt",
+      exitCode: "/tmp/research-exit-code",
       sentinel: "/tmp/research-done",
       structuredOutput: null,
     });
@@ -418,6 +419,7 @@ describe("ClaudeAgentAdapter.artifactPaths", () => {
       input: "/tmp/agent-block-1-requirements.md",
       stdout: "/tmp/agent-block-1-stdout.txt",
       stderr: "/tmp/agent-block-1-stderr.txt",
+      exitCode: "/tmp/agent-block-1-exit-code",
       sentinel: "/tmp/agent-block-1-done",
       structuredOutput: null,
     });

--- a/apps/worker/src/sandbox/agents/claude.ts
+++ b/apps/worker/src/sandbox/agents/claude.ts
@@ -249,11 +249,14 @@ touch ${paths.sentinel}
     const processFailure = artifactFailure(this.cliSpec, phase, artifacts, event);
     if (processFailure) return processFailure;
     if (!envelope) {
+      const records = parseClaudeRecords(artifacts.stdout);
       return protocolFailure({
         spec: this.cliSpec,
         phase,
         artifacts,
-        failureKind: artifacts.stdout.trim() ? "invalid_json" : "missing_result",
+        failureKind: artifacts.stdout.trim()
+          ? records.length > 0 ? "protocol_mismatch" : "invalid_json"
+          : "missing_result",
         category: "parsing",
         message: "The current agent phase returned an invalid structured response.",
         detail: "Claude did not emit a terminal result envelope.",
@@ -565,12 +568,7 @@ function extractClaudePayload(
     });
   }
 
-  const records = artifacts.stdout
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .flatMap((line) => {
-      try { return [JSON.parse(line)]; } catch { return []; }
-    });
+  const records = parseClaudeRecords(artifacts.stdout);
   const lastEvent = eventMetadata(records.at(-1));
   return protocolFailure({
     spec,
@@ -585,6 +583,15 @@ function extractClaudePayload(
       : "Claude output was not valid JSON.",
     includeStdoutTail: records.length === 0,
   });
+}
+
+function parseClaudeRecords(raw: string): unknown[] {
+  return raw
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .flatMap((line) => {
+      try { return [JSON.parse(line)]; } catch { return []; }
+    });
 }
 
 function findResultEnvelope(raw: string): Record<string, unknown> | null {

--- a/apps/worker/src/sandbox/agents/claude.ts
+++ b/apps/worker/src/sandbox/agents/claude.ts
@@ -1,8 +1,23 @@
 import type {
-  AgentAdapter, AgentOutput, ConfigureOpts, PhaseArtifactPaths, PhaseKind,
-  PhaseScriptOpts, PhaseUsage, ResearchResult, ReviewOutput, RunnableSandbox,
+  AgentAdapter, AgentOutput, AgentProtocolResult, CollectedPhaseArtifacts,
+  ConfigureOpts, PhaseArtifactPaths, PhaseKind, PhaseScriptOpts, PhaseUsage,
+  ResearchResult, ReviewOutput, RunnableSandbox,
 } from "./types.js";
-import { agentOutputSchema, foldResearchOutput, researchOutputSchema, reviewOutputSchema } from "./types.js";
+import {
+  AGENT_SCHEMA, agentOutputSchema, foldResearchOutput, RESEARCH_SCHEMA,
+  researchOutputSchema, REVIEW_SCHEMA, reviewOutputSchema,
+} from "./types.js";
+import {
+  AGENT_CLI_SPECS,
+  artifactFailure,
+  attachSchemaDiagnostic,
+  eventMetadata,
+  installAndVerifyCli,
+  protocolFailure,
+  requireProviderSetup,
+  runtimePreparationError,
+  validateStructuredValue,
+} from "./protocol.js";
 import {
   AGENT_ENV_CLAUDE_PATH,
   AGENT_ENV_PATH,
@@ -23,19 +38,24 @@ const ARTHUR_HOOK_EVENTS: ReadonlyArray<readonly [string, string]> = [
 
 export class ClaudeAgentAdapter implements AgentAdapter {
   readonly kind = "claude" as const;
+  readonly cliSpec = AGENT_CLI_SPECS.claude;
 
   async install(sandbox: RunnableSandbox): Promise<void> {
-    await sandbox.runCommand("npm", ["install", "-g", "@anthropic-ai/claude-code"]);
+    await installAndVerifyCli(sandbox, this.cliSpec);
     // Skip interactive onboarding
-    await sandbox.runCommand("bash", [
+    const onboarding = await sandbox.runCommand("bash", [
       "-c",
       `mkdir -p ~/.claude && echo '{"hasCompletedOnboarding":true}' > ~/.claude.json`,
     ]);
+    await requireProviderSetup(onboarding, this.cliSpec, "Claude onboarding setup");
   }
 
   async configure(sandbox: RunnableSandbox, opts: ConfigureOpts): Promise<void> {
     if (!opts.anthropicApiKey) {
-      throw new Error("ClaudeAgentAdapter.configure requires anthropicApiKey");
+      throw runtimePreparationError(
+        this.cliSpec,
+        "Claude authentication credentials were not configured.",
+      );
     }
     // Claude Code CLI accepts standard API keys (`sk-ant-api...`) via
     // ANTHROPIC_API_KEY and OAuth tokens (`sk-ant-oat...`, issued by
@@ -52,10 +72,11 @@ export class ClaudeAgentAdapter implements AgentAdapter {
       { path: AGENT_ENV_CLAUDE_PATH, content: Buffer.from(envLines.join("\n") + "\n") },
       { path: AGENT_ENV_PATH, content: Buffer.from(AGENT_ENV_SHIM) },
     ]);
-    await sandbox.runCommand("chmod", ["600", AGENT_ENV_CLAUDE_PATH]);
+    const secureEnv = await sandbox.runCommand("chmod", ["600", AGENT_ENV_CLAUDE_PATH]);
+    await requireProviderSetup(secureEnv, this.cliSpec, "Claude credential setup");
 
     // Skills: installer writes to ~/.claude/skills and ~/.agents/skills directly.
-    await installSkillsToAgentsDir(sandbox);
+    await installSkillsToAgentsDir(sandbox, this.cliSpec);
 
     // Arthur tracer (no-op without config)
     if (opts.arthur) {
@@ -65,7 +86,7 @@ export class ClaudeAgentAdapter implements AgentAdapter {
 
   async setCommitGuard(sandbox: RunnableSandbox, enabled: boolean): Promise<void> {
     // 1) Drop the guard script (idempotent)
-    await sandbox.runCommand("bash", [
+    const guardScript = await sandbox.runCommand("bash", [
       "-c",
       [
         "mkdir -p ~/.claude",
@@ -85,6 +106,7 @@ export class ClaudeAgentAdapter implements AgentAdapter {
         "chmod +x ~/.claude/commit-guard.sh",
       ].join("\n"),
     ]);
+    await requireProviderSetup(guardScript, this.cliSpec, "Claude commit guard setup");
 
     // 2) Toggle the Stop hook entry via merge-aware settings.json writer
     await this.mergeSettings(sandbox, { commitGuard: enabled ? "enable" : "disable" });
@@ -101,7 +123,7 @@ export class ClaudeAgentAdapter implements AgentAdapter {
     return `#!/bin/bash
 
 # --- Cleanup stale files from prior runs ---
-rm -f ${paths.sentinel} ${paths.stdout} ${paths.stderr}
+rm -f ${paths.sentinel} ${paths.stdout} ${paths.stderr} ${paths.exitCode}
 
 # --- Source auth env vars ---
 [ -f /tmp/agent-env.sh ] && source /tmp/agent-env.sh
@@ -109,7 +131,9 @@ rm -f ${paths.sentinel} ${paths.stdout} ${paths.stderr}
 # --- Phase: ${safePhase} ---
 cat ${paths.input} | claude \\
   ${claudeFlags} \\
-  > ${paths.stdout} 2>${paths.stderr}; echo $? > /tmp/${safePhase}-exit-code || true
+  > ${paths.stdout} 2>${paths.stderr}
+PHASE_EXIT_CODE=$?
+echo "$PHASE_EXIT_CODE" > ${paths.exitCode}
 
 # --- Cleanup ---
 cd /vercel/sandbox
@@ -128,9 +152,139 @@ touch ${paths.sentinel}
       input: `/tmp/${p}-requirements.md`,
       stdout: `/tmp/${p}-stdout.txt`,
       stderr: `/tmp/${p}-stderr.txt`,
+      exitCode: `/tmp/${p}-exit-code`,
       sentinel: `/tmp/${p}-done`,
       structuredOutput: null,
     };
+  }
+
+  parseAgentOutputProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<AgentOutput> {
+    const extracted = attachSchemaDiagnostic(
+      extractClaudePayload(this.cliSpec, artifacts, phase),
+      "agent-output",
+      AGENT_SCHEMA,
+    );
+    if (!extracted.ok) return extracted;
+    return validateStructuredValue({
+      spec: this.cliSpec,
+      phase,
+      artifacts,
+      value: extracted.value,
+      schema: agentOutputSchema,
+      schemaIdentity: "agent-output",
+      schemaSource: AGENT_SCHEMA,
+      event: extracted.event,
+    });
+  }
+
+  parseReviewOutputProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<ReviewOutput> {
+    const extracted = attachSchemaDiagnostic(
+      extractClaudePayload(this.cliSpec, artifacts, phase),
+      "review-output",
+      REVIEW_SCHEMA,
+    );
+    if (!extracted.ok) return extracted;
+    return validateStructuredValue({
+      spec: this.cliSpec,
+      phase,
+      artifacts,
+      value: extracted.value,
+      schema: reviewOutputSchema,
+      schemaIdentity: "review-output",
+      schemaSource: REVIEW_SCHEMA,
+      event: extracted.event,
+    });
+  }
+
+  parseResearchProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<ResearchResult> {
+    const extracted = attachSchemaDiagnostic(
+      extractClaudePayload(this.cliSpec, artifacts, phase),
+      "research-output",
+      RESEARCH_SCHEMA,
+    );
+    if (!extracted.ok) return extracted;
+    const validated = validateStructuredValue({
+      spec: this.cliSpec,
+      phase,
+      artifacts,
+      value: extracted.value,
+      schema: researchOutputSchema,
+      schemaIdentity: "research-output",
+      schemaSource: RESEARCH_SCHEMA,
+      event: extracted.event,
+    });
+    return validated.ok
+      ? { ok: true, value: foldResearchOutput(validated.value) }
+      : validated;
+  }
+
+  parseStructuredObjectProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+    schemaIdentity: string,
+    schema: string,
+  ): AgentProtocolResult<unknown> {
+    return attachSchemaDiagnostic(
+      extractClaudePayload(this.cliSpec, artifacts, phase),
+      schemaIdentity,
+      schema,
+    );
+  }
+
+  validateFreeformProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<void> {
+    const envelope = findResultEnvelope(artifacts.stdout);
+    const event = eventMetadata(envelope);
+    const processFailure = artifactFailure(this.cliSpec, phase, artifacts, event);
+    if (processFailure) return processFailure;
+    if (!envelope) {
+      return protocolFailure({
+        spec: this.cliSpec,
+        phase,
+        artifacts,
+        failureKind: artifacts.stdout.trim() ? "invalid_json" : "missing_result",
+        category: "parsing",
+        message: "The current agent phase returned an invalid structured response.",
+        detail: "Claude did not emit a terminal result envelope.",
+        includeStdoutTail: true,
+      });
+    }
+    if (envelope.is_error === true || envelope.subtype === "error") {
+      return protocolFailure({
+        spec: this.cliSpec,
+        phase,
+        artifacts,
+        failureKind: "provider_error",
+        category: "provider",
+        message: "The current agent phase could not be completed.",
+        event,
+        detail: "Claude emitted an error result envelope.",
+      });
+    }
+    if (envelope.subtype !== "success") {
+      return protocolFailure({
+        spec: this.cliSpec,
+        phase,
+        artifacts,
+        failureKind: "protocol_mismatch",
+        category: "parsing",
+        message: "The current agent phase returned an invalid structured response.",
+        event,
+        detail: "Claude emitted an unrecognized terminal result subtype.",
+      });
+    }
+    return { ok: true, value: undefined };
   }
 
   parseAgentOutput(raw: string, _structured: string | null): AgentOutput {
@@ -329,7 +483,8 @@ touch ${paths.sentinel}
       }
       fs.writeFileSync(settingsPath, JSON.stringify(s, null, 2));
     `;
-    await sandbox.runCommand("node", ["--input-type=module", "-e", script]);
+    const merge = await sandbox.runCommand("node", ["--input-type=module", "-e", script]);
+    await requireProviderSetup(merge, this.cliSpec, "Claude settings setup");
   }
 }
 
@@ -342,6 +497,94 @@ function shellQuote(val: string): string {
 /** Collapse an arbitrary phase label to a shell/file-safe token ([a-z0-9-]). */
 function sanitizePhase(phase: string): string {
   return phase.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+}
+
+function extractClaudePayload(
+  spec: typeof AGENT_CLI_SPECS.claude,
+  artifacts: CollectedPhaseArtifacts,
+  phase: string,
+): AgentProtocolResult<unknown> {
+  const envelope = findResultEnvelope(artifacts.stdout);
+  const event = eventMetadata(envelope);
+  const processFailure = artifactFailure(spec, phase, artifacts, event);
+  if (processFailure) return processFailure;
+
+  if (envelope) {
+    if (envelope.is_error === true || envelope.subtype === "error") {
+      return protocolFailure({
+        spec,
+        phase,
+        artifacts,
+        failureKind: "provider_error",
+        category: "provider",
+        message: "The current agent phase could not be completed.",
+        event,
+        detail: "Claude emitted an error result envelope.",
+      });
+    }
+    if (envelope.subtype !== "success") {
+      return protocolFailure({
+        spec,
+        phase,
+        artifacts,
+        failureKind: "protocol_mismatch",
+        category: "parsing",
+        message: "The current agent phase returned an invalid structured response.",
+        event,
+        detail: "Claude emitted an unrecognized terminal result subtype.",
+      });
+    }
+    if (envelope.structured_output != null) {
+      return { ok: true, value: envelope.structured_output, event };
+    }
+    if (typeof envelope.result === "string") {
+      try {
+        return { ok: true, value: JSON.parse(envelope.result), event };
+      } catch {
+        return protocolFailure({
+          spec,
+          phase,
+          artifacts,
+          failureKind: "protocol_mismatch",
+          category: "parsing",
+          message: "The current agent phase returned an invalid structured response.",
+          event,
+          detail: "Claude emitted a result envelope without structured JSON.",
+        });
+      }
+    }
+    return protocolFailure({
+      spec,
+      phase,
+      artifacts,
+      failureKind: "missing_result",
+      category: "parsing",
+      message: "The current agent phase returned an invalid structured response.",
+      event,
+      detail: "Claude emitted a terminal envelope without a result payload.",
+    });
+  }
+
+  const records = artifacts.stdout
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .flatMap((line) => {
+      try { return [JSON.parse(line)]; } catch { return []; }
+    });
+  const lastEvent = eventMetadata(records.at(-1));
+  return protocolFailure({
+    spec,
+    phase,
+    artifacts,
+    failureKind: records.length > 0 ? "protocol_mismatch" : "invalid_json",
+    category: "parsing",
+    message: "The current agent phase returned an invalid structured response.",
+    event: lastEvent,
+    detail: records.length > 0
+      ? "Claude emitted JSON events without a terminal result."
+      : "Claude output was not valid JSON.",
+    includeStdoutTail: records.length === 0,
+  });
 }
 
 function findResultEnvelope(raw: string): Record<string, unknown> | null {

--- a/apps/worker/src/sandbox/agents/codex.test.ts
+++ b/apps/worker/src/sandbox/agents/codex.test.ts
@@ -216,7 +216,9 @@ describe("CodexAgentAdapter.buildPhaseScript", () => {
   it("removes stale phase artifacts before invoking codex", () => {
     const paths = adapter.artifactPaths("impl");
     const s = adapter.buildPhaseScript({ phase: "impl", model: "gpt-5-codex", paths });
-    expect(s).toContain(`rm -f ${paths.sentinel} ${paths.stdout} ${paths.stderr} ${paths.structuredOutput}`);
+    expect(s).toContain(
+      `rm -f ${paths.sentinel} ${paths.stdout} ${paths.stderr} ${paths.exitCode} ${paths.structuredOutput}`,
+    );
     expect(s).toContain(`touch ${paths.sentinel}`);
   });
 

--- a/apps/worker/src/sandbox/agents/codex.ts
+++ b/apps/worker/src/sandbox/agents/codex.ts
@@ -1,8 +1,23 @@
 import type {
-  AgentAdapter, AgentOutput, ConfigureOpts, PhaseArtifactPaths, PhaseKind,
-  PhaseScriptOpts, PhaseUsage, ResearchResult, ReviewOutput, RunnableSandbox,
+  AgentAdapter, AgentOutput, AgentProtocolResult, CollectedPhaseArtifacts,
+  ConfigureOpts, PhaseArtifactPaths, PhaseKind, PhaseScriptOpts, PhaseUsage,
+  ResearchResult, ReviewOutput, RunnableSandbox,
 } from "./types.js";
-import { agentOutputSchema, foldResearchOutput, researchOutputSchema, reviewOutputSchema } from "./types.js";
+import {
+  AGENT_SCHEMA, agentOutputSchema, foldResearchOutput, RESEARCH_SCHEMA,
+  researchOutputSchema, REVIEW_SCHEMA, reviewOutputSchema,
+} from "./types.js";
+import {
+  AGENT_CLI_SPECS,
+  artifactFailure,
+  attachSchemaDiagnostic,
+  eventMetadata,
+  installAndVerifyCli,
+  protocolFailure,
+  requireProviderSetup,
+  runtimePreparationError,
+  validateStructuredValue,
+} from "./protocol.js";
 import {
   AGENT_ENV_CODEX_PATH,
   AGENT_ENV_PATH,
@@ -20,16 +35,32 @@ const ARTHUR_HOOK_EVENTS: ReadonlyArray<readonly [string, string]> = [
   ["Stop", "stop"],
 ];
 
+const CODEX_PROTOCOL_EVENTS = new Set([
+  "thread.started",
+  "turn.started",
+  "item.started",
+  "item.updated",
+  "item.completed",
+  "turn.completed",
+  "turn.failed",
+  "error",
+  "phase.duration",
+]);
+
 export class CodexAgentAdapter implements AgentAdapter {
   readonly kind = "codex" as const;
+  readonly cliSpec = AGENT_CLI_SPECS.codex;
 
   async install(sandbox: RunnableSandbox): Promise<void> {
-    await sandbox.runCommand("npm", ["install", "-g", "@openai/codex"]);
+    await installAndVerifyCli(sandbox, this.cliSpec);
   }
 
   async configure(sandbox: RunnableSandbox, opts: ConfigureOpts): Promise<void> {
     if (!opts.codexApiKey && !opts.codexChatGptOauthToken) {
-      throw new Error("CodexAgentAdapter.configure requires codexApiKey or codexChatGptOauthToken");
+      throw runtimePreparationError(
+        this.cliSpec,
+        "Codex authentication credentials were not configured.",
+      );
     }
 
     // 1) auth env file. Codex CLI auto-reads OPENAI_API_KEY when no auth.json
@@ -48,7 +79,8 @@ export class CodexAgentAdapter implements AgentAdapter {
       { path: AGENT_ENV_CODEX_PATH, content: Buffer.from(envLines.join("\n") + "\n") },
       { path: AGENT_ENV_PATH, content: Buffer.from(AGENT_ENV_SHIM) },
     ]);
-    await sandbox.runCommand("chmod", ["600", AGENT_ENV_CODEX_PATH]);
+    const secureEnv = await sandbox.runCommand("chmod", ["600", AGENT_ENV_CODEX_PATH]);
+    await requireProviderSetup(secureEnv, this.cliSpec, "Codex credential setup");
 
     // 2) ~/.codex/config.toml — model + sandbox profile + hooks feature flag
     // (codex_hooks is gated; without it ~/.codex/hooks.json is ignored).
@@ -65,20 +97,25 @@ export class CodexAgentAdapter implements AgentAdapter {
       `codex_hooks = true`,
     ].join("\n") + "\n";
     await sandbox.writeFiles([{ path: "/tmp/config.toml", content: Buffer.from(configToml) }]);
-    await sandbox.runCommand("bash", ["-c", "mkdir -p $HOME/.codex && mv /tmp/config.toml $HOME/.codex/config.toml"]);
+    const configureCli = await sandbox.runCommand("bash", [
+      "-c",
+      "mkdir -p $HOME/.codex && mv /tmp/config.toml $HOME/.codex/config.toml",
+    ]);
+    await requireProviderSetup(configureCli, this.cliSpec, "Codex configuration setup");
 
     // 3) Persist API-key auth to ~/.codex/auth.json (OAuth token path uses the
     // ChatGPT-cached auth.json shape directly; for now only API-key login is
     // automated — OAuth tokens are exported via env above).
     if (opts.codexApiKey) {
-      await sandbox.runCommand("bash", [
+      const login = await sandbox.runCommand("bash", [
         "-c",
         `[ -f /tmp/agent-env.sh ] && source /tmp/agent-env.sh; printenv OPENAI_API_KEY | codex login --with-api-key`,
       ]);
+      await requireProviderSetup(login, this.cliSpec, "Codex API-key login");
     }
 
     // 4) skills (~/.agents/skills via `--agent codex`)
-    await installSkillsToAgentsDir(sandbox);
+    await installSkillsToAgentsDir(sandbox, this.cliSpec);
 
     // 5) commit-guard script (idempotent)
     await this.writeCommitGuardScript(sandbox);
@@ -88,10 +125,11 @@ export class CodexAgentAdapter implements AgentAdapter {
     // `.gitignore`, commits only that, and the implementation never runs —
     // observed on AWT-641 ($14 of impl-phase tokens, PR diff = .gitignore).
     // .git/info/exclude is local to this clone and never pushed.
-    await sandbox.runCommand("bash", [
+    const exclude = await sandbox.runCommand("bash", [
       "-c",
       `mkdir -p /vercel/sandbox/.git/info && grep -qxF '.codex/' /vercel/sandbox/.git/info/exclude 2>/dev/null || echo '.codex/' >> /vercel/sandbox/.git/info/exclude`,
     ]);
+    await requireProviderSetup(exclude, this.cliSpec, "Codex workspace exclusion setup");
 
     // 7) Arthur tracer. Re-uses the Claude Code tracer; Codex traces will be
     // labeled as "claude-code" in Arthur until a dedicated Codex tracer ships.
@@ -134,7 +172,7 @@ export class CodexAgentAdapter implements AgentAdapter {
     return `#!/bin/bash
 
 # --- Cleanup stale files ---
-rm -f ${paths.sentinel} ${paths.stdout} ${paths.stderr} ${paths.structuredOutput}
+rm -f ${paths.sentinel} ${paths.stdout} ${paths.stderr} ${paths.exitCode} ${paths.structuredOutput}
 
 # --- Source auth env vars ---
 [ -f /tmp/agent-env.sh ] && source /tmp/agent-env.sh
@@ -148,7 +186,9 @@ START_MS=$(date +%s%3N)
 cat ${paths.input} | codex exec \\
   ${flags.join(" \\\n  ")} \\
   - \\
-  > ${paths.stdout} 2> ${paths.stderr}; echo $? > /tmp/${safePhase}-exit-code || true
+  > ${paths.stdout} 2> ${paths.stderr}
+PHASE_EXIT_CODE=$?
+echo "$PHASE_EXIT_CODE" > ${paths.exitCode}
 END_MS=$(date +%s%3N)
 echo "{\\"type\\":\\"phase.duration\\",\\"duration_ms\\":$((END_MS - START_MS))}" >> ${paths.stdout}
 
@@ -168,9 +208,140 @@ touch ${paths.sentinel}
       input: `/tmp/${p}-requirements.md`,
       stdout: `/tmp/${p}-stdout.txt`,
       stderr: `/tmp/${p}-stderr.txt`,
+      exitCode: `/tmp/${p}-exit-code`,
       sentinel: `/tmp/${p}-done`,
       structuredOutput: `/tmp/${p}-result.json`,
     };
+  }
+
+  parseAgentOutputProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<AgentOutput> {
+    const extracted = attachSchemaDiagnostic(
+      extractCodexPayload(this.cliSpec, artifacts, phase),
+      "agent-output",
+      AGENT_SCHEMA,
+    );
+    if (!extracted.ok) return extracted;
+    return validateStructuredValue({
+      spec: this.cliSpec,
+      phase,
+      artifacts,
+      value: extracted.value,
+      schema: agentOutputSchema,
+      schemaIdentity: "agent-output",
+      schemaSource: AGENT_SCHEMA,
+      event: extracted.event,
+    });
+  }
+
+  parseReviewOutputProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<ReviewOutput> {
+    const extracted = attachSchemaDiagnostic(
+      extractCodexPayload(this.cliSpec, artifacts, phase),
+      "review-output",
+      REVIEW_SCHEMA,
+    );
+    if (!extracted.ok) return extracted;
+    return validateStructuredValue({
+      spec: this.cliSpec,
+      phase,
+      artifacts,
+      value: extracted.value,
+      schema: reviewOutputSchema,
+      schemaIdentity: "review-output",
+      schemaSource: REVIEW_SCHEMA,
+      event: extracted.event,
+    });
+  }
+
+  parseResearchProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<ResearchResult> {
+    const extracted = attachSchemaDiagnostic(
+      extractCodexPayload(this.cliSpec, artifacts, phase),
+      "research-output",
+      RESEARCH_SCHEMA,
+    );
+    if (!extracted.ok) return extracted;
+    const validated = validateStructuredValue({
+      spec: this.cliSpec,
+      phase,
+      artifacts,
+      value: extracted.value,
+      schema: researchOutputSchema,
+      schemaIdentity: "research-output",
+      schemaSource: RESEARCH_SCHEMA,
+      event: extracted.event,
+    });
+    return validated.ok
+      ? { ok: true, value: foldResearchOutput(validated.value) }
+      : validated;
+  }
+
+  parseStructuredObjectProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+    schemaIdentity: string,
+    schema: string,
+  ): AgentProtocolResult<unknown> {
+    return attachSchemaDiagnostic(
+      extractCodexPayload(this.cliSpec, artifacts, phase),
+      schemaIdentity,
+      schema,
+    );
+  }
+
+  validateFreeformProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<void> {
+    const records = parseCodexRecords(artifacts.stdout);
+    const terminal = findCodexTerminal(records.events);
+    const event = eventMetadata(terminal ?? records.events.at(-1));
+    const processFailure = artifactFailure(this.cliSpec, phase, artifacts, event);
+    if (processFailure) return processFailure;
+    const providerError = records.events.find((record) =>
+      record?.type === "error" || record?.type === "turn.failed",
+    );
+    if (providerError) {
+      return protocolFailure({
+        spec: this.cliSpec,
+        phase,
+        artifacts,
+        failureKind: "provider_error",
+        category: "provider",
+        message: "The current agent phase could not be completed.",
+        event: eventMetadata(providerError),
+        detail: "Codex emitted a provider error event.",
+      });
+    }
+    const shapeFailure = codexRecordShapeFailure(
+      this.cliSpec,
+      phase,
+      artifacts,
+      records,
+      event,
+    );
+    if (shapeFailure) return shapeFailure;
+    if (!terminal) {
+      return protocolFailure({
+        spec: this.cliSpec,
+        phase,
+        artifacts,
+        failureKind: records.events.length > 0 ? "missing_result" : "invalid_json",
+        category: "parsing",
+        message: "The current agent phase returned an invalid structured response.",
+        event,
+        detail: "Codex did not emit a turn.completed event.",
+        includeStdoutTail: records.events.length === 0,
+      });
+    }
+    return { ok: true, value: undefined };
   }
 
   parseAgentOutput(raw: string, structured: string | null): AgentOutput {
@@ -295,7 +466,7 @@ touch ${paths.sentinel}
     //   - to FORCE Codex to keep working: print {"decision":"block","reason":"..."}
     //     to stdout, exit 0. (The "continue:false / stopReason" shape stops the
     //     hook itself, NOT Codex — wrong for this use case.)
-    await sandbox.runCommand("bash", [
+    const guardScript = await sandbox.runCommand("bash", [
       "-c",
       [
         "mkdir -p ~/.codex/hooks",
@@ -316,6 +487,7 @@ touch ${paths.sentinel}
         "chmod +x ~/.codex/hooks/commit-guard.sh",
       ].join("\n"),
     ]);
+    await requireProviderSetup(guardScript, this.cliSpec, "Codex commit guard setup");
   }
 
   private async mergeHooks(
@@ -360,7 +532,8 @@ touch ${paths.sentinel}
       }
       fs.writeFileSync(cfgPath, JSON.stringify(s, null, 2));
     `;
-    await sandbox.runCommand("node", ["--input-type=module", "-e", script]);
+    const merge = await sandbox.runCommand("node", ["--input-type=module", "-e", script]);
+    await requireProviderSetup(merge, this.cliSpec, "Codex hooks setup");
   }
 
   private async installArthurTracer(
@@ -411,6 +584,164 @@ function shellQuote(val: string): string {
 /** Collapse an arbitrary phase label to a shell/file-safe token ([a-z0-9-]). */
 function sanitizePhase(phase: string): string {
   return phase.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+}
+
+function extractCodexPayload(
+  spec: typeof AGENT_CLI_SPECS.codex,
+  artifacts: CollectedPhaseArtifacts,
+  phase: string,
+): AgentProtocolResult<unknown> {
+  const records = parseCodexRecords(artifacts.stdout);
+  const terminal = findCodexTerminal(records.events);
+  const event = eventMetadata(terminal ?? records.events.at(-1));
+  const processFailure = artifactFailure(spec, phase, artifacts, event);
+  if (processFailure) return processFailure;
+
+  const providerError = records.events.find((record) =>
+    record?.type === "error" || record?.type === "turn.failed",
+  );
+  if (providerError) {
+    return protocolFailure({
+      spec,
+      phase,
+      artifacts,
+      failureKind: "provider_error",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      event: eventMetadata(providerError),
+      detail: "Codex emitted a provider error event.",
+    });
+  }
+  const shapeFailure = codexRecordShapeFailure(spec, phase, artifacts, records, event);
+  if (shapeFailure) return shapeFailure;
+  if (!terminal) {
+    return protocolFailure({
+      spec,
+      phase,
+      artifacts,
+      failureKind: records.events.length > 0 ? "missing_result" : "invalid_json",
+      category: "parsing",
+      message: "The current agent phase returned an invalid structured response.",
+      event,
+      detail: "Codex did not emit a turn.completed event.",
+      includeStdoutTail: records.events.length === 0,
+    });
+  }
+
+  if (artifacts.structuredOutput !== null) {
+    try {
+      return { ok: true, value: JSON.parse(artifacts.structuredOutput), event };
+    } catch {
+      return protocolFailure({
+        spec,
+        phase,
+        artifacts,
+        failureKind: "invalid_json",
+        category: "parsing",
+        message: "The current agent phase returned an invalid structured response.",
+        event,
+        detail: "Codex wrote an invalid structured-output JSON file.",
+      });
+    }
+  }
+
+  const message = unwrapLastAgentMessage(artifacts.stdout);
+  if (message) {
+    try {
+      return { ok: true, value: JSON.parse(message), event };
+    } catch {
+      return protocolFailure({
+        spec,
+        phase,
+        artifacts,
+        failureKind: "protocol_mismatch",
+        category: "parsing",
+        message: "The current agent phase returned an invalid structured response.",
+        event,
+        detail: "Codex emitted a non-JSON final agent message for a structured phase.",
+      });
+    }
+  }
+  return protocolFailure({
+    spec,
+    phase,
+    artifacts,
+    failureKind: "missing_result",
+    category: "parsing",
+    message: "The current agent phase returned an invalid structured response.",
+    event,
+    detail: "Codex completed without a structured-output file or final agent message.",
+  });
+}
+
+function parseCodexRecords(raw: string): {
+  events: Array<Record<string, unknown>>;
+  malformedLines: number;
+} {
+  const events: Array<Record<string, unknown>> = [];
+  let malformedLines = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        events.push(parsed as Record<string, unknown>);
+      } else {
+        malformedLines++;
+      }
+    } catch {
+      malformedLines++;
+    }
+  }
+  return { events, malformedLines };
+}
+
+function codexRecordShapeFailure(
+  spec: typeof AGENT_CLI_SPECS.codex,
+  phase: string,
+  artifacts: CollectedPhaseArtifacts,
+  records: ReturnType<typeof parseCodexRecords>,
+  event: ReturnType<typeof eventMetadata>,
+): AgentProtocolResult<never> | null {
+  if (records.malformedLines > 0) {
+    return protocolFailure({
+      spec,
+      phase,
+      artifacts,
+      failureKind: "invalid_json",
+      category: "parsing",
+      message: "The current agent phase returned an invalid structured response.",
+      event,
+      detail: "Codex emitted malformed JSONL output.",
+      includeStdoutTail: true,
+    });
+  }
+  const unknown = records.events.find((record) =>
+    typeof record.type !== "string" || !CODEX_PROTOCOL_EVENTS.has(record.type),
+  );
+  if (unknown) {
+    return protocolFailure({
+      spec,
+      phase,
+      artifacts,
+      failureKind: "protocol_mismatch",
+      category: "parsing",
+      message: "The current agent phase returned an invalid structured response.",
+      event: eventMetadata(unknown),
+      detail: "Codex emitted an unrecognized protocol event.",
+    });
+  }
+  return null;
+}
+
+function findCodexTerminal(
+  events: Array<Record<string, unknown>>,
+): Record<string, unknown> | undefined {
+  for (let index = events.length - 1; index >= 0; index--) {
+    const event = events[index];
+    if (event?.type === "turn.completed") return event;
+  }
+  return undefined;
 }
 
 function numOr0(x: unknown): number { return typeof x === "number" ? x : 0; }

--- a/apps/worker/src/sandbox/agents/codex.ts
+++ b/apps/worker/src/sandbox/agents/codex.ts
@@ -300,47 +300,8 @@ touch ${paths.sentinel}
     artifacts: CollectedPhaseArtifacts,
     phase: string,
   ): AgentProtocolResult<void> {
-    const records = parseCodexRecords(artifacts.stdout);
-    const terminal = findCodexTerminal(records.events);
-    const event = eventMetadata(terminal ?? records.events.at(-1));
-    const processFailure = artifactFailure(this.cliSpec, phase, artifacts, event);
-    if (processFailure) return processFailure;
-    const providerError = records.events.find((record) =>
-      record?.type === "error" || record?.type === "turn.failed",
-    );
-    if (providerError) {
-      return protocolFailure({
-        spec: this.cliSpec,
-        phase,
-        artifacts,
-        failureKind: "provider_error",
-        category: "provider",
-        message: "The current agent phase could not be completed.",
-        event: eventMetadata(providerError),
-        detail: "Codex emitted a provider error event.",
-      });
-    }
-    const shapeFailure = codexRecordShapeFailure(
-      this.cliSpec,
-      phase,
-      artifacts,
-      records,
-      event,
-    );
-    if (shapeFailure) return shapeFailure;
-    if (!terminal) {
-      return protocolFailure({
-        spec: this.cliSpec,
-        phase,
-        artifacts,
-        failureKind: records.events.length > 0 ? "missing_result" : "invalid_json",
-        category: "parsing",
-        message: "The current agent phase returned an invalid structured response.",
-        event,
-        detail: "Codex did not emit a turn.completed event.",
-        includeStdoutTail: records.events.length === 0,
-      });
-    }
+    const preamble = codexProtocolPreamble(this.cliSpec, phase, artifacts);
+    if (!preamble.ok) return preamble;
     return { ok: true, value: undefined };
   }
 
@@ -586,11 +547,15 @@ function sanitizePhase(phase: string): string {
   return phase.toLowerCase().replace(/[^a-z0-9-]/g, "-");
 }
 
-function extractCodexPayload(
+function codexProtocolPreamble(
   spec: typeof AGENT_CLI_SPECS.codex,
-  artifacts: CollectedPhaseArtifacts,
   phase: string,
-): AgentProtocolResult<unknown> {
+  artifacts: CollectedPhaseArtifacts,
+): AgentProtocolResult<{
+  records: ReturnType<typeof parseCodexRecords>;
+  terminal: Record<string, unknown>;
+  event: ReturnType<typeof eventMetadata>;
+}> {
   const records = parseCodexRecords(artifacts.stdout);
   const terminal = findCodexTerminal(records.events);
   const event = eventMetadata(terminal ?? records.events.at(-1));
@@ -627,6 +592,17 @@ function extractCodexPayload(
       includeStdoutTail: records.events.length === 0,
     });
   }
+  return { ok: true, value: { records, terminal, event } };
+}
+
+function extractCodexPayload(
+  spec: typeof AGENT_CLI_SPECS.codex,
+  artifacts: CollectedPhaseArtifacts,
+  phase: string,
+): AgentProtocolResult<unknown> {
+  const preamble = codexProtocolPreamble(spec, phase, artifacts);
+  if (!preamble.ok) return preamble;
+  const { event } = preamble.value;
 
   if (artifacts.structuredOutput !== null) {
     try {

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/freeform-success.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/freeform-success.json
@@ -2,9 +2,9 @@
   "package": "@anthropic-ai/claude-code",
   "version": "2.1.216",
   "protocol": "claude-json-2.1.216",
-  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "provenance": "captured locally with authenticated @anthropic-ai/claude-code@2.1.216 on 2026-07-23 during a disposable-repository repair; volatile fields and response content normalized",
   "artifacts": {
-    "stdout": "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"fixture complete\",\"total_cost_usd\":0.001,\"usage\":{\"input_tokens\":7,\"output_tokens\":2}}",
+    "stdout": "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"[sanitized repair response]\",\"total_cost_usd\":0.0398169,\"duration_ms\":6964,\"duration_api_ms\":7814,\"num_turns\":3,\"usage\":{\"input_tokens\":5,\"cache_creation_input_tokens\":5343,\"cache_read_input_tokens\":10133,\"output_tokens\":271}}",
     "stderr": "",
     "structuredOutput": null,
     "exitCode": 0

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/freeform-success.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/freeform-success.json
@@ -1,0 +1,12 @@
+{
+  "package": "@anthropic-ai/claude-code",
+  "version": "2.1.216",
+  "protocol": "claude-json-2.1.216",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"fixture complete\",\"total_cost_usd\":0.001,\"usage\":{\"input_tokens\":7,\"output_tokens\":2}}",
+    "stderr": "",
+    "structuredOutput": null,
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/malformed-json.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/malformed-json.json
@@ -1,0 +1,12 @@
+{
+  "package": "@anthropic-ai/claude-code",
+  "version": "2.1.216",
+  "protocol": "claude-json-2.1.216",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{malformed",
+    "stderr": "",
+    "structuredOutput": null,
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/missing-terminal.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/missing-terminal.json
@@ -1,0 +1,12 @@
+{
+  "package": "@anthropic-ai/claude-code",
+  "version": "2.1.216",
+  "protocol": "claude-json-2.1.216",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"assistant\",\"message\":{\"id\":\"normalized\"}}",
+    "stderr": "",
+    "structuredOutput": null,
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/nonzero-exit.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/nonzero-exit.json
@@ -1,0 +1,12 @@
+{
+  "package": "@anthropic-ai/claude-code",
+  "version": "2.1.216",
+  "protocol": "claude-json-2.1.216",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "",
+    "stderr": "process stopped",
+    "structuredOutput": null,
+    "exitCode": 1
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/provider-error.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/provider-error.json
@@ -1,0 +1,12 @@
+{
+  "package": "@anthropic-ai/claude-code",
+  "version": "2.1.216",
+  "protocol": "claude-json-2.1.216",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"errors\":[\"provider unavailable\"]}",
+    "stderr": "request failed",
+    "structuredOutput": null,
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/schema-mismatch.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/schema-mismatch.json
@@ -1,0 +1,12 @@
+{
+  "package": "@anthropic-ai/claude-code",
+  "version": "2.1.216",
+  "protocol": "claude-json-2.1.216",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"structured_output\":{\"result\":\"unexpected\"},\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}",
+    "stderr": "",
+    "structuredOutput": null,
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/structured-success.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/structured-success.json
@@ -2,9 +2,9 @@
   "package": "@anthropic-ai/claude-code",
   "version": "2.1.216",
   "protocol": "claude-json-2.1.216",
-  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "provenance": "captured locally with authenticated @anthropic-ai/claude-code@2.1.216 on 2026-07-23; volatile fields and response content normalized",
   "artifacts": {
-    "stdout": "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"structured_output\":{\"result\":\"implemented\",\"summary\":\"sanitized fixture\",\"questions\":null,\"suggestedAnswers\":null,\"error\":null},\"total_cost_usd\":0.001,\"duration_ms\":200,\"duration_api_ms\":150,\"num_turns\":1,\"usage\":{\"input_tokens\":11,\"cache_creation_input_tokens\":2,\"cache_read_input_tokens\":3,\"output_tokens\":5}}",
+    "stdout": "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"structured_output\":{\"result\":\"implemented\",\"summary\":\"sanitized local pinned smoke\",\"questions\":null,\"suggestedAnswers\":null,\"error\":null},\"total_cost_usd\":0.028409000000000004,\"duration_ms\":4363,\"duration_api_ms\":5551,\"num_turns\":2,\"usage\":{\"input_tokens\":3,\"cache_creation_input_tokens\":4224,\"cache_read_input_tokens\":0,\"output_tokens\":162}}",
     "stderr": "",
     "structuredOutput": null,
     "exitCode": 0

--- a/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/structured-success.json
+++ b/apps/worker/src/sandbox/agents/fixtures/claude/2.1.216/structured-success.json
@@ -1,0 +1,12 @@
+{
+  "package": "@anthropic-ai/claude-code",
+  "version": "2.1.216",
+  "protocol": "claude-json-2.1.216",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"structured_output\":{\"result\":\"implemented\",\"summary\":\"sanitized fixture\",\"questions\":null,\"suggestedAnswers\":null,\"error\":null},\"total_cost_usd\":0.001,\"duration_ms\":200,\"duration_api_ms\":150,\"num_turns\":1,\"usage\":{\"input_tokens\":11,\"cache_creation_input_tokens\":2,\"cache_read_input_tokens\":3,\"output_tokens\":5}}",
+    "stderr": "",
+    "structuredOutput": null,
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/freeform-success.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/freeform-success.json
@@ -2,11 +2,11 @@
   "package": "@openai/codex",
   "version": "0.144.6",
   "protocol": "codex-jsonl-0.144.6",
-  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "provenance": "captured locally with authenticated @openai/codex@0.144.6 on 2026-07-23 during a workspace-sandboxed disposable-repository repair; volatile fields and response content normalized",
   "artifacts": {
-    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"agent_message\",\"text\":\"fixture complete\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":8,\"cached_input_tokens\":2,\"output_tokens\":3}}",
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"error\"}}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"error\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"agent_message\",\"text\":\"[sanitized response]\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"normalized\",\"type\":\"file_change\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"file_change\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"agent_message\",\"text\":\"[sanitized repair response]\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":38874,\"cached_input_tokens\":29184,\"output_tokens\":84,\"reasoning_output_tokens\":0}}",
     "stderr": "",
-    "structuredOutput": "fixture complete",
+    "structuredOutput": "[sanitized repair response]",
     "exitCode": 0
   }
 }

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/freeform-success.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/freeform-success.json
@@ -1,0 +1,12 @@
+{
+  "package": "@openai/codex",
+  "version": "0.144.6",
+  "protocol": "codex-jsonl-0.144.6",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"agent_message\",\"text\":\"fixture complete\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":8,\"cached_input_tokens\":2,\"output_tokens\":3}}",
+    "stderr": "",
+    "structuredOutput": "fixture complete",
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/malformed-jsonl.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/malformed-jsonl.json
@@ -1,0 +1,12 @@
+{
+  "package": "@openai/codex",
+  "version": "0.144.6",
+  "protocol": "codex-jsonl-0.144.6",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{malformed\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":4,\"cached_input_tokens\":0,\"output_tokens\":1}}",
+    "stderr": "",
+    "structuredOutput": "{\"result\":\"implemented\",\"summary\":null,\"questions\":null,\"suggestedAnswers\":null,\"error\":null}",
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/missing-terminal.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/missing-terminal.json
@@ -1,0 +1,12 @@
+{
+  "package": "@openai/codex",
+  "version": "0.144.6",
+  "protocol": "codex-jsonl-0.144.6",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"agent_message\",\"text\":\"incomplete\"}}",
+    "stderr": "",
+    "structuredOutput": "incomplete",
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/nonzero-exit.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/nonzero-exit.json
@@ -1,0 +1,12 @@
+{
+  "package": "@openai/codex",
+  "version": "0.144.6",
+  "protocol": "codex-jsonl-0.144.6",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}",
+    "stderr": "process stopped",
+    "structuredOutput": null,
+    "exitCode": 1
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/provider-error.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/provider-error.json
@@ -1,0 +1,12 @@
+{
+  "package": "@openai/codex",
+  "version": "0.144.6",
+  "protocol": "codex-jsonl-0.144.6",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"error\",\"message\":\"provider unavailable\"}",
+    "stderr": "request failed",
+    "structuredOutput": null,
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/schema-mismatch.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/schema-mismatch.json
@@ -1,0 +1,12 @@
+{
+  "package": "@openai/codex",
+  "version": "0.144.6",
+  "protocol": "codex-jsonl-0.144.6",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":5,\"cached_input_tokens\":1,\"output_tokens\":2}}",
+    "stderr": "",
+    "structuredOutput": "{\"result\":\"unexpected\"}",
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/structured-success.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/structured-success.json
@@ -2,11 +2,11 @@
   "package": "@openai/codex",
   "version": "0.144.6",
   "protocol": "codex-jsonl-0.144.6",
-  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "provenance": "captured locally with authenticated @openai/codex@0.144.6 on 2026-07-23; volatile fields and response content normalized",
   "artifacts": {
-    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"agent_message\",\"text\":\"sanitized fixture\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":13,\"cached_input_tokens\":4,\"output_tokens\":6}}\n{\"type\":\"phase.duration\",\"duration_ms\":250}",
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"error\"}}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"error\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"agent_message\",\"text\":\"[sanitized response]\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":19232,\"cached_input_tokens\":0,\"output_tokens\":35,\"reasoning_output_tokens\":0}}",
     "stderr": "",
-    "structuredOutput": "{\"result\":\"implemented\",\"summary\":\"sanitized fixture\",\"questions\":null,\"suggestedAnswers\":null,\"error\":null}",
+    "structuredOutput": "{\"result\":\"implemented\",\"summary\":\"sanitized local pinned smoke\",\"questions\":null,\"suggestedAnswers\":null,\"error\":null}",
     "exitCode": 0
   }
 }

--- a/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/structured-success.json
+++ b/apps/worker/src/sandbox/agents/fixtures/codex/0.144.6/structured-success.json
@@ -1,0 +1,12 @@
+{
+  "package": "@openai/codex",
+  "version": "0.144.6",
+  "protocol": "codex-jsonl-0.144.6",
+  "provenance": "normalized pinned-protocol sample; refresh with the capture script",
+  "artifacts": {
+    "stdout": "{\"type\":\"thread.started\",\"thread_id\":\"normalized\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"normalized\",\"type\":\"agent_message\",\"text\":\"sanitized fixture\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":13,\"cached_input_tokens\":4,\"output_tokens\":6}}\n{\"type\":\"phase.duration\",\"duration_ms\":250}",
+    "stderr": "",
+    "structuredOutput": "{\"result\":\"implemented\",\"summary\":\"sanitized fixture\",\"questions\":null,\"suggestedAnswers\":null,\"error\":null}",
+    "exitCode": 0
+  }
+}

--- a/apps/worker/src/sandbox/agents/protocol-fixtures.test.ts
+++ b/apps/worker/src/sandbox/agents/protocol-fixtures.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { CollectedPhaseArtifacts } from "./types.js";
+import { ClaudeAgentAdapter } from "./claude.js";
+import { CodexAgentAdapter } from "./codex.js";
+
+const fixtureRoot = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+
+interface ProtocolFixture {
+  package: string;
+  version: string;
+  protocol: string;
+  provenance: string;
+  artifacts: CollectedPhaseArtifacts;
+}
+
+function fixture(
+  provider: "claude" | "codex",
+  version: string,
+  name: string,
+): ProtocolFixture {
+  return JSON.parse(
+    readFileSync(join(fixtureRoot, provider, version, `${name}.json`), "utf8"),
+  ) as ProtocolFixture;
+}
+
+describe.each([
+  {
+    provider: "claude" as const,
+    version: "2.1.216",
+    adapter: new ClaudeAgentAdapter(),
+    malformed: "malformed-json",
+  },
+  {
+    provider: "codex" as const,
+    version: "0.144.6",
+    adapter: new CodexAgentAdapter(),
+    malformed: "malformed-jsonl",
+  },
+])("$provider pinned protocol fixtures", ({ provider, version, adapter, malformed }) => {
+  it("records the pinned package, version, protocol, and refresh provenance", () => {
+    const loaded = fixture(provider, version, "structured-success");
+    expect(loaded).toMatchObject({
+      package: adapter.cliSpec.packageName,
+      version: adapter.cliSpec.version,
+      protocol: adapter.cliSpec.protocol,
+    });
+    expect(loaded.provenance).toContain("capture script");
+  });
+
+  it("accepts the structured success envelope", () => {
+    const loaded = fixture(provider, version, "structured-success");
+    const result = adapter.parseAgentOutputProtocol(loaded.artifacts, "impl");
+    expect(result).toMatchObject({ ok: true, value: { result: "implemented" } });
+  });
+
+  it("accepts a successful freeform terminal envelope", () => {
+    const loaded = fixture(provider, version, "freeform-success");
+    expect(adapter.validateFreeformProtocol(loaded.artifacts, "pre-pr-fix-1")).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("classifies a terminal provider error as provider", () => {
+    const loaded = fixture(provider, version, "provider-error");
+    const result = adapter.validateFreeformProtocol(loaded.artifacts, "pre-pr-fix-1");
+    expect(result).toMatchObject({
+      ok: false,
+      category: "provider",
+      diagnostic: { failureKind: "provider_error" },
+    });
+  });
+
+  it("preserves a nonzero exit as a process failure", () => {
+    const loaded = fixture(provider, version, "nonzero-exit");
+    const result = adapter.validateFreeformProtocol(loaded.artifacts, "pre-pr-fix-1");
+    expect(result).toMatchObject({
+      ok: false,
+      category: "provider",
+      diagnostic: { failureKind: "cli_exit", exitCode: 1 },
+    });
+    if (!result.ok) expect(result.diagnostic.stdoutTail).toBeUndefined();
+  });
+
+  it("rejects a missing terminal event", () => {
+    const loaded = fixture(provider, version, "missing-terminal");
+    const result = adapter.validateFreeformProtocol(loaded.artifacts, "pre-pr-fix-1");
+    expect(result).toMatchObject({ ok: false, category: "parsing" });
+  });
+
+  it("rejects malformed protocol output and retains only a bounded stdout tail", () => {
+    const loaded = fixture(provider, version, malformed);
+    const result = adapter.parseAgentOutputProtocol(loaded.artifacts, "impl");
+    expect(result).toMatchObject({
+      ok: false,
+      category: "parsing",
+      diagnostic: { failureKind: "invalid_json" },
+    });
+    if (!result.ok) expect(Buffer.byteLength(result.diagnostic.stdoutTail ?? "")).toBeLessThanOrEqual(2048);
+  });
+
+  it("retains valid usage when the terminal structured value fails its schema", () => {
+    const loaded = fixture(provider, version, "schema-mismatch");
+    const result = adapter.parseAgentOutputProtocol(loaded.artifacts, "impl");
+    expect(result).toMatchObject({
+      ok: false,
+      category: "schema",
+      diagnostic: {
+        failureKind: "schema_mismatch",
+        schema: { identity: "agent-output" },
+      },
+    });
+    expect(adapter.extractUsage(loaded.artifacts.stdout, loaded.artifacts.structuredOutput))
+      .not.toBeNull();
+  });
+});

--- a/apps/worker/src/sandbox/agents/protocol-fixtures.test.ts
+++ b/apps/worker/src/sandbox/agents/protocol-fixtures.test.ts
@@ -40,14 +40,14 @@ describe.each([
     malformed: "malformed-jsonl",
   },
 ])("$provider pinned protocol fixtures", ({ provider, version, adapter, malformed }) => {
-  it("records the pinned package, version, protocol, and refresh provenance", () => {
+  it("records the pinned package, version, protocol, and real-capture provenance", () => {
     const loaded = fixture(provider, version, "structured-success");
     expect(loaded).toMatchObject({
       package: adapter.cliSpec.packageName,
       version: adapter.cliSpec.version,
       protocol: adapter.cliSpec.protocol,
     });
-    expect(loaded.provenance).toContain("capture script");
+    expect(loaded.provenance).toContain("captured locally");
   });
 
   it("accepts the structured success envelope", () => {

--- a/apps/worker/src/sandbox/agents/protocol.test.ts
+++ b/apps/worker/src/sandbox/agents/protocol.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+
+const loggerInfo = vi.fn();
+vi.mock("../../lib/logger.js", () => ({
+  logger: { info: loggerInfo },
+}));
+
+import {
+  AGENT_CLI_SPECS,
+  AgentRuntimeError,
+  installAndVerifyCli,
+  protocolFailure,
+  redactDiagnosticText,
+  requireProviderSetup,
+} from "./protocol.js";
+
+function command(exitCode: number, stdout = "", stderr = "") {
+  return {
+    exitCode,
+    stdout: vi.fn().mockResolvedValue(stdout),
+    stderr: vi.fn().mockResolvedValue(stderr),
+  };
+}
+
+describe("pinned CLI specifications", () => {
+  it("pins exact packages, versions, executables, protocols, and version parsers", () => {
+    expect(AGENT_CLI_SPECS.claude).toMatchObject({
+      packageName: "@anthropic-ai/claude-code",
+      version: "2.1.216",
+      executable: "claude",
+      protocol: "claude-json-2.1.216",
+    });
+    expect(AGENT_CLI_SPECS.codex).toMatchObject({
+      packageName: "@openai/codex",
+      version: "0.144.6",
+      executable: "codex",
+      protocol: "codex-jsonl-0.144.6",
+    });
+    expect(AGENT_CLI_SPECS.claude.parseVersion("2.1.216 (Claude Code)"))
+      .toBe("2.1.216");
+    expect(AGENT_CLI_SPECS.codex.parseVersion("codex-cli 0.144.6"))
+      .toBe("0.144.6");
+    expect(AGENT_CLI_SPECS.codex.parseVersion("codex 0.144.6 extra"))
+      .toBeNull();
+  });
+
+  it("installs only the exact package version and logs the verified protocol", async () => {
+    const runCommand = vi.fn()
+      .mockResolvedValueOnce(command(0))
+      .mockResolvedValueOnce(command(0, "codex-cli 0.144.6\n"));
+    await installAndVerifyCli(
+      { runCommand, writeFiles: vi.fn() } as never,
+      AGENT_CLI_SPECS.codex,
+    );
+    expect(runCommand).toHaveBeenNthCalledWith(
+      1,
+      "npm",
+      ["install", "-g", "@openai/codex@0.144.6"],
+    );
+    expect(runCommand).toHaveBeenNthCalledWith(2, "codex", ["--version"]);
+    expect(loggerInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedVersion: "0.144.6",
+        actualVersion: "0.144.6",
+        protocol: "codex-jsonl-0.144.6",
+      }),
+      "agent_cli_verified",
+    );
+  });
+
+  it("rejects a version mismatch without retrying or falling back", async () => {
+    const runCommand = vi.fn()
+      .mockResolvedValueOnce(command(0))
+      .mockResolvedValueOnce(command(0, "codex-cli 0.145.0\n"));
+    await expect(
+      installAndVerifyCli(
+        { runCommand, writeFiles: vi.fn() } as never,
+        AGENT_CLI_SPECS.codex,
+      ),
+    ).rejects.toMatchObject({
+      name: "AgentRuntimeError",
+      diagnostic: { failureKind: "version_mismatch" },
+    });
+    expect(runCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it("turns failed provider setup into a redacted provisioning diagnostic", async () => {
+    process.env.AIW_PROTOCOL_TEST_TOKEN = "secret-value-123";
+    await expect(
+      requireProviderSetup(
+        command(1, "login failed", "Bearer secret-value-123") as never,
+        AGENT_CLI_SPECS.codex,
+        "Codex login",
+      ),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(error).toBeInstanceOf(AgentRuntimeError);
+      const runtime = error as AgentRuntimeError;
+      expect(runtime.safeMessage).toBe("The agent runtime could not be prepared.");
+      expect(runtime.diagnostic.stderrTail).toBe("Bearer [REDACTED]");
+      expect(runtime.diagnostic.stdoutTail).toBeUndefined();
+      return true;
+    });
+    delete process.env.AIW_PROTOCOL_TEST_TOKEN;
+  });
+});
+
+describe("protocol diagnostics", () => {
+  it("redacts recognizable provider, bearer, GitHub, and GitLab token forms", () => {
+    expect(
+      redactDiagnosticText(
+        "sk-ant-abc bearer ghp_abcdefghijklmnopqrstuvwxyz gho_abcdefghijklmnopqrstuvwxyz " +
+          "ghu_abcdefghijklmnopqrstuvwxyz glpat-abcdefghijklmnop token=secretvalue",
+      ),
+    ).not.toMatch(/sk-ant-|gh[pousr]_|glpat-|secretvalue/);
+  });
+
+  it("caps schema issues at twenty and never stores the schema value", () => {
+    const schema = JSON.stringify({ type: "object", properties: { secretField: {} } });
+    const result = protocolFailure({
+      spec: AGENT_CLI_SPECS.claude,
+      phase: "impl",
+      artifacts: { stdout: "", stderr: "", structuredOutput: null, exitCode: 0 },
+      failureKind: "schema_mismatch",
+      category: "schema",
+      message: "The current agent phase returned an invalid structured response.",
+      schema: {
+        identity: "fixture-schema",
+        source: schema,
+        issues: Array.from({ length: 25 }, (_, index) => ({
+          path: ["items", index],
+          code: "custom",
+          message: `issue ${index}`,
+        })),
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.diagnostic.schema?.issues).toHaveLength(20);
+      expect(JSON.stringify(result.diagnostic)).not.toContain(schema);
+    }
+  });
+});

--- a/apps/worker/src/sandbox/agents/protocol.ts
+++ b/apps/worker/src/sandbox/agents/protocol.ts
@@ -1,0 +1,403 @@
+import { createHash } from "node:crypto";
+import type { ZodType } from "zod";
+import type {
+  AgentCliSpec,
+  AgentProtocolDiagnostic,
+  AgentProtocolFailureCategory,
+  AgentProtocolFailureKind,
+  AgentProtocolResult,
+  CollectedPhaseArtifacts,
+  RunnableSandbox,
+} from "./types.js";
+
+const DIAGNOSTIC_TAIL_BYTES = 2 * 1024;
+const MAX_SCHEMA_ISSUES = 20;
+
+export const AGENT_CLI_SPECS = {
+  claude: {
+    kind: "claude",
+    packageName: "@anthropic-ai/claude-code",
+    version: "2.1.216",
+    executable: "claude",
+    parseVersion: (output: string) =>
+      output.trim().match(/^(\d+\.\d+\.\d+)(?:\s+\(Claude Code\))?$/)?.[1] ?? null,
+    protocol: "claude-json-2.1.216",
+  },
+  codex: {
+    kind: "codex",
+    packageName: "@openai/codex",
+    version: "0.144.6",
+    executable: "codex",
+    parseVersion: (output: string) =>
+      output.trim().match(/^(?:codex(?:-cli)?\s+)?(\d+\.\d+\.\d+)$/i)?.[1] ?? null,
+    protocol: "codex-jsonl-0.144.6",
+  },
+} as const satisfies Record<AgentCliSpec["kind"], AgentCliSpec>;
+
+export class AgentRuntimeError extends Error {
+  readonly category: AgentProtocolFailureCategory;
+  readonly safeMessage: string;
+  readonly diagnostic: AgentProtocolDiagnostic;
+
+  constructor(input: {
+    category: AgentProtocolFailureCategory;
+    message: string;
+    diagnostic: AgentProtocolDiagnostic;
+  }) {
+    super(input.message);
+    this.name = "AgentRuntimeError";
+    this.category = input.category;
+    this.safeMessage = input.message;
+    this.diagnostic = input.diagnostic;
+  }
+}
+
+export function isAgentRuntimeError(error: unknown): error is AgentRuntimeError {
+  return error instanceof AgentRuntimeError;
+}
+
+export async function installAndVerifyCli(
+  sandbox: RunnableSandbox,
+  spec: AgentCliSpec,
+): Promise<void> {
+  const install = await sandbox.runCommand("npm", [
+    "install",
+    "-g",
+    `${spec.packageName}@${spec.version}`,
+  ]);
+  if (install.exitCode !== 0) {
+    throw await commandRuntimeError(spec, "install", "install_failed", install);
+  }
+
+  const versionCommand = await sandbox.runCommand(spec.executable, ["--version"]);
+  if (versionCommand.exitCode !== 0) {
+    throw await commandRuntimeError(
+      spec,
+      "install",
+      "version_unreadable",
+      versionCommand,
+    );
+  }
+  const versionText = (await versionCommand.stdout()).trim();
+  const actualVersion = spec.parseVersion(versionText);
+  if (!actualVersion) {
+    throw new AgentRuntimeError({
+      category: "provider",
+      message: "The agent runtime could not be prepared.",
+      diagnostic: baseDiagnostic(spec, "install", "version_unreadable", {
+        detail: "The CLI version command returned no semantic version.",
+      }),
+    });
+  }
+  if (actualVersion !== spec.version) {
+    throw new AgentRuntimeError({
+      category: "provider",
+      message: "The agent runtime could not be prepared.",
+      diagnostic: baseDiagnostic(spec, "install", "version_mismatch", {
+        detail: `Expected ${spec.version}; received ${actualVersion}.`,
+      }),
+    });
+  }
+
+  const { logger } = await import("../../lib/logger.js");
+  logger.info(
+    {
+      provider: spec.kind,
+      packageName: spec.packageName,
+      expectedVersion: spec.version,
+      actualVersion,
+      protocol: spec.protocol,
+    },
+    "agent_cli_verified",
+  );
+}
+
+export async function requireProviderSetup(
+  result: Awaited<ReturnType<RunnableSandbox["runCommand"]>>,
+  spec: AgentCliSpec,
+  label: string,
+): Promise<void> {
+  if (result.exitCode === 0) return;
+  throw await commandRuntimeError(spec, "setup", "setup_failed", result, label);
+}
+
+export function legacyArtifacts(
+  raw: string,
+  structuredOutput: string | null,
+): CollectedPhaseArtifacts {
+  return { stdout: raw, stderr: "", structuredOutput, exitCode: 0 };
+}
+
+export function artifactFailure(
+  spec: AgentCliSpec,
+  phase: string,
+  artifacts: CollectedPhaseArtifacts,
+  event?: AgentProtocolDiagnostic["event"],
+): AgentProtocolResult<never> | null {
+  if (artifacts.exitCode === null) {
+    return protocolFailure({
+      spec,
+      phase,
+      artifacts,
+      failureKind: "missing_exit_code",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      event,
+      detail: "The phase completed without a readable process exit code.",
+    });
+  }
+  if (artifacts.exitCode !== 0) {
+    return protocolFailure({
+      spec,
+      phase,
+      artifacts,
+      failureKind: "cli_exit",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      event,
+      detail: `The CLI exited with code ${artifacts.exitCode}.`,
+    });
+  }
+  return null;
+}
+
+export function validateStructuredValue<T>(input: {
+  spec: AgentCliSpec;
+  phase: string;
+  artifacts: CollectedPhaseArtifacts;
+  value: unknown;
+  schema: ZodType<T>;
+  schemaIdentity: string;
+  schemaSource: string;
+  event?: AgentProtocolDiagnostic["event"];
+}): AgentProtocolResult<T> {
+  const parsed = input.schema.safeParse(input.value);
+  if (parsed.success) return { ok: true, value: parsed.data };
+  return protocolFailure({
+    spec: input.spec,
+    phase: input.phase,
+    artifacts: input.artifacts,
+    failureKind: "schema_mismatch",
+    category: "schema",
+    message: "The current agent phase returned an invalid structured response.",
+    event: input.event,
+    schema: {
+      identity: input.schemaIdentity,
+      source: input.schemaSource,
+      issues: parsed.error.issues,
+    },
+    detail: "The structured response did not satisfy the requested schema.",
+  });
+}
+
+export function attachSchemaDiagnostic<T>(
+  result: AgentProtocolResult<T>,
+  identity: string,
+  schemaSource: string,
+): AgentProtocolResult<T> {
+  if (result.ok || result.diagnostic.schema) return result;
+  return {
+    ...result,
+    diagnostic: {
+      ...result.diagnostic,
+      schema: { identity, sha256: hashText(schemaSource), issues: [] },
+    },
+  };
+}
+
+export function runtimePreparationError(
+  spec: AgentCliSpec,
+  detail: string,
+): AgentRuntimeError {
+  return new AgentRuntimeError({
+    category: "provider",
+    message: "The agent runtime could not be prepared.",
+    diagnostic: baseDiagnostic(spec, "setup", "setup_failed", { detail }),
+  });
+}
+
+export async function commandProtocolFailure(input: {
+  spec: AgentCliSpec;
+  phase: string;
+  result: {
+    exitCode: number | null;
+    stdout(): Promise<string>;
+    stderr(): Promise<string>;
+  };
+  failureKind: "setup_failed" | "cli_exit" | "provider_error";
+  message: string;
+  detail: string;
+}): Promise<Extract<AgentProtocolResult<never>, { ok: false }>> {
+  const stdout = await input.result.stdout().catch(() => "");
+  const stderr = await input.result.stderr().catch(() => "");
+  const failure = protocolFailure({
+    spec: input.spec,
+    phase: input.phase,
+    artifacts: {
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      structuredOutput: null,
+      exitCode: input.result.exitCode,
+    },
+    failureKind: input.failureKind,
+    category: "provider",
+    message: input.message,
+    detail: input.detail,
+  });
+  if (failure.ok) throw new Error("unreachable");
+  return failure;
+}
+
+export function protocolFailure(input: {
+  spec: AgentCliSpec;
+  phase: string;
+  artifacts: CollectedPhaseArtifacts;
+  failureKind: AgentProtocolFailureKind;
+  category: AgentProtocolFailureCategory;
+  message: string;
+  event?: AgentProtocolDiagnostic["event"];
+  schema?: {
+    identity: string;
+    source: string;
+    issues: Array<{ path: Array<string | number>; code: string; message: string }>;
+  };
+  detail?: string;
+  includeStdoutTail?: boolean;
+}): AgentProtocolResult<never> {
+  const { artifacts } = input;
+  const diagnostic: AgentProtocolDiagnostic = {
+    ...baseDiagnostic(input.spec, input.phase, input.failureKind, {
+      exitCode: artifacts.exitCode,
+      event: input.event,
+      detail: input.detail,
+    }),
+    artifacts: {
+      stdoutBytes: Buffer.byteLength(artifacts.stdout),
+      stderrBytes: Buffer.byteLength(artifacts.stderr),
+      structuredOutputBytes: Buffer.byteLength(artifacts.structuredOutput ?? ""),
+      stdoutSha256: hashText(artifacts.stdout),
+      stderrSha256: hashText(artifacts.stderr),
+      structuredOutputSha256:
+        artifacts.structuredOutput === null ? null : hashText(artifacts.structuredOutput),
+    },
+  };
+  if (input.schema) {
+    diagnostic.schema = {
+      identity: input.schema.identity,
+      sha256: hashText(input.schema.source),
+      issues: input.schema.issues.slice(0, MAX_SCHEMA_ISSUES).map((issue) => ({
+        path: issue.path.join("."),
+        code: issue.code,
+        message: safeRedactedText(issue.message).slice(0, 500),
+      })),
+    };
+  }
+  if (input.includeStdoutTail && artifacts.stdout) {
+    const tail = safeDiagnosticTail(artifacts.stdout);
+    if (tail !== undefined) diagnostic.stdoutTail = tail;
+  }
+  if (artifacts.stderr) {
+    const tail = safeDiagnosticTail(artifacts.stderr);
+    if (tail !== undefined) diagnostic.stderrTail = tail;
+  }
+  return {
+    ok: false,
+    category: input.category,
+    message: input.message,
+    diagnostic,
+  };
+}
+
+export function eventMetadata(value: unknown): AgentProtocolDiagnostic["event"] | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const item = record.item && typeof record.item === "object"
+    ? record.item as Record<string, unknown>
+    : undefined;
+  const metadata: NonNullable<AgentProtocolDiagnostic["event"]> = {};
+  if (typeof record.type === "string") metadata.type = record.type;
+  if (typeof record.subtype === "string") metadata.subtype = record.subtype;
+  if (typeof record.is_error === "boolean") metadata.isError = record.is_error;
+  if (typeof item?.type === "string") metadata.itemType = item.type;
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+export function redactDiagnosticText(value: string): string {
+  let redacted = value;
+  const sensitiveValues = Object.entries(process.env)
+    .filter(([key, secret]) =>
+      secret && secret.length >= 8 && /(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)/i.test(key),
+    )
+    .map(([, secret]) => secret as string);
+  for (const secret of sensitiveValues) redacted = redacted.split(secret).join("[REDACTED]");
+  return redacted
+    .replace(/\b(?:sk-ant-[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+|glpat-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
+    .replace(/\b(Bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
+    .replace(/\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+/gi, "$1=[REDACTED]");
+}
+
+export function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function baseDiagnostic(
+  spec: AgentCliSpec,
+  phase: string,
+  failureKind: AgentProtocolFailureKind,
+  extras: Partial<AgentProtocolDiagnostic> = {},
+): AgentProtocolDiagnostic {
+  return {
+    provider: spec.kind,
+    packageName: spec.packageName,
+    cliVersion: spec.version,
+    protocol: spec.protocol,
+    phase,
+    failureKind,
+    exitCode: extras.exitCode ?? null,
+    ...extras,
+  };
+}
+
+async function commandRuntimeError(
+  spec: AgentCliSpec,
+  phase: string,
+  failureKind: "install_failed" | "setup_failed" | "version_unreadable",
+  result: Awaited<ReturnType<RunnableSandbox["runCommand"]>>,
+  label?: string,
+): Promise<AgentRuntimeError> {
+  const stdout = await result.stdout().catch(() => "");
+  const stderr = await result.stderr().catch(() => "");
+  const failure = protocolFailure({
+    spec,
+    phase,
+    artifacts: {
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      structuredOutput: null,
+      exitCode: result.exitCode,
+    },
+    failureKind,
+    category: "provider",
+    message: "The agent runtime could not be prepared.",
+    detail: label ? `${label} failed.` : undefined,
+  });
+  if (failure.ok) throw new Error("unreachable");
+  return new AgentRuntimeError(failure);
+}
+
+function safeRedactedText(value: string): string {
+  try {
+    return redactDiagnosticText(value);
+  } catch {
+    return "[REDACTION FAILED]";
+  }
+}
+
+function safeDiagnosticTail(value: string): string | undefined {
+  try {
+    const redacted = redactDiagnosticText(value);
+    return Buffer.from(redacted).subarray(-DIAGNOSTIC_TAIL_BYTES).toString();
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/worker/src/sandbox/agents/shared.test.ts
+++ b/apps/worker/src/sandbox/agents/shared.test.ts
@@ -6,6 +6,7 @@ import {
   GLOBAL_SKILLS,
   installSkillsToAgentsDir,
 } from "./shared.js";
+import { AGENT_CLI_SPECS } from "./protocol.js";
 
 // Sentinel absent -> `test -f` reports exit 1 so the install proceeds.
 const notYetInstalled = (cmd: string, args?: string[]) =>
@@ -33,7 +34,7 @@ describe("installSkillsToAgentsDir", () => {
     const writeFiles = vi.fn().mockResolvedValue(undefined);
     const sandbox = { runCommand, writeFiles } as any;
 
-    await installSkillsToAgentsDir(sandbox);
+    await installSkillsToAgentsDir(sandbox, AGENT_CLI_SPECS.claude);
 
     const calls = runCommand.mock.calls.filter((c) => c[0] === "npx");
     expect(calls).toHaveLength(GLOBAL_SKILLS.length);
@@ -54,7 +55,7 @@ describe("installSkillsToAgentsDir", () => {
     const runCommand = vi.fn().mockImplementation((cmd, args) => notYetInstalled(cmd, args));
     const sandbox = { runCommand, writeFiles: vi.fn() } as any;
 
-    await installSkillsToAgentsDir(sandbox);
+    await installSkillsToAgentsDir(sandbox, AGENT_CLI_SPECS.claude);
 
     const touch = runCommand.mock.calls.find(
       ([cmd, args]) => cmd === "bash" && typeof args?.[1] === "string" && args[1].startsWith("touch"),
@@ -68,7 +69,7 @@ describe("installSkillsToAgentsDir", () => {
     const runCommand = vi.fn().mockResolvedValue({ exitCode: 0 });
     const sandbox = { runCommand, writeFiles: vi.fn() } as any;
 
-    await installSkillsToAgentsDir(sandbox);
+    await installSkillsToAgentsDir(sandbox, AGENT_CLI_SPECS.claude);
 
     expect(runCommand.mock.calls.filter((c) => c[0] === "npx")).toHaveLength(0);
   });

--- a/apps/worker/src/sandbox/agents/shared.ts
+++ b/apps/worker/src/sandbox/agents/shared.ts
@@ -1,4 +1,4 @@
-import type { RunnableSandbox } from "./types.js";
+import type { AgentCliSpec, RunnableSandbox } from "./types.js";
 
 // Auth env is split per provider so configuring one adapter never clobbers the
 // other's file. Every consumer keeps sourcing AGENT_ENV_PATH; the shim written
@@ -22,7 +22,11 @@ export const GLOBAL_SKILLS = [
   { repo: "https://github.com/anthropics/skills", skill: "frontend-design" },
 ] as const;
 
-export async function installSkillsToAgentsDir(sandbox: RunnableSandbox): Promise<void> {
+export async function installSkillsToAgentsDir(
+  sandbox: RunnableSandbox,
+  spec: AgentCliSpec,
+): Promise<void> {
+  const { requireProviderSetup } = await import("./protocol.js");
   const already = await sandbox.runCommand("bash", ["-c", `test -f ${SKILLS_SENTINEL}`]);
   if (already.exitCode === 0) return;
 
@@ -36,17 +40,15 @@ export async function installSkillsToAgentsDir(sandbox: RunnableSandbox): Promis
       "--copy",
     ]);
     if (result.exitCode !== 0) {
-      const { logger } = await import("../../lib/logger.js");
-      const stderr = await result.stderr().catch(() => "");
-      logger.error(
-        { repo, skill, exitCode: result.exitCode, output: stderr.slice(0, 500) },
-        "skill_install_failed",
-      );
-      throw new Error(`Failed to install skill ${skill} from ${repo} (exit ${result.exitCode})`);
+      await requireProviderSetup(result, spec, `Agent skill setup (${skill} from ${repo})`);
     }
   }
 
-  await sandbox.runCommand("bash", ["-c", `touch ${SKILLS_SENTINEL}`]);
+  const markInstalled = await sandbox.runCommand("bash", [
+    "-c",
+    `touch ${SKILLS_SENTINEL}`,
+  ]);
+  await requireProviderSetup(markInstalled, spec, "Agent skill setup sentinel");
 }
 
 /** Bash body for the commit-guard hook. The output protocol differs between agents,

--- a/apps/worker/src/sandbox/agents/types.ts
+++ b/apps/worker/src/sandbox/agents/types.ts
@@ -208,10 +208,83 @@ export interface PhaseArtifactPaths {
   input: string;
   stdout: string;
   stderr: string;
+  exitCode: string;
   sentinel: string;
   /** Schema-validated JSON file (Codex --output-schema). null for Claude. */
   structuredOutput: string | null;
 }
+
+export interface CollectedPhaseArtifacts {
+  stdout: string;
+  stderr: string;
+  structuredOutput: string | null;
+  exitCode: number | null;
+}
+
+export type AgentProtocolFailureKind =
+  | "install_failed"
+  | "setup_failed"
+  | "version_unreadable"
+  | "version_mismatch"
+  | "missing_exit_code"
+  | "cli_exit"
+  | "provider_error"
+  | "missing_result"
+  | "invalid_json"
+  | "schema_mismatch"
+  | "protocol_mismatch";
+
+export interface AgentCliSpec {
+  kind: "claude" | "codex";
+  packageName: string;
+  version: string;
+  executable: string;
+  parseVersion(output: string): string | null;
+  protocol: string;
+}
+
+export interface AgentProtocolDiagnostic {
+  provider: AgentCliSpec["kind"];
+  packageName: string;
+  cliVersion: string;
+  protocol: string;
+  phase: string;
+  failureKind: AgentProtocolFailureKind;
+  exitCode: number | null;
+  event?: {
+    type?: string;
+    subtype?: string;
+    isError?: boolean;
+    itemType?: string;
+  };
+  artifacts?: {
+    stdoutBytes: number;
+    stderrBytes: number;
+    structuredOutputBytes: number;
+    stdoutSha256: string;
+    stderrSha256: string;
+    structuredOutputSha256: string | null;
+  };
+  schema?: {
+    identity: string;
+    sha256: string;
+    issues: Array<{ path: string; code: string; message: string }>;
+  };
+  stdoutTail?: string;
+  stderrTail?: string;
+  detail?: string;
+}
+
+export type AgentProtocolFailureCategory = "provider" | "parsing" | "schema";
+
+export type AgentProtocolResult<T> =
+  | { ok: true; value: T; event?: AgentProtocolDiagnostic["event"] }
+  | {
+      ok: false;
+      category: AgentProtocolFailureCategory;
+      message: string;
+      diagnostic: AgentProtocolDiagnostic;
+    };
 
 export interface PhaseScriptOpts {
   phase: PhaseKind;
@@ -223,11 +296,34 @@ export interface PhaseScriptOpts {
 
 export interface AgentAdapter {
   kind: "claude" | "codex";
+  cliSpec: AgentCliSpec;
   install(sandbox: RunnableSandbox): Promise<void>;
   configure(sandbox: RunnableSandbox, opts: ConfigureOpts): Promise<void>;
   setCommitGuard(sandbox: RunnableSandbox, enabled: boolean): Promise<void>;
   buildPhaseScript(opts: PhaseScriptOpts): string;
   artifactPaths(phase: PhaseKind): PhaseArtifactPaths;
+  parseAgentOutputProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<AgentOutput>;
+  parseReviewOutputProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<ReviewOutput>;
+  parseResearchProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<ResearchResult>;
+  parseStructuredObjectProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+    schemaIdentity: string,
+    schema: string,
+  ): AgentProtocolResult<unknown>;
+  validateFreeformProtocol(
+    artifacts: CollectedPhaseArtifacts,
+    phase: string,
+  ): AgentProtocolResult<void>;
   parseAgentOutput(raw: string, structured: string | null): AgentOutput;
   parseReviewOutput(raw: string, structured: string | null): ReviewOutput;
   parseResearchStatus(raw: string, structured: string | null): ResearchResult;

--- a/apps/worker/src/sandbox/manager.ts
+++ b/apps/worker/src/sandbox/manager.ts
@@ -13,6 +13,7 @@ import type { VcsProviderKind } from "../../env.js";
 import { isActiveRunOwnerError } from "../lib/run-control-errors.js";
 import { buildVcsUrls, gitAuthArgs } from "../lib/vcs-urls.js";
 import { stopSandboxAndConfirm } from "./stop-ticket-sandboxes.js";
+import { isAgentRuntimeError } from "./agents/protocol.js";
 
 export interface SandboxProviderConfig {
   kind: "github" | "gitlab";
@@ -193,7 +194,7 @@ export class SandboxManager {
         try {
           await this.teardown(sandbox);
         } catch (cleanupError) {
-          if (!isActiveRunOwnerError(err)) throw cleanupError;
+          if (!isActiveRunOwnerError(err) && !isAgentRuntimeError(err)) throw cleanupError;
         }
       }
       throw err;

--- a/apps/worker/src/sandbox/poll-agent.test.ts
+++ b/apps/worker/src/sandbox/poll-agent.test.ts
@@ -106,11 +106,15 @@ describe("collectPhaseOutput", () => {
 describe("collectPhase", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("returns raw and optional structured output", async () => {
+  it("returns stdout, stderr, structured output, and exit code independently", async () => {
     mockRunCommand.mockImplementation((_cmd: string, args: string[]) => {
       const file = args[0];
       const text = file.includes("stdout")
         ? "ndjson body"
+        : file.includes("stderr")
+          ? "warning"
+          : file.includes("exit-code")
+            ? "17"
         : file.includes("result")
           ? '{"result":"implemented"}'
           : "";
@@ -121,7 +125,13 @@ describe("collectPhase", () => {
         stdout: "/tmp/stdout",
         stderr: "/tmp/stderr",
         structuredOutput: "/tmp/result",
+        exitCode: "/tmp/exit-code",
       }),
-    ).resolves.toEqual({ raw: "ndjson body", structured: '{"result":"implemented"}' });
+    ).resolves.toEqual({
+      stdout: "ndjson body",
+      stderr: "warning",
+      structuredOutput: '{"result":"implemented"}',
+      exitCode: 17,
+    });
   });
 });

--- a/apps/worker/src/sandbox/poll-agent.ts
+++ b/apps/worker/src/sandbox/poll-agent.ts
@@ -1,4 +1,5 @@
 import { getSandboxCredentials } from "./credentials.js";
+import type { CollectedPhaseArtifacts, PhaseArtifactPaths } from "./agents/types.js";
 
 /**
  * Generalized sentinel check — works with any sentinel file path.
@@ -52,8 +53,8 @@ export async function collectPhaseOutput(
  */
 export async function collectPhase(
   sandboxId: string,
-  paths: { stdout: string; stderr: string; structuredOutput: string | null },
-): Promise<{ raw: string; structured: string | null }> {
+  paths: Pick<PhaseArtifactPaths, "stdout" | "stderr" | "structuredOutput" | "exitCode">,
+): Promise<CollectedPhaseArtifacts> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
   const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
@@ -62,15 +63,23 @@ export async function collectPhase(
   const stdoutText = (await stdoutResult.stdout()).trim();
   const stderrResult = await sandbox.runCommand("cat", [paths.stderr]);
   const stderrText = (await stderrResult.stdout()).trim();
-  const raw = stdoutText || stderrText;
 
-  let structured: string | null = null;
+  let structuredOutput: string | null = null;
   if (paths.structuredOutput) {
     const result = await sandbox.runCommand("cat", [paths.structuredOutput]);
     const text = (await result.stdout()).trim();
-    structured = text || null;
+    structuredOutput = text || null;
   }
-  return { raw, structured };
+
+  const exitCodeResult = await sandbox.runCommand("cat", [paths.exitCode]);
+  const exitCodeText = (await exitCodeResult.stdout()).trim();
+  const parsedExitCode = /^-?\d+$/.test(exitCodeText) ? Number(exitCodeText) : null;
+  return {
+    stdout: stdoutText,
+    stderr: stderrText,
+    structuredOutput,
+    exitCode: parsedExitCode,
+  };
 }
 
 /**

--- a/apps/worker/src/workflow-definition/interpreter.test.ts
+++ b/apps/worker/src/workflow-definition/interpreter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { WorkflowRunCancelledError } from "workflow/errors";
 import type {
   BlockRunState,
@@ -390,6 +390,60 @@ describe("executeGraph output contracts", () => {
         nodeId: "comment",
       },
     ]);
+  });
+});
+
+describe("executeGraph protocol diagnostics", () => {
+  it("logs one stable structured event and omits protocol detail from run state", async () => {
+    const graph = graphFrom(
+      [node("trig", "trigger_ticket_ai"), node("impl", "implementation_agent")],
+      [{ from: "trig", to: "impl" }],
+    );
+    const rec = makeRecorder();
+    const diagnostic = {
+      provider: "codex" as const,
+      packageName: "@openai/codex",
+      cliVersion: "0.144.6",
+      protocol: "codex-jsonl-0.144.6",
+      phase: "impl",
+      failureKind: "invalid_json" as const,
+      exitCode: 0,
+      stderrTail: "redacted detail",
+    };
+    const onExecutionError = vi.fn();
+
+    const result = await executeGraphWithContractValidation({
+      graph,
+      entryTriggerId: "trig",
+      triggerOutput: { status: "fired", ticketKey: "AIW-106" },
+      executeBlock: async () => executionError("internal parser detail", {
+        category: "parsing",
+        message: "The current agent phase returned an invalid structured response.",
+        phase: "impl",
+        diagnostic,
+      }),
+      hooks: { ...rec.hooks, onExecutionError },
+    });
+
+    expect(onExecutionError).toHaveBeenCalledTimes(1);
+    expect(onExecutionError).toHaveBeenCalledWith({
+      diagnosticId: "AIW-DIAG-test-run-impl-1",
+      nodeId: "impl",
+      attempt: 1,
+      category: "parsing",
+      phase: "impl",
+      detail: "internal parser detail",
+      agentProtocol: diagnostic,
+    });
+    expect(result.executionError).toEqual({
+      category: "parsing",
+      message: "The current agent phase returned an invalid structured response.",
+      phase: "impl",
+      diagnosticId: "AIW-DIAG-test-run-impl-1",
+      nodeId: "impl",
+      attempt: 1,
+    });
+    expect(JSON.stringify(result.executionError)).not.toContain("redacted detail");
   });
 });
 

--- a/apps/worker/src/workflow-definition/interpreter.ts
+++ b/apps/worker/src/workflow-definition/interpreter.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowDefinition,
   WorkflowDefinitionNode,
 } from "@shared/contracts";
+import type { AgentProtocolDiagnostic } from "../sandbox/agents/types.js";
 import { evaluateCondition, parseCondition } from "@shared/conditions";
 import {
   resolveWorkflowInputBindings,
@@ -71,11 +72,13 @@ export interface BlockExecutionError {
   message: string;
   /** Internal context for correlated server logs. Never persist or expose it. */
   detail?: string;
+  /** Redacted internal provider-protocol context. Never persist or expose it. */
+  diagnostic?: AgentProtocolDiagnostic;
   phase?: string;
 }
 
 export interface WorkflowExecutionErrorState
-  extends Omit<BlockExecutionError, "detail"> {
+  extends Omit<BlockExecutionError, "detail" | "diagnostic"> {
   diagnosticId: string;
   nodeId: string;
   attempt: number;
@@ -99,6 +102,7 @@ export function executionError(
     category?: ExecutionErrorCategory;
     message?: string;
     phase?: string;
+    diagnostic?: AgentProtocolDiagnostic;
   } = {},
 ): Extract<BlockExecutionResult, { kind: "execution_error" }> {
   const category = options.category ?? "unknown";
@@ -114,6 +118,7 @@ export function executionError(
           genericMessage: SAFE_EXECUTION_ERROR_MESSAGES[category],
         }),
       detail,
+      ...(options.diagnostic ? { diagnostic: options.diagnostic } : {}),
       ...(options.phase ? { phase: options.phase } : {}),
     },
   };
@@ -206,6 +211,7 @@ export interface ExecuteGraphHooks {
     controlState?: InterpreterControlState,
   ): Promise<string | void>;
   failureExit(phase: string, reason: string, nodeId: string): Promise<void>;
+  onExecutionError?(event: WorkflowExecutionLogEvent): Promise<void>;
   terminate(
     params: {
       terminalStatus: "waiting_for_human" | "failed" | "skipped" | "done";
@@ -215,6 +221,16 @@ export interface ExecuteGraphHooks {
     steps?: StepsRecord,
     controlState?: InterpreterControlState,
   ): Promise<void>;
+}
+
+export interface WorkflowExecutionLogEvent {
+  diagnosticId: string;
+  nodeId: string;
+  attempt: number;
+  category: ExecutionErrorCategory;
+  phase?: string;
+  detail?: string;
+  agentProtocol?: AgentProtocolDiagnostic;
 }
 
 export interface ExecuteGraphResult {
@@ -286,11 +302,17 @@ export async function executeGraph(opts: {
       attempt,
       error,
     );
-    if (error.detail) {
-      console.error(
-        `[${state.diagnosticId}] workflow execution error in ${nodeId}: ${error.detail}`,
-      );
-    }
+    await hooks.onExecutionError?.({
+      diagnosticId: state.diagnosticId,
+      nodeId,
+      attempt,
+      category: state.category,
+      ...(state.phase ? { phase: state.phase } : {}),
+      ...(error.detail ? { detail: error.detail } : {}),
+      ...(error.diagnostic
+        ? { agentProtocol: serializableProtocolDiagnostic(error.diagnostic) }
+        : {}),
+    });
     primaryExecutionError ??= state;
     await hooks.onBlockFinish(nodeId, {
       status: "fail",
@@ -717,4 +739,23 @@ export async function executeGraph(opts: {
   }
 
   return finish("completed");
+}
+
+function serializableProtocolDiagnostic(
+  diagnostic: AgentProtocolDiagnostic,
+): AgentProtocolDiagnostic {
+  try {
+    JSON.stringify(diagnostic);
+    return diagnostic;
+  } catch {
+    return {
+      provider: diagnostic.provider,
+      packageName: diagnostic.packageName,
+      cliVersion: diagnostic.cliVersion,
+      protocol: diagnostic.protocol,
+      phase: diagnostic.phase,
+      failureKind: diagnostic.failureKind,
+      exitCode: diagnostic.exitCode,
+    };
+  }
 }

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -3,7 +3,8 @@ import { branchForTicket } from "../lib/branch-prefix.js";
 import { ticketRunUrl, ticketPageUrl, hasDashboardLinkComment } from "../lib/dashboard-links.js";
 import { computeUsageTotals, type UsageTotals } from "../sandbox/usage.js";
 import type {
-  AgentOutput, PhaseUsage, PhaseKind, PhaseArtifactPaths, ResearchResult, ReviewOutput,
+  AgentOutput, AgentProtocolResult, CollectedPhaseArtifacts, PhaseUsage, PhaseKind,
+  PhaseArtifactPaths, ResearchResult, ReviewOutput,
 } from "../sandbox/agents/types.js";
 import type { AgentKind } from "../sandbox/agents/index.js";
 import type {
@@ -23,6 +24,7 @@ import {
   WorkflowExecutionError,
   type RuntimeGraph,
   type StepsRecord,
+  type WorkflowExecutionLogEvent,
   type WorkflowExecutionErrorState,
 } from "../workflow-definition/interpreter.js";
 import type {
@@ -38,7 +40,11 @@ import {
 } from "./agent-input.js";
 import type { TicketTransitionOwner } from "../lib/ticket-transition.js";
 import { moveTicketStep } from "./ticket-transition-step.js";
-import type { BlockExecuteFn, EngineCtx } from "./blocks/types.js";
+import {
+  agentProtocolExecutionError as agentProtocolBlockError,
+  type BlockExecuteFn,
+  type EngineCtx,
+} from "./blocks/types.js";
 import {
   buildPromptVariables,
   substituteNodePromptParams,
@@ -447,6 +453,15 @@ export async function ensurePlanningAgentSandboxForBlock(
     return { kind: "ready", sandboxId: await ensureAgentSandbox(ctx, kind, model) };
   } catch (error) {
     if (isRunControlError(error)) throw error;
+    const { isAgentRuntimeError } = await import("../sandbox/agents/protocol.js");
+    if (isAgentRuntimeError(error)) {
+      return agentProtocolBlockError({
+        ok: false,
+        category: error.category,
+        message: error.safeMessage,
+        diagnostic: error.diagnostic,
+      });
+    }
     return executionError(error instanceof Error ? error.message : String(error), {
       category: "sandbox",
       phase: "research",
@@ -742,30 +757,81 @@ writeAttachments.maxRetries = 0;
 
 async function writeAndStartPhase(
   sandboxId: string,
+  agentKind: AgentKind,
+  phase: PhaseKind,
   inputFilePath: string,
   inputContent: string,
   scriptPath: string,
   scriptContent: string,
-): Promise<string> {
+): Promise<
+  | { ok: true; commandId: string }
+  | { ok: false; failure: Extract<AgentProtocolResult<unknown>, { ok: false }> }
+> {
   "use step";
-  const { Sandbox } = await import("@vercel/sandbox");
-  const { getSandboxCredentials } = await import("../sandbox/credentials.js");
+  const { createAgentAdapter } = await import("../sandbox/agents/index.js");
+  const { commandProtocolFailure, protocolFailure } = await import(
+    "../sandbox/agents/protocol.js"
+  );
+  const spec = createAgentAdapter(agentKind).cliSpec;
+  try {
+    const { Sandbox } = await import("@vercel/sandbox");
+    const { getSandboxCredentials } = await import("../sandbox/credentials.js");
+    const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
 
-  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+    await sandbox.writeFiles([
+      { path: inputFilePath, content: Buffer.from(inputContent) },
+      { path: scriptPath, content: Buffer.from(scriptContent) },
+    ]);
+    const chmod = await sandbox.runCommand("chmod", ["+x", scriptPath]);
+    if (chmod.exitCode !== 0) {
+      return {
+        ok: false,
+        failure: await commandProtocolFailure({
+          spec,
+          phase,
+          result: chmod,
+          failureKind: "setup_failed",
+          message: "The current agent phase could not be completed.",
+          detail: "The agent phase wrapper could not be made executable.",
+        }),
+      };
+    }
 
-  await sandbox.writeFiles([
-    { path: inputFilePath, content: Buffer.from(inputContent) },
-    { path: scriptPath, content: Buffer.from(scriptContent) },
-  ]);
-  await sandbox.runCommand("chmod", ["+x", scriptPath]);
-
-  const command = await sandbox.runCommand({
-    cmd: "bash",
-    args: [scriptPath],
-    cwd: "/vercel/sandbox",
-    detached: true,
-  });
-  return command.cmdId;
+    const command = await sandbox.runCommand({
+      cmd: "bash",
+      args: [scriptPath],
+      cwd: "/vercel/sandbox",
+      detached: true,
+    });
+    if (command.exitCode !== null && command.exitCode !== 0) {
+      return {
+        ok: false,
+        failure: await commandProtocolFailure({
+          spec,
+          phase,
+          result: command,
+          failureKind: "cli_exit",
+          message: "The current agent phase could not be completed.",
+          detail: "The agent phase process could not be launched.",
+        }),
+      };
+    }
+    return { ok: true, commandId: command.cmdId };
+  } catch (error) {
+    const { isRunControlError } = await import("./run-control-error.js");
+    if (isRunControlError(error)) throw error;
+    const failure = protocolFailure({
+      spec,
+      phase,
+      artifacts: { stdout: "", stderr: "", structuredOutput: null, exitCode: null },
+      failureKind: "provider_error",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      detail: "The agent phase process could not be launched.",
+    });
+    if (failure.ok) throw new Error("unreachable");
+    return { ok: false, failure };
+  }
 }
 writeAndStartPhase.maxRetries = 0;
 
@@ -788,7 +854,11 @@ async function readRunBudgetClockStep(): Promise<number> {
 }
 readRunBudgetClockStep.maxRetries = 0;
 
-async function setCommitGuardStep(sandboxId: string, agentKind: AgentKind, enabled: boolean): Promise<void> {
+async function setCommitGuardStep(
+  sandboxId: string,
+  agentKind: AgentKind,
+  enabled: boolean,
+): Promise<AgentProtocolResult<void>> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
   const { getSandboxCredentials } = await import("../sandbox/credentials.js");
@@ -796,7 +866,19 @@ async function setCommitGuardStep(sandboxId: string, agentKind: AgentKind, enabl
 
   const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
   const agent = createAgentAdapter(agentKind);
-  await agent.setCommitGuard(sandbox, enabled);
+  try {
+    await agent.setCommitGuard(sandbox, enabled);
+    return { ok: true, value: undefined };
+  } catch (error) {
+    const { isAgentRuntimeError } = await import("../sandbox/agents/protocol.js");
+    if (!isAgentRuntimeError(error)) throw error;
+    return {
+      ok: false,
+      category: error.category,
+      message: error.safeMessage,
+      diagnostic: error.diagnostic,
+    };
+  }
 }
 
 // Step wrappers around the AgentAdapter class methods. The adapter classes
@@ -819,35 +901,41 @@ async function planPhaseStep(
 
 async function parseResearchStep(
   agentKind: AgentKind,
-  raw: string,
-  structured: string | null,
-): Promise<{ research: ResearchResult; usage: PhaseUsage | null }> {
+  artifacts: CollectedPhaseArtifacts,
+): Promise<{ result: AgentProtocolResult<ResearchResult>; usage: PhaseUsage | null }> {
   "use step";
   const { createAgentAdapter } = await import("../sandbox/agents/index.js");
   const a = createAgentAdapter(agentKind);
-  return { research: a.parseResearchStatus(raw, structured), usage: a.extractUsage(raw, structured) };
+  return {
+    result: a.parseResearchProtocol(artifacts, "research"),
+    usage: a.extractUsage(artifacts.stdout, artifacts.structuredOutput),
+  };
 }
 
 async function parseAgentOutputStep(
   agentKind: AgentKind,
-  raw: string,
-  structured: string | null,
-): Promise<{ output: AgentOutput; usage: PhaseUsage | null }> {
+  artifacts: CollectedPhaseArtifacts,
+): Promise<{ result: AgentProtocolResult<AgentOutput>; usage: PhaseUsage | null }> {
   "use step";
   const { createAgentAdapter } = await import("../sandbox/agents/index.js");
   const a = createAgentAdapter(agentKind);
-  return { output: a.parseAgentOutput(raw, structured), usage: a.extractUsage(raw, structured) };
+  return {
+    result: a.parseAgentOutputProtocol(artifacts, "impl"),
+    usage: a.extractUsage(artifacts.stdout, artifacts.structuredOutput),
+  };
 }
 
 async function parseReviewStep(
   agentKind: AgentKind,
-  raw: string,
-  structured: string | null,
-): Promise<{ output: ReviewOutput; usage: PhaseUsage | null }> {
+  artifacts: CollectedPhaseArtifacts,
+): Promise<{ result: AgentProtocolResult<ReviewOutput>; usage: PhaseUsage | null }> {
   "use step";
   const { createAgentAdapter } = await import("../sandbox/agents/index.js");
   const a = createAgentAdapter(agentKind);
-  return { output: a.parseReviewOutput(raw, structured), usage: a.extractUsage(raw, structured) };
+  return {
+    result: a.parseReviewOutputProtocol(artifacts, "review"),
+    usage: a.extractUsage(artifacts.stdout, artifacts.structuredOutput),
+  };
 }
 
 export async function postPrLinksComment(
@@ -943,6 +1031,15 @@ async function markRunFailedOnSelfMoveStep(runId: string): Promise<void> {
   await markRunFailedOnSelfMove(getDb(), runId);
 }
 markRunFailedOnSelfMoveStep.maxRetries = 0;
+
+async function logWorkflowExecutionErrorStep(
+  event: WorkflowExecutionLogEvent,
+): Promise<void> {
+  "use step";
+  const { logger } = await import("../lib/logger.js");
+  logger.error(event, "workflow_execution_error");
+}
+logWorkflowExecutionErrorStep.maxRetries = 0;
 
 export function clarificationExitDisposition(providerParked: boolean): {
   outcome: "awaiting";
@@ -1140,6 +1237,7 @@ async function runPrePrChecksStep(
   fixCycleUsages: Array<PhaseUsage | null>;
   budgetFailure: RunBudgetFailure | null;
   summary: string;
+  agentFailure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
 }> {
   "use step";
   const { getDb } = await import("../db/client.js");
@@ -1980,7 +2078,8 @@ async function agentWorkflowBody(
             await writeAttachmentsOnce(sandboxId);
             phaseModels[researchPhase] = model;
             runPhaseModels[researchPhase] = model;
-            await setCommitGuardStep(sandboxId, kind, false);
+            const researchGuard = await setCommitGuardStep(sandboxId, kind, false);
+            if (!researchGuard.ok) return agentProtocolBlockError(researchGuard);
 
             // Review-remediation framing: when this ticket already has a
             // workflow-owned PR, pull its human review feedback in BEFORE the
@@ -2007,11 +2106,13 @@ async function agentWorkflowBody(
               repositoryContexts: ctx.repositoryContexts,
             });
 
-            const researchCommandId = await writeAndStartPhase(
-              sandboxId,
+            const researchLaunch = await writeAndStartPhase(
+              sandboxId, kind, "research",
               researchPaths.input, researchInput,
               researchPaths.wrapper, researchScript,
             );
+            if (!researchLaunch.ok) return agentProtocolBlockError(researchLaunch.failure);
+            const researchCommandId = researchLaunch.commandId;
             launchedPhases.add(researchPhase);
 
             const researchDone = await pollPhaseUntilDone(
@@ -2028,11 +2129,12 @@ async function agentWorkflowBody(
               });
             }
 
-            const { raw: researchRaw, structured: researchStructured } =
-              await collectPhase(sandboxId, researchPaths);
-            const { research, usage: researchUsage } =
-              await parseResearchStep(kind, researchRaw, researchStructured);
+            const researchArtifacts = await collectPhase(sandboxId, researchPaths);
+            const { result: researchResult, usage: researchUsage } =
+              await parseResearchStep(kind, researchArtifacts);
             ctx.recordUsage("Research", researchUsage, model);
+            if (!researchResult.ok) return agentProtocolBlockError(researchResult);
+            const research = researchResult.value;
 
             if (research.status === "clarification_needed") {
               // Prefer the structured questions the parser now folds out; fall
@@ -2073,7 +2175,8 @@ async function agentWorkflowBody(
             state.implementationKind = kind;
             // Mixed-run telemetry: the run's headline model is the impl block's.
             activeModel = model;
-            await setCommitGuardStep(sandboxId, kind, true);
+            const implementationGuard = await setCommitGuardStep(sandboxId, kind, true);
+            if (!implementationGuard.ok) return agentProtocolBlockError(implementationGuard);
 
             const { paths: implPaths, script: implScript } =
               await planPhaseStep(kind, "impl", model, AGENT_SCHEMA);
@@ -2090,11 +2193,13 @@ async function agentWorkflowBody(
               repositoryContexts: ctx.repositoryContexts,
             });
 
-            const implCommandId = await writeAndStartPhase(
-              sandboxId,
+            const implLaunch = await writeAndStartPhase(
+              sandboxId, kind, "impl",
               implPaths.input, implInput,
               implPaths.wrapper, implScript,
             );
+            if (!implLaunch.ok) return agentProtocolBlockError(implLaunch.failure);
+            const implCommandId = implLaunch.commandId;
             launchedPhases.add(implPhase);
 
             const implDone = await pollPhaseUntilDone(
@@ -2107,10 +2212,11 @@ async function agentWorkflowBody(
             let implOutput: AgentOutput;
 
             if (implDone) {
-              const { raw: implRaw, structured: implStructured } = await collectPhase(sandboxId, implPaths);
-              const { output, usage: implUsage } = await parseAgentOutputStep(kind, implRaw, implStructured);
+              const implArtifacts = await collectPhase(sandboxId, implPaths);
+              const { result, usage: implUsage } = await parseAgentOutputStep(kind, implArtifacts);
               ctx.recordUsage("Impl", implUsage, model);
-              implOutput = output;
+              if (!result.ok) return agentProtocolBlockError(result);
+              implOutput = result.value;
             } else {
               implOutput = { result: "failed", error: "Implementation phase timed out" };
             }
@@ -2171,7 +2277,8 @@ async function agentWorkflowBody(
             runPhaseModels[reviewPhase] = model;
             // Install the review provider's commit guard: in a mixed run it may
             // differ from impl's provider, so its guard was never set up.
-            await setCommitGuardStep(sandboxId, kind, true);
+            const reviewGuard = await setCommitGuardStep(sandboxId, kind, true);
+            if (!reviewGuard.ok) return agentProtocolBlockError(reviewGuard);
             const { paths: reviewPaths, script: reviewScript } =
               await planPhaseStep(kind, "review", model, REVIEW_SCHEMA);
             const reviewInput = assembleReviewContext({
@@ -2183,11 +2290,13 @@ async function agentWorkflowBody(
               selectedRepositories: ctx.selectedRepositories,
             });
 
-            const reviewCommandId = await writeAndStartPhase(
-              sandboxId,
+            const reviewLaunch = await writeAndStartPhase(
+              sandboxId, kind, "review",
               reviewPaths.input, reviewInput,
               reviewPaths.wrapper, reviewScript,
             );
+            if (!reviewLaunch.ok) return agentProtocolBlockError(reviewLaunch.failure);
+            const reviewCommandId = reviewLaunch.commandId;
             launchedPhases.add(reviewPhase);
 
             const reviewDone = await pollPhaseUntilDone(
@@ -2200,10 +2309,11 @@ async function agentWorkflowBody(
             let reviewOutput: ReviewOutput;
 
             if (reviewDone) {
-              const { raw: reviewRaw, structured: reviewStructured } = await collectPhase(sandboxId, reviewPaths);
-              const { output, usage: reviewUsage } = await parseReviewStep(kind, reviewRaw, reviewStructured);
+              const reviewArtifacts = await collectPhase(sandboxId, reviewPaths);
+              const { result, usage: reviewUsage } = await parseReviewStep(kind, reviewArtifacts);
               ctx.recordUsage("Review", reviewUsage, model);
-              reviewOutput = output;
+              if (!result.ok) return agentProtocolBlockError(result);
+              reviewOutput = result.value;
             } else {
               return executionError("Review phase timed out", {
                 category: "timeout",
@@ -2260,6 +2370,9 @@ async function agentWorkflowBody(
               state.implementationModel,
               prePrChecks.budgetFailure,
             );
+            if (prePrChecks.agentFailure) {
+              return agentProtocolBlockError(prePrChecks.agentFailure);
+            }
             if (!prePrChecks.passed) {
               return {
                 kind: "next",
@@ -2403,6 +2516,7 @@ async function agentWorkflowBody(
       };
 
       const hooks: ExecuteGraphHooks = {
+        onExecutionError: logWorkflowExecutionErrorStep,
         async onBlockStart(nodeId, attempt) {
           await enforceBudgetAtBoundary(true);
           currentBlockId = nodeId;

--- a/apps/worker/src/workflows/blocks/agent-sandbox.ts
+++ b/apps/worker/src/workflows/blocks/agent-sandbox.ts
@@ -1,4 +1,5 @@
 import type { AgentKind } from "../../sandbox/agents/index.js";
+import type { AgentProtocolResult } from "../../sandbox/agents/types.js";
 import { isRunControlError } from "../run-control-error.js";
 import type { EngineCtx } from "./types.js";
 import { ensureArthurTask } from "./prepare-workspace.js";
@@ -9,7 +10,10 @@ async function blockProvisionAgentSandboxStep(
   agentKind: AgentKind,
   model: string,
   arthurTaskId: string | null,
-): Promise<{ sandboxId: string }> {
+): Promise<
+  | { ok: true; sandboxId: string }
+  | { ok: false; failure: Extract<AgentProtocolResult<unknown>, { ok: false }> }
+> {
   "use step";
   const { env } = await import("../../../env.js");
   const { Sandbox } = await import("@vercel/sandbox");
@@ -17,12 +21,36 @@ async function blockProvisionAgentSandboxStep(
   const { createAgentAdapter } = await import("../../sandbox/agents/index.js");
 
   if (agentKind === "codex" && !env.CODEX_API_KEY && !env.CODEX_CHATGPT_OAUTH_TOKEN) {
-    throw new Error(
-      "agent codex needs CODEX_API_KEY or CODEX_CHATGPT_OAUTH_TOKEN in the deployed environment",
+    const { runtimePreparationError } = await import("../../sandbox/agents/protocol.js");
+    const error = runtimePreparationError(
+      createAgentAdapter(agentKind).cliSpec,
+      "Codex authentication credentials are missing from the deployed environment.",
     );
+    return {
+      ok: false,
+      failure: {
+        ok: false,
+        category: error.category,
+        message: error.safeMessage,
+        diagnostic: error.diagnostic,
+      },
+    };
   }
   if (agentKind === "claude" && !env.ANTHROPIC_API_KEY) {
-    throw new Error("agent claude needs ANTHROPIC_API_KEY in the deployed environment");
+    const { runtimePreparationError } = await import("../../sandbox/agents/protocol.js");
+    const error = runtimePreparationError(
+      createAgentAdapter(agentKind).cliSpec,
+      "Claude authentication credentials are missing from the deployed environment.",
+    );
+    return {
+      ok: false,
+      failure: {
+        ok: false,
+        category: error.category,
+        message: error.safeMessage,
+        diagnostic: error.diagnostic,
+      },
+    };
   }
 
   const arthur =
@@ -55,15 +83,28 @@ async function blockProvisionAgentSandboxStep(
       model,
       arthur,
     });
-    return { sandboxId: sandbox.sandboxId };
+    return { ok: true, sandboxId: sandbox.sandboxId };
   } catch (error) {
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    const agentRuntimeError = isAgentRuntimeError(error);
     const { stopSandboxAndConfirm } = await import(
       "../../sandbox/stop-ticket-sandboxes.js"
     );
     try {
       await stopSandboxAndConfirm(sandbox);
     } catch (cleanupError) {
-      if (!isRunControlError(error)) throw cleanupError;
+      if (!isRunControlError(error) && !agentRuntimeError) throw cleanupError;
+    }
+    if (agentRuntimeError) {
+      return {
+        ok: false,
+        failure: {
+          ok: false,
+          category: error.category,
+          message: error.safeMessage,
+          diagnostic: error.diagnostic,
+        },
+      };
     }
     throw error;
   }
@@ -84,13 +125,18 @@ export async function ensureAgentSandbox(
   if (existing) return existing;
 
   const arthurTaskId = await ensureArthurTask(ctx);
-  const { sandboxId } = await blockProvisionAgentSandboxStep(
+  const provisioned = await blockProvisionAgentSandboxStep(
     ctx.entry.subjectKey,
     ctx.entry.ownerToken,
     agentKind,
     model,
     arthurTaskId,
   );
+  if (!provisioned.ok) {
+    const { AgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    throw new AgentRuntimeError(provisioned.failure);
+  }
+  const { sandboxId } = provisioned;
   ctx.agentSandboxIds[agentKind] = sandboxId;
   // The in-workflow set covers normal teardown; the durable owner-child row
   // registered immediately after create covers cancel/reconcile crash cleanup.

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   artifactPaths: vi.fn(),
   buildPhaseScript: vi.fn(),
   parseAgentOutput: vi.fn(),
+  parseAgentOutputProtocol: vi.fn(),
   extractUsage: vi.fn(),
   writeFiles: vi.fn(),
   runCommand: vi.fn().mockResolvedValue({ exitCode: 0 }),
@@ -37,10 +38,17 @@ vi.mock("@vercel/sandbox", () => ({
 vi.mock("./poll-phase.js", () => ({ pollPhaseUntilDone: mocks.pollPhaseUntilDone }));
 vi.mock("../../sandbox/agents/index.js", () => ({
   createAgentAdapter: vi.fn(() => ({
+    cliSpec: {
+      kind: "claude",
+      packageName: "@anthropic-ai/claude-code",
+      version: "2.1.216",
+      executable: "claude",
+      protocol: "claude-json-2.1.216",
+    },
     setCommitGuard: mocks.setCommitGuard,
     artifactPaths: mocks.artifactPaths,
     buildPhaseScript: mocks.buildPhaseScript,
-    parseAgentOutput: mocks.parseAgentOutput,
+    parseAgentOutputProtocol: mocks.parseAgentOutputProtocol,
     extractUsage: mocks.extractUsage,
   })),
 }));
@@ -75,6 +83,7 @@ function pathsFor(phase: string) {
     input: `/tmp/${phase}-requirements.md`,
     stdout: `/tmp/${phase}-stdout.txt`,
     stderr: `/tmp/${phase}-stderr.txt`,
+    exitCode: `/tmp/${phase}-exit-code`,
     sentinel: `/tmp/${phase}-done`,
     structuredOutput: null,
   };
@@ -100,7 +109,16 @@ describe("fix_agent execute", () => {
     mocks.artifactPaths.mockImplementation((phase: string) => pathsFor(phase));
     mocks.buildPhaseScript.mockReturnValue("#!/bin/bash");
     mocks.checkPhaseDone.mockResolvedValue(true);
-    mocks.collectPhase.mockResolvedValue({ raw: "raw", structured: null });
+    mocks.collectPhase.mockResolvedValue({
+      stdout: "raw",
+      stderr: "",
+      structuredOutput: null,
+      exitCode: 0,
+    });
+    mocks.parseAgentOutputProtocol.mockImplementation(() => ({
+      ok: true,
+      value: mocks.parseAgentOutput(),
+    }));
     mocks.extractUsage.mockReturnValue(usage);
     mocks.ensureWorkspace.mockImplementation(async (ctx) => {
       ctx.sandboxId ??= "sbx-auto";
@@ -115,7 +133,15 @@ describe("fix_agent execute", () => {
       };
     });
     mocks.inspectFixWorkspace.mockResolvedValue({ commits: [], unresolvedConflicts: [] });
-    mocks.runCommand.mockResolvedValue({ cmdId: "cmd-2", exitCode: null });
+    mocks.runCommand.mockImplementation((command) =>
+      command === "chmod"
+        ? {
+            exitCode: 0,
+            stdout: vi.fn().mockResolvedValue(""),
+            stderr: vi.fn().mockResolvedValue(""),
+          }
+        : { cmdId: "cmd-2", exitCode: null },
+    );
     mocks.pollPhaseUntilDone.mockResolvedValue(true);
   });
 
@@ -351,6 +377,30 @@ describe("fix_agent execute", () => {
       expect(result.error.detail).toBe("could not fix");
       expect(result.output).toBeUndefined();
     }
+  });
+
+  it("maps wrapper launch setup failure to a provider protocol error", async () => {
+    mocks.runCommand.mockImplementation((command) =>
+      command === "chmod"
+        ? {
+            exitCode: 1,
+            stdout: vi.fn().mockResolvedValue(""),
+            stderr: vi.fn().mockResolvedValue("permission denied"),
+          }
+        : { cmdId: "cmd-2", exitCode: null },
+    );
+
+    const result = await execute(makeNode("fix_agent"), {}, makeCtx());
+
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error).toMatchObject({
+        category: "provider",
+        message: "The current agent phase could not be completed.",
+        diagnostic: { failureKind: "setup_failed", stderrTail: "permission denied" },
+      });
+    }
+    expect(mocks.pollPhaseUntilDone).not.toHaveBeenCalled();
   });
 
   it.each(runControlErrorCases())("rethrows %s from Fix execution", async (_label, error) => {

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -3,6 +3,8 @@ import type { WorkflowDefinitionNode } from "@shared/contracts";
 import type { AgentKind } from "../../sandbox/agents/index.js";
 import type {
   AgentOutput,
+  AgentProtocolResult,
+  CollectedPhaseArtifacts,
   PhaseArtifactPaths,
   PhaseUsage,
 } from "../../sandbox/agents/types.js";
@@ -18,6 +20,7 @@ import {
 } from "./fix-workspace-state.js";
 import {
   executionError,
+  agentProtocolExecutionError,
   sanitizeBlockId,
   type BlockExecuteFn,
   type BlockExecutionResult,
@@ -40,7 +43,7 @@ async function blockFixAgentCommitGuardStep(
   sandboxId: string,
   agentKind: AgentKind,
   enabled: boolean,
-): Promise<void> {
+): Promise<AgentProtocolResult<void>> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
   const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
@@ -48,7 +51,19 @@ async function blockFixAgentCommitGuardStep(
 
   const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
   const agent = createAgentAdapter(agentKind);
-  await agent.setCommitGuard(sandbox, enabled);
+  try {
+    await agent.setCommitGuard(sandbox, enabled);
+    return { ok: true, value: undefined };
+  } catch (error) {
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    if (!isAgentRuntimeError(error)) throw error;
+    return {
+      ok: false,
+      category: error.category,
+      message: error.safeMessage,
+      diagnostic: error.diagnostic,
+    };
+  }
 }
 
 async function blockFixAgentPlanPhaseStep(
@@ -67,42 +82,94 @@ async function blockFixAgentPlanPhaseStep(
 
 async function blockFixAgentStartPhaseStep(
   sandboxId: string,
+  agentKind: AgentKind,
+  phase: string,
   inputFilePath: string,
   inputContent: string,
   scriptPath: string,
   scriptContent: string,
-): Promise<string> {
+): Promise<
+  | { ok: true; commandId: string }
+  | { ok: false; failure: Extract<AgentProtocolResult<unknown>, { ok: false }> }
+> {
   "use step";
-  const { Sandbox } = await import("@vercel/sandbox");
-  const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
+  const { createAgentAdapter } = await import("../../sandbox/agents/index.js");
+  const { commandProtocolFailure, protocolFailure } = await import(
+    "../../sandbox/agents/protocol.js"
+  );
+  const spec = createAgentAdapter(agentKind).cliSpec;
+  try {
+    const { Sandbox } = await import("@vercel/sandbox");
+    const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
 
-  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
-  await sandbox.writeFiles([
-    { path: inputFilePath, content: Buffer.from(inputContent) },
-    { path: scriptPath, content: Buffer.from(scriptContent) },
-  ]);
-  await sandbox.runCommand("chmod", ["+x", scriptPath]);
-  const command = await sandbox.runCommand({
-    cmd: "bash",
-    args: [scriptPath],
-    cwd: "/vercel/sandbox",
-    detached: true,
-  });
-  return command.cmdId;
+    const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+    await sandbox.writeFiles([
+      { path: inputFilePath, content: Buffer.from(inputContent) },
+      { path: scriptPath, content: Buffer.from(scriptContent) },
+    ]);
+    const chmod = await sandbox.runCommand("chmod", ["+x", scriptPath]);
+    if (chmod.exitCode !== 0) {
+      return {
+        ok: false,
+        failure: await commandProtocolFailure({
+          spec,
+          phase,
+          result: chmod,
+          failureKind: "setup_failed",
+          message: "The current agent phase could not be completed.",
+          detail: "The agent phase wrapper could not be made executable.",
+        }),
+      };
+    }
+    const command = await sandbox.runCommand({
+      cmd: "bash",
+      args: [scriptPath],
+      cwd: "/vercel/sandbox",
+      detached: true,
+    });
+    if (command.exitCode !== null && command.exitCode !== 0) {
+      return {
+        ok: false,
+        failure: await commandProtocolFailure({
+          spec,
+          phase,
+          result: command,
+          failureKind: "cli_exit",
+          message: "The current agent phase could not be completed.",
+          detail: "The agent phase process could not be launched.",
+        }),
+      };
+    }
+    return { ok: true, commandId: command.cmdId };
+  } catch (error) {
+    const { isRunControlError } = await import("../run-control-error.js");
+    if (isRunControlError(error)) throw error;
+    const failure = protocolFailure({
+      spec,
+      phase,
+      artifacts: { stdout: "", stderr: "", structuredOutput: null, exitCode: null },
+      failureKind: "provider_error",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      detail: "The agent phase process could not be launched.",
+    });
+    if (failure.ok) throw new Error("unreachable");
+    return { ok: false, failure };
+  }
 }
 blockFixAgentStartPhaseStep.maxRetries = 0;
 
 async function blockFixAgentParseStep(
   agentKind: AgentKind,
-  raw: string,
-  structured: string | null,
-): Promise<{ output: AgentOutput; usage: PhaseUsage | null }> {
+  artifacts: CollectedPhaseArtifacts,
+  phase: string,
+): Promise<{ result: AgentProtocolResult<AgentOutput>; usage: PhaseUsage | null }> {
   "use step";
   const { createAgentAdapter } = await import("../../sandbox/agents/index.js");
   const adapter = createAgentAdapter(agentKind);
   return {
-    output: adapter.parseAgentOutput(raw, structured),
-    usage: adapter.extractUsage(raw, structured),
+    result: adapter.parseAgentOutputProtocol(artifacts, phase),
+    usage: adapter.extractUsage(artifacts.stdout, artifacts.structuredOutput),
   };
 }
 
@@ -183,15 +250,20 @@ export const execute: BlockExecuteFn = async (
     const input = await buildFixInput(block, ctx);
     const { AGENT_SCHEMA } = await import("../../sandbox/agents/types.js");
 
-    await blockFixAgentCommitGuardStep(sandboxId, kind, true);
+    const guard = await blockFixAgentCommitGuardStep(sandboxId, kind, true);
+    if (!guard.ok) return agentProtocolExecutionError(guard);
     const { paths, script } = await blockFixAgentPlanPhaseStep(kind, phase, model, AGENT_SCHEMA);
-    const commandId = await blockFixAgentStartPhaseStep(
+    const launch = await blockFixAgentStartPhaseStep(
       sandboxId,
+      kind,
+      phase,
       paths.input,
       input,
       paths.wrapper,
       script,
     );
+    if (!launch.ok) return agentProtocolExecutionError(launch.failure);
+    const commandId = launch.commandId;
     ctx.markLaunched(usageLabel(block.id));
 
     const done = await pollPhaseUntilDone(
@@ -206,9 +278,11 @@ export const execute: BlockExecuteFn = async (
     }
 
     const { collectPhase } = await import("../../sandbox/poll-agent.js");
-    const { raw, structured } = await collectPhase(sandboxId, paths);
-    const { output, usage } = await blockFixAgentParseStep(kind, raw, structured);
+    const artifacts = await collectPhase(sandboxId, paths);
+    const { result, usage } = await blockFixAgentParseStep(kind, artifacts, phase);
     ctx.recordUsage(usageLabel(block.id), usage, model);
+    if (!result.ok) return agentProtocolExecutionError(result);
+    const output = result.value;
     const after = await inspectFixWorkspace(sandboxId);
 
     if (output.result === "clarification_needed") {

--- a/apps/worker/src/workflows/blocks/generic-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/generic-agent.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   setCommitGuard: vi.fn(),
   artifactPaths: vi.fn(),
   buildPhaseScript: vi.fn(),
+  parseStructuredObjectProtocol: vi.fn(),
   extractUsage: vi.fn(),
   writeFiles: vi.fn(),
   runCommand: vi.fn().mockResolvedValue({ exitCode: 0 }),
@@ -28,9 +29,17 @@ vi.mock("@vercel/sandbox", () => ({ Sandbox: { get: mocks.sandboxGet } }));
 vi.mock("./poll-phase.js", () => ({ pollPhaseUntilDone: mocks.pollPhaseUntilDone }));
 vi.mock("../../sandbox/agents/index.js", () => ({
   createAgentAdapter: vi.fn(() => ({
+    cliSpec: {
+      kind: "claude",
+      packageName: "@anthropic-ai/claude-code",
+      version: "2.1.216",
+      executable: "claude",
+      protocol: "claude-json-2.1.216",
+    },
     setCommitGuard: mocks.setCommitGuard,
     artifactPaths: mocks.artifactPaths,
     buildPhaseScript: mocks.buildPhaseScript,
+    parseStructuredObjectProtocol: mocks.parseStructuredObjectProtocol,
     extractUsage: mocks.extractUsage,
   })),
 }));
@@ -48,6 +57,7 @@ function pathsFor(phase: string) {
     input: `/tmp/${phase}-requirements.md`,
     stdout: `/tmp/${phase}-stdout.txt`,
     stderr: `/tmp/${phase}-stderr.txt`,
+    exitCode: `/tmp/${phase}-exit-code`,
     sentinel: `/tmp/${phase}-done`,
     structuredOutput: `/tmp/${phase}-result.json`,
   };
@@ -80,8 +90,42 @@ describe("generic_agent execute", () => {
     mocks.buildPhaseScript.mockReturnValue("#!/bin/bash");
     mocks.checkPhaseDone.mockResolvedValue(true);
     mocks.extractUsage.mockReturnValue(null);
+    mocks.parseStructuredObjectProtocol.mockImplementation((artifacts) => {
+      const source = artifacts.structuredOutput ?? artifacts.stdout;
+      try {
+        const envelope = JSON.parse(source);
+        return {
+          ok: true,
+          value: envelope?.type === "result" ? envelope.structured_output : envelope,
+        };
+      } catch {
+        return {
+          ok: false,
+          category: "parsing",
+          message: "The current agent phase returned an invalid structured response.",
+          diagnostic: {
+            provider: "claude",
+            packageName: "@anthropic-ai/claude-code",
+            cliVersion: "2.1.216",
+            protocol: "claude-json-2.1.216",
+            phase: "agent-test",
+            failureKind: "invalid_json",
+            exitCode: 0,
+            detail: "Agent output was not valid JSON.",
+          },
+        };
+      }
+    });
     mocks.ensureAgentSandbox.mockResolvedValue("scratch-new");
-    mocks.runCommand.mockResolvedValue({ cmdId: "cmd-1", exitCode: null });
+    mocks.runCommand.mockImplementation((command) =>
+      command === "chmod"
+        ? {
+            exitCode: 0,
+            stdout: vi.fn().mockResolvedValue(""),
+            stderr: vi.fn().mockResolvedValue(""),
+          }
+        : { cmdId: "cmd-1", exitCode: null },
+    );
     mocks.pollPhaseUntilDone.mockResolvedValue(true);
   });
 
@@ -109,8 +153,10 @@ describe("generic_agent execute", () => {
 
   it("uses an agent-only scratch sandbox in none mode", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ status: "ok", body: "planned", questions: null, error: null }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ status: "ok", body: "planned", questions: null, error: null }),
+      exitCode: 0,
     });
     const ctx = makeCtx({
       sandboxId: null,
@@ -131,8 +177,10 @@ describe("generic_agent execute", () => {
 
   it("adds the clarification answer to the rerun prompt", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ status: "ok", body: "continued", questions: null, error: null }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ status: "ok", body: "continued", questions: null, error: null }),
+      exitCode: 0,
     });
     const ctx = makeCtx({
       sandboxId: null,
@@ -155,8 +203,10 @@ describe("generic_agent execute", () => {
 
   it("provisions agent-only scratch on demand in none mode", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ status: "ok", body: "planned", questions: null, error: null }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ status: "ok", body: "planned", questions: null, error: null }),
+      exitCode: 0,
     });
     const ctx = makeCtx({ sandboxId: null, agentSandboxIds: {} } as never);
 
@@ -217,8 +267,10 @@ describe("generic_agent execute", () => {
 
   it("writes the prompt verbatim, uses GENERIC_SCHEMA, and maps ok output", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ status: "ok", body: "done", questions: null, error: null }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ status: "ok", body: "done", questions: null, error: null }),
+      exitCode: 0,
     });
     const ctx = makeCtx();
 
@@ -252,8 +304,10 @@ describe("generic_agent execute", () => {
 
   it("emits the guaranteed body field when an unstructured success body is empty", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ status: "ok", body: "", questions: null, error: null }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ status: "ok", body: "", questions: null, error: null }),
+      exitCode: 0,
     });
 
     const result = await execute(makeNode("generic_agent", { prompt: "p" }), {}, makeCtx());
@@ -263,8 +317,10 @@ describe("generic_agent execute", () => {
 
   it("prefers a resolved prompt over the static param", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ status: "ok", body: "done", questions: null, error: null }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ status: "ok", body: "done", questions: null, error: null }),
+      exitCode: 0,
     });
 
     await execute(
@@ -283,8 +339,10 @@ describe("generic_agent execute", () => {
 
   it("keeps the telemetry label unique per raw block id while sanitizing the artifact path", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ status: "ok", body: "done", questions: null, error: null }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ status: "ok", body: "done", questions: null, error: null }),
+      exitCode: 0,
     });
     const ctx = makeCtx();
 
@@ -299,13 +357,15 @@ describe("generic_agent execute", () => {
 
   it("maps needs_input output to needs_human_input", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({
         status: "needs_input",
         body: "",
         questions: ["Which region?"],
         error: null,
       }),
+      exitCode: 0,
     });
 
     const result = await execute(makeNode("generic_agent", { prompt: "p" }), {}, makeCtx());
@@ -319,14 +379,16 @@ describe("generic_agent execute", () => {
 
   it("threads suggestedAnswers through needs_input output", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({
         status: "needs_input",
         body: "",
         questions: ["Which region?"],
         suggestedAnswers: ["us-east-1", "eu-west-1"],
         error: null,
       }),
+      exitCode: 0,
     });
 
     const result = await execute(makeNode("generic_agent", { prompt: "p" }), {}, makeCtx());
@@ -345,8 +407,10 @@ describe("generic_agent execute", () => {
 
   it("maps failed output to kind failed with the reported error", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ status: "failed", body: "", questions: null, error: "broke" }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ status: "failed", body: "", questions: null, error: "broke" }),
+      exitCode: 0,
     });
 
     const result = await execute(makeNode("generic_agent", { prompt: "p" }), {}, makeCtx());
@@ -357,8 +421,10 @@ describe("generic_agent execute", () => {
 
   it("returns custom-schema fields at the top level with a compatibility data alias", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ answer: 42 }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ answer: 42 }),
+      exitCode: 0,
     });
     const outputSchema =
       '{"type":"object","properties":{"answer":{"type":"number"}},"required":["answer"],"additionalProperties":false}';
@@ -380,8 +446,10 @@ describe("generic_agent execute", () => {
 
   it("fails when custom-schema output has the wrong declared shape", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: "",
-      structured: JSON.stringify({ answer: "forty-two" }),
+      stdout: "",
+      stderr: "",
+      structuredOutput: JSON.stringify({ answer: "forty-two" }),
+      exitCode: 0,
     });
     const outputSchema =
       '{"type":"object","properties":{"answer":{"type":"number"}},"required":["answer"],"additionalProperties":false}';
@@ -394,12 +462,20 @@ describe("generic_agent execute", () => {
 
     expect(result.kind).toBe("execution_error");
     if (result.kind === "execution_error") {
-      expect(result.error.detail).toBe("agent output did not match the requested schema");
+      expect(result.error.category).toBe("schema");
+      expect(result.error.detail).toBe(
+        "The structured response did not satisfy the requested schema.",
+      );
     }
   });
 
   it("rejects a non-object custom schema because declared fields are top-level", async () => {
-    mocks.collectPhase.mockResolvedValue({ raw: "", structured: "null" });
+    mocks.collectPhase.mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      structuredOutput: "null",
+      exitCode: 0,
+    });
     const node = makeNode("generic_agent", {
       prompt: "p",
       outputSchema: '{"type":"null"}',
@@ -420,7 +496,12 @@ describe("generic_agent execute", () => {
   });
 
   it("fails when custom-schema output is unparseable", async () => {
-    mocks.collectPhase.mockResolvedValue({ raw: "gibberish", structured: "not json" });
+    mocks.collectPhase.mockResolvedValue({
+      stdout: "gibberish",
+      stderr: "",
+      structuredOutput: "not json",
+      exitCode: 0,
+    });
 
     const result = await execute(
       makeNode("generic_agent", { prompt: "p", outputSchema: '{"type":"object"}' }),
@@ -430,17 +511,20 @@ describe("generic_agent execute", () => {
 
     expect(result.kind).toBe("execution_error");
     if (result.kind === "execution_error") {
-      expect(result.error.detail).toBe("agent output did not match the requested schema");
+      expect(result.error.category).toBe("parsing");
+      expect(result.error.detail).toBe("Agent output was not valid JSON.");
     }
   });
 
   it("parses a claude result envelope from raw output", async () => {
     mocks.collectPhase.mockResolvedValue({
-      raw: JSON.stringify({
+      stdout: JSON.stringify({
         type: "result",
         structured_output: { status: "ok", body: "from envelope", questions: null, error: null },
       }),
-      structured: null,
+      stderr: "",
+      structuredOutput: null,
+      exitCode: 0,
     });
 
     const result = await execute(makeNode("generic_agent", { prompt: "p" }), {}, makeCtx());

--- a/apps/worker/src/workflows/blocks/generic-agent.ts
+++ b/apps/worker/src/workflows/blocks/generic-agent.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 import type { JsonValue } from "@shared/contracts";
 import type { AgentKind } from "../../sandbox/agents/index.js";
-import type { PhaseArtifactPaths, PhaseUsage } from "../../sandbox/agents/types.js";
+import type {
+  AgentProtocolResult,
+  CollectedPhaseArtifacts,
+  PhaseArtifactPaths,
+  PhaseUsage,
+} from "../../sandbox/agents/types.js";
 import {
   validateBlockOutputForDefinition,
   workflowBlockDefinitionIssue,
@@ -11,6 +16,7 @@ import { ensureAgentSandbox } from "./agent-sandbox.js";
 import { isRunControlError } from "../run-control-error.js";
 import { pollPhaseUntilDone } from "./poll-phase.js";
 import {
+  agentProtocolExecutionError,
   executionError,
   sanitizeBlockId,
   type BlockExecuteFn,
@@ -37,43 +43,11 @@ const genericOutputSchema = z.object({
   error: z.string().nullish(),
 });
 
-function extractStructuredObject(raw: string, structured: string | null): unknown {
-  if (structured) {
-    try {
-      return JSON.parse(structured);
-    } catch {
-      return undefined;
-    }
-  }
-  const candidates = [raw, ...raw.split("\n").filter(Boolean).reverse()];
-  for (const candidate of candidates) {
-    try {
-      const parsed = JSON.parse(candidate);
-      if (parsed && typeof parsed === "object" && (parsed as { type?: string }).type === "result") {
-        const envelope = parsed as { structured_output?: unknown; result?: unknown };
-        if (envelope.structured_output != null) return envelope.structured_output;
-        if (typeof envelope.result === "string") {
-          try {
-            return JSON.parse(envelope.result);
-          } catch {
-            return undefined;
-          }
-        }
-        continue;
-      }
-      if (parsed && typeof parsed === "object") return parsed;
-    } catch {
-      continue;
-    }
-  }
-  return undefined;
-}
-
 async function blockGenericAgentCommitGuardStep(
   sandboxId: string,
   agentKind: AgentKind,
   enabled: boolean,
-): Promise<void> {
+): Promise<AgentProtocolResult<void>> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
   const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
@@ -81,7 +55,19 @@ async function blockGenericAgentCommitGuardStep(
 
   const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
   const agent = createAgentAdapter(agentKind);
-  await agent.setCommitGuard(sandbox, enabled);
+  try {
+    await agent.setCommitGuard(sandbox, enabled);
+    return { ok: true, value: undefined };
+  } catch (error) {
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    if (!isAgentRuntimeError(error)) throw error;
+    return {
+      ok: false,
+      category: error.category,
+      message: error.safeMessage,
+      diagnostic: error.diagnostic,
+    };
+  }
 }
 
 async function blockGenericAgentPlanPhaseStep(
@@ -100,43 +86,143 @@ async function blockGenericAgentPlanPhaseStep(
 
 async function blockGenericAgentStartPhaseStep(
   sandboxId: string,
+  agentKind: AgentKind,
+  phase: string,
   inputFilePath: string,
   inputContent: string,
   scriptPath: string,
   scriptContent: string,
-): Promise<string> {
+): Promise<
+  | { ok: true; commandId: string }
+  | { ok: false; failure: Extract<AgentProtocolResult<unknown>, { ok: false }> }
+> {
   "use step";
-  const { Sandbox } = await import("@vercel/sandbox");
-  const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
+  const { createAgentAdapter } = await import("../../sandbox/agents/index.js");
+  const { commandProtocolFailure, protocolFailure } = await import(
+    "../../sandbox/agents/protocol.js"
+  );
+  const spec = createAgentAdapter(agentKind).cliSpec;
+  try {
+    const { Sandbox } = await import("@vercel/sandbox");
+    const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
 
-  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
-  await sandbox.writeFiles([
-    { path: inputFilePath, content: Buffer.from(inputContent) },
-    { path: scriptPath, content: Buffer.from(scriptContent) },
-  ]);
-  await sandbox.runCommand("chmod", ["+x", scriptPath]);
-  const command = await sandbox.runCommand({
-    cmd: "bash",
-    args: [scriptPath],
-    cwd: "/vercel/sandbox",
-    detached: true,
-  });
-  return command.cmdId;
+    const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+    await sandbox.writeFiles([
+      { path: inputFilePath, content: Buffer.from(inputContent) },
+      { path: scriptPath, content: Buffer.from(scriptContent) },
+    ]);
+    const chmod = await sandbox.runCommand("chmod", ["+x", scriptPath]);
+    if (chmod.exitCode !== 0) {
+      return {
+        ok: false,
+        failure: await commandProtocolFailure({
+          spec,
+          phase,
+          result: chmod,
+          failureKind: "setup_failed",
+          message: "The current agent phase could not be completed.",
+          detail: "The agent phase wrapper could not be made executable.",
+        }),
+      };
+    }
+    const command = await sandbox.runCommand({
+      cmd: "bash",
+      args: [scriptPath],
+      cwd: "/vercel/sandbox",
+      detached: true,
+    });
+    if (command.exitCode !== null && command.exitCode !== 0) {
+      return {
+        ok: false,
+        failure: await commandProtocolFailure({
+          spec,
+          phase,
+          result: command,
+          failureKind: "cli_exit",
+          message: "The current agent phase could not be completed.",
+          detail: "The agent phase process could not be launched.",
+        }),
+      };
+    }
+    return { ok: true, commandId: command.cmdId };
+  } catch (error) {
+    const { isRunControlError } = await import("../run-control-error.js");
+    if (isRunControlError(error)) throw error;
+    const failure = protocolFailure({
+      spec,
+      phase,
+      artifacts: { stdout: "", stderr: "", structuredOutput: null, exitCode: null },
+      failureKind: "provider_error",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      detail: "The agent phase process could not be launched.",
+    });
+    if (failure.ok) throw new Error("unreachable");
+    return { ok: false, failure };
+  }
 }
 blockGenericAgentStartPhaseStep.maxRetries = 0;
 
 async function blockGenericAgentParseStep(
   agentKind: AgentKind,
-  raw: string,
-  structured: string | null,
-): Promise<{ object: unknown; usage: PhaseUsage | null }> {
+  artifacts: CollectedPhaseArtifacts,
+  phase: string,
+  customSchema: string | undefined,
+): Promise<{ result: AgentProtocolResult<unknown>; usage: PhaseUsage | null }> {
   "use step";
   const { createAgentAdapter } = await import("../../sandbox/agents/index.js");
+  const { GENERIC_SCHEMA } = await import("../../sandbox/agents/types.js");
+  const { validateStructuredValue } = await import("../../sandbox/agents/protocol.js");
   const adapter = createAgentAdapter(agentKind);
+  const extracted = adapter.parseStructuredObjectProtocol(
+    artifacts,
+    phase,
+    customSchema === undefined ? "generic-agent" : "generic-agent-custom",
+    customSchema ?? GENERIC_SCHEMA,
+  );
+  const result = customSchema === undefined && extracted.ok
+    ? validateStructuredValue({
+        spec: adapter.cliSpec,
+        phase,
+        artifacts,
+        value: extracted.value,
+        schema: genericOutputSchema,
+        schemaIdentity: "generic-agent",
+        schemaSource: GENERIC_SCHEMA,
+      })
+    : extracted;
   return {
-    object: extractStructuredObject(raw, structured),
-    usage: adapter.extractUsage(raw, structured),
+    result,
+    usage: adapter.extractUsage(artifacts.stdout, artifacts.structuredOutput),
   };
+}
+
+async function blockGenericAgentSchemaFailureStep(
+  agentKind: AgentKind,
+  artifacts: CollectedPhaseArtifacts,
+  phase: string,
+  schema: string,
+  issues: string[],
+): Promise<Extract<AgentProtocolResult<unknown>, { ok: false }>> {
+  "use step";
+  const { createAgentAdapter } = await import("../../sandbox/agents/index.js");
+  const { protocolFailure } = await import("../../sandbox/agents/protocol.js");
+  const failure = protocolFailure({
+    spec: createAgentAdapter(agentKind).cliSpec,
+    phase,
+    artifacts,
+    failureKind: "schema_mismatch",
+    category: "schema",
+    message: "The current agent phase returned an invalid structured response.",
+    schema: {
+      identity: "generic-agent-custom",
+      source: schema,
+      issues: issues.map((message) => ({ path: [], code: "custom", message })),
+    },
+    detail: "The structured response did not satisfy the requested schema.",
+  });
+  if (failure.ok) throw new Error("unreachable");
+  return failure;
 }
 
 /**
@@ -186,6 +272,15 @@ export const execute: BlockExecuteFn = async (
         : ctx.sandboxId;
   } catch (err) {
     if (isRunControlError(err)) throw err;
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    if (isAgentRuntimeError(err)) {
+      return agentProtocolExecutionError({
+        ok: false,
+        category: err.category,
+        message: err.safeMessage,
+        diagnostic: err.diagnostic,
+      });
+    }
     return executionError(err instanceof Error ? err.message : String(err), {
       category: "sandbox",
     });
@@ -228,15 +323,24 @@ export const execute: BlockExecuteFn = async (
     // it), so the same graph would commit or not depending on block order. Only
     // committed work is pushed, so an unguarded agent's changes are dropped
     // silently; the guard is a no-op when the agent leaves a clean tree.
-    await blockGenericAgentCommitGuardStep(sandboxId, kind, workspaceMode === "read_write");
-    const { paths, script } = await blockGenericAgentPlanPhaseStep(kind, phase, model, jsonSchema);
-    const commandId = await blockGenericAgentStartPhaseStep(
+    const guard = await blockGenericAgentCommitGuardStep(
       sandboxId,
+      kind,
+      workspaceMode === "read_write",
+    );
+    if (!guard.ok) return agentProtocolExecutionError(guard);
+    const { paths, script } = await blockGenericAgentPlanPhaseStep(kind, phase, model, jsonSchema);
+    const launch = await blockGenericAgentStartPhaseStep(
+      sandboxId,
+      kind,
+      phase,
       paths.input,
       prompt,
       paths.wrapper,
       script,
     );
+    if (!launch.ok) return agentProtocolExecutionError(launch.failure);
+    const commandId = launch.commandId;
     ctx.markLaunched(usageLabel);
 
     const done = await pollPhaseUntilDone(
@@ -251,9 +355,16 @@ export const execute: BlockExecuteFn = async (
     }
 
     const { collectPhase } = await import("../../sandbox/poll-agent.js");
-    const { raw, structured } = await collectPhase(sandboxId, paths);
-    const { object, usage } = await blockGenericAgentParseStep(kind, raw, structured);
+    const artifacts = await collectPhase(sandboxId, paths);
+    const { result, usage } = await blockGenericAgentParseStep(
+      kind,
+      artifacts,
+      phase,
+      customSchema,
+    );
     ctx.recordUsage(usageLabel, usage, model);
+    if (!result.ok) return agentProtocolExecutionError(result);
+    const object = result.value;
 
     if (customSchema !== undefined) {
       if (object === undefined) {
@@ -268,28 +379,27 @@ export const execute: BlockExecuteFn = async (
       }
       const data = object as Record<string, JsonValue>;
       const output = { ...data, status: "completed", data } as const;
-      if (
-        validateBlockOutputForDefinition(block.type, block.params, output, {
-          requireNormalOutput: true,
-        }).length > 0
-      ) {
-        return executionError("agent output did not match the requested schema", {
-          category: "schema",
-        });
+      const issues = validateBlockOutputForDefinition(block.type, block.params, output, {
+        requireNormalOutput: true,
+      });
+      if (issues.length > 0) {
+        const failure = await blockGenericAgentSchemaFailureStep(
+          kind,
+          artifacts,
+          phase,
+          customSchema,
+          issues,
+        );
+        return agentProtocolExecutionError(failure);
       }
       return { kind: "next", output };
     }
 
-    const parsed = genericOutputSchema.safeParse(object);
-    if (!parsed.success) {
-      return executionError("agent output was not structured JSON", {
-        category: "parsing",
-      });
-    }
-    if (parsed.data.status === "needs_input") {
-      const listed = (parsed.data.questions ?? []).filter((q) => q.trim().length > 0);
-      const questions = listed.length > 0 ? listed : [parsed.data.body];
-      const suggestedAnswers = (parsed.data.suggestedAnswers ?? []).filter(
+    const parsed = genericOutputSchema.parse(object);
+    if (parsed.status === "needs_input") {
+      const listed = (parsed.questions ?? []).filter((q) => q.trim().length > 0);
+      const questions = listed.length > 0 ? listed : [parsed.body];
+      const suggestedAnswers = (parsed.suggestedAnswers ?? []).filter(
         (s) => s.trim().length > 0,
       );
       return {
@@ -303,9 +413,9 @@ export const execute: BlockExecuteFn = async (
         ...(suggestedAnswers.length > 0 ? { suggestedAnswers } : {}),
       };
     }
-    if (parsed.data.status === "failed") {
+    if (parsed.status === "failed") {
       return executionError(
-        parsed.data.error ?? parsed.data.body.slice(0, 500),
+        parsed.error ?? parsed.body.slice(0, 500),
         { category: "provider" },
       );
     }
@@ -313,7 +423,7 @@ export const execute: BlockExecuteFn = async (
       kind: "next",
       output: {
         status: "completed",
-        body: parsed.data.body.slice(0, 4000),
+        body: parsed.body.slice(0, 4000),
       },
     };
   } catch (err) {

--- a/apps/worker/src/workflows/blocks/prepare-workspace.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { WorkflowDefinitionNode } from "@shared/contracts";
 import type { AgentKind } from "../../sandbox/agents/index.js";
+import type { AgentProtocolResult } from "../../sandbox/agents/types.js";
 import type { SelectedRepository } from "../../adapters/vcs/repository-directory.js";
 import type { PreSandboxPromptAdditionsByTarget } from "../../pre-sandbox/types.js";
 import type {
@@ -10,7 +11,12 @@ import type {
 import { resolveBlockAgent } from "../../workflow-definition/resolve-agent.js";
 import { isRunControlError } from "../run-control-error.js";
 import { blockFetchPrContextsStep, blockPrTriggerRepositoriesStep } from "./fetch-pr-context.js";
-import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
+import {
+  agentProtocolExecutionError,
+  executionError,
+  type BlockExecuteFn,
+  type BlockExecutionResult,
+} from "./types.js";
 import type { BlockExecutionContext } from "../../workflow-definition/interpreter.js";
 
 export const paramsSchema = z.object({}).strict();
@@ -94,7 +100,10 @@ async function blockPrepareWorkspaceProvisionStep(
   selectedRepositories: WorkspaceRepositoryInput[],
   arthurTaskId: string | null,
   requiredKinds: AgentKind[],
-): Promise<{ sandboxId: string; workspaceManifest: WorkspaceManifest }> {
+): Promise<
+  | { ok: true; sandboxId: string; workspaceManifest: WorkspaceManifest }
+  | { ok: false; failure: Extract<AgentProtocolResult<unknown>, { ok: false }> }
+> {
   "use step";
   const { env } = await import("../../../env.js");
   const { SandboxManager } = await import("../../sandbox/manager.js");
@@ -112,14 +121,40 @@ async function blockPrepareWorkspaceProvisionStep(
 
   for (const kind of requiredKinds) {
     if (kind === "codex" && !env.CODEX_API_KEY && !env.CODEX_CHATGPT_OAUTH_TOKEN) {
-      throw new Error(
-        "a workflow block requires agent codex, which needs CODEX_API_KEY or CODEX_CHATGPT_OAUTH_TOKEN in the deployed environment",
+      const { runtimePreparationError } = await import(
+        "../../sandbox/agents/protocol.js"
       );
+      const error = runtimePreparationError(
+        createAgentAdapter(kind).cliSpec,
+        "Codex authentication credentials are missing from the deployed environment.",
+      );
+      return {
+        ok: false,
+        failure: {
+          ok: false,
+          category: error.category,
+          message: error.safeMessage,
+          diagnostic: error.diagnostic,
+        },
+      };
     }
     if (kind === "claude" && !env.ANTHROPIC_API_KEY) {
-      throw new Error(
-        "a workflow block requires agent claude, which needs ANTHROPIC_API_KEY in the deployed environment",
+      const { runtimePreparationError } = await import(
+        "../../sandbox/agents/protocol.js"
       );
+      const error = runtimePreparationError(
+        createAgentAdapter(kind).cliSpec,
+        "Claude authentication credentials are missing from the deployed environment.",
+      );
+      return {
+        ok: false,
+        failure: {
+          ok: false,
+          category: error.category,
+          message: error.safeMessage,
+          diagnostic: error.diagnostic,
+        },
+      };
     }
   }
 
@@ -144,24 +179,39 @@ async function blockPrepareWorkspaceProvisionStep(
     jobTimeoutMs: env.JOB_TIMEOUT_MS,
   });
 
-  const { sandbox, workspaceManifest } = await manager.provisionMultiRepo(
-    { branchName, repositories: selectedRepositories },
-    createAgentAdapter(primaryKind),
-    configureOptsFor(primaryKind),
-    additionalAgents,
-    {
-      onCreated: async (sandboxId) => {
-        const { createStepAdapters } = await import("../../lib/step-adapters.js");
-        await createStepAdapters().runRegistry.registerSandbox(
-          subjectKey,
-          ownerToken,
-          sandboxId,
-        );
+  try {
+    const { sandbox, workspaceManifest } = await manager.provisionMultiRepo(
+      { branchName, repositories: selectedRepositories },
+      createAgentAdapter(primaryKind),
+      configureOptsFor(primaryKind),
+      additionalAgents,
+      {
+        onCreated: async (sandboxId) => {
+          const { createStepAdapters } = await import("../../lib/step-adapters.js");
+          await createStepAdapters().runRegistry.registerSandbox(
+            subjectKey,
+            ownerToken,
+            sandboxId,
+          );
+        },
       },
-    },
-  );
-
-  return { sandboxId: sandbox.sandboxId, workspaceManifest };
+    );
+    return { ok: true, sandboxId: sandbox.sandboxId, workspaceManifest };
+  } catch (error) {
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    if (isAgentRuntimeError(error)) {
+      return {
+        ok: false,
+        failure: {
+          ok: false,
+          category: error.category,
+          message: error.safeMessage,
+          diagnostic: error.diagnostic,
+        },
+      };
+    }
+    throw error;
+  }
 }
 blockPrepareWorkspaceProvisionStep.maxRetries = 0;
 
@@ -321,7 +371,7 @@ export async function ensureWorkspace(
       ctx.runDefaultKind,
       ctx.defaults,
     );
-    const { sandboxId, workspaceManifest } = await blockPrepareWorkspaceProvisionStep(
+    const provisioned = await blockPrepareWorkspaceProvisionStep(
       ctx.entry.subjectKey,
       ctx.entry.ownerToken,
       ctx.branchName,
@@ -329,6 +379,8 @@ export async function ensureWorkspace(
       arthurTaskId,
       requiredKinds,
     );
+    if (!provisioned.ok) return agentProtocolExecutionError(provisioned.failure);
+    const { sandboxId, workspaceManifest } = provisioned;
     // The manager registered this sandbox immediately after external creation,
     // before clone/install/configure. Keep the in-workflow set for normal
     // teardown; the durable child row covers crash/cancel cleanup.

--- a/apps/worker/src/workflows/blocks/types.ts
+++ b/apps/worker/src/workflows/blocks/types.ts
@@ -4,8 +4,9 @@ import type {
   BlockExecutionResult,
   StepsRecord,
 } from "../../workflow-definition/interpreter.js";
+import { executionError } from "../../workflow-definition/interpreter.js";
 import type { AgentKind } from "../../sandbox/agents/index.js";
-import type { PhaseUsage } from "../../sandbox/agents/types.js";
+import type { AgentProtocolResult, PhaseUsage } from "../../sandbox/agents/types.js";
 import type {
   IssueTrackerMoveTarget,
   TicketContent,
@@ -124,7 +125,18 @@ export type {
   BlockExecutionResult,
   StepsRecord,
 } from "../../workflow-definition/interpreter.js";
-export { executionError } from "../../workflow-definition/interpreter.js";
+export { executionError };
+
+export function agentProtocolExecutionError(
+  result: Extract<AgentProtocolResult<unknown>, { ok: false }>,
+): Extract<BlockExecutionResult, { kind: "execution_error" }> {
+  return executionError(result.diagnostic.detail ?? result.diagnostic.failureKind, {
+    category: result.category,
+    message: result.message,
+    phase: result.diagnostic.phase,
+    diagnostic: result.diagnostic,
+  });
+}
 
 /** Executor signature every block module in this directory exports. */
 export type BlockExecuteFn = (

--- a/docs/agent-runtime-diagnostics.md
+++ b/docs/agent-runtime-diagnostics.md
@@ -1,0 +1,65 @@
+# Agent runtime diagnostics
+
+Sandboxed agent failures expose only a provider-neutral message and an
+`AIW-DIAG-<run>-<node>-<attempt>` code. The internal provider details exist only
+in the correlated worker log event `workflow_execution_error`.
+
+## Diagnose a failed run
+
+1. Copy the diagnostic ID from the run detail, notification, dashboard trace,
+   or block tooltip.
+2. Search worker logs for `workflow_execution_error` and that exact
+   `diagnosticId`.
+3. Check `nodeId`, `attempt`, `category`, and `phase` first. When the failure came
+   from a pinned agent protocol, inspect `agentProtocol`:
+   - `provider`, `packageName`, `cliVersion`, and `protocol` identify the runtime;
+   - `failureKind`, `exitCode`, and `event` identify the failure boundary;
+   - artifact byte counts and SHA-256 hashes let repeated failures be compared;
+   - `schema.identity`, `schema.sha256`, and at most 20 issue paths/messages
+     describe contract failures without retaining the schema or model value;
+   - `stderrTail` is redacted and capped at 2 KiB; `stdoutTail` exists only when
+     malformed protocol output could not be structurally parsed.
+
+The logger must not contain prompts, full model responses, structured-output
+values, generated source, full user schemas, or unredacted credentials. If
+redaction cannot safely produce a tail, only metadata is logged.
+
+## Safe messages
+
+- Provisioning: `The agent runtime could not be prepared.`
+- Process/provider failure: `The current agent phase could not be completed.`
+- Parsing/schema failure: `The current agent phase returned an invalid structured response.`
+
+These messages and the diagnostic ID are authoritative in telemetry, API, and
+dashboard payloads. Protocol diagnostics are not persisted or returned by an
+API.
+
+## Pinned versions
+
+- Claude: `@anthropic-ai/claude-code@2.1.216`, protocol `claude-json-2.1.216`
+- Codex: `@openai/codex@0.144.6`, protocol `codex-jsonl-0.144.6`
+
+Provisioning installs the exact package version, runs `<cli> --version`, and
+rejects an unreadable or mismatched semantic version. There is no environment
+override, retry, or fallback. A version change requires a reviewed edit to
+`src/sandbox/agents/protocol.ts` and refreshed fixtures.
+
+## Refresh fixtures and smoke-test
+
+Normal CI uses credential-free fixtures in versioned provider directories. The
+capture command creates a disposable Vercel Sandbox, installs and verifies the
+source-controlled version, runs one harmless structured prompt and one harmless
+freeform prompt, normalizes volatile fields, scans for secrets, and tears the
+sandbox down in a `finally` block.
+
+From `apps/worker`, with Vercel credentials plus the provider API key loaded:
+
+```bash
+pnpm capture:agent-protocol-fixtures -- --provider claude --env-file /secure/path/worker.env --write
+pnpm capture:agent-protocol-fixtures -- --provider codex --env-file /secure/path/worker.env --write
+```
+
+Omit `--write` for a smoke test that prints only versions, artifact sizes, and
+hashes. A secret-scan or protocol-validation failure refuses fixture writes.
+Review the fixture diff, run the protocol fixture tests, and record only exact
+versions plus sanitized success/failure metadata in the pull request.

--- a/docs/agent-runtime-diagnostics.md
+++ b/docs/agent-runtime-diagnostics.md
@@ -63,3 +63,14 @@ Omit `--write` for a smoke test that prints only versions, artifact sizes, and
 hashes. A secret-scan or protocol-validation failure refuses fixture writes.
 Review the fixture diff, run the protocol fixture tests, and record only exact
 versions plus sanitized success/failure metadata in the pull request.
+
+When production credentials must not be copied, the pre-merge protocol smoke
+may instead use an existing local Claude Code or Codex login. Install the exact
+source-controlled packages in a temporary directory; do not use whatever
+global versions happen to be installed. Disable tools or use read-only mode for
+structured-output checks. Run repair checks only in disposable Git repositories,
+with Claude limited to read/edit tools and Codex limited to `workspace-write`.
+This verifies the pinned CLI envelopes and repair behavior; fixture-based tests
+remain responsible for provisioning failures and other negative paths. Delete
+all raw stdout, stderr, structured-output, and temporary repository artifacts
+after recording sanitized versions and results.


### PR DESCRIPTION
## Summary

- pin sandboxed Claude Code to `@anthropic-ai/claude-code@2.1.216` and Codex to `@openai/codex@0.144.6`, with exact install and semantic-version verification
- collect stdout, stderr, structured output, and exit code independently for every agent phase
- route implementation, review, generic-agent, fix-agent, and Pre-PR repair execution through strict provider protocol parsing
- preserve provider/protocol diagnostics only in the correlated `workflow_execution_error` log while exposing only the safe message and `AIW-DIAG-...` code
- add redaction, artifact hashing, bounded diagnostic tails, fixture-driven parser coverage, a manual capture script, and an operator runbook

## Why

Agent CLI protocol drift previously made provisioning and structured-output failures difficult to reproduce and diagnose. The Pre-PR repair loop also bypassed the normal provider-owned invocation path and suppressed process failures with `|| true`.

## Verification

- current base SHA: `ba379e725b90377a099b832a104fcf3516940877`
- current head SHA: `6dd44d26a26c6c56eb7725348790f998b3b8bfa0`
- shared contracts and conditions builds: passed
- worker and dashboard typechecks: passed
- post-rebase targeted worker suites: 309 tests passed across 15 files
- installed Workflow SDK regression: 7 tests passed, including cleanup before terminal failure
- real fixture/parser validation: 22 tests passed
- stale baseline assertion aligned with the query's existing `targetBranch` output: 11/11 focused tests passed
- [GitHub CI run 29970034241](https://github.com/Blazity/ai-workflow/actions/runs/29970034241): passed
- CodeRabbit and Vercel dashboard preview: passed

## Fixture provenance and manual smoke

The success fixtures were captured from the exact pinned packages on 2026-07-23 using the existing local authenticated sessions. Volatile identifiers and response content were normalized; raw prompts, model responses, generated source, and credentials were not committed.

Sanitized manual results:

- `@anthropic-ai/claude-code@2.1.216`: structured-output phase passed; freeform disposable-repository repair passed; usage parsed
- `@openai/codex@0.144.6`: structured-output phase passed; workspace-sandboxed disposable-repository repair passed; usage parsed
- each repair changed only the intended disposable `result.txt`
- the implementation parsers accepted all four captured terminal envelopes
- no production environment values were downloaded or used

## Jira

[AIW-106](https://blazity.atlassian.net/browse/AIW-106) is ready for review.

[AIW-106]: https://blazity.atlassian.net/browse/AIW-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Claude and Codex agent execution with structured protocol validation and clearer failure reporting.
  - Added safer handling for setup, authentication, provider, parsing, schema, and nonzero-exit failures.
  - Workflow errors now include actionable diagnostic events while protecting sensitive details.

- **Bug Fixes**
  - Fixed sandbox phase artifact collection, including stderr and exit codes.
  - Preserved usage data when protocol validation fails.

- **Documentation**
  - Added guidance for diagnosing agent runtime failures and refreshing protocol fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->