### PR TITLE
fix(worker): escape find-group parens in clarification scrub script

### DIFF
--- a/apps/worker/src/workflows/clarification-snapshot-steps.test.ts
+++ b/apps/worker/src/workflows/clarification-snapshot-steps.test.ts
@@ -488,3 +488,18 @@ describe("clarification sandbox snapshot Workflow steps", () => {
     expect(mocks.recordSnapshot).not.toHaveBeenCalled();
   });
 });
+
+describe("SCRUB_CREDENTIALS_SCRIPT", () => {
+  it("is valid bash (escaped find-group parens survive the template literal)", async () => {
+    const { SCRUB_CREDENTIALS_SCRIPT } = await import("./clarification-snapshot-steps.js");
+    // The find group parens must reach bash escaped: a single \( in the JS
+    // template literal collapses to a bare ( and bash fails with
+    // "syntax error near unexpected token `('" (seen in production).
+    expect(SCRUB_CREDENTIALS_SCRIPT).toContain("\\(");
+    expect(SCRUB_CREDENTIALS_SCRIPT).toContain("\\)");
+    const { spawnSync } = await import("node:child_process");
+    const check = spawnSync("bash", ["-n", "-c", SCRUB_CREDENTIALS_SCRIPT], { encoding: "utf8" });
+    expect(check.stderr).toBe("");
+    expect(check.status).toBe(0);
+  });
+});

--- a/apps/worker/src/workflows/clarification-snapshot-steps.ts
+++ b/apps/worker/src/workflows/clarification-snapshot-steps.ts
@@ -5,11 +5,14 @@ const MAX_SOURCE_STOP_POLLS = 180;
 const MAX_SNAPSHOT_LIST_PAGES = 100;
 const SNAPSHOT_CLOCK_SKEW_TOLERANCE_MS = 5 * 60 * 1_000;
 
-const SCRUB_CREDENTIALS_SCRIPT = `set -eu
+// NOTE: this is a JS template literal, so bash's escaped parens must be written
+// as \\( \\) — a single \( collapses to a bare ( in the emitted string, which
+// is a bash syntax error ("syntax error near unexpected token `('").
+export const SCRUB_CREDENTIALS_SCRIPT = `set -eu
 find /tmp -maxdepth 1 -type f -name 'agent-env*.sh' -delete
 rm -rf "$HOME/.codex" "$HOME/.claude" "$HOME/.config/claude" "$HOME/.config/claude-code"
 rm -f "$HOME/.claude.json" /tmp/config.toml /tmp/arthur_config.json /tmp/arthur-tracer.py
-find /tmp -maxdepth 1 -type f \( -iname '*arthur*credential*' -o -iname '*tracer*credential*' \) -delete
+find /tmp -maxdepth 1 -type f \\( -iname '*arthur*credential*' -o -iname '*tracer*credential*' \\) -delete
 `;
 
 export interface SnapshotClarificationSandboxInput {


### PR DESCRIPTION
The clarification credential-scrub script is a JS template literal, so `\(` collapsed to a bare `(` and bash failed with `syntax error near unexpected token '('` — every implementation-stage clarification park died at `snapshotClarificationSandboxStep` (seen on Arthur prod, run `wrun_01KY70W9B0ZF66XJQ17E550FEV`, 2026-07-23 08:22Z). Planning-stage clarifications skip the snapshot, which is why parking appeared to work.

Fix: `\\(` / `\\)` so bash receives the escaped find-group parens. Added a regression test that asserts the escaped parens survive the literal and validates the script with `bash -n`.

Verified: targeted tests 14/14, `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential cleanup during clarification snapshots by ensuring the generated shell command runs successfully.
  * Added validation to prevent future shell syntax errors in the cleanup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->