### PR TITLE
fix(worker): unbreak the worker production build after AIW-106

### DIFF
--- a/apps/worker/src/sandbox/agents/protocol.ts
+++ b/apps/worker/src/sandbox/agents/protocol.ts
@@ -34,27 +34,10 @@ export const AGENT_CLI_SPECS = {
   },
 } as const satisfies Record<AgentCliSpec["kind"], AgentCliSpec>;
 
-export class AgentRuntimeError extends Error {
-  readonly category: AgentProtocolFailureCategory;
-  readonly safeMessage: string;
-  readonly diagnostic: AgentProtocolDiagnostic;
+import { AgentRuntimeError } from "./runtime-error.js";
 
-  constructor(input: {
-    category: AgentProtocolFailureCategory;
-    message: string;
-    diagnostic: AgentProtocolDiagnostic;
-  }) {
-    super(input.message);
-    this.name = "AgentRuntimeError";
-    this.category = input.category;
-    this.safeMessage = input.message;
-    this.diagnostic = input.diagnostic;
-  }
-}
-
-export function isAgentRuntimeError(error: unknown): error is AgentRuntimeError {
-  return error instanceof AgentRuntimeError;
-}
+export { AgentRuntimeError };
+export { isAgentRuntimeError } from "./runtime-error.js";
 
 export async function installAndVerifyCli(
   sandbox: RunnableSandbox,

--- a/apps/worker/src/sandbox/agents/runtime-error.ts
+++ b/apps/worker/src/sandbox/agents/runtime-error.ts
@@ -1,0 +1,33 @@
+import type {
+  AgentProtocolDiagnostic,
+  AgentProtocolFailureCategory,
+} from "./types.js";
+
+/**
+ * Agent runtime failure carried across the step boundary. Lives in its own
+ * module with type-only imports so workflow-context code (non-step) can import
+ * it without dragging protocol.ts, whose module scope touches node:crypto and
+ * the pino logger, into the workflow bundle. The workflow bundler rejects
+ * Node.js modules in workflow functions, so protocol.ts must stay step-only.
+ */
+export class AgentRuntimeError extends Error {
+  readonly category: AgentProtocolFailureCategory;
+  readonly safeMessage: string;
+  readonly diagnostic: AgentProtocolDiagnostic;
+
+  constructor(input: {
+    category: AgentProtocolFailureCategory;
+    message: string;
+    diagnostic: AgentProtocolDiagnostic;
+  }) {
+    super(input.message);
+    this.name = "AgentRuntimeError";
+    this.category = input.category;
+    this.safeMessage = input.message;
+    this.diagnostic = input.diagnostic;
+  }
+}
+
+export function isAgentRuntimeError(error: unknown): error is AgentRuntimeError {
+  return error instanceof AgentRuntimeError;
+}

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -453,7 +453,7 @@ export async function ensurePlanningAgentSandboxForBlock(
     return { kind: "ready", sandboxId: await ensureAgentSandbox(ctx, kind, model) };
   } catch (error) {
     if (isRunControlError(error)) throw error;
-    const { isAgentRuntimeError } = await import("../sandbox/agents/protocol.js");
+    const { isAgentRuntimeError } = await import("../sandbox/agents/runtime-error.js");
     if (isAgentRuntimeError(error)) {
       return agentProtocolBlockError({
         ok: false,
@@ -870,7 +870,7 @@ async function setCommitGuardStep(
     await agent.setCommitGuard(sandbox, enabled);
     return { ok: true, value: undefined };
   } catch (error) {
-    const { isAgentRuntimeError } = await import("../sandbox/agents/protocol.js");
+    const { isAgentRuntimeError } = await import("../sandbox/agents/runtime-error.js");
     if (!isAgentRuntimeError(error)) throw error;
     return {
       ok: false,

--- a/apps/worker/src/workflows/blocks/agent-sandbox.ts
+++ b/apps/worker/src/workflows/blocks/agent-sandbox.ts
@@ -85,7 +85,7 @@ async function blockProvisionAgentSandboxStep(
     });
     return { ok: true, sandboxId: sandbox.sandboxId };
   } catch (error) {
-    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/runtime-error.js");
     const agentRuntimeError = isAgentRuntimeError(error);
     const { stopSandboxAndConfirm } = await import(
       "../../sandbox/stop-ticket-sandboxes.js"
@@ -133,7 +133,7 @@ export async function ensureAgentSandbox(
     arthurTaskId,
   );
   if (!provisioned.ok) {
-    const { AgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    const { AgentRuntimeError } = await import("../../sandbox/agents/runtime-error.js");
     throw new AgentRuntimeError(provisioned.failure);
   }
   const { sandboxId } = provisioned;

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -55,7 +55,7 @@ async function blockFixAgentCommitGuardStep(
     await agent.setCommitGuard(sandbox, enabled);
     return { ok: true, value: undefined };
   } catch (error) {
-    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/runtime-error.js");
     if (!isAgentRuntimeError(error)) throw error;
     return {
       ok: false,

--- a/apps/worker/src/workflows/blocks/generic-agent.ts
+++ b/apps/worker/src/workflows/blocks/generic-agent.ts
@@ -59,7 +59,7 @@ async function blockGenericAgentCommitGuardStep(
     await agent.setCommitGuard(sandbox, enabled);
     return { ok: true, value: undefined };
   } catch (error) {
-    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/runtime-error.js");
     if (!isAgentRuntimeError(error)) throw error;
     return {
       ok: false,
@@ -272,7 +272,7 @@ export const execute: BlockExecuteFn = async (
         : ctx.sandboxId;
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/runtime-error.js");
     if (isAgentRuntimeError(err)) {
       return agentProtocolExecutionError({
         ok: false,

--- a/apps/worker/src/workflows/blocks/prepare-workspace.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.ts
@@ -198,7 +198,7 @@ async function blockPrepareWorkspaceProvisionStep(
     );
     return { ok: true, sandboxId: sandbox.sandboxId, workspaceManifest };
   } catch (error) {
-    const { isAgentRuntimeError } = await import("../../sandbox/agents/protocol.js");
+    const { isAgentRuntimeError } = await import("../../sandbox/agents/runtime-error.js");
     if (isAgentRuntimeError(error)) {
       return {
         ok: false,


### PR DESCRIPTION
## Stack

- PR 1 of 1
- Base: `main`
- Jira: follows up [AIW-106](https://blazity.atlassian.net/browse/AIW-106) (agent CLI protocol pinning)

## What changed

- Moves `AgentRuntimeError` and `isAgentRuntimeError` from `sandbox/agents/protocol.ts` into a new workflow-safe module `sandbox/agents/runtime-error.ts` (type-only imports, no Node.js modules). `protocol.ts` re-exports both, so every existing import keeps working, and its internal constructor call sites now import from the new module.
- Repoints the workflow-context dynamic imports of these two symbols (agent.ts, blocks/agent-sandbox.ts, blocks/fix-agent.ts, blocks/generic-agent.ts, blocks/prepare-workspace.ts) at `runtime-error.js`.

## Why

Since the AIW-106 merge (#134), every production build of the worker fails at the workflow bundling stage: non-step workflow code dynamically imports `isAgentRuntimeError` from `protocol.ts`, which pulls `protocol.ts` (top-level `node:crypto` import) and, transitively, the pino logger into the workflow-function bundle. The bundler rejects Node.js modules there:

```
src/sandbox/agents/protocol.ts:340:9: ERROR: [plugin: workflow-node-module-error] "node:crypto" ...
src/lib/logger.ts:3:22: ERROR: [plugin: workflow-node-module-error] "pino" ...
```

Production has been serving the pre-#134 deployment since; the #137 merge deploy failed the same way. Extracting the error class (the only protocol export needed in workflow context) removes `protocol.ts` from the workflow graph entirely.

## Compatibility

- Class identity is preserved: `protocol.ts` re-exports the same class object, so `instanceof` checks hold across both import paths.
- No behavior change anywhere; imports only.

## Verification

- Local repro: `NITRO_PRESET=vercel nitro build` fails on `main` with the two errors above and passes on this branch (`workflows build complete, 104 steps, 5 workflows`, zero `workflow-node-module-error`).
- `apps/worker` sandbox + workflows suites: 742 of 742 tests passed.
- `pnpm -C apps/worker typecheck`: clean.


[AIW-106]: https://blazity.atlassian.net/browse/AIW-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ