### PR TITLE
AIW-145: answer clarification questions from Jira comments

### DIFF
--- a/.claude/skills/init-jira/references/webhook-setup.md
+++ b/.claude/skills/init-jira/references/webhook-setup.md
@@ -10,6 +10,8 @@ The handler dispatches when the ticket lands in `COLUMN_AI` and cancels in-fligh
 
 If you want creates and new comments to dispatch immediately (rather than waiting for the next `jira:issue_updated` from a transition or edit), also check **Issue → Issue created** and **Comment → Comment created**. Tradeoff: more webhook traffic, but no perceptible latency on freshly-created tickets or replies. The handler still applies the same column/state filters either way — extra events are filtered out, not acted on.
 
+Clarification answers do not need **Comment created**: the `jira:issue_updated` event from moving the ticket back to the AI column triggers the resume, and the cron poller is the backstop if that webhook is missed.
+
 ## Open the webhook admin page
 
 ```

--- a/SETUP.md
+++ b/SETUP.md
@@ -364,7 +364,7 @@ Without this, ai-workflow only learns about ticket changes via the 1-minute cron
 2. Create a webhook:
    - **URL:** `https://<your-vercel-domain>/webhooks/jira`
    - **Secret:** the `JIRA_WEBHOOK_SECRET` value from step 5. Jira signs each delivery with HMAC-SHA256 in the `X-Hub-Signature` header; the handler at `apps/worker/src/routes/webhooks/jira.post.ts` verifies it with `timingSafeEqual`.
-   - **Events:** `jira:issue_updated` (required). Add `jira:issue_created` and `comment_created` if you want creates and comments to dispatch instantly.
+   - **Events:** `jira:issue_updated` (required). Add `jira:issue_created` and `comment_created` if you want creates and comments to dispatch instantly. Answering clarification questions does not require `comment_created`: the answers are picked up when the ticket is moved back to the AI column (comment first, then move), and the cron poller is the backstop if that webhook is missed.
    - **JQL filter** (optional): `project = AWT` to limit deliveries to the relevant project.
 3. Save.
 
@@ -445,6 +445,8 @@ curl -H "Authorization: Bearer $CRON_SECRET" https://<your-vercel-domain>/cron/p
    - Jira ticket — moves to **AI Review** (success) or **Backlog** (clarification needed).
    - Target repo — new branch `blazebot/<ticket-key>` and an open PR.
    - Slack channel — notification fires.
+
+> **Answering a clarification request.** When a run needs input it posts the numbered questions (with suggested answers and a dashboard link) as a Jira comment, includes them in the Slack notification, and parks the ticket in **Backlog**. Answer it either in the dashboard (the run resumes immediately, as before) or by replying in a Jira comment and then moving the ticket back to the **AI** column: the move is the commit gesture (a comment on its own triggers nothing, and the bot's own comments are ignored), and the resumed run reads the comments as the answer. The paused run stays resumable for 7 days; after that the next move to **AI** starts the ticket over fresh.
 
 If anything stalls, jump to [troubleshooting](#13-troubleshooting).
 

--- a/apps/worker/e2e/env.ts
+++ b/apps/worker/e2e/env.ts
@@ -7,6 +7,16 @@ const schema = z.object({
   JIRA_API_TOKEN: z.string().min(1),
   JIRA_PROJECT_KEY: z.string().min(1),
 
+  /**
+   * Optional SECOND Jira identity, used only by US-06 to post the clarification
+   * answer as a NON-bot user. The comment-driven resume path excludes the bot's
+   * own comments by accountId (see src/clarifications/resume-from-comments.ts),
+   * so an answer posted with the bot's JIRA_API_TOKEN is ignored and can never
+   * wake the suspended run. When this is absent, US-06 is skipped. Bearer token
+   * for a user distinct from the one JIRA_API_TOKEN authenticates.
+   */
+  JIRA_E2E_COMMENTER_TOKEN: z.string().min(1).optional(),
+
   COLUMN_AI: z.string().min(1),
   COLUMN_AI_REVIEW: z.string().min(1),
   COLUMN_BACKLOG: z.string().min(1),

--- a/apps/worker/e2e/helpers/jira.ts
+++ b/apps/worker/e2e/helpers/jira.ts
@@ -189,6 +189,37 @@ export async function postComment(
   });
 }
 
+/**
+ * Post a comment as a SECOND Jira identity (a bearer token distinct from
+ * JIRA_API_TOKEN). Used by US-06 so the clarification answer comes from a
+ * non-bot account: the resume path filters the bot's own comments by accountId,
+ * so an answer posted with the bot token can never resume the run. Additive:
+ * `postComment` (bot identity) is unchanged. The per-call auth override rides
+ * jiraRequest's header merge (options.headers wins over the default header).
+ */
+export async function postCommentAs(
+  ticketKey: string,
+  comment: string,
+  token: string,
+): Promise<void> {
+  await jiraRequest(`/rest/api/3/issue/${ticketKey}/comment`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      body: {
+        type: "doc",
+        version: 1,
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: comment }],
+          },
+        ],
+      },
+    }),
+  });
+}
+
 export async function deleteTicket(ticketKey: string): Promise<void> {
   // Only delete tickets created by e2e tests
   const data = await jiraRequest(

--- a/apps/worker/e2e/tier2/us05-unclear-ticket-clarification.test.ts
+++ b/apps/worker/e2e/tier2/us05-unclear-ticket-clarification.test.ts
@@ -18,9 +18,11 @@ import { e2eEnv } from "../env.js";
  * US-5: Unclear ticket triggers clarification
  *
  * When a ticket is too vague/subjective to implement, the agent should
- * return status: "clarification_needed", park the run as awaiting (questions
- * live in the dashboard, not in Jira comments), label the ticket
- * needs-clarification, move it to Backlog, and clean up registry/sandbox.
+ * return status: "clarification_needed" and park the run as awaiting: post a
+ * numbered clarification-questions comment (plus the one-time pickup link) to
+ * Jira, label the ticket needs-clarification, move it to Backlog, snapshot and
+ * stop the sandbox, and KEEP the bound active_runs claim so the same run can
+ * later resume from the snapshot when a human answers.
  */
 describe("US-05: Unclear ticket triggers clarification", () => {
   let ticketKey: string;
@@ -68,13 +70,17 @@ describe("US-05: Unclear ticket triggers clarification", () => {
       },
     );
 
-    // 4. Questions are no longer posted to Jira: the run parks with the
-    //    needs-clarification label and the questions live in the dashboard.
-    //    The only comment the workflow posts is the one-time pickup link
-    //    to the dashboard ticket view.
+    // 4. The parked run posts a numbered clarification-questions comment
+    //    (best-effort postClarificationQuestionsCommentStep) alongside the
+    //    one-time pickup link. The questions comment carries a numbered list
+    //    AND the how-to-answer instructions from comment-format.ts, so a human
+    //    can answer straight from Jira. Match a stable substring, not the whole
+    //    template, so copy tweaks don't break the test.
     const comments = await getTicketComments(ticketKey);
-    const questionComment = comments.find((c) => /^\s*1\.\s/m.test(c.body));
-    expect(questionComment).toBeUndefined();
+    const questionComment = comments.find(
+      (c) => /^\s*1\.\s/m.test(c.body) && c.body.includes("How to answer:"),
+    );
+    expect(questionComment).toBeDefined();
     const pickupComment = comments.find((c) =>
       c.body.includes(`/ticket/${ticketKey}`),
     );
@@ -86,16 +92,22 @@ describe("US-05: Unclear ticket triggers clarification", () => {
     const pr = await findPR(branchName);
     expect(pr).toBeNull();
 
-    // 6. Registry entry cleaned up
-    await waitFor(
-      async () => {
-        const runId = await getRunId(ticketKey);
-        return runId === null ? true : null;
-      },
-      { description: `Registry clean for ${ticketKey}`, timeoutMs: 30_000 },
-    );
+    // 6. The suspended run deliberately KEEPS its bound active_runs claim while
+    //    parked: the registry entry is NOT cleaned up, so the SAME runId can
+    //    resume from the snapshot once a human answers. Assert the claim is
+    //    present and stays present across a short recheck.
+    const parkedRunId = await waitFor(() => getRunId(ticketKey), {
+      description: `bound run for parked ${ticketKey}`,
+      timeoutMs: 30_000,
+    });
+    expect(parkedRunId).not.toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+    expect(await getRunId(ticketKey)).toBe(parkedRunId);
 
-    // 7. No sandbox still running for this ticket
+    // 7. No sandbox is still running for this ticket. The clarification
+    //    snapshot step (clarification-snapshot-steps.ts) snapshots the source
+    //    workspace and polls until Sandbox.get reports it `stopped` before the
+    //    run parks, so nothing is left running to stop here.
     const stopped = await stopSandboxesForTicket(ticketKey);
     expect(stopped).toBe(0);
 

--- a/apps/worker/e2e/tier2/us06-clarification-answered.test.ts
+++ b/apps/worker/e2e/tier2/us06-clarification-answered.test.ts
@@ -4,7 +4,7 @@ import {
   moveTicketToColumn,
   getTicketStatus,
   getTicketComments,
-  postComment,
+  postCommentAs,
   deleteTicket,
 } from "../helpers/jira.js";
 import {
@@ -31,7 +31,14 @@ import { e2eEnv } from "../env.js";
  * This covers two full workflow runs in sequence, so the per-test timeout
  * is larger than the project default.
  */
-describe("US-06: Clarification answered → ticket completes", () => {
+// US-06 answers the clarification from a NON-bot Jira identity. The resume path
+// filters the bot's own comments by accountId (resume-from-comments.ts), so
+// answering with the bot token (JIRA_API_TOKEN) can never wake the run. The
+// test is meaningless without a distinct commenter. Skip the whole suite when
+// JIRA_E2E_COMMENTER_TOKEN is absent.
+describe.skipIf(!e2eEnv.JIRA_E2E_COMMENTER_TOKEN)(
+  "US-06: Clarification answered → ticket completes",
+  () => {
   // Unique value so the PR content check can't pass on pre-existing files
   const uniqueGreeting = `Hello from Blazebot US-6 ${Date.now()}`;
   let ticketKey: string;
@@ -88,34 +95,48 @@ describe("US-06: Clarification answered → ticket completes", () => {
         },
       );
 
-      // Clarification comment must exist before we answer
+      // The parked run must have posted its numbered clarification-questions
+      // comment before we answer, same shape us05 asserts (numbered list plus
+      // the how-to-answer instructions from comment-format.ts).
       const preAnswerComments = await getTicketComments(ticketKey);
-      const clarificationComment = preAnswerComments.find((c) =>
-        /^\s*1\.\s/m.test(c.body),
+      const clarificationComment = preAnswerComments.find(
+        (c) => /^\s*1\.\s/m.test(c.body) && c.body.includes("How to answer:"),
       );
       expect(clarificationComment).toBeDefined();
 
-      // Registry cleaned up after clarification before we restart
-      await waitFor(
-        async () => {
-          const runId = await getRunId(ticketKey);
-          return runId === null ? true : null;
-        },
-        {
-          description: `Registry clean after clarification for ${ticketKey}`,
-          timeoutMs: 30_000,
-        },
-      );
+      // The suspended run KEEPS its bound active_runs claim across the park (it
+      // is NOT cleaned up), so the SAME runId can resume from the snapshot once
+      // the human answers. Capture it now to prove the resume continues this
+      // run rather than starting a fresh dispatch.
+      const suspendedRunId = await waitFor(() => getRunId(ticketKey), {
+        description: `bound run for parked ${ticketKey}`,
+        timeoutMs: 30_000,
+      });
+      expect(suspendedRunId).not.toBeNull();
 
       // --- Phase B: developer answers + moves back to AI ---
 
-      await postComment(
+      // Answer as a SECOND Jira identity. The resume path excludes the bot's
+      // own comments by accountId (resume-from-comments.ts), so an answer
+      // posted with the bot token (JIRA_API_TOKEN) would be filtered out and
+      // could never wake the run. JIRA_E2E_COMMENTER_TOKEN is a distinct user;
+      // the suite is skipped when it is absent.
+      await postCommentAs(
         ticketKey,
         `1. Use "${uniqueGreeting}" as the message value.`,
+        e2eEnv.JIRA_E2E_COMMENTER_TOKEN!,
       );
 
       await moveTicketToColumn(ticketKey, e2eEnv.COLUMN_AI);
       await callCronPoll();
+
+      // The comment + move is the human's commit gesture: cron/webhook detect
+      // the bound suspended run and resume it via resumeHook. Because the run
+      // never released its active_runs claim, getRunId stays pinned to the SAME
+      // suspendedRunId as the resumed run works; a fresh dispatch would surface
+      // a different id (and is anyway blocked by the existing claim).
+      const resumedRunId = await getRunId(ticketKey);
+      expect(resumedRunId).toBe(suspendedRunId);
 
       // Wait for AI Review — this time the full workflow runs
       await waitFor(

--- a/apps/worker/src/adapters/messaging/format.test.ts
+++ b/apps/worker/src/adapters/messaging/format.test.ts
@@ -172,6 +172,50 @@ describe("formatTicketEvent", () => {
     );
   });
 
+  it("needs_clarification: renders questions numbered in order after the head", () => {
+    expect(
+      formatTicketEvent(
+        {
+          kind: "needs_clarification",
+          questions: ["Which repository?", "Which branch?"],
+        },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:question: Task ${LINK} needs clarification\n1. Which repository?\n2. Which branch?`,
+    );
+  });
+
+  it("needs_clarification: renders suggestedAnswers on a Suggested line", () => {
+    expect(
+      formatTicketEvent(
+        {
+          kind: "needs_clarification",
+          questions: ["Which repository?"],
+          suggestedAnswers: ["the api repo", "the web repo"],
+        },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:question: Task ${LINK} needs clarification\n1. Which repository?\nSuggested: the api repo · the web repo`,
+    );
+  });
+
+  it("needs_clarification: defangs a broadcast token inside a question", () => {
+    const text = formatTicketEvent(
+      {
+        kind: "needs_clarification",
+        questions: ["Ping <!channel> which repo?"],
+      },
+      KEY,
+      JIRA,
+    );
+    expect(text).not.toContain("<!channel>");
+    expect(text).toContain(`1. Ping <${ZWSP}!channel> which repo?`);
+  });
+
   it("needs_clarification — empty usage report is treated as absent", () => {
     expect(
       formatTicketEvent(

--- a/apps/worker/src/adapters/messaging/format.ts
+++ b/apps/worker/src/adapters/messaging/format.ts
@@ -85,10 +85,23 @@ export function formatTicketEvent(
         : event.commentUrl
           ? ` (<${event.commentUrl}|view questions>)`
           : "";
-      return appendUsage(
-        `${head} needs clarification${tail}`,
-        event.usageReport,
-      );
+      let body = `${head} needs clarification${tail}`;
+      // Question and suggestion text derive from untrusted ticket content, so
+      // defang Slack broadcast tokens in them (same rationale as extraText)
+      // before they join our system-built copy.
+      if (event.questions && event.questions.length > 0) {
+        const lines = event.questions.map(
+          (q, i) => `${i + 1}. ${neutralizeSlackBroadcasts(q)}`,
+        );
+        body += `\n${lines.join("\n")}`;
+      }
+      if (event.suggestedAnswers && event.suggestedAnswers.length > 0) {
+        const suggested = event.suggestedAnswers
+          .map((s) => neutralizeSlackBroadcasts(s))
+          .join(" · ");
+        body += `\nSuggested: ${suggested}`;
+      }
+      return appendUsage(body, event.usageReport);
     }
 
     case "pr_ready": {

--- a/apps/worker/src/adapters/messaging/types.ts
+++ b/apps/worker/src/adapters/messaging/types.ts
@@ -8,12 +8,16 @@ export type TicketEvent =
        */
       dashboardUrl?: string;
       /**
-       * Deep link to a posted Jira comment (e.g. `?focusedCommentId=...`).
-       * Retained for back-compat; the workflow no longer posts question
-       * comments, so this is no longer sent. Falls back to the plain ticket
-       * link when neither url is present.
+       * Deep link to the posted Jira comment (e.g. `?focusedCommentId=...`).
+       * The workflow posts a best-effort questions comment on pause, so this is
+       * sent when that post succeeds. Falls back to the plain ticket link when
+       * neither url is present.
        */
       commentUrl?: string;
+      /** The clarification questions, rendered numbered in the thread reply. */
+      questions?: string[];
+      /** Optional suggested answers, rendered on a single "Suggested" line. */
+      suggestedAnswers?: string[];
       usageReport?: string;
     }
   | {

--- a/apps/worker/src/clarifications/answer-core.ts
+++ b/apps/worker/src/clarifications/answer-core.ts
@@ -1,0 +1,108 @@
+// Static import so route tests can vi.mock("workflow/api"): a dynamic import
+// would bypass the module mock and hit the real Workflow runtime.
+import { getHookByToken, resumeHook } from "workflow/api";
+import type { Db } from "../db/client.js";
+import {
+  IssueTrackerNotFoundError,
+  type IssueTrackerAdapter,
+} from "../adapters/issue-tracker/types.js";
+import { resolveAwaitingRun } from "../lib/telemetry/run-telemetry.js";
+import { answerHookClarification, type HookClarificationRow } from "./hook-store.js";
+import { supersedeClarification, supersedePendingForTicket } from "./store.js";
+
+export const MAX_ANSWER_LENGTH = 10_000;
+
+export type AnswerClarificationOutcome =
+  | { kind: "answered"; row: HookClarificationRow }
+  | { kind: "invalid_answer" }
+  | { kind: "conflict" }
+  | { kind: "ticket_gone" }
+  | { kind: "resume_failed_retryable"; error: unknown };
+
+/**
+ * Answer a pending clarification and resume its asking run, with the CAS and
+ * retry semantics shared by every caller (dashboard and, later, Jira webhook).
+ * Returns a tagged outcome instead of throwing HTTP errors so the transport
+ * layer owns status-code mapping; the ticket fetch is injected so this module
+ * stays free of adapter-construction and HTTP concerns.
+ */
+export async function answerClarificationAndResume(input: {
+  db: Db;
+  row: HookClarificationRow;
+  rawAnswer: string;
+  actor: { id: string; label: string };
+  issueTracker: Pick<IssueTrackerAdapter, "fetchTicket">;
+  skipTicketFetch?: boolean;
+}): Promise<AnswerClarificationOutcome> {
+  const { db, row, rawAnswer, actor, issueTracker } = input;
+
+  const answer = rawAnswer.trim();
+  if (!answer || answer.length > MAX_ANSWER_LENGTH) {
+    return { kind: "invalid_answer" };
+  }
+
+  const isResumeRetry = row.status === "answered" && row.answer === answer;
+  if (row.status !== "pending" && !isResumeRetry) {
+    return { kind: "conflict" };
+  }
+
+  const answerer = isResumeRetry
+    ? { id: row.answeredById ?? actor.id, label: row.answeredByLabel ?? actor.label }
+    : actor;
+
+  // Ticketless scope:any continuations have no Jira lifecycle. Ticket-backed
+  // checkpoints still fail early when their ticket has been deleted.
+  if (row.ticketKey && !input.skipTicketFetch) {
+    try {
+      await issueTracker.fetchTicket(row.ticketKey);
+    } catch (err) {
+      if (!(err instanceof IssueTrackerNotFoundError)) throw err;
+      await retireClarificationForGoneTicket(db, row);
+      return { kind: "ticket_gone" };
+    }
+  }
+
+  const answered = isResumeRetry
+    ? row
+    : await answerHookClarification(db, row.id, answer, answerer);
+  if (!answered) {
+    return { kind: "conflict" };
+  }
+
+  try {
+    await resumeHook(answered.hookToken, {
+      answer,
+      answeredById: answerer.id,
+      answeredByLabel: answerer.label,
+      answeredAt: answered.answeredAt?.toISOString() ?? new Date().toISOString(),
+    });
+  } catch (error) {
+    // If the hook still exists, the resume definitely did not commit and the
+    // same answer can be retried. A missing hook means the resume won but the
+    // HTTP response was lost (or another identical retry already won).
+    const hookStillExists = await getHookByToken(answered.hookToken)
+      .then(() => true)
+      .catch(() => false);
+    if (hookStillExists) {
+      return { kind: "resume_failed_retryable", error };
+    }
+  }
+
+  return { kind: "answered", row: answered };
+}
+
+/**
+ * Best-effort teardown when a clarification's Jira ticket has been deleted:
+ * supersede sibling questions, supersede this row, and resolve the awaiting run
+ * so it does not stay parked forever. Each step swallows its own error.
+ */
+export async function retireClarificationForGoneTicket(
+  db: Db,
+  row: HookClarificationRow,
+): Promise<void> {
+  if (row.ticketKey) {
+    await supersedePendingForTicket(db, row.ticketKey).catch(() => {});
+  }
+  await supersedeClarification(db, row.id).catch(() => {});
+  await resolveAwaitingRun(db, row.runId).catch(() => {});
+}

--- a/apps/worker/src/clarifications/comment-format.test.ts
+++ b/apps/worker/src/clarifications/comment-format.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLARIFICATION_NUDGE_MARKER,
+  formatAlreadyAnsweredComment,
+  formatClarificationNudgeComment,
+  formatClarificationQuestionsComment,
+} from "./comment-format.js";
+
+const DASHBOARD = "https://app/ticket/AWT-42?run=wrun_9";
+
+describe("formatClarificationQuestionsComment", () => {
+  it("numbers questions in order and includes dashboard URL and column name", () => {
+    const body = formatClarificationQuestionsComment({
+      questions: ["Which repository?", "Which branch?"],
+      suggestedAnswers: null,
+      dashboardUrl: DASHBOARD,
+      aiColumnName: "AI",
+      expiresAtIso: null,
+    });
+    expect(body).toContain("1. Which repository?");
+    expect(body).toContain("2. Which branch?");
+    expect(body.indexOf("1. Which repository?")).toBeLessThan(
+      body.indexOf("2. Which branch?"),
+    );
+    expect(body).toContain(`- In the dashboard: ${DASHBOARD}`);
+    expect(body).toContain('move it back to the "AI" column.');
+  });
+
+  it("omits the suggested-answers block when null or empty", () => {
+    const nullSuggestions = formatClarificationQuestionsComment({
+      questions: ["Which repository?"],
+      suggestedAnswers: null,
+      dashboardUrl: DASHBOARD,
+      aiColumnName: "AI",
+      expiresAtIso: null,
+    });
+    expect(nullSuggestions).not.toContain("Suggested answers:");
+
+    const emptySuggestions = formatClarificationQuestionsComment({
+      questions: ["Which repository?"],
+      suggestedAnswers: [],
+      dashboardUrl: DASHBOARD,
+      aiColumnName: "AI",
+      expiresAtIso: null,
+    });
+    expect(emptySuggestions).not.toContain("Suggested answers:");
+  });
+
+  it("renders the suggested-answers block when present", () => {
+    const body = formatClarificationQuestionsComment({
+      questions: ["Which repository?"],
+      suggestedAnswers: ["the api repo", "the web repo"],
+      dashboardUrl: DASHBOARD,
+      aiColumnName: "AI",
+      expiresAtIso: null,
+    });
+    expect(body).toContain("Suggested answers:");
+    expect(body).toContain("- the api repo");
+    expect(body).toContain("- the web repo");
+  });
+
+  it("renders the expiry paragraph from the ISO input as a UTC minute", () => {
+    const body = formatClarificationQuestionsComment({
+      questions: ["Which repository?"],
+      suggestedAnswers: null,
+      dashboardUrl: DASHBOARD,
+      aiColumnName: "AI",
+      expiresAtIso: "2026-07-29T14:03:07.512Z",
+    });
+    expect(body).toContain(
+      "The paused run is resumable until 2026-07-29 14:03 UTC.",
+    );
+    expect(body).toContain("the ticket starts over from scratch.");
+  });
+
+  it("omits the expiry paragraph when expiresAtIso is null", () => {
+    const body = formatClarificationQuestionsComment({
+      questions: ["Which repository?"],
+      suggestedAnswers: null,
+      dashboardUrl: DASHBOARD,
+      aiColumnName: "AI",
+      expiresAtIso: null,
+    });
+    expect(body).not.toContain("resumable until");
+  });
+});
+
+describe("formatClarificationNudgeComment", () => {
+  it("contains the marker and the dashboard URL and column name", () => {
+    const body = formatClarificationNudgeComment({
+      dashboardUrl: DASHBOARD,
+      aiColumnName: "AI",
+    });
+    expect(body).toContain(CLARIFICATION_NUDGE_MARKER);
+    expect(body).toContain(DASHBOARD);
+    expect(body).toContain('move the ticket back to the "AI" column.');
+  });
+});
+
+describe("formatAlreadyAnsweredComment", () => {
+  it("names the label who answered", () => {
+    expect(formatAlreadyAnsweredComment({ answeredByLabel: "Jane Doe" })).toContain(
+      "Jane Doe",
+    );
+  });
+});

--- a/apps/worker/src/clarifications/comment-format.ts
+++ b/apps/worker/src/clarifications/comment-format.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure text builders for the Jira comments that carry clarification questions
+ * to a human. Kept free of env/adapter imports so both the workflow (posting)
+ * and any later resume path (nudge / already-answered replies) can reuse them
+ * and test them in isolation. The Jira adapter turns newlines into ADF
+ * paragraphs, so these emit plain text with blank lines between sections.
+ */
+
+/**
+ * Substring a later stage matches to recognize its own nudge comment and avoid
+ * re-posting it. Must appear verbatim in the nudge body.
+ */
+export const CLARIFICATION_NUDGE_MARKER =
+  "still waiting for answers to its clarification questions";
+
+/** Format an ISO instant as a human-readable UTC minute, e.g. `2026-07-29 14:03 UTC`. */
+function formatUtcMinute(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())} UTC`;
+}
+
+/** The full questions comment posted when a run pauses for clarification. */
+export function formatClarificationQuestionsComment(input: {
+  questions: string[];
+  suggestedAnswers: string[] | null;
+  dashboardUrl: string;
+  aiColumnName: string;
+  expiresAtIso: string | null;
+}): string {
+  const sections: string[] = [
+    "The AI workflow needs clarification before it can continue with this ticket:",
+    input.questions.map((q, i) => `${i + 1}. ${q}`).join("\n"),
+  ];
+
+  if (input.suggestedAnswers && input.suggestedAnswers.length > 0) {
+    sections.push(
+      ["Suggested answers:", ...input.suggestedAnswers.map((s) => `- ${s}`)].join("\n"),
+    );
+  }
+
+  sections.push(
+    [
+      "How to answer:",
+      `- In the dashboard: ${input.dashboardUrl}`,
+      `- Or reply in a comment on this ticket and move it back to the "${input.aiColumnName}" column.`,
+    ].join("\n"),
+  );
+
+  if (input.expiresAtIso) {
+    sections.push(
+      `The paused run is resumable until ${formatUtcMinute(input.expiresAtIso)}. After that the ticket starts over from scratch.`,
+    );
+  }
+
+  return sections.join("\n\n");
+}
+
+/** Short reminder that a parked run is still waiting on answers. */
+export function formatClarificationNudgeComment(input: {
+  dashboardUrl: string;
+  aiColumnName: string;
+}): string {
+  return [
+    `The AI workflow is ${CLARIFICATION_NUDGE_MARKER} on this ticket.`,
+    `Answer in the dashboard (${input.dashboardUrl}) or reply in a comment here and move the ticket back to the "${input.aiColumnName}" column.`,
+  ].join("\n");
+}
+
+/** One-liner acknowledging that a clarification was answered and the run resumes. */
+export function formatAlreadyAnsweredComment(input: { answeredByLabel: string }): string {
+  return `This clarification was already answered by ${input.answeredByLabel}; the run is resuming.`;
+}

--- a/apps/worker/src/clarifications/hook-store.test.ts
+++ b/apps/worker/src/clarifications/hook-store.test.ts
@@ -1,8 +1,12 @@
+import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
+import type { Db } from "../db/client.js";
+import { activeRuns, clarificationRequests } from "../db/schema.js";
 import { createTestDb } from "../db/test-db.js";
 import {
   answerHookClarification,
   getHookClarification,
+  getResumableClarificationForTicket,
   prepareHookClarification,
   publishHookClarification,
   recordHookClarificationSnapshot,
@@ -17,6 +21,32 @@ const input = {
   definitionVersion: 7,
   questions: ["Which repository?"],
 };
+
+async function bindRun(
+  db: Db,
+  opts: { subjectKey?: string; ticketKey?: string; runId?: string } = {},
+): Promise<void> {
+  await db.insert(activeRuns).values({
+    subjectKey: opts.subjectKey ?? input.subjectKey,
+    ticketKey: opts.ticketKey ?? input.ticketKey,
+    ownerToken: "owner-bound",
+    runId: opts.runId ?? input.runId,
+    state: "bound",
+    runKind: "ticket",
+  });
+}
+
+async function publishPending(db: Db, askedAt?: Date) {
+  const prepared = await prepareHookClarification(db, input);
+  const published = await publishHookClarification(db, prepared.id);
+  if (askedAt) {
+    await db
+      .update(clarificationRequests)
+      .set({ askedAt })
+      .where(eq(clarificationRequests.id, prepared.id));
+  }
+  return published;
+}
 
 describe("clarification hook store", () => {
   it("publishes only after the hook row and optional snapshot are durable", async () => {
@@ -68,5 +98,76 @@ describe("clarification hook store", () => {
 
     expect([first, second].filter(Boolean)).toHaveLength(1);
     expect((await getHookClarification(db, prepared.id))?.status).toBe("answered");
+  });
+});
+
+describe("getResumableClarificationForTicket", () => {
+  it("returns the pending row while its run holds the bound subject claim", async () => {
+    const db = await createTestDb();
+    const published = await publishPending(db);
+    await bindRun(db);
+
+    const found = await getResumableClarificationForTicket(db, "AWT-1");
+    expect(found?.id).toBe(published.id);
+    expect(found?.status).toBe("pending");
+  });
+
+  it("returns null when no run is bound for the subject", async () => {
+    const db = await createTestDb();
+    await publishPending(db);
+
+    expect(await getResumableClarificationForTicket(db, "AWT-1")).toBeNull();
+  });
+
+  it("returns null once the claim is no longer bound", async () => {
+    const db = await createTestDb();
+    await publishPending(db);
+    await bindRun(db);
+    await db
+      .update(activeRuns)
+      .set({ state: "cancelling" })
+      .where(eq(activeRuns.subjectKey, input.subjectKey));
+
+    expect(await getResumableClarificationForTicket(db, "AWT-1")).toBeNull();
+  });
+
+  it("returns null for a superseded row even with a bound claim", async () => {
+    const db = await createTestDb();
+    const published = await publishPending(db);
+    await bindRun(db);
+    await db
+      .update(clarificationRequests)
+      .set({ status: "superseded" })
+      .where(eq(clarificationRequests.id, published.id));
+
+    expect(await getResumableClarificationForTicket(db, "AWT-1")).toBeNull();
+  });
+
+  it("returns an answered row so a lost resume can be retried", async () => {
+    const db = await createTestDb();
+    const published = await publishPending(db);
+    await answerHookClarification(db, published.id, "Use main", {
+      id: "user_1",
+      label: "Ada",
+    });
+    await bindRun(db);
+
+    const found = await getResumableClarificationForTicket(db, "AWT-1");
+    expect(found?.id).toBe(published.id);
+    expect(found?.status).toBe("answered");
+  });
+
+  it("picks the newest round by asked_at", async () => {
+    const db = await createTestDb();
+    const older = await publishPending(db, new Date("2026-07-20T10:00:00.000Z"));
+    await answerHookClarification(db, older.id, "first round", {
+      id: "user_1",
+      label: "Ada",
+    });
+    const newer = await publishPending(db, new Date("2026-07-20T12:00:00.000Z"));
+    await bindRun(db);
+
+    const found = await getResumableClarificationForTicket(db, "AWT-1");
+    expect(found?.id).toBe(newer.id);
   });
 });

--- a/apps/worker/src/clarifications/hook-store.test.ts
+++ b/apps/worker/src/clarifications/hook-store.test.ts
@@ -39,6 +39,23 @@ describe("clarification hook store", () => {
     });
   });
 
+  it("maps expiresAt as a Date about seven days out", async () => {
+    const db = await createTestDb();
+    const before = Date.now();
+    const prepared = await prepareHookClarification(db, input);
+    expect(prepared.expiresAt).toBeInstanceOf(Date);
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1_000;
+    const delta = (prepared.expiresAt as Date).getTime() - before;
+    // Allow slack for DB round-trip; expiry is roughly +7 days from creation.
+    expect(delta).toBeGreaterThan(sevenDaysMs - 60_000);
+    expect(delta).toBeLessThan(sevenDaysMs + 60_000);
+
+    // The mapped value survives a fetch of the same row.
+    const fetched = await getHookClarification(db, prepared.id);
+    expect(fetched?.expiresAt).toBeInstanceOf(Date);
+    expect(fetched?.expiresAt?.getTime()).toBe((prepared.expiresAt as Date).getTime());
+  });
+
   it("allows exactly one answer CAS", async () => {
     const db = await createTestDb();
     const prepared = await prepareHookClarification(db, input);

--- a/apps/worker/src/clarifications/hook-store.ts
+++ b/apps/worker/src/clarifications/hook-store.ts
@@ -17,6 +17,7 @@ export interface HookClarificationRow {
   status: ClarificationStatus;
   hookToken: string;
   askedAt: Date;
+  expiresAt: Date | null;
   answer: string | null;
   answeredById: string | null;
   answeredByLabel: string | null;
@@ -46,6 +47,7 @@ function mapHookRow(
     status: row.status as ClarificationStatus,
     hookToken: row.hookToken,
     askedAt: row.askedAt,
+    expiresAt: row.expiresAt,
     answer: row.answer,
     answeredById: row.answeredById,
     answeredByLabel: row.answeredByLabel,

--- a/apps/worker/src/clarifications/hook-store.ts
+++ b/apps/worker/src/clarifications/hook-store.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import type { ClarificationStatus } from "@shared/contracts";
 import type { Db } from "../db/client.js";
-import { clarificationRequests } from "../db/schema.js";
+import { activeRuns, clarificationRequests } from "../db/schema.js";
 
 export interface HookClarificationRow {
   id: string;
@@ -136,6 +136,35 @@ export async function getHookClarification(
     .select()
     .from(clarificationRequests)
     .where(eq(clarificationRequests.id, id))
+    .limit(1);
+  return row?.hookToken ? mapHookRow(row) : null;
+}
+
+/** Latest pending-or-answered hook clarification for a ticket whose asking run
+ *  still holds the bound subject claim (i.e. is suspended and resumable). */
+export async function getResumableClarificationForTicket(
+  db: Db,
+  ticketKey: string,
+): Promise<HookClarificationRow | null> {
+  const [row] = await db
+    .select()
+    .from(clarificationRequests)
+    .where(
+      and(
+        eq(clarificationRequests.ticketKey, ticketKey),
+        inArray(clarificationRequests.status, ["pending", "answered"]),
+        isNotNull(clarificationRequests.hookToken),
+        // The asking run must still hold its bound subject claim; a released
+        // claim means the run is no longer suspended and cannot be resumed.
+        sql`exists (
+          select 1 from ${activeRuns}
+          where ${activeRuns.subjectKey} = ${clarificationRequests.subjectKey}
+            and ${activeRuns.runId} = ${clarificationRequests.runId}
+            and ${activeRuns.state} = 'bound'
+        )`,
+      ),
+    )
+    .orderBy(desc(clarificationRequests.askedAt))
     .limit(1);
   return row?.hookToken ? mapHookRow(row) : null;
 }

--- a/apps/worker/src/clarifications/resume-from-comments.test.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.test.ts
@@ -203,6 +203,40 @@ describe("resumeClarificationFromComments", () => {
     });
   });
 
+  it("treats an empty/whitespace-only comment body as no answer and nudges", async () => {
+    await seedPending();
+    const tracker = makeTracker({
+      comments: [
+        { author: "Jane", accountId: "human-1", body: "   ", createdAt: AFTER },
+      ],
+    });
+
+    const result = await run(tracker, true);
+
+    expect(result).toEqual({ status: "no_answer_comments", nudged: true });
+    expect(mocks.resumeHook).not.toHaveBeenCalled();
+    expect(tracker.postComment).toHaveBeenCalledTimes(1);
+    expect(tracker.postComment.mock.calls[0]?.[1]).toContain(CLARIFICATION_NUDGE_MARKER);
+  });
+
+  it("caps the answeredBy label at 200 characters for many commenters", async () => {
+    const row = await seedPending();
+    const comments = Array.from({ length: 60 }, (_, i) => ({
+      author: `Person ${i}`,
+      accountId: `acct-${i}`,
+      body: `answer ${i}`,
+      createdAt: AFTER,
+    }));
+    const tracker = makeTracker({ comments });
+
+    const result = await run(tracker);
+
+    expect(result).toEqual({ status: "resumed", runId: RUN });
+    const stored = await getHookClarification(db, row.id);
+    expect(stored?.answeredByLabel?.length).toBe(200);
+    expect(stored?.answeredByLabel?.startsWith("Person 0, Person 1")).toBe(true);
+  });
+
   it("fails closed and skips the nudge when bot identity is unavailable", async () => {
     await seedPending();
     const tracker = makeTracker({

--- a/apps/worker/src/clarifications/resume-from-comments.test.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.test.ts
@@ -1,0 +1,352 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Db } from "../db/client.js";
+import {
+  IssueTrackerNotFoundError,
+  type IssueTrackerAdapter,
+  type TicketComment,
+  type TicketContent,
+} from "../adapters/issue-tracker/types.js";
+import { activeRuns, clarificationRequests } from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+import { CLARIFICATION_NUDGE_MARKER } from "./comment-format.js";
+import {
+  answerHookClarification,
+  getHookClarification,
+  prepareHookClarification,
+  publishHookClarification,
+} from "./hook-store.js";
+import { resumeClarificationFromComments } from "./resume-from-comments.js";
+
+const mocks = vi.hoisted(() => ({
+  resumeHook: vi.fn(),
+  getHookByToken: vi.fn(),
+}));
+
+vi.mock("../../env.js", () => ({
+  env: { COLUMN_AI: "AI", DASHBOARD_ORIGIN: "https://dash.example" },
+}));
+vi.mock("workflow/api", () => ({
+  resumeHook: (...args: unknown[]) => mocks.resumeHook(...args),
+  getHookByToken: (...args: unknown[]) => mocks.getHookByToken(...args),
+}));
+
+const TICKET = "AWT-1";
+const SUBJECT = "ticket:jira:AWT-1";
+const RUN = "run-asked";
+const BOT = "bot-account";
+const ASKED_AT = new Date("2026-07-20T12:00:00.000Z");
+const AFTER = "2026-07-20T13:00:00.000Z";
+const AFTER_LATER = "2026-07-20T14:00:00.000Z";
+const BEFORE = "2026-07-20T11:00:00.000Z";
+
+let db: Db;
+
+async function seedPending() {
+  const prepared = await prepareHookClarification(db, {
+    ticketKey: TICKET,
+    subjectKey: SUBJECT,
+    runId: RUN,
+    blockId: "question",
+    definitionId: 1,
+    definitionVersion: 1,
+    questions: ["What framework?"],
+  });
+  const published = await publishHookClarification(db, prepared.id);
+  await db
+    .update(clarificationRequests)
+    .set({ askedAt: ASKED_AT })
+    .where(eq(clarificationRequests.id, prepared.id));
+  await db.insert(activeRuns).values({
+    subjectKey: SUBJECT,
+    ticketKey: TICKET,
+    ownerToken: "owner-1",
+    runId: RUN,
+    state: "bound",
+    runKind: "ticket",
+  });
+  return published;
+}
+
+function ticketWith(comments: TicketComment[], trackerStatus = "AI"): TicketContent {
+  return {
+    id: "1",
+    identifier: TICKET,
+    projectKey: "AWT",
+    title: "Title",
+    description: "Description",
+    acceptanceCriteria: "",
+    comments,
+    labels: [],
+    trackerStatus,
+    attachments: [],
+  };
+}
+
+function makeTracker(opts: {
+  comments?: TicketComment[];
+  trackerStatus?: string;
+  botId?: () => Promise<string>;
+  fetchTicket?: () => Promise<TicketContent>;
+} = {}) {
+  const ticket = ticketWith(opts.comments ?? [], opts.trackerStatus ?? "AI");
+  return {
+    fetchTicket: vi.fn(opts.fetchTicket ?? (async () => ticket)),
+    postComment: vi.fn(async (_id: string, _comment: string) => null as string | null),
+    getCurrentUserAccountId: vi.fn(opts.botId ?? (async () => BOT)),
+  };
+}
+
+function run(tracker: ReturnType<typeof makeTracker>, allowNudge = false) {
+  return resumeClarificationFromComments({
+    db,
+    issueTracker: tracker as unknown as IssueTrackerAdapter,
+    ticketKey: TICKET,
+    allowNudge,
+  });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mocks.resumeHook.mockResolvedValue({ runId: RUN });
+  mocks.getHookByToken.mockRejectedValue(new Error("hook consumed"));
+  db = await createTestDb();
+});
+
+describe("resumeClarificationFromComments", () => {
+  it("returns no_clarification when nothing is resumable", async () => {
+    const tracker = makeTracker();
+    const result = await run(tracker);
+    expect(result).toEqual({ status: "no_clarification" });
+    expect(tracker.fetchTicket).not.toHaveBeenCalled();
+  });
+
+  it("resumes a pending run with the composed comment answer", async () => {
+    const row = await seedPending();
+    const tracker = makeTracker({
+      comments: [
+        { author: "Jane", accountId: "human-1", body: "  Use Next.js  ", createdAt: AFTER },
+      ],
+    });
+
+    const result = await run(tracker);
+
+    expect(result).toEqual({ status: "resumed", runId: RUN });
+    expect(mocks.resumeHook).toHaveBeenCalledWith(
+      row.hookToken,
+      expect.objectContaining({ answer: "Jane: Use Next.js", answeredById: "jira:human-1" }),
+    );
+    const stored = await getHookClarification(db, row.id);
+    expect(stored).toMatchObject({
+      status: "answered",
+      answer: "Jane: Use Next.js",
+      answeredById: "jira:human-1",
+      answeredByLabel: "Jane (via Jira)",
+    });
+  });
+
+  it("joins multiple commenters and attributes the last one", async () => {
+    const row = await seedPending();
+    const tracker = makeTracker({
+      comments: [
+        { author: "Jane", accountId: "human-1", body: "Prefer A", createdAt: AFTER },
+        { author: "Bob", accountId: "human-2", body: "Actually B", createdAt: AFTER_LATER },
+      ],
+    });
+
+    const result = await run(tracker);
+
+    expect(result).toEqual({ status: "resumed", runId: RUN });
+    const stored = await getHookClarification(db, row.id);
+    expect(stored).toMatchObject({
+      answer: "Jane: Prefer A\n\nBob: Actually B",
+      answeredById: "jira:human-2",
+      answeredByLabel: "Jane, Bob (via Jira)",
+    });
+  });
+
+  it("ignores bot comments and comments posted before the question", async () => {
+    const row = await seedPending();
+    const tracker = makeTracker({
+      comments: [
+        { author: "Bot", accountId: BOT, body: "the question", createdAt: AFTER },
+        { author: "Early", accountId: "human-1", body: "unrelated", createdAt: BEFORE },
+        { author: "Cara", accountId: "human-2", body: "the answer", createdAt: AFTER_LATER },
+      ],
+    });
+
+    await run(tracker);
+
+    const stored = await getHookClarification(db, row.id);
+    expect(stored).toMatchObject({
+      answer: "Cara: the answer",
+      answeredById: "jira:human-2",
+      answeredByLabel: "Cara (via Jira)",
+    });
+  });
+
+  it("ignores comments without an account id", async () => {
+    const row = await seedPending();
+    const tracker = makeTracker({
+      comments: [
+        { author: "Anon", body: "no account", createdAt: AFTER },
+        { author: "Human", accountId: "human-1", body: "real answer", createdAt: AFTER_LATER },
+      ],
+    });
+
+    await run(tracker);
+
+    const stored = await getHookClarification(db, row.id);
+    expect(stored).toMatchObject({
+      answer: "Human: real answer",
+      answeredByLabel: "Human (via Jira)",
+    });
+  });
+
+  it("fails closed and skips the nudge when bot identity is unavailable", async () => {
+    await seedPending();
+    const tracker = makeTracker({
+      botId: async () => "",
+      comments: [
+        { author: "Jane", accountId: "human-1", body: "answer", createdAt: AFTER },
+      ],
+    });
+
+    const result = await run(tracker, true);
+
+    expect(result).toEqual({ status: "no_answer_comments", nudged: false });
+    expect(tracker.postComment).not.toHaveBeenCalled();
+    expect(mocks.resumeHook).not.toHaveBeenCalled();
+  });
+
+  it("nudges once when allowed and no answers are present", async () => {
+    await seedPending();
+    const tracker = makeTracker({ comments: [] });
+
+    const first = await run(tracker, true);
+    expect(first).toEqual({ status: "no_answer_comments", nudged: true });
+    expect(tracker.postComment).toHaveBeenCalledTimes(1);
+    expect(tracker.postComment.mock.calls[0]?.[1]).toContain(CLARIFICATION_NUDGE_MARKER);
+
+    // Second pass: the nudge is now present, so it must not repost.
+    const withNudge = makeTracker({
+      comments: [
+        { author: "Bot", accountId: BOT, body: `... ${CLARIFICATION_NUDGE_MARKER} ...`, createdAt: AFTER },
+      ],
+    });
+    const second = await run(withNudge, true);
+    expect(second).toEqual({ status: "no_answer_comments", nudged: false });
+    expect(withNudge.postComment).not.toHaveBeenCalled();
+  });
+
+  it("never nudges when nudging is disallowed", async () => {
+    await seedPending();
+    const tracker = makeTracker({ comments: [] });
+
+    const result = await run(tracker, false);
+
+    expect(result).toEqual({ status: "no_answer_comments", nudged: false });
+    expect(tracker.postComment).not.toHaveBeenCalled();
+  });
+
+  it("does not commit when the live ticket is outside the AI column", async () => {
+    await seedPending();
+    const tracker = makeTracker({
+      trackerStatus: "Backlog",
+      comments: [
+        { author: "Jane", accountId: "human-1", body: "answer", createdAt: AFTER },
+      ],
+    });
+
+    const result = await run(tracker, true);
+
+    expect(result).toEqual({ status: "not_in_ai_column" });
+    expect(mocks.resumeHook).not.toHaveBeenCalled();
+    expect(tracker.postComment).not.toHaveBeenCalled();
+    expect(tracker.getCurrentUserAccountId).not.toHaveBeenCalled();
+  });
+
+  it("retries a stored answer whose resume was lost", async () => {
+    const row = await seedPending();
+    await answerHookClarification(db, row.id, "Stored answer", { id: "user_1", label: "Ada" });
+    const tracker = makeTracker();
+
+    const result = await run(tracker);
+
+    expect(result).toEqual({ status: "resumed", runId: RUN });
+    expect(mocks.resumeHook).toHaveBeenCalledWith(
+      row.hookToken,
+      expect.objectContaining({ answer: "Stored answer", answeredById: "user_1" }),
+    );
+  });
+
+  it("treats a consumed hook on an answered row as won", async () => {
+    const row = await seedPending();
+    await answerHookClarification(db, row.id, "Stored answer", { id: "user_1", label: "Ada" });
+    mocks.resumeHook.mockRejectedValueOnce(new Error("already consumed"));
+    const tracker = makeTracker();
+
+    const result = await run(tracker);
+
+    expect(result).toEqual({ status: "resumed", runId: RUN });
+  });
+
+  it("acknowledges a dashboard winner when it loses the CAS race", async () => {
+    const row = await seedPending();
+    const tracker = makeTracker({
+      fetchTicket: async () => {
+        // Simulate a dashboard answer landing between our read and our CAS.
+        await answerHookClarification(db, row.id, "dashboard answer", {
+          id: "user_9",
+          label: "Dana Dashboard",
+        });
+        return ticketWith([
+          { author: "Jane", accountId: "human-1", body: "answer", createdAt: AFTER },
+        ]);
+      },
+    });
+
+    const result = await run(tracker);
+
+    expect(result).toEqual({ status: "already_answered" });
+    expect(mocks.resumeHook).not.toHaveBeenCalled();
+    expect(tracker.postComment).toHaveBeenCalledTimes(1);
+    expect(tracker.postComment.mock.calls[0]?.[1]).toContain("Dana Dashboard");
+  });
+
+  it("stays silent when the CAS winner is another Jira comment answer", async () => {
+    const row = await seedPending();
+    const tracker = makeTracker({
+      fetchTicket: async () => {
+        await answerHookClarification(db, row.id, "other jira answer", {
+          id: "jira:other-human",
+          label: "Bob (via Jira)",
+        });
+        return ticketWith([
+          { author: "Jane", accountId: "human-1", body: "answer", createdAt: AFTER },
+        ]);
+      },
+    });
+
+    const result = await run(tracker);
+
+    expect(result).toEqual({ status: "already_answered" });
+    expect(tracker.postComment).not.toHaveBeenCalled();
+    expect(mocks.resumeHook).not.toHaveBeenCalled();
+  });
+
+  it("retires the clarification when the ticket is gone", async () => {
+    const row = await seedPending();
+    const tracker = makeTracker({
+      fetchTicket: async () => {
+        throw new IssueTrackerNotFoundError("issue", TICKET);
+      },
+    });
+
+    const result = await run(tracker);
+
+    expect(result).toEqual({ status: "ticket_gone" });
+    expect((await getHookClarification(db, row.id))?.status).toBe("superseded");
+    expect(mocks.resumeHook).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/clarifications/resume-from-comments.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.ts
@@ -131,7 +131,11 @@ export async function resumeClarificationFromComments(input: {
           // Comments without an accountId cannot be proven non-bot.
           c.accountId &&
           c.accountId !== botAccountId &&
-          Date.parse(c.createdAt) > askedAtMs,
+          Date.parse(c.createdAt) > askedAtMs &&
+          // An empty/whitespace body (e.g. an image-only comment flattened by
+          // extractAdfText) is not an answer; treat it like no comment so the
+          // nudge rules apply instead of resuming with a junk answer.
+          c.body.trim().length > 0,
       )
     : [];
 
@@ -186,7 +190,9 @@ export async function resumeClarificationFromComments(input: {
   for (const c of qualifying) {
     if (!uniqueAuthors.includes(c.author)) uniqueAuthors.push(c.author);
   }
-  const answeredByLabel = `${uniqueAuthors.join(", ")} (via Jira)`;
+  // Cap the label: many distinct commenters would otherwise store an unbounded
+  // string in answered_by_label and inject it into prompts/memory.
+  const answeredByLabel = `${uniqueAuthors.join(", ")} (via Jira)`.slice(0, 200);
 
   const outcome = await answerClarificationAndResume({
     db,

--- a/apps/worker/src/clarifications/resume-from-comments.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.ts
@@ -1,0 +1,241 @@
+import { env } from "../../env.js";
+import {
+  IssueTrackerNotFoundError,
+  type IssueTrackerAdapter,
+} from "../adapters/issue-tracker/types.js";
+import type { Db } from "../db/client.js";
+import { ticketPageUrl } from "../lib/dashboard-links.js";
+import { logger } from "../lib/logger.js";
+import {
+  answerClarificationAndResume,
+  MAX_ANSWER_LENGTH,
+  retireClarificationForGoneTicket,
+} from "./answer-core.js";
+import {
+  CLARIFICATION_NUDGE_MARKER,
+  formatAlreadyAnsweredComment,
+  formatClarificationNudgeComment,
+} from "./comment-format.js";
+import { getHookClarification, getResumableClarificationForTicket } from "./hook-store.js";
+
+export type CommentResumeStatus =
+  | "no_clarification" // caller proceeds to dispatchTicket as today
+  | "resumed"
+  | "resume_retry_pending" // CAS committed but resume failed retryably; cron heals next tick
+  | "no_answer_comments" // nudged or not; do not dispatch
+  | "already_answered" // lost the CAS race to another channel
+  | "ticket_gone"
+  | "not_in_ai_column"; // live ticket is not in AI; caller falls through to dispatch
+
+/**
+ * Wake a suspended clarification run when a human answers by commenting on the
+ * Jira ticket and moving it back into the AI column. Comments alone never
+ * resume; the move is the commit gesture, so this only ever commits while the
+ * ticket is live in the AI column. Composes the human comments into the answer
+ * and rides answer-core's CAS + retry semantics; it never moves tickets,
+ * mutates labels, or touches active_runs (the resumed run owns all of that).
+ */
+export async function resumeClarificationFromComments(input: {
+  db: Db;
+  issueTracker: IssueTrackerAdapter;
+  ticketKey: string;
+  allowNudge: boolean;
+}): Promise<{ status: CommentResumeStatus; runId?: string; nudged?: boolean }> {
+  const { db, issueTracker, ticketKey, allowNudge } = input;
+
+  const row = await getResumableClarificationForTicket(db, ticketKey);
+  if (!row) return { status: "no_clarification" };
+
+  // An already-answered row is a dashboard answer whose resume was lost (e.g. a
+  // 503 that never retried). Retry it with the stored answer via the core's
+  // isResumeRetry path (a consumed hook is treated as won, idempotent). Never
+  // compose from comments here so identical retries stay convergent.
+  if (row.status === "answered") {
+    const outcome = await answerClarificationAndResume({
+      db,
+      row,
+      rawAnswer: row.answer ?? "",
+      actor: {
+        id: row.answeredById ?? "system",
+        label: row.answeredByLabel ?? "system",
+      },
+      issueTracker,
+      skipTicketFetch: false,
+    });
+    switch (outcome.kind) {
+      case "answered":
+        return { status: "resumed", runId: row.runId };
+      case "resume_failed_retryable":
+        logger.warn(
+          { ticketKey, runId: row.runId },
+          "clarification_resume_retry_pending",
+        );
+        return { status: "resume_retry_pending", runId: row.runId };
+      case "ticket_gone":
+        return { status: "ticket_gone" };
+      case "conflict":
+        return { status: "already_answered" };
+      case "invalid_answer":
+        // Defensive: an answered row with an empty answer cannot resume. Do not
+        // throw; the run stays parked and expiry eventually reclaims it.
+        logger.warn(
+          { ticketKey, runId: row.runId },
+          "clarification_resume_answered_row_empty_answer",
+        );
+        return { status: "already_answered" };
+    }
+  }
+
+  let ticket;
+  try {
+    ticket = await issueTracker.fetchTicket(ticketKey);
+  } catch (err) {
+    if (err instanceof IssueTrackerNotFoundError) {
+      await retireClarificationForGoneTicket(db, row);
+      return { status: "ticket_gone" };
+    }
+    throw err;
+  }
+
+  // Resume is the human's commit gesture: only ever act while the ticket is
+  // live in the AI column. Guards the cron's stale JQL snapshot and
+  // status-less webhook payloads from committing an answer prematurely.
+  if (
+    ticket.trackerStatus.trim().toLowerCase() !== env.COLUMN_AI.trim().toLowerCase()
+  ) {
+    return { status: "not_in_ai_column" };
+  }
+
+  // Fail closed on unknowable bot identity: without it we cannot tell our own
+  // questions/nudge comments from a human answer, so treat comments as zero and
+  // skip nudging (the nudge-dedup scan also needs to spot bot comments).
+  let botAccountId = "";
+  let botIdentityAvailable = false;
+  try {
+    const id = (await issueTracker.getCurrentUserAccountId?.())?.trim() ?? "";
+    if (id) {
+      botAccountId = id;
+      botIdentityAvailable = true;
+    }
+  } catch {
+    // Fall through: identity unavailable.
+  }
+  if (!botIdentityAvailable) {
+    logger.warn({ ticketKey }, "clarification_resume_bot_identity_unavailable");
+  }
+
+  const askedAtMs = row.askedAt.getTime();
+  const qualifying = botIdentityAvailable
+    ? ticket.comments.filter(
+        (c) =>
+          // Comments without an accountId cannot be proven non-bot.
+          c.accountId &&
+          c.accountId !== botAccountId &&
+          Date.parse(c.createdAt) > askedAtMs,
+      )
+    : [];
+
+  const noAnswer = async (): Promise<{
+    status: CommentResumeStatus;
+    nudged: boolean;
+  }> => {
+    let nudged = false;
+    if (allowNudge && botIdentityAvailable) {
+      const alreadyNudged = ticket.comments.some(
+        (c) =>
+          c.accountId === botAccountId &&
+          Date.parse(c.createdAt) > askedAtMs &&
+          c.body.includes(CLARIFICATION_NUDGE_MARKER),
+      );
+      if (!alreadyNudged) {
+        try {
+          await issueTracker.postComment(
+            ticketKey,
+            formatClarificationNudgeComment({
+              dashboardUrl: ticketPageUrl(env.DASHBOARD_ORIGIN, ticketKey),
+              aiColumnName: env.COLUMN_AI,
+            }),
+          );
+          nudged = true;
+        } catch (error) {
+          logger.warn(
+            { ticketKey, error: (error as Error).message },
+            "clarification_resume_nudge_failed",
+          );
+        }
+      }
+    }
+    return { status: "no_answer_comments", nudged };
+  };
+
+  if (qualifying.length === 0) return noAnswer();
+
+  const composed = qualifying
+    .map((c) => `${c.author}: ${c.body.trim()}`)
+    .join("\n\n")
+    .trim()
+    .slice(0, MAX_ANSWER_LENGTH);
+  if (!composed) return noAnswer();
+
+  // Attribute to the LAST commenter: their comment completed the answer and the
+  // choice is stable across identical retries. The label lists every unique
+  // author in first-appearance order.
+  const lastCommenter = qualifying[qualifying.length - 1];
+  const answeredById = `jira:${lastCommenter.accountId}`;
+  const uniqueAuthors: string[] = [];
+  for (const c of qualifying) {
+    if (!uniqueAuthors.includes(c.author)) uniqueAuthors.push(c.author);
+  }
+  const answeredByLabel = `${uniqueAuthors.join(", ")} (via Jira)`;
+
+  const outcome = await answerClarificationAndResume({
+    db,
+    row,
+    rawAnswer: composed,
+    actor: { id: answeredById, label: answeredByLabel },
+    issueTracker,
+    skipTicketFetch: true,
+  });
+  switch (outcome.kind) {
+    case "answered":
+      return { status: "resumed", runId: row.runId };
+    case "resume_failed_retryable":
+      // The CAS committed; the cron heals via the answered-retry path next tick.
+      logger.warn(
+        { ticketKey, runId: row.runId },
+        "clarification_resume_retry_pending",
+      );
+      return { status: "resume_retry_pending", runId: row.runId };
+    case "conflict": {
+      // Another channel won. Acknowledge in Jira only when the winner is NOT a
+      // Jira comment answer; suppress noise on duplicate webhook deliveries
+      // where the winner IS our own jira:* answer.
+      const winner = await getHookClarification(db, row.id);
+      if (!(winner?.answeredById ?? "").startsWith("jira:")) {
+        await issueTracker
+          .postComment(
+            ticketKey,
+            formatAlreadyAnsweredComment({
+              answeredByLabel: winner?.answeredByLabel ?? "someone",
+            }),
+          )
+          .catch((error) =>
+            logger.warn(
+              { ticketKey, error: (error as Error).message },
+              "clarification_resume_already_answered_comment_failed",
+            ),
+          );
+      }
+      return { status: "already_answered" };
+    }
+    case "ticket_gone":
+      return { status: "ticket_gone" };
+    case "invalid_answer":
+      // Unreachable after the empty-compose guard above; defensive only.
+      logger.warn(
+        { ticketKey, runId: row.runId },
+        "clarification_resume_unexpected_invalid_answer",
+      );
+      return { status: "no_answer_comments", nudged: false };
+  }
+}

--- a/apps/worker/src/lib/human-decisions-memory.test.ts
+++ b/apps/worker/src/lib/human-decisions-memory.test.ts
@@ -89,6 +89,16 @@ describe("renderHumanDecisionsSection", () => {
     expect(section).toContain("Q [human-decisions:start] ?");
     expect(section).toContain("A [human-decisions:end] tail");
   });
+
+  it("defangs a marker embedded in the answeredBy heading value", () => {
+    const section = renderHumanDecisionsSection([
+      { questions: ["Q?"], answer: "A", answeredBy: `Mallory ${END}` },
+    ]);
+    // The block keeps exactly one end marker: its own, not one smuggled via the
+    // display name.
+    expect(section.indexOf(END)).toBe(section.lastIndexOf(END));
+    expect(section).toContain("answered by Mallory [human-decisions:end]");
+  });
 });
 
 describe("upsertHumanDecisionsSection", () => {

--- a/apps/worker/src/lib/human-decisions-memory.ts
+++ b/apps/worker/src/lib/human-decisions-memory.ts
@@ -25,7 +25,7 @@ function defangMarkers(text: string): string {
 
 function renderRound(roundNumber: number, decision: HumanDecision): string {
   const meta: string[] = [];
-  if (decision.answeredBy) meta.push(`answered by ${decision.answeredBy}`);
+  if (decision.answeredBy) meta.push(`answered by ${defangMarkers(decision.answeredBy)}`);
   if (decision.answeredAt) meta.push(decision.answeredAt);
   const heading = meta.length > 0
     ? `### Round ${roundNumber} (${meta.join(", ")})`

--- a/apps/worker/src/routes/api/v1/clarifications/[id]/answer.post.ts
+++ b/apps/worker/src/routes/api/v1/clarifications/[id]/answer.post.ts
@@ -1,23 +1,17 @@
 import { createError, defineEventHandler, getRouterParam, readBody } from "h3";
 import type { ClarificationAnswerResponse } from "@shared/contracts";
-import { getHookByToken, resumeHook } from "workflow/api";
 import { getDb } from "../../../../../db/client.js";
 import { requireDashboardActor, toHttpError } from "../../../../../lib/auth/request-context.js";
 import { createStepAdapters } from "../../../../../lib/step-adapters.js";
-import { IssueTrackerNotFoundError } from "../../../../../adapters/issue-tracker/types.js";
 import { dashboardUserLabel } from "../../../../../pre-pr-checks/store.js";
 import {
-  supersedeClarification,
-  supersedePendingForTicket,
-} from "../../../../../clarifications/store.js";
+  answerClarificationAndResume,
+  MAX_ANSWER_LENGTH,
+} from "../../../../../clarifications/answer-core.js";
 import {
-  answerHookClarification,
   getHookClarification,
   type HookClarificationRow,
 } from "../../../../../clarifications/hook-store.js";
-import { resolveAwaitingRun } from "../../../../../lib/telemetry/run-telemetry.js";
-
-const MAX_ANSWER_LENGTH = 10_000;
 
 function serialize(row: HookClarificationRow) {
   return {
@@ -57,65 +51,37 @@ export default defineEventHandler(async (event): Promise<ClarificationAnswerResp
     const db = getDb();
     const row = await getHookClarification(db, id);
     if (!row) throw createError({ statusCode: 404, statusMessage: "Unknown clarification" });
-    const isResumeRetry = row.status === "answered" && row.answer === answer;
-    if (row.status !== "pending" && !isResumeRetry) {
-      throw createError({ statusCode: 409, statusMessage: "already_answered" });
-    }
 
     const label = await dashboardUserLabel(db, actor.userId);
-    const answerer = isResumeRetry
-      ? { id: row.answeredById ?? actor.userId, label: row.answeredByLabel ?? label }
-      : { id: actor.userId, label };
     const adapters = createStepAdapters();
 
-    // Ticketless scope:any continuations have no Jira lifecycle. Ticket-backed
-    // checkpoints still fail early when their ticket has been deleted.
-    if (row.ticketKey) {
-      try {
-        await adapters.issueTracker.fetchTicket(row.ticketKey);
-      } catch (err) {
-        if (!(err instanceof IssueTrackerNotFoundError)) throw err;
-        await supersedePendingForTicket(db, row.ticketKey).catch(() => {});
-        await supersedeClarification(db, row.id).catch(() => {});
-        await resolveAwaitingRun(db, row.runId).catch(() => {});
+    const outcome = await answerClarificationAndResume({
+      db,
+      row,
+      rawAnswer,
+      actor: { id: actor.userId, label },
+      issueTracker: adapters.issueTracker,
+    });
+
+    switch (outcome.kind) {
+      case "invalid_answer":
+        throw createError({ statusCode: 400, statusMessage: "invalid_answer" });
+      case "conflict":
+        throw createError({ statusCode: 409, statusMessage: "already_answered" });
+      case "ticket_gone":
         throw createError({ statusCode: 410, statusMessage: "ticket_gone" });
-      }
-    }
-
-    const answered = isResumeRetry
-      ? row
-      : await answerHookClarification(db, row.id, answer, answerer);
-    if (!answered) {
-      throw createError({ statusCode: 409, statusMessage: "already_answered" });
-    }
-
-    try {
-      await resumeHook(answered.hookToken, {
-        answer,
-        answeredById: answerer.id,
-        answeredByLabel: answerer.label,
-        answeredAt: answered.answeredAt?.toISOString() ?? new Date().toISOString(),
-      });
-    } catch (error) {
-      // If the hook still exists, the resume definitely did not commit and the
-      // same answer can be retried. A missing hook means the resume won but the
-      // HTTP response was lost (or another identical retry already won).
-      const hookStillExists = await getHookByToken(answered.hookToken)
-        .then(() => true)
-        .catch(() => false);
-      if (hookStillExists) {
+      case "resume_failed_retryable":
         throw createError({
           statusCode: 503,
           statusMessage: "clarification_resume_failed",
-          cause: error,
+          cause: outcome.error,
         });
-      }
+      case "answered":
+        return {
+          clarification: serialize(outcome.row),
+          runId: outcome.row.runId,
+        };
     }
-
-    return {
-      clarification: serialize(answered),
-      runId: answered.runId,
-    };
   } catch (error) {
     toHttpError(error);
   }

--- a/apps/worker/src/routes/cron/poll.get.test.ts
+++ b/apps/worker/src/routes/cron/poll.get.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
   getApproval: vi.fn(),
   rejectUndispatchableApproval: vi.fn(),
   dispatchPlanApproved: vi.fn(),
+  resumeClarificationFromComments: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({
@@ -80,6 +81,10 @@ vi.mock("../../clarifications/reconciliation.js", () => ({
 }));
 vi.mock("../../clarifications/expiry.js", () => ({
   expireHookClarifications: (...args: any[]) => mocks.expireClarifications(...args),
+}));
+vi.mock("../../clarifications/resume-from-comments.js", () => ({
+  resumeClarificationFromComments: (...args: any[]) =>
+    mocks.resumeClarificationFromComments(...args),
 }));
 vi.mock("../../lib/dispatch-trigger.js", () => ({
   drainOldestPendingTrigger: vi.fn().mockResolvedValue(null),
@@ -147,6 +152,7 @@ describe("cron clarification recovery ordering", () => {
     mocks.getApproval.mockResolvedValue(null);
     mocks.rejectUndispatchableApproval.mockResolvedValue(undefined);
     mocks.dispatchPlanApproved.mockResolvedValue({ status: "run_in_flight" });
+    mocks.resumeClarificationFromComments.mockResolvedValue({ status: "no_clarification" });
   });
 
   it("protects same-run clarifications before discovering generic ticket work", async () => {
@@ -238,5 +244,22 @@ describe("cron clarification recovery ordering", () => {
     await expect(response.json()).resolves.toMatchObject({
       approvalRecovery: { scanned: 1, started: 1, blocked: 0, errors: 0 },
     });
+  });
+
+  it("resumes protected clarifications without dispatching, and skips the helper for open work", async () => {
+    const response = await request();
+
+    expect(response.status).toBe(200);
+    // AIW-1 is protected: the poll tries to wake its suspended run (no nudge —
+    // the cron JQL snapshot is not the human's commit gesture) and never dispatches.
+    expect(mocks.resumeClarificationFromComments).toHaveBeenCalledWith(
+      expect.objectContaining({ ticketKey: "AIW-1", allowNudge: false }),
+    );
+    expect(state.order).not.toContain("dispatch:AIW-1");
+    // AIW-2 is not protected: it dispatches and never touches the resume helper.
+    expect(mocks.resumeClarificationFromComments).not.toHaveBeenCalledWith(
+      expect.objectContaining({ ticketKey: "AIW-2" }),
+    );
+    expect(state.order).toContain("dispatch:AIW-2");
   });
 });

--- a/apps/worker/src/routes/cron/poll.get.ts
+++ b/apps/worker/src/routes/cron/poll.get.ts
@@ -14,6 +14,7 @@ import { drainOldestPendingTrigger } from "../../lib/dispatch-trigger.js";
 import {
   classifyProtectedClarificationSubjects,
 } from "../../clarifications/store.js";
+import { resumeClarificationFromComments } from "../../clarifications/resume-from-comments.js";
 import { ticketSubjectKey } from "../../lib/subject-key.js";
 import { expireHookClarifications } from "../../clarifications/expiry.js";
 import { dispatchPlanApproved } from "../../approvals/dispatch.js";
@@ -100,6 +101,7 @@ export default defineEventHandler(async (event) => {
     ticketKeys,
     adapters,
     protectedDiscoverySubjects,
+    db,
   );
 
   // Housekeeping: physically drop expired gate rows (reads already treat
@@ -221,6 +223,7 @@ async function dispatchDiscoveredTickets(
   ticketKeys: string[],
   adapters: ReturnType<typeof createAdapters>,
   protectedSubjects: ReadonlySet<string>,
+  db: ReturnType<typeof getDb>,
 ): Promise<string[]> {
   // Dispatch in parallel. dispatchTicket is internally atomic — the
   // post-claim fairness check in src/lib/dispatch.ts caps started
@@ -229,6 +232,28 @@ async function dispatchDiscoveredTickets(
   const results = await Promise.all(
     ticketKeys.map(async (key) => {
       if (protectedSubjects.has(ticketSubjectKey("jira", key))) {
+        // A protected subject may hold a suspended clarification run whose
+        // answers arrived as human comments. Try to wake it (no nudging on the
+        // poll: the cron JQL snapshot is not the human's commit gesture). A
+        // resumed run needs no dispatch, so this always returns started:false.
+        const resume = await resumeClarificationFromComments({
+          db,
+          issueTracker: adapters.issueTracker,
+          ticketKey: key,
+          allowNudge: false,
+        }).catch((err) => {
+          logger.warn(
+            { ticketKey: key, error: (err as Error).message },
+            "poll_clarification_resume_failed",
+          );
+          return null;
+        });
+        if (resume && resume.status !== "no_clarification") {
+          logger.info(
+            { ticketKey: key, resumeStatus: resume.status, runId: resume.runId },
+            "poll_clarification_resume",
+          );
+        }
         return { key, started: false };
       }
       try {

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -12,12 +12,17 @@ const state = vi.hoisted(() => ({
   createAdapters: vi.fn(),
   dispatch: vi.fn(),
   cancel: vi.fn(),
+  resume: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({ env: state.env }));
 vi.mock("../../lib/adapters.js", () => ({ createAdapters: state.createAdapters }));
 vi.mock("../../lib/dispatch.js", () => ({ dispatchTicket: state.dispatch }));
 vi.mock("../../lib/cancel-run.js", () => ({ cancelRun: state.cancel }));
+vi.mock("../../db/client.js", () => ({ getDb: () => ({}) }));
+vi.mock("../../clarifications/resume-from-comments.js", () => ({
+  resumeClarificationFromComments: (...args: unknown[]) => state.resume(...args),
+}));
 
 const handler = (await import("./jira.post.js")).default;
 
@@ -162,6 +167,64 @@ describe("POST /webhooks/jira", () => {
     const response = await app()(request({ status: "AI" }));
     await expect(response.json()).resolves.toMatchObject({
       reason: "human_status_change_during_cancellation",
+    });
+    expect(state.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("resumes a suspended clarification run instead of dispatching", async () => {
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.resume.mockResolvedValue({ status: "resumed", runId: "run-9" });
+
+    const response = await app()(request({ status: "AI" }));
+
+    await expect(response.json()).resolves.toEqual({
+      status: "resumed",
+      reason: "clarification_resumed",
+      ticketKey: "PROJ-42",
+    });
+    expect(state.resume).toHaveBeenCalledWith(
+      expect.objectContaining({ ticketKey: "PROJ-42", allowNudge: true }),
+    );
+    expect(state.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches as usual when there is no clarification to resume", async () => {
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.resume.mockResolvedValue({ status: "no_clarification" });
+    state.dispatch.mockResolvedValue({ started: true, reason: "dispatched" });
+
+    const response = await app()(request({ status: "AI" }));
+
+    await expect(response.json()).resolves.toMatchObject({ status: "dispatched" });
+    expect(state.dispatch).toHaveBeenCalledOnce();
+  });
+
+  it("only allows nudging when the delivery carries a status changelog item", async () => {
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.resume.mockResolvedValue({ status: "no_clarification" });
+    state.dispatch.mockResolvedValue({ started: true, reason: "dispatched" });
+
+    await app()(request({ status: "AI", changelog: false }));
+
+    expect(state.resume).toHaveBeenCalledWith(
+      expect.objectContaining({ allowNudge: false }),
+    );
+  });
+
+  it("skips dispatch when the resume helper fails unexpectedly", async () => {
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.resume.mockRejectedValue(new Error("db down"));
+
+    const response = await app()(request({ status: "AI" }));
+
+    await expect(response.json()).resolves.toEqual({
+      status: "skipped",
+      reason: "clarification_resume_error",
+      ticketKey: "PROJ-42",
     });
     expect(state.dispatch).not.toHaveBeenCalled();
   });

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -2,6 +2,8 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import { defineEventHandler, readRawBody, getHeader, createError } from "h3";
 import { env } from "../../../env.js";
 import { IssueTrackerNotFoundError } from "../../adapters/issue-tracker/types.js";
+import { resumeClarificationFromComments } from "../../clarifications/resume-from-comments.js";
+import { getDb } from "../../db/client.js";
 import { createAdapters } from "../../lib/adapters.js";
 import { cancelRun } from "../../lib/cancel-run.js";
 import { dispatchTicket } from "../../lib/dispatch.js";
@@ -161,6 +163,13 @@ export default defineEventHandler(async (event) => {
         },
         "webhook_skip_cancel_live_ticket_in_ai_column",
       );
+      const resumeResult = await tryResumeClarification(
+        ticketKey,
+        adapters,
+        Boolean(statusChange),
+      );
+      if (resumeResult) return resumeResult;
+
       logger.info(
         {
           ticketKey,
@@ -231,6 +240,13 @@ export default defineEventHandler(async (event) => {
     };
   }
 
+  const resumeResult = await tryResumeClarification(
+    ticketKey,
+    adapters,
+    Boolean(statusChange),
+  );
+  if (resumeResult) return resumeResult;
+
   logger.info(
     {
       ticketKey,
@@ -252,6 +268,58 @@ export default defineEventHandler(async (event) => {
     reason: result.reason,
   };
 });
+
+// ---------------------------------------------------------------------------
+// Clarification resume
+// ---------------------------------------------------------------------------
+
+/**
+ * A ticket moved into the AI column may carry a suspended clarification run
+ * whose answers were left as human comments. Wake that run instead of
+ * dispatching. Returns the handler response to send, or null to fall through
+ * to dispatchTicket (no clarification, or the live ticket is not in AI). The
+ * move is the commit gesture, so nudging is only allowed when the delivery
+ * carries a real status changelog item.
+ */
+async function tryResumeClarification(
+  ticketKey: string,
+  adapters: ReturnType<typeof createAdapters>,
+  allowNudge: boolean,
+): Promise<{ status: string; reason: string; ticketKey: string } | null> {
+  const resume = await resumeClarificationFromComments({
+    db: getDb(),
+    issueTracker: adapters.issueTracker,
+    ticketKey,
+    allowNudge,
+  }).catch((err) => {
+    logger.warn(
+      { ticketKey, error: (err as Error).message },
+      "webhook_clarification_resume_failed",
+    );
+    return null;
+  });
+  if (
+    resume &&
+    resume.status !== "no_clarification" &&
+    resume.status !== "not_in_ai_column"
+  ) {
+    logger.info(
+      { ticketKey, resumeStatus: resume.status, runId: resume.runId },
+      "webhook_clarification_resume",
+    );
+    return {
+      status: resume.status === "resumed" ? "resumed" : "skipped",
+      reason: `clarification_${resume.status}`,
+      ticketKey,
+    };
+  }
+  if (resume === null) {
+    // Unexpected resume failure: skip dispatch this delivery, the cron retries.
+    return { status: "skipped", reason: "clarification_resume_error", ticketKey };
+  }
+  // fall through to dispatchTicket (returns already_claimed / not_in_ai itself)
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Auth

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -953,10 +953,12 @@ export async function parkForClarificationStep(
   );
   const db = getDb();
   const { issueTracker } = createStepAdapters();
-  // No Jira comment: the questions live durably in the clarification store and
-  // the overview reads awaiting state from the DB. The label is ticket-status
-  // truth only now (it no longer drives any Jira scan). Best-effort, so a label
-  // failure never blocks the park.
+  // The questions live durably in the clarification store and the overview reads
+  // awaiting state from the DB; the caller also posts a best-effort Jira comment
+  // with the questions separately (postClarificationQuestionsCommentStep). This
+  // step only moves the label/column. The label is ticket-status truth only now
+  // (it no longer drives any Jira scan). Best-effort, so a label failure never
+  // blocks the park.
   if (typeof issueTracker.updateLabels === "function") {
     try {
       await updateTicketLabelsForRun({
@@ -1066,6 +1068,52 @@ export async function postPickupCommentStep(
   }
 }
 postPickupCommentStep.maxRetries = 0;
+
+export async function postClarificationQuestionsCommentStep(
+  ticketKey: string,
+  input: {
+    questions: string[];
+    suggestedAnswers: string[] | null;
+    dashboardUrl: string;
+    expiresAtIso: string | null;
+  },
+  owner: ActiveRunOwner,
+): Promise<string | null> {
+  "use step";
+  const { getDb } = await import("../db/client.js");
+  const { assertActiveRunOwner } = await import("../lib/active-run-owner.js");
+  const { createStepAdapters } = await import("../lib/step-adapters.js");
+  const { env } = await import("../../env.js");
+  const { formatClarificationQuestionsComment } = await import(
+    "../clarifications/comment-format.js"
+  );
+  const { issueTracker } = createStepAdapters();
+  // Best-effort: surfacing the questions in Jira must never fail the paused run.
+  // Returns the comment deep-link on success, null on any failure. A run-control
+  // error still rethrows so the workflow ownership CAS is honored.
+  try {
+    await assertActiveRunOwner(getDb(), owner);
+    return await issueTracker.postComment(
+      ticketKey,
+      formatClarificationQuestionsComment({
+        questions: input.questions,
+        suggestedAnswers: input.suggestedAnswers,
+        dashboardUrl: input.dashboardUrl,
+        aiColumnName: env.COLUMN_AI,
+        expiresAtIso: input.expiresAtIso,
+      }),
+    );
+  } catch (err) {
+    if (isRunControlError(err)) throw err;
+    const { logger } = await import("../lib/logger.js");
+    logger.warn(
+      { ticketKey, err: errorMessage(err) },
+      "clarification_questions_comment_failed",
+    );
+    return null;
+  }
+}
+postClarificationQuestionsCommentStep.maxRetries = 0;
 
 async function loadClarificationHistoryStep(
   ticketKey: string,
@@ -1734,9 +1782,22 @@ async function agentWorkflowBody(
               console.error(`Clarification ticket parking failed for ${clarification.id}:`, error);
               return false;
             });
+            const questionsCommentUrl = await postClarificationQuestionsCommentStep(
+              ticket.identifier,
+              {
+                questions,
+                suggestedAnswers: suggestedAnswers ?? null,
+                dashboardUrl: ticketRunUrl(env.DASHBOARD_ORIGIN, ticket.identifier, workflowRunId),
+                expiresAtIso: clarification.expiresAt,
+              },
+              transitionOwner,
+            );
             await notifyTicketBestEffort(ticket.identifier, {
               kind: "needs_clarification",
               dashboardUrl: ticketRunUrl(env.DASHBOARD_ORIGIN, ticket.identifier, workflowRunId),
+              ...(questionsCommentUrl ? { commentUrl: questionsCommentUrl } : {}),
+              questions,
+              ...(suggestedAnswers && suggestedAnswers.length > 0 ? { suggestedAnswers } : {}),
               usageReport: usageReportOrUndefined(),
             }, transitionOwner);
           }

--- a/apps/worker/src/workflows/clarification-hook-steps.ts
+++ b/apps/worker/src/workflows/clarification-hook-steps.ts
@@ -37,6 +37,7 @@ export async function prepareClarificationHookStep(input: {
     id: row.id,
     hookToken: row.hookToken,
     snapshotRequestedAt: row.askedAt.toISOString(),
+    expiresAt: row.expiresAt?.toISOString() ?? null,
   };
 }
 


### PR DESCRIPTION
## Stack

- PR 1 of 1
- Base: `main`
- Jira: [AIW-145](https://blazity.atlassian.net/browse/AIW-145), extends [AIW-110](https://blazity.atlassian.net/browse/AIW-110) (human-in-the-loop MVP with dashboard answering)

## What changed

- Posts the clarification questions to the Jira ticket as a numbered comment with suggested answers, a dashboard deep link, how-to-answer instructions, and the resumable-until date; includes the question texts in the Slack notification. Both are best-effort and never fail the run.
- Makes clarifications answerable from Jira: reply in a comment, then move the ticket back to the AI column. The move is the commit gesture; comments alone never trigger anything, and the bot's own comments are excluded by accountId (identity resolution fails closed).
- On the move, the webhook (both AI-column dispatch sites) and the cron backstop detect the suspended run that still holds its bound registry claim, compose all qualifying comments (non-bot, newer than the question, non-empty) into the single answer, flip the request from pending to answered under CAS, and resume the same run from its sandbox snapshot. No re-run, no lost work.
- Extracts the dashboard route's answer-and-resume logic into a shared core (`clarifications/answer-core.ts`); the route keeps its exact HTTP contract and its tests pass unmodified.
- Adds `getResumableClarificationForTicket` (newest pending-or-answered row whose asking run is still bound) and the `resume-from-comments.ts` orchestrator: live AI-column guard, one-nudge-per-round dedup, healing of answered rows whose resume was lost, and channel-conflict handling (a dashboard win is acknowledged with a Jira comment).
- Attribution: `answeredById` is `jira:{accountId}` of the last commenter; `answeredByLabel` lists commenters with a "(via Jira)" suffix, capped at 200 characters and marker-defanged in the per-ticket memory section.
- Aligns e2e US-05/US-06 with the design (the suspended run keeps its registry claim; US-06 answers via a second Jira identity and asserts the same runId completes) and updates SETUP.md and the init-jira webhook reference.

## Compatibility

- Dashboard answering is unchanged: same status codes, payloads, and race semantics; the extraction is behavior-preserving.
- Comments alone never wake a run. A comment-only `issue_updated` while the ticket is parked in Backlog hits the existing no-status-change ignore path.
- Runs suspended on older deployments are unaffected: Workflow runs are pinned to the deployment that started them, and pre-feature parked runs resume from comments using only the DB row (no dependency on the new questions comment).
- No new Jira webhook events required: the `jira:issue_updated` event from the move triggers the resume, and the cron poller is the backstop when a webhook is missed.

## Migration and rollout

- Database migration: none (all columns and indexes already exist).
- No new production env vars, endpoints, or dependencies. `JIRA_E2E_COMMENTER_TOKEN` is optional and e2e-only (US-06 skips cleanly without it).
- A paused run stays resumable for 7 days (question and snapshot expiry); after that, moving the ticket to the AI column starts a fresh run that still loads the answered history from the DB.

## Verification

- `apps/worker` unit suite: 2119 of 2120 tests passed. The single failure is the pre-existing `workflow-owned-branches.test.ts` case, reproduced on `main` and unrelated to this branch.
- `pnpm typecheck` at the repo root (worker and dashboard): passed.
- The dashboard clarification route suite passes byte-unmodified as the extraction regression gate.
- e2e files compile under tsc with the e2e directory included; live tier2 runs require the protected e2e environment (US-06 additionally requires `JIRA_E2E_COMMENTER_TOKEN`).
- Two independent prod-readiness reviews (correctness/races and security/operations) returned PROD READY; all three actionable findings are fixed in the final commit (empty-comment bodies no longer count as answers, `answeredBy` is marker-defanged in the memory section, the label is length-capped).

Known follow-ups, out of scope: the pre-existing `workflow-owned-branches` unit test failure (reproduced on `main`), and an optional webhook test pinning the stale-payload dispatch site.


[AIW-145]: https://blazity.atlassian.net/browse/AIW-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIW-110]: https://blazity.atlassian.net/browse/AIW-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clarification requests now post numbered Jira questions, suggested answers, dashboard links, and expiration details.
  * Human answers can resume paused work through Jira comments or the dashboard.
  * Slack notifications now include clarification questions and suggested answers.
  * Paused clarification runs remain resumable for seven days and retain their original run.

* **Bug Fixes**
  * Improved recovery when webhook events are missed, with cron polling as a fallback.
  * Prevented notification and rendered-content markers from being interpreted as broadcast commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->