### PR TITLE
fix(worker): stop silent workflow stalls and complete clarification resume

### DIFF
--- a/apps/worker/src/workflow-definition/interpreter.test.ts
+++ b/apps/worker/src/workflow-definition/interpreter.test.ts
@@ -1116,6 +1116,181 @@ describe("executeGraph human input and ended", () => {
     ]);
   });
 
+  it("re-executes an action block with the answer and resolves downstream bindings", async () => {
+    const graph = graphFrom(
+      [
+        node("trig", "trigger_ticket_ai"),
+        node("plan", "planning_agent"),
+        { ...node("impl", "implementation_agent"), inputs: { plan: "steps.plan.output.plan" } },
+      ],
+      [
+        { from: "trig", to: "plan" },
+        { from: "plan", to: "impl" },
+      ],
+    );
+    const rec = makeRecorder();
+    rec.hooks.clarificationExit = async (questions, nodeId) => {
+      rec.clarifications.push({ questions, nodeId, suggestedAnswers: undefined });
+      return "Use the exact greeting: Hi hi";
+    };
+    const calls: Array<{ id: string; answer?: string; plan?: unknown }> = [];
+    const executor: BlockExecutor = async (
+      block,
+      _steps,
+      resolvedInputs,
+      execution,
+    ): Promise<BlockExecutionResult> => {
+      calls.push({
+        id: block.id,
+        answer: execution?.clarificationAnswer,
+        plan: resolvedInputs.plan,
+      });
+      if (block.id === "plan") {
+        if (!execution?.clarificationAnswer) {
+          return {
+            kind: "needs_human_input",
+            output: { status: "needs_human_input", questions: ["Which greeting?"] },
+            questions: ["Which greeting?"],
+          };
+        }
+        return {
+          kind: "next",
+          output: { status: "ready", plan: `Plan for: ${execution.clarificationAnswer}` },
+        };
+      }
+      return { kind: "next", output: { status: "implemented", id: block.id } };
+    };
+
+    const result = await executeGraph({
+      graph,
+      entryTriggerId: "trig",
+      triggerOutput: { status: "fired" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(result.executionError).toBeUndefined();
+    expect(calls.map((c) => c.id)).toEqual(["plan", "plan", "impl"]);
+    expect(calls[1].answer).toBe("Use the exact greeting: Hi hi");
+    expect(calls[2].answer).toBeUndefined();
+    expect(calls[2].plan).toBe("Plan for: Use the exact greeting: Hi hi");
+    expect(attemptsFor(rec, "plan")).toEqual([1, 2]);
+    // The asking attempt does not finish; only the informed re-execution does.
+    expect(finishStatuses(rec, "plan")).toEqual(["ok"]);
+    expect(result.steps.plan.output).toEqual({
+      status: "ready",
+      plan: "Plan for: Use the exact greeting: Hi hi",
+    });
+  });
+
+  it("keeps the human_question answered envelope without re-executing it", async () => {
+    const graph = graphFrom(
+      [
+        node("trig", "trigger_ticket_ai"),
+        node("waiting", "human_question", { questions: ["Which region?"] }),
+        node("after", "send_slack_message"),
+      ],
+      [
+        { from: "trig", to: "waiting" },
+        { from: "waiting", to: "after" },
+      ],
+    );
+    const rec = makeRecorder();
+    rec.hooks.clarificationExit = async () => "eu-central";
+    const { executor, calls } = makeExecutor({
+      waiting: {
+        kind: "needs_human_input",
+        output: { status: "needs_human_input", questions: ["Which region?"] },
+        questions: ["Which region?"],
+      },
+    });
+
+    const result = await executeGraph({
+      graph,
+      entryTriggerId: "trig",
+      triggerOutput: { status: "fired" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(calls).toEqual(["waiting", "after"]);
+    expect(result.steps.waiting.output).toEqual({ status: "answered", answer: "eu-central" });
+    expect(finishStatuses(rec, "waiting")).toEqual(["ok"]);
+  });
+
+  it("supports a block asking again after re-execution, one round per ask", async () => {
+    const graph = graphFrom(
+      [node("trig", "trigger_ticket_ai"), node("plan", "planning_agent")],
+      [{ from: "trig", to: "plan" }],
+    );
+    const rec = makeRecorder();
+    const answers = ["First answer", "Second answer"];
+    rec.hooks.clarificationExit = async (questions, nodeId) => {
+      rec.clarifications.push({ questions, nodeId, suggestedAnswers: undefined });
+      return answers[rec.clarifications.length - 1];
+    };
+    const seen: Array<string | undefined> = [];
+    const executor: BlockExecutor = async (
+      _block,
+      _steps,
+      _inputs,
+      execution,
+    ): Promise<BlockExecutionResult> => {
+      seen.push(execution?.clarificationAnswer);
+      if (execution?.clarificationAnswer !== "Second answer") {
+        return {
+          kind: "needs_human_input",
+          output: { status: "needs_human_input", questions: [`Q${seen.length}`] },
+          questions: [`Q${seen.length}`],
+        };
+      }
+      return { kind: "next", output: { status: "ready", plan: "final" } };
+    };
+
+    const result = await executeGraph({
+      graph,
+      entryTriggerId: "trig",
+      triggerOutput: { status: "fired" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(seen).toEqual([undefined, "First answer", "Second answer"]);
+    expect(attemptsFor(rec, "plan")).toEqual([1, 2, 3]);
+    expect(rec.clarifications.map((c) => c.questions)).toEqual([["Q1"], ["Q2"]]);
+    expect(result.steps.plan.output).toEqual({ status: "ready", plan: "final" });
+  });
+
+  it("bounds an endlessly re-asking block by maxTotalExecutions", async () => {
+    const graph = graphFrom(
+      [node("trig", "trigger_ticket_ai"), node("plan", "planning_agent")],
+      [{ from: "trig", to: "plan" }],
+    );
+    const rec = makeRecorder();
+    rec.hooks.clarificationExit = async () => "still unclear";
+    const executor: BlockExecutor = async () => ({
+      kind: "needs_human_input",
+      output: { status: "needs_human_input", questions: ["Again?"] },
+      questions: ["Again?"],
+    });
+
+    const result = await executeGraph({
+      graph,
+      entryTriggerId: "trig",
+      triggerOutput: { status: "fired" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+      maxTotalExecutions: 3,
+    });
+
+    expect(result.outcome).toBe("stopped");
+    expect(result.executionError).toMatchObject({ category: "engine" });
+    expect(rec.failures).toEqual([expect.objectContaining({ nodeId: "plan" })]);
+  });
+
   it("ended reports outcome ended with a warn finish and no exit hooks", async () => {
     const rec = makeRecorder();
     const { executor } = makeExecutor({

--- a/apps/worker/src/workflow-definition/interpreter.ts
+++ b/apps/worker/src/workflow-definition/interpreter.ts
@@ -405,6 +405,9 @@ export async function executeGraph(opts: {
   );
   let executions = resume?.controlState?.executions ?? 0;
   let resumeAnswerPending = resume !== undefined;
+  // Set when an in-run clarification is answered for an action block; consumed
+  // by that same block's immediate re-execution.
+  let pendingClarificationAnswer: string | undefined;
   const controlState = (): InterpreterControlState => ({
     attempts: Object.fromEntries(attempts),
     executions,
@@ -649,8 +652,11 @@ export async function executeGraph(opts: {
 
     const execution = resumingWaitingNode
       ? { clarificationAnswer: resume.clarificationAnswer }
-      : undefined;
+      : pendingClarificationAnswer !== undefined
+        ? { clarificationAnswer: pendingClarificationAnswer }
+        : undefined;
     resumeAnswerPending = false;
+    pendingClarificationAnswer = undefined;
     let result: BlockExecutionResult;
     try {
       result = await executeBlock(node, steps, resolvedInputs, execution);
@@ -721,11 +727,24 @@ export async function executeGraph(opts: {
         await hooks.onBlockFinish(id, { status: "warn", attempt, output, error });
         return finish("stopped");
       }
-      const answeredOutput: BlockOutput = { status: "answered", answer };
-      steps[id] = { output: answeredOutput };
-      await hooks.onBlockFinish(id, { status: "ok", attempt, output: answeredOutput });
-      const port = defaultPortOf(node);
-      current = port === undefined ? undefined : graph.outEdges.get(id)?.get(port);
+      if (node.type === "human_question") {
+        // Collecting the answer IS this block's contract, so the answered
+        // envelope is its real output and downstream bindings consume it.
+        const answeredOutput: BlockOutput = { status: "answered", answer };
+        steps[id] = { output: answeredOutput };
+        await hooks.onBlockFinish(id, { status: "ok", attempt, output: answeredOutput });
+        const port = defaultPortOf(node);
+        current = port === undefined ? undefined : graph.outEdges.get(id)?.get(port);
+        continue;
+      }
+      // An action block that asked mid-execution has not produced its real
+      // output yet (a planning agent still owes the plan that downstream
+      // bindings read). Re-execute the same node with the answer available so
+      // the block re-runs informed by it; a block may ask again, bounded by
+      // maxTotalExecutions. This mirrors the cross-run resume path, which also
+      // re-executes the waiting action node with execution.clarificationAnswer.
+      pendingClarificationAnswer = answer;
+      current = id;
       continue;
     }
 

--- a/apps/worker/src/workflow-definition/interpreter.ts
+++ b/apps/worker/src/workflow-definition/interpreter.ts
@@ -302,7 +302,17 @@ export async function executeGraph(opts: {
       attempt,
       error,
     );
-    await hooks.onExecutionError?.({
+    // Invoke the callback detached from the hooks object. agent.ts wires a
+    // "use step" function here directly, and the Workflow SDK captures the
+    // receiver of a method call (`hooks.onExecutionError?.(...)` would pass
+    // `this` = the hooks object) as serialized step state. The hooks object
+    // holds unserializable closures, so that capture makes the SDK's
+    // suspension handler fail before the step is ever created, and the queue
+    // redelivers into the same failure forever: the run stalls silently on its
+    // first error. A detached call passes no receiver, so nothing extra is
+    // serialized.
+    const { onExecutionError } = hooks;
+    await onExecutionError?.({
       diagnosticId: state.diagnosticId,
       nodeId,
       attempt,

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -626,6 +626,26 @@ export function resolveImplementationPlanInput(
 function resolveAgentTicketInput(
   resolvedInputs: Record<string, unknown>,
   fallback: WorkflowTicketInputContext,
+  liveClarifications?: HumanDecision[],
+): WorkflowTicketInputContext {
+  const base = resolveAgentTicketInputFromBindings(resolvedInputs, fallback);
+  if (!liveClarifications || liveClarifications.length === 0) return base;
+  // Same-run clarification rounds (answered via the in-run hook) postdate both
+  // the journaled trigger output and the run-start ticket snapshot, so a
+  // re-executed agent phase would otherwise never see the answer it just asked
+  // for. Merge them in; appendClarificationRound dedupes rounds the snapshot
+  // already carries. Mirrors fix-agent's live read of ctx.clarifications.
+  let clarifications = base.clarifications;
+  for (const round of liveClarifications) {
+    clarifications = appendClarificationRound(clarifications, round);
+  }
+  if (clarifications === base.clarifications) return base;
+  return { ...base, clarifications };
+}
+
+function resolveAgentTicketInputFromBindings(
+  resolvedInputs: Record<string, unknown>,
+  fallback: WorkflowTicketInputContext,
 ): WorkflowTicketInputContext {
   if (!Object.prototype.hasOwnProperty.call(resolvedInputs, "ticket")) return fallback;
   if (
@@ -1918,6 +1938,12 @@ async function agentWorkflowBody(
           if ("expired" in answered) {
             throw new Error("clarification expired before it was answered");
           }
+          // Scratch agent sandboxes have a JOB_TIMEOUT_MS lifetime while the
+          // hook stays answerable for days, so any cached id may point at an
+          // expired sandbox after the park. Drop the cache so the re-executed
+          // block re-provisions; the code workspace is restored from its
+          // snapshot separately below.
+          ctx.agentSandboxIds = {};
           // Hook suspension is free wall time; only active work counts against
           // the run duration budget.
           if (entry.ticketKey) {
@@ -2159,7 +2185,7 @@ async function agentWorkflowBody(
             const { paths: researchPaths, script: researchScript } =
               await planPhaseStep(kind, "research", model, RESEARCH_SCHEMA);
             const researchInput = assembleResearchPlanContext({
-              ticket: resolveAgentTicketInput(resolvedInputs, ticketData),
+              ticket: resolveAgentTicketInput(resolvedInputs, ticketData, ctx.clarifications),
               prompt: promptOverride(node) ?? prompts.research,
               branchName,
               attachments: downloadedAttachments,
@@ -2242,7 +2268,7 @@ async function agentWorkflowBody(
             const { paths: implPaths, script: implScript } =
               await planPhaseStep(kind, "impl", model, AGENT_SCHEMA);
             const implInput = assembleImplementationContext({
-              ticket: resolveAgentTicketInput(resolvedInputs, ticketData),
+              ticket: resolveAgentTicketInput(resolvedInputs, ticketData, ctx.clarifications),
               prompt: promptOverride(node) ?? prompts.implement,
               researchPlanMarkdown: resolveImplementationPlanInput(
                 resolvedInputs,

--- a/apps/worker/workflow-sdk-tests/stall-repro.test.ts
+++ b/apps/worker/workflow-sdk-tests/stall-repro.test.ts
@@ -5,6 +5,7 @@ import { WorkflowRunFailedError } from "workflow/errors";
 import { parseStepName } from "workflow/observability";
 import { getWorld } from "workflow/runtime";
 import {
+  probeClarificationHappyPath,
   probeHookResumeBindingStall,
   probeResumeBindingStall,
   probeUnserializableStepErrorStall,
@@ -84,5 +85,41 @@ describe("workflow error paths must terminate instead of stalling", () => {
       `stall-${randomUUID()}`,
     ]);
     await expectDiagnosticFailure(run, "The block could not be completed.");
+  });
+});
+
+describe("clarification answers complete the run", () => {
+  it("re-executes the asking block with the answer and completes downstream", async () => {
+    const token = `clarification:${randomUUID()}`;
+    const run = await start(probeClarificationHappyPath, [token]);
+
+    const hook = await waitForHook(token);
+    expect(hook.runId).toBe(run.runId);
+
+    await resumeHook(token, {
+      answer: "Use this exact greeting: Hi hi",
+      answeredById: "user-1",
+      answeredByLabel: "Filip Maszota",
+      answeredAt: new Date().toISOString(),
+    });
+
+    await expect(run.returnValue).resolves.toEqual({
+      outcome: "completed",
+      implementationPlan: "Plan honoring: Use this exact greeting: Hi hi",
+    });
+    expect(await run.status).toBe("completed");
+
+    const steps = await getWorld().steps.list({
+      runId: run.runId,
+      resolveData: "none",
+    });
+    const shortNames = steps.data.map(
+      (step) => parseStepName(step.stepName)?.shortName,
+    );
+    expect(shortNames).toContain("prepareProbeHookStep");
+    expect(shortNames).toContain("repairProbeLabelStep");
+    // No error-path steps: the run finished cleanly.
+    expect(shortNames).not.toContain("logProbeExecutionErrorStep");
+    expect(shortNames).not.toContain("markProbeRunFailedStep");
   });
 });

--- a/apps/worker/workflow-sdk-tests/stall-repro.test.ts
+++ b/apps/worker/workflow-sdk-tests/stall-repro.test.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { getHookByToken, resumeHook, start } from "workflow/api";
+import { WorkflowRunFailedError } from "workflow/errors";
+import { parseStepName } from "workflow/observability";
+import { getWorld } from "workflow/runtime";
+import {
+  probeHookResumeBindingStall,
+  probeResumeBindingStall,
+  probeUnserializableStepErrorStall,
+} from "../workflow-test-fixtures/stall-repro/workflow.js";
+
+async function waitForHook(token: string): Promise<{ runId: string }> {
+  const deadline = Date.now() + 10_000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      return await getHookByToken(token);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  throw lastError ?? new Error(`hook ${token} was not registered`);
+}
+
+async function expectDiagnosticFailure(
+  run: { returnValue: Promise<unknown>; runId: string },
+  expectedDetail: string,
+): Promise<void> {
+  let failure: unknown;
+  try {
+    await run.returnValue;
+  } catch (error) {
+    failure = error;
+  }
+
+  expect(WorkflowRunFailedError.is(failure)).toBe(true);
+  if (!WorkflowRunFailedError.is(failure)) throw failure;
+  expect(failure.cause.message).toContain("Diagnostic ID: AIW-DIAG-");
+  expect(failure.cause.message).toContain(expectedDetail);
+
+  const steps = await getWorld().steps.list({
+    runId: run.runId,
+    resolveData: "none",
+  });
+  const shortNames = steps.data.map(
+    (step) => parseStepName(step.stepName)?.shortName,
+  );
+  // The interpreter's recordExecutionError must have run its onExecutionError
+  // step and the failureExit steps: their absence is the production stall.
+  expect(shortNames).toContain("logProbeExecutionErrorStep");
+  expect(shortNames).toContain("markProbeRunFailedStep");
+  expect(shortNames).toContain("notifyProbeFailureStep");
+}
+
+describe("workflow error paths must terminate instead of stalling", () => {
+  it("fails the run when a resumed checkpoint hits an unresolvable binding", async () => {
+    const run = await start(probeResumeBindingStall, [`stall-${randomUUID()}`]);
+    await expectDiagnosticFailure(run, "A block input could not be resolved.");
+  });
+
+  it("fails the run when a hook-resumed run hits an unresolvable binding", async () => {
+    const token = `clarification:${randomUUID()}`;
+    const run = await start(probeHookResumeBindingStall, [token]);
+
+    const hook = await waitForHook(token);
+    expect(hook.runId).toBe(run.runId);
+
+    await resumeHook(token, {
+      answer: "Use this exact greeting: Hi hi",
+      answeredById: "user-1",
+      answeredByLabel: "Filip Maszota",
+      answeredAt: new Date().toISOString(),
+    });
+
+    await expectDiagnosticFailure(run, "A block input could not be resolved.");
+  });
+
+  it("fails the run when a step throws an unserializable DOMException", async () => {
+    const run = await start(probeUnserializableStepErrorStall, [
+      `stall-${randomUUID()}`,
+    ]);
+    await expectDiagnosticFailure(run, "The block could not be completed.");
+  });
+});

--- a/apps/worker/workflow-test-fixtures/stall-repro/workflow.ts
+++ b/apps/worker/workflow-test-fixtures/stall-repro/workflow.ts
@@ -1,0 +1,323 @@
+import { createHook } from "workflow";
+import type {
+  BlockOutput,
+  BlockRunState,
+  WorkflowDefinitionNode,
+} from "@shared/contracts";
+import {
+  buildRuntimeGraph,
+  executeGraph,
+  WorkflowExecutionError,
+  type BlockExecutor,
+  type ExecuteGraphHooks,
+  type StepsRecord,
+  type WorkflowExecutionLogEvent,
+} from "../../src/workflow-definition/interpreter.js";
+import { isRunControlError } from "../../src/workflows/run-control-error.js";
+
+// Probes that mirror the production agent workflow's error paths against the
+// real Workflow SDK: the interpreter runs inside a "use workflow" function and
+// every persistence hook is a registered "use step", exactly like agent.ts.
+
+// --- Steps (mirroring agent.ts's error-path step shapes) ---
+
+async function readProbeClockStep(): Promise<number> {
+  "use step";
+  return Date.now();
+}
+readProbeClockStep.maxRetries = 0;
+
+async function recordProbeBlockStatusesStep(payload: {
+  runId: string;
+  blockStatuses: Record<string, BlockRunState>;
+}): Promise<void> {
+  "use step";
+  probeStatusWrites.push(payload);
+}
+recordProbeBlockStatusesStep.maxRetries = 0;
+const probeStatusWrites: Array<{ runId: string }> = [];
+
+async function logProbeExecutionErrorStep(
+  event: WorkflowExecutionLogEvent,
+): Promise<void> {
+  "use step";
+  console.error("probe_workflow_execution_error", event);
+}
+logProbeExecutionErrorStep.maxRetries = 0;
+
+async function markProbeRunFailedStep(runId: string): Promise<void> {
+  "use step";
+  console.error("probe_run_failed", runId);
+}
+markProbeRunFailedStep.maxRetries = 0;
+
+async function notifyProbeFailureStep(
+  phase: string,
+  reason: string,
+): Promise<void> {
+  "use step";
+  console.error("probe_failure_notified", phase, reason.slice(0, 200));
+}
+notifyProbeFailureStep.maxRetries = 0;
+
+async function prepareProbeHookStep(
+  token: string,
+): Promise<{ hookToken: string }> {
+  "use step";
+  return { hookToken: token };
+}
+
+async function publishProbeHookStep(_token: string): Promise<void> {
+  "use step";
+}
+
+async function supersedeProbeHookStep(_token: string): Promise<void> {
+  "use step";
+}
+
+async function repairProbeLabelStep(): Promise<void> {
+  "use step";
+}
+
+async function throwProbeTimeoutStep(): Promise<never> {
+  "use step";
+  // Mirrors runPrePrChecksStep's AbortSignal.timeout failure: a DOMException
+  // is not an Error subclass, so the SDK's error serializer degrades it.
+  throw new DOMException("The operation timed out", "TimeoutError");
+}
+throwProbeTimeoutStep.maxRetries = 0;
+
+// --- Graph helpers ---
+
+function node(
+  id: string,
+  type: WorkflowDefinitionNode["type"],
+  inputs: WorkflowDefinitionNode["inputs"] = {},
+  params: WorkflowDefinitionNode["params"] = {},
+): WorkflowDefinitionNode {
+  return { id, type, x: 0, y: 0, params, inputs };
+}
+
+const TRIGGER_OUTPUT: BlockOutput = {
+  status: "fired",
+  ticket: { identifier: "AIW-1", title: "Probe ticket" },
+};
+
+function bindingStallGraph() {
+  return buildRuntimeGraph({
+    nodes: [
+      node("trigger", "trigger_ticket_ai"),
+      node("planning", "human_question", {}, { questions: "Which greeting?" }),
+      node("implementation", "implementation_agent", {
+        // Mirrors prod definition v4: the resumed planning output carries only
+        // {status:"answered", answer}, so this binding cannot resolve.
+        plan: "steps.planning.output.plan",
+        ticket: "trigger.ticket",
+      }),
+    ],
+    edges: [
+      { from: "trigger", to: "planning", fromPort: "out" },
+      { from: "planning", to: "implementation", fromPort: "out" },
+    ],
+  });
+}
+
+interface ProbeHooksOptions {
+  runId: string;
+  clarificationExit: ExecuteGraphHooks["clarificationExit"];
+}
+
+function buildProbeHooks(opts: ProbeHooksOptions): ExecuteGraphHooks {
+  const blockStatuses: Record<string, BlockRunState> = {};
+  const writeBlockStatuses = () =>
+    recordProbeBlockStatusesStep({
+      runId: opts.runId,
+      blockStatuses: { ...blockStatuses },
+    }).catch(() => {});
+  return {
+    onExecutionError: logProbeExecutionErrorStep,
+    async onBlockStart(nodeId, attempt) {
+      await readProbeClockStep();
+      blockStatuses[nodeId] = { status: "running", attempt };
+      await writeBlockStatuses();
+    },
+    async onBlockFinish(nodeId, state) {
+      blockStatuses[nodeId] = state;
+      await writeBlockStatuses();
+      await readProbeClockStep();
+    },
+    clarificationExit: opts.clarificationExit,
+    async failureExit(phase, reason) {
+      await markProbeRunFailedStep(opts.runId);
+      await notifyProbeFailureStep(phase, reason);
+    },
+    async terminate() {
+      await writeBlockStatuses();
+    },
+  };
+}
+
+async function runProbeGraph(opts: {
+  runId: string;
+  graph: ReturnType<typeof buildRuntimeGraph>;
+  executeBlock: BlockExecutor;
+  hooks: ExecuteGraphHooks;
+  resume?: NonNullable<Parameters<typeof executeGraph>[0]["resume"]>;
+}): Promise<"completed" | "stopped" | "ended"> {
+  const walk = await executeGraph({
+    runId: opts.runId,
+    graph: opts.graph,
+    entryTriggerId: "trigger",
+    triggerOutput: TRIGGER_OUTPUT,
+    executeBlock: opts.executeBlock,
+    hooks: opts.hooks,
+    shouldRethrowExecutionError: isRunControlError,
+    maxTotalExecutions: 200,
+    // The registry validator is orthogonal to these probes; prod validation
+    // passed on both stalled runs, so the probes skip it to keep the trigger
+    // envelope minimal.
+    outputValidator: () => [],
+    ...(opts.resume ? { resume: opts.resume } : {}),
+  });
+  if (walk.executionError) {
+    // Mirrors agentWorkflow: a terminal execution error surfaces as a thrown
+    // WorkflowExecutionError so the run fails with its diagnostic id.
+    throw new WorkflowExecutionError(walk.executionError);
+  }
+  return walk.outcome;
+}
+
+// --- Probe 1: interpreter resume path (checkpointed waiting node) ---
+
+export async function probeResumeBindingStall(runId: string) {
+  "use workflow";
+  const executeBlock: BlockExecutor = async () => {
+    throw new Error("unreachable: bindings must throw before any block runs");
+  };
+  return runProbeGraph({
+    runId,
+    graph: bindingStallGraph(),
+    executeBlock,
+    hooks: buildProbeHooks({
+      runId,
+      clarificationExit: async () => {
+        throw new Error("unreachable: the resumed run must not park again");
+      },
+    }),
+    resume: {
+      waitingNodeId: "planning",
+      clarificationAnswer: "Use this exact greeting: Hi hi",
+      priorSteps: {},
+      controlState: { attempts: { planning: 1 }, executions: 1 },
+    },
+  });
+}
+
+// --- Probe 2: real hook suspension resumed mid-run (prod run 1's shape) ---
+
+export async function probeHookResumeBindingStall(hookToken: string) {
+  "use workflow";
+  const executeBlock: BlockExecutor = async (block) => {
+    if (block.id === "planning") {
+      const questions = ["Which greeting?"];
+      return {
+        kind: "needs_human_input",
+        output: { status: "needs_human_input", questions },
+        questions,
+      };
+    }
+    throw new Error("unreachable: bindings must throw before implementation");
+  };
+
+  const awaitClarification: ExecuteGraphHooks["clarificationExit"] = async (
+    _questions,
+    nodeId,
+    _suggestedAnswers,
+    checkpointSteps?: StepsRecord,
+  ): Promise<string> => {
+    if (!nodeId || !checkpointSteps) {
+      throw new Error("clarification is missing its waiting block context");
+    }
+    const clarification = await prepareProbeHookStep(hookToken);
+    const hook = createHook<
+      | {
+          answer: string;
+          answeredById: string;
+          answeredByLabel: string;
+          answeredAt: string;
+        }
+      | { expired: true }
+    >({ token: clarification.hookToken });
+    try {
+      const conflict = await hook.getConflict();
+      if (conflict) {
+        throw new Error(
+          `clarification hook ${clarification.hookToken} is already owned by run ${conflict.runId}`,
+        );
+      }
+      await publishProbeHookStep(clarification.hookToken);
+      const answered = await hook;
+      await readProbeClockStep();
+      if ("expired" in answered) {
+        throw new Error("clarification expired before it was answered");
+      }
+      await repairProbeLabelStep();
+      return answered.answer;
+    } catch (error) {
+      await supersedeProbeHookStep(clarification.hookToken).catch(() => undefined);
+      throw error;
+    } finally {
+      hook.dispose();
+    }
+  };
+
+  return runProbeGraph({
+    runId: hookToken,
+    graph: bindingStallGraph(),
+    executeBlock,
+    hooks: buildProbeHooks({ runId: hookToken, clarificationExit: awaitClarification }),
+  });
+}
+
+// --- Probe 3: unserializable step failure caught in-workflow (prod run 2) ---
+
+export async function probeUnserializableStepErrorStall(runId: string) {
+  "use workflow";
+  const graph = buildRuntimeGraph({
+    nodes: [
+      node("trigger", "trigger_ticket_ai"),
+      node("checks", "run_pre_pr_checks"),
+      node("comment", "post_ticket_comment"),
+    ],
+    edges: [
+      { from: "trigger", to: "checks", fromPort: "out" },
+      { from: "checks", to: "comment", fromPort: "out" },
+    ],
+  });
+  const executeBlock: BlockExecutor = async (block) => {
+    if (block.id === "checks") {
+      // Mirrors agent.ts's run_pre_pr_checks case: the failed step is caught,
+      // a budget observation step still completes, then the error is rethrown
+      // into the interpreter's executeBlock catch.
+      try {
+        return await throwProbeTimeoutStep();
+      } catch (err) {
+        if (isRunControlError(err)) throw err;
+        await readProbeClockStep();
+        throw err;
+      }
+    }
+    throw new Error("unreachable: the checks block must fail first");
+  };
+  return runProbeGraph({
+    runId,
+    graph,
+    executeBlock,
+    hooks: buildProbeHooks({
+      runId,
+      clarificationExit: async () => {
+        throw new Error("unreachable: this probe never parks");
+      },
+    }),
+  });
+}

--- a/apps/worker/workflow-test-fixtures/stall-repro/workflow.ts
+++ b/apps/worker/workflow-test-fixtures/stall-repro/workflow.ts
@@ -103,14 +103,14 @@ const TRIGGER_OUTPUT: BlockOutput = {
   ticket: { identifier: "AIW-1", title: "Probe ticket" },
 };
 
-function bindingStallGraph() {
+function bindingStallGraph(planningType: "human_question" | "planning_agent") {
   return buildRuntimeGraph({
     nodes: [
       node("trigger", "trigger_ticket_ai"),
-      node("planning", "human_question", {}, { questions: "Which greeting?" }),
+      node("planning", planningType, {}, { questions: "Which greeting?" }),
       node("implementation", "implementation_agent", {
-        // Mirrors prod definition v4: the resumed planning output carries only
-        // {status:"answered", answer}, so this binding cannot resolve.
+        // Mirrors prod definition v4: this binding resolves only when the
+        // planning node's final output carries a "plan" field.
         plan: "steps.planning.output.plan",
         ticket: "trigger.ticket",
       }),
@@ -196,7 +196,9 @@ export async function probeResumeBindingStall(runId: string) {
   };
   return runProbeGraph({
     runId,
-    graph: bindingStallGraph(),
+    // human_question keeps the synthesized answered envelope on resume, so
+    // the downstream "plan" binding cannot resolve and the error path fires.
+    graph: bindingStallGraph("human_question"),
     executeBlock,
     hooks: buildProbeHooks({
       runId,
@@ -215,21 +217,10 @@ export async function probeResumeBindingStall(runId: string) {
 
 // --- Probe 2: real hook suspension resumed mid-run (prod run 1's shape) ---
 
-export async function probeHookResumeBindingStall(hookToken: string) {
-  "use workflow";
-  const executeBlock: BlockExecutor = async (block) => {
-    if (block.id === "planning") {
-      const questions = ["Which greeting?"];
-      return {
-        kind: "needs_human_input",
-        output: { status: "needs_human_input", questions },
-        questions,
-      };
-    }
-    throw new Error("unreachable: bindings must throw before implementation");
-  };
-
-  const awaitClarification: ExecuteGraphHooks["clarificationExit"] = async (
+function makeProbeAwaitClarification(
+  hookToken: string,
+): ExecuteGraphHooks["clarificationExit"] {
+  return async (
     _questions,
     nodeId,
     _suggestedAnswers,
@@ -270,13 +261,79 @@ export async function probeHookResumeBindingStall(hookToken: string) {
       hook.dispose();
     }
   };
+}
+
+export async function probeHookResumeBindingStall(hookToken: string) {
+  "use workflow";
+  const executeBlock: BlockExecutor = async (block, _steps, _inputs, execution) => {
+    if (block.id === "planning") {
+      if (!execution?.clarificationAnswer) {
+        const questions = ["Which greeting?"];
+        return {
+          kind: "needs_human_input",
+          output: { status: "needs_human_input", questions },
+          questions,
+        };
+      }
+      // The informed re-execution still omits the "plan" field the downstream
+      // binding reads, so the continuation dies in pure code exactly like the
+      // stalled prod run. The regression is that this must FAIL cleanly.
+      return { kind: "next", output: { status: "ready" } };
+    }
+    throw new Error("unreachable: bindings must throw before implementation");
+  };
 
   return runProbeGraph({
     runId: hookToken,
-    graph: bindingStallGraph(),
+    graph: bindingStallGraph("planning_agent"),
     executeBlock,
-    hooks: buildProbeHooks({ runId: hookToken, clarificationExit: awaitClarification }),
+    hooks: buildProbeHooks({
+      runId: hookToken,
+      clarificationExit: makeProbeAwaitClarification(hookToken),
+    }),
   });
+}
+
+// --- Probe 4: the clarification happy path (feature-completing proof). An
+// action block asks, the hook resumes with the answer, the block re-executes
+// informed by it and produces its real output, and the downstream binding
+// resolves so the run completes. ---
+
+export async function probeClarificationHappyPath(hookToken: string) {
+  "use workflow";
+  let implementationPlan: unknown;
+  const executeBlock: BlockExecutor = async (block, _steps, resolvedInputs, execution) => {
+    if (block.id === "planning") {
+      if (!execution?.clarificationAnswer) {
+        const questions = ["Which greeting?"];
+        return {
+          kind: "needs_human_input",
+          output: { status: "needs_human_input", questions },
+          questions,
+        };
+      }
+      return {
+        kind: "next",
+        output: {
+          status: "ready",
+          plan: `Plan honoring: ${execution.clarificationAnswer}`,
+        },
+      };
+    }
+    implementationPlan = resolvedInputs.plan;
+    return { kind: "next", output: { status: "implemented" } };
+  };
+
+  const outcome = await runProbeGraph({
+    runId: hookToken,
+    graph: bindingStallGraph("planning_agent"),
+    executeBlock,
+    hooks: buildProbeHooks({
+      runId: hookToken,
+      clarificationExit: makeProbeAwaitClarification(hookToken),
+    }),
+  });
+  return { outcome, implementationPlan };
 }
 
 // --- Probe 3: unserializable step failure caught in-workflow (prod run 2) ---


### PR DESCRIPTION
## Stack

- PR 1 of 1
- Base: `main`
- Jira: fixes the production incident behind [AIW-145](https://blazity.atlassian.net/browse/AIW-145) dogfooding; root-caused from runs wrun_01KY6WJH9N3BY43HKA5YGWEY7J and wrun_01KY6Y5S55RVQY9T1PEQPA7FCD

## What changed

- Detaches the interpreter's `onExecutionError` hook invocation from the hooks object. The hook is wired to a bare "use step" function, and the Workflow SDK captures a method call's receiver as serialized step state; the hooks object holds closures, serialization failed before `step_created`, the orchestrator invocation 500'd, and the queue redelivered into the identical deterministic failure forever. Every run that hit its first engine error therefore stalled silently: status "running", no new steps, no failed status, no retries, nothing in logs.
- Makes an in-run clarification answer RE-EXECUTE the asking action block (attempt + 1) with `execution.clarificationAnswer`, mirroring the existing cross-run checkpoint-resume semantics, instead of synthesizing an `{status:"answered"}` output and moving on. The old behavior broke every definition that binds the asking block's real output (the default wires `implementation.plan` to `steps.planning.output.plan`), so an answered clarification could never reach a PR.
- Threads the fresh Q&A round into the re-executed prompt: `resolveAgentTicketInput` merges live `ctx.clarifications` (the round is appended on hook resume) over the journaled ticket snapshot, deduped via `appendClarificationRound`.
- Clears cached scratch agent sandbox ids after a hook resume so the re-executed block re-provisions instead of reusing a sandbox that expired during the park (scratch lifetime is JOB_TIMEOUT_MS while the hook stays answerable for 7 days).

## Compatibility

- `human_question` blocks keep their answered-output contract byte for byte; the loop `onExhaust: "human"` path and cross-run checkpoint resume are untouched and cannot double-apply (the resume flag clears before block execution).
- Re-ask cycles are bounded by `maxTotalExecutions` and each round requires a human answer.
- No API, DB, or dashboard contract changes.

## Verification

- Root cause reproduced locally on the real Workflow SDK harness: three probes (engine + resume binding failure, real `createHook` suspension + `resumeHook`, DOMException step failure) hang exactly like production without the fix and fail cleanly with a diagnostic after it; a new happy-path probe proves ask → answer → informed re-execution → downstream binding resolves → run completes.
- `vitest --config vitest.run-control-workflow.config.ts`: 11/11.
- Full worker unit suite: 2188/2188 (reviewer-run) and targeted reruns green after the sandbox-cache tweak; `pnpm typecheck` clean.
- Independent engine review: APPROVE; its one major follow-up (stale scratch sandboxes after long parks) is included here as the third commit's cache reset.

Known follow-ups, out of scope: pre-PR checks can exceed the duration budget when the agent picks a heavy repository (fails cleanly now, needs its own tuning ticket); the dashboard's "resume run has not started yet" panel text shows for every answered clarification because `dispatchedRunId` is always null in the hook design.
