### PR TITLE
fix(dashboard): honest clarification answer panel states

### DIFF
--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 
 import { FlameGraph } from "@/components/flame-graph";
 import { CkCard, CkKPI, CkChip, CkStatusPill } from "@/components/ui";
+import { answerPanelMode } from "@/lib/answer-panel-mode";
 import { readErrorMessage } from "@/lib/api/error-message";
 import { runHref } from "@/lib/run-href";
 import { SPAN_KIND_COLOR } from "@/lib/theme";
@@ -14,6 +15,7 @@ import type {
   ClarificationAnswerResponse,
   ClarificationRequest,
   RunDetailResponse,
+  RunStatus,
   RunStep,
   StepStatus,
 } from "@shared/contracts";
@@ -336,7 +338,11 @@ export function TraceDetail({
       )}
 
       {data.clarification && (
-        <AnswerPanel clarification={data.clarification} ticket={run.ticket} />
+        <AnswerPanel
+          clarification={data.clarification}
+          ticket={run.ticket}
+          runStatus={run.status}
+        />
       )}
 
       <CkCard
@@ -463,17 +469,21 @@ export function TraceDetail({
 }
 
 /**
- * Answer panel for a run parked on a clarification question. Rendered purely
- * from `data.clarification` (never `run.status`) so an answered-but-undispatched
- * clarification still shows on a run whose status already flipped. Old workers
- * that never send the field simply omit the panel.
+ * Answer panel for a run parked on a clarification question. Under the
+ * hook-resume design the answer resumes the SAME run in place, so the run's
+ * live status (not the deprecated `dispatchedRunId`) tells whether the answer
+ * took: any status but "awaiting" means the run woke up. The state decision
+ * lives in `answerPanelMode`; a fresh in-page submit result stands in for the
+ * server props until the next poll catches up.
  */
 function AnswerPanel({
   clarification,
   ticket,
+  runStatus,
 }: {
   clarification: ClarificationRequest;
   ticket: string;
+  runStatus: RunStatus;
 }) {
   const router = useRouter();
   const [answer, setAnswer] = React.useState(clarification.answer ?? "");
@@ -483,25 +493,31 @@ function AnswerPanel({
     null,
   );
 
-  if (clarification.status === "superseded") return null;
+  // A fresh submit response is newer than the server props; render from it.
+  const view = result?.clarification ?? clarification;
+  // Legacy rows only: the old design dispatched a separate resume run, so the
+  // asking run stays "awaiting" forever; never offer a retry for those.
+  const legacyRunId = clarification.dispatchedRunId;
+  const mode =
+    legacyRunId !== null
+      ? "resumed"
+      : answerPanelMode(view.status, runStatus, result !== null);
 
-  const answered = clarification.status === "answered";
-  const dispatchedRunId = clarification.dispatchedRunId ?? result?.runId ?? null;
-  // Answer saved but the resume run never started; this is the endpoint retry path.
-  const pendingDispatch =
-    dispatchedRunId === null &&
-    ((answered && clarification.dispatchedRunId === null) || result !== null);
-  const showForm =
-    dispatchedRunId === null && (clarification.status === "pending" || pendingDispatch);
+  if (mode === "hidden") return null;
+
+  const answered = view.status === "answered";
+  const retry = mode === "retry";
+  const showForm = mode === "form" || retry;
 
   async function submit() {
     setBusy(true);
     setError(null);
     try {
       // The worker's retry path deliberately skips the answer CAS (it only
-      // re-verifies and re-dispatches), so any edit would be silently dropped.
-      // Send the SAVED answer on retry; the pending path sends the typed one.
-      const answerToSend = pendingDispatch
+      // re-verifies and re-sends the wake-up), so any edit would be silently
+      // dropped. Send the SAVED answer on retry; the pending path sends the
+      // typed one.
+      const answerToSend = retry
         ? (clarification.answer ?? "").trim()
         : answer.trim();
       const res = await fetch(
@@ -545,47 +561,49 @@ function AnswerPanel({
               Answer
             </span>
             <p className="m-0 whitespace-pre-wrap break-words rounded-[3px] border border-neutral-200 bg-off-white p-3 font-body text-[13px] leading-[1.5] text-coal">
-              {clarification.answer}
+              {view.answer}
             </p>
-            {clarification.answeredAt && (
+            {view.answeredAt && (
               <span className="font-mono text-[11px] text-neutral-500">
                 Answered by{" "}
-                {clarification.answeredByLabel ??
-                  clarification.answeredById ??
-                  "unknown"}{" "}
-                · {fmtClock(clarification.answeredAt)}
+                {view.answeredByLabel ?? view.answeredById ?? "unknown"} ·{" "}
+                {fmtClock(view.answeredAt)}
               </span>
             )}
           </div>
         )}
 
-        {dispatchedRunId && (
+        {legacyRunId ? (
           <div className="font-mono text-[11px] text-success-fg">
             Resumed as{" "}
             <Link
-              href={runHref({ id: dispatchedRunId, ticket })}
+              href={runHref({ id: legacyRunId, ticket })}
               className="text-mariner underline-offset-2 hover:underline"
             >
-              run {dispatchedRunId}
+              run {legacyRunId}
             </Link>
           </div>
-        )}
+        ) : mode === "resumed" ? (
+          <div className="font-mono text-[11px] text-success-fg">
+            The run resumed with this answer.
+          </div>
+        ) : null}
 
         {showForm && (
           <>
-            {pendingDispatch && (
+            {retry && (
               <div className="font-body text-[12px] leading-snug text-neutral-700">
-                The resume run has not started yet. Retry it with the saved
-                answer above.
+                The answer is saved but the run has not resumed yet. It
+                normally resumes automatically within a minute; you can also
+                retry now with the saved answer.
               </div>
             )}
 
             {/* Retry state edits nothing: the worker re-uses the saved answer,
                 so no chips or textarea here - only the read-only Q&A above. */}
-            {!pendingDispatch && (
+            {!retry && (
               <>
-                {!answered &&
-                clarification.suggestedAnswers &&
+                {clarification.suggestedAnswers &&
                 clarification.suggestedAnswers.length > 0 ? (
                   <div className="flex flex-wrap items-center gap-1.5">
                     {clarification.suggestedAnswers.map((a, j) => (
@@ -619,12 +637,12 @@ function AnswerPanel({
             <div className="flex items-center gap-2">
               <DarkButton
                 type="button"
-                disabled={busy || (!pendingDispatch && answer.trim().length === 0)}
+                disabled={busy || (!retry && answer.trim().length === 0)}
                 onClick={submit}
               >
                 {busy
                   ? "Submitting…"
-                  : pendingDispatch
+                  : retry
                     ? "Retry resume run"
                     : "Submit answer"}
               </DarkButton>

--- a/apps/dashboard/lib/answer-panel-mode.test.ts
+++ b/apps/dashboard/lib/answer-panel-mode.test.ts
@@ -1,0 +1,28 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { answerPanelMode } from "./answer-panel-mode";
+
+test("pending clarification shows the form regardless of run status", () => {
+  assert.equal(answerPanelMode("pending", "awaiting", false), "form");
+  assert.equal(answerPanelMode("pending", "running", false), "form");
+});
+
+test("answered clarification with a progressing or finished run reads as resumed", () => {
+  for (const runStatus of ["running", "success", "failed", "blocked"] as const) {
+    assert.equal(answerPanelMode("answered", runStatus, false), "resumed");
+  }
+});
+
+test("answered clarification on a run still awaiting offers the retry", () => {
+  assert.equal(answerPanelMode("answered", "awaiting", false), "retry");
+});
+
+test("a fresh successful submit renders as resumed even while props lag", () => {
+  assert.equal(answerPanelMode("answered", "awaiting", true), "resumed");
+  assert.equal(answerPanelMode("pending", "awaiting", true), "resumed");
+});
+
+test("superseded clarification hides the panel", () => {
+  assert.equal(answerPanelMode("superseded", "running", false), "hidden");
+  assert.equal(answerPanelMode("superseded", "awaiting", true), "hidden");
+});

--- a/apps/dashboard/lib/answer-panel-mode.ts
+++ b/apps/dashboard/lib/answer-panel-mode.ts
@@ -1,0 +1,26 @@
+import type { ClarificationStatus, RunStatus } from "@shared/contracts";
+
+/** What the clarification answer panel on the run trace screen should render. */
+export type AnswerPanelMode = "hidden" | "form" | "resumed" | "retry";
+
+/**
+ * Decide the panel state from the clarification status and the LIVE run
+ * status. The clarification's `dispatchedRunId` is deprecated and always null
+ * under the hook-resume design (the asking run resumes in place), so the run
+ * status is the honest signal for whether the saved answer actually woke the
+ * run up: anything but "awaiting" means it did.
+ *
+ * `submittedNow` marks a successful in-page submit. Both the clarification
+ * prop and the run prop can lag until the next poll, so a fresh submit
+ * renders as resumed instead of flashing the retry state.
+ */
+export function answerPanelMode(
+  clarificationStatus: ClarificationStatus,
+  runStatus: RunStatus,
+  submittedNow: boolean,
+): AnswerPanelMode {
+  if (clarificationStatus === "superseded") return "hidden";
+  if (submittedNow) return "resumed";
+  if (clarificationStatus === "pending") return "form";
+  return runStatus === "awaiting" ? "retry" : "resumed";
+}


### PR DESCRIPTION
## Stack

- PR 1 of 1
- Base: `main`
- Follow-up to #137/#144: dashboard-only UX fix observed during the AWP-14/AWP-17 dogfooding.

## What changed

- The run trace's clarification answer panel now decides its state from the run's live status via a small pure helper (`answerPanelMode`), instead of the deprecated `clarification.dispatchedRunId`, which is always null under the hook-resume design. That stale check made every answered clarification permanently show "The resume run has not started yet" plus a retry button, even while the resumed run was working or had already opened its PR.
- Answered + run progressing or finished: a calm "The run resumed with this answer." line, no button. Answered + run still "awaiting" (the genuine lost-resume state, which the cron heals and the retry re-sends idempotently): honest copy plus the existing retry button. Pending: unchanged form. A fresh in-page submit renders as resumed immediately so the retry state cannot flash while props lag a poll cycle.
- Legacy rows with a real `dispatchedRunId` keep their "Resumed as run X" link and never show retry.

## Verification

- `pnpm -C apps/dashboard test`: 308 passing (5 new helper tests).
- `pnpm -C apps/dashboard typecheck`: clean.
