### PR TITLE
fix(worker): ask which repository instead of trusting keyword scoring

### DIFF
--- a/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
@@ -84,20 +84,42 @@ describe("selectRepositoriesFromMetadata", () => {
 
     expect(selected).toEqual({
       status: "clarification_needed",
-      questions: ["Which repository should this ticket modify?"],
+      questions: [
+        "Which repository should this ticket modify? Reply with the full repository path in the form owner/repo. Accessible candidates: web, api.",
+      ],
     });
   });
 
-  it("selects repositories by name and description terms", () => {
+  it("asks instead of trusting keyword scoring across multiple repositories", () => {
+    // Scoring picked the wrong repository outright in production, so a
+    // metadata match is a ranking signal for the question, not a selection.
     const selected = selectRepositoriesFromMetadata({
       ticketText: "Fix billing webhook retry behavior",
       repositories: repos,
       workflowOwnedBranches: [],
     });
 
-    expect(selected.status).toBe("selected");
-    if (selected.status !== "selected") throw new Error("expected selected");
-    expect(selected.repositories.map((r) => r.repoPath)).toEqual(["acme/api"]);
+    expect(selected).toEqual({
+      status: "clarification_needed",
+      questions: [
+        "Which repository should this ticket modify? Reply with the full repository path in the form owner/repo. Accessible candidates: api, web.",
+      ],
+    });
+  });
+
+  it("never leaks full repository paths into the question (a posted question comment would pin every candidate)", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+    });
+
+    expect(selected.status).toBe("clarification_needed");
+    if (selected.status !== "clarification_needed") throw new Error("expected clarification");
+    for (const question of selected.questions) {
+      expect(question).not.toContain("acme/api");
+      expect(question).not.toContain("acme/web");
+    }
   });
 
   it("asks clarification when no repository matches", () => {
@@ -109,7 +131,9 @@ describe("selectRepositoriesFromMetadata", () => {
 
     expect(selected).toEqual({
       status: "clarification_needed",
-      questions: ["Which repository should this ticket modify?"],
+      questions: [
+        "Which repository should this ticket modify? Reply with the full repository path in the form owner/repo. Accessible candidates: web, api.",
+      ],
     });
   });
 

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.ts
@@ -5,6 +5,9 @@ import type {
 } from "../../adapters/vcs/repository-directory.js";
 import type { PreSandboxStepHandler } from "../types.js";
 
+/** Cap the repositories named in the which-repo clarification question. */
+const MAX_CLARIFICATION_CANDIDATES = 5;
+
 export interface WorkflowOwnedBranchSelectionInput {
   provider: RepositoryMetadata["provider"];
   repoPath: string;
@@ -94,17 +97,6 @@ export function selectRepositoriesFromMetadata(input: {
     }
   }
 
-  if (selected.size === 0) {
-    const scored = input.repositories
-      .map((repo) => ({ repo, score: scoreRepository(input.ticketText, repo) }))
-      .filter((item) => item.score > 0)
-      .sort((a, b) => b.score - a.score);
-    const topScore = scored[0]?.score ?? 0;
-    for (const item of scored.filter((candidate) => candidate.score === topScore)) {
-      selected.set(repositoryKey(item.repo), selectedRepository(item.repo, "ticket text matches repository metadata"));
-    }
-  }
-
   if (selected.size > 0) {
     return { status: "selected", repositories: [...selected.values()] };
   }
@@ -116,9 +108,23 @@ export function selectRepositoriesFromMetadata(input: {
     };
   }
 
+  // Keyword scoring proved too weak to commit to silently: in production it
+  // picked the wrong repository outright. With several accessible repositories
+  // and no deterministic signal (a workflow-owned branch or an exact repo-path
+  // mention), ask the human instead. The answer lands in the ticket context, so
+  // the re-run pins the repository via the exact-path match above. The question
+  // deliberately lists short names only: it can be posted back to the ticket as
+  // a comment, and full paths there would exact-match every candidate.
+  const candidates = input.repositories
+    .map((repo) => ({ repo, score: scoreRepository(input.ticketText, repo) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, MAX_CLARIFICATION_CANDIDATES)
+    .map(({ repo }) => repo.name || repo.repoPath.split("/").pop() || repo.repoPath);
   return {
     status: "clarification_needed",
-    questions: ["Which repository should this ticket modify?"],
+    questions: [
+      `Which repository should this ticket modify? Reply with the full repository path in the form owner/repo. Accessible candidates: ${candidates.join(", ")}.`,
+    ],
   };
 }
 


### PR DESCRIPTION
Repo selection silently committed to keyword scoring, and in production it picked the wrong repository outright (Arthur, UP-4693: `arthur-engine-any-agent-tool` instead of `arthur-engine`), sending the whole run into a wrong-repo implementation.

New behavior in `selectRepositoriesFromMetadata`:
- Deterministic signals still select silently: workflow-owned branch for the ticket, an exact `owner/repo` mention in the ticket text (comments included), or a single accessible repository.
- Otherwise (multiple repositories, keyword scoring only) it now returns `clarification_needed`: the pre-sandbox halt parks the ticket as awaiting input BEFORE any sandbox exists, the human replies with the full `owner/repo` path, and the answer lands in the ticket context so the re-run pins the repository via the exact-path match.
- The question lists short repository names only (ranked by the old scoring, capped at 5). Full paths are deliberately kept out of the question because it can be posted back to the ticket as a comment, and paths there would exact-match every candidate on the next run.

Tests updated/added (pre-sandbox 29/29, prepare-workspace 21/21), `tsc --noEmit` clean.

Refs AIW-146