### PR TITLE
AIW-140: close PR review-comment ingestion gaps across workflow versions

### DIFF
--- a/apps/worker/drizzle/0022_gigantic_onslaught.sql
+++ b/apps/worker/drizzle/0022_gigantic_onslaught.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "trigger_deliveries" ADD COLUMN "semantic_key" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "trigger_deliveries_semantic_key_idx" ON "trigger_deliveries" USING btree ("provider","semantic_key") WHERE "trigger_deliveries"."semantic_key" is not null;

--- a/apps/worker/drizzle/meta/0022_snapshot.json
+++ b/apps/worker/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,2823 @@
+{
+  "id": "133d331c-3125-44ea-b0ba-685fb8c88701",
+  "prevId": "836d7d3f-1a6a-4f66-96d6-0f1d3542aabf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1784572984693,
       "tag": "0021_common_kingpin",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1784785053327,
+      "tag": "0022_gigantic_onslaught",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/env.test.ts
+++ b/apps/worker/env.test.ts
@@ -237,7 +237,7 @@ describe("env", () => {
     const { env, getVcsBotLogin } = await import("./env.js");
 
     expect(env.GITHUB_BOT_LOGIN).toBe("GitHub-App[Bot]");
-    expect(getVcsBotLogin("github")).toBe("github-app[bot]");
+    expect(getVcsBotLogin("github")).toBe("github-app");
   });
 
   it("uses the legacy bot login only for an unambiguous single provider", async () => {
@@ -263,7 +263,7 @@ describe("env", () => {
 
     const { getVcsBotLogin } = await import("./env.js");
 
-    expect(getVcsBotLogin("github")).toBe("github-app[bot]");
+    expect(getVcsBotLogin("github")).toBe("github-app");
     expect(getVcsBotLogin("gitlab")).toBeUndefined();
   });
 

--- a/apps/worker/src/db/queries/workflow-owned-branches.test.ts
+++ b/apps/worker/src/db/queries/workflow-owned-branches.test.ts
@@ -229,6 +229,7 @@ describe("workflow-owned branch records", () => {
         repoPath: "acme/web",
         branchName: "blazebot/aiw-45",
         publishedHeadSha: "new-head",
+        targetBranch: "main",
       },
     ]);
     await expect(
@@ -544,6 +545,64 @@ describe("workflow-owned branch records", () => {
         repoPath: "acme/web",
         prNumber: 42,
         branchName: "feature/owned",
+        publishedHeadSha: "human-push",
+        baseBranch: "main",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("matches a confirmed PR by head and target when the branch name is unknown", async () => {
+    // issue_comment events carry no branch name. The published-head-SHA and
+    // target-branch checks alone still prove workflow ownership.
+    const db = await createTestDb();
+    await upsertWorkflowOwnedBranch(db, {
+      ticketKey: "AIW-140",
+      provider: "github",
+      repoPath: "acme/web",
+      branchName: "blazebot/aiw-140",
+      publishedHeadSha: "published-sha",
+      targetBranch: "main",
+      pr: {
+        id: 88,
+        url: "https://github.com/acme/web/pull/88",
+        branch: "blazebot/aiw-140",
+      },
+    });
+
+    await expect(
+      findWorkflowOwnedPullRequest(db, {
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 88,
+        branchName: "",
+        publishedHeadSha: "published-sha",
+        baseBranch: "main",
+      }),
+    ).resolves.toMatchObject({ ticketKey: "AIW-140", pr: { id: 88 } });
+  });
+
+  it("does not match an unknown-branch lookup when the head sha differs", async () => {
+    const db = await createTestDb();
+    await upsertWorkflowOwnedBranch(db, {
+      ticketKey: "AIW-140",
+      provider: "github",
+      repoPath: "acme/web",
+      branchName: "blazebot/aiw-140",
+      publishedHeadSha: "published-sha",
+      targetBranch: "main",
+      pr: {
+        id: 88,
+        url: "https://github.com/acme/web/pull/88",
+        branch: "blazebot/aiw-140",
+      },
+    });
+
+    await expect(
+      findWorkflowOwnedPullRequest(db, {
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 88,
+        branchName: "",
         publishedHeadSha: "human-push",
         baseBranch: "main",
       }),

--- a/apps/worker/src/db/queries/workflow-owned-branches.ts
+++ b/apps/worker/src/db/queries/workflow-owned-branches.ts
@@ -116,7 +116,12 @@ export async function findWorkflowOwnedPullRequest(
         eq(workflowOwnedBranches.provider, input.provider),
         eq(workflowOwnedBranches.repoPath, input.repoPath),
         eq(workflowOwnedBranches.prId, input.prNumber),
-        eq(workflowOwnedBranches.prBranchName, input.branchName),
+        // issue_comment events cannot know the PR branch name. Dropping only the
+        // branch equality still leaves the published-head-SHA and target-branch
+        // checks below, which prove the workflow itself published this head.
+        input.branchName
+          ? eq(workflowOwnedBranches.prBranchName, input.branchName)
+          : undefined,
         or(
           eq(workflowOwnedBranches.prPublishedHeadSha, input.publishedHeadSha),
           and(

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -79,6 +79,9 @@ export const triggerDeliveries = pgTable(
     provider: text("provider").notNull(),
     deliveryId: text("delivery_id").notNull(),
     producer: text("producer").notNull(),
+    /** Stable identity of the human action behind this delivery. One review's
+     * fan-out of N webhooks shares one key so it accepts exactly one run. */
+    semanticKey: text("semantic_key"),
     triggerType: text("trigger_type").notNull(),
     subjectKey: text("subject_key").notNull(),
     ticketKey: text("ticket_key"),
@@ -96,6 +99,9 @@ export const triggerDeliveries = pgTable(
     uniqueIndex("trigger_deliveries_one_pending_per_subject_idx")
       .on(t.subjectKey)
       .where(sql`${t.pending} = true`),
+    uniqueIndex("trigger_deliveries_semantic_key_idx")
+      .on(t.provider, t.semanticKey)
+      .where(sql`${t.semanticKey} is not null`),
     foreignKey({
       columns: [t.definitionId, t.definitionVersion],
       foreignColumns: [

--- a/apps/worker/src/lib/dispatch-pr-trigger-coalesce.test.ts
+++ b/apps/worker/src/lib/dispatch-pr-trigger-coalesce.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ActiveRunEntry,
   RunRegistryAdapter,
   RunReservation,
 } from "../adapters/run-registry/types.js";
+import type { Db } from "../db/client.js";
+import {
+  workflowDefinitions,
+  workflowDefinitionVersions,
+} from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
 import { claimSubjectRun } from "./dispatch.js";
+import {
+  acceptTriggerDelivery,
+  coalescePendingTrigger,
+  completeTriggerDelivery,
+  listPendingTriggersForSubject,
+  type AcceptedTriggerDelivery,
+} from "./trigger-delivery-store.js";
 
 vi.mock("../../env.js", () => ({
   env: { JIRA_PROJECT_KEY: "PROJ", COLUMN_AI: "AI" },
@@ -120,5 +133,101 @@ describe("PR trigger coalescing with owner-CAS", () => {
     });
     expect(await runRegistry.release(subject.subjectKey, predecessorOwner, "run-1")).toBe(false);
     expect(await runRegistry.get(subject.subjectKey)).not.toBeNull();
+  });
+});
+
+describe("PR trigger semantic dedup at the coalesce boundary", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await db.insert(workflowDefinitions).values({
+      id: 7,
+      name: "Coalesce test",
+      createdById: "test",
+      createdByLabel: "Test",
+    });
+    await db.insert(workflowDefinitionVersions).values({
+      definitionId: 7,
+      version: 11,
+      definition: {},
+      createdById: "test",
+      createdByLabel: "Test",
+    });
+  });
+
+  function prReview(
+    deliveryId: string,
+    semanticKey: string,
+  ): AcceptedTriggerDelivery {
+    return {
+      delivery: {
+        provider: "github",
+        producer: "human",
+        deliveryId,
+        semanticKey,
+      },
+      triggerType: "trigger_pr_review",
+      scope: "workflow_owned",
+      subjectKey: subject.subjectKey,
+      ticketKey: null,
+      definitionId: 7,
+      definitionVersion: 11,
+      pr: {
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 7,
+        prUrl: "https://github.com/acme/app/pull/7",
+        headRef: "feature/x",
+        headSha: "sha-1",
+        baseRef: "main",
+        title: "Review me",
+        author: "alice",
+        isDraft: false,
+        review: { state: "commented", author: "human", body: "fix this" },
+      },
+    };
+  }
+
+  // Faithful model of dispatchTriggerEvent's accept-then-coalesce decision
+  // (dispatch-trigger.ts:148-153 and :288): a duplicate (semantic or exact)
+  // short-circuits without ever coalescing; a fresh delivery either becomes the
+  // run on an idle subject or coalesces into the one pending successor while the
+  // subject is busy.
+  async function dispatch(
+    accepted: AcceptedTriggerDelivery,
+    subjectBusy: boolean,
+  ): Promise<"started" | "coalesced" | "deduped"> {
+    const durable = await acceptTriggerDelivery(db, accepted);
+    if (!durable.inserted) return "deduped";
+    if (subjectBusy) {
+      await coalescePendingTrigger(db, durable.stored);
+      return "coalesced";
+    }
+    await completeTriggerDelivery(db, "github", accepted.delivery.deliveryId, {
+      result: "started",
+      runId: `run-${accepted.delivery.deliveryId}`,
+    });
+    return "started";
+  }
+
+  it("accepts one run for a review fan-out and queues no successor", async () => {
+    const results = [
+      await dispatch(prReview("d-review", "review:99"), false),
+      await dispatch(prReview("d-c1", "review:99"), true),
+      await dispatch(prReview("d-c2", "review:99"), true),
+    ];
+    expect(results).toEqual(["started", "deduped", "deduped"]);
+    expect(await listPendingTriggersForSubject(db, subject.subjectKey)).toHaveLength(0);
+  });
+
+  it("still coalesces two independent comments into at most one successor", async () => {
+    const results = [
+      await dispatch(prReview("d-1", "comment:1"), false),
+      await dispatch(prReview("d-2", "comment:2"), true),
+      await dispatch(prReview("d-3", "comment:3"), true),
+    ];
+    expect(results).toEqual(["started", "coalesced", "coalesced"]);
+    expect(await listPendingTriggersForSubject(db, subject.subjectKey)).toHaveLength(1);
   });
 });

--- a/apps/worker/src/lib/trigger-current-pull-request.test.ts
+++ b/apps/worker/src/lib/trigger-current-pull-request.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PullRequestHead } from "../adapters/vcs/types.js";
+
+// bindCurrentPullRequest is a pure function, but the module also imports
+// createRepositoryVCS (-> env.js). Mock the runtime so the import chain never
+// validates environment variables during this unit test.
+vi.mock("./vcs-runtime.js", () => ({
+  createRepositoryVCS: vi.fn(),
+}));
+
+const { bindCurrentPullRequest } = await import("./trigger-current-pull-request.js");
+type TriggerEvent = import("./trigger-events.js").TriggerEvent;
+
+function reviewEvent(overrides: Partial<TriggerEvent["pr"]> = {}): TriggerEvent {
+  return {
+    delivery: { provider: "github", producer: "human", deliveryId: "d1" },
+    triggerType: "trigger_pr_review",
+    pr: {
+      provider: "github",
+      repoPath: "acme/app",
+      prNumber: 7,
+      prUrl: "https://github.com/acme/app/pull/7",
+      headRef: "",
+      headSha: "",
+      baseRef: "",
+      title: "Fix things",
+      author: "human",
+      isDraft: false,
+      review: { state: "commented", author: "human", body: "please fix" },
+      ...overrides,
+    },
+  };
+}
+
+const openHead: PullRequestHead = {
+  headSha: "live-sha",
+  baseRef: "main",
+  state: "open",
+};
+
+describe("bindCurrentPullRequest", () => {
+  it("adopts the current head and base for a review with empty head/base", () => {
+    const bound = bindCurrentPullRequest(reviewEvent(), openHead);
+
+    expect(bound).not.toBeNull();
+    expect(bound?.pr.headSha).toBe("live-sha");
+    expect(bound?.pr.baseRef).toBe("main");
+    // headRef has no provider equivalent in PullRequestHead and stays as-is.
+    expect(bound?.pr.headRef).toBe("");
+  });
+
+  it("keeps a non-empty matching head/base for a review", () => {
+    const bound = bindCurrentPullRequest(
+      reviewEvent({ headSha: "live-sha", baseRef: "main" }),
+      openHead,
+    );
+
+    expect(bound?.pr.headSha).toBe("live-sha");
+    expect(bound?.pr.baseRef).toBe("main");
+  });
+
+  it("rejects a review whose non-empty head no longer matches the current head", () => {
+    const bound = bindCurrentPullRequest(
+      reviewEvent({ headSha: "stale-sha", baseRef: "main" }),
+      openHead,
+    );
+
+    expect(bound).toBeNull();
+  });
+
+  it("rejects a review on a PR that is no longer open", () => {
+    const bound = bindCurrentPullRequest(reviewEvent(), { ...openHead, state: "merged" });
+
+    expect(bound).toBeNull();
+  });
+
+  it("still rejects a non-review trigger that carries an empty base ref", () => {
+    const event: TriggerEvent = {
+      delivery: { provider: "github", producer: "bot", deliveryId: "d2" },
+      triggerType: "trigger_pr_created",
+      pr: { ...reviewEvent().pr, baseRef: "", headSha: "live-sha", review: undefined },
+    };
+
+    expect(bindCurrentPullRequest(event, openHead)).toBeNull();
+  });
+});

--- a/apps/worker/src/lib/trigger-current-pull-request.ts
+++ b/apps/worker/src/lib/trigger-current-pull-request.ts
@@ -36,11 +36,20 @@ export function bindCurrentPullRequest<T extends TriggerEvent>(
 ): T | null {
   if (!current) return null;
   const { pr } = event;
-  if (current.baseRef !== pr.baseRef) return null;
+  // Review triggers are about the PR, not a specific head. A comment event may
+  // carry no base ref (issue_comment), so an empty pr.baseRef means "unknown,
+  // adopt the provider-authoritative value" rather than "stale".
+  const isReview = event.triggerType === "trigger_pr_review";
+  if (current.baseRef !== pr.baseRef && !(isReview && pr.baseRef === "")) return null;
   const expectedState =
     event.triggerType === "trigger_pr_merged" ? "merged" : "open";
   if (current.state !== expectedState) return null;
   if (pr.provider === "github") {
+    if (isReview) {
+      // Empty pr.headSha (issue_comment) is unknown, not stale: adopt current.
+      if (pr.headSha && pr.headSha !== current.headSha) return null;
+      return { ...event, pr: { ...pr, headSha: current.headSha, baseRef: current.baseRef } };
+    }
     if (current.headSha !== pr.headSha) return null;
     if (event.triggerType !== "trigger_pr_checks_failed") return event;
     const failedChecks = (pr.failedChecks ?? []).filter((failed) =>

--- a/apps/worker/src/lib/trigger-delivery-store.test.ts
+++ b/apps/worker/src/lib/trigger-delivery-store.test.ts
@@ -10,6 +10,7 @@ import {
   acceptTriggerDelivery,
   acknowledgeStartedTriggerDelivery,
   coalescePendingTrigger,
+  completeTriggerDelivery,
   getTriggerDelivery,
   listPendingTriggersForSubject,
   recordCandidateStartedTriggerDelivery,
@@ -71,6 +72,14 @@ function delivery(
     },
     ...overrides,
   };
+}
+
+function reviewFanout(
+  deliveryId: string,
+  semanticKey: string,
+): AcceptedTriggerDelivery {
+  const base = delivery(deliveryId, { triggerType: "trigger_pr_review" });
+  return { ...base, delivery: { ...base.delivery, semanticKey } };
 }
 
 describe("provider event inbox", () => {
@@ -148,5 +157,54 @@ describe("provider event inbox", () => {
       pending: false,
       result: { result: "started", runId: "run-1" },
     });
+  });
+
+  it("accepts one review fan-out: a shared semantic key returns the winner's envelope", async () => {
+    const winner = await acceptTriggerDelivery(db, reviewFanout("d-review", "review:99"));
+    expect(winner.inserted).toBe(true);
+
+    const sibling = await acceptTriggerDelivery(db, reviewFanout("d-comment", "review:99"));
+    expect(sibling.inserted).toBe(false);
+    expect(sibling.stored.delivery.deliveryId).toBe("d-review");
+    expect(sibling.stored.delivery.semanticKey).toBe("review:99");
+  });
+
+  it("resolves the semantic winner even after it has a result recorded", async () => {
+    await acceptTriggerDelivery(db, reviewFanout("d-review", "review:100"));
+    await completeTriggerDelivery(db, "github", "d-review", {
+      result: "started",
+      runId: "run-9",
+    });
+
+    const sibling = await acceptTriggerDelivery(db, reviewFanout("d-comment", "review:100"));
+    expect(sibling.inserted).toBe(false);
+    expect(sibling.stored).toMatchObject({
+      delivery: { deliveryId: "d-review" },
+      result: { result: "started", runId: "run-9" },
+    });
+  });
+
+  it("inserts separately when semantic keys differ", async () => {
+    const first = await acceptTriggerDelivery(db, reviewFanout("d-1", "review:1"));
+    const second = await acceptTriggerDelivery(db, reviewFanout("d-2", "review:2"));
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(true);
+  });
+
+  it("never conflicts two deliveries that carry no semantic key", async () => {
+    const first = await acceptTriggerDelivery(db, delivery("d-1"));
+    const second = await acceptTriggerDelivery(db, delivery("d-2"));
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(true);
+  });
+
+  it("replays the original by delivery id even when a semantic key is set", async () => {
+    await acceptTriggerDelivery(db, reviewFanout("d-review", "review:7"));
+    const replay = await acceptTriggerDelivery(
+      db,
+      reviewFanout("d-review", "review:7"),
+    );
+    expect(replay.inserted).toBe(false);
+    expect(replay.stored.delivery.deliveryId).toBe("d-review");
   });
 });

--- a/apps/worker/src/lib/trigger-delivery-store.ts
+++ b/apps/worker/src/lib/trigger-delivery-store.ts
@@ -34,7 +34,10 @@ export interface StoredTriggerDelivery extends AcceptedTriggerDelivery {
 }
 
 /** Insert one fully authenticated and normalized provider event. Provider
- * retries return the first stored envelope and can never change its pin. */
+ * retries return the first stored envelope and can never change its pin. A
+ * delivery whose semantic key already exists returns the semantic winner's
+ * envelope instead: the loser's delivery id is never recorded, and provider
+ * redeliveries of the loser keep resolving to the same winner. */
 export async function acceptTriggerDelivery(
   db: Db,
   accepted: AcceptedTriggerDelivery,
@@ -48,6 +51,7 @@ export async function acceptTriggerDelivery(
       provider: accepted.delivery.provider,
       deliveryId: accepted.delivery.deliveryId,
       producer: accepted.delivery.producer,
+      semanticKey: accepted.delivery.semanticKey ?? null,
       triggerType: accepted.triggerType,
       subjectKey: accepted.subjectKey,
       ticketKey: accepted.ticketKey,
@@ -56,16 +60,22 @@ export async function acceptTriggerDelivery(
       definitionVersion: accepted.definitionVersion,
       payload: accepted,
     })
-    .onConflictDoNothing({
-      target: [triggerDeliveries.provider, triggerDeliveries.deliveryId],
-    })
+    .onConflictDoNothing()
     .returning();
   if (rows[0]) return { inserted: true, stored: mapDelivery(rows[0]) };
-  const stored = await getTriggerDelivery(
-    db,
-    accepted.delivery.provider,
-    accepted.delivery.deliveryId,
-  );
+  const stored =
+    (await getTriggerDelivery(
+      db,
+      accepted.delivery.provider,
+      accepted.delivery.deliveryId,
+    )) ??
+    (accepted.delivery.semanticKey
+      ? await getTriggerDeliveryBySemanticKey(
+          db,
+          accepted.delivery.provider,
+          accepted.delivery.semanticKey,
+        )
+      : null);
   if (!stored) throw new Error("trigger delivery disappeared after unique conflict");
   return { inserted: false, stored };
 }
@@ -114,6 +124,26 @@ export async function getTriggerDelivery(
       and(
         eq(triggerDeliveries.provider, provider),
         eq(triggerDeliveries.deliveryId, deliveryId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ? mapDelivery(rows[0]) : null;
+}
+
+/** Resolve the delivery that owns a semantic key (the winner of a
+ * semantic-key conflict). */
+export async function getTriggerDeliveryBySemanticKey(
+  db: Db,
+  provider: "github" | "gitlab",
+  semanticKey: string,
+): Promise<StoredTriggerDelivery | null> {
+  const rows = await db
+    .select()
+    .from(triggerDeliveries)
+    .where(
+      and(
+        eq(triggerDeliveries.provider, provider),
+        eq(triggerDeliveries.semanticKey, semanticKey),
       ),
     )
     .limit(1);
@@ -330,6 +360,7 @@ function mapDelivery(row: typeof triggerDeliveries.$inferSelect): StoredTriggerD
       deliveryId: row.deliveryId,
       producer: row.producer,
       ...(payload.delivery.source ? { source: payload.delivery.source } : {}),
+      ...(row.semanticKey ? { semanticKey: row.semanticKey } : {}),
     },
     triggerType: row.triggerType as PrTriggerType,
     subjectKey: row.subjectKey,

--- a/apps/worker/src/lib/trigger-events.test.ts
+++ b/apps/worker/src/lib/trigger-events.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { normalizeGitHubEvent, normalizeGitLabEvent } from "./trigger-events.js";
+import { AI_WORKFLOW_COMMENT_MARKER } from "./vcs-bot-identity.js";
 
 const options = {
   gateCheckNames: ["blazebot / code-hygiene"],
@@ -334,6 +335,315 @@ describe("normalizeGitHubEvent", () => {
     expect(evt).toBeNull();
   });
 
+  it("adds a semantic key derived from the review id", () => {
+    const evt = normalizeGitHubEvent(
+      "pull_request_review",
+      {
+        action: "submitted",
+        repository: githubRepo(),
+        pull_request: githubPr(),
+        review: { id: 321, state: "changes_requested", user: { login: "human" }, body: "please fix" },
+      },
+      options,
+    );
+    expect(evt?.delivery.semanticKey).toBe("review:321");
+  });
+
+  const commentOptions = { ...options, reviewStates: ["commented"] as const };
+
+  it("maps a pull_request_review_comment created to a commented review", () => {
+    const evt = normalizeGitHubEvent(
+      "pull_request_review_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        pull_request: githubPr({ user: { login: "human" } }),
+        comment: {
+          id: 555,
+          pull_request_review_id: 999,
+          user: { login: "human", type: "User" },
+          body: "please fix the null check",
+        },
+      },
+      commentOptions,
+    );
+    expect(evt).toEqual({
+      delivery: {
+        provider: "github",
+        producer: "human",
+        deliveryId: "github-delivery-1",
+        semanticKey: "review:999",
+      },
+      triggerType: "trigger_pr_review",
+      pr: {
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 7,
+        prUrl: "https://github.com/acme/app/pull/7",
+        headRef: "blazebot/aiw-1",
+        headSha: "abc123",
+        baseRef: "main",
+        title: "Fix things",
+        author: "human",
+        isDraft: false,
+        review: {
+          state: "commented",
+          author: "human",
+          body: "please fix the null check",
+        },
+      },
+    });
+  });
+
+  it("falls back to comment:<id> when the review-comment has no parent review id", () => {
+    const evt = normalizeGitHubEvent(
+      "pull_request_review_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        pull_request: githubPr(),
+        comment: { id: 555, user: { login: "human", type: "User" }, body: "x" },
+      },
+      commentOptions,
+    );
+    expect(evt?.delivery.semanticKey).toBe("comment:555");
+  });
+
+  it("ignores non-created review-comment actions", () => {
+    for (const action of ["edited", "deleted"]) {
+      expect(
+        normalizeGitHubEvent(
+          "pull_request_review_comment",
+          {
+            action,
+            repository: githubRepo(),
+            pull_request: githubPr(),
+            comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+          },
+          commentOptions,
+        ),
+      ).toBeNull();
+    }
+  });
+
+  it("drops a review-comment authored by the bot itself", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request_review_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          pull_request: githubPr(),
+          comment: { id: 1, user: { login: "blazebot[bot]", type: "User" }, body: "self" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops a review-comment from any Bot-type account", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request_review_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          pull_request: githubPr(),
+          comment: { id: 1, user: { login: "dependabot", type: "Bot" }, body: "ci noise" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops a review-comment carrying the AI Workflow marker", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request_review_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          pull_request: githubPr(),
+          comment: {
+            id: 1,
+            user: { login: "human", type: "User" },
+            body: `looks good ${AI_WORKFLOW_COMMENT_MARKER}`,
+          },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops a review-comment when reviewStates is not opted into commented", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request_review_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          pull_request: githubPr(),
+          comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+        },
+        options,
+      ),
+    ).toBeNull();
+  });
+
+  it("maps an issue_comment on a PR to a commented review", () => {
+    const evt = normalizeGitHubEvent(
+      "issue_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        issue: {
+          number: 7,
+          title: "Fix things",
+          user: { login: "author-person" },
+          pull_request: { html_url: "https://github.com/acme/app/pull/7" },
+        },
+        comment: { id: 777, user: { login: "human", type: "User" }, body: "conversation feedback" },
+      },
+      commentOptions,
+    );
+    expect(evt).toEqual({
+      delivery: {
+        provider: "github",
+        producer: "human",
+        deliveryId: "github-delivery-1",
+        semanticKey: "comment:777",
+      },
+      triggerType: "trigger_pr_review",
+      pr: {
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 7,
+        prUrl: "https://github.com/acme/app/pull/7",
+        headRef: "",
+        headSha: "",
+        baseRef: "",
+        title: "Fix things",
+        author: "author-person",
+        isDraft: false,
+        review: {
+          state: "commented",
+          author: "human",
+          body: "conversation feedback",
+        },
+      },
+    });
+  });
+
+  it("derives the PR url from the repo when issue.pull_request omits html_url", () => {
+    const evt = normalizeGitHubEvent(
+      "issue_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+        comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+      },
+      commentOptions,
+    );
+    expect(evt?.pr.prUrl).toBe("https://github.com/acme/app/pull/7");
+  });
+
+  it("ignores an issue_comment on a plain issue (no pull_request)", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "bug", user: { login: "author-person" } },
+          comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores non-created issue_comment actions", () => {
+    for (const action of ["edited", "deleted"]) {
+      expect(
+        normalizeGitHubEvent(
+          "issue_comment",
+          {
+            action,
+            repository: githubRepo(),
+            issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+            comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+          },
+          commentOptions,
+        ),
+      ).toBeNull();
+    }
+  });
+
+  it("drops an issue_comment authored by the bot itself", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+          comment: { id: 1, user: { login: "blazebot[bot]", type: "User" }, body: "self" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops an issue_comment from any Bot-type account", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+          comment: { id: 1, user: { login: "dependabot", type: "Bot" }, body: "ci noise" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops an issue_comment carrying the AI Workflow marker", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+          comment: {
+            id: 1,
+            user: { login: "human", type: "User" },
+            body: `looks good ${AI_WORKFLOW_COMMENT_MARKER}`,
+          },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops an issue_comment when reviewStates is not opted into commented", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+          comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+        },
+        options,
+      ),
+    ).toBeNull();
+  });
+
   it("ignores unrelated events", () => {
     expect(normalizeGitHubEvent("push", { repository: githubRepo() }, options)).toBeNull();
   });
@@ -550,6 +860,23 @@ describe("normalizeGitLabEvent", () => {
         botUsername: "  GitLab-Bot  ",
         reviewStates: ["commented"],
       }),
+    ).toBeNull();
+  });
+
+  it("adds a semantic key derived from the GitLab note id", () => {
+    const note = notePayload();
+    note.object_attributes.id = 4321;
+    const evt = normalizeGitLabEvent("Note Hook", note, {
+      reviewStates: ["commented"],
+    });
+    expect(evt?.delivery.semanticKey).toBe("note:4321");
+  });
+
+  it("drops a GitLab note carrying the AI Workflow marker", () => {
+    const note = notePayload();
+    note.object_attributes.note = `looks good ${AI_WORKFLOW_COMMENT_MARKER}`;
+    expect(
+      normalizeGitLabEvent("Note Hook", note, { reviewStates: ["commented"] }),
     ).toBeNull();
   });
 

--- a/apps/worker/src/lib/trigger-events.ts
+++ b/apps/worker/src/lib/trigger-events.ts
@@ -1,5 +1,5 @@
 import type { PrTriggerPayload } from "../workflows/agent-input.js";
-import { vcsLoginsMatch } from "./vcs-bot-identity.js";
+import { hasAiWorkflowCommentMarker, vcsLoginsMatch } from "./vcs-bot-identity.js";
 
 export type PrTriggerType =
   | "trigger_pr_created"
@@ -14,6 +14,10 @@ export interface TriggerEvent {
     /** Provider event source, such as GitLab's merge_request_event pipeline source. */
     source?: string;
     deliveryId: string;
+    /** Stable identity of the human action behind this delivery, used for
+     * semantic dedup so one review's fan-out of N webhooks starts one run.
+     * Derived here at normalization; a later stage consumes it. */
+    semanticKey?: string;
   };
   triggerType: PrTriggerType;
   pr: PrTriggerPayload;
@@ -121,7 +125,10 @@ export function normalizeGitHubEvent(
     if (!allowedStates.includes(review.state)) return null;
     if (vcsLoginsMatch(review.user?.login, options.botLogin)) return null;
     return {
-      delivery: githubDelivery(options.deliveryId, review.user?.login),
+      delivery: {
+        ...githubDelivery(options.deliveryId, review.user?.login),
+        ...(typeof review.id === "number" ? { semanticKey: `review:${review.id}` } : {}),
+      },
       triggerType: "trigger_pr_review",
       pr: {
         ...mapGitHubPullRequest(pr, repo),
@@ -129,6 +136,83 @@ export function normalizeGitHubEvent(
           state: review.state as "changes_requested" | "commented",
           author: review.user?.login ?? "unknown",
           body: review.body ?? "",
+        },
+      },
+    };
+  }
+
+  if (eventName === "pull_request_review_comment") {
+    if (body?.action !== "created") return null;
+    const comment = body?.comment;
+    const pr = body?.pull_request;
+    if (!comment || !pr) return null;
+    const allowedStates = options.reviewStates ?? DEFAULT_REVIEW_STATES;
+    if (!allowedStates.includes("commented")) return null;
+    if (vcsLoginsMatch(comment.user?.login, options.botLogin)) return null;
+    if (comment.user?.type === "Bot") return null;
+    if (hasAiWorkflowCommentMarker(comment.body)) return null;
+    // GitHub wraps inline comments in a review container, so the N sibling
+    // comments and their parent review submission share one semantic key.
+    const semanticKey =
+      typeof comment.pull_request_review_id === "number"
+        ? `review:${comment.pull_request_review_id}`
+        : typeof comment.id === "number"
+          ? `comment:${comment.id}`
+          : undefined;
+    return {
+      delivery: {
+        ...githubDelivery(options.deliveryId, comment.user?.login),
+        ...(semanticKey ? { semanticKey } : {}),
+      },
+      triggerType: "trigger_pr_review",
+      pr: {
+        ...mapGitHubPullRequest(pr, repo),
+        review: {
+          state: "commented",
+          author: comment.user?.login ?? "unknown",
+          body: comment.body ?? "",
+        },
+      },
+    };
+  }
+
+  if (eventName === "issue_comment") {
+    if (body?.action !== "created") return null;
+    const comment = body?.comment;
+    const issue = body?.issue;
+    // issue.pull_request is only present when the issue is a PR conversation.
+    if (!comment || !issue?.pull_request) return null;
+    const allowedStates = options.reviewStates ?? DEFAULT_REVIEW_STATES;
+    if (!allowedStates.includes("commented")) return null;
+    if (vcsLoginsMatch(comment.user?.login, options.botLogin)) return null;
+    if (comment.user?.type === "Bot") return null;
+    if (hasAiWorkflowCommentMarker(comment.body)) return null;
+    const semanticKey =
+      typeof comment.id === "number" ? `comment:${comment.id}` : undefined;
+    return {
+      delivery: {
+        ...githubDelivery(options.deliveryId, comment.user?.login),
+        ...(semanticKey ? { semanticKey } : {}),
+      },
+      triggerType: "trigger_pr_review",
+      pr: {
+        // issue_comment carries no pull_request object, so head facts are
+        // unknown here. Dispatch binds the authoritative values before
+        // acceptance, mirroring the GitLab Pipeline Hook empty-head pattern.
+        provider: "github",
+        repoPath: `${repo.owner.login}/${repo.name}`,
+        prNumber: issue.number,
+        prUrl: issue.pull_request.html_url ?? `${repo.html_url}/pull/${issue.number}`,
+        headRef: "",
+        headSha: "",
+        baseRef: "",
+        title: issue.title ?? "",
+        author: issue.user?.login ?? "unknown",
+        isDraft: false,
+        review: {
+          state: "commented",
+          author: comment.user?.login ?? "unknown",
+          body: comment.body ?? "",
         },
       },
     };
@@ -194,14 +278,18 @@ export function normalizeGitLabEvent(
       attrs.noteable_type !== "MergeRequest" ||
       attrs.system === true ||
       attrs.internal === true ||
-      attrs.confidential === true
+      attrs.confidential === true ||
+      hasAiWorkflowCommentMarker(attrs.note)
     ) {
       return null;
     }
     const allowedStates = options.reviewStates ?? DEFAULT_REVIEW_STATES;
     if (!allowedStates.includes("commented")) return null;
     return {
-      delivery: gitLabDelivery(options.deliveryId, producer),
+      delivery: {
+        ...gitLabDelivery(options.deliveryId, producer),
+        ...(typeof attrs.id === "number" ? { semanticKey: `note:${attrs.id}` } : {}),
+      },
       triggerType: "trigger_pr_review",
       pr: {
         ...mapGitLabMergeRequest(mr, project),

--- a/apps/worker/src/lib/vcs-bot-identity.test.ts
+++ b/apps/worker/src/lib/vcs-bot-identity.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { resolveVcsBotLogin } from "./vcs-bot-identity.js";
+import {
+  AI_WORKFLOW_COMMENT_MARKER,
+  hasAiWorkflowCommentMarker,
+  normalizeVcsLogin,
+  resolveVcsBotLogin,
+  vcsLoginsMatch,
+} from "./vcs-bot-identity.js";
 
 describe("resolveVcsBotLogin", () => {
   it("trims and case-normalizes a provider-specific login", () => {
@@ -7,7 +13,7 @@ describe("resolveVcsBotLogin", () => {
       resolveVcsBotLogin("github", ["github"], {
         github: "  GitHub-App[Bot]  ",
       }),
-    ).toBe("github-app[bot]");
+    ).toBe("github-app");
   });
 
   it("treats whitespace-only values as unset and falls back only when unambiguous", () => {
@@ -23,5 +29,76 @@ describe("resolveVcsBotLogin", () => {
         legacy: "   ",
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("normalizeVcsLogin", () => {
+  it("strips a single trailing [bot] suffix after lowercasing", () => {
+    expect(normalizeVcsLogin("Blazebot[bot]")).toBe("blazebot");
+    expect(normalizeVcsLogin("BlazeBot[Bot]")).toBe("blazebot");
+  });
+
+  it("strips only one trailing [bot] suffix", () => {
+    expect(normalizeVcsLogin("x[bot][bot]")).toBe("x[bot]");
+  });
+
+  it("does not strip a [bot] token that is not a trailing suffix", () => {
+    expect(normalizeVcsLogin("[bot]x")).toBe("[bot]x");
+  });
+
+  it("returns undefined for a bare [bot] input", () => {
+    expect(normalizeVcsLogin("[bot]")).toBeUndefined();
+  });
+
+  it("returns undefined for empty, whitespace and null-ish input", () => {
+    expect(normalizeVcsLogin("")).toBeUndefined();
+    expect(normalizeVcsLogin("   ")).toBeUndefined();
+    expect(normalizeVcsLogin(null)).toBeUndefined();
+    expect(normalizeVcsLogin(undefined)).toBeUndefined();
+  });
+});
+
+describe("vcsLoginsMatch", () => {
+  it("matches when the actual login carries a [bot] suffix but the configured one does not", () => {
+    expect(vcsLoginsMatch("blazebot[bot]", "blazebot")).toBe(true);
+  });
+
+  it("matches when the configured login carries a [bot] suffix but the actual one does not", () => {
+    expect(vcsLoginsMatch("blazebot", "blazebot[bot]")).toBe(true);
+  });
+
+  it("matches case-insensitively across the [bot] suffix", () => {
+    expect(vcsLoginsMatch("BlazeBot[Bot]", "blazebot")).toBe(true);
+  });
+
+  it("does not match a bare [bot] against a bare [bot]", () => {
+    expect(vcsLoginsMatch("[bot]", "[bot]")).toBe(false);
+  });
+
+  it("does not match unrelated logins", () => {
+    expect(vcsLoginsMatch("alice", "bob")).toBe(false);
+    expect(vcsLoginsMatch("alice[bot]", "bob")).toBe(false);
+  });
+
+  it("returns false when either side is undefined", () => {
+    expect(vcsLoginsMatch(undefined, "blazebot")).toBe(false);
+    expect(vcsLoginsMatch("blazebot", null)).toBe(false);
+  });
+});
+
+describe("hasAiWorkflowCommentMarker", () => {
+  it("returns true when the body contains the marker", () => {
+    expect(
+      hasAiWorkflowCommentMarker(`Some review feedback\n${AI_WORKFLOW_COMMENT_MARKER}`),
+    ).toBe(true);
+  });
+
+  it("returns false when the body does not contain the marker", () => {
+    expect(hasAiWorkflowCommentMarker("Some review feedback")).toBe(false);
+  });
+
+  it("returns false for null and undefined bodies", () => {
+    expect(hasAiWorkflowCommentMarker(null)).toBe(false);
+    expect(hasAiWorkflowCommentMarker(undefined)).toBe(false);
   });
 });

--- a/apps/worker/src/lib/vcs-bot-identity.ts
+++ b/apps/worker/src/lib/vcs-bot-identity.ts
@@ -1,5 +1,7 @@
 import type { VcsProviderKind } from "@shared/contracts";
 
+const BOT_LOGIN_SUFFIX = "[bot]";
+
 export interface VcsBotLoginConfig {
   github?: string;
   gitlab?: string;
@@ -30,6 +32,16 @@ export function vcsLoginsMatch(
 }
 
 export function normalizeVcsLogin(login: string | null | undefined): string | undefined {
-  const normalized = login?.trim().toLowerCase();
-  return normalized ? normalized : undefined;
+  const lowercased = login?.trim().toLowerCase();
+  if (!lowercased) return undefined;
+  const stripped = lowercased.endsWith(BOT_LOGIN_SUFFIX)
+    ? lowercased.slice(0, -BOT_LOGIN_SUFFIX.length)
+    : lowercased;
+  return stripped ? stripped : undefined;
+}
+
+export const AI_WORKFLOW_COMMENT_MARKER = "<!-- ai-workflow:bot -->";
+
+export function hasAiWorkflowCommentMarker(body: string | null | undefined): boolean {
+  return typeof body === "string" && body.includes(AI_WORKFLOW_COMMENT_MARKER);
 }

--- a/apps/worker/src/routes/webhooks/github.post.test.ts
+++ b/apps/worker/src/routes/webhooks/github.post.test.ts
@@ -386,6 +386,87 @@ describe("POST /webhooks/github", () => {
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
 
+  it("dispatches a pull_request_review_comment through the trigger path", async () => {
+    mockDispatchTriggerEvent.mockResolvedValueOnce({ result: "started", runId: "run_rc" });
+    const body = {
+      action: "created",
+      repository: repo(),
+      pull_request: {
+        number: 7,
+        html_url: "https://github.com/acme/app/pull/7",
+        head: { ref: "blazebot/aiw-1", sha: "abc123" },
+        base: { ref: "main" },
+        title: "Fix",
+        user: { login: "human" },
+        draft: false,
+      },
+      comment: {
+        id: 5,
+        pull_request_review_id: 9,
+        user: { login: "human", type: "User" },
+        body: "please fix",
+      },
+    };
+
+    const response = await makeApp()(makeRequest(body, "pull_request_review_comment"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "dispatched", runId: "run_rc" });
+    expect(mockDispatchTriggerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggerType: "trigger_pr_review",
+        pr: expect.objectContaining({
+          review: expect.objectContaining({ state: "commented" }),
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
+  it("dispatches an issue_comment on a PR through the trigger path", async () => {
+    mockDispatchTriggerEvent.mockResolvedValueOnce({ result: "started", runId: "run_ic" });
+    const body = {
+      action: "created",
+      repository: repo(),
+      issue: {
+        number: 7,
+        title: "Fix",
+        user: { login: "author-person" },
+        pull_request: { html_url: "https://github.com/acme/app/pull/7" },
+      },
+      comment: { id: 77, user: { login: "human", type: "User" }, body: "conversation feedback" },
+    };
+
+    const response = await makeApp()(makeRequest(body, "issue_comment"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "dispatched", runId: "run_ic" });
+    expect(mockDispatchTriggerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggerType: "trigger_pr_review",
+        pr: expect.objectContaining({
+          prNumber: 7,
+          review: expect.objectContaining({ state: "commented" }),
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
+  it("ignores an unrelated event without dispatching or gating", async () => {
+    const response = await makeApp()(makeRequest({ repository: repo() }, "workflow_run"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "event_workflow_run",
+    });
+    expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
   it("matches the configured repo case-insensitively", async () => {
     // GitHub org/repo slugs are case-insensitive: payload "acme/app" must match
     // a configured "Acme/App" instead of dropping as other_repo.

--- a/apps/worker/src/routes/webhooks/github.post.test.ts
+++ b/apps/worker/src/routes/webhooks/github.post.test.ts
@@ -19,8 +19,20 @@ vi.mock("../../../env.js", () => ({
   getVcsBotLogin: mocks.getVcsBotLogin,
 }));
 
+const mockVerifySignature = vi.fn();
 vi.mock("../../lib/github-webhook-sig.js", () => ({
-  verifyGitHubWebhookSignature: vi.fn(),
+  verifyGitHubWebhookSignature: (...args: any[]) => mockVerifySignature(...args),
+}));
+
+const loggerInfo = vi.fn();
+const loggerWarn = vi.fn();
+vi.mock("../../lib/logger.js", () => ({
+  logger: {
+    info: (...a: any[]) => loggerInfo(...a),
+    warn: (...a: any[]) => loggerWarn(...a),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
 }));
 vi.mock("../../lib/repo-allowlist.js", () => ({
   isRepoAllowed: (...args: any[]) => mocks.isRepoAllowed(...args),
@@ -124,6 +136,7 @@ describe("POST /webhooks/github", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "other_repo",
+      diagnosticId: "delivery-test",
     });
     expect(mocks.isRepoAllowed).toHaveBeenCalledWith("acme/app");
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
@@ -141,6 +154,7 @@ describe("POST /webhooks/github", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "ignored_untrusted_event",
+      diagnosticId: "delivery-test",
     });
     expect(mockDispatchTriggerEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -211,6 +225,7 @@ describe("POST /webhooks/github", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "ignored_untrusted_event",
+      diagnosticId: "delivery-test",
     });
     expect(mockDispatchTriggerEvent).toHaveBeenCalledWith(
       expect.objectContaining({ triggerType: "trigger_pr_review" }),
@@ -298,7 +313,7 @@ describe("POST /webhooks/github", () => {
     const response = await makeApp()(makeRequest(checkRunBody, "check_run"));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "no_definition" });
+    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "no_definition", diagnosticId: "delivery-test" });
     expect(mockDispatchTriggerEvent).toHaveBeenCalledWith(
       expect.objectContaining({ triggerType: "trigger_pr_checks_failed" }),
       expect.anything(),
@@ -333,7 +348,7 @@ describe("POST /webhooks/github", () => {
     const response = await makeApp()(makeRequest(body));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "no_definition" });
+    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "no_definition", diagnosticId: "delivery-test" });
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
 
@@ -361,7 +376,7 @@ describe("POST /webhooks/github", () => {
     const response = await makeApp()(makeRequest(pullRequestBody("opened")));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "coalesced" });
+    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "coalesced", diagnosticId: "delivery-test" });
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
 
@@ -369,7 +384,7 @@ describe("POST /webhooks/github", () => {
     const response = await makeApp()(makeRequest(pullRequestBody("closed")));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "action_closed" });
+    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "action_closed", diagnosticId: "delivery-test" });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
@@ -381,7 +396,7 @@ describe("POST /webhooks/github", () => {
     const response = await makeApp()(makeRequest(pullRequestBody("opened")));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "other_repo" });
+    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "other_repo", diagnosticId: "delivery-test" });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
@@ -462,6 +477,7 @@ describe("POST /webhooks/github", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "event_workflow_run",
+      diagnosticId: "delivery-test",
     });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
@@ -479,5 +495,79 @@ describe("POST /webhooks/github", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ status: "dispatched", runId: "run-x" });
     expect(mockDispatchTriggerEvent).toHaveBeenCalled();
+  });
+
+  it("returns the delivery header as the diagnosticId on a rejected event", async () => {
+    const response = await makeApp()(makeRequest({ repository: repo() }, "workflow_run"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "event_workflow_run",
+      diagnosticId: "delivery-test",
+    });
+  });
+
+  it("mints a uuid diagnosticId when the delivery header is absent", async () => {
+    const request = new Request("http://localhost/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": "sha256=whatever",
+        "x-github-event": "workflow_run",
+      },
+      body: JSON.stringify({ repository: repo() }),
+    });
+
+    const response = await makeApp()(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.reason).toBe("missing_delivery_id");
+    expect(body.diagnosticId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("carries the diagnosticId in the 401 error data on a signature failure", async () => {
+    mockVerifySignature.mockImplementationOnce(() => {
+      throw new Error("invalid signature");
+    });
+
+    const response = await makeApp()(makeRequest(pullRequestBody("opened")));
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.data).toEqual({ diagnosticId: "delivery-test" });
+  });
+
+  it("logs exactly one trigger_ingestion_rejected on a rejected request", async () => {
+    await makeApp()(makeRequest({ repository: repo() }, "workflow_run"));
+
+    const rejectedLogs = loggerInfo.mock.calls.filter(
+      ([, msg]) => msg === "trigger_ingestion_rejected",
+    );
+    expect(rejectedLogs).toHaveLength(1);
+    expect(rejectedLogs[0][0]).toMatchObject({
+      diagnosticId: "delivery-test",
+      provider: "github",
+      event: "workflow_run",
+      reason: "event_workflow_run",
+    });
+  });
+
+  it("does not log trigger_ingestion_rejected on a dispatched request", async () => {
+    mockDispatchTriggerEvent.mockResolvedValueOnce({ result: "started", runId: "run_ok" });
+
+    await makeApp()(makeRequest(reviewBody("commented"), "pull_request_review"));
+
+    const rejectedInfo = loggerInfo.mock.calls.filter(
+      ([, msg]) => msg === "trigger_ingestion_rejected",
+    );
+    const rejectedWarn = loggerWarn.mock.calls.filter(
+      ([, msg]) => msg === "trigger_ingestion_rejected",
+    );
+    expect(rejectedInfo).toHaveLength(0);
+    expect(rejectedWarn).toHaveLength(0);
   });
 });

--- a/apps/worker/src/routes/webhooks/github.post.ts
+++ b/apps/worker/src/routes/webhooks/github.post.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { defineEventHandler, readRawBody, getHeader, createError } from "h3";
 import { env, getVcsBotLogin } from "../../../env.js";
 import { PostgresRunRegistry } from "../../adapters/run-registry/postgres.js";
@@ -16,6 +17,12 @@ import { loadPostPrGateConfig } from "../../post-pr-gate/config.js";
 
 const GATE_ACTIONS = new Set(["opened", "synchronize", "reopened"]);
 
+// Context for the AC5 diagnostic id: a safe, quotable handle attached to every
+// non-dispatched response and logged once per rejected/errored branch. It is
+// either the provider delivery id or a random UUID, never derived from config.
+type RejectCtx = { diagnosticId: string; event: string; deliveryId: string };
+type IgnoredResponse = { status: "ignored"; reason: string; diagnosticId: string };
+
 export default defineEventHandler(async (event) => {
   const rawBody = (await readRawBody(event, "utf8")) ?? "";
 
@@ -26,31 +33,49 @@ export default defineEventHandler(async (event) => {
       env.GITHUB_WEBHOOK_SECRET!,
     );
   } catch (err) {
-    throw createError({ statusCode: 401, statusMessage: (err as Error).message });
+    // The payload is untrusted here, but the delivery header is a safe
+    // provider-minted handle for the diagnostic id.
+    const deliveryHeader = getHeader(event, "x-github-delivery")?.trim() ?? "";
+    const ctx: RejectCtx = {
+      diagnosticId: deliveryHeader || randomUUID(),
+      event: getHeader(event, "x-github-event") ?? "",
+      deliveryId: deliveryHeader,
+    };
+    logIngestionRejected("signature_verification_failed", ctx, "warn");
+    throw createError({
+      statusCode: 401,
+      statusMessage: (err as Error).message,
+      data: { diagnosticId: ctx.diagnosticId },
+    });
   }
 
   const ghEvent = getHeader(event, "x-github-event") ?? "";
   const deliveryId = getHeader(event, "x-github-delivery")?.trim() ?? "";
+  const ctx: RejectCtx = {
+    diagnosticId: deliveryId || randomUUID(),
+    event: ghEvent,
+    deliveryId,
+  };
   if (!deliveryId) {
-    return { status: "ignored", reason: "missing_delivery_id" };
+    return ignored("missing_delivery_id", ctx);
   }
 
   let body;
   try {
     body = rawBody ? JSON.parse(rawBody) : {};
   } catch {
-    return { status: "ignored", reason: "malformed_payload" };
+    return ignored("malformed_payload", ctx);
   }
 
   const repo = body?.repository;
   if (!repo) {
-    return { status: "ignored", reason: "malformed_payload" };
+    return ignored("malformed_payload", ctx);
   }
 
   const ownerRepo = `${repo.owner.login}/${repo.name}`;
   if (!isRepoAllowed(ownerRepo)) {
     logger.info({ ownerRepo }, "github_webhook_skipped_repo_not_allowed");
-    return { status: "ignored", reason: "other_repo" };
+    return ignored("other_repo", ctx);
   }
   if (env.GITHUB_OWNER && env.GITHUB_REPO) {
     const expected = `${env.GITHUB_OWNER}/${env.GITHUB_REPO}`;
@@ -60,7 +85,7 @@ export default defineEventHandler(async (event) => {
     // webhook is silently dropped as other_repo.
     if (ownerRepo.toLowerCase() !== expected.toLowerCase()) {
       logger.info({ ownerRepo, expected }, "github_webhook_skipped_other_repo");
-      return { status: "ignored", reason: "other_repo" };
+      return ignored("other_repo", ctx);
     }
   }
 
@@ -111,20 +136,20 @@ export default defineEventHandler(async (event) => {
         "post_pr_gate_superseded_by_definition",
       );
     }
-    return triggerResponse(result);
+    return triggerResponse(result, ctx);
   }
 
   if (ghEvent === "pull_request") {
     if (!body?.pull_request) {
-      return { status: "ignored", reason: "malformed_payload" };
+      return ignored("malformed_payload", ctx);
     }
     if (!GATE_ACTIONS.has(body.action)) {
-      return { status: "ignored", reason: `action_${body.action}` };
+      return ignored(`action_${body.action}`, ctx);
     }
     return dispatchPostPrGateWebhook(buildGateInput(body, ownerRepo));
   }
 
-  return { status: "ignored", reason: `event_${ghEvent}` };
+  return ignored(`event_${ghEvent}`, ctx);
 });
 
 function buildGateInput(body: any, ownerRepo: string) {
@@ -147,7 +172,31 @@ function buildGateInput(body: any, ownerRepo: string) {
   };
 }
 
-function triggerResponse(result: DispatchTriggerResult) {
+// One structured log line per rejected/errored branch, carrying the same
+// diagnosticId that the response returns. Payload and secrets are never logged.
+function logIngestionRejected(
+  reason: string,
+  ctx: RejectCtx,
+  level: "info" | "warn" = "info",
+) {
+  logger[level](
+    {
+      diagnosticId: ctx.diagnosticId,
+      provider: "github",
+      event: ctx.event,
+      reason,
+      ...(ctx.deliveryId ? { deliveryId: ctx.deliveryId } : {}),
+    },
+    "trigger_ingestion_rejected",
+  );
+}
+
+function ignored(reason: string, ctx: RejectCtx): IgnoredResponse {
+  logIngestionRejected(reason, ctx);
+  return { status: "ignored", reason, diagnosticId: ctx.diagnosticId };
+}
+
+function triggerResponse(result: DispatchTriggerResult, ctx: RejectCtx) {
   if (result.result === "started") {
     return { status: "dispatched", runId: result.runId };
   }
@@ -155,7 +204,12 @@ function triggerResponse(result: DispatchTriggerResult) {
     // Surface a retryable HTTP failure. Received envelopes also have local poll
     // recovery; failures before durable receipt still need provider retry.
     logger.info({ reason: result.result }, "trigger_webhook_retryable_failure");
-    throw createError({ statusCode: 503, statusMessage: `trigger_${result.result}` });
+    logIngestionRejected(result.result, ctx, "warn");
+    throw createError({
+      statusCode: 503,
+      statusMessage: `trigger_${result.result}`,
+      data: { diagnosticId: ctx.diagnosticId },
+    });
   }
-  return { status: "ignored", reason: result.result };
+  return ignored(result.result, ctx);
 }

--- a/apps/worker/src/routes/webhooks/github.post.ts
+++ b/apps/worker/src/routes/webhooks/github.post.ts
@@ -71,11 +71,14 @@ export default defineEventHandler(async (event) => {
   // Normalize every structurally supported review state here. The dispatcher
   // applies provider/state selectors from the same immutable definition
   // snapshot that it pins, avoiding a load-then-deploy race in this route.
+  // Comment events (inline diff + PR conversation) can only ever be "commented".
   const botLogin = getVcsBotLogin("github");
   const reviewStates =
     ghEvent === "pull_request_review"
       ? ["changes_requested", "commented"] as const
-      : undefined;
+      : ghEvent === "pull_request_review_comment" || ghEvent === "issue_comment"
+        ? ["commented"] as const
+        : undefined;
   const evt = normalizeGitHubEvent(ghEvent, body, {
     gateCheckNames,
     deliveryId,

--- a/apps/worker/src/routes/webhooks/gitlab.post.test.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.test.ts
@@ -46,6 +46,17 @@ vi.mock("../../adapters/vcs/repository-directory.js", () => ({
   })),
 }));
 
+const loggerInfo = vi.fn();
+const loggerWarn = vi.fn();
+vi.mock("../../lib/logger.js", () => ({
+  logger: {
+    info: (...a: any[]) => loggerInfo(...a),
+    warn: (...a: any[]) => loggerWarn(...a),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 const gitLabHandler = (await import("./gitlab.post.js")).default;
 
 function makeApp() {
@@ -166,6 +177,7 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "malformed_payload",
+      diagnosticId: expect.any(String),
     });
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
@@ -246,6 +258,7 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "missing_delivery_id",
+      diagnosticId: expect.any(String),
     });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
   });
@@ -290,6 +303,7 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "other_project",
+      diagnosticId: expect.any(String),
     });
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
@@ -304,6 +318,7 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "other_project",
+      diagnosticId: expect.any(String),
     });
     expect(mocks.isRepoAllowed).toHaveBeenCalledWith("group/demo");
     expect(mocks.listRepositories).not.toHaveBeenCalled();
@@ -333,6 +348,7 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "other_project",
+      diagnosticId: expect.any(String),
     });
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
@@ -347,6 +363,7 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "action_close",
+      diagnosticId: expect.any(String),
     });
     expect(mocks.listRepositories).not.toHaveBeenCalled();
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
@@ -474,7 +491,7 @@ describe("POST /webhooks/gitlab", () => {
     const response = await makeApp()(makeRequest(validMergeRequestPayload()));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "coalesced" });
+    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "coalesced", diagnosticId: expect.any(String) });
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
 
@@ -544,7 +561,7 @@ describe("POST /webhooks/gitlab", () => {
     const response = await makeApp()(makeRequest(JSON.stringify(payload)));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "no_definition" });
+    await expect(response.json()).resolves.toEqual({ status: "ignored", reason: "no_definition", diagnosticId: expect.any(String) });
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
 
@@ -579,6 +596,7 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "note_ignored",
+      diagnosticId: expect.any(String),
     });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
     expect(mocks.listRepositories).not.toHaveBeenCalled();
@@ -595,6 +613,7 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "note_ignored",
+      diagnosticId: expect.any(String),
     });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
     expect(mocks.listRepositories).not.toHaveBeenCalled();
@@ -666,11 +685,82 @@ describe("POST /webhooks/gitlab", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "ignored_untrusted_event",
+      diagnosticId: expect.any(String),
     });
     expect(mocks.fetch).not.toHaveBeenCalled();
     expect(mockDispatchTriggerEvent).toHaveBeenCalledWith(
       expect.objectContaining({ triggerType: "trigger_pr_review" }),
       expect.anything(),
     );
+  });
+
+  it("returns the event uuid as the diagnosticId on an unsupported event", async () => {
+    const response = await makeApp()(
+      makeRequest(validMergeRequestPayload(), "secret", "Push Hook", {
+        "x-gitlab-event-uuid": "delivery-abc",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "not_supported_event",
+      diagnosticId: "delivery-abc",
+    });
+  });
+
+  it("mints a uuid diagnosticId when no delivery header is present", async () => {
+    const response = await makeApp()(
+      makeRequest(validMergeRequestPayload(), "secret", "Merge Request Hook", {}),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.reason).toBe("missing_delivery_id");
+    expect(body.diagnosticId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("carries the diagnosticId in the 401 error data on a token failure", async () => {
+    const response = await makeApp()(makeRequest(validMergeRequestPayload(), "wrong"));
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.data).toEqual({ diagnosticId: "delivery-test" });
+  });
+
+  it("logs exactly one trigger_ingestion_rejected on a rejected request", async () => {
+    await makeApp()(
+      makeRequest(validMergeRequestPayload(), "secret", "Push Hook", {
+        "x-gitlab-event-uuid": "delivery-abc",
+      }),
+    );
+
+    const rejectedLogs = loggerInfo.mock.calls.filter(
+      ([, msg]) => msg === "trigger_ingestion_rejected",
+    );
+    expect(rejectedLogs).toHaveLength(1);
+    expect(rejectedLogs[0][0]).toMatchObject({
+      diagnosticId: "delivery-abc",
+      provider: "gitlab",
+      event: "Push Hook",
+      reason: "not_supported_event",
+    });
+  });
+
+  it("does not log trigger_ingestion_rejected on a dispatched request", async () => {
+    mockDispatchTriggerEvent.mockResolvedValueOnce({ result: "started", runId: "run_note" });
+
+    await makeApp()(makeRequest(validNotePayload(), "secret", "Note Hook"));
+
+    const rejectedInfo = loggerInfo.mock.calls.filter(
+      ([, msg]) => msg === "trigger_ingestion_rejected",
+    );
+    const rejectedWarn = loggerWarn.mock.calls.filter(
+      ([, msg]) => msg === "trigger_ingestion_rejected",
+    );
+    expect(rejectedInfo).toHaveLength(0);
+    expect(rejectedWarn).toHaveLength(0);
   });
 });

--- a/apps/worker/src/routes/webhooks/gitlab.post.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createError, defineEventHandler, getHeader, readRawBody } from "h3";
 import { env, getConfiguredVcsProviders, getVcsBotLogin } from "../../../env.js";
 import { PostgresRunRegistry } from "../../adapters/run-registry/postgres.js";
@@ -22,33 +22,63 @@ import { normalizeGitLabEvent } from "../../lib/trigger-events.js";
 
 const ALLOWED_ACTIONS = new Set(["opened", "update", "reopened"]);
 
+// Context for the AC5 diagnostic id: a safe, quotable handle attached to every
+// non-dispatched response and logged once per rejected/errored branch. It is
+// either the provider delivery id or a random UUID, never derived from config.
+type RejectCtx = { diagnosticId: string; event: string; deliveryId: string };
+type IgnoredResponse = { status: "ignored"; reason: string; diagnosticId: string };
+
 export default defineEventHandler(async (event) => {
   const rawBody = (await readRawBody(event, "utf8")) ?? "";
 
   try {
     verifyGitLabWebhookToken(getHeader(event, "x-gitlab-token"), env.GITLAB_WEBHOOK_SECRET!);
   } catch (err) {
-    throw createError({ statusCode: 401, statusMessage: (err as Error).message });
+    // The payload is untrusted here, but the event-uuid header is a safe
+    // provider-minted handle for the diagnostic id.
+    const eventUuid = getHeader(event, "x-gitlab-event-uuid")?.trim() ?? "";
+    const ctx: RejectCtx = {
+      diagnosticId: eventUuid || randomUUID(),
+      event: getHeader(event, "x-gitlab-event") ?? "",
+      deliveryId: "",
+    };
+    logIngestionRejected("token_verification_failed", ctx, "warn");
+    throw createError({
+      statusCode: 401,
+      statusMessage: (err as Error).message,
+      data: { diagnosticId: ctx.diagnosticId },
+    });
   }
 
   const gitLabEvent = getHeader(event, "x-gitlab-event");
+  // Seed the diagnostic id from the raw event uuid before the delivery id is
+  // resolved; it is upgraded to the resolved delivery id once available.
+  const ctx: RejectCtx = {
+    diagnosticId: getHeader(event, "x-gitlab-event-uuid")?.trim() || randomUUID(),
+    event: gitLabEvent ?? "",
+    deliveryId: "",
+  };
   if (
     gitLabEvent !== "Merge Request Hook" &&
     gitLabEvent !== "Pipeline Hook" &&
     gitLabEvent !== "Note Hook"
   ) {
-    return { status: "ignored", reason: "not_supported_event" };
+    return ignored("not_supported_event", ctx);
   }
   const deliveryId = resolveGitLabDeliveryId(event, rawBody);
+  if (deliveryId) {
+    ctx.deliveryId = deliveryId;
+    ctx.diagnosticId = deliveryId;
+  }
   if (!deliveryId) {
-    return { status: "ignored", reason: "missing_delivery_id" };
+    return ignored("missing_delivery_id", ctx);
   }
 
   let body;
   try {
     body = rawBody ? JSON.parse(rawBody) : {};
   } catch {
-    return { status: "ignored", reason: "malformed_payload" };
+    return ignored("malformed_payload", ctx);
   }
 
   if (
@@ -56,10 +86,10 @@ export default defineEventHandler(async (event) => {
     (body?.object_attributes?.internal === true ||
       body?.object_attributes?.confidential === true)
   ) {
-    return { status: "ignored", reason: "note_ignored" };
+    return ignored("note_ignored", ctx);
   }
 
-  const localScope = checkLocalProjectScope(body);
+  const localScope = checkLocalProjectScope(body, ctx);
   if (localScope) return localScope;
 
   const botUsername = getVcsBotLogin("gitlab");
@@ -91,7 +121,7 @@ export default defineEventHandler(async (event) => {
         result.result === "ignored_not_workflow_owned" ||
         result.result === "ignored_provider")
     ) {
-      return dispatchMergeRequestGate(body);
+      return dispatchMergeRequestGate(body, ctx);
     }
     if (evt.triggerType === "trigger_pr_created" && ticketKeyFromBranch(evt.pr.headRef)) {
       logger.info(
@@ -99,31 +129,31 @@ export default defineEventHandler(async (event) => {
         "post_pr_gate_superseded_by_definition",
       );
     }
-    return triggerResponse(result);
+    return triggerResponse(result, ctx);
   }
 
   if (gitLabEvent === "Merge Request Hook") {
-    return dispatchMergeRequestGate(body);
+    return dispatchMergeRequestGate(body, ctx);
   }
   if (gitLabEvent === "Note Hook") {
-    return { status: "ignored", reason: "note_ignored" };
+    return ignored("note_ignored", ctx);
   }
-  return { status: "ignored", reason: "pipeline_ignored" };
+  return ignored("pipeline_ignored", ctx);
 });
 
-async function dispatchMergeRequestGate(body: any) {
+async function dispatchMergeRequestGate(body: any, ctx: RejectCtx) {
   let normalized;
   try {
     normalized = normalizeGitLabMergeRequestEvent(body);
   } catch {
-    return { status: "ignored", reason: "malformed_payload" };
+    return ignored("malformed_payload", ctx);
   }
 
   if (!ALLOWED_ACTIONS.has(normalized.action)) {
-    return { status: "ignored", reason: `action_${normalized.action}` };
+    return ignored(`action_${normalized.action}`, ctx);
   }
 
-  const scope = await checkProjectScope(body);
+  const scope = await checkProjectScope(body, ctx);
   if (scope) return scope;
 
   return dispatchPostPrGateWebhook(normalized);
@@ -131,20 +161,22 @@ async function dispatchMergeRequestGate(body: any) {
 
 async function checkProjectScope(
   body: any,
-): Promise<{ status: "ignored"; reason: "other_project" } | null> {
-  if (body?.project && !(await gitLabProjectIsAllowed(body.project))) {
+  ctx: RejectCtx,
+): Promise<IgnoredResponse | null> {
+  if (body?.project && !(await gitLabProjectIsAllowed(body.project, ctx))) {
     logger.info(
       { project: body.project, expected: env.GITLAB_PROJECT_ID ?? "configured_gitlab_repositories" },
       "post_pr_gate_gitlab_webhook_skipped_other_project",
     );
-    return { status: "ignored", reason: "other_project" };
+    return ignored("other_project", ctx);
   }
   return null;
 }
 
 function checkLocalProjectScope(
   body: any,
-): { status: "ignored"; reason: "other_project" } | null {
+  ctx: RejectCtx,
+): IgnoredResponse | null {
   const project = body?.project as GitLabProject | undefined;
   if (!project) return null;
   const projectPath = project.path_with_namespace;
@@ -159,7 +191,7 @@ function checkLocalProjectScope(
     { project, expected: env.GITLAB_PROJECT_ID ?? "AGENT_ALLOWED_REPOS" },
     "post_pr_gate_gitlab_webhook_skipped_other_project",
   );
-  return { status: "ignored", reason: "other_project" };
+  return ignored("other_project", ctx);
 }
 
 function resolveGitLabDeliveryId(event: Parameters<typeof getHeader>[0], rawBody: string): string {
@@ -176,7 +208,31 @@ function resolveGitLabDeliveryId(event: Parameters<typeof getHeader>[0], rawBody
     .digest("hex");
 }
 
-function triggerResponse(result: DispatchTriggerResult) {
+// One structured log line per rejected/errored branch, carrying the same
+// diagnosticId that the response returns. Payload and secrets are never logged.
+function logIngestionRejected(
+  reason: string,
+  ctx: RejectCtx,
+  level: "info" | "warn" = "info",
+) {
+  logger[level](
+    {
+      diagnosticId: ctx.diagnosticId,
+      provider: "gitlab",
+      event: ctx.event,
+      reason,
+      ...(ctx.deliveryId ? { deliveryId: ctx.deliveryId } : {}),
+    },
+    "trigger_ingestion_rejected",
+  );
+}
+
+function ignored(reason: string, ctx: RejectCtx): IgnoredResponse {
+  logIngestionRejected(reason, ctx);
+  return { status: "ignored", reason, diagnosticId: ctx.diagnosticId };
+}
+
+function triggerResponse(result: DispatchTriggerResult, ctx: RejectCtx) {
   if (result.result === "started") {
     return { status: "dispatched", runId: result.runId };
   }
@@ -184,12 +240,20 @@ function triggerResponse(result: DispatchTriggerResult) {
     // Surface a retryable HTTP failure. Received envelopes also have local poll
     // recovery; failures before durable receipt still need provider retry.
     logger.info({ reason: result.result }, "trigger_webhook_retryable_failure");
-    throw createError({ statusCode: 503, statusMessage: `trigger_${result.result}` });
+    logIngestionRejected(result.result, ctx, "warn");
+    throw createError({
+      statusCode: 503,
+      statusMessage: `trigger_${result.result}`,
+      data: { diagnosticId: ctx.diagnosticId },
+    });
   }
-  return { status: "ignored", reason: result.result };
+  return ignored(result.result, ctx);
 }
 
-async function gitLabProjectIsAllowed(project: GitLabProject): Promise<boolean> {
+async function gitLabProjectIsAllowed(
+  project: GitLabProject,
+  ctx: RejectCtx,
+): Promise<boolean> {
   if (!project.path_with_namespace || !isRepoAllowed(project.path_with_namespace)) {
     return false;
   }
@@ -211,9 +275,11 @@ async function gitLabProjectIsAllowed(project: GitLabProject): Promise<boolean> 
       { err: (err as Error).message, project },
       "post_pr_gate_gitlab_webhook_scope_check_failed_closed",
     );
+    logIngestionRejected("gitlab_repository_scope_unavailable", ctx, "warn");
     throw createError({
       statusCode: 503,
       statusMessage: "gitlab_repository_scope_unavailable",
+      data: { diagnosticId: ctx.diagnosticId },
     });
   }
 }

--- a/apps/worker/src/workflows/blocks/io-blocks.edge.test.ts
+++ b/apps/worker/src/workflows/blocks/io-blocks.edge.test.ts
@@ -53,6 +53,7 @@ import type {
 } from "../../sandbox/repo-workspace.js";
 import { emptyPrePrCheckConfig } from "../../pre-pr-checks/config.js";
 import { isRepoAllowed, filterAllowedRepositories } from "../../lib/repo-allowlist.js";
+import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 import {
   createRepositoryDirectory,
   createRepositoryDirectoryForProviders,
@@ -77,6 +78,8 @@ const activeOwner = {
   ownerToken: "owner-1",
   runId: "run-1",
 };
+
+const marked = (body: string) => `${body}\n\n${AI_WORKFLOW_COMMENT_MARKER}`;
 
 function setAllowlist(value: string | undefined): void {
   if (value === undefined) delete process.env.AGENT_ALLOWED_REPOS;
@@ -527,8 +530,8 @@ describe("post_pr_comment edge cases", () => {
 
     expect(result.kind).toBe("next");
     expect(postPRComment).toHaveBeenCalledTimes(2);
-    expect(postPRComment).toHaveBeenCalledWith(7, "LGTM");
-    expect(postPRComment).toHaveBeenCalledWith(9, "LGTM");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("LGTM"));
+    expect(postPRComment).toHaveBeenCalledWith(9, marked("LGTM"));
   });
 
   it("does not infer a missing publication target from the trigger payload", async () => {

--- a/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
@@ -13,9 +13,12 @@ vi.mock("../../lib/vcs-runtime.js", () => ({
   createRepositoryVCS: mocks.createRepositoryVCS,
 }));
 
+import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 import type { WorkspacePublicationResult } from "../workspace-publication.js";
 import { execute, paramsSchema } from "./post-pr-comment.js";
 import { makeCtx, makeNode, makePrPayload, runControlErrorCases } from "./test-support.js";
+
+const marked = (body: string) => `${body}\n\n${AI_WORKFLOW_COMMENT_MARKER}`;
 
 function publication(): WorkspacePublicationResult {
   return {
@@ -101,7 +104,7 @@ describe("post_pr_comment execute", () => {
     );
 
     expect(postPRComment).toHaveBeenCalledTimes(1);
-    expect(postPRComment).toHaveBeenCalledWith(7, "LGTM");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("LGTM"));
     expect(result).toEqual({
       kind: "next",
       output: {
@@ -111,6 +114,53 @@ describe("post_pr_comment execute", () => {
         ],
       },
     });
+  });
+
+  it("appends the bot marker to the posted body", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: null });
+    mockFreshVcs(postPRComment);
+
+    await execute(
+      makeNode("post_pr_comment", { body: "LGTM" }),
+      {},
+      makeCtx({ publication: publication() }),
+    );
+
+    const [, postedBody] = postPRComment.mock.calls[0] as [number, string];
+    expect(postedBody.endsWith(AI_WORKFLOW_COMMENT_MARKER)).toBe(true);
+  });
+
+  it("does not double-mark a body that already carries the marker", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: null });
+    mockFreshVcs(postPRComment);
+
+    const preMarked = marked("LGTM");
+    await execute(
+      makeNode("post_pr_comment", { body: preMarked }),
+      {},
+      makeCtx({ publication: publication() }),
+    );
+
+    expect(postPRComment).toHaveBeenCalledWith(7, preMarked);
+    const [, postedBody] = postPRComment.mock.calls[0] as [number, string];
+    expect(postedBody.split(AI_WORKFLOW_COMMENT_MARKER)).toHaveLength(2);
+  });
+
+  it("rejects an empty body before appending the marker", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: null });
+    mockFreshVcs(postPRComment);
+
+    const result = await execute(
+      makeNode("post_pr_comment", { body: "" }),
+      {},
+      makeCtx({ publication: publication() }),
+    );
+
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("requires a body");
+    }
+    expect(postPRComment).not.toHaveBeenCalled();
   });
 
   it("prefers a resolved body over the static param", async () => {
@@ -124,7 +174,7 @@ describe("post_pr_comment execute", () => {
       { body: " Bound " },
     );
 
-    expect(postPRComment).toHaveBeenCalledWith(7, "Bound");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("Bound"));
   });
 
   it("comments every PR when target is all", async () => {
@@ -182,7 +232,7 @@ describe("post_pr_comment execute", () => {
       repoPath: "acme/api",
       baseBranch: "main",
     });
-    expect(postPRComment).toHaveBeenCalledWith(7, "checks are red");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("checks are red"));
     expect(result.kind).toBe("next");
   });
 
@@ -295,7 +345,7 @@ describe("post_pr_comment execute", () => {
     );
 
     expect(result.kind).toBe("next");
-    expect(postPRComment).toHaveBeenCalledWith(7, "merged");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("merged"));
   });
 
   it("returns an execution error without publishing partial comments", async () => {

--- a/apps/worker/src/workflows/blocks/post-pr-comment.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 import type { VcsProvider } from "../../adapters/vcs/repository-directory.js";
 import type { PullRequestHead } from "../../adapters/vcs/types.js";
 import type { ActiveRunOwner } from "../../lib/active-run-owner.js";
+import {
+  AI_WORKFLOW_COMMENT_MARKER,
+  hasAiWorkflowCommentMarker,
+} from "../../lib/vcs-bot-identity.js";
 import { isRunControlError } from "../run-control-error.js";
 import {
   executionError,
@@ -45,6 +49,12 @@ async function blockPostPrCommentStep(
   const comments: PostPrCommentsResult["comments"] = [];
   const errors: string[] = [];
 
+  // Every comment we post carries the marker so that even a misconfigured bot
+  // login cannot let our own comments re-trigger the workflow (AIW-140).
+  const markedBody = hasAiWorkflowCommentMarker(body)
+    ? body
+    : `${body}\n\n${AI_WORKFLOW_COMMENT_MARKER}`;
+
   for (const target of targets) {
     try {
       if (!isRepoAllowed(target.repoPath)) {
@@ -58,7 +68,7 @@ async function blockPostPrCommentStep(
       const current = await vcs.getPRHead(target.prId);
       assertCurrentPrCommentTarget(target, current);
       await assertActiveRunOwner(db, owner);
-      const { url } = await vcs.postPRComment(target.prId, body);
+      const { url } = await vcs.postPRComment(target.prId, markedBody);
       comments.push({
         provider: target.provider,
         repoPath: target.repoPath,

--- a/apps/worker/src/workflows/loader-triggers.edge.test.ts
+++ b/apps/worker/src/workflows/loader-triggers.edge.test.ts
@@ -337,6 +337,7 @@ describe("POST /webhooks/github edge cases", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "malformed_payload",
+      diagnosticId: "delivery-edge-test",
     });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
   });
@@ -348,6 +349,7 @@ describe("POST /webhooks/github edge cases", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "malformed_payload",
+      diagnosticId: "delivery-edge-test",
     });
   });
 
@@ -360,6 +362,7 @@ describe("POST /webhooks/github edge cases", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "malformed_payload",
+      diagnosticId: "delivery-edge-test",
     });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
   });
@@ -373,6 +376,7 @@ describe("POST /webhooks/github edge cases", () => {
     await expect(response.json()).resolves.toEqual({
       status: "ignored",
       reason: "event_check_run",
+      diagnosticId: "delivery-edge-test",
     });
     expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
   });

--- a/docs/plans/2026-07-23-aiw-140-pr-review-ingestion.md
+++ b/docs/plans/2026-07-23-aiw-140-pr-review-ingestion.md
@@ -1,0 +1,280 @@
+# AIW-140: Restore PR review-comment ingestion across workflow versions
+
+- Ticket: [AIW-140](https://blazity.atlassian.net/browse/AIW-140) (Highest, epic AIW-118)
+- Date: 2026-07-23
+- Branch: `fix/aiw-140-pr-review-ingestion`
+- Code references are as of commit `ea307e5`.
+
+## 1. Scope and acceptance criteria
+
+Human PR review comments do not reliably reach the right workflow run. This plan traces the real ingestion flow (webhook received -> matched to a run -> routed to a fix/review block) for both execution paths and states, per acceptance criterion, the root cause, the proposed fix, edge cases, and verification.
+
+Acceptance criteria:
+
+1. **AC1**: A human PR review comment reaches the correct run and its fix/review block.
+2. **AC2**: Both legacy and definition-driven (v2) paths are covered.
+3. **AC3**: Duplicate webhook deliveries do not create duplicate runs.
+4. **AC4**: AI Workflow's own comments cannot recursively trigger the workflow (bot-loop guard).
+5. **AC5**: Failed ingestion is visible via a safe diagnostic ID.
+
+## 2. Current end-to-end flow (traced)
+
+### 2.1 Shared entry and dispatch (both paths)
+
+There is a single execution engine. "Legacy" is not a separate dispatcher: it is the built-in default graph (`defaultWorkflowDefinition`, `apps/worker/src/workflow-definition/default.ts:16`) selected via the `BUILTIN_FALLBACK_DEFINITION_VERSION` sentinel (`apps/worker/src/workflows/agent-input.ts:37`). Everything below is shared until definition resolution.
+
+GitHub review-submission event, hop by hop:
+
+| # | Step | Location |
+|---|------|----------|
+| 1 | HMAC signature verified (401 on failure) | `apps/worker/src/routes/webhooks/github.post.ts:22-30`, `apps/worker/src/lib/github-webhook-sig.ts:9-27` |
+| 2 | Event type from `X-GitHub-Event`, delivery id from `X-GitHub-Delivery` | `github.post.ts:32-36` |
+| 3 | Normalization to a `TriggerEvent` | `normalizeGitHubEvent`, `apps/worker/src/lib/trigger-events.ts:44-138` |
+| 4 | `pull_request_review` (action `submitted`) becomes `trigger_pr_review` with `pr.review = { state, author, body }`; bot-authored reviews dropped | `trigger-events.ts:115-135` |
+| 5 | Dispatch: enabled-definition gate, provider/scope filter, eligibility re-check | `dispatchTriggerEvent`, `apps/worker/src/lib/dispatch-trigger.ts:92-122` |
+| 6 | Freshness: re-read live PR head, bind or reject stale | `dispatch-trigger.ts:129-132`, `apps/worker/src/lib/trigger-current-pull-request.ts:33-78` |
+| 7 | Run matching: PR -> owning ticket -> subject key | `resolveSubjectIdentity`, `dispatch-trigger.ts:418-446`; `findWorkflowOwnedPullRequest`, `apps/worker/src/db/queries/workflow-owned-branches.ts:100-142` |
+| 8 | Durable idempotent inbox insert | `acceptTriggerDelivery`, `apps/worker/src/lib/trigger-delivery-store.ts:38-71` (PK `(provider, delivery_id)`, `apps/worker/src/db/schema.ts:95`) |
+| 9 | Capacity claim + workflow start (always a fresh run, never a resume) | `dispatchAcceptedTrigger`, `dispatch-trigger.ts:266-317`; `claimSubjectRun`, `apps/worker/src/lib/dispatch.ts:143-188` |
+| 10 | Run loads the pinned definition version and walks the graph | `agentWorkflow`, `apps/worker/src/workflows/agent.ts:1234`; `loadWorkflowDefinitionFor`, `apps/worker/src/workflows/definition-step.ts:62` |
+
+GitLab: `gitlab.post.ts:34-41` allows `Merge Request Hook`, `Pipeline Hook`, `Note Hook`. Every eligible MR note (discussion and inline diff notes alike) becomes `trigger_pr_review` with state `commented` (`trigger-events.ts:185-215`), then follows the same dispatch chain.
+
+Concurrency and backlog around the shared chain:
+
+- One pending semantic event per subject: partial unique index `trigger_deliveries_one_pending_per_subject_idx` (`schema.ts:96-98`); newer feedback merges into the pending row (`coalescePendingTrigger`, `trigger-delivery-store.ts:126-184`).
+- Same-subject serialization through `active_runs` owner CAS (`schema.ts:29-53`); a second event while a run is active coalesces (`coalesceOrRecoverStarted`, `dispatch-trigger.ts:340-375`).
+- After a run releases its subject, the cron poll drains at most one successor (`routes/cron/poll.get.ts:77` -> `drainOldestPendingTrigger`, `dispatch-trigger.ts:378-416`).
+
+### 2.2 Definition-driven (v2) path
+
+`trigger_pr_review` is an entry trigger node (`apps/shared/contracts/domain.ts:182`, params `providers`/`scope`/`on` at `apps/shared/contracts/workflow-graph.ts:83`; zod at `apps/worker/src/workflow-definition/schema.ts:132-144`). A review event starts a fresh run of the currently enabled definition (resolved by `getEnabledWorkflowDefinitionForTrigger`, `apps/worker/src/workflow-definition/store.ts:330`), pinned to `definitionId` + `definitionVersion` at accept time (`dispatch-trigger.ts:140-147`) so later deploys cannot change an in-flight run (this is the "across workflow versions" dimension).
+
+Inside the run, the interpreter (`executeGraph`, `apps/worker/src/workflow-definition/interpreter.ts:254`) walks from the trigger. The reference shape is the integration-tested fixture `prReviewFixDefinition()` (`apps/worker/src/workflow-definition/graph-fixtures.ts:240-260`):
+
+```
+trigger_pr_review -> fetch_pr_context -> fix_agent -> finalize_workspace -> post_pr_comment
+```
+
+`fix_agent` folds `pr.review` into its context (`apps/worker/src/workflows/blocks/fix-agent.ts:122-135`); `fetch_pr_context` re-reads all PR comments with anchors (`apps/worker/src/workflows/blocks/fetch-pr-context.ts:37-71`, `apps/worker/src/adapters/vcs/github.ts:227-272`), surfaced to prompts as `{{pr_review_feedback}}` (`apps/shared/contracts/prompt-variables.ts:22`).
+
+### 2.3 Legacy path
+
+The built-in default graph is ticket-only: its single trigger is `trigger_ticket_ai` and it contains no `trigger_pr_review` and no `fix_agent` (`default.ts:17-54`). The PR-trigger dispatcher hard-requires a stored enabled definition: `if (!enabled?.current) return { result: "no_definition" }` (`dispatch-trigger.ts:104-105`). The ticket dispatcher has a builtin fallback (`dispatch.ts:108-110`) but the PR-trigger dispatcher does not, and `loadWorkflowDefinitionFor` only builds the builtin for ticket triggers (`definition-step.ts:118-128`, `:158-164`).
+
+Net effect: on a legacy install, every `trigger_pr_review` webhook dies with `no_definition`. Review feedback is only consumed indirectly when a human moves the ticket back into the AI column: the ticket re-run pre-fetches PR comments into planning (`agent.ts:1925-1937`, remediation framing in `apps/worker/src/sandbox/context.ts:387-399`, shipped in `43c4f94`).
+
+### 2.4 What works today, per event
+
+| Provider event | Today | After this plan |
+|---|---|---|
+| GitHub `pull_request_review` submitted (`changes_requested`/`commented`) | v2 only, needs enabled definition with `trigger_pr_review` | v2 + legacy fallback |
+| GitHub `pull_request_review_comment` (inline diff comment) | dropped: `ignored event_pull_request_review_comment` | ingested as `commented` review |
+| GitHub `issue_comment` on a PR (conversation comment) | dropped: `ignored event_issue_comment` | ingested as `commented` review |
+| GitLab MR note (discussion + inline) | v2 only, needs enabled definition | v2 + legacy fallback |
+
+## 3. Gap analysis and fixes per acceptance criterion
+
+### AC1: a human PR review comment reaches the correct run and its fix/review block
+
+**Root causes**
+
+1. GitHub comment events are not ingested at all. `normalizeGitHubEvent` handles only `pull_request`, `check_run`, `pull_request_review` and returns `null` for everything else (`trigger-events.ts:137`); the route then answers `{ status: "ignored", reason: "event_pull_request_review_comment" | "event_issue_comment" }` (`github.post.ts:124`). Zero references to `pull_request_review_comment` or `issue_comment` exist in `apps/worker/src`. GitLab already ingests the equivalent notes, so this is a GitHub-only parity gap.
+2. `issue_comment` payloads carry no head SHA, head ref, or base ref (only `issue`), while freshness binding hard-compares `current.headSha !== pr.headSha` and `current.baseRef !== pr.baseRef` (`trigger-current-pull-request.ts:39,44`) and run matching requires branch-name equality (`workflow-owned-branches.ts:119`).
+
+**Proposed fix**
+
+- F1.1 Normalize `pull_request_review_comment` (action `created` only) in `normalizeGitHubEvent` (`trigger-events.ts`, new branch next to `:115`): `triggerType: "trigger_pr_review"`, `review = { state: "commented", author: comment.user.login, body: comment.body }`, delivery producer = comment author. The payload carries a full `pull_request` object, so `mapGitHubPullRequest` applies unchanged.
+- F1.2 Normalize `issue_comment` (action `created`, only when `body.issue.pull_request` is present, which marks the issue as a PR): same review shape; `pr` built from issue fields (`prNumber = issue.number`, `prUrl = issue.pull_request.html_url`, `title = issue.title`, `author = issue.user.login`) with empty `headRef`/`headSha`/`baseRef`.
+- F1.3 Route: extend the `reviewStates` pre-seed condition (`github.post.ts:75-78`) so the two new event names seed `["commented"]`, and pass them into normalization like today.
+- F1.4 Freshness binding tolerance, restricted to `trigger_pr_review`: in `bindCurrentPullRequest` (`trigger-current-pull-request.ts:39-44`) treat an empty `pr.baseRef`/`pr.headSha` as "unknown, adopt the current provider value" instead of "stale". This mirrors the existing GitLab pattern (`:64` guards with `pr.headSha &&`, `:76` adopts `current.headSha`). Review feedback is about the PR, not about a specific head, so adopting the live head is semantically correct.
+- F1.5 Run matching without a branch name: in `findWorkflowOwnedPullRequest` (`workflow-owned-branches.ts:100-142`) drop the `prBranchName` equality when the caller passes an empty `branchName` (the published-head-SHA and target-branch checks at `:120-127` remain, so we still only match PRs whose head the workflow itself published). `resolveSubjectIdentity` (`dispatch-trigger.ts:439-446`) passes the post-binding values, which after F1.4 are the provider-authoritative ones.
+
+With these, both new events flow through the existing chain (section 2.1) to the same subject and, on v2, start the definition's `trigger_pr_review` entry (fix/review block per the definition graph). Legacy coverage is AC2.
+
+**Edge cases**
+
+- `issue_comment` on a plain issue (no `issue.pull_request`): ignored.
+- Comment actions `edited`/`deleted`: ignored (only `created`), matching GitLab's `action === "create"` guard (`trigger-events.ts:196`).
+- Comment on a closed/merged PR: `bindCurrentPullRequest` requires state `open` for review triggers (`trigger-current-pull-request.ts:40-42`) -> `ignored_stale_head`. Intentional: there is nothing to fix on a closed PR.
+- Review-thread replies are `pull_request_review_comment` `created` events and are covered by F1.1.
+- `approved` review submissions stay filtered by allowed states (`trigger-events.ts:120-121`).
+- All new events carry state `commented`, which stays opt-in per definition (`on` param) and hard-gated on a configured bot login (`dispatch-trigger.ts:254-258`); without `GITHUB_BOT_LOGIN`/`VCS_BOT_LOGIN` comment ingestion stays off (fails safe, see AC4).
+- GitLab needs no change here (Note Hook already covers both note kinds).
+
+**Verification**
+
+- `apps/worker/src/lib/trigger-events.test.ts`: new cases: review-comment maps to `commented` review; issue-comment on PR maps; issue-comment on non-PR returns null; `edited` returns null; bot author returns null.
+- `apps/worker/src/routes/webhooks/github.post.test.ts`: the two new event names dispatch; unrelated events still `ignored`.
+- New unit tests for `bindCurrentPullRequest` adoption (empty headSha/baseRef) and `findWorkflowOwnedPullRequest` empty-branch lookup (`apps/worker/src/db/queries/workflow-owned-branches.test.ts`).
+- Manual reproduction: section 5.
+
+### AC2: both legacy and definition-driven paths are covered
+
+**Root cause**
+
+`dispatchTriggerEvent` returns `no_definition` when no stored enabled definition exists for `trigger_pr_review` (`dispatch-trigger.ts:104-105`); the builtin fallback exists only for ticket dispatch (`dispatch.ts:108-110`) and only ticket triggers may load the builtin graph (`definition-step.ts:118-128`). The builtin graph itself has no review path (`default.ts:17-54`). Additionally `trigger_deliveries.definition_id`/`definition_version` are `NOT NULL` with a composite FK to `workflow_definition_versions` (`schema.ts:86-87,99-106`), so a builtin-fallback delivery cannot even be recorded today.
+
+**Proposed fix**
+
+- F2.1 Add `defaultReviewFixDefinition()` to `apps/worker/src/workflow-definition/default.ts`, shaped exactly like the already integration-tested fixture (`graph-fixtures.ts:240-260`): `trigger_pr_review` (providers `github`+`gitlab`, scope `workflow_owned`, on `["changes_requested","commented"]`) -> `fetch_pr_context` -> `fix_agent` -> `finalize_workspace` -> `post_pr_comment`.
+- F2.2 Builtin fallback in `dispatchTriggerEvent` (`dispatch-trigger.ts:104-105`): when `!enabled?.current` and `event.triggerType === "trigger_pr_review"` **and the install is pure legacy** (no enabled workflow definitions exist at all, checked via the store), proceed using the builtin trigger params and `definitionId = null`, `definitionVersion = null`, with the run input carrying `BUILTIN_FALLBACK_DEFINITION_VERSION` exactly like ticket dispatch does (`dispatch.ts:108-110`). The legacy-only guard matters: if an org runs v2 definitions but deliberately did not wire `trigger_pr_review`, we must respect that choice and keep returning `no_definition`.
+- F2.3 Migration (drizzle, `apps/worker/drizzle/`): make `trigger_deliveries.definition_id` and `definition_version` nullable. The composite FK stops being enforced for NULLs (Postgres MATCH SIMPLE), existing rows are unaffected. Adjust `AcceptedTriggerDelivery` and `acceptTriggerDelivery` typing (`trigger-delivery-store.ts:38-71`).
+- F2.4 Extend the sentinel branch of `loadWorkflowDefinitionFor` (`definition-step.ts:118-128`): for `BUILTIN_FALLBACK_DEFINITION_VERSION` + `trigger_pr_review`, build `defaultReviewFixDefinition()` (today the branch returns null for non-ticket triggers at `:119-122`).
+
+**Edge cases**
+
+- Subject serialization: the review-fix run shares the ticket's `subjectKey` (`dispatch-trigger.ts:498-521`), so it can never run concurrently with the ticket run of the same PR. Desired.
+- Capacity: falls under `MAX_CONCURRENT_AGENTS` like every claim (`dispatch.ts:143-188`); at capacity the delivery stays pending and drains later. Existing behavior.
+- `ENABLE_REVIEW_PHASE` only controls the `review_agent` node inside the ticket default (`definition-step.ts:110`); it does not gate this new fallback graph.
+- The fallback graph must not include `update_ticket_status`, so it cannot fight the ticket-status flow.
+- `commented` remains bot-login-gated even on the fallback path (`dispatch-trigger.ts:254-258`); a legacy install without a configured bot login gets `changes_requested`-only ingestion. Document this in SETUP.
+- v2 remains the primary path: any enabled definition for `trigger_pr_review` takes precedence, pinned per delivery, and definition authors keep full control of the graph shape.
+
+**Verification**
+
+- `apps/worker/src/lib/dispatch-trigger.test.ts`: fallback dispatch happens when no definitions are enabled; `no_definition` still returned when some other definition is enabled; delivery recorded with null pin.
+- `definition-step` tests: sentinel + `trigger_pr_review` loads the review-fix builtin.
+- `apps/worker/src/workflow-definition/revisions-lifecycle.integration.test.ts`: extend with a legacy-fallback scenario next to the existing versioned scenarios.
+- Migration applies cleanly against the test DB (`apps/worker/src/db/test-db.ts` harness).
+
+### AC3: duplicate webhook deliveries do not create duplicate runs
+
+**Current state (mostly solid)**
+
+- Exact redeliveries: the PK `(provider, delivery_id)` plus `onConflictDoNothing` replay (`trigger-delivery-store.ts:45-71`, `dispatch-trigger.ts:148-152`) makes provider retries and manual redeliveries idempotent. GitHub redeliveries reuse the delivery GUID; GitLab uses idempotency headers or a content hash (`gitlab.post.ts:165-177`).
+- Concurrent same-subject events: one-pending-per-subject index + coalescing + at-most-one-successor drain (section 2.1).
+- Documented residual race at `dispatch-trigger.ts:319-337` (candidate vs recovery owner) resolves by re-reading the stored winner; no duplicate run results.
+
+**Gap: semantic fan-out of one human action**
+
+One review submission containing N inline comments emits 1 `pull_request_review` + N `pull_request_review_comment` webhooks, each with a distinct delivery id. After AC1 lands, all N+1 normalize to `trigger_pr_review` on the same subject: the first starts a run, the rest coalesce into one pending row, and after the run finishes the drain starts a second run for the same human action. Not an unbounded dupe, but a systematic double-run.
+
+**Proposed fix**
+
+- F3.1 Add a nullable `semantic_key` column to `trigger_deliveries` plus a partial unique index on `(provider, semantic_key) WHERE semantic_key IS NOT NULL` (migration next to F2.3). Key derivation at normalization:
+  - `pull_request_review` submitted: `review:<review.id>`
+  - `pull_request_review_comment`: `review:<comment.pull_request_review_id>` when present (GitHub wraps inline comments in a review container, so the N comment events and their parent review share one key), else `comment:<comment.id>`
+  - `issue_comment`: `comment:<comment.id>`
+  - GitLab note: `note:<object_attributes.id>`
+- F3.2 `acceptTriggerDelivery` treats a semantic-key conflict exactly like a PK conflict: return the stored winner's envelope, replay its result (`trigger-delivery-store.ts:45-71`). Nothing is lost: the winning run's `fetch_pr_context` re-reads all PR comments from the provider anyway (`fetch-pr-context.ts:37-71`).
+
+**Edge cases**
+
+- Uncertain review-id semantics (e.g. thread replies): the `comment:<id>` fallback is always safe; the worst case is one extra coalesced pending event, never a lost comment or a duplicate exact-delivery run.
+- Old rows have `semantic_key = NULL` and never collide (partial index).
+- Two genuinely separate human comments have distinct semantic keys by construction; subject coalescing still merges them into at most one successor run, which is intended (new feedback = new work).
+
+**Verification**
+
+- `apps/worker/src/lib/trigger-delivery-store.test.ts`: semantic conflict returns the stored envelope; NULL keys never conflict.
+- `apps/worker/src/lib/dispatch-pr-trigger-coalesce.test.ts`: a review + its N comment deliveries produce exactly one run and no successor; two independent comments produce one run + one coalesced successor.
+- Manual reproduction step 3 (redelivery button) and step 4 (multi-comment review).
+
+### AC4: AI Workflow's own comments cannot recursively trigger the workflow
+
+**Current state**
+
+Identity-only, layered: normalization drops bot-authored reviews/notes (`trigger-events.ts:122`, `:191-200`), dispatch re-checks author and producer (`dispatch-trigger.ts:214-221`), and the `commented` state is only selectable when a bot login is configured (`dispatch-trigger.ts:254-258`). Two real holes:
+
+1. `normalizeVcsLogin` (`apps/worker/src/lib/vcs-bot-identity.ts:32-35`) only trims and lowercases. GitHub App installations comment as `<app-slug>[bot]`; with `GITHUB_BOT_LOGIN=blazebot` and actual author `blazebot[bot]`, `vcsLoginsMatch` fails and the guard silently stops working. This is the likeliest real-world loop scenario.
+2. The bot's own comments carry no machine-readable marker (`post-pr-comment.ts` posts the body verbatim, `:61`, body resolution `:117-127`), so a misconfigured login has no second line of defense.
+
+**Proposed fix**
+
+- F4.1 Apply the same author guard to the new AC1 events at normalization (`comment.user.login` vs `botLogin`); the dispatch-layer re-check at `dispatch-trigger.ts:214-221` covers them automatically since they produce a standard `review` payload.
+- F4.2 Harden `normalizeVcsLogin`: strip a trailing `[bot]` suffix before comparison. GitHub usernames cannot contain brackets, so `blazebot[bot]` == `blazebot` cannot be spoofed by a registered user. Additionally, for the new GitHub comment events, drop any comment whose `user.type === "Bot"`: other bots' comments (CI, linters) are not human review feedback and must not start fix runs either.
+- F4.3 Defense-in-depth marker: append an invisible HTML comment `<!-- ai-workflow:bot -->` to every body posted by `post_pr_comment` (single place: body resolution in `apps/worker/src/workflows/blocks/post-pr-comment.ts:117-127`), and drop any incoming comment/note whose body contains the marker (new GitHub branches + GitLab note branch `trigger-events.ts:185-215`). This holds even when the bot login is unset or wrong, and it covers GitLab bot users that `user.type` cannot identify.
+
+**Edge cases**
+
+- A human deliberately pasting the marker disables triggering for their own comment: harmless self-inflicted opt-out.
+- HTML comments do not render on GitHub or GitLab, so PR cosmetics are unchanged.
+- Existing bot comments posted before the marker ships only matter for triggering via identity match, which F4.2 fixes independently: the two guards overlap on purpose.
+- Explicitly not in scope for AC4: `getPRComments` (`github.ts:227-272`) re-reads the bot's own comments into planning/fix context (prompt pollution, not a trigger loop). Worth a follow-up ticket: tag or filter marker-bearing comments in `formatPRComments` (`sandbox/context.ts:293-318`).
+
+**Verification**
+
+- `apps/worker/src/lib/vcs-bot-identity.test.ts`: `[bot]` suffix matching cases.
+- `apps/worker/src/lib/trigger-events.test.ts`: bot-authored comment dropped; `user.type === "Bot"` dropped; marker-bearing body dropped (GitHub + GitLab).
+- `apps/worker/src/workflows/blocks/post-pr-comment.test.ts`: marker appended exactly once.
+- Manual reproduction step 5.
+
+### AC5: failed ingestion is visible via a safe diagnostic ID
+
+**Root cause**
+
+No failure path returns a referenceable identifier. Rejections return bare reason strings (`{ status: "ignored", reason }`), retryable failures return `503 trigger_<result>` (`github.post.ts:151-156`, `gitlab.post.ts:183-188`), and 401s surface the raw internal error message (`github.post.ts:29`). Logs carry the delivery id only on some branches (`dispatch-trigger.ts:154-159`). A user reporting "my comment did nothing" has nothing to quote, and the operator has nothing to grep.
+
+**Proposed fix**
+
+- F5.1 Mint a per-request `diagnosticId` at the top of both webhook routes: the provider delivery id when present (GitHub GUID / GitLab derived id, already unique and durable), else `crypto.randomUUID()` (covers 401 and missing-header branches).
+- F5.2 Include `diagnosticId` in every non-dispatched response: `{ status: "ignored" | "error", reason, diagnosticId }` for 200-level rejects, and in the `data` of `createError` for 401/503. Keep the existing coarse reason strings (they leak nothing); keep the current 401 messages (signature-header hints are standard webhook-config feedback and contain no secrets).
+- F5.3 Emit one structured log event `trigger_ingestion_rejected` with `{ diagnosticId, provider, event, reason }` on every rejected/errored branch of `github.post.ts` and `gitlab.post.ts` (info for ignores, warn for errors), complementing the existing `trigger_webhook_retryable_failure` and `trigger_delivery_dispatch_failed` logs. The GitHub/GitLab delivery UIs display the response body, so the ID becomes visible to whoever inspects the delivery, and `rg`-able in worker logs.
+
+"Safe" holds because the ID is either the provider's own delivery GUID or a random UUID: it encodes no configuration, repo names, or internal state.
+
+**Edge cases**
+
+- Malformed payload / missing delivery id: random UUID still gives a quotable handle.
+- Successful dispatch keeps returning `runId` (a stronger handle than any diagnostic id).
+- Log volume: ignores are logged at info and are already low-frequency per repo.
+
+**Verification**
+
+- `github.post.test.ts` / `gitlab.post.test.ts`: every rejected branch carries `diagnosticId`; 401 includes it in error data; log spy sees `trigger_ingestion_rejected`.
+- Manual reproduction step 6.
+
+## 4. Implementation order
+
+Each step ends green on `pnpm --filter worker test` and `pnpm --filter worker typecheck`.
+
+1. **AC4 groundwork**: `normalizeVcsLogin` `[bot]` handling + tests (tiny, unblocks safe AC1 work).
+2. **AC1**: normalization branches for the two GitHub events, route `reviewStates` seed, binding tolerance (F1.4), matching relaxation (F1.5), AC4 guards (author, `Bot` type, marker check) built in from the start; unit tests.
+3. **AC4 marker emit**: `post_pr_comment` marker append + tests.
+4. **AC3**: `semantic_key` migration + store conflict handling + coalesce tests.
+5. **AC2**: pin-columns migration, `defaultReviewFixDefinition`, dispatch fallback with the legacy-only guard, `definition-step` sentinel branch; integration test extension.
+6. **AC5**: diagnosticId plumbing in both routes + tests.
+7. e2e pass (`apps/worker/e2e/tier2/us03-review-fix-cycle.test.ts`, `us13-webhook-immediate-dispatch.test.ts`) and the manual reproduction below.
+
+Estimated blast radius: `apps/worker/src/lib/` (trigger-events, dispatch-trigger, trigger-delivery-store, trigger-current-pull-request, vcs-bot-identity), `apps/worker/src/routes/webhooks/`, `apps/worker/src/workflow-definition/default.ts`, `apps/worker/src/workflows/definition-step.ts`, `apps/worker/src/workflows/blocks/post-pr-comment.ts`, `apps/worker/src/db/` (schema + 2 migrations + queries). No dashboard changes required (the editor already renders `trigger_pr_review`, `apps/dashboard/components/cockpit/flow-editor/blocks.ts:39`).
+
+## 5. Manual reproduction (one honest end-to-end check)
+
+Prereqs: local worker (`pnpm --filter worker dev`) with a test DB, `GITHUB_WEBHOOK_SECRET` set, `GITHUB_BOT_LOGIN` set, a seeded `workflow_owned_branches` row for a real or fabricated PR (`ticket_key`, `repo_path`, `pr_id`, `pr_branch_name`, `pr_published_head_sha`, `pr_target_branch`).
+
+Helper to send a signed event:
+
+```bash
+payload='{"action":"created","repository":{...},"pull_request":{...},"comment":{"id":1,"user":{"login":"human","type":"User"},"body":"please fix the null check"}}'
+sig="sha256=$(printf '%s' "$payload" | openssl dgst -sha256 -hmac "$GITHUB_WEBHOOK_SECRET" -hex | sed 's/^.* //')"
+curl -s -X POST localhost:3000/webhooks/github \
+  -H "content-type: application/json" \
+  -H "x-github-event: pull_request_review_comment" \
+  -H "x-github-delivery: manual-test-1" \
+  -H "x-hub-signature-256: $sig" \
+  -d "$payload"
+```
+
+Expected sequence:
+
+1. POST the inline-comment payload: response `{ status: "dispatched", runId }`; the run appears and executes the fix path (fallback graph on a legacy DB, the enabled definition otherwise).
+2. Re-POST the identical request (same `x-github-delivery`): same stored result replayed, no second run (AC3 exact).
+3. POST a sibling comment of the same review (different delivery id, same `pull_request_review_id`): rejected as semantic duplicate (AC3 semantic).
+4. POST with `"user":{"login":"<bot login>[bot]","type":"Bot"}`: `ignored` (AC4 identity), and again with a human login but marker-bearing body: `ignored` (AC4 marker).
+5. POST with a broken signature: 401 carrying a `diagnosticId`; `rg <diagnosticId>` over worker logs finds the `trigger_ingestion_rejected` line (AC5).
+6. On a DB with an enabled v2 definition lacking `trigger_pr_review`: response `no_definition` (AC2 guard respects definition authors).
+
+## 6. Explicitly out of scope
+
+- Pruning `trigger_deliveries` (no TTL today, rows grow forever): known issue, separate ticket.
+- Filtering the bot's own comments out of `{{pr_review_feedback}}` context (prompt pollution, not a trigger loop): follow-up ticket.
+- Carrying per-comment file/line anchors inside the trigger payload: unnecessary, `fetch_pr_context` fetches anchored comments in-run.
+- GitLab note sub-typing (discussion vs diff): both already map to `commented` and nothing downstream distinguishes them.
+- Any dashboard/editor UI changes.
+
+## 7. Assumptions to confirm during implementation
+
+- GitHub manual "Redeliver" reuses the original delivery GUID (basis of exact-dedup). Confirm once against a staging webhook before relying on it in the AC3 tests' naming.
+- `comment.pull_request_review_id` is present on all inline review comments, including thread replies (fallback `comment:<id>` already handles absence).
+- `createRepositoryVCS` (`trigger-current-pull-request.ts:11-15`) tolerates an empty `baseBranch` for `getPRHead`; if not, thread the base ref from the post-binding value instead.

--- a/docs/plans/2026-07-23-aiw-140-pr-review-ingestion.md
+++ b/docs/plans/2026-07-23-aiw-140-pr-review-ingestion.md
@@ -68,10 +68,10 @@ Net effect: on a legacy install, every `trigger_pr_review` webhook dies with `no
 
 | Provider event | Today | After this plan |
 |---|---|---|
-| GitHub `pull_request_review` submitted (`changes_requested`/`commented`) | v2 only, needs enabled definition with `trigger_pr_review` | v2 + legacy fallback |
-| GitHub `pull_request_review_comment` (inline diff comment) | dropped: `ignored event_pull_request_review_comment` | ingested as `commented` review |
-| GitHub `issue_comment` on a PR (conversation comment) | dropped: `ignored event_issue_comment` | ingested as `commented` review |
-| GitLab MR note (discussion + inline) | v2 only, needs enabled definition | v2 + legacy fallback |
+| GitHub `pull_request_review` submitted (`changes_requested`/`commented`) | v2 only, needs enabled definition with `trigger_pr_review` | v2 via the enabled definition; legacy stays on the AIW-141 AI-column path |
+| GitHub `pull_request_review_comment` (inline diff comment) | dropped: `ignored event_pull_request_review_comment` | ingested as `commented` review (v2 dispatch; also read by AIW-141 legacy re-runs via `getPRComments`) |
+| GitHub `issue_comment` on a PR (conversation comment) | dropped: `ignored event_issue_comment` | ingested as `commented` review (v2 dispatch; also read by AIW-141 legacy re-runs via `getPRComments`) |
+| GitLab MR note (discussion + inline) | v2 only, needs enabled definition | v2 via the enabled definition; legacy stays on the AIW-141 AI-column path |
 
 ## 3. Gap analysis and fixes per acceptance criterion
 
@@ -115,28 +115,16 @@ With these, both new events flow through the existing chain (section 2.1) to the
 
 `dispatchTriggerEvent` returns `no_definition` when no stored enabled definition exists for `trigger_pr_review` (`dispatch-trigger.ts:104-105`); the builtin fallback exists only for ticket dispatch (`dispatch.ts:108-110`) and only ticket triggers may load the builtin graph (`definition-step.ts:118-128`). The builtin graph itself has no review path (`default.ts:17-54`). Additionally `trigger_deliveries.definition_id`/`definition_version` are `NOT NULL` with a composite FK to `workflow_definition_versions` (`schema.ts:86-87,99-106`), so a builtin-fallback delivery cannot even be recorded today.
 
-**Proposed fix**
+**Resolution: DESCOPED after auditing merged AIW-141 / PR #130 (2026-07-23)**
 
-- F2.1 Add `defaultReviewFixDefinition()` to `apps/worker/src/workflow-definition/default.ts`, shaped exactly like the already integration-tested fixture (`graph-fixtures.ts:240-260`): `trigger_pr_review` (providers `github`+`gitlab`, scope `workflow_owned`, on `["changes_requested","commented"]`) -> `fetch_pr_context` -> `fix_agent` -> `finalize_workspace` -> `post_pr_comment`.
-- F2.2 Builtin fallback in `dispatchTriggerEvent` (`dispatch-trigger.ts:104-105`): when `!enabled?.current` and `event.triggerType === "trigger_pr_review"` **and the install is pure legacy** (no enabled workflow definitions exist at all, checked via the store), proceed using the builtin trigger params and `definitionId = null`, `definitionVersion = null`, with the run input carrying `BUILTIN_FALLBACK_DEFINITION_VERSION` exactly like ticket dispatch does (`dispatch.ts:108-110`). The legacy-only guard matters: if an org runs v2 definitions but deliberately did not wire `trigger_pr_review`, we must respect that choice and keep returning `no_definition`.
-- F2.3 Migration (drizzle, `apps/worker/drizzle/`): make `trigger_deliveries.definition_id` and `definition_version` nullable. The composite FK stops being enforced for NULLs (Postgres MATCH SIMPLE), existing rows are unaffected. Adjust `AcceptedTriggerDelivery` and `acceptTriggerDelivery` typing (`trigger-delivery-store.ts:38-71`).
-- F2.4 Extend the sentinel branch of `loadWorkflowDefinitionFor` (`definition-step.ts:118-128`): for `BUILTIN_FALLBACK_DEFINITION_VERSION` + `trigger_pr_review`, build `defaultReviewFixDefinition()` (today the branch returns null for non-ticket triggers at `:119-122`).
+The ticket's scope note ("Audit merged AIW-141 and PR #130 first. Keep this ticket limited to uncovered legacy or v2 gaps rather than reimplementing shipped behavior") rules the originally drafted builtin webhook fallback out of AIW-140:
 
-**Edge cases**
+- AIW-141 (Done, verified on prod, AWP-11 / ai-workflow-prod#7) established the legacy consumption path: a human moves the ticket back to the AI column, the remediation run fetches PR feedback BEFORE planning (`agent.ts:1925-1937`) and reframes the run around addressing the review (`sandbox/context.ts:387-399`). PR #130 additionally made `getPRComments` fetch review summary bodies, so plain comments, inline comments, and Request Changes text all reach that run.
+- A webhook-triggered builtin fix run on legacy would mean one human review can produce TWO remediation runs (the immediate webhook one plus the AIW-141 AI-column one), and "trigger remediation from Request Changes" is tracked separately as AIW-109.
 
-- Subject serialization: the review-fix run shares the ticket's `subjectKey` (`dispatch-trigger.ts:498-521`), so it can never run concurrently with the ticket run of the same PR. Desired.
-- Capacity: falls under `MAX_CONCURRENT_AGENTS` like every claim (`dispatch.ts:143-188`); at capacity the delivery stays pending and drains later. Existing behavior.
-- `ENABLE_REVIEW_PHASE` only controls the `review_agent` node inside the ticket default (`definition-step.ts:110`); it does not gate this new fallback graph.
-- The fallback graph must not include `update_ticket_status`, so it cannot fight the ticket-status flow.
-- `commented` remains bot-login-gated even on the fallback path (`dispatch-trigger.ts:254-258`); a legacy install without a configured bot login gets `changes_requested`-only ingestion. Document this in SETUP.
-- v2 remains the primary path: any enabled definition for `trigger_pr_review` takes precedence, pinned per delivery, and definition authors keep full control of the graph shape.
+AC2 is therefore satisfied without new code: legacy coverage = the shipped AIW-141 AI-column path (which now also benefits from this ticket's ingestion fixes: the new GitHub comment events are readable through `getPRComments`, bot-loop guards protect normalization, and the marker keeps bot comments out of triggering). v2 coverage = an enabled definition with a `trigger_pr_review` node, now correctly fed by the AC1 ingestion work and protected by the AC3 dedup. On a legacy install a review webhook keeps answering `no_definition` (with the AC5 `diagnosticId`), by design.
 
-**Verification**
-
-- `apps/worker/src/lib/dispatch-trigger.test.ts`: fallback dispatch happens when no definitions are enabled; `no_definition` still returned when some other definition is enabled; delivery recorded with null pin.
-- `definition-step` tests: sentinel + `trigger_pr_review` loads the review-fix builtin.
-- `apps/worker/src/workflow-definition/revisions-lifecycle.integration.test.ts`: extend with a legacy-fallback scenario next to the existing versioned scenarios.
-- Migration applies cleanly against the test DB (`apps/worker/src/db/test-db.ts` harness).
+The builtin fallback design above (defaultReviewFixDefinition + nullable delivery pins + sentinel loading) remains documented in this section's history for AIW-109 to pick up if that ticket chooses the webhook-triggered route.
 
 ### AC3: duplicate webhook deliveries do not create duplicate runs
 
@@ -229,15 +217,15 @@ No failure path returns a referenceable identifier. Rejections return bare reaso
 
 Each step ends green on `pnpm --filter worker test` and `pnpm --filter worker typecheck`.
 
-1. **AC4 groundwork**: `normalizeVcsLogin` `[bot]` handling + tests (tiny, unblocks safe AC1 work).
-2. **AC1**: normalization branches for the two GitHub events, route `reviewStates` seed, binding tolerance (F1.4), matching relaxation (F1.5), AC4 guards (author, `Bot` type, marker check) built in from the start; unit tests.
-3. **AC4 marker emit**: `post_pr_comment` marker append + tests.
-4. **AC3**: `semantic_key` migration + store conflict handling + coalesce tests.
-5. **AC2**: pin-columns migration, `defaultReviewFixDefinition`, dispatch fallback with the legacy-only guard, `definition-step` sentinel branch; integration test extension.
-6. **AC5**: diagnosticId plumbing in both routes + tests.
-7. e2e pass (`apps/worker/e2e/tier2/us03-review-fix-cycle.test.ts`, `us13-webhook-immediate-dispatch.test.ts`) and the manual reproduction below.
+1. **AC4 groundwork**: `normalizeVcsLogin` `[bot]` handling + tests (tiny, unblocks safe AC1 work). [shipped: f3d2ed9]
+2. **AC1**: normalization branches for the two GitHub events, route `reviewStates` seed, binding tolerance (F1.4), matching relaxation (F1.5), AC4 guards (author, `Bot` type, marker check) built in from the start; unit tests. [shipped: 144ab24]
+3. **AC4 marker emit**: `post_pr_comment` marker append + tests. [shipped: cc5b90f]
+4. **AC3**: `semantic_key` migration + store conflict handling + coalesce tests. [shipped: d27621c]
+5. **AC2**: descoped after the AIW-141 / PR #130 audit, see section AC2 (legacy stays on the AI-column path; webhook-triggered remediation belongs to AIW-109).
+6. **AC5**: diagnosticId plumbing in both routes + tests. [shipped: 9d0632b]
+7. Full-suite verification and the manual reproduction below.
 
-Estimated blast radius: `apps/worker/src/lib/` (trigger-events, dispatch-trigger, trigger-delivery-store, trigger-current-pull-request, vcs-bot-identity), `apps/worker/src/routes/webhooks/`, `apps/worker/src/workflow-definition/default.ts`, `apps/worker/src/workflows/definition-step.ts`, `apps/worker/src/workflows/blocks/post-pr-comment.ts`, `apps/worker/src/db/` (schema + 2 migrations + queries). No dashboard changes required (the editor already renders `trigger_pr_review`, `apps/dashboard/components/cockpit/flow-editor/blocks.ts:39`).
+Blast radius as shipped: `apps/worker/src/lib/` (trigger-events, trigger-delivery-store, trigger-current-pull-request, vcs-bot-identity), `apps/worker/src/routes/webhooks/`, `apps/worker/src/workflows/blocks/post-pr-comment.ts`, `apps/worker/src/db/` (schema + 1 migration + queries). `dispatch-trigger.ts` needed no changes. No dashboard changes (the editor already renders `trigger_pr_review`, `apps/dashboard/components/cockpit/flow-editor/blocks.ts:39`).
 
 ## 5. Manual reproduction (one honest end-to-end check)
 
@@ -258,7 +246,7 @@ curl -s -X POST localhost:3000/webhooks/github \
 
 Expected sequence:
 
-1. POST the inline-comment payload: response `{ status: "dispatched", runId }`; the run appears and executes the fix path (fallback graph on a legacy DB, the enabled definition otherwise).
+1. POST the inline-comment payload: with an enabled `trigger_pr_review` definition the response is `{ status: "dispatched", runId }` and the run executes the fix path; on a legacy DB the response is `{ status: "ignored", reason: "no_definition", diagnosticId }` and the feedback is consumed by the next AIW-141 AI-column run instead.
 2. Re-POST the identical request (same `x-github-delivery`): same stored result replayed, no second run (AC3 exact).
 3. POST a sibling comment of the same review (different delivery id, same `pull_request_review_id`): rejected as semantic duplicate (AC3 semantic).
 4. POST with `"user":{"login":"<bot login>[bot]","type":"Bot"}`: `ignored` (AC4 identity), and again with a human login but marker-bearing body: `ignored` (AC4 marker).
@@ -267,6 +255,7 @@ Expected sequence:
 
 ## 6. Explicitly out of scope
 
+- Webhook-triggered remediation on legacy installs (builtin review-fix fallback): descoped after the AIW-141 / PR #130 audit; belongs to AIW-109. See section AC2.
 - Pruning `trigger_deliveries` (no TTL today, rows grow forever): known issue, separate ticket.
 - Filtering the bot's own comments out of `{{pr_review_feedback}}` context (prompt pollution, not a trigger loop): follow-up ticket.
 - Carrying per-comment file/line anchors inside the trigger payload: unnecessary, `fetch_pr_context` fetches anchored comments in-run.

--- a/docs/plans/2026-07-23-aiw-140-pr-review-ingestion.md
+++ b/docs/plans/2026-07-23-aiw-140-pr-review-ingestion.md
@@ -120,11 +120,11 @@ With these, both new events flow through the existing chain (section 2.1) to the
 The ticket's scope note ("Audit merged AIW-141 and PR #130 first. Keep this ticket limited to uncovered legacy or v2 gaps rather than reimplementing shipped behavior") rules the originally drafted builtin webhook fallback out of AIW-140:
 
 - AIW-141 (Done, verified on prod, AWP-11 / ai-workflow-prod#7) established the legacy consumption path: a human moves the ticket back to the AI column, the remediation run fetches PR feedback BEFORE planning (`agent.ts:1925-1937`) and reframes the run around addressing the review (`sandbox/context.ts:387-399`). PR #130 additionally made `getPRComments` fetch review summary bodies, so plain comments, inline comments, and Request Changes text all reach that run.
-- A webhook-triggered builtin fix run on legacy would mean one human review can produce TWO remediation runs (the immediate webhook one plus the AIW-141 AI-column one), and "trigger remediation from Request Changes" is tracked separately as AIW-109.
+- A webhook-triggered builtin fix run on legacy would mean one human review can produce TWO remediation runs (the immediate webhook one plus the AIW-141 AI-column one). Webhook-triggered remediation itself already shipped in AIW-109 / PR #120 for the v2 path (enabled `trigger_pr_review` definition); extending it to definition-less legacy installs is a product decision that needs its own ticket, not a side effect of this one.
 
 AC2 is therefore satisfied without new code: legacy coverage = the shipped AIW-141 AI-column path (which now also benefits from this ticket's ingestion fixes: the new GitHub comment events are readable through `getPRComments`, bot-loop guards protect normalization, and the marker keeps bot comments out of triggering). v2 coverage = an enabled definition with a `trigger_pr_review` node, now correctly fed by the AC1 ingestion work and protected by the AC3 dedup. On a legacy install a review webhook keeps answering `no_definition` (with the AC5 `diagnosticId`), by design.
 
-The builtin fallback design above (defaultReviewFixDefinition + nullable delivery pins + sentinel loading) remains documented in this section's history for AIW-109 to pick up if that ticket chooses the webhook-triggered route.
+The builtin fallback design (defaultReviewFixDefinition + nullable delivery pins + sentinel loading) remains documented here as the starting point for a future ticket, should the team decide legacy installs need webhook-triggered remediation without a stored definition (AIW-109 is closed and covered v2 only; GitLab formal Request Changes detection is AIW-116).
 
 ### AC3: duplicate webhook deliveries do not create duplicate runs
 
@@ -255,7 +255,7 @@ Expected sequence:
 
 ## 6. Explicitly out of scope
 
-- Webhook-triggered remediation on legacy installs (builtin review-fix fallback): descoped after the AIW-141 / PR #130 audit; belongs to AIW-109. See section AC2.
+- Webhook-triggered remediation on legacy installs (builtin review-fix fallback): descoped after the AIW-141 / PR #130 audit; would need a new ticket (AIW-109 shipped the v2 webhook path and is closed). See section AC2.
 - Pruning `trigger_deliveries` (no TTL today, rows grow forever): known issue, separate ticket.
 - Filtering the bot's own comments out of `{{pr_review_feedback}}` context (prompt pollution, not a trigger loop): follow-up ticket.
 - Carrying per-comment file/line anchors inside the trigger payload: unnecessary, `fetch_pr_context` fetches anchored comments in-run.


### PR DESCRIPTION
## Stack

- PR 1 of 1
- Base: `main`
- Jira: [AIW-140](https://blazity.atlassian.net/browse/AIW-140), builds on [AIW-109](https://blazity.atlassian.net/browse/AIW-109) (webhook remediation dispatch, PR #120) and [AIW-141](https://blazity.atlassian.net/browse/AIW-141) (AI-column feedback consumption, PR #130)

## What changed

- GitHub inline diff comments (`pull_request_review_comment`) and PR conversation comments (`issue_comment` on a PR) now normalize to `trigger_pr_review` events with state `commented`, mirroring the GitLab Note Hook. Previously only submitted reviews triggered anything; both comment event types were dropped as `ignored` at the webhook route. Ingestion is fail-safe: comment events fire only when the enabled definition opts into `on: ["commented"]` AND a bot login is configured.
- Freshness binding and run matching tolerate payloads without head facts. `issue_comment` carries no head SHA/refs, so review triggers adopt the provider-authoritative head (the existing GitLab Pipeline Hook pattern), and the workflow-owned PR lookup can match without a branch name while still enforcing the published-head SHA and target branch.
- Semantic dedup: one human action fanning out to N+1 webhooks (a review submission with N inline comments) dedupes to exactly one accepted delivery via a new nullable `semantic_key` column with a partial unique index on `trigger_deliveries` (migration 0022). Keys: `review:<id>` / `comment:<id>` / `note:<id>`, derived at normalization. Exact-redelivery behavior (same delivery id) is unchanged.
- Bot-loop hardening, layered: bot-login matching strips the GitHub App `[bot]` suffix (a `GITHUB_BOT_LOGIN` of `blazebot` now matches the actual `blazebot[bot]` author); comments from `Bot`-type accounts never trigger; every PR/MR comment the workflow posts carries an invisible HTML marker (`<!-- ai-workflow:bot -->`) that ingestion rejects, so even a misconfigured bot login cannot cause recursion.
- Failed ingestion is observable: every non-dispatched webhook response carries a safe `diagnosticId` (the provider delivery id, else a random UUID; never config or internals), 401/503 errors carry it in `data`, and each rejected branch emits exactly one structured `trigger_ingestion_rejected` log with the same id. Reason strings and status codes are byte-identical to before.
- `docs/plans/2026-07-23-aiw-140-pr-review-ingestion.md` records the full end-to-end trace for both execution paths and the AIW-141 / PR #130 audit that descoped a webhook-triggered legacy fallback (webhook dispatch stays v2-only by design; legacy consumes feedback through the AI-column path).

## Compatibility

- Legacy installs: review webhooks keep answering `no_definition` (now with a `diagnosticId`); the AIW-141 AI-column consumption path is untouched.
- v2 definitions: `trigger_pr_review` with `on: ["changes_requested"]` behaves exactly as before. Comment ingestion is opt-in per definition and additionally gated on a configured `GITHUB_BOT_LOGIN`/`GITLAB_BOT_LOGIN` (untrusted-body safety, same rule as before).
- Dispatched success responses are byte-identical; the post-PR gate subsystem is untouched; GitLab note handling only gained the marker guard and a semantic key.
- Also fixes a stale expectation in `workflow-owned-branches.test.ts` ("preserves confirmed correlation but hides its stale PR...") that has been red on `main` since 43c4f94 exposed `targetBranch`; PR #137's verification section independently reproduced that failure on `main`.

## Migration and rollout

- One additive migration (`0022`): nullable `semantic_key` column plus a partial unique index on `trigger_deliveries`. Applied by the standard `db:migrate` build step; existing rows keep NULL keys and never conflict.
- No new env vars, endpoints, or dependencies. Behavior note: a bot login configured without the `[bot]` suffix now also matches the suffixed GitHub App author (previously a silent guard miss).
- The comment marker protects comments posted after this deploy; identity-based guards cover older bot comments.

## Verification

- Full `apps/worker` suite: 175 files, 2178 tests, all passing (includes PGlite integration tests that replay the real migration chain). `pnpm --filter worker typecheck` clean.
- Each stage passed an independent read-only review gate before its commit (five gates total).
- New coverage: normalization of both new event types including all guard cases (bot author, `Bot` type, marker, missing opt-in), head-fact adoption in `bindCurrentPullRequest`, branchless owned-PR lookup, semantic-dedup winner/replay semantics, review fan-out coalescing (one review + N inline comments = one run, no pending successor), `diagnosticId` on every rejected branch with exactly-one-log assertions, `[bot]` suffix matching, and marker append/no-double-append.
- Pending: a live smoke on a deployed tenant (signed webhook -> fix run; step-by-step recipe in the plan doc, section 5).

Known follow-ups, out of scope: `trigger_deliveries` pruning (no TTL today), filtering the bot's own comments out of `{{pr_review_feedback}}` context (prompt pollution, not a loop), webhook-triggered remediation for definition-less legacy installs (design parked in the plan doc for a future ticket), and GitLab formal Request Changes detection (AIW-116).


[AIW-140]: https://blazity.atlassian.net/browse/AIW-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIW-109]: https://blazity.atlassian.net/browse/AIW-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIW-141]: https://blazity.atlassian.net/browse/AIW-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ