### PR TITLE
Add manual workflow dispatch from trigger blocks

### DIFF
--- a/apps/dashboard/app/api/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch/preflight/route.ts
+++ b/apps/dashboard/app/api/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch/preflight/route.ts
@@ -1,0 +1,9 @@
+import { proxyWorker } from "@/lib/api/proxy";
+import { handleManualDispatchPreflight } from "../../../../../handler";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string; nodeId: string }> },
+) {
+  return handleManualDispatchPreflight(req, { params }, proxyWorker);
+}

--- a/apps/dashboard/app/api/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch/route.ts
+++ b/apps/dashboard/app/api/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch/route.ts
@@ -1,0 +1,9 @@
+import { proxyWorker } from "@/lib/api/proxy";
+import { handleManualDispatch } from "../../../../handler";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string; nodeId: string }> },
+) {
+  return handleManualDispatch(req, { params }, proxyWorker);
+}

--- a/apps/dashboard/app/api/workflow-definitions/handler.ts
+++ b/apps/dashboard/app/api/workflow-definitions/handler.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 type WorkerProxy = (path: string, init?: RequestInit) => Promise<Response>;
 type IdRouteContext = { params: Promise<{ id: string }> };
+type TriggerRouteContext = { params: Promise<{ id: string; nodeId: string }> };
 
 export async function handleDefinitionsList(workerProxy: WorkerProxy) {
   return forward(workerProxy, "/api/v1/workflow-definitions", { method: "GET" });
@@ -111,6 +112,41 @@ export async function handleDefinitionLayout(
   workerProxy: WorkerProxy,
 ) {
   return forwardJsonAction(req, context, workerProxy, "layout", "PATCH");
+}
+
+export async function handleManualDispatchPreflight(
+  req: Request,
+  context: TriggerRouteContext,
+  workerProxy: WorkerProxy,
+) {
+  return forwardManualDispatch(req, context, workerProxy, "preflight");
+}
+
+export async function handleManualDispatch(
+  req: Request,
+  context: TriggerRouteContext,
+  workerProxy: WorkerProxy,
+) {
+  return forwardManualDispatch(req, context, workerProxy);
+}
+
+async function forwardManualDispatch(
+  req: Request,
+  { params }: TriggerRouteContext,
+  workerProxy: WorkerProxy,
+  action?: "preflight",
+) {
+  const { id, nodeId } = await params;
+  const suffix = action ? `/manual-dispatch/${action}` : "/manual-dispatch";
+  return forward(
+    workerProxy,
+    `/api/v1/workflow-definitions/${encodeURIComponent(id)}/triggers/${encodeURIComponent(nodeId)}${suffix}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: await req.text(),
+    },
+  );
 }
 
 async function forwardJsonAction(

--- a/apps/dashboard/app/api/workflow-definitions/route.test.ts
+++ b/apps/dashboard/app/api/workflow-definitions/route.test.ts
@@ -12,11 +12,16 @@ import {
   handleDefinitionRollback,
   handleDefinitionValidate,
   handleDefinitionRestore,
+  handleManualDispatch,
+  handleManualDispatchPreflight,
   handleDefinitionsCreate,
   handleDefinitionsList,
 } from "./handler.ts";
 
 const idParams = (id: string) => ({ params: Promise.resolve({ id }) });
+const triggerParams = (id: string, nodeId: string) => ({
+  params: Promise.resolve({ id, nodeId }),
+});
 
 test("list GET forwards to the worker and re-serializes status", async () => {
   const res = await handleDefinitionsList(async (path, init) => {
@@ -107,6 +112,53 @@ test("detail DELETE forwards and re-serializes status", async () => {
   });
   assert.equal(res.status, 200);
   assert.deepEqual(await res.json(), { ok: true });
+});
+
+test("manual dispatch preflight forwards the trigger path and body", async () => {
+  const calls: Array<{ path: string; init: RequestInit }> = [];
+  const res = await handleManualDispatchPreflight(
+    new Request("https://dashboard.example.com/api/workflow-definitions/12", {
+      method: "POST",
+      body: JSON.stringify({ kind: "ticket", ticketKey: "AIW-173" }),
+    }),
+    triggerParams("12", "ticket trigger"),
+    async (path, init) => {
+      calls.push({ path, init: init ?? {} });
+      return Response.json({ runnable: true }, { status: 200 });
+    },
+  );
+  assert.equal(res.status, 200);
+  assert.equal(
+    calls[0].path,
+    "/api/v1/workflow-definitions/12/triggers/ticket%20trigger/manual-dispatch/preflight",
+  );
+  assert.deepEqual(JSON.parse(String(calls[0].init.body)), {
+    kind: "ticket",
+    ticketKey: "AIW-173",
+  });
+});
+
+test("manual dispatch preserves recovering status from the worker", async () => {
+  const res = await handleManualDispatch(
+    new Request("https://dashboard.example.com/api/workflow-definitions/12", {
+      method: "POST",
+      body: JSON.stringify({
+        requestId: "1b02cf6d-d510-4ae1-a26d-c22f777b1b3a",
+        expectedDeployedVersion: 3,
+        input: { kind: "ticket", ticketKey: "AIW-173" },
+      }),
+    }),
+    triggerParams("12", "trigger"),
+    async (path) => {
+      assert.equal(
+        path,
+        "/api/v1/workflow-definitions/12/triggers/trigger/manual-dispatch",
+      );
+      return Response.json({ status: "recovering" }, { status: 202 });
+    },
+  );
+  assert.equal(res.status, 202);
+  assert.deepEqual(await res.json(), { status: "recovering" });
 });
 
 test("restore forwards to the nested worker path", async () => {

--- a/apps/dashboard/app/editor-data.tsx
+++ b/apps/dashboard/app/editor-data.tsx
@@ -53,6 +53,8 @@ export async function EditorData({
         options={list.options}
         liveBlocks={liveBlocks}
         canEdit={session.canEditWorkflows}
+        canDispatch={session.canDispatchWorkflows}
+        actorLabel={session.actorLabel}
         initialNodeId={nodeId}
       />
     );

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor-validation.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor-validation.test.tsx
@@ -236,6 +236,53 @@ test("generic editor errors retain their in-flow presentation", () => {
   assert.doesNotMatch(html, /data-error-presentation="overlay"/);
 });
 
+test("a runnable deployed trigger shows the circular play button beside the node", () => {
+  const html = renderToStaticMarkup(
+    <FlowEditor
+      nodes={[node]}
+      edges={[]}
+      {...editorInteractionProps}
+      schemaVersion={1}
+      limits={{}}
+      onLimitsChange={() => undefined}
+      onNodesChange={() => undefined}
+      onEdgesChange={() => undefined}
+      canEdit
+      runnableTriggerIds={new Set(["entry"])}
+      onRunTrigger={() => undefined}
+      dirty={false}
+      saveEnabled
+      saving={false}
+      error={null}
+      validation={{
+        status: "valid",
+        issues: [],
+        nodeContracts: { entry: triggerContract },
+        availableValuesByNode: {},
+      }}
+      onSave={() => undefined}
+      headerTitle="Ticket workflow"
+      headerVersionBadge="deployed v3"
+      options={options}
+    />,
+  );
+
+  assert.match(html, /aria-label="Run Ticket received"/);
+  assert.match(html, /h-7 w-7/);
+  assert.match(html, /-right-\[38px\] -top-\[15px\]/);
+  assert.match(html, /title="Run trigger"/);
+});
+
+test("draft-only triggers do not expose manual dispatch", () => {
+  const html = renderEditor({
+    status: "valid",
+    issues: [],
+    nodeContracts: { entry: triggerContract },
+    availableValuesByNode: {},
+  });
+  assert.doesNotMatch(html, /aria-label="Run Ticket received"/);
+});
+
 test("editor actions and canvas controls expose keyboard labels and names", () => {
   const html = renderEditor({
     status: "valid",

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { PlayIcon } from "@phosphor-icons/react/dist/csr/Play";
 import {
   fromFlowDefinitionV1Node,
   fromFlowDefinitionV2Node,
@@ -207,11 +208,13 @@ const FlowNode = React.memo(function FlowNode({
   node,
   options,
   canEdit,
+  canRun,
   selected,
   dataSourceHighlighted,
   locked,
   outPorts,
   onSelect,
+  onRun,
   onRequestDelete,
   onDragStart,
   onPortDown,
@@ -226,11 +229,13 @@ const FlowNode = React.memo(function FlowNode({
   node: FlowNodeDef;
   options: WorkflowEditorOptions;
   canEdit: boolean;
+  canRun: boolean;
   selected: boolean;
   dataSourceHighlighted: boolean;
   locked: boolean;
   outPorts: string[];
   onSelect: (id: string, event: React.MouseEvent) => void;
+  onRun: (node: FlowNodeDef) => void;
   onRequestDelete: (id: string) => void;
   onDragStart: (e: React.PointerEvent, node: FlowNodeDef) => void;
   onPortDown: (e: React.PointerEvent, nodeId: string, portId: string) => void;
@@ -299,6 +304,22 @@ const FlowNode = React.memo(function FlowNode({
         data-canvas-node-selector={node.id}
         className="absolute inset-0 z-[1] appearance-none rounded-[3px] bg-transparent text-left outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-mariner focus-visible:outline-offset-2"
       />
+      {canRun && (
+        <button
+          type="button"
+          aria-label={`Run ${node.name || cat.label}`}
+          title="Run trigger"
+          onPointerDown={(event) => event.stopPropagation()}
+          onPointerUp={(event) => event.stopPropagation()}
+          onClick={(event) => {
+            event.stopPropagation();
+            onRun(node);
+          }}
+          className="absolute -right-[38px] -top-[15px] z-[8] inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-full border border-mariner bg-panel text-mariner shadow-[0_2px_5px_rgba(24,27,32,0.16)] transition-[background,color,transform] duration-[120ms] hover:scale-105 hover:bg-mariner hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mariner focus-visible:ring-offset-2"
+        >
+          <PlayIcon size={13} weight="fill" aria-hidden />
+        </button>
+      )}
       {invalid && (
         <span id={validationDescriptionId(node.id)} className="sr-only">
           Validation errors: {validationIssues.map((issue) => issue.message).join("; ")}
@@ -438,6 +459,7 @@ function FlowCanvas({
   edgeGeometry,
   schemaVersion,
   canEdit,
+  runnableTriggerIds,
   options,
   onNodesChange,
   onEdgeGeometryChange,
@@ -451,6 +473,7 @@ function FlowCanvas({
   selection,
   setSelection,
   highlightedSourceIds,
+  onRunTrigger,
   fullView,
   onToggleFullView,
   fitSignal,
@@ -464,6 +487,7 @@ function FlowCanvas({
   edgeGeometry: Record<string, WorkflowEdgeGeometry>;
   schemaVersion: 1 | 2;
   canEdit: boolean;
+  runnableTriggerIds?: ReadonlySet<string>;
   options: WorkflowEditorOptions;
   onNodesChange: React.Dispatch<React.SetStateAction<FlowNodeDef[]>>;
   onEdgeGeometryChange: React.Dispatch<
@@ -479,6 +503,7 @@ function FlowCanvas({
   selection: CanvasSelection;
   setSelection: React.Dispatch<React.SetStateAction<CanvasSelection>>;
   highlightedSourceIds: ReadonlySet<string>;
+  onRunTrigger?: (node: FlowNodeDef) => void;
   fullView: boolean;
   onToggleFullView: () => void;
   fitSignal: number;
@@ -1202,11 +1227,15 @@ function FlowCanvas({
             node={n}
             options={options}
             canEdit={canEdit}
+            canRun={Boolean(
+              onRunTrigger && runnableTriggerIds?.has(n.id),
+            )}
             selected={selection.nodeIds.includes(n.id)}
             dataSourceHighlighted={highlightedSourceIds.has(n.id)}
             locked={isTriggerBlockType(n.type) && triggerCount === 1}
             outPorts={portsByNode[n.id] ?? []}
             onSelect={selectNode}
+            onRun={(node) => onRunTrigger?.(node)}
             onRequestDelete={onDeleteNode}
             onDragStart={startNodeDrag}
             onPortDown={onPortDown}
@@ -1283,6 +1312,8 @@ export function FlowEditor({
   onCommitTransaction,
   onCancelTransaction,
   canEdit,
+  runnableTriggerIds,
+  onRunTrigger,
   dirty,
   saveEnabled,
   saving,
@@ -1328,6 +1359,8 @@ export function FlowEditor({
   onCommitTransaction: () => void;
   onCancelTransaction: () => void;
   canEdit: boolean;
+  runnableTriggerIds?: ReadonlySet<string>;
+  onRunTrigger?: (node: FlowNodeDef) => void;
   dirty: boolean;
   saveEnabled: boolean;
   saving: boolean;
@@ -1983,6 +2016,7 @@ export function FlowEditor({
           edgeGeometry={edgeGeometry}
           schemaVersion={schemaVersion}
           canEdit={canEdit}
+          runnableTriggerIds={runnableTriggerIds}
           options={options}
           onNodesChange={onNodePositionsChange}
           onEdgeGeometryChange={onEdgeGeometryChange}
@@ -1996,6 +2030,7 @@ export function FlowEditor({
           selection={selection}
           setSelection={setSelection}
           highlightedSourceIds={highlightedSourceIdSet}
+          onRunTrigger={onRunTrigger}
           fullView={fullView}
           onToggleFullView={() => setFullView((v) => !v)}
           fitSignal={fitSignal ?? 0}

--- a/apps/dashboard/components/cockpit/manual-dispatch-modal.test.tsx
+++ b/apps/dashboard/components/cockpit/manual-dispatch-modal.test.tsx
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type {
+  WorkflowBlockContract,
+  WorkflowEditorOptions,
+} from "@shared/contracts";
+import type { FlowNodeDef } from "@/lib/flows";
+import { ManualDispatchModal } from "./manual-dispatch-modal";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const unknownSchema = { type: "unknown" } as const;
+const ticketContract: WorkflowBlockContract = {
+  type: "trigger_ticket_ai",
+  presentation: {
+    group: "trigger",
+    label: "Ticket assigned to AI",
+    description: "Starts from Jira.",
+    color: "#3C43E7",
+    softColor: "#EEF0FF",
+    glyph: "T",
+  },
+  defaults: {},
+  ports: ["next"],
+  allowsFailurePort: false,
+  inputs: {},
+  additionalInputs: [],
+  output: {
+    schema: unknownSchema,
+    bindingSchema: unknownSchema,
+    statusVariants: ["ok"],
+  },
+  availability: { available: true, unavailableReason: null },
+};
+const prContract: WorkflowBlockContract = {
+  ...ticketContract,
+  type: "trigger_pr_created",
+  presentation: {
+    ...ticketContract.presentation,
+    label: "PR created",
+  },
+};
+const options = {
+  defaultModel: "model",
+  blockRegistry: {
+    trigger_ticket_ai: ticketContract,
+    trigger_pr_created: prContract,
+  },
+} as WorkflowEditorOptions;
+
+function render(trigger: FlowNodeDef, dirty = false) {
+  return renderToStaticMarkup(
+    <ManualDispatchModal
+      definitionId={9}
+      workflowName="Standard delivery"
+      deployedVersion={7}
+      trigger={trigger}
+      options={options}
+      actorLabel="Karol"
+      dirty={dirty}
+      onClose={() => undefined}
+    />,
+  );
+}
+
+test("ticket modal names the exact deployed version and excludes dirty drafts", () => {
+  const html = render(
+    {
+      id: "ticket-trigger",
+      type: "trigger_ticket_ai",
+      name: "Ticket assigned to AI",
+      x: 0,
+      y: 0,
+      params: {},
+      inputs: {},
+    },
+    true,
+  );
+  assert.match(html, /Run from Ticket assigned to AI/);
+  assert.match(html, /Standard delivery · deployed v7/);
+  assert.match(html, /Unsaved draft changes are excluded/);
+  assert.match(html, /Ticket key/);
+  assert.match(html, /Requested by Karol/);
+});
+
+test("PR modal accepts an authoritative provider URL without Jira movement copy", () => {
+  const html = render({
+    id: "pr-trigger",
+    type: "trigger_pr_created",
+    name: "PR created",
+    x: 0,
+    y: 0,
+    params: {},
+    inputs: {},
+  });
+  assert.match(html, /Pull or merge request URL/);
+  assert.match(html, /https:\/\/github\.com\/org\/repo\/pull\/123/);
+  assert.doesNotMatch(html, /Move to AI/);
+  assert.match(html, /One active run per pull request/);
+});

--- a/apps/dashboard/components/cockpit/manual-dispatch-modal.tsx
+++ b/apps/dashboard/components/cockpit/manual-dispatch-modal.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/csr/ArrowSquareOut";
+import { ShieldCheckIcon } from "@phosphor-icons/react/dist/csr/ShieldCheck";
+import { UserIcon } from "@phosphor-icons/react/dist/csr/User";
+import { XIcon } from "@phosphor-icons/react/dist/csr/X";
+import type {
+  ManualDispatchInput,
+  ManualDispatchPreflightResponse,
+  ManualDispatchResponse,
+} from "@shared/contracts";
+import type { FlowNodeDef } from "@/lib/flows";
+import { readErrorMessage } from "@/lib/api/error-message";
+import { blockPresentation } from "./flow-editor/blocks";
+import type { WorkflowEditorOptions } from "@shared/contracts";
+
+export function ManualDispatchModal({
+  definitionId,
+  workflowName,
+  deployedVersion,
+  trigger,
+  options,
+  actorLabel,
+  dirty,
+  onClose,
+}: {
+  definitionId: number;
+  workflowName: string;
+  deployedVersion: number;
+  trigger: FlowNodeDef;
+  options: WorkflowEditorOptions;
+  actorLabel: string;
+  dirty: boolean;
+  onClose: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isTicket = trigger.type === "trigger_ticket_ai";
+  const triggerLabel =
+    trigger.name || blockPresentation(options, trigger.type).label;
+  const [rawInput, setRawInput] = useState("");
+  const [preflight, setPreflight] =
+    useState<ManualDispatchPreflightResponse | null>(null);
+  const [result, setResult] = useState<ManualDispatchResponse | null>(null);
+  const [busy, setBusy] = useState<"preflight" | "dispatch" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const dispatchInput = (): ManualDispatchInput =>
+    isTicket
+      ? { kind: "ticket", ticketKey: rawInput.trim() }
+      : { kind: "pull_request", url: rawInput.trim() };
+
+  async function runPreflight(event: React.FormEvent) {
+    event.preventDefault();
+    if (!rawInput.trim()) return;
+    setBusy("preflight");
+    setError(null);
+    setResult(null);
+    try {
+      const response = await fetch(
+        `/api/workflow-definitions/${definitionId}/triggers/${encodeURIComponent(trigger.id)}/manual-dispatch/preflight`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(dispatchInput()),
+        },
+      );
+      if (!response.ok) throw new Error(await readErrorMessage(response));
+      setPreflight((await response.json()) as ManualDispatchPreflightResponse);
+    } catch (caught) {
+      setPreflight(null);
+      setError(
+        caught instanceof Error ? caught.message : "Unable to check this dispatch",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function startDispatch() {
+    if (!preflight?.runnable) return;
+    setBusy("dispatch");
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/workflow-definitions/${definitionId}/triggers/${encodeURIComponent(trigger.id)}/manual-dispatch`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            requestId: globalThis.crypto.randomUUID(),
+            expectedDeployedVersion: preflight.deployedVersion,
+            input: preflight.input,
+          }),
+        },
+      );
+      if (!response.ok) throw new Error(await readErrorMessage(response));
+      setResult((await response.json()) as ManualDispatchResponse);
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "Unable to start this workflow",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const movesTicket =
+    isTicket && preflight?.steps.some((step) => step.title.startsWith("Move "));
+  const primaryLabel = movesTicket ? "Move to AI & Run" : "Run workflow";
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-coal/30 px-4 py-6 backdrop-blur-[1px]"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="manual-dispatch-title"
+        className="w-full max-w-[476px] overflow-hidden rounded-[6px] border border-neutral-200 bg-panel shadow-[0_18px_60px_rgba(24,27,32,0.22)]"
+      >
+        <div className="px-7 pb-6 pt-7">
+          <div className="flex items-start gap-4">
+            <div className="min-w-0 flex-1">
+              <h2
+                id="manual-dispatch-title"
+                className="font-display text-[20px] font-semibold leading-tight text-coal"
+              >
+                Run from {triggerLabel}
+              </h2>
+              <p className="mt-1 font-body text-[13px] text-neutral-600">
+                {workflowName} · deployed v{deployedVersion}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close manual dispatch"
+              className="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-full border-none bg-transparent text-neutral-600 hover:bg-app-bg hover:text-coal"
+            >
+              <XIcon size={19} weight="bold" aria-hidden />
+            </button>
+          </div>
+
+          <div className="mt-4 border-l-2 border-mariner bg-app-bg px-3 py-2 font-body text-[12px] leading-relaxed text-neutral-700">
+            This runs deployed v{deployedVersion}.{" "}
+            {dirty ? "Unsaved draft changes" : "Draft changes"} are excluded.
+          </div>
+
+          <form onSubmit={runPreflight} className="mt-6">
+            <label
+              htmlFor="manual-dispatch-input"
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-600"
+            >
+              {isTicket ? "Ticket key" : "Pull or merge request URL"}
+            </label>
+            <div className="mt-2 flex gap-2">
+              <input
+                ref={inputRef}
+                id="manual-dispatch-input"
+                value={rawInput}
+                onChange={(event) => {
+                  setRawInput(event.target.value);
+                  setPreflight(null);
+                  setResult(null);
+                  setError(null);
+                }}
+                placeholder={
+                  isTicket
+                    ? "AIW-173"
+                    : "https://github.com/org/repo/pull/123"
+                }
+                autoComplete="off"
+                className="h-10 min-w-0 flex-1 rounded-[3px] border border-neutral-300 bg-panel px-3 font-mono text-[13px] text-coal outline-none focus:border-mariner focus:ring-2 focus:ring-mariner/15"
+              />
+              <button
+                type="submit"
+                disabled={!rawInput.trim() || busy !== null}
+                className="h-10 cursor-pointer rounded-[3px] border border-neutral-300 bg-app-bg px-3.5 font-mono text-[10px] font-semibold uppercase tracking-[0.05em] text-coal hover:border-mariner disabled:cursor-default disabled:opacity-40"
+              >
+                {busy === "preflight" ? "Checking…" : "Check"}
+              </button>
+            </div>
+          </form>
+
+          {preflight && (
+            <div className="mt-5">
+              <div className="font-display text-[16px] font-semibold text-coal">
+                {preflight.subject.key} · {preflight.subject.title}
+              </div>
+              <ol className="mt-5">
+                {preflight.steps.map((step, index) => (
+                  <li
+                    key={`${index}:${step.title}`}
+                    className="relative flex gap-4 pb-5 last:pb-0"
+                  >
+                    {index < preflight.steps.length - 1 && (
+                      <span
+                        className="absolute left-[13px] top-7 h-[calc(100%-20px)] w-px bg-mariner"
+                        aria-hidden
+                      />
+                    )}
+                    <span className="relative z-[1] inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-mariner bg-panel font-mono text-[11px] font-semibold text-mariner">
+                      {index + 1}
+                    </span>
+                    <span className="min-w-0 pt-0.5">
+                      <span className="block font-body text-[14px] font-semibold text-coal">
+                        {step.title}
+                      </span>
+                      <span className="mt-0.5 block font-body text-[12px] text-neutral-600">
+                        {step.description}
+                      </span>
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {preflight?.blocker && (
+            <div
+              role="alert"
+              className="mt-5 rounded-[3px] border border-red-300 bg-red-50 px-3 py-2 font-body text-[12px] text-red-700"
+            >
+              {preflight.blocker.message}
+            </div>
+          )}
+          {error && (
+            <div
+              role="alert"
+              className="mt-5 rounded-[3px] border border-red-300 bg-red-50 px-3 py-2 font-body text-[12px] text-red-700"
+            >
+              {error}
+            </div>
+          )}
+
+          {result && (
+            <div
+              role="status"
+              className="mt-5 rounded-[3px] border border-green-300 bg-green-50 px-4 py-3 font-body text-[13px] text-green-800"
+            >
+              {result.status === "started" ? (
+                <div className="flex items-center justify-between gap-3">
+                  <span>
+                    Workflow started. Run ID{" "}
+                    <span className="font-mono text-[11px]">{result.runId}</span>
+                  </span>
+                  <Link
+                    href={`/trace/${encodeURIComponent(result.runId)}`}
+                    className="inline-flex shrink-0 items-center gap-1 font-semibold text-green-900 underline decoration-green-500 underline-offset-2"
+                  >
+                    Open run
+                    <ArrowSquareOutIcon size={15} aria-hidden />
+                  </Link>
+                </div>
+              ) : (
+                <span>
+                  This dispatch was accepted and is retrying safely. Request ID{" "}
+                  <span className="font-mono text-[11px]">{result.requestId}</span>
+                </span>
+              )}
+            </div>
+          )}
+
+          <div className="mt-6 flex items-center justify-between gap-4 border-t border-neutral-200 pt-4">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-5 gap-y-2 text-neutral-600">
+              <span className="inline-flex items-center gap-2 font-body text-[12px]">
+                <UserIcon size={17} aria-hidden />
+                Requested by {actorLabel}
+              </span>
+              <span className="inline-flex items-center gap-2 font-body text-[12px]">
+                <ShieldCheckIcon size={17} aria-hidden />
+                One active run per {isTicket ? "ticket" : "pull request"}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-neutral-200 bg-app-bg px-7 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="cursor-pointer border-none bg-transparent px-2 py-2 font-mono text-[11px] font-semibold uppercase tracking-[0.05em] text-neutral-700"
+          >
+            {result ? "Close" : "Cancel"}
+          </button>
+          {!result && preflight && (
+            <button
+              type="button"
+              onClick={() => void startDispatch()}
+              disabled={!preflight.runnable || busy !== null}
+              className="cursor-pointer rounded-[3px] border border-mariner bg-mariner px-4 py-2.5 font-mono text-[11px] font-semibold uppercase tracking-[0.05em] text-white shadow-[0_2px_4px_rgba(60,67,231,0.2)] hover:bg-[#3037d8] disabled:cursor-default disabled:opacity-40"
+            >
+              {busy === "dispatch" ? "Starting…" : primaryLabel}
+            </button>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
@@ -29,6 +29,7 @@ import { FlowEditor } from "@/components/cockpit/flow-editor/flow-editor";
 import { PromptLibraryProvider } from "@/components/cockpit/flow-editor/prompt-library-context";
 import { HarnessProfileCatalogProvider } from "@/components/cockpit/flow-editor/harness-profile-context";
 import { Listbox } from "@/components/cockpit/listbox";
+import { ManualDispatchModal } from "@/components/cockpit/manual-dispatch-modal";
 import {
   toFlowDefinition,
   type FlowEdgeDef,
@@ -136,6 +137,8 @@ export function WorkflowEditorScreen({
   options,
   liveBlocks,
   canEdit,
+  canDispatch,
+  actorLabel,
   initialNodeId,
 }: {
   definitions: WorkflowDefinitionMeta[];
@@ -145,6 +148,8 @@ export function WorkflowEditorScreen({
   options: WorkflowEditorOptions;
   liveBlocks: RunBlockStatusesResponse;
   canEdit: boolean;
+  canDispatch: boolean;
+  actorLabel: string;
   initialNodeId?: string;
 }) {
   const seed = initialDetail.draft ?? initialDetail.deployed?.definition ?? defaultDefinition;
@@ -186,6 +191,9 @@ export function WorkflowEditorScreen({
   const [switchState, setSwitchState] = useState<DefinitionSwitchState>({ kind: "idle" });
   const [defsOpen, setDefsOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
+  const [manualDispatchTrigger, setManualDispatchTrigger] =
+    useState<FlowNodeDef | null>(null);
+  useEffect(() => setManualDispatchTrigger(null), [selectedId]);
   const [rowError, setRowError] = useState<{ id: number; message: string } | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
@@ -398,6 +406,22 @@ export function WorkflowEditorScreen({
   const validationTargetKey = `${selectedId}:${semanticKey}`;
   const validationIsCurrent = validation.key === validationTargetKey;
   const dirty = editorHistoryIsDirty(editorHistory, semanticKey);
+  const runnableTriggerIds = useMemo(() => {
+    if (!canDispatch || !deployed) return new Set<string>();
+    const deployedTypes = new Map(
+      deployed.definition.nodes.map((node) => [node.id, node.type]),
+    );
+    return new Set(
+      nodes
+        .filter(
+          (node) =>
+            isTriggerBlockType(node.type) &&
+            node.type !== "trigger_plan_approved" &&
+            deployedTypes.get(node.id) === node.type,
+        )
+        .map((node) => node.id),
+    );
+  }, [canDispatch, deployed, nodes]);
   const { canSave, canDeploy } = workflowEditorActions({
     dirty,
     structurallyValid: nodesValid(nodes),
@@ -974,6 +998,8 @@ export function WorkflowEditorScreen({
           onCommitTransaction={commitEditorTransaction}
           onCancelTransaction={cancelEditorTransaction}
           canEdit={canEdit}
+          runnableTriggerIds={runnableTriggerIds}
+          onRunTrigger={setManualDispatchTrigger}
           dirty={dirty}
           saveEnabled={canSave}
           saving={busy === "save"}
@@ -1032,6 +1058,18 @@ export function WorkflowEditorScreen({
           initialSelectedId={deepLinkNodeId.current}
           onSelectionChange={handleSelectionChange}
         />
+        {manualDispatchTrigger && deployed && (
+          <ManualDispatchModal
+            definitionId={selectedId}
+            workflowName={selectedMeta?.name ?? "Workflow"}
+            deployedVersion={deployed.version}
+            trigger={manualDispatchTrigger}
+            options={options}
+            actorLabel={actorLabel}
+            dirty={dirty}
+            onClose={() => setManualDispatchTrigger(null)}
+          />
+        )}
         {defsOpen && (
           <div className="absolute right-4 top-[56px] z-[60] w-[440px] max-h-[70vh] overflow-y-auto bg-panel border border-neutral-200 rounded-[4px] shadow-[0_12px_28px_-8px_rgba(24,27,32,0.22),0_2px_6px_rgba(24,27,32,0.08)] px-4 py-3">
             <div className="flex items-center justify-between mb-1">

--- a/apps/dashboard/lib/auth/session.ts
+++ b/apps/dashboard/lib/auth/session.ts
@@ -6,10 +6,12 @@ import { fetchAuthWorker } from "@/lib/auth/worker";
 
 export type DashboardSession = {
   organizationName: string;
+  actorLabel: string;
   role: "owner" | "admin" | "member";
   canManageUsers: boolean;
   canEditChecks: boolean;
   canEditWorkflows: boolean;
+  canDispatchWorkflows: boolean;
 };
 
 function isDashboardSession(value: unknown): value is DashboardSession {
@@ -18,12 +20,15 @@ function isDashboardSession(value: unknown): value is DashboardSession {
   return (
     typeof session.organizationName === "string" &&
     session.organizationName.trim().length > 0 &&
+    typeof session.actorLabel === "string" &&
+    session.actorLabel.trim().length > 0 &&
     (session.role === "owner" ||
       session.role === "admin" ||
       session.role === "member") &&
     typeof session.canManageUsers === "boolean" &&
     typeof session.canEditChecks === "boolean" &&
-    typeof session.canEditWorkflows === "boolean"
+    typeof session.canEditWorkflows === "boolean" &&
+    typeof session.canDispatchWorkflows === "boolean"
   );
 }
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@octokit/auth-app": "^8.2.0",
     "@octokit/request": "^10.0.10",
+    "@phosphor-icons/react": "2.1.10",
     "@shared/conditions": "workspace:*",
     "@shared/contracts": "workspace:*",
     "@tiptap/core": "^3.28.0",

--- a/apps/shared/contracts/api.ts
+++ b/apps/shared/contracts/api.ts
@@ -215,6 +215,63 @@ export interface WorkflowDefinitionDetailResponse {
   versions: WorkflowDefinitionVersion[];
 }
 
+export type ManualDispatchInput =
+  | { kind: "ticket"; ticketKey: string }
+  | { kind: "pull_request"; url: string };
+
+export type ManualDispatchBlockerCode =
+  | "active_run"
+  | "at_capacity"
+  | "approval_pending"
+  | "deployment_changed"
+  | "invalid_input"
+  | "not_eligible"
+  | "provider_unavailable";
+
+export interface ManualDispatchPreflightStep {
+  title: string;
+  description: string;
+}
+
+export interface ManualDispatchPreflightResponse {
+  definitionId: number;
+  definitionName: string;
+  deployedVersion: number;
+  triggerNodeId: string;
+  triggerType: WorkflowBlockType;
+  input: ManualDispatchInput;
+  subject: {
+    kind: "ticket" | "pull_request";
+    key: string;
+    title: string;
+    currentStatus?: string;
+    url?: string;
+  };
+  steps: ManualDispatchPreflightStep[];
+  runnable: boolean;
+  blocker?: {
+    code: ManualDispatchBlockerCode;
+    message: string;
+  };
+}
+
+export interface ManualDispatchRequest {
+  requestId: string;
+  expectedDeployedVersion: number;
+  input: ManualDispatchInput;
+}
+
+export type ManualDispatchResponse =
+  | {
+      requestId: string;
+      status: "started";
+      runId: string;
+    }
+  | {
+      requestId: string;
+      status: "recovering";
+    };
+
 /** Legacy single-definition GET shim response; removed once the dashboard
  *  switches to the multi-definition routes. */
 export interface WorkflowDefinitionResponse {

--- a/apps/worker/drizzle/0025_manual_dispatch_requests.sql
+++ b/apps/worker/drizzle/0025_manual_dispatch_requests.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "manual_dispatch_requests" (
+	"request_id" text PRIMARY KEY NOT NULL,
+	"payload_hash" text NOT NULL,
+	"definition_id" integer NOT NULL,
+	"definition_version" integer NOT NULL,
+	"trigger_node_id" text NOT NULL,
+	"trigger_type" text NOT NULL,
+	"input_kind" text NOT NULL,
+	"subject_key" text NOT NULL,
+	"ticket_key" text,
+	"input_payload" jsonb NOT NULL,
+	"actor_user_id" text NOT NULL,
+	"actor_label" text NOT NULL,
+	"owner_token" text,
+	"run_id" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"error_code" text,
+	"error_message" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "manual_dispatch_requests_status_check" CHECK ("manual_dispatch_requests"."status" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')),
+	CONSTRAINT "manual_dispatch_requests_input_kind_check" CHECK ("manual_dispatch_requests"."input_kind" in ('ticket', 'pull_request'))
+);
+--> statement-breakpoint
+ALTER TABLE "manual_dispatch_requests" ADD CONSTRAINT "manual_dispatch_requests_definition_version_fk" FOREIGN KEY ("definition_id","definition_version") REFERENCES "public"."workflow_definition_versions"("definition_id","version") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "manual_dispatch_requests_status_idx" ON "manual_dispatch_requests" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "manual_dispatch_requests_subject_key_idx" ON "manual_dispatch_requests" USING btree ("subject_key");--> statement-breakpoint
+CREATE INDEX "manual_dispatch_requests_run_id_idx" ON "manual_dispatch_requests" USING btree ("run_id");

--- a/apps/worker/drizzle/meta/0025_snapshot.json
+++ b/apps/worker/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,4160 @@
+{
+  "id": "783f4167-fce4-4c1f-823f-298ec6b60456",
+  "prevId": "0811959e-7ec7-4cfe-a6aa-4c7a61b0e295",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1784804822580,
       "tag": "0024_mighty_ink",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1784826395341,
+      "tag": "0025_manual_dispatch_requests",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/adapters/run-registry/types.ts
+++ b/apps/worker/src/adapters/run-registry/types.ts
@@ -15,7 +15,11 @@ export interface FailedTicketOwner {
  * covers the PR webhook triggers. Stored on active_runs.run_kind (default
  * 'ticket'); reconcile and the Jira webhook branch on it.
  */
-export type RunKind = "ticket" | "pr_trigger";
+export type RunKind =
+  | "ticket"
+  | "pr_trigger"
+  | "manual_ticket"
+  | "manual_pr_trigger";
 
 /** Unbound reservations stop occupying capacity and become ineligible to bind
  * after this grace period. Both checks must use the same boundary. */

--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -163,6 +163,77 @@ describe("GitHubAdapter", () => {
     });
   });
 
+  describe("getManualDispatchPullRequest", () => {
+    it("returns authoritative lifecycle, current failures, and eligible review facts", async () => {
+      mockOctokit.pulls.get.mockResolvedValueOnce({
+        data: {
+          html_url: "https://github.com/test-org/test-repo/pull/42",
+          head: { ref: "feature/manual", sha: "head-sha" },
+          base: { ref: "main" },
+          title: "Manual dispatch",
+          user: { login: "alice" },
+          draft: false,
+          state: "open",
+          merged: false,
+        },
+      });
+      mockOctokit.paginate
+        .mockResolvedValueOnce([
+          {
+            id: 100,
+            name: "ci / build",
+            app: { slug: "github-actions" },
+            status: "completed",
+            conclusion: "failure",
+          },
+          {
+            id: 101,
+            name: "ci / lint",
+            app: { slug: "github-actions" },
+            status: "completed",
+            conclusion: "success",
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            state: "CHANGES_REQUESTED",
+            user: { login: "reviewer" },
+            body: "Please cover the retry path.",
+          },
+          {
+            state: "APPROVED",
+            user: { login: "maintainer" },
+            body: "",
+          },
+        ]);
+
+      await expect(
+        ghAdapter().getManualDispatchPullRequest(42),
+      ).resolves.toMatchObject({
+        prNumber: 42,
+        headRef: "feature/manual",
+        headSha: "head-sha",
+        baseRef: "main",
+        state: "open",
+        failedChecks: [
+          {
+            name: "ci / build",
+            conclusion: "failure",
+            checkRunId: 100,
+            appSlug: "github-actions",
+          },
+        ],
+        reviews: [
+          {
+            state: "changes_requested",
+            author: "reviewer",
+            body: "Please cover the retry path.",
+          },
+        ],
+      });
+    });
+  });
+
   describe("getLatestCheckRuns", () => {
     it("returns latest check-run identity and conclusion for an exact head", async () => {
       mockOctokit.paginate.mockResolvedValueOnce([

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -14,6 +14,8 @@ import type {
   PullRequestHead,
   RichGateStatusCapableVCS,
   RichGateStatusUpdate,
+  ManualDispatchPrCapableVCS,
+  ManualDispatchPullRequestSnapshot,
 } from "./types.js";
 
 export interface GitHubConfig {
@@ -28,7 +30,8 @@ export class GitHubAdapter
     VCSAdapter,
     GateStatusCapableVCS,
     RichGateStatusCapableVCS,
-    PRFilesCapableVCS
+    PRFilesCapableVCS,
+    ManualDispatchPrCapableVCS
 {
   private octokit: Octokit;
 
@@ -203,6 +206,74 @@ export class GitHubAdapter
       throw new Error(`GitHub PR #${prId} has unsupported lifecycle state ${String(state)}`);
     }
     return { headSha: data.head.sha, baseRef, state };
+  }
+
+  async getManualDispatchPullRequest(
+    prId: number,
+  ): Promise<ManualDispatchPullRequestSnapshot> {
+    const { data } = await this.octokit.pulls.get({
+      ...this.ownerRepo,
+      pull_number: prId,
+    });
+    const baseRef = data.base.ref?.trim();
+    if (!baseRef) throw new Error(`GitHub PR #${prId} is missing its target branch`);
+    const state = data.merged === true ? "merged" : data.state;
+    if (state !== "open" && state !== "closed" && state !== "merged") {
+      throw new Error(`GitHub PR #${prId} has unsupported lifecycle state ${String(state)}`);
+    }
+    const [checks, reviews] = await Promise.all([
+      this.getLatestCheckRuns(data.head.sha),
+      this.octokit.paginate(this.octokit.pulls.listReviews, {
+        ...this.ownerRepo,
+        pull_number: prId,
+        per_page: 100,
+      }),
+    ]);
+    const failedChecks = checks
+      .filter(
+        (check) =>
+          check.status === "completed" &&
+          (check.conclusion === "failure" || check.conclusion === "timed_out"),
+      )
+      .map((check) => ({
+        name: check.name,
+        conclusion: check.conclusion!,
+        checkRunId: check.id,
+        appSlug: check.appSlug,
+      }));
+    return {
+      prNumber: prId,
+      prUrl: data.html_url,
+      headRef: data.head.ref,
+      headSha: data.head.sha,
+      baseRef,
+      title: data.title,
+      author: data.user?.login ?? "unknown",
+      isDraft: data.draft === true,
+      state,
+      ...(state === "merged" && data.merge_commit_sha
+        ? { mergeSha: data.merge_commit_sha }
+        : {}),
+      ...(state === "merged" && data.merged_at
+        ? { mergedAt: data.merged_at }
+        : {}),
+      failedChecks,
+      reviews: reviews.flatMap((review) => {
+        const reviewState =
+          review.state === "CHANGES_REQUESTED"
+            ? "changes_requested"
+            : review.state === "COMMENTED"
+              ? "commented"
+              : null;
+        return reviewState
+          ? [{
+              state: reviewState,
+              author: review.user?.login ?? "unknown",
+              body: review.body ?? "",
+            }]
+          : [];
+      }),
+    };
   }
 
   async getLatestCheckRuns(headSha: string) {

--- a/apps/worker/src/adapters/vcs/gitlab.test.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.test.ts
@@ -35,6 +35,9 @@ const mockJobs = {
   all: vi.fn(),
   showLog: vi.fn(),
 };
+const mockPipelines = {
+  show: vi.fn(),
+};
 
 const mockFetch = vi.fn();
 
@@ -62,6 +65,7 @@ vi.mock("@gitbeaker/rest", () => ({
     MergeRequestNotes: mockMergeRequestNotes,
     MergeRequestDiscussions: mockMergeRequestDiscussions,
     Jobs: mockJobs,
+    Pipelines: mockPipelines,
   })),
 }));
 
@@ -351,6 +355,65 @@ describe("GitLabAdapter", () => {
         headSha: "source-head-sha",
         baseRef: "main",
         state: "merged",
+      });
+    });
+  });
+
+  describe("getManualDispatchPullRequest", () => {
+    it("returns current MR pipeline failures and human review comments", async () => {
+      mockMergeRequests.show
+        .mockResolvedValueOnce({
+          web_url: "https://gitlab.com/blazity/demo-app/-/merge_requests/42",
+          source_branch: "feature/manual",
+          target_branch: "main",
+          title: "Manual dispatch",
+          author: { username: "alice" },
+          draft: false,
+          state: "opened",
+          diff_refs: { head_sha: "head-sha" },
+          head_pipeline: { id: 901, status: "failed" },
+        })
+        .mockResolvedValueOnce({
+          target_branch: "main",
+          state: "opened",
+          diff_refs: { head_sha: "head-sha" },
+          head_pipeline: { id: 901, status: "failed" },
+        });
+      mockJobs.all.mockResolvedValueOnce([
+        { id: 11, name: "lint", status: "failed" },
+      ]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);
+      mockMergeRequestNotes.all.mockResolvedValueOnce([
+        {
+          author: { username: "reviewer" },
+          body: "Please cover the retry path.",
+          system: false,
+          type: null,
+        },
+      ]);
+      mockPipelines.show.mockResolvedValueOnce({
+        id: 901,
+        source: "merge_request_event",
+      });
+
+      await expect(
+        glAdapter().getManualDispatchPullRequest(42),
+      ).resolves.toMatchObject({
+        prNumber: 42,
+        headRef: "feature/manual",
+        headSha: "head-sha",
+        baseRef: "main",
+        state: "open",
+        pipelineId: 901,
+        pipelineSource: "merge_request_event",
+        failedChecks: [{ name: "lint", conclusion: "failed" }],
+        reviews: [
+          {
+            state: "commented",
+            author: "reviewer",
+            body: "Please cover the retry path.",
+          },
+        ],
       });
     });
   });

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -11,6 +11,8 @@ import type {
   PullRequestHead,
   PRComment,
   CheckRunResult,
+  ManualDispatchPrCapableVCS,
+  ManualDispatchPullRequestSnapshot,
 } from "./types.js";
 
 // Minimal shapes for gitbeaker responses we touch. Declared locally so we do
@@ -26,7 +28,15 @@ interface GitLabMRHead {
   diff_refs?: { head_sha?: string };
   sha?: string;
   target_branch?: string;
+  source_branch?: string;
   state?: string;
+  web_url?: string;
+  title?: string;
+  author?: { username?: string };
+  draft?: boolean;
+  work_in_progress?: boolean;
+  merge_commit_sha?: string;
+  merged_at?: string;
   head_pipeline?: { id?: number; status?: string } | null;
 }
 interface GitLabNotePosition {
@@ -79,7 +89,12 @@ export interface GitLabConfig {
   host?: string;
 }
 
-export class GitLabAdapter implements VCSAdapter, GateStatusCapableVCS, PRFilesCapableVCS {
+export class GitLabAdapter implements
+  VCSAdapter,
+  GateStatusCapableVCS,
+  PRFilesCapableVCS,
+  ManualDispatchPrCapableVCS
+{
   private gl: InstanceType<typeof Gitlab>;
   private projectId: string;
   private baseBranch: string;
@@ -352,6 +367,58 @@ export class GitLabAdapter implements VCSAdapter, GateStatusCapableVCS, PRFilesC
       ...(typeof headPipelineId === "number" ? { headPipelineId } : {}),
       ...(typeof headPipelineStatus === "string" ? { headPipelineStatus } : {}),
       ...(headPipelineFailedChecks ? { headPipelineFailedChecks } : {}),
+    };
+  }
+
+  async getManualDispatchPullRequest(
+    prId: number,
+  ): Promise<ManualDispatchPullRequestSnapshot> {
+    const mr = (await this.gl.MergeRequests.show(
+      this.projectId,
+      prId,
+    )) as unknown as GitLabMRHead;
+    const current = await this.getPRHead(prId);
+    const [comments, pipeline] = await Promise.all([
+      this.getPRComments(prId),
+      typeof current.headPipelineId === "number"
+        ? this.gl.Pipelines.show(this.projectId, current.headPipelineId)
+        : Promise.resolve(null),
+    ]);
+    return {
+      prNumber: prId,
+      prUrl:
+        mr.web_url ??
+        `${(this.config.host ?? "https://gitlab.com").replace(/\/+$/, "")}/${this.projectId}/-/merge_requests/${prId}`,
+      headRef: mr.source_branch ?? "",
+      headSha: current.headSha,
+      baseRef: current.baseRef,
+      title: mr.title ?? "",
+      author: mr.author?.username ?? "unknown",
+      isDraft: mr.draft === true || mr.work_in_progress === true,
+      state: current.state,
+      ...(current.state === "merged" && mr.merge_commit_sha
+        ? { mergeSha: mr.merge_commit_sha }
+        : {}),
+      ...(current.state === "merged" && mr.merged_at
+        ? { mergedAt: mr.merged_at }
+        : {}),
+      ...(typeof current.headPipelineId === "number"
+        ? { pipelineId: current.headPipelineId }
+        : {}),
+      ...(pipeline && typeof (pipeline as { source?: unknown }).source === "string"
+        ? { pipelineSource: (pipeline as { source: string }).source }
+        : {}),
+      failedChecks: (current.headPipelineFailedChecks ?? []).map((check) => ({
+        name: check.name,
+        conclusion: "failed",
+      })),
+      reviews: comments
+        .filter((comment) => comment.body.trim().length > 0)
+        .map((comment) => ({
+          state: "commented" as const,
+          author: comment.author,
+          body: comment.body,
+        })),
     };
   }
 

--- a/apps/worker/src/adapters/vcs/types.ts
+++ b/apps/worker/src/adapters/vcs/types.ts
@@ -28,6 +28,47 @@ export interface LatestCheckRun {
   conclusion: string | null;
 }
 
+export interface ManualDispatchPullRequestSnapshot {
+  prNumber: number;
+  prUrl: string;
+  headRef: string;
+  headSha: string;
+  baseRef: string;
+  title: string;
+  author: string;
+  isDraft: boolean;
+  state: "open" | "closed" | "merged";
+  mergeSha?: string;
+  mergedAt?: string;
+  pipelineId?: number;
+  pipelineSource?: string;
+  failedChecks: Array<{
+    name: string;
+    conclusion: string;
+    detailsUrl?: string;
+    checkRunId?: number;
+    appSlug?: string;
+  }>;
+  reviews: Array<{
+    state: "changes_requested" | "commented";
+    author: string;
+    body: string;
+  }>;
+}
+
+export interface ManualDispatchPrCapableVCS {
+  getManualDispatchPullRequest(prId: number): Promise<ManualDispatchPullRequestSnapshot>;
+}
+
+export function hasManualDispatchPrCapability(
+  adapter: VCSAdapter,
+): adapter is VCSAdapter & ManualDispatchPrCapableVCS {
+  return (
+    typeof (adapter as Partial<ManualDispatchPrCapableVCS>)
+      .getManualDispatchPullRequest === "function"
+  );
+}
+
 export interface PRComment {
   author: string;
   body: string;

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -120,6 +120,52 @@ export const triggerDeliveries = pgTable(
   ],
 );
 
+export const manualDispatchRequests = pgTable(
+  "manual_dispatch_requests",
+  {
+    requestId: text("request_id").primaryKey(),
+    payloadHash: text("payload_hash").notNull(),
+    definitionId: integer("definition_id").notNull(),
+    definitionVersion: integer("definition_version").notNull(),
+    triggerNodeId: text("trigger_node_id").notNull(),
+    triggerType: text("trigger_type").notNull(),
+    inputKind: text("input_kind").notNull(),
+    subjectKey: text("subject_key").notNull(),
+    ticketKey: text("ticket_key"),
+    inputPayload: jsonb("input_payload").$type<Record<string, unknown>>().notNull(),
+    actorUserId: text("actor_user_id").notNull(),
+    actorLabel: text("actor_label").notNull(),
+    ownerToken: text("owner_token"),
+    runId: text("run_id"),
+    status: text("status").notNull().default("pending"),
+    errorCode: text("error_code"),
+    errorMessage: text("error_message"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    check(
+      "manual_dispatch_requests_status_check",
+      sql`${t.status} in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')`,
+    ),
+    check(
+      "manual_dispatch_requests_input_kind_check",
+      sql`${t.inputKind} in ('ticket', 'pull_request')`,
+    ),
+    index("manual_dispatch_requests_status_idx").on(t.status),
+    index("manual_dispatch_requests_subject_key_idx").on(t.subjectKey),
+    index("manual_dispatch_requests_run_id_idx").on(t.runId),
+    foreignKey({
+      columns: [t.definitionId, t.definitionVersion],
+      foreignColumns: [
+        workflowDefinitionVersions.definitionId,
+        workflowDefinitionVersions.version,
+      ],
+      name: "manual_dispatch_requests_definition_version_fk",
+    }),
+  ],
+);
+
 /** Replaces blazebot:failed-tickets — FailedTicketMeta as typed columns. */
 export const failedTickets = pgTable("failed_tickets", {
   ticketKey: text("ticket_key").primaryKey(),

--- a/apps/worker/src/lib/auth/roles.ts
+++ b/apps/worker/src/lib/auth/roles.ts
@@ -30,6 +30,10 @@ export function canEditWorkflowDefinitions(role: DashboardRole): boolean {
   return role === "owner" || role === "admin";
 }
 
+export function canDispatchWorkflowRuns(role: DashboardRole): boolean {
+  return role === "owner" || role === "admin";
+}
+
 export function canApproveWorkflowPlans(role: DashboardRole): boolean {
   return role === "owner" || role === "admin";
 }

--- a/apps/worker/src/lib/dispatch-trigger.ts
+++ b/apps/worker/src/lib/dispatch-trigger.ts
@@ -70,7 +70,7 @@ export interface DispatchTriggerDeps {
   deletePending?: typeof deletePendingTrigger;
 }
 
-function triggerNodeParams(
+export function triggerNodeParams(
   definition: WorkflowDefinition,
   triggerType: string,
 ): Record<string, unknown> {
@@ -223,7 +223,7 @@ async function readRepositoryScope(
   }
 }
 
-async function isConfiguredTriggerRepository(pr: PrTriggerPayload): Promise<boolean> {
+export async function isConfiguredTriggerRepository(pr: PrTriggerPayload): Promise<boolean> {
   if (pr.provider !== "gitlab") return true;
   const { env, getConfiguredVcsProviders } = await import("../../env.js");
   if (env.GITLAB_PROJECT_ID) {
@@ -249,7 +249,7 @@ async function isConfiguredTriggerRepository(pr: PrTriggerPayload): Promise<bool
 }
 
 
-function selectEligibleEvent(
+export function selectEligibleEvent(
   event: TriggerEvent,
   params: Record<string, unknown>,
 ): TriggerEvent | null {
@@ -289,7 +289,7 @@ function selectEligibleEvent(
   };
 }
 
-function selectedReviewStates(
+export function selectedReviewStates(
   params: Record<string, unknown>,
   provider: VcsProviderKind,
   botLogin: string | undefined,

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -505,6 +505,25 @@ describe("reconcileRuns owner-CAS recovery", () => {
     expect(onReleased).toHaveBeenCalledWith(bound.subjectKey);
   });
 
+  it("applies normal AI-column cancellation semantics to manual ticket runs", async () => {
+    const bound = entry({ kind: "manual_ticket" });
+    const runRegistry = registry([bound]);
+    mockCancelRun.mockResolvedValue(true);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(new Set(), runRegistry, issueTracker("Done")),
+    ).resolves.toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockCancelRun).toHaveBeenCalledWith(
+      "PROJ-1",
+      "run-1",
+      runRegistry,
+      expect.anything(),
+      undefined,
+      undefined,
+    );
+  });
+
   it("retains a bound run whose ticket sits in the AI Review column while it still executes", async () => {
     // A Jira automation rule raced the run's own success move: the ticket
     // reached AI Review while the run is still finalizing (world status

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -104,7 +104,9 @@ export async function reconcileRuns(
     if (!entry.runId) continue;
     const boundEntry = { ...entry, runId: entry.runId };
 
-    const followsTicketColumn = entry.kind === "ticket" && entry.ticketKey !== null;
+    const followsTicketColumn =
+      (entry.kind === "ticket" || entry.kind === "manual_ticket") &&
+      entry.ticketKey !== null;
     const ticketStillInAiColumn =
       followsTicketColumn && aiColumnTickets.has(entry.ticketKey as string);
 

--- a/apps/worker/src/lib/trigger-events.ts
+++ b/apps/worker/src/lib/trigger-events.ts
@@ -337,7 +337,7 @@ function gitLabMergeRequestAuthor(attrs: any, fallback?: any): string {
   return fallback?.username ?? fallback?.name ?? "unknown";
 }
 
-function isGateCheckName(
+export function isGateCheckName(
   name: string,
   gateCheckNames: readonly string[],
 ): boolean {

--- a/apps/worker/src/manual-dispatch/errors.ts
+++ b/apps/worker/src/manual-dispatch/errors.ts
@@ -1,0 +1,12 @@
+import type { ManualDispatchBlockerCode } from "@shared/contracts";
+
+export class ManualDispatchError extends Error {
+  constructor(
+    readonly statusCode: number,
+    readonly code: ManualDispatchBlockerCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ManualDispatchError";
+  }
+}

--- a/apps/worker/src/manual-dispatch/http.ts
+++ b/apps/worker/src/manual-dispatch/http.ts
@@ -1,0 +1,62 @@
+import type {
+  ManualDispatchInput,
+  ManualDispatchRequest,
+} from "@shared/contracts";
+import { createError } from "h3";
+import { ManualDispatchError } from "./errors.js";
+
+export function parseManualDispatchInput(value: unknown): ManualDispatchInput {
+  if (!value || typeof value !== "object") {
+    throw createError({ statusCode: 400, statusMessage: "Invalid dispatch input" });
+  }
+  const input = value as Record<string, unknown>;
+  if (
+    input.kind === "ticket" &&
+    typeof input.ticketKey === "string" &&
+    input.ticketKey.trim().length > 0
+  ) {
+    return { kind: "ticket", ticketKey: input.ticketKey.trim() };
+  }
+  if (
+    input.kind === "pull_request" &&
+    typeof input.url === "string" &&
+    input.url.trim().length > 0
+  ) {
+    return { kind: "pull_request", url: input.url.trim() };
+  }
+  throw createError({ statusCode: 400, statusMessage: "Invalid dispatch input" });
+}
+
+export function parseManualDispatchRequest(value: unknown): ManualDispatchRequest {
+  if (!value || typeof value !== "object") {
+    throw createError({ statusCode: 400, statusMessage: "Invalid dispatch request" });
+  }
+  const request = value as Record<string, unknown>;
+  if (
+    typeof request.requestId !== "string" ||
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      request.requestId,
+    ) ||
+    typeof request.expectedDeployedVersion !== "number" ||
+    !Number.isInteger(request.expectedDeployedVersion) ||
+    request.expectedDeployedVersion <= 0
+  ) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid dispatch request" });
+  }
+  return {
+    requestId: request.requestId,
+    expectedDeployedVersion: request.expectedDeployedVersion,
+    input: parseManualDispatchInput(request.input),
+  };
+}
+
+export function toManualDispatchHttpError(error: unknown): never {
+  if (error instanceof ManualDispatchError) {
+    throw createError({
+      statusCode: error.statusCode,
+      statusMessage: error.message,
+      data: { code: error.code, message: error.message },
+    });
+  }
+  throw error;
+}

--- a/apps/worker/src/manual-dispatch/resolve.test.ts
+++ b/apps/worker/src/manual-dispatch/resolve.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ManualDispatchPullRequestSnapshot } from "../adapters/vcs/types.js";
+import type { PrTriggerPayload } from "../workflows/agent-input.js";
+
+vi.mock("../../env.js", () => ({
+  env: {},
+  getConfiguredVcsProviders: () => [
+    {
+      kind: "github",
+      host: "https://github.com",
+      auth: {},
+      legacyBaseBranch: "main",
+    },
+    {
+      kind: "gitlab",
+      host: "https://gitlab.example.com",
+      token: "token",
+      legacyBaseBranch: "main",
+    },
+  ],
+  getVcsBotLogin: () => "workflow-bot",
+}));
+
+const { parsePullRequestUrl, selectManualTriggerEvent } = await import(
+  "./resolve.js"
+);
+
+const pr: PrTriggerPayload = {
+  provider: "github",
+  repoPath: "acme/api",
+  prNumber: 42,
+  prUrl: "https://github.com/acme/api/pull/42",
+  headRef: "feature/manual",
+  headSha: "head-sha",
+  baseRef: "main",
+  title: "Manual dispatch",
+  author: "alice",
+  isDraft: false,
+};
+
+function snapshot(
+  overrides: Partial<ManualDispatchPullRequestSnapshot> = {},
+): ManualDispatchPullRequestSnapshot {
+  return {
+    prNumber: 42,
+    prUrl: pr.prUrl,
+    headRef: pr.headRef,
+    headSha: pr.headSha,
+    baseRef: pr.baseRef,
+    title: pr.title,
+    author: pr.author,
+    isDraft: false,
+    state: "open",
+    failedChecks: [],
+    reviews: [],
+    ...overrides,
+  };
+}
+
+describe("manual pull request input", () => {
+  it("parses only configured GitHub and nested GitLab MR URLs", () => {
+    expect(parsePullRequestUrl("https://github.com/acme/api/pull/42")).toEqual({
+      provider: "github",
+      repoPath: "acme/api",
+      prNumber: 42,
+    });
+    expect(
+      parsePullRequestUrl(
+        "https://gitlab.example.com/platform/services/api/-/merge_requests/17",
+      ),
+    ).toEqual({
+      provider: "gitlab",
+      repoPath: "platform/services/api",
+      prNumber: 17,
+    });
+  });
+
+  it.each([
+    "https://example.com/acme/api/pull/42",
+    "https://github.com/acme/api/issues/42",
+    "https://gitlab.example.com/platform/api/merge_requests/17",
+  ])("rejects unsupported provider input %s", (url) => {
+    expect(() => parsePullRequestUrl(url)).toThrow();
+  });
+
+  it("requires created and merged triggers to match current lifecycle state", () => {
+    expect(
+      selectManualTriggerEvent(
+        "trigger_pr_created",
+        pr,
+        snapshot({ state: "open" }),
+        {},
+      ),
+    ).not.toBeNull();
+    expect(
+      selectManualTriggerEvent(
+        "trigger_pr_created",
+        pr,
+        snapshot({ state: "closed" }),
+        {},
+      ),
+    ).toBeNull();
+    expect(
+      selectManualTriggerEvent(
+        "trigger_pr_merged",
+        pr,
+        snapshot({ state: "merged" }),
+        {},
+      ),
+    ).not.toBeNull();
+  });
+
+  it("requires a configured current non-gate GitHub check failure", () => {
+    const failed = snapshot({
+      failedChecks: [
+        {
+          name: "ci / build",
+          conclusion: "failure",
+          checkRunId: 100,
+          appSlug: "github-actions",
+        },
+      ],
+    });
+    expect(
+      selectManualTriggerEvent("trigger_pr_checks_failed", pr, failed, {
+        checkNames: ["ci / build"],
+        githubAppSlugs: ["github-actions"],
+      })?.pr.failedChecks,
+    ).toEqual(failed.failedChecks);
+    expect(
+      selectManualTriggerEvent("trigger_pr_checks_failed", pr, failed, {
+        checkNames: ["ci / lint"],
+        githubAppSlugs: ["github-actions"],
+      }),
+    ).toBeNull();
+  });
+
+  it("uses the latest eligible non-bot review matching configured states", () => {
+    const reviews = snapshot({
+      reviews: [
+        {
+          state: "changes_requested",
+          author: "human-reviewer",
+          body: "Cover the retry path.",
+        },
+        {
+          state: "changes_requested",
+          author: "workflow-bot",
+          body: "Automated review.",
+        },
+      ],
+    });
+    expect(
+      selectManualTriggerEvent("trigger_pr_review", pr, reviews, {
+        on: ["changes_requested"],
+      })?.pr.review,
+    ).toEqual({
+      state: "changes_requested",
+      author: "human-reviewer",
+      body: "Cover the retry path.",
+    });
+  });
+});

--- a/apps/worker/src/manual-dispatch/resolve.ts
+++ b/apps/worker/src/manual-dispatch/resolve.ts
@@ -1,0 +1,571 @@
+import type {
+  ManualDispatchInput,
+  ManualDispatchPreflightStep,
+} from "@shared/contracts";
+import { isTriggerBlockType } from "@shared/contracts";
+import { eq } from "drizzle-orm";
+import { env, getConfiguredVcsProviders, getVcsBotLogin } from "../../env.js";
+import {
+  IssueTrackerNotFoundError,
+  type IssueTrackerAdapter,
+} from "../adapters/issue-tracker/types.js";
+import {
+  hasManualDispatchPrCapability,
+  type ManualDispatchPullRequestSnapshot,
+} from "../adapters/vcs/types.js";
+import type { Db } from "../db/client.js";
+import { workflowDefinitions } from "../db/schema.js";
+import { findWorkflowOwnedPullRequest } from "../db/queries/workflow-owned-branches.js";
+import {
+  isConfiguredTriggerRepository,
+  selectEligibleEvent,
+  triggerNodeParams,
+} from "../lib/dispatch-trigger.js";
+import { isRepoAllowed } from "../lib/repo-allowlist.js";
+import { prSubjectKey, ticketSubjectKey } from "../lib/subject-key.js";
+import type { TriggerEvent } from "../lib/trigger-events.js";
+import { isGateCheckName } from "../lib/trigger-events.js";
+import { createRepositoryVCS } from "../lib/vcs-runtime.js";
+import { loadPostPrGateConfig } from "../post-pr-gate/config.js";
+import {
+  getDeployedWorkflowDefinitionVersion,
+  getWorkflowDefinitionVersion,
+  type WorkflowDefinitionVersionRow,
+} from "../workflow-definition/store.js";
+import type { PrTriggerPayload } from "../workflows/agent-input.js";
+import { hasDispatchBlockingApprovalForTicket } from "../approvals/store.js";
+import { ManualDispatchError } from "./errors.js";
+
+type PrTriggerType =
+  | "trigger_pr_created"
+  | "trigger_pr_checks_failed"
+  | "trigger_pr_review"
+  | "trigger_pr_merged";
+type RunnableTriggerType = "trigger_ticket_ai" | PrTriggerType;
+
+export type ResolvedManualDispatch =
+  | {
+      definitionId: number;
+      definitionName: string;
+      definitionVersion: number;
+      triggerNodeId: string;
+      triggerType: "trigger_ticket_ai";
+      input: Extract<ManualDispatchInput, { kind: "ticket" }>;
+      inputKind: "ticket";
+      inputPayload: { kind: "ticket"; ticketKey: string };
+      subjectKey: string;
+      ticketKey: string;
+      subjectTitle: string;
+      subjectUrl?: string;
+      currentStatus: string;
+      steps: ManualDispatchPreflightStep[];
+    }
+  | {
+      definitionId: number;
+      definitionName: string;
+      definitionVersion: number;
+      triggerNodeId: string;
+      triggerType: Exclude<RunnableTriggerType, "trigger_ticket_ai">;
+      input: Extract<ManualDispatchInput, { kind: "pull_request" }>;
+      inputKind: "pull_request";
+      inputPayload: {
+        kind: "pull_request";
+        scope: "workflow_owned" | "any";
+        pr: PrTriggerPayload;
+      };
+      subjectKey: string;
+      ticketKey: string | null;
+      subjectTitle: string;
+      subjectUrl: string;
+      steps: ManualDispatchPreflightStep[];
+    };
+
+export async function resolveManualDispatch(input: {
+  db: Db;
+  issueTracker: IssueTrackerAdapter;
+  definitionId: number;
+  triggerNodeId: string;
+  dispatchInput: ManualDispatchInput;
+  /** Resolve an already-accepted request against its immutable pinned graph. */
+  definitionVersion?: number;
+}): Promise<ResolvedManualDispatch> {
+  const deployed = await loadDeployedTrigger(
+    input.db,
+    input.definitionId,
+    input.triggerNodeId,
+    input.definitionVersion,
+  );
+  if (deployed.triggerType === "trigger_ticket_ai") {
+    if (input.dispatchInput.kind !== "ticket") {
+      throw new ManualDispatchError(422, "invalid_input", "This trigger requires a Jira ticket key.");
+    }
+    return resolveTicketDispatch(
+      { ...input, dispatchInput: input.dispatchInput },
+      { ...deployed, triggerType: deployed.triggerType },
+    );
+  }
+  if (input.dispatchInput.kind !== "pull_request") {
+    throw new ManualDispatchError(422, "invalid_input", "This trigger requires a pull or merge request URL.");
+  }
+  return resolvePullRequestDispatch(
+    { ...input, dispatchInput: input.dispatchInput },
+    { ...deployed, triggerType: deployed.triggerType },
+  );
+}
+
+async function loadDeployedTrigger(
+  db: Db,
+  definitionId: number,
+  triggerNodeId: string,
+  definitionVersion?: number,
+): Promise<{
+  definition: WorkflowDefinitionVersionRow;
+  definitionName: string;
+  triggerType: RunnableTriggerType;
+}> {
+  const deployed =
+    definitionVersion === undefined
+      ? await getDeployedWorkflowDefinitionVersion(db, definitionId)
+      : await getWorkflowDefinitionVersion(db, definitionId, definitionVersion);
+  if (!deployed) {
+    throw new ManualDispatchError(422, "not_eligible", "This workflow has no deployed version.");
+  }
+  const node = deployed.definition.nodes.find((candidate) => candidate.id === triggerNodeId);
+  if (
+    !node ||
+    !isTriggerBlockType(node.type) ||
+    node.type === "trigger_plan_approved"
+  ) {
+    throw new ManualDispatchError(
+      422,
+      "not_eligible",
+      "This trigger is not present in the deployed workflow.",
+    );
+  }
+  const rows = await db
+    .select({ name: workflowDefinitions.name })
+    .from(workflowDefinitions)
+    .where(eq(workflowDefinitions.id, definitionId))
+    .limit(1);
+  if (!rows[0]) {
+    throw new ManualDispatchError(404, "invalid_input", "Workflow definition not found.");
+  }
+  return {
+    definition: deployed,
+    definitionName: rows[0].name,
+    triggerType: node.type as RunnableTriggerType,
+  };
+}
+
+async function resolveTicketDispatch(
+  input: {
+    db: Db;
+    issueTracker: IssueTrackerAdapter;
+    definitionId: number;
+    triggerNodeId: string;
+    dispatchInput: Extract<ManualDispatchInput, { kind: "ticket" }>;
+  },
+  deployed: {
+    definition: WorkflowDefinitionVersionRow;
+    definitionName: string;
+    triggerType: "trigger_ticket_ai";
+  },
+): Promise<Extract<ResolvedManualDispatch, { inputKind: "ticket" }>> {
+  const ticketKey = normalizeTicketKey(input.dispatchInput.ticketKey);
+  let ticket;
+  try {
+    ticket = await input.issueTracker.fetchTicket(ticketKey);
+  } catch (error) {
+    if (error instanceof IssueTrackerNotFoundError) {
+      throw new ManualDispatchError(
+        422,
+        "invalid_input",
+        `Ticket ${ticketKey} was not found.`,
+      );
+    }
+    throw new ManualDispatchError(
+      502,
+      "provider_unavailable",
+      "Jira could not be reached.",
+    );
+  }
+  const expectedProject = env.JIRA_PROJECT_KEY.trim().toUpperCase();
+  if (projectKey(ticket.identifier) !== expectedProject) {
+    throw new ManualDispatchError(
+      422,
+      "invalid_input",
+      `Ticket must belong to Jira project ${expectedProject}.`,
+    );
+  }
+  if (await hasDispatchBlockingApprovalForTicket(input.db, ticketKey)) {
+    throw new ManualDispatchError(
+      409,
+      "approval_pending",
+      "This ticket has a pending or approved workflow plan.",
+    );
+  }
+  const alreadyInAi =
+    ticket.trackerStatus.trim().toLowerCase() === env.COLUMN_AI.trim().toLowerCase();
+  return {
+    definitionId: input.definitionId,
+    definitionName: deployed.definitionName,
+    definitionVersion: deployed.definition.version,
+    triggerNodeId: input.triggerNodeId,
+    triggerType: "trigger_ticket_ai",
+    input: { kind: "ticket", ticketKey },
+    inputKind: "ticket",
+    inputPayload: { kind: "ticket", ticketKey },
+    subjectKey: ticketSubjectKey("jira", ticketKey),
+    ticketKey,
+    subjectTitle: ticket.title,
+    currentStatus: ticket.trackerStatus,
+    steps: [
+      {
+        title: "Reserve ticket",
+        description: "Prevent duplicate automatic or manual runs",
+      },
+      {
+        title: alreadyInAi ? `Keep in ${env.COLUMN_AI}` : `Move ${ticket.trackerStatus} → ${env.COLUMN_AI}`,
+        description: alreadyInAi
+          ? "Ticket is already ready for execution"
+          : "Jira changes before execution",
+      },
+      {
+        title: `Start deployed v${deployed.definition.version}`,
+        description: "Draft changes are excluded",
+      },
+    ],
+  };
+}
+
+async function resolvePullRequestDispatch(
+  input: {
+    db: Db;
+    issueTracker: IssueTrackerAdapter;
+    definitionId: number;
+    triggerNodeId: string;
+    dispatchInput: Extract<ManualDispatchInput, { kind: "pull_request" }>;
+  },
+  deployed: {
+    definition: WorkflowDefinitionVersionRow;
+    definitionName: string;
+    triggerType: Exclude<RunnableTriggerType, "trigger_ticket_ai">;
+  },
+): Promise<Extract<ResolvedManualDispatch, { inputKind: "pull_request" }>> {
+  const parsed = parsePullRequestUrl(input.dispatchInput.url);
+  const providerConfig = getConfiguredVcsProviders().find(
+    (provider) => provider.kind === parsed.provider,
+  );
+  if (!providerConfig) {
+    throw new ManualDispatchError(
+      422,
+      "not_eligible",
+      `${parsed.provider === "github" ? "GitHub" : "GitLab"} is not configured.`,
+    );
+  }
+  const vcs = createRepositoryVCS({
+    provider: parsed.provider,
+    repoPath: parsed.repoPath,
+    baseBranch: providerConfig.legacyBaseBranch,
+  });
+  if (!hasManualDispatchPrCapability(vcs)) {
+    throw new ManualDispatchError(
+      422,
+      "not_eligible",
+      "The configured provider cannot resolve manual dispatch input.",
+    );
+  }
+  let snapshot: ManualDispatchPullRequestSnapshot;
+  try {
+    snapshot = await vcs.getManualDispatchPullRequest(parsed.prNumber);
+  } catch {
+    throw new ManualDispatchError(
+      502,
+      "provider_unavailable",
+      "The pull request provider could not be reached.",
+    );
+  }
+  const params = triggerNodeParams(
+    deployed.definition.definition,
+    deployed.triggerType,
+  );
+  const providers = Array.isArray(params.providers) ? params.providers : [];
+  if (providers.length > 0 && !providers.includes(parsed.provider)) {
+    throw new ManualDispatchError(
+      422,
+      "not_eligible",
+      "This deployed trigger does not allow that provider.",
+    );
+  }
+  const scope = params.scope === "any" ? "any" : "workflow_owned";
+  if (scope === "any" && !isRepoAllowed(parsed.repoPath)) {
+    throw new ManualDispatchError(
+      422,
+      "not_eligible",
+      "This repository is outside the configured allowlist.",
+    );
+  }
+  const pr = snapshotToPayload(parsed.provider, parsed.repoPath, snapshot);
+  if (!(await isConfiguredTriggerRepository(pr))) {
+    throw new ManualDispatchError(
+      422,
+      "not_eligible",
+      "This repository is not accessible to the configured provider.",
+    );
+  }
+  const gateCheckNames = loadPostPrGateConfig().postPrGate.steps.map(
+    (step) => `blazebot / ${step.name ?? step.uses}`,
+  );
+  const eligible = selectManualTriggerEvent(
+    deployed.triggerType,
+    pr,
+    {
+      ...snapshot,
+      failedChecks: snapshot.failedChecks.filter(
+        (check) => !isGateCheckName(check.name, gateCheckNames),
+      ),
+    },
+    params,
+  );
+  if (!eligible) {
+    throw new ManualDispatchError(
+      422,
+      "not_eligible",
+      "The pull request's current provider state does not match this trigger.",
+    );
+  }
+
+  let subjectKey: string;
+  let ticketKey: string | null = null;
+  if (scope === "any") {
+    subjectKey = prSubjectKey(pr.provider, pr.repoPath, pr.prNumber);
+  } else {
+    const owned = await findWorkflowOwnedPullRequest(input.db, {
+      provider: pr.provider,
+      repoPath: pr.repoPath,
+      prNumber: pr.prNumber,
+      branchName: pr.headRef,
+      publishedHeadSha: pr.headSha,
+      baseBranch: pr.baseRef,
+    });
+    if (!owned) {
+      throw new ManualDispatchError(
+        422,
+        "not_eligible",
+        "This trigger only accepts pull requests created by AI Workflow.",
+      );
+    }
+    const ticket = await input.issueTracker.fetchTicket(owned.ticketKey).catch(() => null);
+    if (!ticket) {
+      throw new ManualDispatchError(
+        502,
+        "provider_unavailable",
+        "The linked Jira ticket could not be verified.",
+      );
+    }
+    ticketKey = ticket.identifier.trim().toUpperCase();
+    if (await hasDispatchBlockingApprovalForTicket(input.db, ticketKey)) {
+      throw new ManualDispatchError(
+        409,
+        "approval_pending",
+        "The linked Jira ticket has a pending or approved workflow plan.",
+      );
+    }
+    subjectKey = ticketSubjectKey("jira", ticketKey);
+  }
+
+  return {
+    definitionId: input.definitionId,
+    definitionName: deployed.definitionName,
+    definitionVersion: deployed.definition.version,
+    triggerNodeId: input.triggerNodeId,
+    triggerType: deployed.triggerType,
+    input: { kind: "pull_request", url: snapshot.prUrl },
+    inputKind: "pull_request",
+    inputPayload: { kind: "pull_request", scope, pr: eligible.pr },
+    subjectKey,
+    ticketKey,
+    subjectTitle: snapshot.title || `${parsed.repoPath}#${parsed.prNumber}`,
+    subjectUrl: snapshot.prUrl,
+    steps: [
+      {
+        title: "Reserve pull request",
+        description: "Prevent duplicate automatic or manual runs",
+      },
+      {
+        title: "Verify current provider state",
+        description: ticketKey
+          ? `Linked ticket ${ticketKey} remains unchanged`
+          : "No Jira status change",
+      },
+      {
+        title: `Start deployed v${deployed.definition.version}`,
+        description: "Draft changes are excluded",
+      },
+    ],
+  };
+}
+
+export function selectManualTriggerEvent(
+  triggerType: Exclude<RunnableTriggerType, "trigger_ticket_ai">,
+  pr: PrTriggerPayload,
+  snapshot: ManualDispatchPullRequestSnapshot,
+  params: Record<string, unknown>,
+): TriggerEvent | null {
+  if (triggerType === "trigger_pr_created") {
+    if (snapshot.state !== "open") return null;
+    return baseEvent(triggerType, pr, "manual");
+  }
+  if (triggerType === "trigger_pr_merged") {
+    if (snapshot.state !== "merged") return null;
+    return baseEvent(triggerType, pr, "manual");
+  }
+  if (snapshot.state !== "open") return null;
+  if (triggerType === "trigger_pr_review") {
+    for (const review of [...snapshot.reviews].reverse()) {
+      const event = {
+        ...baseEvent(triggerType, { ...pr, review }, review.author),
+        pr: { ...pr, review },
+      };
+      const eligible = selectEligibleEvent(event, params);
+      if (eligible) return eligible;
+    }
+    return null;
+  }
+
+  if (pr.provider === "github") {
+    const byProducer = new Map<string, NonNullable<PrTriggerPayload["failedChecks"]>>();
+    for (const check of snapshot.failedChecks) {
+      const producer = check.appSlug ?? "";
+      if (!producer) continue;
+      byProducer.set(producer, [...(byProducer.get(producer) ?? []), check]);
+    }
+    for (const [producer, failedChecks] of byProducer) {
+      const eligible = selectEligibleEvent(
+        baseEvent(triggerType, { ...pr, failedChecks }, producer),
+        params,
+      );
+      if (eligible) return eligible;
+    }
+    return null;
+  }
+  return selectEligibleEvent(
+    {
+      ...baseEvent(triggerType, { ...pr, failedChecks: snapshot.failedChecks }, "gitlab-ci"),
+      delivery: {
+        provider: "gitlab",
+        producer: "gitlab-ci",
+        source: snapshot.pipelineSource ?? "merge_request_event",
+        deliveryId: "manual",
+      },
+    },
+    params,
+  );
+}
+
+function baseEvent(
+  triggerType: Exclude<RunnableTriggerType, "trigger_ticket_ai">,
+  pr: PrTriggerPayload,
+  producer: string,
+): TriggerEvent {
+  return {
+    delivery: {
+      provider: pr.provider,
+      producer,
+      deliveryId: "manual",
+    },
+    triggerType,
+    pr,
+  };
+}
+
+function snapshotToPayload(
+  provider: "github" | "gitlab",
+  repoPath: string,
+  snapshot: ManualDispatchPullRequestSnapshot,
+): PrTriggerPayload {
+  return {
+    provider,
+    repoPath,
+    prNumber: snapshot.prNumber,
+    prUrl: snapshot.prUrl,
+    headRef: snapshot.headRef,
+    headSha: snapshot.headSha,
+    baseRef: snapshot.baseRef,
+    title: snapshot.title,
+    author: snapshot.author,
+    isDraft: snapshot.isDraft,
+    ...(snapshot.mergeSha ? { mergeSha: snapshot.mergeSha } : {}),
+    ...(snapshot.mergedAt ? { mergedAt: snapshot.mergedAt } : {}),
+    ...(snapshot.pipelineId !== undefined ? { pipelineId: snapshot.pipelineId } : {}),
+    ...(snapshot.failedChecks.length > 0
+      ? { failedChecks: snapshot.failedChecks }
+      : {}),
+  };
+}
+
+export function parsePullRequestUrl(urlText: string): {
+  provider: "github" | "gitlab";
+  repoPath: string;
+  prNumber: number;
+} {
+  let url: URL;
+  try {
+    url = new URL(urlText.trim());
+  } catch {
+    throw new ManualDispatchError(422, "invalid_input", "Enter a valid pull or merge request URL.");
+  }
+  const provider = getConfiguredVcsProviders().find(
+    (candidate) => new URL(candidate.host).host.toLowerCase() === url.host.toLowerCase(),
+  );
+  if (!provider) {
+    throw new ManualDispatchError(
+      422,
+      "invalid_input",
+      "The URL does not match a configured GitHub or GitLab host.",
+    );
+  }
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (provider.kind === "github") {
+    if (segments.length !== 4 || segments[2] !== "pull") {
+      throw new ManualDispatchError(422, "invalid_input", "Enter a GitHub pull request URL.");
+    }
+    return {
+      provider: "github",
+      repoPath: `${segments[0]}/${segments[1]}`,
+      prNumber: positiveInteger(segments[3]),
+    };
+  }
+  const marker = segments.findIndex(
+    (segment, index) => segment === "-" && segments[index + 1] === "merge_requests",
+  );
+  if (marker < 1 || marker + 2 >= segments.length) {
+    throw new ManualDispatchError(422, "invalid_input", "Enter a GitLab merge request URL.");
+  }
+  return {
+    provider: "gitlab",
+    repoPath: segments.slice(0, marker).join("/"),
+    prNumber: positiveInteger(segments[marker + 2]),
+  };
+}
+
+function positiveInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new ManualDispatchError(422, "invalid_input", "Pull request number is invalid.");
+  }
+  return parsed;
+}
+
+function normalizeTicketKey(value: string): string {
+  const normalized = value.trim().toUpperCase();
+  if (!/^[A-Z][A-Z0-9_]*-\d+$/.test(normalized)) {
+    throw new ManualDispatchError(422, "invalid_input", "Enter a valid Jira ticket key.");
+  }
+  return normalized;
+}
+
+function projectKey(identifier: string): string | null {
+  const dash = identifier.indexOf("-");
+  return dash > 0 ? identifier.slice(0, dash).trim().toUpperCase() : null;
+}

--- a/apps/worker/src/manual-dispatch/routes.test.ts
+++ b/apps/worker/src/manual-dispatch/routes.test.ts
@@ -1,0 +1,188 @@
+import { createApp, createRouter, toWebHandler } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  role: "admin" as "owner" | "admin" | "member",
+}));
+const preflight = vi.hoisted(() => vi.fn());
+const dispatch = vi.hoisted(() => vi.fn());
+
+vi.mock("../../env.js", () => ({
+  env: { MAX_CONCURRENT_AGENTS: 4 },
+}));
+vi.mock("../db/client.js", () => ({
+  getDb: () => ({ kind: "db" }),
+}));
+vi.mock("../lib/adapters.js", () => ({
+  createAdapters: () => ({ kind: "adapters" }),
+}));
+vi.mock("../lib/auth/request-context.js", () => ({
+  requireDashboardActor: async () => ({
+    role: state.role,
+    userId: "user-1",
+    organizationName: "AI Workflow",
+  }),
+}));
+vi.mock("../pre-pr-checks/store.js", () => ({
+  dashboardUserLabel: async () => "Karol",
+}));
+vi.mock("./service.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./service.js")>();
+  return {
+    ...actual,
+    preflightManualDispatch: (...args: unknown[]) => preflight(...args),
+    dispatchManualWorkflow: (...args: unknown[]) => dispatch(...args),
+  };
+});
+
+const dispatchRoute = (
+  await import(
+    "../routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch.post.js"
+  )
+).default;
+const preflightRoute = (
+  await import(
+    "../routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch/preflight.post.js"
+  )
+).default;
+
+function routeHandler(
+  pattern: string,
+  route: Parameters<ReturnType<typeof createRouter>["post"]>[1],
+) {
+  const app = createApp();
+  const router = createRouter();
+  router.post(pattern, route);
+  app.use(router);
+  return toWebHandler(app);
+}
+
+const dispatchHandler = routeHandler(
+  "/api/v1/workflow-definitions/:id/triggers/:nodeId/manual-dispatch",
+  dispatchRoute,
+);
+const preflightHandler = routeHandler(
+  "/api/v1/workflow-definitions/:id/triggers/:nodeId/manual-dispatch/preflight",
+  preflightRoute,
+);
+
+function post(path: string, body: unknown) {
+  return new Request(`http://worker.test${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  state.role = "admin";
+  preflight.mockReset().mockResolvedValue({
+    definitionId: 9,
+    definitionName: "Standard delivery",
+    deployedVersion: 3,
+    triggerNodeId: "ticket-trigger",
+    triggerType: "trigger_ticket_ai",
+    input: { kind: "ticket", ticketKey: "AIW-173" },
+    subject: { kind: "ticket", key: "AIW-173", title: "Manual dispatch" },
+    steps: [],
+    runnable: true,
+  });
+  dispatch.mockReset().mockResolvedValue({
+    requestId: "1b02cf6d-d510-4ae1-a26d-c22f777b1b3a",
+    status: "started",
+    runId: "run-1",
+  });
+});
+
+describe("manual dispatch routes", () => {
+  it.each(["owner", "admin"] as const)(
+    "allows %s to preflight a deployed trigger",
+    async (role) => {
+      state.role = role;
+      const response = await preflightHandler(
+        post(
+          "/api/v1/workflow-definitions/9/triggers/ticket-trigger/manual-dispatch/preflight",
+          { kind: "ticket", ticketKey: "AIW-173" },
+        ),
+      );
+      expect(response.status).toBe(200);
+      expect(preflight).toHaveBeenCalledWith(
+        expect.objectContaining({
+          definitionId: 9,
+          triggerNodeId: "ticket-trigger",
+          dispatchInput: { kind: "ticket", ticketKey: "AIW-173" },
+        }),
+      );
+    },
+  );
+
+  it("rejects members before preflight", async () => {
+    state.role = "member";
+    const response = await preflightHandler(
+      post(
+        "/api/v1/workflow-definitions/9/triggers/ticket-trigger/manual-dispatch/preflight",
+        { kind: "ticket", ticketKey: "AIW-173" },
+      ),
+    );
+    expect(response.status).toBe(403);
+    expect(preflight).not.toHaveBeenCalled();
+  });
+
+  it("returns 201 for a started dispatch and records the actor", async () => {
+    const response = await dispatchHandler(
+      post(
+        "/api/v1/workflow-definitions/9/triggers/ticket-trigger/manual-dispatch",
+        {
+          requestId: "1b02cf6d-d510-4ae1-a26d-c22f777b1b3a",
+          expectedDeployedVersion: 3,
+          input: { kind: "ticket", ticketKey: "aiw-173" },
+        },
+      ),
+    );
+    expect(response.status).toBe(201);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        definitionId: 9,
+        triggerNodeId: "ticket-trigger",
+        actor: { id: "user-1", label: "Karol" },
+        request: expect.objectContaining({
+          expectedDeployedVersion: 3,
+          input: { kind: "ticket", ticketKey: "aiw-173" },
+        }),
+      }),
+    );
+  });
+
+  it("returns 202 when durable recovery owns the accepted request", async () => {
+    dispatch.mockResolvedValueOnce({
+      requestId: "1b02cf6d-d510-4ae1-a26d-c22f777b1b3a",
+      status: "recovering",
+    });
+    const response = await dispatchHandler(
+      post(
+        "/api/v1/workflow-definitions/9/triggers/ticket-trigger/manual-dispatch",
+        {
+          requestId: "1b02cf6d-d510-4ae1-a26d-c22f777b1b3a",
+          expectedDeployedVersion: 3,
+          input: { kind: "ticket", ticketKey: "AIW-173" },
+        },
+      ),
+    );
+    expect(response.status).toBe(202);
+  });
+
+  it("rejects malformed request IDs before dispatch", async () => {
+    const response = await dispatchHandler(
+      post(
+        "/api/v1/workflow-definitions/9/triggers/ticket-trigger/manual-dispatch",
+        {
+          requestId: "not-a-request-id",
+          expectedDeployedVersion: 3,
+          input: { kind: "ticket", ticketKey: "AIW-173" },
+        },
+      ),
+    );
+    expect(response.status).toBe(400);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/manual-dispatch/service.test.ts
+++ b/apps/worker/src/manual-dispatch/service.test.ts
@@ -1,0 +1,361 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManualDispatchInput } from "@shared/contracts";
+import { eq } from "drizzle-orm";
+import type { Adapters } from "../lib/adapters.js";
+import type { Db } from "../db/client.js";
+import {
+  manualDispatchRequests,
+  workflowDefinitions,
+  workflowDefinitionVersions,
+} from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+import { getManualDispatchRequest } from "./store.js";
+
+const testState = vi.hoisted(() => ({
+  order: [] as string[],
+  runNumber: 0,
+}));
+const mockResolve = vi.hoisted(() => vi.fn());
+const mockReserve = vi.hoisted(() => vi.fn());
+const mockMove = vi.hoisted(() => vi.fn());
+const mockStart = vi.hoisted(() => vi.fn());
+
+vi.mock("../../env.js", () => ({
+  env: {
+    COLUMN_AI: "AI",
+    JIRA_AI_TRANSITION_ID: undefined,
+    MAX_CONCURRENT_AGENTS: 4,
+  },
+}));
+vi.mock("../lib/dispatch.js", () => ({
+  reserveSubjectWithinCapacity: (...args: unknown[]) => mockReserve(...args),
+}));
+vi.mock("../lib/ticket-transition.js", () => ({
+  moveTicketForRun: (...args: unknown[]) => mockMove(...args),
+}));
+vi.mock("workflow/api", () => ({
+  start: (...args: unknown[]) => mockStart(...args),
+}));
+vi.mock("../workflows/agent.js", () => ({
+  agentWorkflow: "agent-workflow",
+}));
+vi.mock("./resolve.js", () => ({
+  resolveManualDispatch: (...args: unknown[]) => mockResolve(...args),
+}));
+
+const {
+  acknowledgeManualDispatchWorkflow,
+  dispatchManualWorkflow,
+  recoverManualDispatches,
+} = await import("./service.js");
+
+let db: Db;
+let runRegistry: {
+  get: ReturnType<typeof vi.fn>;
+  listAll: ReturnType<typeof vi.fn>;
+  listCapacityConsumers: ReturnType<typeof vi.fn>;
+  releaseReservation: ReturnType<typeof vi.fn>;
+};
+let adapters: Adapters;
+
+function ticketResolution(dispatchInput: ManualDispatchInput) {
+  const ticketKey =
+    dispatchInput.kind === "ticket" ? dispatchInput.ticketKey.trim().toUpperCase() : "AIW-173";
+  return {
+    definitionId: 9,
+    definitionName: "Standard delivery",
+    definitionVersion: 3,
+    triggerNodeId: "ticket-trigger",
+    triggerType: "trigger_ticket_ai" as const,
+    input: { kind: "ticket" as const, ticketKey },
+    inputKind: "ticket" as const,
+    inputPayload: { kind: "ticket" as const, ticketKey },
+    subjectKey: `ticket:jira:${ticketKey}`,
+    ticketKey,
+    subjectTitle: "Manual dispatch",
+    currentStatus: "Backlog",
+    steps: [],
+  };
+}
+
+function request(
+  requestId = "1b02cf6d-d510-4ae1-a26d-c22f777b1b3a",
+  ticketKey = "AIW-173",
+) {
+  return {
+    requestId,
+    expectedDeployedVersion: 3,
+    input: { kind: "ticket" as const, ticketKey },
+  };
+}
+
+beforeEach(async () => {
+  db = await createTestDb();
+  await db.insert(workflowDefinitions).values({
+    id: 9,
+    name: "Standard delivery",
+    createdById: "test",
+    createdByLabel: "Test",
+  });
+  await db.insert(workflowDefinitionVersions).values({
+    definitionId: 9,
+    version: 3,
+    definition: {
+      schemaVersion: 1,
+      nodes: [
+        {
+          id: "ticket-trigger",
+          type: "trigger_ticket_ai",
+          x: 0,
+          y: 0,
+          params: {},
+          inputs: {},
+        },
+      ],
+      edges: [],
+    },
+    createdById: "test",
+    createdByLabel: "Test",
+  });
+  await db
+    .update(workflowDefinitions)
+    .set({ deployedVersion: 3 })
+    .where(eq(workflowDefinitions.id, 9));
+
+  testState.order.length = 0;
+  testState.runNumber = 0;
+  mockResolve.mockReset().mockImplementation(
+    async ({ dispatchInput }: { dispatchInput: ManualDispatchInput }) => {
+      testState.order.push("resolve");
+      return ticketResolution(dispatchInput);
+    },
+  );
+  mockReserve.mockReset().mockImplementation(async () => {
+    testState.order.push("reserve");
+    return "reserved";
+  });
+  mockMove.mockReset().mockImplementation(async () => {
+    testState.order.push("move");
+  });
+  mockStart.mockReset().mockImplementation(async () => {
+    testState.order.push("start");
+    testState.runNumber += 1;
+    return { runId: `run-${testState.runNumber}` };
+  });
+  runRegistry = {
+    get: vi.fn().mockResolvedValue(null),
+    listAll: vi.fn().mockResolvedValue([]),
+    listCapacityConsumers: vi.fn().mockResolvedValue([]),
+    releaseReservation: vi.fn().mockResolvedValue(true),
+  };
+  adapters = {
+    issueTracker: {} as Adapters["issueTracker"],
+    vcs: {} as Adapters["vcs"],
+    messaging: {} as Adapters["messaging"],
+    runRegistry: runRegistry as unknown as Adapters["runRegistry"],
+  };
+});
+
+describe("manual dispatch durability", () => {
+  it("reserves, revalidates, moves Jira, then starts the pinned workflow", async () => {
+    await expect(
+      dispatchManualWorkflow({
+        db,
+        adapters,
+        definitionId: 9,
+        triggerNodeId: "ticket-trigger",
+        request: request(),
+        actor: { id: "user-admin", label: "Karol" },
+        maxConcurrentAgents: 4,
+      }),
+    ).resolves.toEqual({
+      requestId: request().requestId,
+      status: "started",
+      runId: "run-1",
+    });
+
+    expect(testState.order).toEqual([
+      "resolve",
+      "reserve",
+      "resolve",
+      "move",
+      "start",
+    ]);
+    expect(await getManualDispatchRequest(db, request().requestId)).toMatchObject({
+      status: "candidate_started",
+      runId: "run-1",
+      actorUserId: "user-admin",
+      actorLabel: "Karol",
+    });
+  });
+
+  it("returns the stored candidate for an identical request without starting twice", async () => {
+    const input = {
+      db,
+      adapters,
+      definitionId: 9,
+      triggerNodeId: "ticket-trigger",
+      request: request(),
+      actor: { id: "user-admin", label: "Karol" },
+      maxConcurrentAgents: 4,
+    };
+    await dispatchManualWorkflow(input);
+    testState.order.length = 0;
+
+    await expect(dispatchManualWorkflow(input)).resolves.toEqual({
+      requestId: request().requestId,
+      status: "started",
+      runId: "run-1",
+    });
+    expect(testState.order).toEqual(["resolve"]);
+  });
+
+  it("rejects reuse of a request ID with different normalized input", async () => {
+    const base = {
+      db,
+      adapters,
+      definitionId: 9,
+      triggerNodeId: "ticket-trigger",
+      actor: { id: "user-admin", label: "Karol" },
+      maxConcurrentAgents: 4,
+    };
+    await dispatchManualWorkflow({ ...base, request: request() });
+
+    await expect(
+      dispatchManualWorkflow({
+        ...base,
+        request: request(request().requestId, "AIW-174"),
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a deployment change before reserving the subject", async () => {
+    await expect(
+      dispatchManualWorkflow({
+        db,
+        adapters,
+        definitionId: 9,
+        triggerNodeId: "ticket-trigger",
+        request: { ...request(), expectedDeployedVersion: 2 },
+        actor: { id: "user-admin", label: "Karol" },
+        maxConcurrentAgents: 4,
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: "deployment_changed",
+    });
+    expect(mockReserve).not.toHaveBeenCalled();
+  });
+
+  it("records exhausted capacity as a durable conflict", async () => {
+    mockReserve.mockResolvedValueOnce("at_capacity");
+    await expect(
+      dispatchManualWorkflow({
+        db,
+        adapters,
+        definitionId: 9,
+        triggerNodeId: "ticket-trigger",
+        request: request(),
+        actor: { id: "user-admin", label: "Karol" },
+        maxConcurrentAgents: 4,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409, code: "at_capacity" });
+    expect(await getManualDispatchRequest(db, request().requestId)).toMatchObject({
+      status: "failed",
+      errorCode: "at_capacity",
+    });
+    expect(mockMove).not.toHaveBeenCalled();
+  });
+
+  it("records a Jira transition failure and releases the reservation", async () => {
+    mockMove.mockRejectedValueOnce(new Error("transition rejected"));
+
+    await expect(
+      dispatchManualWorkflow({
+        db,
+        adapters,
+        definitionId: 9,
+        triggerNodeId: "ticket-trigger",
+        request: request(),
+        actor: { id: "user-admin", label: "Karol" },
+        maxConcurrentAgents: 4,
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 502,
+      code: "provider_unavailable",
+    });
+    expect(runRegistry.releaseReservation).toHaveBeenCalledOnce();
+    expect(await getManualDispatchRequest(db, request().requestId)).toMatchObject({
+      status: "failed",
+      errorCode: "provider_unavailable",
+    });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("recovers the pinned request after workflow start loses its response", async () => {
+    mockStart.mockRejectedValueOnce(new Error("lost response"));
+    const input = {
+      db,
+      adapters,
+      definitionId: 9,
+      triggerNodeId: "ticket-trigger",
+      request: request(),
+      actor: { id: "user-admin", label: "Karol" },
+      maxConcurrentAgents: 4,
+    };
+    await expect(dispatchManualWorkflow(input)).resolves.toEqual({
+      requestId: request().requestId,
+      status: "recovering",
+    });
+
+    await expect(
+      recoverManualDispatches({ db, adapters, maxConcurrentAgents: 4 }),
+    ).resolves.toMatchObject({ scanned: 1, started: 1, failed: 0 });
+    expect(mockResolve).toHaveBeenLastCalledWith(
+      expect.objectContaining({ definitionVersion: 3 }),
+    );
+    expect(mockStart).toHaveBeenCalledTimes(2);
+    expect(await getManualDispatchRequest(db, request().requestId)).toMatchObject({
+      status: "candidate_started",
+      runId: "run-1",
+    });
+  });
+
+  it("acknowledges the winning workflow only for its durable owner", async () => {
+    await dispatchManualWorkflow({
+      db,
+      adapters,
+      definitionId: 9,
+      triggerNodeId: "ticket-trigger",
+      request: request(),
+      actor: { id: "user-admin", label: "Karol" },
+      maxConcurrentAgents: 4,
+    });
+    const row = await getManualDispatchRequest(db, request().requestId);
+
+    await expect(
+      acknowledgeManualDispatchWorkflow(db, {
+        requestId: request().requestId,
+        ownerToken: "wrong-owner",
+        runId: "run-loser",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      acknowledgeManualDispatchWorkflow(db, {
+        requestId: request().requestId,
+        ownerToken: row!.ownerToken!,
+        runId: "run-1",
+      }),
+    ).resolves.toBe(true);
+    expect(await getManualDispatchRequest(db, request().requestId)).toMatchObject({
+      status: "started",
+      runId: "run-1",
+    });
+  });
+
+  it("migration creates the durable table with its pinned-version foreign key", async () => {
+    const rows = await db.select().from(manualDispatchRequests);
+    expect(rows).toEqual([]);
+  });
+});

--- a/apps/worker/src/manual-dispatch/service.ts
+++ b/apps/worker/src/manual-dispatch/service.ts
@@ -1,0 +1,549 @@
+import { createHash, randomUUID } from "node:crypto";
+import { start } from "workflow/api";
+import type {
+  ManualDispatchInput,
+  ManualDispatchPreflightResponse,
+  ManualDispatchRequest,
+  ManualDispatchResponse,
+} from "@shared/contracts";
+import { env } from "../../env.js";
+import type { Adapters } from "../lib/adapters.js";
+import { reserveSubjectWithinCapacity } from "../lib/dispatch.js";
+import { aiColumnMoveTarget } from "../lib/move-targets.js";
+import { moveTicketForRun } from "../lib/ticket-transition.js";
+import type { Db } from "../db/client.js";
+import type { AgentWorkflowInput, PrTriggerPayload } from "../workflows/agent-input.js";
+import { agentWorkflow } from "../workflows/agent.js";
+import { getDeployedWorkflowDefinitionVersion } from "../workflow-definition/store.js";
+import { ManualDispatchError } from "./errors.js";
+import {
+  acknowledgeManualDispatchStarted,
+  createManualDispatchRequest,
+  getManualDispatchRequest,
+  listRecoverableManualDispatches,
+  markManualDispatchCandidateStarted,
+  markManualDispatchFailed,
+  markManualDispatchPrepared,
+  reserveManualDispatchRequest,
+  resetManualDispatchToPending,
+  type ManualDispatchRow,
+} from "./store.js";
+import { resolveManualDispatch, type ResolvedManualDispatch } from "./resolve.js";
+
+export interface ManualDispatchActor {
+  id: string;
+  label: string;
+}
+
+export async function preflightManualDispatch(input: {
+  db: Db;
+  adapters: Adapters;
+  definitionId: number;
+  triggerNodeId: string;
+  dispatchInput: ManualDispatchInput;
+  maxConcurrentAgents: number;
+}): Promise<ManualDispatchPreflightResponse> {
+  const resolved = await resolveManualDispatch({
+    db: input.db,
+    issueTracker: input.adapters.issueTracker,
+    definitionId: input.definitionId,
+    triggerNodeId: input.triggerNodeId,
+    dispatchInput: input.dispatchInput,
+  });
+  const active = await input.adapters.runRegistry.get(resolved.subjectKey);
+  const atCapacity =
+    !active && (await capacityCount(input.adapters)) >= input.maxConcurrentAgents;
+  return {
+    definitionId: resolved.definitionId,
+    definitionName: resolved.definitionName,
+    deployedVersion: resolved.definitionVersion,
+    triggerNodeId: resolved.triggerNodeId,
+    triggerType: resolved.triggerType,
+    input: resolved.input,
+    subject: {
+      kind: resolved.inputKind === "ticket" ? "ticket" : "pull_request",
+      key:
+        resolved.inputKind === "ticket"
+          ? resolved.ticketKey
+          : `${(resolved.inputPayload.pr as PrTriggerPayload).repoPath}#${(resolved.inputPayload.pr as PrTriggerPayload).prNumber}`,
+      title: resolved.subjectTitle,
+      ...(resolved.inputKind === "ticket"
+        ? { currentStatus: resolved.currentStatus }
+        : { url: resolved.subjectUrl }),
+    },
+    steps: resolved.steps,
+    runnable: !active && !atCapacity,
+    ...(active
+      ? {
+          blocker: {
+            code: "active_run" as const,
+            message: "This ticket or pull request already has an active workflow run.",
+          },
+        }
+      : atCapacity
+        ? {
+            blocker: {
+              code: "at_capacity" as const,
+              message: "All workflow execution slots are currently in use.",
+            },
+          }
+        : {}),
+  };
+}
+
+export async function dispatchManualWorkflow(input: {
+  db: Db;
+  adapters: Adapters;
+  definitionId: number;
+  triggerNodeId: string;
+  request: ManualDispatchRequest;
+  actor: ManualDispatchActor;
+  maxConcurrentAgents: number;
+}): Promise<ManualDispatchResponse> {
+  const resolved = await resolveManualDispatch({
+    db: input.db,
+    issueTracker: input.adapters.issueTracker,
+    definitionId: input.definitionId,
+    triggerNodeId: input.triggerNodeId,
+    dispatchInput: input.request.input,
+  });
+  if (resolved.definitionVersion !== input.request.expectedDeployedVersion) {
+    throw new ManualDispatchError(
+      409,
+      "deployment_changed",
+      "The deployed workflow changed. Run the preflight again.",
+    );
+  }
+  const payloadHash = hashRequest({
+    definitionId: input.definitionId,
+    definitionVersion: resolved.definitionVersion,
+    triggerNodeId: input.triggerNodeId,
+    input: resolved.input,
+  });
+  const persisted = await createManualDispatchRequest(input.db, {
+    requestId: input.request.requestId,
+    payloadHash,
+    definitionId: resolved.definitionId,
+    definitionVersion: resolved.definitionVersion,
+    triggerNodeId: resolved.triggerNodeId,
+    triggerType: resolved.triggerType,
+    inputKind: resolved.inputKind,
+    subjectKey: resolved.subjectKey,
+    ticketKey: resolved.ticketKey,
+    inputPayload: resolved.inputPayload,
+    actorUserId: input.actor.id,
+    actorLabel: input.actor.label,
+  });
+  if (!persisted.inserted && persisted.row.payloadHash !== payloadHash) {
+    throw new ManualDispatchError(
+      409,
+      "invalid_input",
+      "That request ID was already used for different dispatch input.",
+    );
+  }
+  if (!persisted.inserted) return storedResponse(persisted.row);
+  return processManualDispatch({
+    db: input.db,
+    adapters: input.adapters,
+    row: persisted.row,
+    requireCurrentDeployment: true,
+    maxConcurrentAgents: input.maxConcurrentAgents,
+  });
+}
+
+function storedResponse(row: ManualDispatchRow): ManualDispatchResponse {
+  if (
+    (row.status === "candidate_started" || row.status === "started") &&
+    row.runId
+  ) {
+    return { requestId: row.requestId, status: "started", runId: row.runId };
+  }
+  if (row.status === "failed") throw storedFailure(row);
+  return { requestId: row.requestId, status: "recovering" };
+}
+
+export async function acknowledgeManualDispatchWorkflow(
+  db: Db,
+  input: {
+    requestId: string;
+    ownerToken: string;
+    runId: string;
+  },
+): Promise<boolean> {
+  return acknowledgeManualDispatchStarted(
+    db,
+    input.requestId,
+    input.ownerToken,
+    input.runId,
+  );
+}
+
+export async function recoverManualDispatches(input: {
+  db: Db;
+  adapters: Adapters;
+  maxConcurrentAgents: number;
+}): Promise<{ scanned: number; started: number; recovering: number; failed: number }> {
+  const rows = await listRecoverableManualDispatches(input.db);
+  const metrics = { scanned: rows.length, started: 0, recovering: 0, failed: 0 };
+  for (const listed of rows) {
+    let row = listed;
+    try {
+      if (row.ownerToken) {
+        const active = await input.adapters.runRegistry.get(row.subjectKey);
+        if (
+          active?.ownerToken === row.ownerToken &&
+          active.runId &&
+          active.state !== "reserved"
+        ) {
+          await acknowledgeManualDispatchStarted(
+            input.db,
+            row.requestId,
+            row.ownerToken,
+            active.runId,
+          );
+          metrics.started++;
+          continue;
+        }
+        if (!active) {
+          if (!(await resetManualDispatchToPending(input.db, row.requestId, row.ownerToken))) {
+            metrics.recovering++;
+            continue;
+          }
+          row = (await getManualDispatchRequest(input.db, row.requestId))!;
+        } else if (active.ownerToken !== row.ownerToken) {
+          await markManualDispatchFailed(
+            input.db,
+            row.requestId,
+            "active_run",
+            "The subject is now owned by another workflow run.",
+          );
+          metrics.failed++;
+          continue;
+        }
+      }
+      const dispatchInput = storedInput(row);
+      const resolved = await resolveManualDispatch({
+        db: input.db,
+        issueTracker: input.adapters.issueTracker,
+        definitionId: row.definitionId,
+        triggerNodeId: row.triggerNodeId,
+        dispatchInput,
+        definitionVersion: row.definitionVersion,
+      });
+      if (
+        resolved.definitionVersion !== row.definitionVersion ||
+        hashRequest({
+          definitionId: row.definitionId,
+          definitionVersion: row.definitionVersion,
+          triggerNodeId: row.triggerNodeId,
+          input: resolved.input,
+        }) !== row.payloadHash
+      ) {
+        await failAndRelease(input, row, "deployment_changed", "The pinned dispatch is no longer valid.");
+        metrics.failed++;
+        continue;
+      }
+      const result = await processManualDispatch({
+        ...input,
+        row,
+        requireCurrentDeployment: false,
+      });
+      if (result.status === "started") metrics.started++;
+      else metrics.recovering++;
+    } catch (error) {
+      if (error instanceof ManualDispatchError && error.statusCode < 500) {
+        await failAndRelease(input, row, error.code, error.message);
+        metrics.failed++;
+      } else {
+        metrics.recovering++;
+      }
+    }
+  }
+  return metrics;
+}
+
+async function processManualDispatch(input: {
+  db: Db;
+  adapters: Adapters;
+  row: ManualDispatchRow;
+  requireCurrentDeployment: boolean;
+  maxConcurrentAgents: number;
+}): Promise<ManualDispatchResponse> {
+  if (input.row.status === "started" && input.row.runId) {
+    return { requestId: input.row.requestId, status: "started", runId: input.row.runId };
+  }
+  if (input.row.status === "failed") {
+    throw storedFailure(input.row);
+  }
+
+  let ownerToken = input.row.ownerToken;
+  if (!ownerToken) {
+    ownerToken = `owner:${randomUUID()}`;
+    const reservation = await reserveSubjectWithinCapacity(
+      {
+        subjectKey: input.row.subjectKey,
+        ticketKey: input.row.ticketKey,
+        kind:
+          input.row.inputKind === "ticket"
+            ? "manual_ticket"
+            : "manual_pr_trigger",
+      },
+      ownerToken,
+      input.adapters.runRegistry,
+      input.maxConcurrentAgents,
+    );
+    if (reservation !== "reserved") {
+      const code = reservation === "at_capacity" ? "at_capacity" : "active_run";
+      await markManualDispatchFailed(
+        input.db,
+        input.row.requestId,
+        code,
+        reservation === "at_capacity"
+          ? "All workflow execution slots are currently in use."
+          : "This ticket or pull request already has an active workflow run.",
+      );
+      throw new ManualDispatchError(
+        409,
+        code,
+        reservation === "at_capacity"
+          ? "All workflow execution slots are currently in use."
+          : "This ticket or pull request already has an active workflow run.",
+      );
+    }
+    if (!(await reserveManualDispatchRequest(input.db, input.row.requestId, ownerToken))) {
+      await input.adapters.runRegistry
+        .releaseReservation(input.row.subjectKey, ownerToken)
+        .catch(() => false);
+      const fresh = await getManualDispatchRequest(input.db, input.row.requestId);
+      if (fresh?.status === "started" && fresh.runId) {
+        return { requestId: fresh.requestId, status: "started", runId: fresh.runId };
+      }
+      return { requestId: input.row.requestId, status: "recovering" };
+    }
+  }
+
+  if (input.requireCurrentDeployment) {
+    const deployed = await getDeployedWorkflowDefinitionVersion(
+      input.db,
+      input.row.definitionId,
+    );
+    if (deployed?.version !== input.row.definitionVersion) {
+      await failAndRelease(
+        input,
+        { ...input.row, ownerToken },
+        "deployment_changed",
+        "The deployed workflow changed. Run the preflight again.",
+      );
+      throw new ManualDispatchError(
+        409,
+        "deployment_changed",
+        "The deployed workflow changed. Run the preflight again.",
+      );
+    }
+  }
+
+  let resolved: ResolvedManualDispatch;
+  try {
+    resolved = await resolveManualDispatch({
+      db: input.db,
+      issueTracker: input.adapters.issueTracker,
+      definitionId: input.row.definitionId,
+      triggerNodeId: input.row.triggerNodeId,
+      dispatchInput: storedInput(input.row),
+      definitionVersion: input.row.definitionVersion,
+    });
+  } catch (error) {
+    if (error instanceof ManualDispatchError && error.statusCode < 500) {
+      await failAndRelease(input, { ...input.row, ownerToken }, error.code, error.message);
+      throw error;
+    }
+    return { requestId: input.row.requestId, status: "recovering" };
+  }
+  if (
+    resolved.definitionVersion !== input.row.definitionVersion ||
+    resolved.subjectKey !== input.row.subjectKey ||
+    resolved.triggerType !== input.row.triggerType
+  ) {
+    await failAndRelease(
+      input,
+      { ...input.row, ownerToken },
+      "deployment_changed",
+      "The deployed workflow or resolved subject changed. Run the preflight again.",
+    );
+    throw new ManualDispatchError(
+      409,
+      "deployment_changed",
+      "The deployed workflow or resolved subject changed. Run the preflight again.",
+    );
+  }
+
+  if (resolved.inputKind === "ticket") {
+    try {
+      await moveTicketForRun({
+        db: input.db,
+        issueTracker: input.adapters.issueTracker,
+        ticketKey: resolved.ticketKey,
+        target: aiColumnMoveTarget(env),
+        owner: {
+          subjectKey: resolved.subjectKey,
+          ownerToken,
+          runId: null,
+        },
+        requiredOwnerState: "reserved",
+      });
+      if (
+        !(await markManualDispatchPrepared(
+          input.db,
+          input.row.requestId,
+          ownerToken,
+          resolved.inputPayload,
+        ))
+      ) {
+        return { requestId: input.row.requestId, status: "recovering" };
+      }
+    } catch (error) {
+      await input.adapters.runRegistry
+        .releaseReservation(input.row.subjectKey, ownerToken)
+        .catch(() => false);
+      await markManualDispatchFailed(
+        input.db,
+        input.row.requestId,
+        "provider_unavailable",
+        "Jira could not move the ticket to the AI column.",
+      );
+      throw new ManualDispatchError(
+        502,
+        "provider_unavailable",
+        "Jira could not move the ticket to the AI column.",
+      );
+    }
+  } else if (
+    !(await markManualDispatchPrepared(
+      input.db,
+      input.row.requestId,
+      ownerToken,
+      resolved.inputPayload,
+    ))
+  ) {
+    return { requestId: input.row.requestId, status: "recovering" };
+  }
+
+  try {
+    const workflowInput = workflowInputFor(resolved, ownerToken, input.row.requestId);
+    const handle = await start(agentWorkflow, [workflowInput]);
+    const recorded = await markManualDispatchCandidateStarted(
+      input.db,
+      input.row.requestId,
+      ownerToken,
+      handle.runId,
+    );
+    if (!recorded) {
+      const fresh = await getManualDispatchRequest(input.db, input.row.requestId);
+      if (fresh?.status === "started" && fresh.runId) {
+        return { requestId: fresh.requestId, status: "started", runId: fresh.runId };
+      }
+      return { requestId: input.row.requestId, status: "recovering" };
+    }
+    return {
+      requestId: input.row.requestId,
+      status: "started",
+      runId: handle.runId,
+    };
+  } catch {
+    // The ticket may already be in AI and start() may have accepted the
+    // candidate before losing its response. Retain both durable request and
+    // reservation so cron recovery retries this exact pinned dispatch.
+    return { requestId: input.row.requestId, status: "recovering" };
+  }
+}
+
+function workflowInputFor(
+  resolved: ResolvedManualDispatch,
+  ownerToken: string,
+  requestId: string,
+): AgentWorkflowInput {
+  if (resolved.inputKind === "ticket") {
+    return {
+      kind: "ticket",
+      subjectKey: resolved.subjectKey,
+      ticketKey: resolved.ticketKey,
+      ownerToken,
+      definitionId: resolved.definitionId,
+      definitionVersion: resolved.definitionVersion,
+      manualDispatchId: requestId,
+    };
+  }
+  return {
+    kind: "pr_trigger",
+    triggerType: resolved.triggerType,
+    subjectKey: resolved.subjectKey,
+    ...(resolved.ticketKey ? { ticketKey: resolved.ticketKey } : {}),
+    ownerToken,
+    definitionId: resolved.definitionId,
+    definitionVersion: resolved.definitionVersion,
+    scope: resolved.inputPayload.scope,
+    pr: resolved.inputPayload.pr,
+    manualDispatchId: requestId,
+  };
+}
+
+async function capacityCount(adapters: Adapters): Promise<number> {
+  const entries = adapters.runRegistry.listCapacityConsumers
+    ? await adapters.runRegistry.listCapacityConsumers()
+    : await adapters.runRegistry.listAll();
+  return entries.length;
+}
+
+function storedInput(row: ManualDispatchRow): ManualDispatchInput {
+  if (row.inputKind === "ticket") {
+    return { kind: "ticket", ticketKey: row.ticketKey! };
+  }
+  const pr = row.inputPayload.pr as unknown as PrTriggerPayload;
+  return { kind: "pull_request", url: pr.prUrl };
+}
+
+function hashRequest(input: unknown): string {
+  return createHash("sha256").update(stableJson(input)).digest("hex");
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+function storedFailure(row: ManualDispatchRow): ManualDispatchError {
+  const statusCode =
+    row.errorCode === "provider_unavailable"
+      ? 502
+      : row.errorCode === "invalid_input" || row.errorCode === "not_eligible"
+        ? 422
+        : 409;
+  return new ManualDispatchError(
+    statusCode,
+    (row.errorCode ?? "invalid_input") as ManualDispatchError["code"],
+    row.errorMessage ?? "Manual dispatch failed.",
+  );
+}
+
+async function failAndRelease(
+  input: {
+    db: Db;
+    adapters: Adapters;
+  },
+  row: ManualDispatchRow,
+  code: ManualDispatchError["code"],
+  message: string,
+): Promise<void> {
+  if (row.ownerToken) {
+    await input.adapters.runRegistry
+      .releaseReservation(row.subjectKey, row.ownerToken)
+      .catch(() => false);
+  }
+  await markManualDispatchFailed(input.db, row.requestId, code, message);
+}

--- a/apps/worker/src/manual-dispatch/store.ts
+++ b/apps/worker/src/manual-dispatch/store.ts
@@ -1,0 +1,263 @@
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import type { Db } from "../db/client.js";
+import { manualDispatchRequests } from "../db/schema.js";
+
+export type ManualDispatchStatus =
+  | "pending"
+  | "reserved"
+  | "prepared"
+  | "candidate_started"
+  | "started"
+  | "failed";
+
+export interface ManualDispatchRow {
+  requestId: string;
+  payloadHash: string;
+  definitionId: number;
+  definitionVersion: number;
+  triggerNodeId: string;
+  triggerType: string;
+  inputKind: "ticket" | "pull_request";
+  subjectKey: string;
+  ticketKey: string | null;
+  inputPayload: Record<string, unknown>;
+  actorUserId: string;
+  actorLabel: string;
+  ownerToken: string | null;
+  runId: string | null;
+  status: ManualDispatchStatus;
+  errorCode: string | null;
+  errorMessage: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export async function createManualDispatchRequest(
+  db: Db,
+  input: Omit<
+    ManualDispatchRow,
+    | "ownerToken"
+    | "runId"
+    | "status"
+    | "errorCode"
+    | "errorMessage"
+    | "createdAt"
+    | "updatedAt"
+  >,
+): Promise<{ inserted: boolean; row: ManualDispatchRow }> {
+  const inserted = await db
+    .insert(manualDispatchRequests)
+    .values(input)
+    .onConflictDoNothing({ target: manualDispatchRequests.requestId })
+    .returning();
+  if (inserted[0]) return { inserted: true, row: mapRow(inserted[0]) };
+  const existing = await getManualDispatchRequest(db, input.requestId);
+  if (!existing) throw new Error(`Manual dispatch ${input.requestId} disappeared after conflict`);
+  return { inserted: false, row: existing };
+}
+
+export async function getManualDispatchRequest(
+  db: Db,
+  requestId: string,
+): Promise<ManualDispatchRow | null> {
+  const rows = await db
+    .select()
+    .from(manualDispatchRequests)
+    .where(eq(manualDispatchRequests.requestId, requestId))
+    .limit(1);
+  return rows[0] ? mapRow(rows[0]) : null;
+}
+
+export async function reserveManualDispatchRequest(
+  db: Db,
+  requestId: string,
+  ownerToken: string,
+): Promise<boolean> {
+  const rows = await db
+    .update(manualDispatchRequests)
+    .set({
+      ownerToken,
+      status: "reserved",
+      errorCode: null,
+      errorMessage: null,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(manualDispatchRequests.requestId, requestId),
+        eq(manualDispatchRequests.status, "pending"),
+        isNull(manualDispatchRequests.ownerToken),
+      ),
+    )
+    .returning({ requestId: manualDispatchRequests.requestId });
+  return rows.length === 1;
+}
+
+export async function markManualDispatchPrepared(
+  db: Db,
+  requestId: string,
+  ownerToken: string,
+  inputPayload?: Record<string, unknown>,
+): Promise<boolean> {
+  const rows = await db
+    .update(manualDispatchRequests)
+    .set({
+      status: "prepared",
+      ...(inputPayload ? { inputPayload } : {}),
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(manualDispatchRequests.requestId, requestId),
+        eq(manualDispatchRequests.ownerToken, ownerToken),
+        inArray(manualDispatchRequests.status, [
+          "reserved",
+          "prepared",
+          "candidate_started",
+        ]),
+      ),
+    )
+    .returning({ requestId: manualDispatchRequests.requestId });
+  return rows.length === 1;
+}
+
+export async function markManualDispatchCandidateStarted(
+  db: Db,
+  requestId: string,
+  ownerToken: string,
+  runId: string,
+): Promise<boolean> {
+  const rows = await db
+    .update(manualDispatchRequests)
+    .set({ status: "candidate_started", runId, updatedAt: sql`now()` })
+    .where(
+      and(
+        eq(manualDispatchRequests.requestId, requestId),
+        eq(manualDispatchRequests.ownerToken, ownerToken),
+        inArray(manualDispatchRequests.status, [
+          "reserved",
+          "prepared",
+          "candidate_started",
+        ]),
+      ),
+    )
+    .returning({ requestId: manualDispatchRequests.requestId });
+  return rows.length === 1;
+}
+
+export async function acknowledgeManualDispatchStarted(
+  db: Db,
+  requestId: string,
+  ownerToken: string,
+  runId: string,
+): Promise<boolean> {
+  const rows = await db
+    .update(manualDispatchRequests)
+    .set({
+      status: "started",
+      runId,
+      errorCode: null,
+      errorMessage: null,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(manualDispatchRequests.requestId, requestId),
+        eq(manualDispatchRequests.ownerToken, ownerToken),
+        inArray(manualDispatchRequests.status, [
+          "reserved",
+          "prepared",
+          "candidate_started",
+          "started",
+        ]),
+      ),
+    )
+    .returning({ requestId: manualDispatchRequests.requestId });
+  return rows.length === 1;
+}
+
+export async function markManualDispatchFailed(
+  db: Db,
+  requestId: string,
+  errorCode: string,
+  errorMessage: string,
+): Promise<void> {
+  await db
+    .update(manualDispatchRequests)
+    .set({
+      status: "failed",
+      errorCode,
+      errorMessage,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(manualDispatchRequests.requestId, requestId),
+        inArray(manualDispatchRequests.status, [
+          "pending",
+          "reserved",
+          "prepared",
+          "candidate_started",
+        ]),
+      ),
+    );
+}
+
+export async function resetManualDispatchToPending(
+  db: Db,
+  requestId: string,
+  ownerToken: string,
+): Promise<boolean> {
+  const rows = await db
+    .update(manualDispatchRequests)
+    .set({
+      status: "pending",
+      ownerToken: null,
+      runId: null,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(manualDispatchRequests.requestId, requestId),
+        eq(manualDispatchRequests.ownerToken, ownerToken),
+        inArray(manualDispatchRequests.status, [
+          "reserved",
+          "prepared",
+          "candidate_started",
+        ]),
+      ),
+    )
+    .returning({ requestId: manualDispatchRequests.requestId });
+  return rows.length === 1;
+}
+
+export async function listRecoverableManualDispatches(
+  db: Db,
+  limit = 25,
+): Promise<ManualDispatchRow[]> {
+  const rows = await db
+    .select()
+    .from(manualDispatchRequests)
+    .where(
+      inArray(manualDispatchRequests.status, [
+        "pending",
+        "reserved",
+        "prepared",
+        "candidate_started",
+      ]),
+    )
+    .orderBy(manualDispatchRequests.createdAt)
+    .limit(limit);
+  return rows.map(mapRow);
+}
+
+function mapRow(
+  row: typeof manualDispatchRequests.$inferSelect,
+): ManualDispatchRow {
+  return {
+    ...row,
+    inputKind: row.inputKind as ManualDispatchRow["inputKind"],
+    inputPayload: row.inputPayload as Record<string, unknown>,
+    status: row.status as ManualDispatchStatus,
+  };
+}

--- a/apps/worker/src/routes/api/v1/session.get.ts
+++ b/apps/worker/src/routes/api/v1/session.get.ts
@@ -1,20 +1,25 @@
 import { defineEventHandler } from "h3";
+import { getDb } from "../../../db/client.js";
 import { requireDashboardActor, toHttpError } from "../../../lib/auth/request-context.js";
 import {
+  canDispatchWorkflowRuns,
   canEditPrePrChecks,
   canEditWorkflowDefinitions,
   canInvite,
 } from "../../../lib/auth/roles.js";
+import { dashboardUserLabel } from "../../../pre-pr-checks/store.js";
 
 export default defineEventHandler(async (event) => {
   try {
     const actor = await requireDashboardActor(event);
     return {
       organizationName: actor.organizationName,
+      actorLabel: await dashboardUserLabel(getDb(), actor.userId),
       role: actor.role,
       canManageUsers: canInvite(actor.role),
       canEditChecks: canEditPrePrChecks(actor.role),
       canEditWorkflows: canEditWorkflowDefinitions(actor.role),
+      canDispatchWorkflows: canDispatchWorkflowRuns(actor.role),
     };
   } catch (error) {
     toHttpError(error);

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -2012,12 +2012,19 @@ describe("POST /api/v1/workflow-definition/restore (shim)", () => {
 });
 
 describe("GET /api/v1/session", () => {
-  it("reports canEditWorkflows per role", async () => {
+  it("reports workflow edit and dispatch capabilities per role", async () => {
     let res = await handlerFor(sessionGet)(new Request("http://worker.test/"));
-    expect((await res.json()).canEditWorkflows).toBe(true);
+    expect(await res.json()).toMatchObject({
+      actorLabel: "Admin",
+      canEditWorkflows: true,
+      canDispatchWorkflows: true,
+    });
 
     state.sessionUserId = "user_member";
     res = await handlerFor(sessionGet)(new Request("http://worker.test/"));
-    expect((await res.json()).canEditWorkflows).toBe(false);
+    expect(await res.json()).toMatchObject({
+      canEditWorkflows: false,
+      canDispatchWorkflows: false,
+    });
   });
 });

--- a/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch.post.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch.post.ts
@@ -1,0 +1,56 @@
+import type { ManualDispatchResponse } from "@shared/contracts";
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  readBody,
+  setResponseStatus,
+} from "h3";
+import { env } from "../../../../../../../../env.js";
+import { getDb } from "../../../../../../../db/client.js";
+import { createAdapters } from "../../../../../../../lib/adapters.js";
+import { requireDashboardActor } from "../../../../../../../lib/auth/request-context.js";
+import { canDispatchWorkflowRuns } from "../../../../../../../lib/auth/roles.js";
+import {
+  parseManualDispatchRequest,
+  toManualDispatchHttpError,
+} from "../../../../../../../manual-dispatch/http.js";
+import { dispatchManualWorkflow } from "../../../../../../../manual-dispatch/service.js";
+import { dashboardUserLabel } from "../../../../../../../pre-pr-checks/store.js";
+import { parseDefinitionId } from "../../../../workflow-definitions.get.js";
+
+export default defineEventHandler(
+  async (event): Promise<ManualDispatchResponse | undefined> => {
+    try {
+      const actor = await requireDashboardActor(event);
+      if (!canDispatchWorkflowRuns(actor.role)) {
+        throw createError({ statusCode: 403, statusMessage: "Forbidden" });
+      }
+      const definitionId = parseDefinitionId(event);
+      const triggerNodeId = getRouterParam(event, "nodeId")?.trim();
+      if (!triggerNodeId) {
+        throw createError({ statusCode: 404, statusMessage: "Unknown trigger" });
+      }
+      const request = parseManualDispatchRequest(
+        await readBody<unknown>(event).catch(() => null),
+      );
+      const db = getDb();
+      const response = await dispatchManualWorkflow({
+        db,
+        adapters: createAdapters(),
+        definitionId,
+        triggerNodeId,
+        request,
+        actor: {
+          id: actor.userId,
+          label: await dashboardUserLabel(db, actor.userId),
+        },
+        maxConcurrentAgents: env.MAX_CONCURRENT_AGENTS,
+      });
+      setResponseStatus(event, response.status === "started" ? 201 : 202);
+      return response;
+    } catch (error) {
+      toManualDispatchHttpError(error);
+    }
+  },
+);

--- a/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch/preflight.post.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/manual-dispatch/preflight.post.ts
@@ -1,0 +1,50 @@
+import type {
+  ManualDispatchInput,
+  ManualDispatchPreflightResponse,
+} from "@shared/contracts";
+import {
+  createError,
+  defineEventHandler,
+  getRouterParam,
+  readBody,
+} from "h3";
+import { env } from "../../../../../../../../../env.js";
+import { getDb } from "../../../../../../../../db/client.js";
+import { createAdapters } from "../../../../../../../../lib/adapters.js";
+import { requireDashboardActor } from "../../../../../../../../lib/auth/request-context.js";
+import { canDispatchWorkflowRuns } from "../../../../../../../../lib/auth/roles.js";
+import {
+  parseManualDispatchInput,
+  toManualDispatchHttpError,
+} from "../../../../../../../../manual-dispatch/http.js";
+import { preflightManualDispatch } from "../../../../../../../../manual-dispatch/service.js";
+import { parseDefinitionId } from "../../../../../workflow-definitions.get.js";
+
+export default defineEventHandler(
+  async (event): Promise<ManualDispatchPreflightResponse | undefined> => {
+    try {
+      const actor = await requireDashboardActor(event);
+      if (!canDispatchWorkflowRuns(actor.role)) {
+        throw createError({ statusCode: 403, statusMessage: "Forbidden" });
+      }
+      const definitionId = parseDefinitionId(event);
+      const triggerNodeId = getRouterParam(event, "nodeId")?.trim();
+      if (!triggerNodeId) {
+        throw createError({ statusCode: 404, statusMessage: "Unknown trigger" });
+      }
+      const dispatchInput = parseManualDispatchInput(
+        await readBody<ManualDispatchInput>(event).catch(() => null),
+      );
+      return await preflightManualDispatch({
+        db: getDb(),
+        adapters: createAdapters(),
+        definitionId,
+        triggerNodeId,
+        dispatchInput,
+        maxConcurrentAgents: env.MAX_CONCURRENT_AGENTS,
+      });
+    } catch (error) {
+      toManualDispatchHttpError(error);
+    }
+  },
+);

--- a/apps/worker/src/routes/cron/poll.get.test.ts
+++ b/apps/worker/src/routes/cron/poll.get.test.ts
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   listPendingTriggers: vi.fn(),
   deleteExpiredRunObservations: vi.fn(),
   resumeClarificationFromComments: vi.fn(),
+  recoverManualDispatches: vi.fn(),
+  listRecoverableManualDispatches: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({
@@ -105,6 +107,14 @@ vi.mock("../../post-pr-gate/gate-store.js", () => ({
     purgeExpired = vi.fn().mockResolvedValue(undefined);
   },
 }));
+vi.mock("../../manual-dispatch/service.js", () => ({
+  recoverManualDispatches: (...args: unknown[]) =>
+    mocks.recoverManualDispatches(...args),
+}));
+vi.mock("../../manual-dispatch/store.js", () => ({
+  listRecoverableManualDispatches: (...args: unknown[]) =>
+    mocks.listRecoverableManualDispatches(...args),
+}));
 vi.mock("../../lib/telemetry/collect-snapshots.js", () => ({
   collectSnapshots: vi.fn().mockResolvedValue([]),
 }));
@@ -170,6 +180,11 @@ describe("cron clarification recovery ordering", () => {
       runIds: [],
     });
     mocks.resumeClarificationFromComments.mockResolvedValue({ status: "no_clarification" });
+    mocks.recoverManualDispatches.mockImplementation(async () => {
+      state.order.push("recover-manual-dispatches");
+      return { scanned: 0, started: 0, recovering: 0, failed: 0 };
+    });
+    mocks.listRecoverableManualDispatches.mockResolvedValue([]);
   });
 
   it("protects same-run clarifications before discovering generic ticket work", async () => {
@@ -276,6 +291,9 @@ describe("cron clarification recovery ordering", () => {
       state.order.indexOf("discover"),
     );
     expect(state.order.indexOf("discover")).toBeLessThan(
+      state.order.indexOf("recover-manual-dispatches"),
+    );
+    expect(state.order.indexOf("recover-manual-dispatches")).toBeLessThan(
       state.order.indexOf("reconcile-runs"),
     );
     expect(state.order.indexOf("reconcile-runs")).toBeLessThan(
@@ -294,6 +312,12 @@ describe("cron clarification recovery ordering", () => {
     );
     await expect(response.json()).resolves.toMatchObject({
       approvalRecovery: { scanned: 1, started: 1, blocked: 0, errors: 0 },
+      manualDispatchRecovery: {
+        scanned: 0,
+        started: 0,
+        recovering: 0,
+        failed: 0,
+      },
     });
   });
 

--- a/apps/worker/src/routes/cron/poll.get.ts
+++ b/apps/worker/src/routes/cron/poll.get.ts
@@ -25,6 +25,8 @@ import {
   type ApprovalRow,
 } from "../../approvals/store.js";
 import { deleteExpiredRunObservations } from "../../run-observability/store.js";
+import { recoverManualDispatches } from "../../manual-dispatch/service.js";
+import { listRecoverableManualDispatches } from "../../manual-dispatch/store.js";
 
 const PENDING_TRIGGER_RECOVERY_SCAN_LIMIT = 20;
 
@@ -61,6 +63,16 @@ export default defineEventHandler(async (event) => {
   // protected and cannot be replaced by a fresh ticket workflow.
   const ticketKeys = await discoverAiColumnTickets(adapters);
 
+  const manualDispatchRecovery = await recoverManualDispatches({
+    db,
+    adapters,
+    maxConcurrentAgents: env.MAX_CONCURRENT_AGENTS,
+  });
+  const protectedRunSubjects = new Set(retainedClarificationSubjects);
+  for (const request of await listRecoverableManualDispatches(db)) {
+    protectedRunSubjects.add(request.subjectKey);
+  }
+
   const releasedTriggerRecovery = { attempted: 0, started: 0, errors: 0 };
   const releasedTriggerSubjects = new Set<string>();
   const { cancelled, cleaned } = await reconcileRuns(
@@ -94,7 +106,7 @@ export default defineEventHandler(async (event) => {
         throw error;
       }
     },
-    retainedClarificationSubjects,
+    protectedRunSubjects,
     db,
     terminalClarificationSubjects,
   );
@@ -163,6 +175,7 @@ export default defineEventHandler(async (event) => {
     },
     clarificationExpiry,
     approvalRecovery,
+    manualDispatchRecovery,
     replayRetention: { deleted: replayRetention.deleted },
   };
 });

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -70,7 +70,11 @@ function request(input: {
   });
 }
 
-function adapters(options: { state?: "bound" | "cancelling"; active?: boolean } = {}) {
+function adapters(options: {
+  state?: "bound" | "cancelling";
+  active?: boolean;
+  kind?: "ticket" | "manual_pr_trigger";
+} = {}) {
   const active = options.active === false
     ? null
     : {
@@ -79,7 +83,7 @@ function adapters(options: { state?: "bound" | "cancelling"; active?: boolean } 
         ownerToken: "owner-1",
         runId: "run-1",
         state: options.state ?? "bound",
-        kind: "ticket",
+        kind: options.kind ?? "ticket",
         createdAt: Date.now(),
         updatedAt: Date.now(),
       };
@@ -142,6 +146,21 @@ describe("POST /webhooks/jira", () => {
       connected.runRegistry,
       connected.issueTracker,
     );
+  });
+
+  it("keeps a manual PR dispatch independent from linked Jira status", async () => {
+    const connected = adapters({ kind: "manual_pr_trigger" });
+    state.createAdapters.mockReturnValue(connected);
+
+    const response = await app()(request({ actor: "human-account" }));
+
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "manual_pr_dispatch_independent",
+      ticketKey: "PROJ-42",
+    });
+    expect(state.isRunRecordedFailed).not.toHaveBeenCalled();
+    expect(state.cancel).not.toHaveBeenCalled();
   });
 
   it("does not cancel a run whose failure is already recorded (its own backlog move)", async () => {

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -229,6 +229,20 @@ export default defineEventHandler(async (event) => {
     // human abort still cancels, because a live run records neither outcome.
     const subjectKey = ticketSubjectKey("jira", ticketKey);
     const activeRun = await adapters.runRegistry.get(subjectKey).catch(() => null);
+    // Manual PR/MR dispatch can correlate through a workflow-owned Jira ticket
+    // for ownership, but its lifecycle remains provider-driven. A human Jira
+    // move must therefore never cancel this independently dispatched run.
+    if (activeRun?.kind === "manual_pr_trigger") {
+      logger.info(
+        { ticketKey, runId: activeRun.runId, payloadStatus: ticketStatus },
+        "webhook_skip_cancel_manual_pr_dispatch",
+      );
+      return {
+        status: "ignored",
+        reason: "manual_pr_dispatch_independent",
+        ticketKey,
+      };
+    }
     if (activeRun?.runId) {
       let recordedFailed: boolean;
       let recordedSucceeded: boolean;

--- a/apps/worker/src/workflows/agent-input.ts
+++ b/apps/worker/src/workflows/agent-input.ts
@@ -56,6 +56,8 @@ export type AgentWorkflowInput =
       subjectKey: string;
       ticketKey: string;
       ownerToken: string;
+      /** Durable manual-dispatch request acknowledged after owner binding. */
+      manualDispatchId?: string;
       continuation?: ClarificationContinuationMarker;
       definitionId?: number;
       definitionVersion?: WorkflowDefinitionVersionPin;
@@ -70,6 +72,8 @@ export type AgentWorkflowInput =
       subjectKey: string;
       ticketKey?: string;
       ownerToken: string;
+      /** Durable manual-dispatch request acknowledged after owner binding. */
+      manualDispatchId?: string;
       continuation?: ClarificationContinuationMarker;
       definitionId: number;
       definitionVersion: number;

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -2201,6 +2201,7 @@ export async function agentWorkflow(input: string | AgentWorkflowInput) {
   if (!legacyInput) {
     const {
       acknowledgeApprovalDispatchStep,
+      acknowledgeManualDispatchStep,
       acknowledgePendingTriggerStep,
       acknowledgePrTriggerDispatchStep,
       bindWorkflowCandidateStep,
@@ -2211,6 +2212,7 @@ export async function agentWorkflow(input: string | AgentWorkflowInput) {
       workflowRunId,
     );
     if (!bound) return;
+    await acknowledgeManualDispatchStep(entry, workflowRunId);
     await acknowledgeApprovalDispatchStep(entry, workflowRunId);
     if (!(await acknowledgePrTriggerDispatchStep(entry, workflowRunId))) return;
     await acknowledgePendingTriggerStep(entry);

--- a/apps/worker/src/workflows/run-ownership-steps.test.ts
+++ b/apps/worker/src/workflows/run-ownership-steps.test.ts
@@ -25,6 +25,7 @@ const assertActiveRunOwner = vi.fn();
 const moveTicket = vi.fn();
 const fetchTicket = vi.fn();
 const updateTicketLabels = vi.fn();
+const acknowledgeManualDispatch = vi.fn();
 vi.mock("../lib/step-adapters.js", () => ({
   createStepAdapters: () => ({
     runRegistry: {
@@ -80,6 +81,10 @@ vi.mock("../lib/ticket-label-mutation.js", () => ({
   updateTicketLabelsForRun: (...args: any[]) =>
     updateTicketLabels(...args),
 }));
+vi.mock("../manual-dispatch/service.js", () => ({
+  acknowledgeManualDispatchWorkflow: (...args: unknown[]) =>
+    acknowledgeManualDispatch(...args),
+}));
 
 describe("workflow owner steps", () => {
   beforeEach(() => {
@@ -119,6 +124,51 @@ describe("workflow owner steps", () => {
     moveTicket.mockReset().mockResolvedValue(undefined);
     fetchTicket.mockReset();
     updateTicketLabels.mockReset().mockResolvedValue(undefined);
+    acknowledgeManualDispatch.mockReset().mockResolvedValue(true);
+  });
+
+  it("acknowledges a manual request after the workflow wins owner binding", async () => {
+    const { acknowledgeManualDispatchStep } = await import(
+      "./run-ownership-steps.js"
+    );
+    await acknowledgeManualDispatchStep(
+      {
+        kind: "ticket",
+        subjectKey: "ticket:jira:AIW-173",
+        ticketKey: "AIW-173",
+        ownerToken: "owner-1",
+        manualDispatchId: "dispatch-1",
+      },
+      "run-1",
+    );
+
+    expect(acknowledgeManualDispatch).toHaveBeenCalledWith(
+      { db: true },
+      {
+        requestId: "dispatch-1",
+        ownerToken: "owner-1",
+        runId: "run-1",
+      },
+    );
+  });
+
+  it("fails closed when a manual request cannot acknowledge the bound owner", async () => {
+    acknowledgeManualDispatch.mockResolvedValue(false);
+    const { acknowledgeManualDispatchStep } = await import(
+      "./run-ownership-steps.js"
+    );
+    await expect(
+      acknowledgeManualDispatchStep(
+        {
+          kind: "ticket",
+          subjectKey: "ticket:jira:AIW-173",
+          ticketKey: "AIW-173",
+          ownerToken: "owner-1",
+          manualDispatchId: "dispatch-1",
+        },
+        "run-loser",
+      ),
+    ).rejects.toThrow("could not be acknowledged");
   });
 
   it("self-records the exact plan-approval workflow after owner bind", async () => {

--- a/apps/worker/src/workflows/run-ownership-steps.ts
+++ b/apps/worker/src/workflows/run-ownership-steps.ts
@@ -9,6 +9,30 @@ export async function bindWorkflowCandidateStep(
 }
 bindWorkflowCandidateStep.maxRetries = 0;
 
+/** Close the manual-dispatch start ambiguity from inside the winning workflow.
+ * The request is acknowledged only after the candidate owns the reserved
+ * subject, so duplicate workflow candidates cannot both publish success. */
+export async function acknowledgeManualDispatchStep(
+  entry: import("./agent-input.js").AgentWorkflowInput,
+  workflowRunId: string,
+): Promise<void> {
+  "use step";
+  if (!("manualDispatchId" in entry) || !entry.manualDispatchId) return;
+  const { getDb } = await import("../db/client.js");
+  const { acknowledgeManualDispatchWorkflow } = await import(
+    "../manual-dispatch/service.js"
+  );
+  const acknowledged = await acknowledgeManualDispatchWorkflow(getDb(), {
+    requestId: entry.manualDispatchId,
+    ownerToken: entry.ownerToken,
+    runId: workflowRunId,
+  });
+  if (!acknowledged) {
+    throw new Error(`Manual dispatch ${entry.manualDispatchId} could not be acknowledged`);
+  }
+}
+acknowledgeManualDispatchStep.maxRetries = 0;
+
 /** The dashboard starts the run before it can persist the returned run id. The
  * winning Workflow candidate records the same correlation after owner bind so
  * a lost route response/write cannot make a later approval retry start twice. */

--- a/docs/plans/2026-07-23-manual-workflow-dispatch-design.md
+++ b/docs/plans/2026-07-23-manual-workflow-dispatch-design.md
@@ -1,0 +1,121 @@
+# Manual workflow dispatch from trigger blocks
+
+Date: 2026-07-23
+Status: Implemented
+Jira: [AIW-173](https://blazity.atlassian.net/browse/AIW-173)
+Parent: [AIW-118](https://blazity.atlassian.net/browse/AIW-118)
+
+## Product behavior
+
+Owners and admins can manually dispatch an exact deployed workflow from the
+small circular play button beside a deployed trigger block.
+
+- The button is outside the trigger's upper-right corner and never sits on a
+  connector.
+- It appears only when the canvas node ID and type match the selected
+  definition's deployed snapshot.
+- Draft-only triggers do not expose the control.
+- Disabled definitions remain manually runnable when they have a deployment.
+- The modal always names the pinned deployed version and states that draft
+  changes are excluded.
+
+Ticket triggers accept a Jira key. Pull-request triggers accept an authoritative
+GitHub PR or GitLab MR URL. The preflight shows the resolved subject, exact
+deployed version, ordered operations, actor, eligibility, and blockers before
+the dispatch action is enabled.
+
+## Ticket dispatch
+
+Ticket dispatch uses the same subject and global-capacity ownership rules as
+automatic dispatch. A previous automatic failed-ticket marker does not prevent
+an explicit retry.
+
+Execution order:
+
+1. reserve the ticket subject within global capacity;
+2. revalidate the ticket and deployed-version guard;
+3. idempotently move the ticket to the configured AI column under the reserved
+   owner;
+4. start the immutable pinned workflow version;
+5. bind the winning Workflow candidate and acknowledge the durable request.
+
+Tickets already in AI skip the provider transition. Manual ticket runs retain
+normal AI-column cancellation semantics.
+
+## Pull-request dispatch
+
+Manual PR/MR dispatch supports these deployed triggers:
+
+- PR/MR created: the provider says it is currently open;
+- checks failed: the current head has an eligible, non-gate failure from a
+  trusted producer;
+- review: the latest eligible non-bot review matches the configured states;
+- merged: the provider says it is currently merged.
+
+The worker accepts only configured provider hosts, re-fetches authoritative
+state, enforces provider selection, repository access/allowlisting, trigger
+scope, bot filtering, and workflow-owned correlation. It does not synthesize a
+webhook delivery and does not write to `trigger_deliveries`.
+
+A workflow-owned PR may correlate through its linked Jira ticket for subject
+ownership, but Jira status is never changed and cannot cancel the manual PR
+run.
+
+## API and authorization
+
+The dashboard session exposes `canDispatchWorkflows`; the worker grants it only
+to owners and admins and rechecks the same policy on both endpoints:
+
+```text
+POST /api/v1/workflow-definitions/:id/triggers/:nodeId/manual-dispatch/preflight
+POST /api/v1/workflow-definitions/:id/triggers/:nodeId/manual-dispatch
+```
+
+The dashboard provides same-origin proxies at the equivalent
+`/api/workflow-definitions/...` paths.
+
+Shared contracts use a discriminated Jira-ticket or PR/MR input, a preflight
+response, a client-generated request ID with the expected deployed version,
+and a `started` or `recovering` result.
+
+## Durability and recovery
+
+`manual_dispatch_requests` records:
+
+- request and actor identity;
+- immutable definition/version foreign key;
+- trigger node/type;
+- normalized input snapshot and subject;
+- owner token and run ID;
+- safe error information;
+- timestamps and the states `pending`, `reserved`, `prepared`,
+  `candidate_started`, `started`, and `failed`.
+
+The request ID is idempotent. Repeating the same request returns its stored
+result; reusing it for different normalized input conflicts.
+
+Cron recovery runs before generic stale-reservation cleanup. It retries the
+exact immutable version after a crash, a proven-or-ambiguous Jira transition,
+or a lost Workflow start response. Duplicate candidates are safe because only
+one can bind the reserved owner, and the winner acknowledges the request from
+inside the Workflow.
+
+Run registry kinds distinguish `manual_ticket` and `manual_pr_trigger`.
+
+## Verification
+
+Coverage includes:
+
+- owner/admin authorization and member rejection;
+- ticket reservation/transition/start ordering;
+- tickets already in AI, approvals, active subjects, capacity, transition
+  failures, lost starts, duplicate request IDs, and deployment changes;
+- recovery and winner acknowledgment;
+- GitHub/GitLab URL parsing and authoritative created/check/review/merged
+  semantics;
+- bot, gate-check, provider, repository, and workflow-owned filtering;
+- linked-Jira independence for manual PR runs;
+- dashboard proxying, deployed-trigger button visibility/placement,
+  draft-exclusion copy, modal variants, blockers, and recovery/success states;
+- migration shape, worker/dashboard typechecks, complete test suites, and
+  production builds.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@octokit/request':
         specifier: ^10.0.10
         version: 10.0.10
+      '@phosphor-icons/react':
+        specifier: 2.1.10
+        version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@shared/conditions':
         specifier: workspace:*
         version: link:../shared/conditions
@@ -1638,6 +1641,13 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@phosphor-icons/react@2.1.10':
+    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -6877,6 +6887,11 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@pinojs/redact@0.4.0': {}
 


### PR DESCRIPTION
## Summary

- add an owner/admin-only circular run action beside triggers present in the exact deployed workflow graph
- add ticket and GitHub/GitLab PR/MR preflight flows with deployed-version pinning and authoritative provider validation
- add durable, idempotent manual dispatch requests, reservation-first ticket transitions, workflow ownership binding, and crash recovery
- preserve capacity, approval, repository scope, provider trust, and ticket cancellation semantics

## Why

Operators need a safe way to run a specific deployed workflow without waiting for an automatic Jira or VCS event. Manual ticket runs must move the ticket into the configured AI column without racing automatic dispatch, while manual PR/MR runs must validate current provider state without changing Jira.

## Impact

Owners and admins can dispatch deployed ticket and PR/MR triggers from the workflow editor. Draft-only or changed triggers remain unavailable, disabled workflows with a deployed version remain runnable, and successful requests link to the resulting run. The worker stores every accepted request against the immutable definition version and recovers unfinished requests before generic stale-reservation cleanup.

The schema change is migration `0025_manual_dispatch_requests`.

## Validation

- worker tests: 2,712 passed
- dashboard tests: 494 passed
- worker and dashboard TypeScript checks passed
- dashboard Next.js production build passed
- worker Nitro production build passed
- live browser interaction and visual comparison passed

Jira: [AIW-173](https://blazity.atlassian.net/browse/AIW-173)
Parent: [AIW-118](https://blazity.atlassian.net/browse/AIW-118)

[AIW-173]: https://blazity.atlassian.net/browse/AIW-173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual dispatch for eligible deployed workflow triggers.
  * Owners and admins can enter a ticket key or pull/merge request URL, review preflight checks, and start a workflow.
  * Added clear blocking, error, started, and recovery status messaging.
  * Added support for GitHub and GitLab pull/merge request validation, checks, reviews, and deployment eligibility.
* **Bug Fixes**
  * Improved recovery and duplicate-request handling for interrupted dispatches.
  * Prevented unrelated Jira updates from cancelling manually dispatched runs.
* **Documentation**
  * Added design documentation covering manual workflow dispatch behavior and safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->