### PR TITLE
fix(worker): stop the Jira automation review-move race cancelling finishing runs

### DIFF
--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../env.js", () => ({
   env: {
     JIRA_PROJECT_KEY: "PROJ",
     COLUMN_AI: "AI",
+    COLUMN_AI_REVIEW: "Review",
     COLUMN_BACKLOG: "Backlog",
     JIRA_BACKLOG_TRANSITION_ID: undefined,
   },
@@ -502,6 +503,38 @@ describe("reconcileRuns owner-CAS recovery", () => {
       onReleased,
     );
     expect(onReleased).toHaveBeenCalledWith(bound.subjectKey);
+  });
+
+  it("retains a bound run whose ticket sits in the AI Review column while it still executes", async () => {
+    // A Jira automation rule raced the run's own success move: the ticket
+    // reached AI Review while the run is still finalizing (world status
+    // "running"). Cancelling now would record a genuine success as blocked.
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(new Set(), runRegistry, issueTracker("Review")),
+    ).toEqual({ cancelled: 0, cleaned: 0 });
+    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(runRegistry.release).not.toHaveBeenCalled();
+  });
+
+  it("still releases an AI Review ticket's owner once its world run is terminal", async () => {
+    // Normal post-success janitor duty: the run completed, its ticket sits in
+    // AI Review, and the orphan path's already-terminal cancellation releases
+    // the exact owner as before.
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+    mockCancelRun.mockResolvedValue(true);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(new Set(), runRegistry, issueTracker("Review")),
+    ).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockCancelRun).toHaveBeenCalledOnce();
   });
 
   it("never releases an owner solely because the Workflow status API is unreachable", async () => {

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -127,7 +127,17 @@ export async function reconcileRuns(
       );
       continue;
     }
-    if (!(await verifyTicketLeftAiColumn(ticketKey, issueTracker))) continue;
+    const departure = await verifyTicketLeftAiColumn(ticketKey, issueTracker);
+    if (!departure.left) continue;
+    if (
+      await shouldRetainFinalizingRunInAiReview(
+        ticketKey,
+        entry.runId,
+        departure.trackerStatus,
+      )
+    ) {
+      continue;
+    }
 
     const cancellationConfirmed = await cancelRun(
       ticketKey,
@@ -384,8 +394,8 @@ async function stopOwnedSandboxes(
 async function verifyTicketLeftAiColumn(
   ticketKey: string,
   issueTracker?: IssueTrackerAdapter,
-): Promise<boolean> {
-  if (!issueTracker) return true;
+): Promise<{ left: boolean; trackerStatus: string | null }> {
+  if (!issueTracker) return { left: true, trackerStatus: null };
 
   try {
     const ticket = await issueTracker.fetchTicket(ticketKey);
@@ -398,19 +408,54 @@ async function verifyTicketLeftAiColumn(
         { ticketKey, status: ticket.trackerStatus, projectKey: ticketProjectKey },
         "reconcile_kept_run_missing_from_poll_snapshot",
       );
-      return false;
+      return { left: false, trackerStatus: ticket.trackerStatus };
     }
-    return true;
+    return { left: true, trackerStatus: ticket.trackerStatus };
   } catch (err) {
     if (err instanceof IssueTrackerNotFoundError || getErrorCode(err) === "NOT_FOUND") {
-      return true;
+      return { left: true, trackerStatus: null };
     }
     logger.warn(
       { ticketKey, error: (err as Error).message },
       "reconcile_orphan_verification_failed",
     );
+    return { left: false, trackerStatus: null };
+  }
+}
+
+/**
+ * A ticket sitting in the AI Review column while its bound run is still
+ * executing is the run's own success destination reached early: a Jira
+ * automation rule (or an eager human) raced the run's final self-move as soon
+ * as the PR appeared, before the run could freeze its "success" status.
+ * Cancelling would record that genuine success as "cancelled"/"blocked".
+ * Retain the owner until the Workflow world reports a terminal status; the
+ * next tick then releases it through this same orphan path (cancelRun's
+ * already-terminal branch) exactly as for a normal completion.
+ */
+async function shouldRetainFinalizingRunInAiReview(
+  ticketKey: string,
+  runId: string,
+  trackerStatus: string | null,
+): Promise<boolean> {
+  if (
+    trackerStatus === null ||
+    trackerStatus.trim().toLowerCase() !== env.COLUMN_AI_REVIEW.trim().toLowerCase()
+  ) {
     return false;
   }
+  try {
+    const status = await getRun(runId).status;
+    if (TERMINAL_STATUSES.has(status)) return false;
+  } catch {
+    // Reachability is not terminal proof (same rule as cleanFinishedRun):
+    // retain the exact owner and let a later tick decide.
+  }
+  logger.info(
+    { ticketKey, runId },
+    "reconcile_retained_finalizing_run_in_ai_review",
+  );
+  return true;
 }
 
 function resolveTicketProjectKey(ticket: {

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -6,6 +6,7 @@ const state = vi.hoisted(() => ({
   env: {
     JIRA_PROJECT_KEY: "PROJ",
     COLUMN_AI: "AI",
+    COLUMN_AI_REVIEW: "Review",
     MAX_CONCURRENT_AGENTS: 3,
     JIRA_WEBHOOK_SECRET: "secret" as string | undefined,
   },
@@ -179,6 +180,33 @@ describe("POST /webhooks/jira", () => {
     });
     expect(state.isRunRecordedSucceeded).toHaveBeenCalledWith(expect.anything(), "run-1");
     expect(state.cancel).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel a still-finalizing run when the live ticket sits in the AI Review column", async () => {
+    // A Jira automation rule races the run's own success move: it lands the
+    // ticket in AI Review right after the PR link appears, BEFORE the run
+    // froze its "success" status. Entering the review column is a completion
+    // gesture, never an abort, so the webhook must not cancel the run.
+    const connected = adapters();
+    connected.issueTracker.fetchTicket.mockResolvedValue({
+      identifier: "PROJ-42",
+      projectKey: "PROJ",
+      trackerStatus: "Review",
+    });
+    state.createAdapters.mockReturnValue(connected);
+
+    const response = await app()(request({ actor: "automation-account", status: "Review" }));
+
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "ticket_in_ai_review_column",
+      ticketKey: "PROJ-42",
+    });
+    expect(state.cancel).not.toHaveBeenCalled();
+    // The guard sits before the recorded-outcome lookup: a review-column move
+    // must never surface the retryable 503 of a failed lookup either.
+    expect(state.isRunRecordedFailed).not.toHaveBeenCalled();
+    expect(state.isRunRecordedSucceeded).not.toHaveBeenCalled();
   });
 
   it("surfaces a retryable error when the failed-status lookup fails (does not cancel)", async () => {

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -197,6 +197,28 @@ export default defineEventHandler(async (event) => {
       };
     }
 
+    // The AI Review column is the flow's own success destination: the run's
+    // final update_ticket_status block moves the finished ticket there right
+    // after the PR opens. A Jira automation rule (or an eager human) can race
+    // that same move as soon as the PR link appears, landing the ticket in AI
+    // Review while the run is still finalizing and BEFORE the self-move froze
+    // the "success" status, so the recorded-outcome guard below cannot help.
+    // Entering the review column is a completion gesture, never an abort:
+    // skip cancellation and let the run finish. Its own later move lands as a
+    // no-op (moveTicketForRun's already-at-target check). A human abort still
+    // cancels, because it moves the ticket to a non-review column.
+    if (isAiReviewColumnStatus(liveTicketState.status)) {
+      logger.info(
+        {
+          ticketKey,
+          payloadStatus: ticketStatus,
+          liveStatus: liveTicketState.status,
+        },
+        "webhook_skip_cancel_ticket_in_ai_review_column",
+      );
+      return { status: "ignored", reason: "ticket_in_ai_review_column", ticketKey };
+    }
+
     // The bot's OWN finalization moves this ticket out of the AI column: its
     // failure handling moves a failed run's ticket to the backlog, and its
     // success handling moves a finished run's ticket to AI Review. Both fire
@@ -460,6 +482,13 @@ function extractStatusChange(
 
 function isAiColumnStatus(status: string): boolean {
   return status.trim().toLowerCase() === env.COLUMN_AI.trim().toLowerCase();
+}
+
+function isAiReviewColumnStatus(status: string | null): boolean {
+  return (
+    status !== null &&
+    status.trim().toLowerCase() === env.COLUMN_AI_REVIEW.trim().toLowerCase()
+  );
 }
 
 async function cancelTrackedRun(


### PR DESCRIPTION
## Stack

- PR 1 of 1
- Base: `main`
- Closes the remaining terminal-status incident behind #145 (runs AWP-17 wrun_01KY74FC..., AWP-19 wrun_01KY782W..., reproduced deterministically on AWP-20 wrun_01KY79V4...).

## Root cause (evidence-backed)

A Jira Automation rule ("Automation for Jira", accountId 557058:f58131cb...) moves the ticket Ai to REVIEW as soon as the run's PR appears, racing the run's own final `update_ticket_status` move. When the automation wins, the webhook sees a genuine non-workflow actor leaving the AI column and cancels the still-finalizing run; the #145 freeze cannot help because it runs immediately before the run's OWN move, which has not happened yet. The world run flips to cancelled ("blocked" in telemetry) and the answered clarification rows get tombstoned. Changelog actors prove it: AWP-19's Ai to REVIEW at 12:33:11 was authored by Automation for Jira, the world cancel followed 2.7 s later; AWP-15 recorded success only because its own move won the race. A fully automated repro (AWP-20: clarification answered via the dashboard API, no human) captured the same sequence live.

## What changed

- Jira webhook, outside-AI cancel branch: when the LIVE ticket status is the AI Review column, skip cancellation (`ticket_in_ai_review_column`). Entering the review column is a completion gesture, never an abort; the run's own later move no-ops via the already-at-target check and `recordRunUsage` freezes the genuine success. Human aborts are untouched: any non-review move still cancels.
- Reconcile: the cron retains a finalizing run whose ticket sits in AI Review until the world run is terminal (`reconcile_retained_finalizing_run_in_ai_review`); terminal runs release the claim exactly as before.

## Verification

- Targeted suites (jira webhook, reconcile, cancel-run, poll): 46/46.
- `pnpm -C apps/worker typecheck`: clean.
- Live repro AWP-20 documented in the run history; its stray PR (Blazity/ai-workflow-prod #10) should be closed manually.

Operational note: the Automation rule duplicates the flow's own Ai to REVIEW move; consider disabling or re-targeting it, though with this fix it is harmless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tickets moved to the **AI Review** column while an automated run is still finishing.
  * Active runs are no longer incorrectly cancelled when a ticket reaches AI Review.
  * Finalizing runs remain associated with their owner until completion is confirmed.
  * Webhook events for tickets in AI Review are safely ignored to prevent incorrect failure or success updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->