### PR TITLE
Add safe v1-to-v2 workflow migration

### DIFF
--- a/apps/dashboard/app/api/workflow-definitions/[id]/migrate/route.ts
+++ b/apps/dashboard/app/api/workflow-definitions/[id]/migrate/route.ts
@@ -1,0 +1,9 @@
+import { proxyWorker } from "@/lib/api/proxy";
+import { handleDefinitionMigrate } from "../../handler";
+
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  return handleDefinitionMigrate(req, context, proxyWorker);
+}

--- a/apps/dashboard/app/api/workflow-definitions/handler.ts
+++ b/apps/dashboard/app/api/workflow-definitions/handler.ts
@@ -90,6 +90,22 @@ export async function handleDefinitionValidate(
   return forwardJsonAction(req, context, workerProxy, "validate", "POST");
 }
 
+export async function handleDefinitionMigrate(
+  req: Request,
+  context: IdRouteContext,
+  workerProxy: WorkerProxy,
+) {
+  const response = await forwardJsonAction(
+    req,
+    context,
+    workerProxy,
+    "migrate",
+    "POST",
+  );
+  response.headers.set("cache-control", "private, no-store");
+  return response;
+}
+
 export async function handleDefinitionPromptPreview(
   req: Request,
   context: IdRouteContext,

--- a/apps/dashboard/app/api/workflow-definitions/route.test.ts
+++ b/apps/dashboard/app/api/workflow-definitions/route.test.ts
@@ -9,6 +9,7 @@ import {
   handleDefinitionPromptPreview,
   handleDefinitionPut,
   handleDefinitionLayout,
+  handleDefinitionMigrate,
   handleDefinitionRollback,
   handleDefinitionValidate,
   handleDefinitionRestore,
@@ -228,6 +229,7 @@ for (const [name, handler, method] of [
   ["deploy", handleDefinitionDeploy, "POST"],
   ["rollback", handleDefinitionRollback, "POST"],
   ["validate", handleDefinitionValidate, "POST"],
+  ["migrate", handleDefinitionMigrate, "POST"],
   ["layout", handleDefinitionLayout, "PATCH"],
 ] as const) {
   test(`${name} forwards its body to the nested worker path`, async () => {
@@ -246,6 +248,9 @@ for (const [name, handler, method] of [
       },
     );
     assert.equal(res.status, 200);
+    if (name === "migrate") {
+      assert.equal(res.headers.get("cache-control"), "private, no-store");
+    }
   });
 }
 
@@ -273,3 +278,37 @@ for (const workerResponse of [
     assert.equal(await res.text(), expectedBody);
   });
 }
+
+test("migration preserves the worker status and structured blockers", async () => {
+  const payload = {
+    error: "Workflow migration is blocked",
+    blockers: [
+      {
+        code: "migration.edge.failure_port",
+        message: "A connected FAILED path cannot be converted.",
+        nodeId: "implementation",
+      },
+    ],
+  };
+  const res = await handleDefinitionMigrate(
+    new Request(
+      "https://dashboard.example.com/api/workflow-definitions/12/migrate",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          mode: "apply",
+          sourceVersion: 3,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 3,
+          expectedConversionHash: "a".repeat(64),
+        }),
+      },
+    ),
+    idParams("12"),
+    async () => Response.json(payload, { status: 422 }),
+  );
+
+  assert.equal(res.status, 422);
+  assert.deepEqual(await res.json(), payload);
+  assert.equal(res.headers.get("cache-control"), "private, no-store");
+});

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
@@ -1323,12 +1323,14 @@ export function FlowEditor({
   saveLabel = "Save changes",
   headerTitle,
   headerVersionBadge,
+  headerInlineExtra,
   headerExtra,
   options,
   runStatuses,
   runErrors,
   fitSignal,
   initialSelectedId,
+  selectionRequest,
   onSelectionChange,
   definitionId,
 }: {
@@ -1370,12 +1372,14 @@ export function FlowEditor({
   saveLabel?: string;
   headerTitle: string;
   headerVersionBadge: string;
+  headerInlineExtra?: React.ReactNode;
   headerExtra?: React.ReactNode;
   options: WorkflowEditorOptions;
   runStatuses?: RunStatusMap;
   runErrors?: Record<string, string>;
   fitSignal?: number;
   initialSelectedId?: string;
+  selectionRequest?: { nodeId: string; requestId: number } | null;
   onSelectionChange?: (nodeId: string | null) => void;
   definitionId?: number;
 }) {
@@ -1442,6 +1446,15 @@ export function FlowEditor({
   useEffect(() => {
     onSelectionChange?.(selectedId);
   }, [onSelectionChange, selectedId]);
+
+  useEffect(() => {
+    if (
+      selectionRequest &&
+      nodes.some((node) => node.id === selectionRequest.nodeId)
+    ) {
+      setSelectedId(selectionRequest.nodeId);
+    }
+  }, [nodes, selectionRequest, setSelectedId]);
 
   useEffect(() => {
     if (!fullView) return;
@@ -1918,6 +1931,7 @@ export function FlowEditor({
         <div className="flex items-center gap-2.5 min-w-0">
           <div className="font-display font-semibold text-sm leading-[1.2] text-coal truncate">{headerTitle}</div>
           <span className="rounded-[3px] bg-app-bg px-[6px] py-[2px] font-mono text-[10px] uppercase tracking-[0.05em] text-neutral-600">{headerVersionBadge}</span>
+          {headerInlineExtra}
           {dirty && (
             <span className="rounded-full border border-mariner px-2 py-0.5 font-mono text-[10px] font-semibold tracking-[0.04em] uppercase text-mariner">Unsaved changes</span>
           )}

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
@@ -1414,6 +1414,7 @@ export function FlowEditor({
     useState<CanvasSelection | null>(null);
   const editingSurfaceRef = useRef<HTMLElement | null>(null);
   const editorRootRef = useRef<HTMLDivElement | null>(null);
+  const handledSelectionRequestIdRef = useRef<number | null>(null);
   const deleteDialogRef = useRef<HTMLDivElement | null>(null);
   const deleteDialogRestoreFocusRef = useRef<HTMLElement | null>(null);
   const [shortcutPlatform, setShortcutPlatform] = useState<"mac" | "other">(
@@ -1450,8 +1451,10 @@ export function FlowEditor({
   useEffect(() => {
     if (
       selectionRequest &&
+      selectionRequest.requestId !== handledSelectionRequestIdRef.current &&
       nodes.some((node) => node.id === selectionRequest.nodeId)
     ) {
+      handledSelectionRequestIdRef.current = selectionRequest.requestId;
       setSelectedId(selectionRequest.nodeId);
     }
   }, [nodes, selectionRequest, setSelectedId]);

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-migration-drawer.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-migration-drawer.test.tsx
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { WorkflowDefinitionMigrationPreview } from "@shared/contracts";
+import {
+  canApplyWorkflowMigration,
+  workflowMigrationVisibility,
+  WorkflowMigrationDrawer,
+  type WorkflowMigrationDrawerState,
+} from "./workflow-migration-drawer";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const v2Definition = {
+  schemaVersion: 2,
+  nodes: [],
+  edges: [],
+} as WorkflowDefinitionMigrationPreview["definition"];
+
+function preview(
+  overrides: Partial<WorkflowDefinitionMigrationPreview> = {},
+): WorkflowDefinitionMigrationPreview {
+  return {
+    sourceDefinitionId: 12,
+    sourceVersion: 4,
+    targetSchemaVersion: 2,
+    conversionHash: "a".repeat(64),
+    definition: v2Definition,
+    conversions: [
+      {
+        code: "migration.prompt.default_materialized",
+        message: "Materialized the Implementation Agent default prompt.",
+        nodeId: "implementation",
+      },
+      {
+        code: "migration.edge.id_assigned",
+        message: "Assigned edge id.",
+        nodeId: null,
+      },
+    ],
+    warnings: [],
+    blockers: [],
+    ...overrides,
+  };
+}
+
+function render(state: WorkflowMigrationDrawerState) {
+  return renderToStaticMarkup(
+    <WorkflowMigrationDrawer
+      open
+      state={state}
+      workflowName="Ticket workflow"
+      onClose={() => undefined}
+      onSaveAndPreview={() => undefined}
+      onRetry={() => undefined}
+      onApply={() => undefined}
+      onOpenNode={() => undefined}
+    />,
+  );
+}
+
+test("shows legacy status to everyone but migration only to editors", () => {
+  assert.deepEqual(workflowMigrationVisibility(1, false), {
+    showLegacyStatus: true,
+    showMigrationAction: false,
+  });
+  assert.deepEqual(workflowMigrationVisibility(1, true), {
+    showLegacyStatus: true,
+    showMigrationAction: true,
+  });
+  assert.deepEqual(workflowMigrationVisibility(2, true), {
+    showLegacyStatus: false,
+    showMigrationAction: false,
+  });
+});
+
+test("renders the save-and-preview and loading states", () => {
+  const saveHtml = render({ kind: "save_required" });
+  assert.match(saveHtml, /Save &amp; preview/);
+  assert.match(saveHtml, /exact saved version/);
+  assert.match(saveHtml, /role="dialog"/);
+  assert.match(saveHtml, /aria-modal="true"/);
+
+  const loadingHtml = render({ kind: "loading" });
+  assert.match(loadingHtml, /Checking this workflow for v2/);
+  assert.match(loadingHtml, /Nothing is being saved yet/);
+});
+
+test("renders automatic changes, review items, blockers, and block links", () => {
+  const migrationPreview = preview({
+    warnings: [
+      {
+        code: "migration.review",
+        message: "Review this converted condition.",
+        nodeId: "branch",
+      },
+    ],
+    blockers: [
+      {
+        code: "migration.edge.failure_port",
+        message: "A connected FAILED path cannot be converted safely.",
+        nodeId: "implementation",
+        path: "/edges/2",
+      },
+    ],
+    definition: null,
+    conversionHash: null,
+  });
+  const html = render({ kind: "preview", preview: migrationPreview });
+
+  assert.match(html, /Automatic changes/);
+  assert.match(html, /Review items/);
+  assert.match(html, /Resolve before migrating/);
+  assert.match(html, /Open block/);
+  assert.match(html, /\/edges\/2/);
+  assert.match(html, /Create v2 draft/);
+  assert.match(html, /disabled=""/);
+  assert.equal(canApplyWorkflowMigration(migrationPreview), false);
+});
+
+test("allows a clean or acknowledged-review preview to create a draft", () => {
+  const migrationPreview = preview({
+    warnings: [
+      {
+        code: "migration.review",
+        message: "Review the converted condition.",
+        nodeId: "branch",
+      },
+    ],
+  });
+  const html = render({ kind: "preview", preview: migrationPreview });
+
+  assert.match(html, /Review before creating the draft/);
+  assert.doesNotMatch(
+    html.match(/<button[^>]*>Create v2 draft<\/button>/)?.[0] ?? "",
+    /\sdisabled=""/,
+  );
+  assert.equal(canApplyWorkflowMigration(migrationPreview), true);
+});
+
+test("renders retry and success states with the deployed-v1 guarantee", () => {
+  const errorHtml = render({
+    kind: "error",
+    stale: true,
+    message: "Migration resolution changed.",
+  });
+  assert.match(errorHtml, /Preview is out of date/);
+  assert.match(errorHtml, /Preview again/);
+
+  const successHtml = render({ kind: "success", deployedVersion: 7 });
+  assert.match(successHtml, /V2 draft created/);
+  assert.match(successHtml, /Production still runs deployed v1 version 7/);
+  assert.match(successHtml, /Review v2 draft/);
+});

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-migration-drawer.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-migration-drawer.tsx
@@ -60,6 +60,8 @@ export function WorkflowMigrationDrawer({
 }) {
   const dialogRef = useRef<HTMLElement>(null);
   const restoreFocus = useRef<HTMLElement | null>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
   const [showAllConversions, setShowAllConversions] = useState(false);
 
   useEffect(() => {
@@ -79,7 +81,7 @@ export function WorkflowMigrationDrawer({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        onClose();
+        onCloseRef.current();
         return;
       }
       if (event.key !== "Tab") return;
@@ -108,7 +110,7 @@ export function WorkflowMigrationDrawer({
       window.removeEventListener("keydown", onKeyDown, { capture: true });
       restoreFocus.current?.focus?.();
     };
-  }, [onClose, open]);
+  }, [open]);
 
   useEffect(() => {
     if (open) setShowAllConversions(false);
@@ -477,12 +479,6 @@ function plainDiagnosticMessage(
 ): string {
   if (diagnostic.code === "migration.prompt.default_materialized") {
     return diagnostic.message.replace(/^Materialized/, "Added");
-  }
-  if (diagnostic.code === "migration.prompt.reference_pinned") {
-    return diagnostic.message.replace(/^Pinned/, "Pinned");
-  }
-  if (diagnostic.code === "migration.prompt.nested_snapshot") {
-    return diagnostic.message.replace(/^Snapshotted/, "Snapshotted");
   }
   if (diagnostic.code === "migration.edge.id_assigned") {
     return "Added stable connection IDs so this workflow remains editable.";

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-migration-drawer.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-migration-drawer.tsx
@@ -1,0 +1,497 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type {
+  WorkflowDefinitionMigrationDiagnostic,
+  WorkflowDefinitionMigrationPreview,
+} from "@shared/contracts";
+import {
+  DIALOG_FOCUSABLE_SELECTOR,
+  initialDialogFocusTarget,
+  trappedDialogTabTarget,
+} from "@/lib/prompt-library/prompt-editor-modal-contract";
+
+export type WorkflowMigrationDrawerState =
+  | { kind: "save_required" }
+  | { kind: "loading" }
+  | { kind: "preview"; preview: WorkflowDefinitionMigrationPreview }
+  | { kind: "applying"; preview: WorkflowDefinitionMigrationPreview }
+  | { kind: "error"; message: string; stale: boolean }
+  | { kind: "success"; deployedVersion: number | null };
+
+export function workflowMigrationVisibility(
+  schemaVersion: 1 | 2,
+  canEdit: boolean,
+) {
+  return {
+    showLegacyStatus: schemaVersion === 1,
+    showMigrationAction: schemaVersion === 1 && canEdit,
+  };
+}
+
+export function canApplyWorkflowMigration(
+  preview: WorkflowDefinitionMigrationPreview,
+): boolean {
+  return Boolean(
+    preview.definition &&
+      preview.conversionHash &&
+      preview.blockers.length === 0,
+  );
+}
+
+export function WorkflowMigrationDrawer({
+  open,
+  state,
+  workflowName,
+  onClose,
+  onSaveAndPreview,
+  onRetry,
+  onApply,
+  onOpenNode,
+}: {
+  open: boolean;
+  state: WorkflowMigrationDrawerState;
+  workflowName: string;
+  onClose: () => void;
+  onSaveAndPreview: () => void;
+  onRetry: () => void;
+  onApply: () => void;
+  onOpenNode: (nodeId: string) => void;
+}) {
+  const dialogRef = useRef<HTMLElement>(null);
+  const restoreFocus = useRef<HTMLElement | null>(null);
+  const [showAllConversions, setShowAllConversions] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    restoreFocus.current = document.activeElement as HTMLElement | null;
+    const frame = requestAnimationFrame(() => {
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(DIALOG_FOCUSABLE_SELECTOR),
+      );
+      const preferred = dialog.querySelector<HTMLElement>(
+        "[data-dialog-initial-focus]",
+      );
+      initialDialogFocusTarget(preferred, focusable, dialog).focus();
+    });
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+      const focusable = Array.from(
+        dialog.querySelectorAll<HTMLElement>(DIALOG_FOCUSABLE_SELECTOR),
+      );
+      if (focusable.length === 0) {
+        event.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const target = trappedDialogTabTarget(
+        focusable,
+        document.activeElement as HTMLElement | null,
+        event.shiftKey,
+      );
+      if (!target) return;
+      event.preventDefault();
+      target.focus();
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+      restoreFocus.current?.focus?.();
+    };
+  }, [onClose, open]);
+
+  useEffect(() => {
+    if (open) setShowAllConversions(false);
+  }, [open, state.kind]);
+
+  if (!open) return null;
+
+  const preview =
+    state.kind === "preview" || state.kind === "applying"
+      ? state.preview
+      : null;
+  const canApply = Boolean(
+    preview &&
+      canApplyWorkflowMigration(preview) &&
+      state.kind === "preview",
+  );
+
+  return (
+    <div className="absolute inset-0 z-[80] flex justify-end bg-coal/20">
+      <button
+        type="button"
+        className="absolute inset-0 cursor-default border-none bg-transparent"
+        aria-label="Close migration"
+        onClick={onClose}
+      />
+      <aside
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="workflow-migration-title"
+        tabIndex={-1}
+        className="relative flex h-full w-full flex-col overflow-hidden border-l border-neutral-200 bg-panel shadow-[-14px_0_36px_-20px_rgba(24,27,32,0.35)] sm:max-w-[520px]"
+      >
+        <header className="flex shrink-0 items-start gap-4 border-b border-neutral-200 px-6 py-5">
+          <div className="min-w-0">
+            <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-mariner">
+              Upgrade workflow
+            </p>
+            <h2
+              id="workflow-migration-title"
+              className="mt-1 truncate font-display text-[20px] font-semibold text-coal"
+            >
+              Migrate {workflowName} to v2
+            </h2>
+            <p className="mt-1 font-body text-[12px] leading-5 text-neutral-600">
+              Your deployed v1 stays live. This creates a separate v2 draft for
+              review.
+            </p>
+          </div>
+          <button
+            type="button"
+            data-dialog-initial-focus
+            onClick={onClose}
+            className="ml-auto shrink-0 appearance-none rounded-[3px] border border-neutral-200 bg-panel px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.05em] text-neutral-700 hover:bg-app-bg"
+          >
+            Close
+          </button>
+        </header>
+
+        <div
+          className="grid shrink-0 grid-cols-3 border-b border-neutral-200 bg-app-bg px-6"
+          aria-label="Migration steps"
+        >
+          {["Preview", "Review", "Create draft"].map((step, index) => {
+            const active =
+              state.kind === "success"
+                ? index <= 2
+                : state.kind === "preview" || state.kind === "applying"
+                  ? index <= 1
+                  : index === 0;
+            return (
+              <div
+                key={step}
+                className={`border-b-2 py-3 font-mono text-[10px] uppercase tracking-[0.06em] ${
+                  active
+                    ? "border-mariner text-mariner"
+                    : "border-transparent text-neutral-400"
+                }`}
+              >
+                {index + 1}. {step}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          {state.kind === "save_required" && (
+            <MigrationMessage
+              eyebrow="Save first"
+              title="Save your latest changes before previewing"
+              body="Migration always uses an exact saved version, so the preview cannot drift from what becomes the v2 draft."
+              actionLabel="Save & preview"
+              onAction={onSaveAndPreview}
+            />
+          )}
+
+          {state.kind === "loading" && (
+            <MigrationMessage
+              eyebrow="Preparing preview"
+              title="Checking this workflow for v2"
+              body="We’re applying safe upgrades and validating the complete candidate. Nothing is being saved yet."
+            />
+          )}
+
+          {state.kind === "error" && (
+            <MigrationMessage
+              eyebrow={state.stale ? "Preview is out of date" : "Preview failed"}
+              title={
+                state.stale
+                  ? "The workflow or its prompts changed"
+                  : "We couldn’t prepare the migration"
+              }
+              body={state.message}
+              actionLabel="Preview again"
+              onAction={onRetry}
+              tone="error"
+            />
+          )}
+
+          {state.kind === "success" && (
+            <MigrationMessage
+              eyebrow="V2 draft created"
+              title="Your upgraded draft is ready"
+              body={
+                state.deployedVersion === null
+                  ? "The v2 draft is loaded. Nothing is deployed until you use the existing Deploy action."
+                  : `The v2 draft is loaded. Production still runs deployed v1 version ${state.deployedVersion} until you choose Deploy.`
+              }
+              actionLabel="Review v2 draft"
+              onAction={onClose}
+              tone="success"
+            />
+          )}
+
+          {preview && (
+            <div className="space-y-5">
+              <div className="grid grid-cols-3 gap-2">
+                <CountCard
+                  count={preview.conversions.length}
+                  label="Automatic changes"
+                  tone="default"
+                />
+                <CountCard
+                  count={preview.warnings.length}
+                  label="Review items"
+                  tone="warning"
+                />
+                <CountCard
+                  count={preview.blockers.length}
+                  label="Blockers"
+                  tone={preview.blockers.length > 0 ? "error" : "success"}
+                />
+              </div>
+
+              <DiagnosticSection
+                title="Automatic changes"
+                description="Mechanical updates that preserve how this workflow behaves."
+                diagnostics={
+                  showAllConversions
+                    ? preview.conversions
+                    : preview.conversions.slice(0, 5)
+                }
+              />
+              {preview.conversions.length > 5 && (
+                <button
+                  type="button"
+                  className="appearance-none border-none bg-transparent font-body text-[12px] font-semibold text-mariner hover:underline"
+                  onClick={() => setShowAllConversions((value) => !value)}
+                >
+                  {showAllConversions
+                    ? "Show representative changes"
+                    : `View all ${preview.conversions.length} changes`}
+                </button>
+              )}
+
+              {preview.warnings.length > 0 && (
+                <DiagnosticSection
+                  title="Review before creating the draft"
+                  description="Creating the draft confirms that you have reviewed these items."
+                  diagnostics={preview.warnings}
+                  tone="warning"
+                  onOpenNode={onOpenNode}
+                />
+              )}
+
+              {preview.blockers.length > 0 && (
+                <DiagnosticSection
+                  title="Resolve before migrating"
+                  description="These items would change behavior or cannot be converted safely."
+                  diagnostics={preview.blockers}
+                  tone="error"
+                  onOpenNode={onOpenNode}
+                />
+              )}
+            </div>
+          )}
+        </div>
+
+        {(state.kind === "preview" || state.kind === "applying") && (
+          <footer className="shrink-0 border-t border-neutral-200 bg-panel px-6 py-4">
+            <p className="mb-3 font-body text-[11px] leading-4 text-neutral-500">
+              This creates a draft only. Production stays on the deployed v1
+              version until you deploy the v2 draft.
+            </p>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={onRetry}
+                disabled={state.kind === "applying"}
+                className="appearance-none rounded-[3px] border border-neutral-200 bg-panel px-3 py-2 font-mono text-[10px] uppercase tracking-[0.05em] text-neutral-700 hover:bg-app-bg disabled:opacity-40"
+              >
+                Preview again
+              </button>
+              <button
+                type="button"
+                onClick={onApply}
+                disabled={!canApply}
+                className="appearance-none rounded-[3px] border border-mariner bg-mariner px-4 py-2 font-mono text-[10px] uppercase tracking-[0.05em] text-white disabled:cursor-default disabled:opacity-40"
+              >
+                {state.kind === "applying"
+                  ? "Creating draft…"
+                  : "Create v2 draft"}
+              </button>
+            </div>
+          </footer>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+function CountCard({
+  count,
+  label,
+  tone,
+}: {
+  count: number;
+  label: string;
+  tone: "default" | "warning" | "error" | "success";
+}) {
+  const toneClass = {
+    default: "border-neutral-200 bg-app-bg text-coal",
+    warning: "border-amber-200 bg-amber-50 text-amber-900",
+    error: "border-red-200 bg-red-50 text-red-800",
+    success: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  }[tone];
+  return (
+    <div className={`rounded-[4px] border px-3 py-3 ${toneClass}`}>
+      <p className="font-display text-[22px] font-semibold">{count}</p>
+      <p className="mt-0.5 font-body text-[10px] leading-4">{label}</p>
+    </div>
+  );
+}
+
+function DiagnosticSection({
+  title,
+  description,
+  diagnostics,
+  tone = "default",
+  onOpenNode,
+}: {
+  title: string;
+  description: string;
+  diagnostics: WorkflowDefinitionMigrationDiagnostic[];
+  tone?: "default" | "warning" | "error";
+  onOpenNode?: (nodeId: string) => void;
+}) {
+  const shellClass =
+    tone === "error"
+      ? "border-red-200 bg-red-50"
+      : tone === "warning"
+        ? "border-amber-200 bg-amber-50"
+        : "border-neutral-200 bg-panel";
+  return (
+    <section className={`rounded-[4px] border ${shellClass}`}>
+      <div className="border-b border-inherit px-4 py-3">
+        <h3 className="font-body text-[13px] font-semibold text-coal">{title}</h3>
+        <p className="mt-0.5 font-body text-[11px] leading-4 text-neutral-600">
+          {description}
+        </p>
+      </div>
+      {diagnostics.length === 0 ? (
+        <p className="px-4 py-4 font-body text-[12px] text-neutral-500">
+          No items.
+        </p>
+      ) : (
+        <ul className="divide-y divide-neutral-200">
+          {diagnostics.map((diagnostic, index) => (
+            <li key={`${diagnostic.code}:${diagnostic.path ?? ""}:${index}`} className="px-4 py-3">
+              <div className="flex items-start gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="font-body text-[12px] leading-5 text-neutral-800">
+                    {plainDiagnosticMessage(diagnostic)}
+                  </p>
+                  {diagnostic.path && (
+                    <p className="mt-0.5 break-all font-mono text-[9px] text-neutral-500">
+                      {diagnostic.path}
+                    </p>
+                  )}
+                </div>
+                {diagnostic.nodeId && onOpenNode && (
+                  <button
+                    type="button"
+                    onClick={() => onOpenNode(diagnostic.nodeId!)}
+                    className="shrink-0 appearance-none border-none bg-transparent font-body text-[11px] font-semibold text-mariner hover:underline"
+                  >
+                    Open block
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function MigrationMessage({
+  eyebrow,
+  title,
+  body,
+  actionLabel,
+  onAction,
+  tone = "default",
+}: {
+  eyebrow: string;
+  title: string;
+  body: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  tone?: "default" | "error" | "success";
+}) {
+  const shellClass =
+    tone === "error"
+      ? "border-red-200 bg-red-50"
+      : tone === "success"
+        ? "border-emerald-200 bg-emerald-50"
+        : "border-neutral-200 bg-app-bg";
+  return (
+    <div className={`rounded-[4px] border px-5 py-5 ${shellClass}`}>
+      <p className="font-mono text-[10px] uppercase tracking-[0.07em] text-neutral-500">
+        {eyebrow}
+      </p>
+      <h3 className="mt-2 font-display text-[18px] font-semibold text-coal">
+        {title}
+      </h3>
+      <p className="mt-2 font-body text-[12px] leading-5 text-neutral-600">
+        {body}
+      </p>
+      {actionLabel && onAction && (
+        <button
+          type="button"
+          onClick={onAction}
+          className="mt-4 appearance-none rounded-[3px] border border-mariner bg-mariner px-4 py-2 font-mono text-[10px] uppercase tracking-[0.05em] text-white"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function plainDiagnosticMessage(
+  diagnostic: WorkflowDefinitionMigrationDiagnostic,
+): string {
+  if (diagnostic.code === "migration.prompt.default_materialized") {
+    return diagnostic.message.replace(/^Materialized/, "Added");
+  }
+  if (diagnostic.code === "migration.prompt.reference_pinned") {
+    return diagnostic.message.replace(/^Pinned/, "Pinned");
+  }
+  if (diagnostic.code === "migration.prompt.nested_snapshot") {
+    return diagnostic.message.replace(/^Snapshotted/, "Snapshotted");
+  }
+  if (diagnostic.code === "migration.edge.id_assigned") {
+    return "Added stable connection IDs so this workflow remains editable.";
+  }
+  if (diagnostic.code === "migration.branch.condition_parsed") {
+    return "Converted the branch rule into the visual v2 condition format.";
+  }
+  if (diagnostic.code === "migration.binding.canonicalized") {
+    return "Converted an existing input mapping into the v2 workflow value format.";
+  }
+  return diagnostic.message;
+}

--- a/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
@@ -16,6 +16,8 @@ import {
   type WorkflowDefinitionDeploymentValidationResponse,
   type WorkflowDefinitionDetailResponse,
   type WorkflowDefinitionLayoutResponse,
+  type WorkflowDefinitionMigrationPreview,
+  type WorkflowDefinitionMigrationResponse,
   type WorkflowDefinitionMeta,
   type WorkflowDefinitionTemplate,
   type WorkflowDefinitionSaveResponse,
@@ -26,6 +28,11 @@ import {
   type WorkflowEditorOptions,
 } from "@shared/contracts";
 import { FlowEditor } from "@/components/cockpit/flow-editor/flow-editor";
+import {
+  WorkflowMigrationDrawer,
+  type WorkflowMigrationDrawerState,
+  workflowMigrationVisibility,
+} from "@/components/cockpit/flow-editor/workflow-migration-drawer";
 import { PromptLibraryProvider } from "@/components/cockpit/flow-editor/prompt-library-context";
 import { HarnessProfileCatalogProvider } from "@/components/cockpit/flow-editor/harness-profile-context";
 import { Listbox } from "@/components/cockpit/listbox";
@@ -188,6 +195,13 @@ export function WorkflowEditorScreen({
   const [confirmRestore, setConfirmRestore] = useState<number | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [fitSignal, setFitSignal] = useState(0);
+  const [editorGeneration, setEditorGeneration] = useState(0);
+  const [selectionRequest, setSelectionRequest] = useState<{
+    nodeId: string;
+    requestId: number;
+  } | null>(null);
+  const [migrationState, setMigrationState] =
+    useState<WorkflowMigrationDrawerState | null>(null);
   const [switchState, setSwitchState] = useState<DefinitionSwitchState>({ kind: "idle" });
   const [defsOpen, setDefsOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
@@ -655,6 +669,192 @@ export function WorkflowEditorScreen({
     }
   }
 
+  async function saveForMigration(): Promise<WorkflowDefinitionSaveResponse | null> {
+    const requestRevision = editorResponseGuard.capture();
+    const definition = serializeWorkflowDefinition(
+      nodes,
+      edges,
+      budgets,
+      schemaVersion,
+    );
+    setBusy("migration-save");
+    setError(null);
+    try {
+      await validationController
+        .validateNow({ definitionId: selectedId, definition })
+        .catch(() => undefined);
+      let saved: WorkflowDefinitionSaveResponse | null = null;
+      const layoutSaved = await afterPendingLayoutSave(
+        pendingLayoutSave,
+        async () => {
+          const response = await fetch(
+            `/api/workflow-definitions/${selectedId}`,
+            {
+              method: "PUT",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({
+                definition,
+                expectedDraftRevision: selectedMeta?.draftRevision ?? 0,
+              }),
+            },
+          );
+          if (!response.ok) {
+            throw new Error(await readErrorMessage(response));
+          }
+          saved = (await response.json()) as WorkflowDefinitionSaveResponse;
+        },
+      );
+      if (!layoutSaved || !saved) {
+        throw new Error("Unable to save the latest workflow layout");
+      }
+      if (!editorResponseGuard.isCurrent(requestRevision)) {
+        throw new Error(
+          "The workflow changed while it was being saved. Save and preview again.",
+        );
+      }
+      applySave(saved, false, true);
+      return saved;
+    } catch (err) {
+      setMigrationState({
+        kind: "error",
+        stale: false,
+        message:
+          err instanceof Error ? err.message : "Unable to save the workflow",
+      });
+      return null;
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function previewMigration(
+    meta: WorkflowDefinitionMeta | undefined = selectedMeta,
+  ) {
+    if (!meta?.currentVersion) {
+      setMigrationState({ kind: "save_required" });
+      return;
+    }
+    setDefsOpen(false);
+    setHistoryOpen(false);
+    setMigrationState({ kind: "loading" });
+    try {
+      const response = await fetch(
+        `/api/workflow-definitions/${meta.id}/migrate`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            mode: "preview",
+            sourceVersion: meta.currentVersion,
+            targetSchemaVersion: 2,
+            expectedDraftRevision: meta.draftRevision,
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw Object.assign(new Error(await readErrorMessage(response)), {
+          stale: response.status === 409,
+        });
+      }
+      const preview =
+        (await response.json()) as WorkflowDefinitionMigrationResponse;
+      setMigrationState({
+        kind: "preview",
+        preview: preview as WorkflowDefinitionMigrationPreview,
+      });
+    } catch (err) {
+      setMigrationState({
+        kind: "error",
+        stale:
+          typeof err === "object" &&
+          err !== null &&
+          "stale" in err &&
+          err.stale === true,
+        message:
+          err instanceof Error
+            ? err.message
+            : "Unable to preview this migration",
+      });
+    }
+  }
+
+  function openMigration() {
+    if (dirty || !selectedMeta?.currentVersion) {
+      setMigrationState({ kind: "save_required" });
+      return;
+    }
+    void previewMigration();
+  }
+
+  async function saveAndPreviewMigration() {
+    const saved = await saveForMigration();
+    if (saved) await previewMigration(saved.meta);
+  }
+
+  async function applyMigration() {
+    if (
+      migrationState?.kind !== "preview" ||
+      !migrationState.preview.conversionHash ||
+      !migrationState.preview.definition ||
+      migrationState.preview.blockers.length > 0 ||
+      !selectedMeta
+    ) {
+      return;
+    }
+    const preview = migrationState.preview;
+    setMigrationState({ kind: "applying", preview });
+    try {
+      const response = await fetch(
+        `/api/workflow-definitions/${selectedId}/migrate`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            mode: "apply",
+            sourceVersion: preview.sourceVersion,
+            targetSchemaVersion: 2,
+            expectedDraftRevision: selectedMeta.draftRevision,
+            expectedConversionHash: preview.conversionHash,
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw Object.assign(new Error(await readErrorMessage(response)), {
+          stale: response.status === 409,
+        });
+      }
+      const detailResponse = await fetch(
+        `/api/workflow-definitions/${selectedId}`,
+      );
+      if (!detailResponse.ok) {
+        throw new Error(await readErrorMessage(detailResponse));
+      }
+      const detail =
+        (await detailResponse.json()) as WorkflowDefinitionDetailResponse;
+      applyAuthoritativeDetail(detail, true);
+      setMigrationState({
+        kind: "success",
+        deployedVersion:
+          detail.deployed?.definition.schemaVersion === 1
+            ? detail.deployed.version
+            : null,
+      });
+    } catch (err) {
+      setMigrationState({
+        kind: "error",
+        stale:
+          typeof err === "object" &&
+          err !== null &&
+          "stale" in err &&
+          err.stale === true,
+        message:
+          err instanceof Error
+            ? err.message
+            : "Unable to create the v2 draft",
+      });
+    }
+  }
+
   async function deploy() {
     if (!selectedMeta) return;
     const requestRevision = editorResponseGuard.capture();
@@ -787,6 +987,41 @@ export function WorkflowEditorScreen({
     }
   }
 
+  function applyAuthoritativeDetail(
+    detail: WorkflowDefinitionDetailResponse,
+    forceRemount = false,
+  ) {
+    setSelectedId(detail.meta.id);
+    setMetas((prev) =>
+      prev.map((meta) => (meta.id === detail.meta.id ? detail.meta : meta)),
+    );
+    setVersions(detail.versions);
+    setDeployed(detail.deployed);
+    setBaselineDraft(detail.draft);
+    setLayoutBaseline(JSON.stringify(detail.layout));
+    const definition =
+      detail.draft ?? detail.deployed?.definition ?? defaultDefinition;
+    const flow = toFlowDefinition(definition);
+    const nextDocument: WorkflowEditorDocument = {
+      nodes: flow.nodes,
+      edges: flow.edges,
+      budgets: executionLimitsFromDefinition(definition),
+      edgeGeometry: structuredClone(detail.layout.edges),
+    };
+    setSchemaVersion(flow.schemaVersion);
+    editorDocumentRef.current = nextDocument;
+    dispatchEditorHistory({
+      type: "reset",
+      value: nextDocument,
+      savedSemanticKey: detail.draft
+        ? semanticKeyForDefinition(detail.draft)
+        : null,
+    });
+    setConfirmRestore(null);
+    setFitSignal((signal) => signal + 1);
+    if (forceRemount) setEditorGeneration((generation) => generation + 1);
+  }
+
   async function applySwitch(targetId: number, requestRevision: number) {
     setBusy("switch");
     setError(null);
@@ -803,31 +1038,8 @@ export function WorkflowEditorScreen({
         );
         return;
       }
-      setSelectedId(detail.meta.id);
-      setMetas((prev) => prev.map((m) => (m.id === detail.meta.id ? detail.meta : m)));
-      setVersions(detail.versions);
-      setDeployed(detail.deployed);
-      setBaselineDraft(detail.draft);
-      setLayoutBaseline(JSON.stringify(detail.layout));
-      const def = detail.draft ?? detail.deployed?.definition ?? defaultDefinition;
-      const flow = toFlowDefinition(def);
-      const nextDocument: WorkflowEditorDocument = {
-        nodes: flow.nodes,
-        edges: flow.edges,
-        budgets: executionLimitsFromDefinition(def),
-        edgeGeometry: structuredClone(detail.layout.edges),
-      };
-      setSchemaVersion(flow.schemaVersion);
-      editorDocumentRef.current = nextDocument;
-      dispatchEditorHistory({
-        type: "reset",
-        value: nextDocument,
-        savedSemanticKey: detail.draft
-          ? semanticKeyForDefinition(detail.draft)
-          : null,
-      });
-      setConfirmRestore(null);
-      setFitSignal((s) => s + 1);
+      applyAuthoritativeDetail(detail);
+      setMigrationState(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to load definition");
     } finally {
@@ -946,6 +1158,12 @@ export function WorkflowEditorScreen({
 
   const triggerLabel = (type: WorkflowDefinitionMeta["triggerTypes"][number]) =>
     options.blockRegistry[type]?.presentation.label ?? type;
+  const migrationVisibility = workflowMigrationVisibility(
+    schemaVersion,
+    canEdit,
+  );
+  const isV2DraftWithV1Live =
+    schemaVersion === 2 && deployed?.definition.schemaVersion === 1;
 
   return (
     <HarnessProfileCatalogProvider>
@@ -977,7 +1195,7 @@ export function WorkflowEditorScreen({
       {statusBar}
       <div className="relative flex-1 min-h-0">
         <FlowEditor
-          key={selectedId}
+          key={`${selectedId}:${editorGeneration}`}
           definitionId={selectedId}
           nodes={nodes}
           edges={edges}
@@ -1018,6 +1236,32 @@ export function WorkflowEditorScreen({
           saveLabel="Save draft"
           headerTitle={selectedMeta?.name ?? "Workflow"}
           headerVersionBadge={deployed ? `deployed v${deployed.version}` : "not deployed"}
+          headerInlineExtra={
+            <>
+              {migrationVisibility.showLegacyStatus && (
+                <span
+                  title="Legacy v1 workflows keep FAILED ports for compatibility. Migrate to v2 to make execution errors fail the whole workflow automatically."
+                  className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-amber-800"
+                >
+                  Legacy v1
+                </span>
+              )}
+              {migrationVisibility.showMigrationAction && (
+                <button
+                  type="button"
+                  onClick={openMigration}
+                  className="appearance-none rounded-[3px] border border-mariner bg-panel px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.04em] text-mariner hover:bg-mariner-100"
+                >
+                  Migrate to v2
+                </button>
+              )}
+              {isV2DraftWithV1Live && (
+                <span className="rounded-full border border-mariner-200 bg-mariner-100 px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-mariner">
+                  v2 draft · v1 live
+                </span>
+              )}
+            </>
+          }
           headerExtra={
             <>
               {canEdit && (
@@ -1056,6 +1300,7 @@ export function WorkflowEditorScreen({
           runErrors={derived?.errors}
           fitSignal={fitSignal}
           initialSelectedId={deepLinkNodeId.current}
+          selectionRequest={selectionRequest}
           onSelectionChange={handleSelectionChange}
         />
         {manualDispatchTrigger && deployed && (
@@ -1070,6 +1315,22 @@ export function WorkflowEditorScreen({
             onClose={() => setManualDispatchTrigger(null)}
           />
         )}
+        <WorkflowMigrationDrawer
+          open={migrationState !== null}
+          state={migrationState ?? { kind: "loading" }}
+          workflowName={selectedMeta?.name ?? "workflow"}
+          onClose={() => setMigrationState(null)}
+          onSaveAndPreview={() => void saveAndPreviewMigration()}
+          onRetry={() => void previewMigration()}
+          onApply={() => void applyMigration()}
+          onOpenNode={(nodeId) => {
+            setMigrationState(null);
+            setSelectionRequest((current) => ({
+              nodeId,
+              requestId: (current?.requestId ?? 0) + 1,
+            }));
+          }}
+        />
         {defsOpen && (
           <div className="absolute right-4 top-[56px] z-[60] w-[440px] max-h-[70vh] overflow-y-auto bg-panel border border-neutral-200 rounded-[4px] shadow-[0_12px_28px_-8px_rgba(24,27,32,0.22),0_2px_6px_rgba(24,27,32,0.08)] px-4 py-3">
             <div className="flex items-center justify-between mb-1">

--- a/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { CircleIcon } from "@phosphor-icons/react/dist/csr/Circle";
 import {
   isTriggerBlockType,
   type RunBlockStatusesResponse,
@@ -1500,7 +1501,7 @@ export function WorkflowEditorScreen({
           </div>
         )}
         {historyOpen && (
-          <div className="absolute right-4 top-[56px] z-[60] w-[380px] max-h-[60vh] overflow-y-auto bg-panel border border-neutral-200 rounded-[4px] shadow-[0_12px_28px_-8px_rgba(24,27,32,0.22),0_2px_6px_rgba(24,27,32,0.08)] px-4 py-3">
+          <div className="absolute right-4 top-[56px] z-[60] w-[720px] max-w-[calc(100vw-2rem)] bg-panel border border-neutral-200 rounded-[4px] shadow-[0_12px_28px_-8px_rgba(24,27,32,0.22),0_2px_6px_rgba(24,27,32,0.08)] px-4 py-3">
             <div className="flex items-center justify-between mb-1">
               <h2 className="font-body text-[14px] font-semibold text-neutral-900">History</h2>
               <button
@@ -1521,9 +1522,9 @@ export function WorkflowEditorScreen({
             {versions.map((v) => (
               <div
                 key={v.version}
-                className="flex items-center gap-3 border-b border-neutral-100 py-2 font-body text-[12px] text-neutral-700"
+                className="flex flex-wrap items-center gap-x-3 gap-y-1 border-b border-neutral-100 py-2 font-body text-[12px] text-neutral-700"
               >
-                <span className="font-mono text-neutral-900">v{v.version}</span>
+                <span className="shrink-0 font-mono text-neutral-900">v{v.version}</span>
                 <span
                   title={`Workflow definition schema v${v.definition.schemaVersion}`}
                   className={`shrink-0 rounded-[3px] border px-[6px] py-[2px] font-mono text-[9px] uppercase tracking-[0.04em] ${
@@ -1535,14 +1536,32 @@ export function WorkflowEditorScreen({
                   schema v{v.definition.schemaVersion}
                 </span>
                 {v.version === deployed?.version && (
-                  <span className="rounded-[3px] bg-emerald-50 px-[6px] py-[2px] font-mono text-[10px] text-emerald-700">
-                    deployed
+                  <span
+                    className="group relative shrink-0"
+                    tabIndex={0}
+                    aria-label="Currently deployed version"
+                    aria-describedby={`history-version-${v.version}-deployed-tooltip`}
+                  >
+                    <CircleIcon
+                      aria-hidden="true"
+                      weight="fill"
+                      className="size-2.5 text-emerald-500"
+                    />
+                    <span
+                      id={`history-version-${v.version}-deployed-tooltip`}
+                      role="tooltip"
+                      className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 -translate-x-1/2 whitespace-nowrap rounded-[3px] bg-neutral-900 px-2 py-1 font-body text-[10px] text-white opacity-0 shadow-sm transition-opacity group-hover:opacity-100 group-focus:opacity-100"
+                    >
+                      Currently deployed version
+                    </span>
                   </span>
                 )}
-                <span>{v.createdByLabel}</span>
-                <span className="text-neutral-400">{new Date(v.createdAt).toLocaleString()}</span>
+                <span className="min-w-0 flex-1 basis-[170px] truncate">{v.createdByLabel}</span>
+                <span className="shrink-0 text-neutral-400">
+                  {new Date(v.createdAt).toLocaleString()}
+                </span>
                 {v.restoredFromVersion !== null && (
-                  <span className="rounded-[3px] bg-app-bg px-[6px] py-[2px] font-mono text-[10px] text-neutral-600">
+                  <span className="shrink-0 rounded-[3px] bg-app-bg px-[6px] py-[2px] font-mono text-[10px] text-neutral-600">
                     restored from v{v.restoredFromVersion}
                   </span>
                 )}

--- a/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
@@ -1524,6 +1524,16 @@ export function WorkflowEditorScreen({
                 className="flex items-center gap-3 border-b border-neutral-100 py-2 font-body text-[12px] text-neutral-700"
               >
                 <span className="font-mono text-neutral-900">v{v.version}</span>
+                <span
+                  title={`Workflow definition schema v${v.definition.schemaVersion}`}
+                  className={`shrink-0 rounded-[3px] border px-[6px] py-[2px] font-mono text-[9px] uppercase tracking-[0.04em] ${
+                    v.definition.schemaVersion === 1
+                      ? "border-amber-200 bg-amber-50 text-amber-800"
+                      : "border-mariner-200 bg-mariner-100 text-mariner"
+                  }`}
+                >
+                  schema v{v.definition.schemaVersion}
+                </span>
                 {v.version === deployed?.version && (
                   <span className="rounded-[3px] bg-emerald-50 px-[6px] py-[2px] font-mono text-[10px] text-emerald-700">
                     deployed

--- a/apps/shared/contracts/default-prompts.ts
+++ b/apps/shared/contracts/default-prompts.ts
@@ -223,6 +223,9 @@ Return a JSON object with:
 - \`issues\`: Array of issues found — each with \`file\`, \`description\`, \`severity\` ("critical" or "suggestion"). Include both fixed and unfixable issues.
 - \`error\`: Failure details (when failed).`;
 
+export const DEFAULT_FIX_PROMPT =
+  "Resolve the supplied pull-request feedback, failing checks, and merge conflicts.";
+
 /** Built-in agent prompt templates keyed by their registry names. These bodies
  *  seed the versioned prompt library and preserve the canonical first-party text. */
 export const DEFAULT_AGENT_PROMPTS = {

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -15,6 +15,7 @@ import {
 import { createTestDb } from "../../../db/test-db.js";
 import {
   createPrompt,
+  getPromptVersion,
   savePromptVersion,
 } from "../../../prompt-library/store.js";
 import {
@@ -144,6 +145,31 @@ function migratableV1Definition(prompt?: string): WorkflowDefinitionV1 {
     schemaVersion: 1,
     nodes,
     edges: [{ from: "trigger", to: nodes[1]!.id }],
+  };
+}
+
+function migratableImplementationDefinition(): WorkflowDefinitionV1 {
+  return {
+    schemaVersion: 1,
+    nodes: [
+      {
+        id: "trigger",
+        type: "trigger_ticket_ai",
+        x: 0,
+        y: 0,
+        params: {},
+        inputs: {},
+      },
+      {
+        id: "implementation",
+        type: "implementation_agent",
+        x: 240,
+        y: 0,
+        params: {},
+        inputs: {},
+      },
+    ],
+    edges: [{ from: "trigger", to: "implementation" }],
   };
 }
 
@@ -785,6 +811,256 @@ describe("PUT /api/v1/workflow-definitions/:id", () => {
 
 describe("POST /api/v1/workflow-definitions/:id/migrate", () => {
   const migrate = paramHandler("post", "/d/:id/migrate", detailMigrate);
+
+  it("materializes the exact pinned v1 default prompt before validating v2", async () => {
+    await saveDraft(migratableImplementationDefinition(), 0);
+
+    const previewRes = await migrate(
+      jsonRequest(
+        "POST",
+        {
+          mode: "preview",
+          sourceVersion: 1,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 1,
+        },
+        "http://worker.test/d/1/migrate",
+      ),
+    );
+
+    expect(previewRes.status).toBe(200);
+    const preview = await previewRes.json();
+    expect(preview.blockers).toEqual([]);
+    expect(
+      preview.definition.nodes.find(
+        ({ id }: { id: string }) => id === "implementation",
+      ).configuration.prompt,
+    ).toBe("{{prompt:implement@1}}");
+    expect(preview.conversions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "migration.prompt.default_materialized",
+          nodeId: "implementation",
+        }),
+        expect.objectContaining({
+          code: "migration.prompt.reference_pinned",
+          nodeId: "implementation",
+        }),
+      ]),
+    );
+  });
+
+  it("produces a deployable v2 candidate for the legacy Ticket workflow", async () => {
+    await saveDraft(defaultWorkflowDefinition({ includeReview: true }), 0);
+
+    const previewRes = await migrate(
+      jsonRequest(
+        "POST",
+        {
+          mode: "preview",
+          sourceVersion: 1,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 1,
+        },
+        "http://worker.test/d/1/migrate",
+      ),
+    );
+    const preview = await previewRes.json();
+
+    expect(preview.blockers).toEqual([]);
+    expect(preview.conversionHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(preview.definition).toMatchObject({ schemaVersion: 2 });
+  });
+
+  it("snapshots only legacy nested prompt composition without changing the library", async () => {
+    const leaf = await createPrompt(db, {
+      name: "Migration nested leaf",
+      body: "Leaf body",
+      actor: STORE_ACTOR,
+    });
+    const outer = await createPrompt(db, {
+      name: "Migration nested outer",
+      body: `Outer {{prompt:${leaf.prompt.id}}}`,
+      actor: STORE_ACTOR,
+    });
+    await saveDraft(
+      migratableV1Definition(
+        `Use {{prompt:${outer.prompt.id}}}`,
+      ),
+      0,
+    );
+
+    const previewRes = await migrate(
+      jsonRequest(
+        "POST",
+        {
+          mode: "preview",
+          sourceVersion: 1,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 1,
+        },
+        "http://worker.test/d/1/migrate",
+      ),
+    );
+
+    expect(previewRes.status).toBe(200);
+    const preview = await previewRes.json();
+    expect(preview.blockers).toEqual([]);
+    expect(
+      preview.definition.nodes.find(({ id }: { id: string }) => id === "llm")
+        .configuration.prompt,
+    ).toBe("Use Outer {{prompt:migration-nested-leaf@1}}");
+    expect(preview.conversions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "migration.prompt.nested_snapshot",
+          nodeId: "llm",
+        }),
+        expect.objectContaining({
+          code: "migration.prompt.reference_pinned",
+          nodeId: "llm",
+        }),
+      ]),
+    );
+    expect(
+      (await getPromptVersion(db, outer.prompt.id, 1))?.body,
+    ).toBe(`Outer {{prompt:${leaf.prompt.id}}}`);
+  });
+
+  it("blocks missing, malformed, and cyclic prompt trees at their exact workflow paths", async () => {
+    const cycleA = await createPrompt(db, {
+      name: "Migration cycle A",
+      body: "Initial A",
+      actor: STORE_ACTOR,
+    });
+    const cycleB = await createPrompt(db, {
+      name: "Migration cycle B",
+      body: "{{prompt:migration-cycle-a@2}}",
+      actor: STORE_ACTOR,
+    });
+    await savePromptVersion(db, {
+      promptId: cycleA.prompt.id,
+      body: `{{prompt:${cycleB.prompt.id}@1}}`,
+      actor: STORE_ACTOR,
+    });
+    const invalidPrompts: WorkflowDefinitionV1 = {
+      schemaVersion: 1,
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger_ticket_ai",
+          x: 0,
+          y: 0,
+          params: {},
+          inputs: {},
+        },
+        ...[
+          ["missing", "{{prompt:migration-does-not-exist@1}}"],
+          ["malformed", "{{prompt:}}"],
+          ["cyclic", "{{prompt:migration-cycle-a@2}}"],
+        ].map(([id, prompt], index) => ({
+          id: id!,
+          type: "call_llm" as const,
+          x: 240,
+          y: index * 160,
+          params: { prompt: prompt! },
+          inputs: {},
+        })),
+      ],
+      edges: [
+        { from: "trigger", to: "missing" },
+        { from: "trigger", to: "malformed" },
+        { from: "trigger", to: "cyclic" },
+      ],
+    };
+    await saveDraft(invalidPrompts, 0);
+
+    const previewRes = await migrate(
+      jsonRequest(
+        "POST",
+        {
+          mode: "preview",
+          sourceVersion: 1,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 1,
+        },
+        "http://worker.test/d/1/migrate",
+      ),
+    );
+    const preview = await previewRes.json();
+
+    expect(preview.definition).toBeNull();
+    expect(preview.conversionHash).toBeNull();
+    expect(preview.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "migration.prompt.resolution_failed",
+          nodeId: "missing",
+          path: "/nodes/1/params/prompt",
+        }),
+        expect.objectContaining({
+          code: "migration.prompt.resolution_failed",
+          nodeId: "malformed",
+          path: "/nodes/2/params/prompt",
+        }),
+        expect.objectContaining({
+          code: "migration.prompt.resolution_failed",
+          nodeId: "cyclic",
+          path: "/nodes/3/params/prompt",
+        }),
+      ]),
+    );
+  });
+
+  it("turns asynchronous v2 prompt validation failures into apply blockers", async () => {
+    const invalid: WorkflowDefinitionV1 = {
+      schemaVersion: 1,
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger_ticket_ai",
+          x: 0,
+          y: 0,
+          params: {},
+          inputs: {},
+        },
+        {
+          id: "generic",
+          type: "generic_agent",
+          x: 240,
+          y: 0,
+          params: { workspaceMode: "none" },
+          inputs: {},
+        },
+      ],
+      edges: [{ from: "trigger", to: "generic" }],
+    };
+    await saveDraft(invalid, 0);
+
+    const previewRes = await migrate(
+      jsonRequest(
+        "POST",
+        {
+          mode: "preview",
+          sourceVersion: 1,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 1,
+        },
+        "http://worker.test/d/1/migrate",
+      ),
+    );
+    const preview = await previewRes.json();
+
+    expect(preview.definition).toBeNull();
+    expect(preview.conversionHash).toBeNull();
+    expect(preview.blockers).toContainEqual(
+      expect.objectContaining({
+        code: "migration.target.prompt_empty",
+        nodeId: "generic",
+        path: "/nodes/1/configuration/prompt",
+      }),
+    );
+  });
 
   it("previews and applies an exact immutable source without changing deployment", async () => {
     await saveDraft(migratableV1Definition(), 0);

--- a/apps/worker/src/workflow-definition/v2-converter.ts
+++ b/apps/worker/src/workflow-definition/v2-converter.ts
@@ -60,6 +60,18 @@ export interface WorkflowV2MigrationDiagnostic {
   path?: string;
 }
 
+export function dedupeWorkflowV2MigrationDiagnostics(
+  diagnostics: WorkflowV2MigrationDiagnostic[],
+): WorkflowV2MigrationDiagnostic[] {
+  const seen = new Set<string>();
+  return diagnostics.filter((diagnostic) => {
+    const key = stableStringify(diagnostic);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
 export interface WorkflowV2MigrationResult {
   sourceDefinitionId: number;
   sourceVersion: number;
@@ -246,7 +258,7 @@ export function convertWorkflowDefinitionV1ToV2(
       issue.path,
     );
   }
-  const blockers = dedupeDiagnostics(state.blockers);
+  const blockers = dedupeWorkflowV2MigrationDiagnostics(state.blockers);
   const definition = blockers.length === 0 ? candidate : null;
   return {
     sourceDefinitionId: input.sourceDefinitionId,
@@ -266,8 +278,8 @@ export function convertWorkflowDefinitionV1ToV2(
             )
             .digest("hex"),
     definition,
-    conversions: dedupeDiagnostics(state.conversions),
-    warnings: dedupeDiagnostics(state.warnings),
+    conversions: dedupeWorkflowV2MigrationDiagnostics(state.conversions),
+    warnings: dedupeWorkflowV2MigrationDiagnostics(state.warnings),
     blockers,
   };
 }
@@ -1012,18 +1024,6 @@ function addDiagnostic(
   if (kind === "conversion") state.conversions.push(diagnostic);
   else if (kind === "warning") state.warnings.push(diagnostic);
   else state.blockers.push(diagnostic);
-}
-
-function dedupeDiagnostics(
-  diagnostics: WorkflowV2MigrationDiagnostic[],
-): WorkflowV2MigrationDiagnostic[] {
-  const seen = new Set<string>();
-  return diagnostics.filter((diagnostic) => {
-    const key = stableStringify(diagnostic);
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
 }
 
 function escapePointerSegment(segment: string): string {

--- a/apps/worker/src/workflow-definition/v2-migration-prompts.ts
+++ b/apps/worker/src/workflow-definition/v2-migration-prompts.ts
@@ -17,7 +17,10 @@ import type {
   LoadedPromptReference,
   PromptReferenceLoader,
 } from "../workflows/prompt-references.js";
-import type { WorkflowV2MigrationDiagnostic } from "./v2-converter.js";
+import {
+  dedupeWorkflowV2MigrationDiagnostics,
+  type WorkflowV2MigrationDiagnostic,
+} from "./v2-converter.js";
 
 const MAX_PROMPT_REFERENCE_DEPTH = 10;
 const MAX_MIGRATED_PROMPT_LENGTH = 200_000;
@@ -92,8 +95,8 @@ export async function prepareWorkflowV1PromptsForMigration(
 
   return {
     definition: prepared,
-    conversions: dedupeDiagnostics(conversions),
-    blockers: dedupeDiagnostics(blockers),
+    conversions: dedupeWorkflowV2MigrationDiagnostics(conversions),
+    blockers: dedupeWorkflowV2MigrationDiagnostics(blockers),
   };
 }
 
@@ -304,21 +307,4 @@ function humanAgentName(type: string): string {
 
 function pointerSegment(value: string): string {
   return value.replaceAll("~", "~0").replaceAll("/", "~1");
-}
-
-function dedupeDiagnostics(
-  diagnostics: WorkflowV2MigrationDiagnostic[],
-): WorkflowV2MigrationDiagnostic[] {
-  const seen = new Set<string>();
-  return diagnostics.filter((diagnostic) => {
-    const key = JSON.stringify([
-      diagnostic.code,
-      diagnostic.nodeId,
-      diagnostic.path ?? null,
-      diagnostic.message,
-    ]);
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
 }

--- a/apps/worker/src/workflow-definition/v2-migration-prompts.ts
+++ b/apps/worker/src/workflow-definition/v2-migration-prompts.ts
@@ -1,0 +1,324 @@
+import {
+  containsMalformedPromptReference,
+  DEFAULT_FIX_PROMPT,
+  DEFAULT_PROMPT_NAME_BY_AGENT,
+  formatPromptReferenceToken,
+  parsePromptReferenceTokens,
+  type WorkflowDefinitionV1,
+} from "@shared/contracts";
+import type { Db } from "../db/client.js";
+import {
+  createPromptReferenceLoader,
+  findPromptRowsByNames,
+  getPrompt,
+} from "../prompt-library/store.js";
+import { VARIABLE_PARAM_KEYS } from "../workflows/prompt-vars.js";
+import type {
+  LoadedPromptReference,
+  PromptReferenceLoader,
+} from "../workflows/prompt-references.js";
+import type { WorkflowV2MigrationDiagnostic } from "./v2-converter.js";
+
+const MAX_PROMPT_REFERENCE_DEPTH = 10;
+const MAX_MIGRATED_PROMPT_LENGTH = 200_000;
+
+export interface PreparedWorkflowV1Prompts {
+  definition: WorkflowDefinitionV1;
+  conversions: WorkflowV2MigrationDiagnostic[];
+  blockers: WorkflowV2MigrationDiagnostic[];
+}
+
+/**
+ * Materializes v1's implicit specialized-agent prompts and freezes every
+ * reusable prompt reference to the behavior observed by this preview.
+ *
+ * Safe prompt references remain references. When an immutable prompt version
+ * contains legacy nested composition, only that composition is snapshotted
+ * into the workflow so migration never mutates the shared prompt library.
+ */
+export async function prepareWorkflowV1PromptsForMigration(
+  db: Db,
+  definition: WorkflowDefinitionV1,
+): Promise<PreparedWorkflowV1Prompts> {
+  const prepared = structuredClone(definition);
+  const conversions: WorkflowV2MigrationDiagnostic[] = [];
+  const blockers: WorkflowV2MigrationDiagnostic[] = [];
+
+  await materializeImplicitAgentPrompts(
+    db,
+    prepared,
+    conversions,
+    blockers,
+  );
+
+  const canonicalizer = new MigrationPromptCanonicalizer(
+    createPromptReferenceLoader(db),
+    async (promptId) => (await getPrompt(db, promptId))?.slug ?? null,
+    conversions,
+  );
+  for (const [nodeIndex, node] of prepared.nodes.entries()) {
+    for (const paramName of VARIABLE_PARAM_KEYS[node.type] ?? []) {
+      const current = node.params[paramName];
+      const path = `/nodes/${nodeIndex}/params/${pointerSegment(paramName)}`;
+      if (typeof current === "string") {
+        try {
+          node.params[paramName] = await canonicalizer.canonicalize(
+            current,
+            node.id,
+            path,
+          );
+        } catch (error) {
+          blockers.push(promptBlocker(node.id, path, error));
+        }
+        continue;
+      }
+      if (!Array.isArray(current)) continue;
+      const next = [...current];
+      for (const [index, value] of current.entries()) {
+        if (typeof value !== "string") continue;
+        try {
+          next[index] = await canonicalizer.canonicalize(
+            value,
+            node.id,
+            `${path}/${index}`,
+          );
+        } catch (error) {
+          blockers.push(promptBlocker(node.id, `${path}/${index}`, error));
+        }
+      }
+      node.params[paramName] = next;
+    }
+  }
+
+  return {
+    definition: prepared,
+    conversions: dedupeDiagnostics(conversions),
+    blockers: dedupeDiagnostics(blockers),
+  };
+}
+
+async function materializeImplicitAgentPrompts(
+  db: Db,
+  definition: WorkflowDefinitionV1,
+  conversions: WorkflowV2MigrationDiagnostic[],
+  blockers: WorkflowV2MigrationDiagnostic[],
+): Promise<void> {
+  const requiredNames = [
+    ...new Set(
+      definition.nodes.flatMap((node) => {
+        const name = DEFAULT_PROMPT_NAME_BY_AGENT[node.type];
+        const current = node.params.prompt;
+        return name &&
+          !(typeof current === "string" && current.trim().length > 0)
+          ? [name]
+          : [];
+      }),
+    ),
+  ];
+  const rows = await findPromptRowsByNames(db, requiredNames);
+
+  for (const [nodeIndex, node] of definition.nodes.entries()) {
+    if (node.type === "fix_agent") {
+      const current = node.params.instructions;
+      if (!(typeof current === "string" && current.trim().length > 0)) {
+        node.params.instructions = DEFAULT_FIX_PROMPT;
+        conversions.push({
+          code: "migration.prompt.default_materialized",
+          message: `Added the standard Fix Agent instructions that v1 supplied implicitly.`,
+          nodeId: node.id,
+          path: `/nodes/${nodeIndex}/params/instructions`,
+        });
+      }
+      continue;
+    }
+
+    const name = DEFAULT_PROMPT_NAME_BY_AGENT[node.type];
+    if (!name) continue;
+    const current = node.params.prompt;
+    if (typeof current === "string" && current.trim().length > 0) continue;
+    const active = rows.find(
+      (row) => row.name === name && row.archivedAt === null,
+    );
+    const path = `/nodes/${nodeIndex}/params/prompt`;
+    if (!active) {
+      blockers.push({
+        code: "migration.prompt.default_unavailable",
+        message: `Block "${node.id}" relies on the v1 default prompt "${name}", but that prompt is missing or archived.`,
+        nodeId: node.id,
+        path,
+      });
+      continue;
+    }
+    node.params.prompt = formatPromptReferenceToken({
+      slug: active.slug,
+      version: "latest",
+    });
+    conversions.push({
+      code: "migration.prompt.default_materialized",
+      message: `Added the standard ${humanAgentName(node.type)} prompt that v1 supplied implicitly.`,
+      nodeId: node.id,
+      path,
+    });
+  }
+}
+
+class MigrationPromptCanonicalizer {
+  private readonly promptSlugs = new Map<number, Promise<string | null>>();
+
+  constructor(
+    private readonly load: PromptReferenceLoader,
+    private readonly loadSlug: (promptId: number) => Promise<string | null>,
+    private readonly conversions: WorkflowV2MigrationDiagnostic[],
+  ) {}
+
+  canonicalize(
+    source: string,
+    nodeId: string,
+    path: string,
+  ): Promise<string> {
+    return this.expand(source, nodeId, path, []);
+  }
+
+  private async expand(
+    source: string,
+    nodeId: string,
+    path: string,
+    stack: string[],
+  ): Promise<string> {
+    if (containsMalformedPromptReference(source)) {
+      throw new Error(
+        "Malformed reusable-prompt reference; expected {{prompt:<slug>}} or {{prompt:<slug>@<version>}}.",
+      );
+    }
+    const tokens = parsePromptReferenceTokens(source);
+    if (tokens.length === 0) {
+      assertPromptLength(source);
+      return source;
+    }
+
+    let output = "";
+    let cursor = 0;
+    for (const token of tokens) {
+      output += source.slice(cursor, token.start);
+      if (stack.length >= MAX_PROMPT_REFERENCE_DEPTH) {
+        throw new Error(
+          `Reusable-prompt nesting exceeds ${MAX_PROMPT_REFERENCE_DEPTH} levels.`,
+        );
+      }
+      const loaded = await this.load(
+        token.slug === undefined
+          ? { legacyPromptId: token.legacyPromptId }
+          : { slug: token.slug },
+        token.version,
+      );
+      const resolvedKey = `${loaded.promptId}@${loaded.resolvedVersion}`;
+      if (stack.includes(resolvedKey)) {
+        throw new Error(
+          `Reusable-prompt cycle: ${[...stack, resolvedKey].join(" -> ")}.`,
+        );
+      }
+      const slug = await this.slugFor(loaded);
+      const canonicalBody = await this.expand(
+        loaded.body,
+        nodeId,
+        path,
+        [...stack, resolvedKey],
+      );
+      const canonicalReference = formatPromptReferenceToken({
+        slug,
+        version: loaded.resolvedVersion,
+      });
+
+      if (canonicalBody === loaded.body) {
+        output += canonicalReference;
+        if (canonicalReference !== token.raw) {
+          this.conversions.push({
+            code: "migration.prompt.reference_pinned",
+            message: `Pinned "${token.raw}" to "${canonicalReference}".`,
+            nodeId,
+            path,
+          });
+        }
+      } else {
+        output += canonicalBody;
+        this.conversions.push({
+          code: "migration.prompt.nested_snapshot",
+          message: `Snapshotted legacy nested prompt composition from "${token.raw}" without changing its resolved content.`,
+          nodeId,
+          path,
+        });
+      }
+      assertPromptLength(output);
+      cursor = token.end;
+    }
+    output += source.slice(cursor);
+    assertPromptLength(output);
+    return output;
+  }
+
+  private async slugFor(loaded: LoadedPromptReference): Promise<string> {
+    let pending = this.promptSlugs.get(loaded.promptId);
+    if (!pending) {
+      pending = this.loadSlug(loaded.promptId);
+      this.promptSlugs.set(loaded.promptId, pending);
+    }
+    const slug = await pending;
+    if (!slug) {
+      throw new Error(
+        `Reusable prompt #${loaded.promptId} disappeared during migration preview.`,
+      );
+    }
+    return slug;
+  }
+}
+
+function assertPromptLength(value: string): void {
+  if (value.length > MAX_MIGRATED_PROMPT_LENGTH) {
+    throw new Error(
+      `Resolved prompt exceeds ${MAX_MIGRATED_PROMPT_LENGTH} characters.`,
+    );
+  }
+}
+
+function promptBlocker(
+  nodeId: string,
+  path: string,
+  error: unknown,
+): WorkflowV2MigrationDiagnostic {
+  return {
+    code: "migration.prompt.resolution_failed",
+    message: `Block "${nodeId}" prompt could not be migrated safely: ${
+      error instanceof Error ? error.message : "Reusable-prompt resolution failed."
+    }`,
+    nodeId,
+    path,
+  };
+}
+
+function humanAgentName(type: string): string {
+  return type
+    .replace(/_agent$/, " Agent")
+    .replaceAll("_", " ")
+    .replace(/^\w/, (letter) => letter.toUpperCase());
+}
+
+function pointerSegment(value: string): string {
+  return value.replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+function dedupeDiagnostics(
+  diagnostics: WorkflowV2MigrationDiagnostic[],
+): WorkflowV2MigrationDiagnostic[] {
+  const seen = new Set<string>();
+  return diagnostics.filter((diagnostic) => {
+    const key = JSON.stringify([
+      diagnostic.code,
+      diagnostic.nodeId,
+      diagnostic.path ?? null,
+      diagnostic.message,
+    ]);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/apps/worker/src/workflow-definition/v2-migration.ts
+++ b/apps/worker/src/workflow-definition/v2-migration.ts
@@ -19,7 +19,9 @@ import {
   getWorkflowDefinitionRawState,
   WorkflowDefinitionStoreError,
 } from "./store.js";
+import { validateWorkflowDefinitionCandidateWithPromptAuthoring } from "./prompt-authoring.js";
 import { upgradeStoredWorkflowDefinition } from "./schema.js";
+import { prepareWorkflowV1PromptsForMigration } from "./v2-migration-prompts.js";
 import {
   convertWorkflowDefinitionV1ToV2,
   workflowV2PromptResolutionKey,
@@ -107,24 +109,63 @@ export async function previewWorkflowDefinitionV2Migration(
     });
   }
 
+  const registryContext =
+    input.registryContext ?? workflowBlockRegistryContextFromEnv();
+  const preparedPrompts = await prepareWorkflowV1PromptsForMigration(
+    db,
+    upgraded,
+  );
   const converted = await convertWorkflowDefinitionV1ToV2WithPromptResolution(db, {
     sourceDefinitionId: input.definitionId,
     sourceVersion: input.sourceVersion,
-    definition: upgraded,
-    registryContext:
-      input.registryContext ?? workflowBlockRegistryContextFromEnv(),
+    definition: preparedPrompts.definition,
+    registryContext,
   });
   const rawSourceBlocked = preflight.blockers.length > 0;
+  const preliminaryBlockers = dedupeMigrationDiagnostics([
+    ...preflight.blockers,
+    ...preparedPrompts.blockers,
+    ...converted.blockers,
+  ]);
+  const targetBlockers: WorkflowV2MigrationDiagnostic[] = [];
+  if (preliminaryBlockers.length === 0 && converted.definition) {
+    const validation =
+      await validateWorkflowDefinitionCandidateWithPromptAuthoring(
+        db,
+        converted.definition,
+        registryContext,
+      );
+    for (const issue of validation.response.issues) {
+      targetBlockers.push({
+        code: `migration.target.${issue.code}`,
+        message: `Converted v2 workflow is not deployable: ${issue.message}`,
+        nodeId: issue.nodeId,
+        ...(issue.path === undefined ? {} : { path: issue.path }),
+      });
+    }
+  }
+  const blockers = dedupeMigrationDiagnostics([
+    ...preliminaryBlockers,
+    ...targetBlockers,
+  ]);
+  const applicable =
+    !rawSourceBlocked &&
+    blockers.length === 0 &&
+    converted.definition !== null;
   return {
     ...converted,
     // The compatibility copy is used only to discover additional actionable
     // blockers. Unknown raw fields remain authoritative and can never be
     // normalized away into an applicable conversion.
-    conversionHash: rawSourceBlocked ? null : converted.conversionHash,
-    definition: rawSourceBlocked ? null : converted.definition,
-    conversions: [...preflight.conversions, ...converted.conversions],
+    conversionHash: applicable ? converted.conversionHash : null,
+    definition: applicable ? converted.definition : null,
+    conversions: dedupeMigrationDiagnostics([
+      ...preflight.conversions,
+      ...preparedPrompts.conversions,
+      ...converted.conversions,
+    ]),
     warnings: [...preflight.warnings, ...converted.warnings],
-    blockers: [...preflight.blockers, ...converted.blockers],
+    blockers,
   };
 }
 
@@ -413,6 +454,23 @@ function blockedMigrationResult(
     warnings: preflight.warnings,
     blockers: preflight.blockers,
   };
+}
+
+function dedupeMigrationDiagnostics(
+  diagnostics: WorkflowV2MigrationDiagnostic[],
+): WorkflowV2MigrationDiagnostic[] {
+  const seen = new Set<string>();
+  return diagnostics.filter((diagnostic) => {
+    const key = JSON.stringify([
+      diagnostic.code,
+      diagnostic.nodeId,
+      diagnostic.path ?? null,
+      diagnostic.message,
+    ]);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 function restoreRawPromptProvenance(

--- a/apps/worker/src/workflow-definition/v2-migration.ts
+++ b/apps/worker/src/workflow-definition/v2-migration.ts
@@ -24,6 +24,7 @@ import { upgradeStoredWorkflowDefinition } from "./schema.js";
 import { prepareWorkflowV1PromptsForMigration } from "./v2-migration-prompts.js";
 import {
   convertWorkflowDefinitionV1ToV2,
+  dedupeWorkflowV2MigrationDiagnostics,
   workflowV2PromptResolutionKey,
   type WorkflowV2MigrationDiagnostic,
   type WorkflowV2MigrationResult,
@@ -122,7 +123,7 @@ export async function previewWorkflowDefinitionV2Migration(
     registryContext,
   });
   const rawSourceBlocked = preflight.blockers.length > 0;
-  const preliminaryBlockers = dedupeMigrationDiagnostics([
+  const preliminaryBlockers = dedupeWorkflowV2MigrationDiagnostics([
     ...preflight.blockers,
     ...preparedPrompts.blockers,
     ...converted.blockers,
@@ -144,7 +145,7 @@ export async function previewWorkflowDefinitionV2Migration(
       });
     }
   }
-  const blockers = dedupeMigrationDiagnostics([
+  const blockers = dedupeWorkflowV2MigrationDiagnostics([
     ...preliminaryBlockers,
     ...targetBlockers,
   ]);
@@ -159,7 +160,7 @@ export async function previewWorkflowDefinitionV2Migration(
     // normalized away into an applicable conversion.
     conversionHash: applicable ? converted.conversionHash : null,
     definition: applicable ? converted.definition : null,
-    conversions: dedupeMigrationDiagnostics([
+    conversions: dedupeWorkflowV2MigrationDiagnostics([
       ...preflight.conversions,
       ...preparedPrompts.conversions,
       ...converted.conversions,
@@ -454,23 +455,6 @@ function blockedMigrationResult(
     warnings: preflight.warnings,
     blockers: preflight.blockers,
   };
-}
-
-function dedupeMigrationDiagnostics(
-  diagnostics: WorkflowV2MigrationDiagnostic[],
-): WorkflowV2MigrationDiagnostic[] {
-  const seen = new Set<string>();
-  return diagnostics.filter((diagnostic) => {
-    const key = JSON.stringify([
-      diagnostic.code,
-      diagnostic.nodeId,
-      diagnostic.path ?? null,
-      diagnostic.message,
-    ]);
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
 }
 
 function restoreRawPromptProvenance(

--- a/apps/worker/src/workflows/effective-prompt.ts
+++ b/apps/worker/src/workflows/effective-prompt.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_AGENT_PROMPTS,
+  DEFAULT_FIX_PROMPT,
   containsMalformedPromptDataToken,
   containsMalformedPromptReference,
   containsMalformedPromptSlotToken,
@@ -157,9 +158,6 @@ export interface EffectivePromptCompilation {
 }
 
 const MAX_SECTION_LENGTH = 200_000;
-const COMPATIBILITY_FIX_PROMPT =
-  "Resolve the supplied pull-request feedback, failing checks, and merge conflicts.";
-
 /**
  * PR2/PR3 v2 snapshots predate explicit Harness Profile and prompt pinning.
  * Only those profile-less specialized blocks retain their former code-owned
@@ -177,7 +175,7 @@ export function compatibilityPromptSourceForV2Node(
     case "review_agent":
       return DEFAULT_AGENT_PROMPTS.review;
     case "fix_agent":
-      return COMPATIBILITY_FIX_PROMPT;
+      return DEFAULT_FIX_PROMPT;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

- adds the owner/admin-only v1-to-v2 migration drawer, legacy status, save-and-preview flow, blocker navigation, stale-preview recovery, and draft-only success state
- automatically materializes the exact v1 specialized-agent defaults and pins deterministic prompt versions
- snapshots legacy nested prompt composition into the workflow only when necessary, without changing shared prompt-library history
- runs complete asynchronous v2 prompt, profile, graph, binding, and deployment validation before returning an applicable candidate
- preserves connected v1 failure paths as explicit blockers and keeps the deployed v1 version live after Apply
- adds the missing authenticated, no-store dashboard migration proxy

## Compatibility and rollout

- Existing v1 definitions and execution are unchanged.
- Apply appends a v2 draft to the same Workflow Definition and never changes the deployed pointer.
- Deployment remains a separate explicit action.
- No database migration is required.
- Browser QA was intentionally left to manual review as requested.

## Verification

- `pnpm --filter worker test -- src/workflow-definition/v2-converter.test.ts src/routes/api/v1/workflow-definitions.test.ts` — 84 passed
- final focused Ticket-workflow migration regression — 77 passed
- `pnpm --filter ai-workflow-dashboard test` — 495 passed
- `pnpm test` — dashboard 495 passed; worker 2,688 passed
- `pnpm typecheck` — passed

## Jira

- [AIW-174](https://blazity.atlassian.net/browse/AIW-174)
- [AIW-175](https://blazity.atlassian.net/browse/AIW-175)


[AIW-174]: https://blazity.atlassian.net/browse/AIW-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a v1 → v2 workflow migration drawer in the workflow editor, with Preview/Review/Create draft steps, conversion metrics, and navigable warnings/blockers.
  * Enhanced the flow editor with header inline content and migration-driven node selection overrides.
  * Upgraded v2 migration preview behavior for pinned/default and reusable-prompt handling.

* **Bug Fixes**
  * Prevented applying or creating v2 drafts when previews contain blockers or prerequisites aren’t met.
  * Ensured migration API responses are cache-protected (`private, no-store`) with consistent structured blocker/error details.

* **Tests**
  * Expanded migration and prompt-materialization coverage across preview/apply paths, including stale/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->