### PR TITLE
AI Workflow follow-ups: shared data picker and editor

### DIFF
--- a/apps/dashboard/app/api/workflow-definitions/[id]/catalog/route.ts
+++ b/apps/dashboard/app/api/workflow-definitions/[id]/catalog/route.ts
@@ -1,0 +1,9 @@
+import { handleDefinitionCatalog } from "../../handler";
+import { proxyWorker } from "@/lib/api/proxy";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  return handleDefinitionCatalog(req, { params }, proxyWorker);
+}

--- a/apps/dashboard/app/api/workflow-definitions/handler.ts
+++ b/apps/dashboard/app/api/workflow-definitions/handler.ts
@@ -90,6 +90,22 @@ export async function handleDefinitionValidate(
   return forwardJsonAction(req, context, workerProxy, "validate", "POST");
 }
 
+export async function handleDefinitionCatalog(
+  req: Request,
+  context: IdRouteContext,
+  workerProxy: WorkerProxy,
+) {
+  const response = await forwardJsonAction(
+    req,
+    context,
+    workerProxy,
+    "catalog",
+    "POST",
+  );
+  response.headers.set("cache-control", "private, no-store");
+  return response;
+}
+
 export async function handleDefinitionMigrate(
   req: Request,
   context: IdRouteContext,

--- a/apps/dashboard/app/api/workflow-definitions/route.test.ts
+++ b/apps/dashboard/app/api/workflow-definitions/route.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   handleDefinitionDelete,
+  handleDefinitionCatalog,
   handleDefinitionDeploy,
   handleDefinitionGet,
   handleDefinitionPatch,
@@ -229,6 +230,7 @@ for (const [name, handler, method] of [
   ["deploy", handleDefinitionDeploy, "POST"],
   ["rollback", handleDefinitionRollback, "POST"],
   ["validate", handleDefinitionValidate, "POST"],
+  ["catalog", handleDefinitionCatalog, "POST"],
   ["migrate", handleDefinitionMigrate, "POST"],
   ["layout", handleDefinitionLayout, "PATCH"],
 ] as const) {
@@ -248,7 +250,7 @@ for (const [name, handler, method] of [
       },
     );
     assert.equal(res.status, 200);
-    if (name === "migrate") {
+    if (name === "migrate" || name === "catalog") {
       assert.equal(res.headers.get("cache-control"), "private, no-store");
     }
   });

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
@@ -3,7 +3,7 @@ import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type {
-  WorkflowAvailableValue,
+  WorkflowDataCatalogEntry,
   WorkflowBlockContract,
   WorkflowDefinitionV2Node,
 } from "@shared/contracts";
@@ -68,7 +68,7 @@ const node: WorkflowDefinitionV2Node = {
   ],
 };
 
-const availableValues: WorkflowAvailableValue[] = [
+const availableValues: WorkflowDataCatalogEntry[] = [
   {
     reference: "steps.planning.output.plan",
     label: "Planning · plan",
@@ -77,13 +77,9 @@ const availableValues: WorkflowAvailableValue[] = [
     source: {
       kind: "step",
       nodeId: "planning",
-      blockType: "planning_agent",
     },
-    guarantee: {
-      kind: "unconditional_activation",
-      triggerNodeIds: ["trigger"],
-      viaEdgeIds: ["planning-to-implementation"],
-    },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
     compatibleInputNames: ["plan"],
   },
   {
@@ -94,13 +90,9 @@ const availableValues: WorkflowAvailableValue[] = [
     source: {
       kind: "step",
       nodeId: "review",
-      blockType: "review_agent",
     },
-    guarantee: {
-      kind: "unconditional_activation",
-      triggerNodeIds: ["trigger"],
-      viaEdgeIds: ["review-to-implementation"],
-    },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
     compatibleInputNames: [],
   },
 ];
@@ -119,7 +111,7 @@ test("v2 bindings use worker labels and compatibility without client graph trave
   assert.match(html, /Input values/);
   assert.match(html, /Planning · plan/);
   assert.doesNotMatch(html, /Review · decision/);
-  assert.match(html, /aria-label="plan workflow value"/);
+  assert.match(html, /aria-label="Change Planning · plan"/);
   assert.match(html, /aria-label="score JSON Schema"/);
   assert.match(html, /aria-label="score literal JSON"/);
   assert.match(html, /Add typed input/);

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   isSafeWorkflowInputName,
   type JsonSchema202012,
   type JsonValue,
   type WorkflowAdditionalInputV2,
-  type WorkflowAvailableValue,
+  type WorkflowDataCatalogEntry,
   type WorkflowBlockContract,
   type WorkflowDataReferenceV2,
   type WorkflowDefinitionV1,
@@ -21,6 +21,11 @@ import {
   canAddAdditionalInput,
 } from "@/lib/workflow-editor/binding-options";
 import { JsonSchemaEditor } from "./json-schema-editor";
+import {
+  inputCompatibility,
+  WorkflowDataPicker,
+  WorkflowValueChip,
+} from "./workflow-data-picker";
 
 const inputClass =
   "h-[28px] min-w-0 px-2 bg-off-white border border-neutral-200 rounded-xs font-mono text-[11px] text-coal outline-none disabled:opacity-60";
@@ -258,7 +263,12 @@ function JsonSchemaObjectField({
 }) {
   const serialized = JSON.stringify(value, null, 2);
   const [source, setSource] = useState(serialized);
+  const lastCommitted = useRef<string | null>(null);
   useEffect(() => {
+    if (lastCommitted.current === serialized) {
+      lastCommitted.current = null;
+      return;
+    }
     setSource(serialized);
   }, [serialized]);
   const update = (nextSource: string) => {
@@ -268,6 +278,7 @@ function JsonSchemaObjectField({
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
         throw new Error("schema");
       }
+      lastCommitted.current = JSON.stringify(parsed, null, 2);
       onChange(parsed as JsonSchema202012);
     } catch {
       // Keep invalid source in the raw editor until the author finishes it.
@@ -288,6 +299,7 @@ function V2BindingEditor({
   binding,
   inputSchema,
   availableValues,
+  valuesRefreshing,
   required,
   canEdit,
   onChange,
@@ -295,13 +307,16 @@ function V2BindingEditor({
   inputName: string;
   binding: WorkflowInputBindingV2 | undefined;
   inputSchema: WorkflowValueSchema | JsonSchema202012;
-  availableValues: WorkflowAvailableValue[];
+  availableValues: WorkflowDataCatalogEntry[];
+  valuesRefreshing: boolean;
   required: boolean;
   canEdit: boolean;
   onChange: (binding: WorkflowInputBindingV2 | undefined) => void;
 }) {
-  const compatible = availableValues.filter((value) =>
-    value.compatibleInputNames.includes(inputName),
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const compatibility = useMemo(
+    () => inputCompatibility(inputName),
+    [inputName],
   );
   const currentReference =
     binding?.kind === "reference"
@@ -318,12 +333,7 @@ function V2BindingEditor({
         onChange={(event) => {
           if (event.target.value === "") onChange(undefined);
           else if (event.target.value === "reference") {
-            const first = compatible[0];
-            onChange(
-              first
-                ? { kind: "reference", reference: first.reference }
-                : undefined,
-            );
+            setPickerOpen(true);
           } else {
             onChange({ kind: "literal", value: literalDefault });
           }
@@ -331,34 +341,34 @@ function V2BindingEditor({
         className={`${inputClass} w-full`}
       >
         <option value="">{required ? "Choose a value…" : "Not bound"}</option>
-        <option value="reference" disabled={compatible.length === 0 && !currentReference}>
+        <option value="reference">
           Workflow value
         </option>
         <option value="literal">Literal value</option>
       </select>
       {binding?.kind === "reference" && (
-        <select
-          aria-label={`${inputName} workflow value`}
-          value={binding.reference}
+        <WorkflowValueChip
+          value={currentReference ?? null}
+          reference={binding.reference}
           disabled={!canEdit}
-          onChange={(event) =>
-            onChange({
-              kind: "reference",
-              reference: event.target.value as WorkflowDataReferenceV2,
-            })
-          }
-          className={`${inputClass} w-full`}
-        >
-          {!currentReference && (
-            <option value={binding.reference}>Unavailable: {binding.reference}</option>
-          )}
-          {compatible.map((value) => (
-            <option key={value.reference} value={value.reference}>
-              {value.label}
-            </option>
-          ))}
-        </select>
+          onOpen={() => setPickerOpen(true)}
+          onClear={() => onChange(undefined)}
+        />
       )}
+      <WorkflowDataPicker
+        open={pickerOpen}
+        entries={availableValues}
+        selectedReference={
+          binding?.kind === "reference" ? binding.reference : undefined
+        }
+        compatibility={compatibility}
+        refreshing={valuesRefreshing}
+        onClose={() => setPickerOpen(false)}
+        onSelect={(entry) => {
+          onChange({ kind: "reference", reference: entry.reference });
+          setPickerOpen(false);
+        }}
+      />
       {binding?.kind === "literal" && (
         <JsonValueField
           label={`${inputName} literal JSON`}
@@ -382,12 +392,14 @@ export function V2BindingFields({
   node,
   contract,
   availableValues,
+  valuesRefreshing = false,
   canEdit,
   onChange,
 }: {
   node: WorkflowDefinitionV2Node;
   contract: WorkflowBlockContract;
-  availableValues: WorkflowAvailableValue[];
+  availableValues: WorkflowDataCatalogEntry[];
+  valuesRefreshing?: boolean;
   canEdit: boolean;
   onChange: (
     inputs: WorkflowDefinitionV2Node["inputs"],
@@ -447,6 +459,7 @@ export function V2BindingFields({
             binding={node.inputs[name]}
             inputSchema={input.schema}
             availableValues={availableValues}
+            valuesRefreshing={valuesRefreshing}
             required={input.required}
             canEdit={canEdit}
             onChange={(binding) => {
@@ -498,6 +511,7 @@ export function V2BindingFields({
             binding={input.binding}
             inputSchema={input.schema}
             availableValues={availableValues}
+            valuesRefreshing={valuesRefreshing}
             required
             canEdit={canEdit}
             onChange={(binding) => {

--- a/apps/dashboard/components/cockpit/flow-editor/branch-fields.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/branch-fields.test.tsx
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { WorkflowAvailableValue } from "@shared/contracts";
+import type { WorkflowDataCatalogEntry } from "@shared/contracts";
 import { BranchFields } from "./branch-fields";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
-const availableValues: WorkflowAvailableValue[] = [
+const availableValues: WorkflowDataCatalogEntry[] = [
   {
     reference: "steps.review.output.decision",
     label: "Review · decision",
@@ -19,13 +19,9 @@ const availableValues: WorkflowAvailableValue[] = [
     source: {
       kind: "step",
       nodeId: "review",
-      blockType: "review_agent",
     },
-    guarantee: {
-      kind: "unconditional_activation",
-      triggerNodeIds: ["trigger"],
-      viaEdgeIds: ["review-decision"],
-    },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
     compatibleInputNames: [],
   },
   {
@@ -36,13 +32,9 @@ const availableValues: WorkflowAvailableValue[] = [
     source: {
       kind: "step",
       nodeId: "checks",
-      blockType: "run_checks",
     },
-    guarantee: {
-      kind: "unconditional_activation",
-      triggerNodeIds: ["trigger"],
-      viaEdgeIds: ["checks-decision"],
-    },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
     compatibleInputNames: [],
   },
 ];
@@ -104,11 +96,8 @@ test("Branch editor preserves an unavailable path instead of replacing it", () =
     />,
   );
 
-  assert.match(
-    html,
-    /Unavailable: steps\.old-review\.output\.decision/,
-  );
-  assert.match(html, /value="steps\.old-review\.output\.decision" selected=""/);
+  assert.match(html, /The saved value is unavailable in the current workflow/);
+  assert.doesNotMatch(html, /steps\.old-review\.output\.decision/);
 });
 
 test("Branch editor leaves malformed raw configuration untouched until replacement", () => {

--- a/apps/dashboard/components/cockpit/flow-editor/branch-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/branch-fields.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { createContext, useContext, useState } from "react";
 import type {
   JsonSchema202012,
   JsonValue,
-  WorkflowAvailableValue,
+  WorkflowDataCatalogEntry,
   WorkflowBranchBooleanAstV2,
   WorkflowBranchConfigurationV2,
   WorkflowBranchOperandV2,
@@ -17,11 +18,16 @@ import {
   isBooleanWorkflowValue,
   parseWorkflowBranchConfigurationV2,
 } from "@/lib/workflow-editor/branch-ast";
+import {
+  WorkflowDataPicker,
+  WorkflowValueChip,
+} from "./workflow-data-picker";
 
 const inputClass =
   "h-[28px] min-w-0 rounded-xs border border-neutral-200 bg-off-white px-2 font-mono text-[10px] text-coal outline-none disabled:opacity-60";
 const buttonClass =
   "h-[28px] appearance-none rounded-xs border border-mariner bg-panel px-2 font-mono text-[10px] uppercase tracking-[0.04em] text-mariner disabled:cursor-default disabled:opacity-40";
+const BranchValuesRefreshingContext = createContext(false);
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -40,35 +46,46 @@ function PathPicker({
   onChange,
 }: {
   value: WorkflowDataReferenceV2;
-  availableValues: readonly WorkflowAvailableValue[];
+  availableValues: readonly WorkflowDataCatalogEntry[];
   booleanOnly?: boolean;
   disabled: boolean;
   label: string;
   onChange: (reference: WorkflowDataReferenceV2) => void;
 }) {
-  const choices = availableValues.filter(
-    (candidate) => !booleanOnly || isBooleanWorkflowValue(candidate),
-  );
-  const current = choices.find(
+  const [open, setOpen] = useState(false);
+  const refreshing = useContext(BranchValuesRefreshingContext);
+  const current = availableValues.find(
     (candidate) => candidate.reference === value,
   );
   return (
-    <select
-      aria-label={label}
-      value={value}
-      disabled={disabled}
-      onChange={(event) =>
-        onChange(event.target.value as WorkflowDataReferenceV2)
-      }
-      className={`${inputClass} w-full`}
-    >
-      {!current && <option value={value}>Unavailable: {value}</option>}
-      {choices.map((candidate) => (
-        <option key={candidate.reference} value={candidate.reference}>
-          {candidate.label}
-        </option>
-      ))}
-    </select>
+    <>
+      <span className="sr-only">{label}</span>
+      <WorkflowValueChip
+        value={current ?? null}
+        reference={value}
+        disabled={disabled}
+        onOpen={() => setOpen(true)}
+      />
+      <WorkflowDataPicker
+        open={open}
+        entries={availableValues}
+        selectedReference={value}
+        refreshing={refreshing}
+        compatibility={(entry) =>
+          !booleanOnly || isBooleanWorkflowValue(entry)
+            ? { compatible: true }
+            : {
+                compatible: false,
+                reason: "This condition requires a boolean value.",
+              }
+        }
+        onClose={() => setOpen(false)}
+        onSelect={(entry) => {
+          onChange(entry.reference);
+          setOpen(false);
+        }}
+      />
+    </>
   );
 }
 
@@ -208,13 +225,15 @@ function OperandEditor({
   operand,
   otherOperand,
   availableValues,
+  valuesRefreshing = false,
   disabled,
   label,
   onChange,
 }: {
   operand: WorkflowBranchOperandV2;
   otherOperand: WorkflowBranchOperandV2;
-  availableValues: readonly WorkflowAvailableValue[];
+  availableValues: readonly WorkflowDataCatalogEntry[];
+  valuesRefreshing?: boolean;
   disabled: boolean;
   label: string;
   onChange: (operand: WorkflowBranchOperandV2) => void;
@@ -274,7 +293,7 @@ function ConditionEditor({
   onChange,
 }: {
   condition: WorkflowBranchBooleanAstV2;
-  availableValues: readonly WorkflowAvailableValue[];
+  availableValues: readonly WorkflowDataCatalogEntry[];
   disabled: boolean;
   depth: number;
   onChange: (condition: WorkflowBranchBooleanAstV2) => void;
@@ -401,16 +420,19 @@ function ConditionEditor({
 export function BranchFields({
   configuration,
   availableValues,
+  valuesRefreshing = false,
   canEdit,
   onChange,
 }: {
   configuration: Readonly<Record<string, JsonValue>>;
-  availableValues: readonly WorkflowAvailableValue[];
+  availableValues: readonly WorkflowDataCatalogEntry[];
+  valuesRefreshing?: boolean;
   canEdit: boolean;
   onChange: (configuration: WorkflowBranchConfigurationV2) => void;
 }) {
   const parsed = parseWorkflowBranchConfigurationV2(configuration);
   return (
+    <BranchValuesRefreshingContext.Provider value={valuesRefreshing}>
     <section className="border-t border-neutral-200">
       <div className="border-b border-neutral-200 bg-app-bg px-[14px] py-2">
         <div className="font-mono text-[9px] uppercase tracking-[0.06em] text-neutral-700">
@@ -455,5 +477,6 @@ export function BranchFields({
         </div>
       )}
     </section>
+    </BranchValuesRefreshingContext.Provider>
   );
 }

--- a/apps/dashboard/components/cockpit/flow-editor/config-fields-v2-prose.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/config-fields-v2-prose.test.tsx
@@ -3,7 +3,7 @@ import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type {
-  WorkflowAvailableValue,
+  WorkflowDataCatalogEntry,
   WorkflowEditorOptions,
 } from "@shared/contracts";
 import type { FlowNodeDef, WorkflowBlockType } from "@/lib/flows";
@@ -27,18 +27,15 @@ const options = {
   blockRegistry: {},
 } as unknown as WorkflowEditorOptions;
 
-const availableValues: WorkflowAvailableValue[] = [
+const availableValues: WorkflowDataCatalogEntry[] = [
   {
     reference: "steps.entry.output.ticketKey",
     label: "Active trigger · ticketKey",
     description: "Ticket identifier.",
     schema: { type: "string" },
-    source: { kind: "entry", nodeId: null, blockType: null },
-    guarantee: {
-      kind: "active_entry",
-      triggerNodeIds: ["trigger"],
-      viaEdgeIds: [],
-    },
+    source: { kind: "trigger", nodeId: "trigger" },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
     compatibleInputNames: [],
   },
 ];

--- a/apps/dashboard/components/cockpit/flow-editor/config-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/config-fields.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import type { FlowNodeDef } from "@/lib/flows";
 import type {
   PromptSourceRef,
-  WorkflowAvailableValue,
+  WorkflowDataCatalogEntry,
   WorkflowBlockType,
   WorkflowEditorOptions,
   WorkflowParamValue,
@@ -24,6 +24,7 @@ import {
 import { Listbox } from "@/components/cockpit/listbox";
 import { PromptField } from "./prompt-field";
 import { PromptEditor } from "@/components/cockpit/prompt-editor/prompt-editor";
+import { WorkflowTextTemplateEditor } from "./workflow-text-template-editor";
 import { JsonSchemaEditor } from "./json-schema-editor";
 import { usePromptAuthoringContext } from "./prompt-authoring-context";
 import { AgentHarnessProfile } from "./agent-harness-profile";
@@ -184,6 +185,7 @@ function RichTextField({
   minHeightClass,
   authoringMode = "v1",
   availableValues = [],
+  valuesRefreshing,
   compact,
   singleLine,
   onChange,
@@ -192,18 +194,34 @@ function RichTextField({
   disabled: boolean;
   minHeightClass?: string;
   authoringMode?: "v1" | "v2";
-  availableValues?: readonly WorkflowAvailableValue[];
+  availableValues?: readonly WorkflowDataCatalogEntry[];
+  valuesRefreshing?: boolean;
   compact?: boolean;
   singleLine?: boolean;
   onChange: (v: string) => void;
 }) {
+  const promptAuthoring = usePromptAuthoringContext();
+  const refreshing =
+    valuesRefreshing ?? promptAuthoring?.valuesRefreshing ?? false;
+  if (authoringMode === "v2") {
+    return (
+      <WorkflowTextTemplateEditor
+        value={value}
+        disabled={disabled}
+        entries={availableValues}
+        refreshing={refreshing}
+        minHeightClass={minHeightClass ?? "min-h-[96px]"}
+        singleLine={singleLine}
+        onChange={onChange}
+      />
+    );
+  }
   return (
     <PromptEditor
       value={value}
       disabled={disabled}
       minHeightClass={minHeightClass ?? "min-h-[96px]"}
       authoringMode={authoringMode}
-      availableValues={availableValues}
       compact={compact}
       singleLine={singleLine}
       onChange={onChange}
@@ -215,11 +233,13 @@ function CanonicalQuestionsField({
   value,
   disabled,
   availableValues,
+  valuesRefreshing,
   onChange,
 }: {
   value: WorkflowParamValue | undefined;
   disabled: boolean;
-  availableValues: readonly WorkflowAvailableValue[];
+  availableValues: readonly WorkflowDataCatalogEntry[];
+  valuesRefreshing?: boolean;
   onChange: (value: string[] | undefined) => void;
 }) {
   const questions = Array.isArray(value)
@@ -240,13 +260,12 @@ function CanonicalQuestionsField({
           className="flex items-start gap-1.5"
         >
           <div className="min-w-0 flex-1">
-            <PromptEditor
+            <WorkflowTextTemplateEditor
               value={question}
               disabled={disabled}
-              authoringMode="v2"
-              availableValues={availableValues}
+              entries={availableValues}
+              refreshing={valuesRefreshing}
               minHeightClass="min-h-[54px]"
-              compact
               onChange={(next) => update(index, next)}
             />
           </div>
@@ -609,6 +628,7 @@ export function ConfigFields({
   const proseValues = node.v2
     ? (promptAuthoring?.availableValues ?? [])
     : [];
+  const valuesRefreshing = promptAuthoring?.valuesRefreshing ?? false;
   switch (node.type) {
     case "trigger_ticket_ai":
       return <ConfigNote>Fires when a Jira ticket enters the AI column.</ConfigNote>;
@@ -957,6 +977,7 @@ export function ConfigFields({
               value={node.params.questions}
               disabled={!canEdit}
               availableValues={proseValues}
+              valuesRefreshing={valuesRefreshing}
               onChange={(v) => onChange("params.questions", v)}
             />
           ) : (

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor-validation.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor-validation.test.tsx
@@ -480,7 +480,8 @@ test("v2 Branch replaces the legacy expression field with a typed visual editor"
   assert.doesNotMatch(v2, /placeholder="steps\.review\.output\.ok == true"/);
   assert.match(v2, /Branch decision/);
   assert.match(v2, /Values are equal/);
-  assert.match(v2, /Unavailable: steps\.review\.output\.ok/);
+  assert.match(v2, /The saved value is unavailable in the current workflow/);
+  assert.doesNotMatch(v2, /steps\.review\.output\.ok/);
 });
 
 function renderSelectedOpenPr(schemaVersion: 1 | 2): string {

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
@@ -15,7 +15,8 @@ import type {
   PromptSourceRef,
   TransformConfiguration,
   WorkflowAdditionalInputV2,
-  WorkflowAvailableValue,
+  WorkflowDataCatalogEntry,
+  WorkflowDefinitionCatalogResponse,
   WorkflowDefinitionV1,
   WorkflowDefinitionV2,
   WorkflowDefinitionValidationIssue,
@@ -97,7 +98,6 @@ import {
 import {
   workflowEditorKeyboardAction,
   workflowShortcutLabel,
-  wrappedDialogTabIndex,
 } from "@/lib/workflow-editor/keyboard-actions";
 import {
   automaticEdgeBendPoint,
@@ -236,7 +236,7 @@ const FlowNode = React.memo(function FlowNode({
   outPorts: string[];
   onSelect: (id: string, event: React.MouseEvent) => void;
   onRun: (node: FlowNodeDef) => void;
-  onRequestDelete: (id: string) => void;
+  onRequestDelete: (id: string, at: { x: number; y: number }) => void;
   onDragStart: (e: React.PointerEvent, node: FlowNodeDef) => void;
   onPortDown: (e: React.PointerEvent, nodeId: string, portId: string) => void;
   onPortUp: (e: React.PointerEvent, nodeId: string) => void;
@@ -289,7 +289,12 @@ const FlowNode = React.memo(function FlowNode({
         onContextMenu={(event) => {
           event.preventDefault();
           event.stopPropagation();
-          if (canEdit && !locked) onRequestDelete(node.id);
+          if (canEdit && !locked) {
+            onRequestDelete(node.id, {
+              x: event.clientX,
+              y: event.clientY,
+            });
+          }
         }}
         onClick={(event) => {
           event.stopPropagation();
@@ -495,7 +500,7 @@ function FlowCanvas({
   >;
   onAddEdge: (from: string, fromPort: string, to: string) => void;
   onRemoveEdge: (instanceKey: string) => void;
-  onDeleteNode: (nodeId: string) => void;
+  onDeleteNode: (nodeId: string, at: { x: number; y: number }) => void;
   onDropNode: (item: PaletteItem, at: Point) => void;
   runStatuses?: RunStatusMap;
   runErrors?: Record<string, string>;
@@ -796,9 +801,6 @@ function FlowCanvas({
 
   // For edges
   const nodeById = useMemo(() => Object.fromEntries(nodes.map(n => [n.id, n])), [nodes]);
-
-  // A sole trigger cannot be deleted (a graph needs at least one entry point).
-  const triggerCount = useMemo(() => nodes.filter(n => isTriggerBlockType(n.type)).length, [nodes]);
 
   // Nodes whose "failed" port is wired by an existing edge — such ports render
   // even when the node isn't selected.
@@ -1232,7 +1234,7 @@ function FlowCanvas({
             )}
             selected={selection.nodeIds.includes(n.id)}
             dataSourceHighlighted={highlightedSourceIds.has(n.id)}
-            locked={isTriggerBlockType(n.type) && triggerCount === 1}
+            locked={false}
             outPorts={portsByNode[n.id] ?? []}
             onSelect={selectNode}
             onRun={(node) => onRunTrigger?.(node)}
@@ -1319,6 +1321,9 @@ export function FlowEditor({
   saving,
   error,
   validation,
+  dataCatalog,
+  dataCatalogRefreshing = false,
+  dataCatalogError,
   onSave,
   saveLabel = "Save changes",
   headerTitle,
@@ -1368,6 +1373,9 @@ export function FlowEditor({
   saving: boolean;
   error: string | null;
   validation: WorkflowValidationState;
+  dataCatalog?: WorkflowDefinitionCatalogResponse | null;
+  dataCatalogRefreshing?: boolean;
+  dataCatalogError?: string | null;
   onSave: () => void;
   saveLabel?: string;
   headerTitle: string;
@@ -1410,13 +1418,14 @@ export function FlowEditor({
   const [clipboardIssues, setClipboardIssues] = useState<
     WorkflowDefinitionValidationIssue[]
   >([]);
-  const [pendingContextDelete, setPendingContextDelete] =
-    useState<CanvasSelection | null>(null);
+  const [pendingContextDelete, setPendingContextDelete] = useState<{
+    selection: CanvasSelection;
+    x: number;
+    y: number;
+  } | null>(null);
   const editingSurfaceRef = useRef<HTMLElement | null>(null);
   const editorRootRef = useRef<HTMLDivElement | null>(null);
   const handledSelectionRequestIdRef = useRef<number | null>(null);
-  const deleteDialogRef = useRef<HTMLDivElement | null>(null);
-  const deleteDialogRestoreFocusRef = useRef<HTMLElement | null>(null);
   const [shortcutPlatform, setShortcutPlatform] = useState<"mac" | "other">(
     "other",
   );
@@ -1479,8 +1488,7 @@ export function FlowEditor({
     },
     [nodes],
   );
-  const triggerCount = nodes.filter(n => isTriggerBlockType(n.type)).length;
-  const selectedLocked = selected ? isTriggerBlockType(selected.type) && triggerCount === 1 : false;
+  const selectedLocked = false;
   useEffect(() => {
     if (validation.status === "checking") return;
     setClipboardIssues((current) => (current.length === 0 ? current : []));
@@ -1496,6 +1504,10 @@ export function FlowEditor({
           },
     [clipboardIssues, validation],
   );
+  const effectiveNodeContracts =
+    schemaVersion === 2 && dataCatalog
+      ? dataCatalog.nodeContracts
+      : effectiveValidation.nodeContracts;
   const groupedValidationIssues = useMemo(
     () => groupValidationIssues(effectiveValidation.issues),
     [effectiveValidation.issues],
@@ -1708,12 +1720,6 @@ export function FlowEditor({
   const deleteCanvasSelection = useCallback(
     (target: CanvasSelection) => {
       const result = removeSelectionFromGraph(nodes, edges, target);
-      if (result.blocker === "trigger_required") {
-        setInteractionError(
-          "A workflow must keep at least one trigger. Add another trigger before deleting this selection.",
-        );
-        return;
-      }
       if (!result.removed) return;
       const retainedEdgeIds = new Set(
         result.edges.flatMap((edge) => (edge.id ? [edge.id] : [])),
@@ -1734,7 +1740,7 @@ export function FlowEditor({
     [edgeGeometry, edges, nodes, onGraphChange],
   );
   const requestContextDelete = useCallback(
-    (nodeId: string) => {
+    (nodeId: string, at: { x: number; y: number }) => {
       finalizeEditingSurfaceTransaction();
       const target = selection.nodeIds.includes(nodeId)
         ? selection
@@ -1743,12 +1749,12 @@ export function FlowEditor({
             edgeKeys: [],
             primaryNodeId: nodeId,
           };
-      deleteDialogRestoreFocusRef.current =
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement
-          : null;
       setSelection(target);
-      setPendingContextDelete(target);
+      setPendingContextDelete({
+        selection: target,
+        x: at.x,
+        y: at.y,
+      });
     },
     [finalizeEditingSurfaceTransaction, selection],
   );
@@ -1833,7 +1839,6 @@ export function FlowEditor({
 
   useEffect(() => {
     const handleKeyboard = (event: KeyboardEvent) => {
-      if (pendingContextDelete) return;
       const action = workflowEditorKeyboardAction(event, { canEdit });
       if (!action) return;
       event.preventDefault();
@@ -1852,46 +1857,21 @@ export function FlowEditor({
     onRedo,
     onUndo,
     pasteSelection,
-    pendingContextDelete,
   ]);
 
   useEffect(() => {
     if (!pendingContextDelete) return;
-    const dialog = deleteDialogRef.current;
-    if (!dialog) return;
-    const restoreFocus = deleteDialogRestoreFocusRef.current;
-    const handleDialogKeyboard = (event: KeyboardEvent) => {
+    const handleMenuKeyboard = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
         event.stopPropagation();
         closeContextDelete();
-        return;
+        editorRootRef.current?.focus();
       }
-      if (event.key !== "Tab") return;
-      const focusable = Array.from(
-        dialog.querySelectorAll<HTMLElement>(
-          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-        ),
-      ).filter((element) => !element.hidden);
-      const targetIndex = wrappedDialogTabIndex({
-        activeIndex: focusable.indexOf(
-          document.activeElement as HTMLElement,
-        ),
-        focusableCount: focusable.length,
-        shiftKey: event.shiftKey,
-      });
-      if (targetIndex === null) return;
-      event.preventDefault();
-      focusable[targetIndex]?.focus();
     };
-    window.addEventListener("keydown", handleDialogKeyboard, true);
-    return () => {
-      window.removeEventListener("keydown", handleDialogKeyboard, true);
-      queueMicrotask(() => {
-        if (restoreFocus?.isConnected) restoreFocus.focus();
-        else editorRootRef.current?.focus();
-      });
-    };
+    window.addEventListener("keydown", handleMenuKeyboard, true);
+    return () =>
+      window.removeEventListener("keydown", handleMenuKeyboard, true);
   }, [closeContextDelete, pendingContextDelete]);
 
   const handleEditorFocusCapture = useCallback(
@@ -2064,8 +2044,10 @@ export function FlowEditor({
             definition={bindingDefinition}
             previewDefinition={previewDefinition}
             definitionId={definitionId}
-            nodeContracts={effectiveValidation.nodeContracts}
-            availableValues={effectiveValidation.availableValuesByNode[selected.id] ?? []}
+            nodeContracts={effectiveNodeContracts}
+            availableValues={dataCatalog?.catalogByNode[selected.id] ?? []}
+            valuesRefreshing={dataCatalogRefreshing}
+            valuesError={dataCatalogError}
             validationIssues={groupedValidationIssues.byNode[selected.id] ?? []}
             canEdit={canEdit}
             locked={selectedLocked}
@@ -2092,8 +2074,10 @@ export function FlowEditor({
                 definition={bindingDefinition}
                 previewDefinition={previewDefinition}
                 definitionId={definitionId}
-                nodeContracts={effectiveValidation.nodeContracts}
-                availableValues={effectiveValidation.availableValuesByNode[selected.id] ?? []}
+                nodeContracts={effectiveNodeContracts}
+                availableValues={dataCatalog?.catalogByNode[selected.id] ?? []}
+                valuesRefreshing={dataCatalogRefreshing}
+                valuesError={dataCatalogError}
                 validationIssues={groupedValidationIssues.byNode[selected.id] ?? []}
                 canEdit={canEdit}
                 locked={selectedLocked}
@@ -2122,57 +2106,47 @@ export function FlowEditor({
         )}
       </div>
       {pendingContextDelete && (
-        <div
-          className="fixed inset-0 z-[70] flex items-center justify-center bg-black/25 p-4"
-          role="presentation"
-          onPointerDown={(event) => {
-            if (event.target === event.currentTarget) {
-              closeContextDelete();
-            }
-          }}
-        >
+        <>
           <div
-            ref={deleteDialogRef}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="confirm-canvas-delete-title"
-            className="w-full max-w-sm rounded-[4px] border border-neutral-200 bg-panel p-5 shadow-xl"
+            className="fixed inset-0 z-[69]"
+            role="presentation"
+            onPointerDown={closeContextDelete}
+          />
+          <div
+            role="menu"
+            aria-label="Canvas selection actions"
+            style={{
+              left: Math.min(
+                pendingContextDelete.x,
+                typeof window === "undefined"
+                  ? pendingContextDelete.x
+                  : window.innerWidth - 210,
+              ),
+              top: Math.min(
+                pendingContextDelete.y,
+                typeof window === "undefined"
+                  ? pendingContextDelete.y
+                  : window.innerHeight - 64,
+              ),
+            }}
+            className="fixed z-[70] min-w-[190px] rounded-[4px] border border-neutral-200 bg-panel p-1 shadow-[0_12px_30px_-8px_rgba(24,27,32,0.35)]"
           >
-            <h2
-              id="confirm-canvas-delete-title"
-              className="font-display text-base font-semibold text-coal"
+            <button
+              type="button"
+              role="menuitem"
+              autoFocus
+              onClick={() => {
+                deleteCanvasSelection(pendingContextDelete.selection);
+                closeContextDelete();
+              }}
+              className="w-full rounded-[3px] border-none bg-transparent px-3 py-2 text-left font-body text-[12px] text-red-700 hover:bg-red-50"
             >
-              Delete canvas selection?
-            </h2>
-            <p className="mt-2 font-body text-sm text-neutral-600">
-              This removes{" "}
-              {pendingContextDelete.nodeIds.length === 1
-                ? "this block"
-                : `${pendingContextDelete.nodeIds.length} selected blocks`}{" "}
-              and their connected edges. You can undo the change.
-            </p>
-            <div className="mt-5 flex justify-end gap-2">
-              <button
-                type="button"
-                autoFocus
-                onClick={closeContextDelete}
-                className="appearance-none rounded-[3px] border border-neutral-200 bg-panel px-3 py-1.5 font-mono text-[11px] uppercase text-neutral-700"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  deleteCanvasSelection(pendingContextDelete);
-                  closeContextDelete();
-                }}
-                className="appearance-none rounded-[3px] border border-red-600 bg-red-600 px-3 py-1.5 font-mono text-[11px] uppercase text-white"
-              >
-                Delete
-              </button>
-            </div>
+              {pendingContextDelete.selection.nodeIds.length > 1
+                ? `Delete ${pendingContextDelete.selection.nodeIds.length} blocks`
+                : "Delete block"}
+            </button>
           </div>
-        </div>
+        </>
       )}
     </div>
   );
@@ -2187,6 +2161,8 @@ function NodeConfig({
   definitionId,
   nodeContracts,
   availableValues,
+  valuesRefreshing,
+  valuesError,
   validationIssues,
   canEdit,
   locked,
@@ -2205,7 +2181,9 @@ function NodeConfig({
   previewDefinition: WorkflowDefinitionV2 | null;
   definitionId?: number;
   nodeContracts: WorkflowValidationState["nodeContracts"];
-  availableValues: WorkflowAvailableValue[];
+  availableValues: WorkflowDataCatalogEntry[];
+  valuesRefreshing: boolean;
+  valuesError?: string | null;
   validationIssues: WorkflowDefinitionValidationIssue[];
   canEdit: boolean;
   locked: boolean;
@@ -2264,10 +2242,27 @@ function NodeConfig({
         }}
         onBlurCapture={() => onReferenceHighlight(null)}
       >
+        {valuesRefreshing && (
+          <div
+            role="status"
+            className="border-b border-mariner-200 bg-mariner-100 px-[14px] py-2 font-body text-[11px] text-mariner"
+          >
+            Refreshing values…
+          </div>
+        )}
+        {!valuesRefreshing && valuesError && (
+          <div
+            role="alert"
+            className="border-b border-red-200 bg-red-50 px-[14px] py-2 font-body text-[11px] text-red-800"
+          >
+            Workflow values could not be refreshed. {valuesError}
+          </div>
+        )}
         <NodeValidationErrors nodeId={node.id} issues={validationIssues} />
         {(schemaVersion === 1 || node.type !== "branch") && (
           <PromptAuthoringProvider
             availableValues={availableValues}
+            valuesRefreshing={valuesRefreshing}
             onV2ConfigurationChange={onV2ConfigurationChange}
             previewCandidate={
               schemaVersion === 2 &&
@@ -2306,6 +2301,7 @@ function NodeConfig({
               node={fromFlowDefinitionV2Node(node)}
               contract={contract}
               availableValues={availableValues}
+              valuesRefreshing={valuesRefreshing}
               canEdit={canEdit}
               onChange={onV2BindingsChange}
             />
@@ -2327,6 +2323,7 @@ function NodeConfig({
               <BranchFields
                 configuration={node.v2.configuration}
                 availableValues={availableValues}
+                valuesRefreshing={valuesRefreshing}
                 canEdit={canEdit}
                 onChange={(configuration) =>
                   onV2ConfigurationChange(

--- a/apps/dashboard/components/cockpit/flow-editor/json-schema-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/json-schema-editor.tsx
@@ -600,7 +600,7 @@ export function JsonSchemaEditor({
         <div className="p-2">
           {visualSchema ? (
             <SchemaNodeEditor
-              key={`${label}:${value}`}
+              key={label}
               schema={visualSchema}
               disabled={disabled}
               depth={0}

--- a/apps/dashboard/components/cockpit/flow-editor/prompt-authoring-context.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/prompt-authoring-context.tsx
@@ -3,12 +3,13 @@
 import { createContext, useContext } from "react";
 import type {
   JsonValue,
-  WorkflowAvailableValue,
+  WorkflowDataCatalogEntry,
   WorkflowDefinitionV2,
 } from "@shared/contracts";
 
 interface PromptAuthoringContextValue {
-  availableValues: readonly WorkflowAvailableValue[];
+  availableValues: readonly WorkflowDataCatalogEntry[];
+  valuesRefreshing?: boolean;
   onV2ConfigurationChange: (
     configuration: Record<string, JsonValue>,
   ) => void;
@@ -24,6 +25,7 @@ const PromptAuthoringContext =
 
 export function PromptAuthoringProvider({
   availableValues,
+  valuesRefreshing,
   onV2ConfigurationChange,
   previewCandidate,
   children,
@@ -32,6 +34,7 @@ export function PromptAuthoringProvider({
     <PromptAuthoringContext.Provider
       value={{
         availableValues,
+        valuesRefreshing,
         onV2ConfigurationChange,
         ...(previewCandidate === undefined ? {} : { previewCandidate }),
       }}

--- a/apps/dashboard/components/cockpit/flow-editor/prompt-editor-modal.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/prompt-editor-modal.tsx
@@ -6,7 +6,7 @@ import {
   formatPromptReferenceToken,
   type PromptLibraryEntryMeta,
   type PromptSlotDefinition,
-  type WorkflowAvailableValue,
+  type WorkflowDataCatalogEntry,
 } from "@shared/contracts";
 import {
   PromptEditor,
@@ -103,7 +103,7 @@ export function PromptEditorModal({
   initialPreviewTarget?: PromptPreviewTarget | null;
   library?: PromptEditorModalLibraryProps;
   authoringMode?: "v1" | "v2";
-  availableValues?: readonly WorkflowAvailableValue[];
+  availableValues?: readonly WorkflowDataCatalogEntry[];
   slots?: readonly PromptEditorSlotOption[];
 }) {
   const { mounted, state } = useEnterExit(open, 180);

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
@@ -1,0 +1,473 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import type {
+  JsonSchema202012,
+  WorkflowDataCatalogEntry,
+  WorkflowDataReferenceV2,
+} from "@shared/contracts";
+
+type PickerTab = "steps" | "run";
+
+export type WorkflowDataCompatibility = (
+  entry: WorkflowDataCatalogEntry,
+) => { compatible: true } | { compatible: false; reason: string };
+
+function schemaType(schema: JsonSchema202012): string {
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) return "enum";
+  const values = Array.isArray(schema.type)
+    ? schema.type.filter((type) => type !== "null")
+    : [schema.type];
+  const type = values[0];
+  if (type === "string") return "text";
+  if (type === "integer" || type === "number") return "number";
+  if (type === "boolean") return "boolean";
+  if (type === "array") return "list";
+  if (type === "object") return "object";
+  return "value";
+}
+
+function sourceName(entry: WorkflowDataCatalogEntry): string {
+  const separator = entry.label.indexOf(" · ");
+  return separator === -1 ? entry.label : entry.label.slice(0, separator);
+}
+
+function fieldName(entry: WorkflowDataCatalogEntry): string {
+  const separator = entry.label.indexOf(" · ");
+  return separator === -1 ? entry.label : entry.label.slice(separator + 3);
+}
+
+function sourceKey(entry: WorkflowDataCatalogEntry): string {
+  if (entry.source.kind === "run") return "run";
+  if (entry.source.kind === "trigger") {
+    return `trigger:${entry.source.nodeId ?? "entry"}`;
+  }
+  return `step:${entry.source.nodeId ?? sourceName(entry)}`;
+}
+
+function sourceGlyph(entry: WorkflowDataCatalogEntry): string {
+  if (entry.source.kind === "trigger") return "▶";
+  if (entry.source.kind === "run") return "◎";
+  return "↳";
+}
+
+function availableReason(
+  entry: WorkflowDataCatalogEntry,
+  compatibility: WorkflowDataCompatibility,
+): string | null {
+  if (entry.availability.state === "unavailable") {
+    return entry.availability.reason;
+  }
+  const result = compatibility(entry);
+  return result.compatible ? null : result.reason;
+}
+
+export function textTemplateCompatibility(
+  entry: WorkflowDataCatalogEntry,
+):
+  | { compatible: true }
+  | { compatible: false; reason: string } {
+  if (
+    entry.presence !== "required" ||
+    (Array.isArray(entry.schema.type) &&
+      entry.schema.type.includes("null"))
+  ) {
+    return {
+      compatible: false,
+      reason: "This value may be missing or null when the block runs.",
+    };
+  }
+  const types = Array.isArray(entry.schema.type)
+    ? entry.schema.type
+    : [entry.schema.type];
+  const stringEnum =
+    Array.isArray(entry.schema.enum) &&
+    entry.schema.enum.length > 0 &&
+    entry.schema.enum.every((value) => typeof value === "string");
+  if (!types.includes("string") && !stringEnum) {
+    return {
+      compatible: false,
+      reason: "Only guaranteed text values can be inserted into text.",
+    };
+  }
+  return { compatible: true };
+}
+
+export function inputCompatibility(
+  inputName: string,
+): WorkflowDataCompatibility {
+  return (entry) =>
+    entry.compatibleInputNames.includes(inputName)
+      ? { compatible: true }
+      : {
+          compatible: false,
+          reason: "This value is not compatible with this input.",
+        };
+}
+
+export function WorkflowValueChip({
+  value,
+  reference,
+  disabled,
+  onOpen,
+  onClear,
+}: {
+  value: WorkflowDataCatalogEntry | null;
+  reference?: WorkflowDataReferenceV2;
+  disabled?: boolean;
+  onOpen: () => void;
+  onClear?: () => void;
+}) {
+  if (!value) {
+    return (
+      <div className="space-y-1">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onOpen}
+          className="flex min-h-9 w-full items-center gap-2 rounded-[3px] border border-dashed border-neutral-300 bg-panel px-3 text-left font-body text-[12px] text-mariner disabled:opacity-50"
+        >
+          <span aria-hidden>＋</span>
+          Choose workflow value
+        </button>
+        {reference && (
+          <p className="m-0 font-body text-[10px] leading-[1.35] text-red-700">
+            The saved value is unavailable in the current workflow.
+          </p>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="flex min-h-10 overflow-hidden rounded-[3px] border border-neutral-200 bg-panel">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onOpen}
+        aria-label={`Change ${value.label}`}
+        className="flex min-w-0 flex-1 items-center gap-2 border-none bg-transparent px-2.5 py-1.5 text-left disabled:opacity-50"
+      >
+        <span className="inline-flex size-7 shrink-0 items-center justify-center rounded-[3px] bg-mariner-100 font-mono text-[12px] text-mariner">
+          {sourceGlyph(value)}
+        </span>
+        <span className="min-w-0">
+          <small className="block truncate font-mono text-[8px] uppercase tracking-[0.04em] text-neutral-500">
+            {sourceName(value)}
+          </small>
+          <strong className="block truncate font-body text-[12px] font-medium text-coal">
+            {fieldName(value)}
+          </strong>
+        </span>
+        <span className="ml-auto font-mono text-[10px] text-neutral-400" aria-hidden>
+          ▾
+        </span>
+      </button>
+      {onClear && (
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onClear}
+          aria-label={`Remove ${value.label}`}
+          className="w-9 shrink-0 border-y-0 border-r-0 border-l border-neutral-200 bg-transparent font-mono text-[13px] text-neutral-500 disabled:opacity-50"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function WorkflowDataPicker({
+  open,
+  entries,
+  selectedReference,
+  compatibility,
+  refreshing,
+  onClose,
+  onSelect,
+}: {
+  open: boolean;
+  entries: readonly WorkflowDataCatalogEntry[];
+  selectedReference?: WorkflowDataReferenceV2;
+  compatibility: WorkflowDataCompatibility;
+  refreshing?: boolean;
+  onClose: () => void;
+  onSelect: (entry: WorkflowDataCatalogEntry) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [tab, setTab] = useState<PickerTab>("steps");
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [unavailableOpen, setUnavailableOpen] = useState(false);
+  const dialogRef = useRef<HTMLElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    requestAnimationFrame(() => searchRef.current?.focus());
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      const buttons = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLButtonElement>(
+          "button[data-picker-value]:not([disabled])",
+        ) ?? [],
+      );
+      if (buttons.length === 0) return;
+      const current = buttons.indexOf(document.activeElement as HTMLButtonElement);
+      const next =
+        event.key === "ArrowDown"
+          ? (current + 1 + buttons.length) % buttons.length
+          : (current - 1 + buttons.length) % buttons.length;
+      event.preventDefault();
+      buttons[next]?.focus();
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [onClose, open]);
+
+  useEffect(() => {
+    if (!open || !selectedReference) return;
+    const selected = entries.find(
+      (entry) => entry.reference === selectedReference,
+    );
+    if (!selected) return;
+    setTab(selected.source.kind === "run" ? "run" : "steps");
+    setExpanded((current) => new Set(current).add(sourceKey(selected)));
+  }, [entries, open, selectedReference]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleEntries = useMemo(
+    () =>
+      entries.filter((entry) => {
+        const expectedTab = entry.source.kind === "run" ? "run" : "steps";
+        return (
+          expectedTab === tab &&
+          `${entry.label} ${entry.description} ${schemaType(entry.schema)}`
+            .toLowerCase()
+            .includes(normalizedQuery)
+        );
+      }),
+    [entries, normalizedQuery, tab],
+  );
+  const available = visibleEntries.filter(
+    (entry) => availableReason(entry, compatibility) === null,
+  );
+  const unavailable = visibleEntries
+    .map((entry) => ({
+      entry,
+      reason: availableReason(entry, compatibility),
+    }))
+    .filter(
+      (
+        item,
+      ): item is { entry: WorkflowDataCatalogEntry; reason: string } =>
+        item.reason !== null,
+    );
+  const grouped = useMemo(() => {
+    const groups = new Map<string, WorkflowDataCatalogEntry[]>();
+    for (const entry of available) {
+      const key = sourceKey(entry);
+      groups.set(key, [...(groups.get(key) ?? []), entry]);
+    }
+    return groups;
+  }, [available]);
+
+  if (!open || typeof document === "undefined") return null;
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[130] flex items-center justify-center bg-black/25 p-4"
+      role="presentation"
+      onMouseDown={onClose}
+    >
+      <section
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Choose workflow value"
+        onMouseDown={(event) => event.stopPropagation()}
+        className="flex max-h-[min(680px,calc(100vh-32px))] w-full max-w-[560px] flex-col overflow-hidden rounded-[6px] border border-neutral-200 bg-panel shadow-[0_24px_70px_-20px_rgba(24,27,32,0.45)]"
+      >
+        <header className="flex items-start justify-between border-b border-neutral-200 px-5 py-4">
+          <div>
+            <span className="font-mono text-[9px] uppercase tracking-[0.08em] text-neutral-500">
+              Workflow data
+            </span>
+            <h2 className="m-0 mt-1 font-display text-xl font-medium text-coal">
+              Choose a value
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close workflow value picker"
+            className="size-8 border-none bg-transparent font-mono text-lg text-neutral-500"
+          >
+            ×
+          </button>
+        </header>
+        <div className="p-4 pb-0">
+          <label className="flex h-10 items-center gap-2 rounded-[3px] border border-neutral-200 bg-off-white px-3">
+            <span aria-hidden className="text-neutral-400">
+              ⌕
+            </span>
+            <input
+              ref={searchRef}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search steps and fields"
+              className="min-w-0 flex-1 border-none bg-transparent font-body text-[12px] outline-none"
+            />
+          </label>
+        </div>
+        <nav
+          aria-label="Workflow data sources"
+          className="flex border-b border-neutral-200 px-4 pt-3"
+        >
+          {([
+            ["steps", "Previous steps"],
+            ["run", "Run info"],
+          ] as const).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setTab(value)}
+              aria-pressed={tab === value}
+              className={`border-x-0 border-t-0 bg-transparent px-3 py-2 font-body text-[12px] ${
+                tab === value
+                  ? "border-b-2 border-mariner text-mariner"
+                  : "border-b-2 border-transparent text-neutral-600"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </nav>
+        {refreshing && (
+          <div role="status" className="bg-mariner-100 px-5 py-2 font-body text-[11px] text-mariner">
+            Refreshing values…
+          </div>
+        )}
+        <div className="min-h-0 flex-1 overflow-y-auto p-3">
+          {[...grouped.entries()].map(([key, values]) => {
+            const isExpanded =
+              expanded.has(key) || normalizedQuery.length > 0;
+            return (
+              <div key={key} className="border-b border-neutral-100 last:border-b-0">
+                <button
+                  type="button"
+                  aria-expanded={isExpanded}
+                  onClick={() =>
+                    setExpanded((current) => {
+                      const next = new Set(current);
+                      if (next.has(key)) next.delete(key);
+                      else next.add(key);
+                      return next;
+                    })
+                  }
+                  className="flex w-full items-center gap-2 border-none bg-transparent px-2 py-2.5 text-left"
+                >
+                  <span className="inline-flex size-7 items-center justify-center rounded-[3px] bg-mariner-100 font-mono text-[11px] text-mariner">
+                    {sourceGlyph(values[0]!)}
+                  </span>
+                  <span className="font-body text-[12px] font-medium text-coal">
+                    {sourceName(values[0]!)}
+                  </span>
+                  <span className="ml-auto font-mono text-[10px] text-neutral-400">
+                    {isExpanded ? "▴" : "▾"}
+                  </span>
+                </button>
+                {isExpanded && (
+                  <div className="pb-2 pl-9">
+                    {values.map((entry) => (
+                      <button
+                        key={entry.reference}
+                        type="button"
+                        data-picker-value
+                        disabled={refreshing}
+                        aria-current={
+                          selectedReference === entry.reference
+                            ? "true"
+                            : undefined
+                        }
+                        onClick={() => onSelect(entry)}
+                        className={`flex w-full items-start gap-3 rounded-[3px] border-none px-3 py-2 text-left disabled:opacity-50 ${
+                          selectedReference === entry.reference
+                            ? "bg-mariner-100"
+                            : "bg-transparent hover:bg-off-white"
+                        }`}
+                      >
+                        <span className="min-w-0 flex-1">
+                          <strong className="block font-body text-[12px] font-medium text-coal">
+                            {fieldName(entry)}
+                          </strong>
+                          <small className="block font-body text-[10px] leading-[1.4] text-neutral-500">
+                            {entry.description}
+                          </small>
+                        </span>
+                        <span className="rounded-full bg-off-white px-2 py-0.5 font-mono text-[8px] uppercase text-neutral-500">
+                          {schemaType(entry.schema)}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          {grouped.size === 0 && unavailable.length === 0 && (
+            <div className="px-3 py-8 text-center font-body text-[12px] text-neutral-500">
+              No workflow values match this search.
+            </div>
+          )}
+          {unavailable.length > 0 && (
+            <div className="mt-2 border-t border-neutral-200 pt-2">
+              <button
+                type="button"
+                aria-expanded={unavailableOpen}
+                onClick={() => setUnavailableOpen((current) => !current)}
+                className="flex w-full items-center gap-2 border-none bg-transparent px-2 py-2 font-body text-[11px] text-neutral-600"
+              >
+                <span aria-hidden>⚠</span>
+                Unavailable
+                <span className="rounded-full bg-off-white px-1.5 font-mono text-[9px]">
+                  {unavailable.length}
+                </span>
+                <span className="ml-auto font-mono text-[10px]">
+                  {unavailableOpen ? "▴" : "▾"}
+                </span>
+              </button>
+              {unavailableOpen && (
+                <div className="space-y-1 px-2 pb-2">
+                  {unavailable.map(({ entry, reason }) => (
+                    <div
+                      key={entry.reference}
+                      className="rounded-[3px] bg-off-white px-3 py-2"
+                    >
+                      <strong className="block font-body text-[11px] font-medium text-neutral-700">
+                        {entry.label}
+                      </strong>
+                      <small className="block font-body text-[10px] leading-[1.4] text-neutral-500">
+                        {reason}
+                      </small>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-text-template-editor.test.ts
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-text-template-editor.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  textTemplateDocument,
+  textTemplateValue,
+} from "./workflow-text-template-editor.tsx";
+
+test("plain text templates preserve lines and canonical workflow tokens", () => {
+  const value = [
+    "Review {{data:steps.review.output.decision}}",
+    "",
+    "Run {{data:run.id}} for {{data:steps.entry.output}}.",
+  ].join("\n");
+
+  assert.equal(textTemplateValue(textTemplateDocument(value)), value);
+});
+
+test("plain text templates preserve adjacent and repeated chips", () => {
+  const value =
+    "{{data:steps.first.output}}{{data:steps.second.output.value}}" +
+    " / {{data:steps.first.output}}";
+
+  assert.equal(textTemplateValue(textTemplateDocument(value)), value);
+});
+
+test("plain text templates leave malformed tokens as literal text", () => {
+  const value = "Keep {{data:steps.plan.output.value open";
+
+  assert.equal(textTemplateValue(textTemplateDocument(value)), value);
+});

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-text-template-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-text-template-editor.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import type {
+  WorkflowDataCatalogEntry,
+} from "@shared/contracts";
+import {
+  findCanonicalPromptTokens,
+  PromptTokenNode,
+  promptTokenNodeAttributes,
+} from "@/components/cockpit/prompt-editor/prompt-token-node";
+import {
+  textTemplateCompatibility,
+  WorkflowDataPicker,
+} from "./workflow-data-picker";
+
+interface TiptapJsonNode {
+  type?: string;
+  text?: string;
+  attrs?: Record<string, unknown>;
+  content?: TiptapJsonNode[];
+}
+
+export function textTemplateDocument(value: string): TiptapJsonNode {
+  return {
+    type: "doc",
+    content: value.split("\n").map((line) => {
+      const content: TiptapJsonNode[] = [];
+      let offset = 0;
+      for (const token of findCanonicalPromptTokens(line)) {
+        if (token.start > offset) {
+          content.push({
+            type: "text",
+            text: line.slice(offset, token.start),
+          });
+        }
+        const attrs = promptTokenNodeAttributes(token.raw);
+        if (attrs) {
+          content.push({
+            type: PromptTokenNode.name,
+            attrs,
+          });
+        } else {
+          content.push({ type: "text", text: token.raw });
+        }
+        offset = token.end;
+      }
+      if (offset < line.length) {
+        content.push({ type: "text", text: line.slice(offset) });
+      }
+      return {
+        type: "paragraph",
+        ...(content.length === 0 ? {} : { content }),
+      };
+    }),
+  };
+}
+
+export function textTemplateValue(document: TiptapJsonNode): string {
+  return (document.content ?? [])
+    .map((paragraph) =>
+      (paragraph.content ?? [])
+        .map((node) => {
+          if (node.type === "text") return node.text ?? "";
+          if (node.type === PromptTokenNode.name) {
+            return String(node.attrs?.token ?? "");
+          }
+          return "";
+        })
+        .join(""),
+    )
+    .join("\n");
+}
+
+export function WorkflowTextTemplateEditor({
+  value,
+  entries,
+  disabled,
+  refreshing,
+  minHeightClass = "min-h-[96px]",
+  singleLine = false,
+  onChange,
+}: {
+  value: string;
+  entries: readonly WorkflowDataCatalogEntry[];
+  disabled?: boolean;
+  refreshing?: boolean;
+  minHeightClass?: string;
+  singleLine?: boolean;
+  onChange: (value: string) => void;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const setting = useRef(false);
+  const extensions = useMemo(
+    () => [
+      StarterKit.configure({
+        blockquote: false,
+        bold: false,
+        bulletList: false,
+        code: false,
+        codeBlock: false,
+        heading: false,
+        horizontalRule: false,
+        italic: false,
+        listItem: false,
+        orderedList: false,
+        strike: false,
+      }),
+      PromptTokenNode,
+    ],
+    [],
+  );
+  const editor = useEditor({
+    immediatelyRender: false,
+    editable: !disabled,
+    extensions,
+    content: textTemplateDocument(value),
+    editorProps: {
+      attributes: {
+        class: `${minHeightClass} whitespace-pre-wrap px-3 py-2.5 font-body text-[12px] leading-[1.55] text-coal focus:outline-none`,
+      },
+      handleKeyDown: (_view, event) =>
+        singleLine && event.key === "Enter",
+    },
+    onUpdate: ({ editor: current }) => {
+      if (setting.current) return;
+      const next = textTemplateValue(current.getJSON() as TiptapJsonNode);
+      onChange(singleLine ? next.replaceAll("\n", " ") : next);
+    },
+  }, [singleLine]);
+
+  useEffect(() => {
+    editor?.setEditable(!disabled);
+  }, [disabled, editor]);
+
+  useEffect(() => {
+    if (!editor) return;
+    const current = textTemplateValue(editor.getJSON() as TiptapJsonNode);
+    if (current === value) return;
+    setting.current = true;
+    editor.commands.setContent(textTemplateDocument(value), {
+      emitUpdate: false,
+    });
+    setting.current = false;
+  }, [editor, value]);
+
+  return (
+    <div className="overflow-hidden rounded-[3px] border border-neutral-200 bg-panel">
+      <div className="flex items-center border-b border-neutral-200 px-1.5 py-1">
+        <button
+          type="button"
+          aria-label="Insert workflow value"
+          disabled={disabled}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => setPickerOpen(true)}
+          className="inline-flex h-7 items-center gap-1 rounded-[3px] border border-transparent bg-transparent px-2 font-mono text-[10px] text-mariner hover:bg-off-white disabled:opacity-40"
+        >
+          <span className="text-[13px]" aria-hidden>
+            +
+          </span>
+          Value
+        </button>
+        {refreshing && (
+          <span className="ml-auto pr-2 font-body text-[10px] text-mariner">
+            Refreshing values…
+          </span>
+        )}
+      </div>
+      <EditorContent editor={editor} />
+      <WorkflowDataPicker
+        open={pickerOpen}
+        entries={entries}
+        compatibility={textTemplateCompatibility}
+        refreshing={refreshing}
+        onClose={() => setPickerOpen(false)}
+        onSelect={(entry) => {
+          const token = `{{data:${entry.reference}}}`;
+          const attrs = promptTokenNodeAttributes(token);
+          if (!attrs || !editor) return;
+          editor
+            .chain()
+            .focus()
+            .insertContent({
+              type: PromptTokenNode.name,
+              attrs,
+            })
+            .run();
+          setPickerOpen(false);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/components/cockpit/prompt-editor/prompt-drag.test.ts
+++ b/apps/dashboard/components/cockpit/prompt-editor/prompt-drag.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  markdownForDroppedPrompt,
   PROMPT_DRAG_MIME,
   readPromptDrag,
   writePromptDrag,
@@ -56,5 +57,41 @@ test("legacy latest drag payload remains readable", () => {
   assert.equal(
     payload?.kind === "library-reference" ? payload.version : null,
     "latest",
+  );
+});
+
+test("shared drop formatting handles references and sections consistently", () => {
+  assert.equal(
+    markdownForDroppedPrompt({
+      kind: "library-reference",
+      slug: "implementation",
+      label: "Implementation",
+      version: 7,
+    }),
+    "{{prompt:implementation@7}}",
+  );
+  assert.equal(
+    markdownForDroppedPrompt({
+      kind: "library-reference",
+      slug: "implementation",
+      label: "Implementation",
+    }),
+    "{{prompt:implementation}}",
+  );
+  assert.equal(
+    markdownForDroppedPrompt({
+      kind: "library-section",
+      markdown: "## Verify",
+      label: "Verify",
+    }),
+    "## Verify",
+  );
+  assert.equal(
+    markdownForDroppedPrompt({
+      kind: "composer-block",
+      blockId: "block-1",
+      label: "Block",
+    }),
+    null,
   );
 });

--- a/apps/dashboard/components/cockpit/prompt-editor/prompt-drag.ts
+++ b/apps/dashboard/components/cockpit/prompt-editor/prompt-drag.ts
@@ -1,3 +1,5 @@
+import { formatPromptReferenceToken } from "@shared/contracts";
+
 export const PROMPT_DRAG_MIME = "application/x-ai-workflow-prompt-block";
 
 export type PromptDragPayload =
@@ -9,6 +11,17 @@ export type PromptDragPayload =
     }
   | { kind: "library-section"; markdown: string; label: string }
   | { kind: "composer-block"; blockId: string; label: string };
+
+export function markdownForDroppedPrompt(
+  payload: PromptDragPayload,
+): string | null {
+  if (payload.kind === "library-section") return payload.markdown;
+  if (payload.kind !== "library-reference") return null;
+  return formatPromptReferenceToken({
+    slug: payload.slug,
+    version: payload.version ?? "latest",
+  });
+}
 
 export function writePromptDrag(event: React.DragEvent, payload: PromptDragPayload): void {
   event.dataTransfer.effectAllowed = payload.kind === "composer-block" ? "move" : "copy";

--- a/apps/dashboard/components/cockpit/prompt-editor/prompt-editor.tsx
+++ b/apps/dashboard/components/cockpit/prompt-editor/prompt-editor.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { useEditor, EditorContent, type Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Markdown } from "@tiptap/markdown";
-import type { WorkflowAvailableValue } from "@shared/contracts";
+import type { WorkflowDataCatalogEntry } from "@shared/contracts";
 import { VariableHighlight } from "./variable-highlight";
 import { VariablePickerPopover } from "@/components/cockpit/prompt-library/variable-picker-popover";
 import { AVAILABLE_VARIABLES } from "@/lib/prompt-library/variables";
@@ -14,8 +14,10 @@ import {
   PromptTokenNode,
   promptTokenNodeAttributes,
 } from "./prompt-token-node";
-import { readPromptDrag } from "./prompt-drag";
-import { formatPromptReferenceToken } from "@shared/contracts";
+import {
+  markdownForDroppedPrompt,
+  readPromptDrag,
+} from "./prompt-drag";
 
 export interface PromptEditorSlotOption {
   name: string;
@@ -36,7 +38,7 @@ export interface PromptEditorProps {
   /** V2 turns canonical data, pinned prompt, and slot tokens into atomic chips. */
   authoringMode?: "v1" | "v2";
   /** Worker-owned values guaranteed to be available at the consuming block. */
-  availableValues?: readonly WorkflowAvailableValue[];
+  availableValues?: readonly WorkflowDataCatalogEntry[];
   slots?: readonly PromptEditorSlotOption[];
   /** Compact prose fields keep formatting actions out of the toolbar. */
   compact?: boolean;
@@ -236,7 +238,14 @@ function CanonicalTokenPicker({
       }
     };
     document.addEventListener("pointerdown", close, true);
-    return () => document.removeEventListener("pointerdown", close, true);
+    const escape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", escape, true);
+    return () => {
+      document.removeEventListener("pointerdown", close, true);
+      window.removeEventListener("keydown", escape, true);
+    };
   }, [anchorRef, onClose, open]);
 
   if (!open || !anchorRef.current) return null;
@@ -329,11 +338,16 @@ export function PromptEditor({
     () =>
       canonical
         ? [
-            ...availableValues.map((available) => ({
-              token: `{{data:${available.reference}}}`,
-              label: available.label,
-              description: available.description,
-            })),
+            ...availableValues
+              .filter(
+                (available) =>
+                  available.availability.state === "available",
+              )
+              .map((available) => ({
+                token: `{{data:${available.reference}}}`,
+                label: available.label,
+                description: available.description,
+              })),
             ...slots.map((slot) => ({
               token: `{{slot:${slot.name}}}`,
               label: `Slot · ${slot.name}`,
@@ -511,19 +525,16 @@ export function PromptEditor({
             e.preventDefault();
             setMenuAt({ x: e.clientX, y: e.clientY });
           }}
+          onDragOver={(event) => {
+            if (disabled) return;
+            event.preventDefault();
+            event.dataTransfer.dropEffect = "copy";
+          }}
           onDrop={(event) => {
             const payload = readPromptDrag(event);
             if (!payload || disabled || !editor) return;
             event.preventDefault();
-            const markdown =
-              payload.kind === "library-reference"
-                ? formatPromptReferenceToken({
-                    slug: payload.slug,
-                    version: payload.version ?? "latest",
-                  })
-                : payload.kind === "library-section"
-                  ? payload.markdown
-                  : null;
+            const markdown = markdownForDroppedPrompt(payload);
             if (markdown === null) return;
             editor
               .chain()

--- a/apps/dashboard/components/cockpit/prompt-editor/prompt-section-composer.tsx
+++ b/apps/dashboard/components/cockpit/prompt-editor/prompt-section-composer.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { formatPromptReferenceToken } from "@shared/contracts";
 import { PromptPreview } from "@/components/cockpit/prompt-library/prompt-preview";
 import {
   appendComposerSection,
@@ -15,7 +14,11 @@ import {
 } from "@/lib/prompt-library/composer";
 import { PromptEditor } from "./prompt-editor";
 import { PromptReferenceChips } from "./prompt-reference-chips";
-import { readPromptDrag, writePromptDrag } from "./prompt-drag";
+import {
+  markdownForDroppedPrompt,
+  readPromptDrag,
+  writePromptDrag,
+} from "./prompt-drag";
 
 const iconButton =
   "inline-flex size-7 shrink-0 appearance-none items-center justify-center rounded-[3px] border border-transparent bg-transparent font-mono text-[11px] text-neutral-500 transition-colors hover:border-neutral-200 hover:bg-off-white hover:text-mariner disabled:cursor-default disabled:opacity-30";
@@ -119,12 +122,8 @@ export function PromptSectionComposer({
       commit(moveComposerBlock(blocks, payload.blockId, adjustedTarget));
       return;
     }
-    const markdown = payload.kind === "library-reference"
-      ? formatPromptReferenceToken({
-          slug: payload.slug,
-          version: payload.version ?? "latest",
-        })
-      : payload.markdown;
+    const markdown = markdownForDroppedPrompt(payload);
+    if (markdown === null) return;
     const next = insertComposerMarkdown(blocks, targetIndex, markdown, makeId);
     commit(next);
     setActiveId(next[targetIndex]?.kind === "section" ? next[targetIndex].id : null);

--- a/apps/dashboard/components/cockpit/prompt-editor/prompt-slot-fields.test.tsx
+++ b/apps/dashboard/components/cockpit/prompt-editor/prompt-slot-fields.test.tsx
@@ -5,7 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type {
   JsonValue,
   PromptSlotDefinition,
-  WorkflowAvailableValue,
+  WorkflowDataCatalogEntry,
 } from "@shared/contracts";
 import {
   aggregatePromptSlotSchemaDraftState,
@@ -34,7 +34,7 @@ const definitions: PromptSlotDefinition[] = [
   },
 ];
 
-const availableValues: WorkflowAvailableValue[] = [
+const availableValues: WorkflowDataCatalogEntry[] = [
   {
     reference: "steps.planning.output.plan",
     label: "Planning · plan",
@@ -43,13 +43,9 @@ const availableValues: WorkflowAvailableValue[] = [
     source: {
       kind: "step",
       nodeId: "planning",
-      blockType: "planning_agent",
     },
-    guarantee: {
-      kind: "unconditional_activation",
-      triggerNodeIds: ["trigger"],
-      viaEdgeIds: ["planning-to-implementation"],
-    },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
     compatibleInputNames: [],
   },
 ];

--- a/apps/dashboard/components/cockpit/prompt-editor/prompt-slot-fields.tsx
+++ b/apps/dashboard/components/cockpit/prompt-editor/prompt-slot-fields.tsx
@@ -8,7 +8,7 @@ import {
   type JsonValue,
   type PromptSlotBinding,
   type PromptSlotDefinition,
-  type WorkflowAvailableValue,
+  type WorkflowDataCatalogEntry,
   type WorkflowDataReferenceV2,
 } from "@shared/contracts";
 import { JsonSchemaEditor } from "@/components/cockpit/flow-editor/json-schema-editor";
@@ -563,7 +563,7 @@ export function PromptSlotBindingsEditor({
 }: {
   definitions: readonly PromptSlotDefinition[];
   bindings: Readonly<Record<string, PromptSlotBinding>>;
-  availableValues: readonly WorkflowAvailableValue[];
+  availableValues: readonly WorkflowDataCatalogEntry[];
   disabled: boolean;
   onChange: (bindings: Record<string, PromptSlotBinding>) => void;
 }) {
@@ -587,10 +587,13 @@ export function PromptSlotBindingsEditor({
         </p>
       </div>
       {definitions.map((definition) => {
+        const selectableValues = availableValues.filter(
+          (value) => value.availability.state === "available",
+        );
         const binding = bindings[definition.name];
         const currentReference =
           binding?.kind === "reference"
-            ? availableValues.find(
+            ? selectableValues.find(
                 (value) => value.reference === binding.reference,
               )
             : undefined;
@@ -627,7 +630,7 @@ export function PromptSlotBindingsEditor({
                 if (event.target.value === "") {
                   update(definition.name, undefined);
                 } else if (event.target.value === "reference") {
-                  const first = availableValues[0];
+                  const first = selectableValues[0];
                   update(
                     definition.name,
                     first
@@ -653,7 +656,7 @@ export function PromptSlotBindingsEditor({
                     ? "Choose a value…"
                     : "Leave unfilled"}
               </option>
-              <option value="reference" disabled={availableValues.length === 0}>
+              <option value="reference" disabled={selectableValues.length === 0}>
                 Workflow value
               </option>
               <option value="literal">Literal value</option>
@@ -677,7 +680,7 @@ export function PromptSlotBindingsEditor({
                     Unavailable: {binding.reference}
                   </option>
                 )}
-                {availableValues.map((value) => (
+                {selectableValues.map((value) => (
                   <option key={value.reference} value={value.reference}>
                     {value.label}
                   </option>

--- a/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
@@ -13,6 +13,7 @@ import {
   isTriggerBlockType,
   type RunBlockStatusesResponse,
   type WorkflowDefinition,
+  type WorkflowDefinitionV2,
   type WorkflowDefinitionDeploymentResponse,
   type WorkflowDefinitionDeploymentValidationResponse,
   type WorkflowDefinitionDetailResponse,
@@ -64,6 +65,7 @@ import {
   type WorkflowValidationState,
 } from "@/lib/workflow-editor/validation-controller";
 import { useWorkflowValidationController } from "@/lib/workflow-editor/use-validation-controller";
+import { useWorkflowDataCatalog } from "@/lib/workflow-editor/use-workflow-data-catalog";
 import {
   workflowDeploymentAfterSave,
   workflowEditorActions,
@@ -415,6 +417,12 @@ export function WorkflowEditorScreen({
   const semanticKey = JSON.stringify(semanticDefinition);
   const validationTargetKey = `${selectedId}:${semanticKey}`;
   const validationIsCurrent = validation.key === validationTargetKey;
+  const dataCatalog = useWorkflowDataCatalog(
+    selectedId,
+    schemaVersion === 2
+      ? (semanticDefinition as WorkflowDefinitionV2)
+      : null,
+  );
   const dirty = editorHistoryIsDirty(editorHistory, semanticKey);
   const runnableTriggerIds = useMemo(() => {
     if (!canDispatch || !deployed) return new Set<string>();
@@ -1199,6 +1207,9 @@ export function WorkflowEditorScreen({
                   availableValuesByNode: {},
                 }
           }
+          dataCatalog={dataCatalog.response}
+          dataCatalogRefreshing={dataCatalog.refreshing}
+          dataCatalogError={dataCatalog.error}
           onSave={save}
           saveLabel="Save draft"
           headerTitle={selectedMeta?.name ?? "Workflow"}

--- a/apps/dashboard/lib/workflow-editor/branch-ast.test.ts
+++ b/apps/dashboard/lib/workflow-editor/branch-ast.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { WorkflowAvailableValue } from "@shared/contracts";
+import type { WorkflowDataCatalogEntry } from "@shared/contracts";
 import {
   branchConditionForKind,
   branchLiteralForSchema,
@@ -9,7 +9,7 @@ import {
   summarizeWorkflowBranchCondition,
 } from "./branch-ast";
 
-const values: WorkflowAvailableValue[] = [
+const values: WorkflowDataCatalogEntry[] = [
   {
     reference: "steps.review.output.decision",
     label: "Review · decision",
@@ -18,12 +18,9 @@ const values: WorkflowAvailableValue[] = [
       type: "string",
       enum: ["approve", "request_changes"],
     },
-    source: { kind: "step", nodeId: "review", blockType: "review_agent" },
-    guarantee: {
-      kind: "unconditional_activation",
-      triggerNodeIds: ["trigger"],
-      viaEdgeIds: ["review-decision"],
-    },
+    source: { kind: "step", nodeId: "review" },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
     compatibleInputNames: [],
   },
   {
@@ -31,12 +28,9 @@ const values: WorkflowAvailableValue[] = [
     label: "Checks · ok",
     description: "Check result",
     schema: { type: "boolean" },
-    source: { kind: "step", nodeId: "check", blockType: "run_checks" },
-    guarantee: {
-      kind: "unconditional_activation",
-      triggerNodeIds: ["trigger"],
-      viaEdgeIds: ["check-decision"],
-    },
+    source: { kind: "step", nodeId: "check" },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
     compatibleInputNames: [],
   },
 ];

--- a/apps/dashboard/lib/workflow-editor/branch-ast.ts
+++ b/apps/dashboard/lib/workflow-editor/branch-ast.ts
@@ -1,7 +1,7 @@
 import type {
   JsonSchema202012,
   JsonValue,
-  WorkflowAvailableValue,
+  WorkflowDataCatalogEntry,
   WorkflowBranchBooleanAstV2,
   WorkflowBranchConfigurationV2,
   WorkflowBranchOperandV2,
@@ -97,7 +97,7 @@ function schemaTypes(schema: JsonSchema202012): string[] {
       : [];
 }
 
-export function isBooleanWorkflowValue(value: WorkflowAvailableValue): boolean {
+export function isBooleanWorkflowValue(value: WorkflowDataCatalogEntry): boolean {
   return schemaTypes(value.schema).includes("boolean");
 }
 
@@ -118,24 +118,28 @@ export function branchLiteralForSchema(
 
 export function branchSchemaForOperand(
   operand: WorkflowBranchOperandV2,
-  availableValues: readonly WorkflowAvailableValue[],
+  availableValues: readonly WorkflowDataCatalogEntry[],
 ): JsonSchema202012 | undefined {
   if (operand.kind !== "path") return undefined;
   return availableValues.find((value) => value.reference === operand.reference)?.schema;
 }
 
 function firstPath(
-  availableValues: readonly WorkflowAvailableValue[],
+  availableValues: readonly WorkflowDataCatalogEntry[],
   booleanOnly = false,
 ): WorkflowDataReferenceV2 | null {
   return (
-    availableValues.find((value) => !booleanOnly || isBooleanWorkflowValue(value))
+    availableValues.find(
+      (value) =>
+        value.availability.state === "available" &&
+        (!booleanOnly || isBooleanWorkflowValue(value)),
+    )
       ?.reference ?? null
   );
 }
 
 function defaultOperandPair(
-  availableValues: readonly WorkflowAvailableValue[],
+  availableValues: readonly WorkflowDataCatalogEntry[],
 ): [WorkflowBranchOperandV2, WorkflowBranchOperandV2] {
   const reference = firstPath(availableValues);
   if (!reference) {
@@ -152,7 +156,7 @@ function defaultOperandPair(
 }
 
 export function defaultWorkflowBranchCondition(
-  availableValues: readonly WorkflowAvailableValue[],
+  availableValues: readonly WorkflowDataCatalogEntry[],
 ): WorkflowBranchBooleanAstV2 {
   const reference = firstPath(availableValues, true);
   return reference
@@ -162,7 +166,7 @@ export function defaultWorkflowBranchCondition(
 
 export function branchConditionForKind(
   kind: WorkflowBranchBooleanAstV2["kind"],
-  availableValues: readonly WorkflowAvailableValue[],
+  availableValues: readonly WorkflowDataCatalogEntry[],
 ): WorkflowBranchBooleanAstV2 {
   const base = defaultWorkflowBranchCondition(availableValues);
   switch (kind) {
@@ -185,7 +189,7 @@ export function branchConditionForKind(
 
 function valueLabel(
   reference: WorkflowDataReferenceV2,
-  availableValues: readonly WorkflowAvailableValue[],
+  availableValues: readonly WorkflowDataCatalogEntry[],
 ): string {
   const catalogLabel = availableValues.find(
     (value) => value.reference === reference,
@@ -201,7 +205,7 @@ function valueLabel(
 
 function operandSummary(
   operand: WorkflowBranchOperandV2,
-  availableValues: readonly WorkflowAvailableValue[],
+  availableValues: readonly WorkflowDataCatalogEntry[],
 ): string {
   return operand.kind === "path"
     ? valueLabel(operand.reference, availableValues)
@@ -210,7 +214,7 @@ function operandSummary(
 
 export function summarizeWorkflowBranchCondition(
   condition: WorkflowBranchBooleanAstV2,
-  availableValues: readonly WorkflowAvailableValue[] = [],
+  availableValues: readonly WorkflowDataCatalogEntry[] = [],
 ): string {
   switch (condition.kind) {
     case "lit":

--- a/apps/dashboard/lib/workflow-editor/catalog-fingerprint.test.ts
+++ b/apps/dashboard/lib/workflow-editor/catalog-fingerprint.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { WorkflowDefinitionV2 } from "@shared/contracts";
+import { workflowCatalogFingerprint } from "./catalog-fingerprint.ts";
+
+const definition: WorkflowDefinitionV2 = {
+  schemaVersion: 2,
+  nodes: [
+    {
+      id: "trigger",
+      type: "trigger_ticket_ai",
+      x: 10,
+      y: 20,
+      configuration: {},
+      inputs: {},
+      additionalInputs: [],
+    },
+    {
+      id: "message",
+      type: "post_ticket_comment",
+      x: 200,
+      y: 20,
+      configuration: { body: "Initial prose" },
+      inputs: {},
+      additionalInputs: [],
+    },
+  ],
+  edges: [{ id: "edge", from: "trigger", to: "message" }],
+};
+
+test("catalog fingerprint ignores layout and ordinary prose", () => {
+  const changed = structuredClone(definition);
+  changed.nodes[1]!.x = 500;
+  changed.nodes[1]!.y = 700;
+  changed.nodes[1]!.configuration.body = "Edited prose";
+
+  assert.equal(
+    workflowCatalogFingerprint(changed),
+    workflowCatalogFingerprint(definition),
+  );
+});
+
+test("catalog fingerprint changes for graph and contract configuration", () => {
+  const graph = structuredClone(definition);
+  graph.edges[0]!.fromPort = "true";
+  assert.notEqual(
+    workflowCatalogFingerprint(graph),
+    workflowCatalogFingerprint(definition),
+  );
+
+  const schema = structuredClone(definition);
+  schema.nodes[1]!.additionalInputs.push({
+    name: "score",
+    schema: { type: "number" },
+    binding: { kind: "literal", value: 1 },
+  });
+  assert.notEqual(
+    workflowCatalogFingerprint(schema),
+    workflowCatalogFingerprint(definition),
+  );
+});

--- a/apps/dashboard/lib/workflow-editor/catalog-fingerprint.ts
+++ b/apps/dashboard/lib/workflow-editor/catalog-fingerprint.ts
@@ -1,0 +1,44 @@
+import type { JsonValue, WorkflowDefinitionV2 } from "@shared/contracts";
+
+const PROSE_CONFIGURATION_KEYS = new Set([
+  "body",
+  "instructions",
+  "message",
+  "postComment",
+  "prompt",
+  "questions",
+  "system",
+  "title",
+]);
+
+function dataContractConfiguration(
+  configuration: Record<string, JsonValue>,
+): Record<string, JsonValue> {
+  return Object.fromEntries(
+    Object.entries(configuration).filter(
+      ([key]) => !PROSE_CONFIGURATION_KEYS.has(key),
+    ),
+  );
+}
+
+export function workflowCatalogFingerprint(
+  definition: WorkflowDefinitionV2,
+): string {
+  return JSON.stringify({
+    nodes: definition.nodes.map((node) => ({
+      id: node.id,
+      type: node.type,
+      configuration: dataContractConfiguration(node.configuration),
+      additionalInputs: node.additionalInputs.map((input) => ({
+        name: input.name,
+        schema: input.schema,
+      })),
+    })),
+    edges: definition.edges.map((edge) => ({
+      id: edge.id,
+      from: edge.from,
+      to: edge.to,
+      fromPort: edge.fromPort,
+    })),
+  });
+}

--- a/apps/dashboard/lib/workflow-editor/graph-edit.test.ts
+++ b/apps/dashboard/lib/workflow-editor/graph-edit.test.ts
@@ -23,11 +23,11 @@ test("node deletion removes the block and all incident connections", () => {
   assert.equal(result.removed, true);
 });
 
-test("the sole trigger remains protected from context-menu deletion", () => {
+test("the sole trigger can be deleted from a saveable draft", () => {
   const result = removeNodeFromGraph(nodes, edges, "trigger");
-  assert.equal(result.nodes, nodes);
-  assert.equal(result.edges, edges);
-  assert.equal(result.removed, false);
+  assert.deepEqual(result.nodes.map((node) => node.id), ["agent", "done"]);
+  assert.deepEqual(result.edges, [{ from: "agent", to: "done" }]);
+  assert.equal(result.removed, true);
 });
 
 test("multi-delete removes selected nodes, incident edges, and selected standalone edges", () => {
@@ -62,7 +62,7 @@ test("multi-delete removes selected nodes, incident edges, and selected standalo
   assert.deepEqual(result.edges, []);
 });
 
-test("multi-delete is atomic when the selection contains every trigger", () => {
+test("multi-delete can leave a triggerless saveable draft", () => {
   const secondTrigger: FlowNodeDef = {
     id: "manual",
     type: "trigger_plan_approved",
@@ -77,10 +77,10 @@ test("multi-delete is atomic when the selection contains every trigger", () => {
     edgeKeys: [],
   });
 
-  assert.equal(result.removed, false);
-  assert.equal(result.blocker, "trigger_required");
-  assert.equal(result.nodes, graphNodes);
-  assert.equal(result.edges, edges);
+  assert.equal(result.removed, true);
+  assert.equal(result.blocker, null);
+  assert.deepEqual(result.nodes.map((node) => node.id), ["done"]);
+  assert.deepEqual(result.edges, []);
 });
 
 test("multi-delete allows one of multiple triggers to be removed", () => {

--- a/apps/dashboard/lib/workflow-editor/graph-edit.ts
+++ b/apps/dashboard/lib/workflow-editor/graph-edit.ts
@@ -1,8 +1,7 @@
-import { isTriggerBlockType } from "@shared/contracts";
 import type { FlowEdgeDef, FlowNodeDef } from "@/lib/flows";
 import { edgeInstanceKey } from "./edges";
 
-export type GraphSelectionDeleteBlocker = "trigger_required";
+export type GraphSelectionDeleteBlocker = never;
 
 export interface GraphSelectionDeleteResult {
   nodes: FlowNodeDef[];
@@ -31,25 +30,6 @@ export function removeSelectionFromGraph(
     if (selectedEdgeKeys.has(edgeInstanceKey(edges, index))) {
       selectedEdgeIndexes.add(index);
     }
-  }
-
-  const triggerCount = nodes.filter((node) =>
-    isTriggerBlockType(node.type),
-  ).length;
-  const selectedTriggerCount = nodes.filter(
-    (node) =>
-      selectedNodeIds.has(node.id) && isTriggerBlockType(node.type),
-  ).length;
-  if (
-    selectedTriggerCount > 0 &&
-    triggerCount - selectedTriggerCount < 1
-  ) {
-    return {
-      nodes,
-      edges,
-      removed: false,
-      blocker: "trigger_required",
-    };
   }
 
   if (selectedNodeIds.size === 0 && selectedEdgeIndexes.size === 0) {

--- a/apps/dashboard/lib/workflow-editor/layout-geometry.ts
+++ b/apps/dashboard/lib/workflow-editor/layout-geometry.ts
@@ -30,14 +30,15 @@ export function edgeBezierPath(
   const bend = geometry.bend;
   const firstDirection = bend.x >= from.x ? 1 : -1;
   const secondDirection = to.x >= bend.x ? 1 : -1;
+  const joinDirection = to.x >= from.x ? 1 : -1;
   const firstDx = Math.max(20, Math.abs(bend.x - from.x) * 0.45);
   const secondDx = Math.max(20, Math.abs(to.x - bend.x) * 0.45);
   return [
     `M ${from.x} ${from.y}`,
     `C ${from.x + firstDirection * firstDx} ${from.y},`,
-    `${bend.x - firstDirection * firstDx} ${bend.y},`,
+    `${bend.x - joinDirection * firstDx} ${bend.y},`,
     `${bend.x} ${bend.y}`,
-    `C ${bend.x + secondDirection * secondDx} ${bend.y},`,
+    `C ${bend.x + joinDirection * secondDx} ${bend.y},`,
     `${to.x - secondDirection * secondDx} ${to.y},`,
     `${to.x} ${to.y}`,
   ].join(" ");

--- a/apps/dashboard/lib/workflow-editor/reference-highlight.test.ts
+++ b/apps/dashboard/lib/workflow-editor/reference-highlight.test.ts
@@ -39,6 +39,16 @@ test("the virtual entry source highlights the active trigger node", () => {
   );
 });
 
+test("whole-output references stop at canonical token boundaries", () => {
+  assert.deepEqual(
+    sourceNodeIdsForReference(
+      "{{data:steps.plan.output}} steps.plan.output-more",
+      nodes,
+    ),
+    ["plan"],
+  );
+});
+
 test("run values, literals, and unknown nodes do not produce highlights", () => {
   assert.deepEqual(
     sourceNodeIdsForReference(

--- a/apps/dashboard/lib/workflow-editor/reference-highlight.ts
+++ b/apps/dashboard/lib/workflow-editor/reference-highlight.ts
@@ -1,7 +1,8 @@
 import { isTriggerBlockType } from "@shared/contracts";
 import type { FlowNodeDef } from "@/lib/flows";
 
-const STEP_REFERENCE = /(?:^|[^A-Za-z0-9_-])steps\.([A-Za-z_][A-Za-z0-9_-]*)\.output(?:\.|$)/g;
+const STEP_REFERENCE =
+  /(?:^|[^A-Za-z0-9_-])steps\.([A-Za-z_][A-Za-z0-9_-]*)\.output(?=\.|\}\}|[^A-Za-z0-9_-]|$)/g;
 
 /**
  * Resolves only the producing nodes represented by a canonical data reference.

--- a/apps/dashboard/lib/workflow-editor/use-workflow-data-catalog.ts
+++ b/apps/dashboard/lib/workflow-editor/use-workflow-data-catalog.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type {
+  WorkflowDefinitionCatalogResponse,
+  WorkflowDefinitionV2,
+} from "@shared/contracts";
+import { readErrorMessage } from "@/lib/api/error-message";
+import { workflowCatalogFingerprint } from "./catalog-fingerprint";
+
+export interface WorkflowDataCatalogState {
+  fingerprint: string | null;
+  response: WorkflowDefinitionCatalogResponse | null;
+  refreshing: boolean;
+  error: string | null;
+}
+
+export function useWorkflowDataCatalog(
+  definitionId: number,
+  definition: WorkflowDefinitionV2 | null,
+): WorkflowDataCatalogState {
+  const [state, setState] = useState<WorkflowDataCatalogState>({
+    fingerprint: null,
+    response: null,
+    refreshing: false,
+    error: null,
+  });
+  const latestFingerprint = useRef<string | null>(null);
+  const definitionRef = useRef(definition);
+  definitionRef.current = definition;
+
+  const fingerprint = definition
+    ? workflowCatalogFingerprint(definition)
+    : null;
+
+  useEffect(() => {
+    latestFingerprint.current = fingerprint;
+    const requestDefinition = definitionRef.current;
+    if (!requestDefinition || !fingerprint) {
+      setState({
+        fingerprint: null,
+        response: null,
+        refreshing: false,
+        error: null,
+      });
+      return;
+    }
+    const controller = new AbortController();
+    setState((current) => ({
+      ...current,
+      refreshing: true,
+      error: null,
+    }));
+    void fetch(`/api/workflow-definitions/${definitionId}/catalog`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ definition: requestDefinition }),
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(await readErrorMessage(response));
+        return (await response.json()) as WorkflowDefinitionCatalogResponse;
+      })
+      .then((response) => {
+        if (
+          controller.signal.aborted ||
+          latestFingerprint.current !== fingerprint
+        ) {
+          return;
+        }
+        setState({
+          fingerprint,
+          response,
+          refreshing: false,
+          error: null,
+        });
+      })
+      .catch((error: unknown) => {
+        if (
+          controller.signal.aborted ||
+          latestFingerprint.current !== fingerprint
+        ) {
+          return;
+        }
+        setState((current) => ({
+          ...current,
+          refreshing: false,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Could not refresh workflow values.",
+        }));
+      });
+    return () => controller.abort();
+  }, [definitionId, fingerprint]);
+
+  return state;
+}

--- a/apps/shared/contracts/api.ts
+++ b/apps/shared/contracts/api.ts
@@ -2,6 +2,7 @@ import type {
   ApprovalRequest,
   ClarificationRequest,
   JsonSchema202012,
+  JsonValue,
   PrePrCheckConfigVersion,
   RepositoryOption,
   Run,
@@ -367,6 +368,38 @@ export interface WorkflowAvailableValue {
 }
 
 export type WorkflowAvailableValuesByNode = Record<string, WorkflowAvailableValue[]>;
+
+export type NodeDataContract = WorkflowBlockContract;
+
+export type WorkflowDataCatalogPresence =
+  | "required"
+  | "optional"
+  | "nullable"
+  | "optional_nullable";
+
+export type WorkflowDataCatalogAvailability =
+  | { state: "available"; guarantee: string }
+  | { state: "unavailable"; reason: string };
+
+export interface WorkflowDataCatalogEntry {
+  reference: WorkflowDataReferenceV2;
+  label: string;
+  description: string;
+  schema: JsonSchema202012;
+  source: {
+    kind: "trigger" | "step" | "run";
+    nodeId?: string;
+  };
+  presence: WorkflowDataCatalogPresence;
+  availability: WorkflowDataCatalogAvailability;
+  compatibleInputNames: string[];
+  example?: JsonValue;
+}
+
+export interface WorkflowDefinitionCatalogResponse {
+  nodeContracts: Record<string, NodeDataContract>;
+  catalogByNode: Record<string, WorkflowDataCatalogEntry[]>;
+}
 
 export interface WorkflowDefinitionValidationResponse {
   valid: boolean;

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -360,7 +360,9 @@ export type WorkflowDefinitionEdge = WorkflowDefinitionV1Edge;
 /** Canonical data paths persisted by v2 bindings. `entry` is the virtual
  * active-trigger source and is therefore reserved as a real node id. */
 export type WorkflowDataReferenceV2 =
+  | "steps.entry.output"
   | `steps.entry.output.${string}`
+  | `steps.${string}.output`
   | `steps.${string}.output.${string}`
   | `run.${string}`;
 

--- a/apps/shared/contracts/prompt-slots.ts
+++ b/apps/shared/contracts/prompt-slots.ts
@@ -88,7 +88,7 @@ export function isPromptDataReference(
   }
   if (
     segments[0] !== "steps" ||
-    segments.length < 4 ||
+    segments.length < 3 ||
     segments[2] !== "output"
   ) {
     return false;

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -100,6 +100,7 @@ const detailDeploy = (await import("./workflow-definitions/[id]/deploy.post.js")
 const detailRollback = (await import("./workflow-definitions/[id]/rollback.post.js")).default;
 const detailLayout = (await import("./workflow-definitions/[id]/layout.patch.js")).default;
 const detailValidate = (await import("./workflow-definitions/[id]/validate.post.js")).default;
+const detailCatalog = (await import("./workflow-definitions/[id]/catalog.post.js")).default;
 const detailPromptPreview = (
   await import("./workflow-definitions/[id]/prompt-preview.post.js")
 ).default;
@@ -1765,6 +1766,47 @@ describe("POST /api/v1/workflow-definitions/:id/validate", () => {
       new Request("http://worker.test/d/1"),
     );
     expect((await detail.json()).meta.draftRevision).toBe(1);
+  });
+});
+
+describe("POST /api/v1/workflow-definitions/:id/catalog", () => {
+  const catalog = paramHandler("post", "/d/:id/catalog", detailCatalog);
+
+  it("returns a no-store authoring catalog for an unsaved v2 candidate", async () => {
+    const definition = defaultWorkflowDefinitionV2({ includeReview: false });
+    const res = await catalog(
+      jsonRequest(
+        "POST",
+        { definition },
+        "http://worker.test/d/1/catalog",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+    expect(await res.json()).toMatchObject({
+      nodeContracts: expect.any(Object),
+      catalogByNode: expect.any(Object),
+    });
+  });
+
+  it("rejects malformed bodies without changing the saved draft", async () => {
+    const before = await handlerFor(detailGet)(
+      new Request("http://worker.test/?id=1"),
+    );
+    const res = await catalog(
+      jsonRequest(
+        "POST",
+        { definition: { schemaVersion: 2, nodes: "invalid" } },
+        "http://worker.test/d/1/catalog",
+      ),
+    );
+    const after = await handlerFor(detailGet)(
+      new Request("http://worker.test/?id=1"),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await after.json()).toEqual(await before.json());
   });
 });
 

--- a/apps/worker/src/routes/api/v1/workflow-definitions/[id]/catalog.post.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions/[id]/catalog.post.ts
@@ -1,0 +1,54 @@
+import {
+  createError,
+  defineEventHandler,
+  readBody,
+  setResponseHeader,
+} from "h3";
+import type {
+  WorkflowDefinitionCatalogResponse,
+  WorkflowDefinitionV2,
+} from "@shared/contracts";
+import { getDb } from "../../../../../db/client.js";
+import {
+  requireDashboardActor,
+  toHttpError,
+} from "../../../../../lib/auth/request-context.js";
+import { analyzeWorkflowV2Catalog } from "../../../../../workflow-definition/available-values.js";
+import { workflowBlockRegistryContextFromEnv } from "../../../../../workflow-definition/models.js";
+import { workflowDefinitionV2Schema } from "../../../../../workflow-definition/schema.js";
+import { getWorkflowDefinition } from "../../../../../workflow-definition/store.js";
+import { parseDefinitionId } from "../../workflow-definitions.get.js";
+
+export default defineEventHandler(
+  async (event): Promise<WorkflowDefinitionCatalogResponse | undefined> => {
+    try {
+      setResponseHeader(event, "Cache-Control", "private, no-store");
+      await requireDashboardActor(event);
+      const definitionId = parseDefinitionId(event);
+      const stored = await getWorkflowDefinition(getDb(), definitionId);
+      if (!stored || stored.archivedAt !== null) {
+        throw createError({
+          statusCode: 404,
+          statusMessage: "Unknown definition",
+        });
+      }
+      const body =
+        (await readBody<{ definition?: unknown }>(event).catch(() => null)) ??
+        {};
+      const parsed = workflowDefinitionV2Schema.safeParse(body.definition);
+      if (!parsed.success) {
+        throw createError({
+          statusCode: 400,
+          statusMessage: "Invalid v2 definition",
+        });
+      }
+      return analyzeWorkflowV2Catalog(
+        parsed.data as WorkflowDefinitionV2,
+        workflowBlockRegistryContextFromEnv(),
+      );
+    } catch (error) {
+      if (error instanceof Error && "statusCode" in error) throw error;
+      toHttpError(error);
+    }
+  },
+);

--- a/apps/worker/src/workflow-definition/available-values.test.ts
+++ b/apps/worker/src/workflow-definition/available-values.test.ts
@@ -7,6 +7,7 @@ import type {
   WorkflowInputBindingV2,
 } from "@shared/contracts";
 import {
+  analyzeWorkflowV2Catalog,
   analyzeWorkflowV2Bindings,
 } from "./available-values.js";
 import type { WorkflowBlockRegistryContext } from "./block-registry.js";
@@ -265,6 +266,109 @@ describe("v2 available values", () => {
         "steps.shape.output.output.title",
       ).schema,
     ).toEqual({ type: "string" });
+  });
+});
+
+describe("v2 authoring catalog", () => {
+  it("includes whole outputs and marks conditional producers unavailable", () => {
+    const result = analyzeWorkflowV2Catalog(
+      definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("decision", "branch"),
+          node("plan", "planning_agent"),
+          node("consumer", "post_ticket_comment"),
+        ],
+        [
+          { id: "to-decision", from: "trigger", to: "decision" },
+          { id: "true-plan", from: "decision", fromPort: "true", to: "plan" },
+          { id: "false-consumer", from: "decision", fromPort: "false", to: "consumer" },
+          { id: "plan-consumer", from: "plan", to: "consumer" },
+        ],
+      ),
+      registryContext,
+    );
+    const catalog = result.catalogByNode.consumer ?? [];
+
+    expect(catalog).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reference: "steps.entry.output",
+          source: { kind: "trigger", nodeId: "trigger" },
+          availability: expect.objectContaining({ state: "available" }),
+        }),
+        expect.objectContaining({
+          reference: "steps.plan.output",
+          source: { kind: "step", nodeId: "plan" },
+          availability: expect.objectContaining({ state: "unavailable" }),
+        }),
+      ]),
+    );
+  });
+
+  it("describes common and trigger-specific values for multiple triggers", () => {
+    const result = analyzeWorkflowV2Catalog(
+      definition(
+        [
+          node("ticket", "trigger_ticket_ai"),
+          node("approval", "trigger_plan_approved"),
+          node("consumer", "post_ticket_comment"),
+        ],
+        [
+          { id: "ticket-consumer", from: "ticket", to: "consumer" },
+          { id: "approval-consumer", from: "approval", to: "consumer" },
+        ],
+      ),
+      registryContext,
+    );
+    const catalog = result.catalogByNode.consumer ?? [];
+    const common = catalog.find(
+      (entry) => entry.reference === "steps.entry.output.ticketKey",
+    );
+    const triggerSpecific = catalog.find(
+      (entry) => entry.reference === "steps.entry.output.approvedPlan",
+    );
+
+    expect(common).toMatchObject({
+      label: "Trigger that started this run · ticketKey",
+      availability: { state: "available" },
+    });
+    expect(triggerSpecific).toMatchObject({
+      availability: { state: "unavailable" },
+    });
+    expect(
+      triggerSpecific?.availability.state === "unavailable"
+        ? triggerSpecific.availability.reason
+        : "",
+    ).toContain("Trigger ID or Trigger type");
+  });
+
+  it("publishes friendly typed run trigger enums", () => {
+    const result = analyzeWorkflowV2Catalog(
+      definition(
+        [
+          node("ticket", "trigger_ticket_ai"),
+          node("approval", "trigger_plan_approved"),
+          node("consumer", "post_ticket_comment"),
+        ],
+        [
+          { id: "ticket-consumer", from: "ticket", to: "consumer" },
+          { id: "approval-consumer", from: "approval", to: "consumer" },
+        ],
+      ),
+      registryContext,
+    );
+    const catalog = result.catalogByNode.consumer ?? [];
+
+    expect(
+      catalog.find((entry) => entry.reference === "run.trigger.id")?.schema,
+    ).toMatchObject({ type: "string", enum: ["ticket", "approval"] });
+    expect(
+      catalog.find((entry) => entry.reference === "run.trigger.type")?.schema,
+    ).toMatchObject({
+      type: "string",
+      enum: ["trigger_ticket_ai", "trigger_plan_approved"],
+    });
   });
 });
 

--- a/apps/worker/src/workflow-definition/available-values.ts
+++ b/apps/worker/src/workflow-definition/available-values.ts
@@ -6,6 +6,9 @@ import {
   type JsonValue,
   type TransformConfiguration,
   type WorkflowBlockContract,
+  type WorkflowDataCatalogEntry,
+  type WorkflowDataCatalogPresence,
+  type WorkflowDefinitionCatalogResponse,
   type WorkflowAvailableValue,
   type WorkflowAvailableValuesByNode,
   type WorkflowDefinitionV2,
@@ -195,6 +198,71 @@ function requiredSchemaPaths(
     result.push(...requiredSchemaPaths(child, path));
   }
   return result;
+}
+
+interface CatalogSchemaPath {
+  path: string[];
+  schema: WorkflowValueSchema;
+  presence: WorkflowDataCatalogPresence;
+}
+
+function nullableSchema(schema: WorkflowValueSchema): {
+  schema: WorkflowValueSchema;
+  nullable: boolean;
+} {
+  return schema.type === "nullable"
+    ? { schema: schema.value, nullable: true }
+    : { schema, nullable: schema.type === "null" };
+}
+
+function catalogPresence(
+  optional: boolean,
+  nullable: boolean,
+): WorkflowDataCatalogPresence {
+  if (optional && nullable) return "optional_nullable";
+  if (optional) return "optional";
+  if (nullable) return "nullable";
+  return "required";
+}
+
+function catalogSchemaPaths(
+  schema: WorkflowValueSchema,
+  prefix: string[] = [],
+  parentOptional = false,
+): CatalogSchemaPath[] {
+  const unwrapped = nullableSchema(schema);
+  if (unwrapped.schema.type !== "object") return [];
+  const result: CatalogSchemaPath[] = [];
+  for (const [name, child] of Object.entries(unwrapped.schema.properties)) {
+    if (!isWorkflowAddressablePathSegment(name)) continue;
+    const optional =
+      parentOptional || !unwrapped.schema.required.includes(name);
+    const childUnwrapped = nullableSchema(child);
+    const path = [...prefix, name];
+    result.push({
+      path,
+      schema: child,
+      presence: catalogPresence(optional, childUnwrapped.nullable),
+    });
+    result.push(...catalogSchemaPaths(child, path, optional));
+  }
+  return result;
+}
+
+function authoredExample(schema: JsonSchema202012): JsonValue | undefined {
+  const record = schema as Record<string, unknown>;
+  const candidate =
+    record.example ??
+    record.default ??
+    (Array.isArray(record.examples) ? record.examples[0] : undefined);
+  return candidate === null ||
+    typeof candidate === "string" ||
+    typeof candidate === "number" ||
+    typeof candidate === "boolean" ||
+    Array.isArray(candidate) ||
+    (candidate !== null && typeof candidate === "object")
+    ? (candidate as JsonValue)
+    : undefined;
 }
 
 function requiredSchemaAtPath(
@@ -767,6 +835,25 @@ export function analyzeWorkflowV2Bindings(
         .filter((schema): schema is WorkflowValueSchema => schema !== undefined);
       const first = triggerSchemas[0];
       if (first && triggerSchemas.length === activeTriggerIds.length) {
+        const commonOutput = commonSourceSchema(triggerSchemas);
+        if (commonOutput) {
+          values.push({
+            reference: "steps.entry.output",
+            label:
+              activeTriggerIds.length === 1
+                ? `${nodeById.get(activeTriggerIds[0]!)?.name ?? contracts.get(activeTriggerIds[0]!)?.presentation.label ?? "Trigger"} · output`
+                : "Trigger that started this run · output",
+            description: "Complete output from the trigger that started this run.",
+            schema: workflowValueSchemaToJsonSchema(commonOutput),
+            source: { kind: "entry", nodeId: null, blockType: null },
+            guarantee: {
+              kind: "active_entry",
+              triggerNodeIds: activeTriggerIds,
+              viaEdgeIds: [],
+            },
+            compatibleInputNames: targetCompatibility(commonOutput, targets),
+          });
+        }
         for (const candidate of requiredSchemaPaths(first)) {
           const schemas = triggerSchemas
             .map((schema) => requiredSchemaAtPath(schema, candidate.path))
@@ -821,6 +908,26 @@ export function analyzeWorkflowV2Bindings(
         (incoming.get(consumer.id)?.length ?? 0) > 1
           ? "join"
           : "unconditional_activation";
+      values.push({
+        reference: `steps.${source.id}.output`,
+        label: `${source.name ?? contract.presentation.label} · output`,
+        description: contract.presentation.description,
+        schema: workflowValueSchemaToJsonSchema(contract.output.bindingSchema),
+        source: {
+          kind: "step",
+          nodeId: source.id,
+          blockType: source.type,
+        },
+        guarantee: {
+          kind: guaranteeKind,
+          triggerNodeIds,
+          viaEdgeIds,
+        },
+        compatibleInputNames: targetCompatibility(
+          contract.output.bindingSchema,
+          targets,
+        ),
+      });
       for (const candidate of requiredSchemaPaths(contract.output.bindingSchema)) {
         const path = candidate.path.join(".");
         values.push({
@@ -843,7 +950,9 @@ export function analyzeWorkflowV2Bindings(
       }
     }
 
-    for (const candidate of requiredSchemaPaths(RUN_BINDING_SCHEMA)) {
+    for (const candidate of requiredSchemaPaths(
+      v2RunBindingSchema(definition),
+    )) {
       const path = candidate.path.join(".");
       values.push({
         reference: `run.${path}`,
@@ -867,5 +976,382 @@ export function analyzeWorkflowV2Bindings(
     availableValuesByNode,
     nodeContracts: Object.fromEntries(contracts),
     issues,
+  };
+}
+
+function v2RunBindingSchema(
+  definition: WorkflowDefinitionV2,
+): WorkflowValueSchema {
+  const triggers = definition.nodes.filter((node) =>
+    isTriggerBlockType(node.type),
+  );
+  return {
+    type: "object",
+    properties: {
+      ...(
+        RUN_BINDING_SCHEMA.type === "object"
+          ? RUN_BINDING_SCHEMA.properties
+          : {}
+      ),
+      trigger: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            enum: triggers.map((trigger) => trigger.id),
+            description: "Trigger block that started this run.",
+          },
+          type: {
+            type: "string",
+            enum: [...new Set(triggers.map((trigger) => trigger.type))],
+            description: "Type of trigger that started this run.",
+          },
+        },
+        required: ["id", "type"],
+        additionalProperties: false,
+      },
+    },
+    required: [
+      ...(
+        RUN_BINDING_SCHEMA.type === "object"
+          ? RUN_BINDING_SCHEMA.required
+          : []
+      ),
+      "trigger",
+    ],
+    additionalProperties: false,
+  };
+}
+
+function catalogEntry(
+  input: Omit<WorkflowDataCatalogEntry, "schema" | "example"> & {
+    valueSchema: WorkflowValueSchema;
+  },
+): WorkflowDataCatalogEntry {
+  const schema = workflowValueSchemaToJsonSchema(input.valueSchema);
+  const example = authoredExample(schema);
+  return {
+    reference: input.reference,
+    label: input.label,
+    description: input.description,
+    schema,
+    source: input.source,
+    presence: input.presence,
+    availability: input.availability,
+    compatibleInputNames: input.compatibleInputNames,
+    ...(example === undefined ? {} : { example }),
+  };
+}
+
+/**
+ * Builds the editor's structural data catalog without running prompt/profile
+ * authoring checks. Incomplete drafts are expected: unavailable values remain
+ * visible with an explanation instead of becoming request failures.
+ */
+export function analyzeWorkflowV2Catalog(
+  definition: WorkflowDefinitionV2,
+  registryContext: WorkflowBlockRegistryContext,
+): WorkflowDefinitionCatalogResponse {
+  const bindingAnalysis = analyzeWorkflowV2Bindings(
+    definition,
+    registryContext,
+  );
+  const nodeById = new Map(definition.nodes.map((node) => [node.id, node]));
+  const forward = new Map(
+    definition.nodes.map((node) => [node.id, [] as string[]]),
+  );
+  const incoming = new Map(
+    definition.nodes.map((node) => [
+      node.id,
+      [] as WorkflowDefinitionV2ControlEdge[],
+    ]),
+  );
+  for (const edge of definition.edges) {
+    if (!nodeById.has(edge.from) || !nodeById.has(edge.to)) continue;
+    forward.get(edge.from)?.push(edge.to);
+    incoming.get(edge.to)?.push(edge);
+  }
+  const reachability = new Map(
+    definition.nodes.map((node) => [
+      node.id,
+      reachableFrom(node.id, forward),
+    ]),
+  );
+  const cyclicNodeIds = stronglyConnectedNodeIds(definition);
+  const formulas = activationFormulas(definition, nodeById, cyclicNodeIds);
+  const triggers = definition.nodes.filter((node) =>
+    isTriggerBlockType(node.type),
+  );
+  const contracts = new Map(
+    definition.nodes.map((node) => [
+      node.id,
+      contractForNode(node, registryContext),
+    ]),
+  );
+  const targetsByNode = new Map<string, InputTarget[]>();
+  for (const [nodeIndex, node] of definition.nodes.entries()) {
+    targetsByNode.set(
+      node.id,
+      inputTargets(node, nodeIndex, contracts.get(node.id)!, []),
+    );
+  }
+
+  const catalogByNode: Record<string, WorkflowDataCatalogEntry[]> = {};
+  for (const consumer of definition.nodes) {
+    const targets = targetsByNode.get(consumer.id) ?? [];
+    const entries: WorkflowDataCatalogEntry[] = [];
+    const activeTriggerIds = reachingTriggerIds(
+      consumer.id,
+      triggers,
+      reachability,
+    );
+    const triggerSchemas = activeTriggerIds
+      .map((id) => contracts.get(id)?.output.bindingSchema)
+      .filter((schema): schema is WorkflowValueSchema => schema !== undefined);
+    const commonTriggerOutput =
+      triggerSchemas.length === activeTriggerIds.length
+        ? commonSourceSchema(triggerSchemas)
+        : null;
+    const triggerLabel =
+      activeTriggerIds.length === 1
+        ? nodeById.get(activeTriggerIds[0]!)?.name ??
+          contracts.get(activeTriggerIds[0]!)?.presentation.label ??
+          "Trigger"
+        : "Trigger that started this run";
+
+    if (commonTriggerOutput) {
+      entries.push(
+        catalogEntry({
+          reference: "steps.entry.output",
+          label: `${triggerLabel} · output`,
+          description: "Complete output from the trigger that started this run.",
+          valueSchema: commonTriggerOutput,
+          source: {
+            kind: "trigger",
+            ...(activeTriggerIds.length === 1
+              ? { nodeId: activeTriggerIds[0] }
+              : {}),
+          },
+          presence: catalogPresence(
+            false,
+            nullableSchema(commonTriggerOutput).nullable,
+          ),
+          availability: {
+            state: "available",
+            guarantee: "The active trigger always supplies this output.",
+          },
+          compatibleInputNames: targetCompatibility(
+            commonTriggerOutput,
+            targets,
+          ),
+        }),
+      );
+      for (const candidate of catalogSchemaPaths(commonTriggerOutput)) {
+        const path = candidate.path.join(".");
+        entries.push(
+          catalogEntry({
+            reference: `steps.entry.output.${path}`,
+            label: `${triggerLabel} · ${path}`,
+            description:
+              candidate.schema.description ??
+              "Value supplied by every possible trigger.",
+            valueSchema: candidate.schema,
+            source: {
+              kind: "trigger",
+              ...(activeTriggerIds.length === 1
+                ? { nodeId: activeTriggerIds[0] }
+                : {}),
+            },
+            presence: candidate.presence,
+            availability: {
+              state: "available",
+              guarantee: "Every possible active trigger exposes this field.",
+            },
+            compatibleInputNames: targetCompatibility(
+              candidate.schema,
+              targets,
+            ),
+          }),
+        );
+      }
+    }
+
+    const commonTriggerReferences = new Set(
+      entries
+        .filter((entry) => entry.source.kind === "trigger")
+        .map((entry) => entry.reference),
+    );
+    const triggerSpecific = new Map<
+      string,
+      {
+        path: string;
+        schemas: WorkflowValueSchema[];
+        triggerIds: string[];
+        presence: WorkflowDataCatalogPresence;
+      }
+    >();
+    for (const triggerId of activeTriggerIds) {
+      const schema = contracts.get(triggerId)?.output.bindingSchema;
+      if (!schema) continue;
+      for (const candidate of catalogSchemaPaths(schema)) {
+        const path = candidate.path.join(".");
+        const reference =
+          `steps.entry.output.${path}` as const;
+        if (commonTriggerReferences.has(reference)) continue;
+        const existing = triggerSpecific.get(reference);
+        if (existing) {
+          existing.schemas.push(candidate.schema);
+          existing.triggerIds.push(triggerId);
+        } else {
+          triggerSpecific.set(reference, {
+            path,
+            schemas: [candidate.schema],
+            triggerIds: [triggerId],
+            presence: candidate.presence,
+          });
+        }
+      }
+    }
+    for (const [reference, candidate] of triggerSpecific) {
+      const schema = commonSourceSchema(candidate.schemas);
+      if (!schema) continue;
+      const names = candidate.triggerIds.map(
+        (id) =>
+          nodeById.get(id)?.name ??
+          contracts.get(id)?.presentation.label ??
+          id,
+      );
+      entries.push(
+        catalogEntry({
+          reference: reference as WorkflowDataCatalogEntry["reference"],
+          label: `${triggerLabel} · ${candidate.path}`,
+          description:
+            schema.description ??
+            `Only supplied by ${names.join(", ")}.`,
+          valueSchema: schema,
+          source: {
+            kind: "trigger",
+            ...(candidate.triggerIds.length === 1
+              ? { nodeId: candidate.triggerIds[0] }
+              : {}),
+          },
+          presence: candidate.presence,
+          availability: {
+            state: "unavailable",
+            reason:
+              `Only available when ${names.join(" or ")} starts the run. ` +
+              "Branch on Run info → Trigger ID or Trigger type first.",
+          },
+          compatibleInputNames: targetCompatibility(schema, targets),
+        }),
+      );
+    }
+
+    const consumerFormula = formulas.get(consumer.id) ?? emptyFormula();
+    for (const source of definition.nodes) {
+      if (
+        source.id === consumer.id ||
+        isTriggerBlockType(source.type) ||
+        !reachability.get(source.id)?.has(consumer.id)
+      ) {
+        continue;
+      }
+      const contract = contracts.get(source.id)!;
+      const guaranteed =
+        !cyclicNodeIds.has(source.id) &&
+        formulaImplies(
+          consumerFormula,
+          formulas.get(source.id) ?? emptyFormula(),
+        );
+      const availability = guaranteed
+        ? ({
+            state: "available",
+            guarantee:
+              (incoming.get(consumer.id)?.length ?? 0) > 1
+                ? "This value is guaranteed at the join."
+                : "This step always runs before the current block.",
+          } as const)
+        : ({
+            state: "unavailable",
+            reason:
+              "This step can be skipped on a path that reaches the current block.",
+          } as const);
+      const sourceDetails = {
+        kind: "step" as const,
+        nodeId: source.id,
+      };
+      entries.push(
+        catalogEntry({
+          reference: `steps.${source.id}.output`,
+          label: `${source.name ?? contract.presentation.label} · output`,
+          description: contract.presentation.description,
+          valueSchema: contract.output.bindingSchema,
+          source: sourceDetails,
+          presence: catalogPresence(
+            false,
+            nullableSchema(contract.output.bindingSchema).nullable,
+          ),
+          availability,
+          compatibleInputNames: targetCompatibility(
+            contract.output.bindingSchema,
+            targets,
+          ),
+        }),
+      );
+      for (const candidate of catalogSchemaPaths(
+        contract.output.bindingSchema,
+      )) {
+        const path = candidate.path.join(".");
+        entries.push(
+          catalogEntry({
+            reference: `steps.${source.id}.output.${path}`,
+            label: `${source.name ?? contract.presentation.label} · ${path}`,
+            description:
+              candidate.schema.description ??
+              contract.presentation.description,
+            valueSchema: candidate.schema,
+            source: sourceDetails,
+            presence: candidate.presence,
+            availability,
+            compatibleInputNames: targetCompatibility(
+              candidate.schema,
+              targets,
+            ),
+          }),
+        );
+      }
+    }
+
+    for (const candidate of catalogSchemaPaths(
+      v2RunBindingSchema(definition),
+    )) {
+      const path = candidate.path.join(".");
+      entries.push(
+        catalogEntry({
+          reference: `run.${path}`,
+          label: `Run info · ${path}`,
+          description:
+            candidate.schema.description ??
+            "Value fixed for this workflow run.",
+          valueSchema: candidate.schema,
+          source: { kind: "run" },
+          presence: candidate.presence,
+          availability: {
+            state: "available",
+            guarantee: "Run information is always available.",
+          },
+          compatibleInputNames: targetCompatibility(
+            candidate.schema,
+            targets,
+          ),
+        }),
+      );
+    }
+    catalogByNode[consumer.id] = entries;
+  }
+
+  return {
+    nodeContracts: bindingAnalysis.nodeContracts,
+    catalogByNode,
   };
 }

--- a/apps/worker/src/workflow-definition/v2-bindings.test.ts
+++ b/apps/worker/src/workflow-definition/v2-bindings.test.ts
@@ -38,9 +38,18 @@ function node(
 
 describe("v2 data bindings", () => {
   it("parses canonical entry, step, and run references", () => {
+    expect(parseWorkflowDataReferenceV2("steps.entry.output")).toEqual({
+      root: "entry",
+      path: [],
+    });
     expect(parseWorkflowDataReferenceV2("steps.entry.output.ticket.key")).toEqual({
       root: "entry",
       path: ["ticket", "key"],
+    });
+    expect(parseWorkflowDataReferenceV2("steps.plan.output")).toEqual({
+      root: "steps",
+      nodeId: "plan",
+      path: [],
     });
     expect(parseWorkflowDataReferenceV2("steps.plan.output.plan.title")).toEqual({
       root: "steps",
@@ -60,6 +69,12 @@ describe("v2 data bindings", () => {
   });
 
   it("resolves literals, entry values, scoped step values, run values, and additional inputs", () => {
+    expect(
+      resolveWorkflowDataReferenceV2("steps.entry.output", context),
+    ).toEqual(entryOutput);
+    expect(
+      resolveWorkflowDataReferenceV2("steps.plan.output", context),
+    ).toEqual({ status: "ok", plan: { title: "Implement scheduler" } });
     expect(
       resolveWorkflowNodeInputsV2(
         node(

--- a/apps/worker/src/workflow-definition/v2-bindings.ts
+++ b/apps/worker/src/workflow-definition/v2-bindings.ts
@@ -47,7 +47,7 @@ export function parseWorkflowDataReferenceV2(
   }
   if (
     segments[0] !== "steps" ||
-    segments.length < 4 ||
+    segments.length < 3 ||
     segments[2] !== "output"
   ) {
     return null;

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -3971,6 +3971,10 @@ async function agentWorkflowBody(
         id: workflowRunId,
         branchName,
         defaultAgent: { provider: runDefaultKind, model: defaultModel },
+        trigger: {
+          id: entryTrigger.id,
+          type: entryTrigger.type,
+        },
       };
       const v2AgentArtifactKeys =
         plan.schemaVersion === 2


### PR DESCRIPTION
## Stack

- Base: `codex/aiw-followups-validation-hardening` (#154)
- This is PR 2 of 3 in the AI Workflow follow-up stack.

## Jira

AIW-150, AIW-154, AIW-155, AIW-157, AIW-161, AIW-164, AIW-165, AIW-166, AIW-168, AIW-170

## Behavior

- Adds a worker-owned live catalog for whole outputs, nested values, multiple triggers, availability, presence, and input compatibility.
- Replaces separate workflow-value controls with one searchable Previous steps / Run info picker.
- Adds one lossless plain-text template editor with inline workflow-value chips for v2 prose and messages.
- Makes context-menu and keyboard deletion share one undoable transaction, including allowing triggerless drafts while deployment validation remains authoritative.
- Completes the prompt drag/drop, schema focus, token Escape, edge tangent, and whole-reference boundary follow-ups.

## Compatibility

- Workflow Definition v1 reading and execution are unchanged.
- Existing invalid v2 bindings remain visible with an explanation and are never silently cleared.
- No database migration.

## Verification

- `pnpm -r typecheck`
- Dashboard full suite: 512 tests passed
- Worker full suite: 2,729 tests passed
- Focused catalog, binding, text-template, deletion, prompt, geometry, and proxy suites passed
- `git diff --check`

No browser QA was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow data catalogs for V2 workflows, including available values, schemas, compatibility details, and availability status.
  * Added searchable workflow value pickers for bindings, branches, prompts, and text templates.
  * Added support for inserting workflow values into text templates and dragging prompt content into editors.
  * Added contextual deletion controls for workflow nodes.
* **Bug Fixes**
  * Improved handling and messaging for saved values that are unavailable in the current workflow.
  * Improved reference parsing and highlighting for complete workflow outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->