### PR TITLE
fix(worker): stop the success self-move webhook race recording runs as blocked

### DIFF
--- a/apps/worker/src/db/queries/runs-read.ts
+++ b/apps/worker/src/db/queries/runs-read.ts
@@ -101,6 +101,22 @@ export async function isRunRecordedFailed(db: Db, runId: string): Promise<boolea
   return row?.status === "failed";
 }
 
+/**
+ * True when the run has already recorded a terminal "success" outcome. Same
+ * webhook guard as isRunRecordedFailed: the bot's own success finalization
+ * moves a finished ticket to AI Review, which fires the "ticket left the AI
+ * column" webhook, and cancelling would overwrite the run's genuine success
+ * with a "cancelled" status even though the PR and ticket move already landed.
+ */
+export async function isRunRecordedSucceeded(db: Db, runId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ status: workflowRuns.status })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, runId))
+    .limit(1);
+  return row?.status === "success";
+}
+
 const RUN_STATUSES = new Set<RunStatus>([
   "success",
   "running",

--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -11,6 +11,7 @@ import {
   resolveAwaitingRun,
   resolveAwaitingRunsForTicket,
   markRunFailedOnSelfMove,
+  markRunSucceededOnSelfMove,
   type RunSnapshot,
   type RunUsage,
   type RunBlockStatusWrite,
@@ -414,6 +415,46 @@ describe("markRunFailedOnSelfMove", () => {
   it("is a no-op for a missing run", async () => {
     await markRunFailedOnSelfMove(db, "wrun_missing");
     expect(await row("wrun_missing")).toBeUndefined();
+  });
+});
+
+describe("markRunSucceededOnSelfMove", () => {
+  it("advances an in-flight 'running' row to 'success'", async () => {
+    await recordBlockStatuses(db, blockWrite()); // inserts status 'running'
+    await markRunSucceededOnSelfMove(db, "wrun_1");
+    expect((await row("wrun_1")).status).toBe("success");
+  });
+
+  it("never downgrades an already-frozen outcome", async () => {
+    for (const frozen of ["failed", "blocked", "awaiting"] as const) {
+      const runId = `wrun_s_${frozen}`;
+      await db.insert(workflowRuns).values({
+        runId,
+        subjectKey: "ticket:jira:PROJ-1",
+        workflowId: "wf_agent",
+        workflowName: "Agent",
+        status: frozen,
+      });
+      await markRunSucceededOnSelfMove(db, runId);
+      expect((await row(runId)).status).toBe(frozen);
+    }
+  });
+
+  it("marks a null-status (in-flight) row as success", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_s_null",
+      subjectKey: "ticket:jira:PROJ-2",
+      workflowId: "wf_agent",
+      workflowName: "Agent",
+      // status omitted -> stored NULL; must be treated as in-flight, not skipped
+    });
+    await markRunSucceededOnSelfMove(db, "wrun_s_null");
+    expect((await row("wrun_s_null")).status).toBe("success");
+  });
+
+  it("is a no-op for a missing run", async () => {
+    await markRunSucceededOnSelfMove(db, "wrun_s_missing");
+    expect(await row("wrun_s_missing")).toBeUndefined();
   });
 });
 

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -309,6 +309,36 @@ export async function markRunFailedOnSelfMove(db: Db, runId: string): Promise<vo
 }
 
 /**
+ * Commits a run's authoritative "success" status the moment its own
+ * success-finalizing AI Review move is about to fire a Jira webhook. The bot
+ * moving a finished ticket out of the AI column triggers the "ticket left the
+ * AI column" webhook, which would otherwise race in and cancel this
+ * still-finalizing run, flipping its world status to "cancelled" (stored as
+ * "blocked") even though the PR and ticket move already happened. Recording
+ * "success" first makes the outcome durable before that self-triggered cancel
+ * can land: the cron never downgrades a frozen status, so the run stays
+ * "success". Guarded to only advance an in-flight row and never clobber an
+ * already-frozen outcome.
+ */
+export async function markRunSucceededOnSelfMove(db: Db, runId: string): Promise<void> {
+  await db
+    .update(workflowRuns)
+    .set({ status: "success", updatedAt: sql`now()` })
+    .where(
+      and(
+        eq(workflowRuns.runId, runId),
+        // A NULL status is an in-flight row too: `status NOT IN (...)` is NULL
+        // (not true) for NULL, so without this a null-status run would be
+        // skipped and its success lost.
+        or(
+          isNull(workflowRuns.status),
+          notInArray(workflowRuns.status, ["success", "failed", "blocked", "awaiting"]),
+        ),
+      ),
+    );
+}
+
+/**
  * Flips a run parked on a clarification from "awaiting" to "success". Called
  * when the clarification is answered (or superseded by a re-pickup) so parked
  * runs don't stay "awaiting" forever. Guarded on status='awaiting', so it is a

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -14,6 +14,7 @@ const state = vi.hoisted(() => ({
   cancel: vi.fn(),
   resume: vi.fn(),
   isRunRecordedFailed: vi.fn(),
+  isRunRecordedSucceeded: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({ env: state.env }));
@@ -26,6 +27,7 @@ vi.mock("../../clarifications/resume-from-comments.js", () => ({
 }));
 vi.mock("../../db/queries/runs-read.js", () => ({
   isRunRecordedFailed: state.isRunRecordedFailed,
+  isRunRecordedSucceeded: state.isRunRecordedSucceeded,
 }));
 
 const handler = (await import("./jira.post.js")).default;
@@ -101,6 +103,7 @@ describe("POST /webhooks/jira", () => {
     state.cancel.mockResolvedValue(true);
     state.dispatch.mockResolvedValue({ started: false, reason: "not_applicable" });
     state.isRunRecordedFailed.mockResolvedValue(false);
+    state.isRunRecordedSucceeded.mockResolvedValue(false);
   });
 
   it("rejects unauthenticated configuration", async () => {
@@ -159,12 +162,44 @@ describe("POST /webhooks/jira", () => {
     expect(state.cancel).not.toHaveBeenCalled();
   });
 
+  it("does not cancel a run whose success is already recorded (its own AI Review move)", async () => {
+    // The bot's success finalization moved the ticket to AI Review, firing this
+    // webhook. The run already recorded 'success', so cancelling would
+    // overwrite that with a 'blocked' status even though the PR already opened.
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.isRunRecordedSucceeded.mockResolvedValue(true);
+
+    const response = await app()(request({ actor: "human-account" }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "ignored",
+      reason: "run_already_succeeded",
+      ticketKey: "PROJ-42",
+    });
+    expect(state.isRunRecordedSucceeded).toHaveBeenCalledWith(expect.anything(), "run-1");
+    expect(state.cancel).not.toHaveBeenCalled();
+  });
+
   it("surfaces a retryable error when the failed-status lookup fails (does not cancel)", async () => {
     // A transient lookup failure must not be read as "not failed": guessing
     // would cancel a genuinely failed run. Return a retryable 503 instead.
     const connected = adapters();
     state.createAdapters.mockReturnValue(connected);
     state.isRunRecordedFailed.mockRejectedValue(new Error("db down"));
+
+    const response = await app()(request({ actor: "human-account" }));
+
+    expect(response.status).toBe(503);
+    expect(state.cancel).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a retryable error when the success-status lookup fails (does not cancel)", async () => {
+    // Same fail-closed rule for the success lookup: guessing "not succeeded"
+    // would cancel a genuinely finished run. Return a retryable 503 instead.
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.isRunRecordedSucceeded.mockRejectedValue(new Error("db down"));
 
     const response = await app()(request({ actor: "human-account" }));
 

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -4,7 +4,7 @@ import { env } from "../../../env.js";
 import { IssueTrackerNotFoundError } from "../../adapters/issue-tracker/types.js";
 import { resumeClarificationFromComments } from "../../clarifications/resume-from-comments.js";
 import { getDb } from "../../db/client.js";
-import { isRunRecordedFailed } from "../../db/queries/runs-read.js";
+import { isRunRecordedFailed, isRunRecordedSucceeded } from "../../db/queries/runs-read.js";
 import { createAdapters } from "../../lib/adapters.js";
 import { cancelRun } from "../../lib/cancel-run.js";
 import { dispatchTicket } from "../../lib/dispatch.js";
@@ -197,21 +197,29 @@ export default defineEventHandler(async (event) => {
       };
     }
 
-    // The bot's OWN failure handling moves a failed run's ticket to the
-    // backlog, which fires this exact webhook. Refuse to cancel a run whose
-    // failure is already recorded: cancelling would overwrite its "failed"
-    // outcome with a "cancelled" world status the errors KPI never counts. A
-    // human abort still cancels, because a live run is never recorded "failed".
+    // The bot's OWN finalization moves this ticket out of the AI column: its
+    // failure handling moves a failed run's ticket to the backlog, and its
+    // success handling moves a finished run's ticket to AI Review. Both fire
+    // this exact webhook. Refuse to cancel a run whose terminal outcome is
+    // already recorded: cancelling would overwrite a "failed" outcome with a
+    // "cancelled" world status the errors KPI never counts, or a "success"
+    // outcome with a "blocked" status even though the PR already opened. A
+    // human abort still cancels, because a live run records neither outcome.
     const subjectKey = ticketSubjectKey("jira", ticketKey);
     const activeRun = await adapters.runRegistry.get(subjectKey).catch(() => null);
     if (activeRun?.runId) {
       let recordedFailed: boolean;
+      let recordedSucceeded: boolean;
       try {
         recordedFailed = await isRunRecordedFailed(getDb(), activeRun.runId);
+        recordedSucceeded = recordedFailed
+          ? false
+          : await isRunRecordedSucceeded(getDb(), activeRun.runId);
       } catch (lookupError) {
-        // Do not guess on a lookup failure: treating it as "not failed" would let
-        // this self-triggered webhook cancel a genuinely failed run (the exact
-        // masking bug). Surface a retryable error so the webhook is redelivered.
+        // Do not guess on a lookup failure: treating it as "not terminal" would
+        // let this self-triggered webhook cancel a genuinely finished run (the
+        // exact masking bug). Surface a retryable error so the webhook is
+        // redelivered.
         logger.warn(
           { ticketKey, runId: activeRun.runId, err: String(lookupError) },
           "webhook_run_failed_lookup_failed",
@@ -227,6 +235,13 @@ export default defineEventHandler(async (event) => {
           "webhook_skip_cancel_run_already_failed",
         );
         return { status: "ignored", reason: "run_already_failed", ticketKey };
+      }
+      if (recordedSucceeded) {
+        logger.info(
+          { ticketKey, runId: activeRun.runId, payloadStatus: ticketStatus },
+          "webhook_skip_cancel_run_already_succeeded",
+        );
+        return { status: "ignored", reason: "run_already_succeeded", ticketKey };
       }
     }
 

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -1052,6 +1052,20 @@ async function markRunFailedOnSelfMoveStep(runId: string): Promise<void> {
 }
 markRunFailedOnSelfMoveStep.maxRetries = 0;
 
+/**
+ * Records the run's "success" status before its success-finalizing AI Review
+ * move fires the self-triggered "ticket left the AI column" webhook, so that
+ * webhook cannot cancel the run out of a genuine success. See
+ * markRunSucceededOnSelfMove.
+ */
+async function markRunSucceededOnSelfMoveStep(runId: string): Promise<void> {
+  "use step";
+  const { getDb } = await import("../db/client.js");
+  const { markRunSucceededOnSelfMove } = await import("../lib/telemetry/run-telemetry.js");
+  await markRunSucceededOnSelfMove(getDb(), runId);
+}
+markRunSucceededOnSelfMoveStep.maxRetries = 0;
+
 async function logWorkflowExecutionErrorStep(
   event: WorkflowExecutionLogEvent,
 ): Promise<void> {
@@ -2586,6 +2600,17 @@ async function agentWorkflowBody(
             });
             if (!entry.ticketKey) {
               throw new Error("Update Ticket Status requires a correlated ticket.");
+            }
+            // The "ai_review" move is the run's own successful completion.
+            // Commit the run's "success" status BEFORE that move fires the
+            // self-triggered "ticket left the AI column" webhook (same race as
+            // failureExit): when the webhook's actor lookup transiently fails
+            // it fails safe as a human move and would cancel this
+            // still-finalizing run, recording a real success as "blocked".
+            // Only the symbolic success target gets this; backlog or arbitrary
+            // status moves are generic ticket moves, not a completion.
+            if (targetName === "ai_review") {
+              await markRunSucceededOnSelfMoveStep(workflowRunId);
             }
             await moveTicketStep(entry.ticketKey, target, transitionOwner);
             return { kind: "next", output: { status: "ok", target: targetName } };


### PR DESCRIPTION
## Stack

- PR 1 of 1
- Base: `main`
- Follow-up to #144, observed on the AWP-17 dogfooding run (wrun_01KY74FC7JZ9PYHC7GF6GEK20X): the run finished with a PR and the AI Review move, yet its recorded status ended "blocked".

## What changed

- Freezes the run's "success" status (markRunSucceededOnSelfMove + a "use step" caller) immediately BEFORE the success-finalizing move to the AI Review column, mirroring the existing markRunFailedOnSelfMove pattern for backlog moves. Applied at the single success-move call site (the update_ticket_status executor, gated on the symbolic "ai_review" target); backlog and arbitrary status-id moves stay generic.
- Extends the Jira webhook's outside-AI cancel guard: a run already recorded successful is not cancelled (`run_already_succeeded`), alongside the existing `run_already_failed`; lookup errors still fail closed with a retryable 503.

## Why

The bot's own success move fires the "ticket left the AI column" webhook. The webhook normally ignores workflow-actor moves, but on a transient actor-lookup failure it deliberately fails safe as a human move and cancels the still-finalizing run, overwriting a genuine success (PR opened, ticket moved) with a "blocked" status and tombstoning the answered clarification. Same race as the fixed failed-run-masked-as-cancelled bug, on the success path.

## Verification

- Targeted suites (telemetry, jira webhook, workflows, db queries): 580/580.
- Real-SDK workflow harness: 11/11.
- `pnpm -C apps/worker typecheck`: clean.
- New tests mirror the failed-path coverage: freeze semantics (advance in-flight and NULL-status rows, never downgrade a frozen outcome), webhook skip on recorded success, fail-closed 503 on lookup errors.
