### PR TITLE
AIW-180: Preserve agent models during v1-to-v2 migration

### DIFF
--- a/apps/shared/contracts/harness-profiles.ts
+++ b/apps/shared/contracts/harness-profiles.ts
@@ -322,7 +322,7 @@ const CLAUDE_COMPATIBILITY_MANIFEST = {
 const CODEX_COMPATIBILITY_MANIFEST = {
   schemaVersion: 1,
   profileId: BUILTIN_HARNESS_PROFILE_IDS.codex,
-  version: 1,
+  version: 2,
   slug: "codex",
   displayName: "Codex",
   description: "Code-owned Codex compatibility profile.",
@@ -334,7 +334,7 @@ const CODEX_COMPATIBILITY_MANIFEST = {
     protocolVersion: "codex-jsonl-0.144.6",
   },
   model: {
-    id: "gpt-5-codex",
+    id: "gpt-5.4",
     options: {},
   },
   homeFiles: [],

--- a/apps/worker/env.ts
+++ b/apps/worker/env.ts
@@ -79,7 +79,7 @@ export const env = createEnv({
     CODEX_CHATGPT_OAUTH_TOKEN: z.string().min(1).optional(),
 
     // Codex model selection.
-    CODEX_MODEL: z.string().default("gpt-5-codex"),
+    CODEX_MODEL: z.string().default("gpt-5.4"),
 
     // LiteLLM community-maintained pricing JSON. Operator overridable.
     CODEX_PRICING_URL: z

--- a/apps/worker/src/harness-profiles/store.test.ts
+++ b/apps/worker/src/harness-profiles/store.test.ts
@@ -156,29 +156,29 @@ describe("system profile seeding", () => {
       new Set(["builtin-claude", "builtin-codex"]),
     );
 
-    const [codexV1] = versions.filter(
+    const [currentCodex] = versions.filter(
       (version) => version.profileId === "builtin-codex",
     );
-    const codexV2: HarnessProfileManifestV1 = {
-      ...structuredClone(codexV1!.manifest),
-      version: 2,
+    const nextCodex: HarnessProfileManifestV1 = {
+      ...structuredClone(currentCodex!.manifest),
+      version: currentCodex!.version + 1,
       instructions: "Updated code-owned instructions",
     };
 
-    await ensureSystemHarnessProfiles(db, catalogWithCodex(codexV2));
+    await ensureSystemHarnessProfiles(db, catalogWithCodex(nextCodex));
     versions = await db
       .select()
       .from(harnessProfileVersions)
       .where(eq(harnessProfileVersions.profileId, "builtin-codex"));
-    expect(versions.map((version) => version.version).sort()).toEqual([1, 2]);
+    expect(versions.map((version) => version.version).sort()).toEqual([2, 3]);
     const profile = await getHarnessProfile(db, {
       organizationId: "org-a",
       profileId: "builtin-codex",
     });
-    expect(profile?.publishedVersion).toBe(2);
-    expect(profile?.draftManifest.instructions).toBe(codexV2.instructions);
+    expect(profile?.publishedVersion).toBe(3);
+    expect(profile?.draftManifest.instructions).toBe(nextCodex.instructions);
 
-    await ensureSystemHarnessProfiles(db, catalogWithCodex(codexV2));
+    await ensureSystemHarnessProfiles(db, catalogWithCodex(nextCodex));
     expect(
       await db
         .select()
@@ -188,17 +188,17 @@ describe("system profile seeding", () => {
   });
 
   it("never rolls back or ping-pongs when old and new seeders interleave", async () => {
-    const codexV1 =
+    const currentCodex =
       BUILTIN_HARNESS_PROFILE_MANIFESTS[
         BUILTIN_HARNESS_PROFILE_IDS.codex
       ];
-    const codexV2: HarnessProfileManifestV1 = {
-      ...structuredClone(codexV1),
-      version: 2,
+    const nextCodex: HarnessProfileManifestV1 = {
+      ...structuredClone(currentCodex),
+      version: currentCodex.version + 1,
       instructions: "New binary instructions",
     };
-    const oldCatalog = catalogWithCodex(codexV1);
-    const newCatalog = catalogWithCodex(codexV2);
+    const oldCatalog = catalogWithCodex(currentCodex);
+    const newCatalog = catalogWithCodex(nextCodex);
 
     await ensureSystemHarnessProfiles(db, oldCatalog);
     await ensureSystemHarnessProfiles(db, newCatalog);
@@ -215,30 +215,30 @@ describe("system profile seeding", () => {
       .select()
       .from(harnessProfileVersions)
       .where(eq(harnessProfileVersions.profileId, "builtin-codex"));
-    expect(versions.map((version) => version.version).sort()).toEqual([1, 2]);
+    expect(versions.map((version) => version.version).sort()).toEqual([2, 3]);
     const profile = await getHarnessProfile(db, {
       organizationId: "org-a",
       profileId: "builtin-codex",
     });
     expect(profile).toMatchObject({
-      publishedVersion: 2,
-      draftManifest: { instructions: codexV2.instructions },
+      publishedVersion: 3,
+      draftManifest: { instructions: nextCodex.instructions },
     });
   });
 
   it("rejects code-owned content drift without a catalog version bump", async () => {
     await ensureSystemHarnessProfiles(db);
-    const codexV1 =
+    const currentCodex =
       BUILTIN_HARNESS_PROFILE_MANIFESTS[
         BUILTIN_HARNESS_PROFILE_IDS.codex
       ];
-    const driftedV1: HarnessProfileManifestV1 = {
-      ...structuredClone(codexV1),
+    const driftedCurrent: HarnessProfileManifestV1 = {
+      ...structuredClone(currentCodex),
       instructions: "Changed without a version bump",
     };
 
     await expect(
-      ensureSystemHarnessProfiles(db, catalogWithCodex(driftedV1)),
+      ensureSystemHarnessProfiles(db, catalogWithCodex(driftedCurrent)),
     ).rejects.toMatchObject({
       statusCode: 409,
     });
@@ -246,8 +246,8 @@ describe("system profile seeding", () => {
       organizationId: "org-a",
       profileId: "builtin-codex",
     });
-    expect(profile?.publishedVersion).toBe(1);
-    expect(profile?.draftManifest.instructions).toBe(codexV1.instructions);
+    expect(profile?.publishedVersion).toBe(2);
+    expect(profile?.draftManifest.instructions).toBe(currentCodex.instructions);
   });
 });
 

--- a/apps/worker/src/routes/api/v1/workflow-definitions.post.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.post.ts
@@ -34,8 +34,12 @@ import {
 import { upgradeStoredWorkflowDefinition } from "../../../workflow-definition/schema.js";
 import {
   convertWorkflowDefinitionV1ToV2WithPromptResolution,
-  previewWorkflowDefinitionV2Migration,
+  prepareWorkflowDefinitionV2Migration,
 } from "../../../workflow-definition/v2-migration.js";
+import {
+  ensureMigratedHarnessProfiles,
+  type MigratedHarnessProfilePlan,
+} from "../../../workflow-definition/v2-migration-harness-profiles.js";
 import {
   serializeDefinitionMeta,
   toWorkflowDefinitionHttpError,
@@ -120,6 +124,7 @@ export default defineEventHandler(
         );
 
       let seed: WorkflowDefinition;
+      let migratedHarnessProfiles: MigratedHarnessProfilePlan[] = [];
       if (source.kind === "duplicate") {
         if (body.targetSchemaVersion === 2) {
           const sourceRow = await getWorkflowDefinitionRawState(
@@ -173,7 +178,7 @@ export default defineEventHandler(
             ) {
               seed = upgradeStoredWorkflowDefinition(raw.definition);
             } else {
-              const migration = await previewWorkflowDefinitionV2Migration(
+              const prepared = await prepareWorkflowDefinitionV2Migration(
                 dbHandle,
                 {
                   definitionId: source.definitionId,
@@ -181,6 +186,7 @@ export default defineEventHandler(
                   expectedDraftRevision: sourceRow.draftRevision,
                 },
               );
+              const migration = prepared.result;
               if (!migration.definition) {
                 setResponseStatus(event, 422, "Workflow migration is blocked");
                 return {
@@ -188,6 +194,7 @@ export default defineEventHandler(
                   error: "Workflow migration is blocked",
                 };
               }
+              migratedHarnessProfiles = prepared.harnessProfiles;
               seed = migration.definition;
             }
           }
@@ -235,6 +242,14 @@ export default defineEventHandler(
         });
       }
 
+      await ensureMigratedHarnessProfiles(dbHandle, {
+        plans: migratedHarnessProfiles,
+        actor: {
+          organizationId: actor.organizationId,
+          role: actor.role,
+          id: actor.userId,
+        },
+      });
       const created = await createWorkflowDefinitionDraft(dbHandle, {
         name,
         seed,

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -7,6 +7,8 @@ import type {
 import { BUILTIN_HARNESS_PROFILE_IDS } from "@shared/contracts";
 import type { Db } from "../../../db/client.js";
 import {
+  harnessProfiles,
+  harnessProfileVersions,
   member,
   organization,
   user,
@@ -149,7 +151,9 @@ function migratableV1Definition(prompt?: string): WorkflowDefinitionV1 {
   };
 }
 
-function migratableImplementationDefinition(): WorkflowDefinitionV1 {
+function migratableImplementationDefinition(
+  agent?: { provider: "claude" | "codex"; model: string },
+): WorkflowDefinitionV1 {
   return {
     schemaVersion: 1,
     nodes: [
@@ -166,7 +170,7 @@ function migratableImplementationDefinition(): WorkflowDefinitionV1 {
         type: "implementation_agent",
         x: 240,
         y: 0,
-        params: {},
+        params: agent ?? {},
         inputs: {},
       },
     ],
@@ -415,7 +419,7 @@ describe("GET /api/v1/workflow-definitions", () => {
             JSON.stringify(configuration.harnessProfile) ===
             JSON.stringify({
               profileId: BUILTIN_HARNESS_PROFILE_IDS.codex,
-              version: 1,
+              version: 2,
             }),
         ),
       ).toBe(true);
@@ -849,6 +853,119 @@ describe("POST /api/v1/workflow-definitions/:id/migrate", () => {
         }),
       ]),
     );
+  });
+
+  it("previews models without writes and creates one exact compatibility profile on apply", async () => {
+    await saveDraft(
+      migratableImplementationDefinition({
+        provider: "codex",
+        model: "gpt-custom",
+      }),
+      0,
+    );
+
+    const previewRes = await migrate(
+      jsonRequest(
+        "POST",
+        {
+          mode: "preview",
+          sourceVersion: 1,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 1,
+        },
+        "http://worker.test/d/1/migrate",
+      ),
+    );
+    expect(previewRes.status).toBe(200);
+    const preview = await previewRes.json();
+    expect(preview.blockers).toEqual([]);
+    const profileReference = preview.definition.nodes.find(
+      ({ id }: { id: string }) => id === "implementation",
+    ).configuration.harnessProfile;
+    expect(profileReference).toMatchObject({ version: 1 });
+    expect(profileReference.profileId).toMatch(/^migration-/);
+    expect(preview.conversions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "migration.agent.profile_materialized",
+          nodeId: "implementation",
+        }),
+      ]),
+    );
+    expect(
+      (await db.select().from(harnessProfiles)).filter(
+        (profile) => !profile.system,
+      ),
+    ).toEqual([]);
+
+    const applyRes = await migrate(
+      jsonRequest(
+        "POST",
+        {
+          mode: "apply",
+          sourceVersion: 1,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 1,
+          expectedConversionHash: preview.conversionHash,
+        },
+        "http://worker.test/d/1/migrate",
+      ),
+    );
+    expect(applyRes.status).toBe(200);
+    const createdProfiles = (await db.select().from(harnessProfiles)).filter(
+      (profile) => !profile.system,
+    );
+    expect(createdProfiles).toHaveLength(1);
+    expect(createdProfiles[0]).toMatchObject({
+      id: profileReference.profileId,
+      publishedVersion: 1,
+      draftManifest: {
+        harness: { provider: "codex" },
+        model: { id: "gpt-custom" },
+      },
+    });
+    expect(
+      (await db.select().from(harnessProfileVersions)).filter(
+        (version) => version.profileId === profileReference.profileId,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("uses the current GPT-5.4 built-in profile without creating a compatibility profile", async () => {
+    await saveDraft(
+      migratableImplementationDefinition({
+        provider: "codex",
+        model: "gpt-5.4",
+      }),
+      0,
+    );
+
+    const previewRes = await migrate(
+      jsonRequest(
+        "POST",
+        {
+          mode: "preview",
+          sourceVersion: 1,
+          targetSchemaVersion: 2,
+          expectedDraftRevision: 1,
+        },
+        "http://worker.test/d/1/migrate",
+      ),
+    );
+    const preview = await previewRes.json();
+
+    expect(preview.blockers).toEqual([]);
+    expect(
+      preview.definition.nodes.find(
+        ({ id }: { id: string }) => id === "implementation",
+      ).configuration.harnessProfile,
+    ).toEqual({ profileId: "builtin-codex", version: 2 });
+    expect(
+      preview.conversions.some(
+        ({ code }: { code: string }) =>
+          code === "migration.agent.profile_materialized",
+      ),
+    ).toBe(false);
   });
 
   it("produces a deployable v2 candidate for the legacy Ticket workflow", async () => {

--- a/apps/worker/src/routes/api/v1/workflow-definitions/[id]/migrate.post.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions/[id]/migrate.post.ts
@@ -15,7 +15,9 @@ import { dashboardUserLabel } from "../../../../../pre-pr-checks/store.js";
 import {
   saveWorkflowDefinitionDraft,
 } from "../../../../../workflow-definition/store.js";
-import { previewWorkflowDefinitionV2Migration } from "../../../../../workflow-definition/v2-migration.js";
+import { ensureMigratedHarnessProfiles } from "../../../../../workflow-definition/v2-migration-harness-profiles.js";
+import { prepareWorkflowDefinitionV2Migration } from "../../../../../workflow-definition/v2-migration.js";
+import { validateWorkflowDefinitionCandidateWithPromptAuthoring } from "../../../../../workflow-definition/prompt-authoring.js";
 import {
   parseDefinitionId,
   serializeDefinitionMeta,
@@ -89,11 +91,12 @@ export default defineEventHandler(
       }
 
       const dbHandle = getDb();
-      const preview = await previewWorkflowDefinitionV2Migration(dbHandle, {
+      const prepared = await prepareWorkflowDefinitionV2Migration(dbHandle, {
         definitionId,
         sourceVersion: body.sourceVersion,
         expectedDraftRevision: body.expectedDraftRevision,
       });
+      const preview = prepared.result;
       if (mode === "preview") return { mode, ...preview };
 
       if (preview.blockers.length > 0 || !preview.definition) {
@@ -112,9 +115,39 @@ export default defineEventHandler(
         });
       }
 
+      await ensureMigratedHarnessProfiles(dbHandle, {
+        plans: prepared.harnessProfiles,
+        actor: {
+          organizationId: actor.organizationId,
+          role: actor.role,
+          id: actor.userId,
+        },
+      });
+      const validation =
+        await validateWorkflowDefinitionCandidateWithPromptAuthoring(
+          dbHandle,
+          preview.definition,
+        );
+      if (!validation.response.valid || !validation.parsed) {
+        setResponseStatus(event, 422, "Workflow migration is blocked");
+        return {
+          mode,
+          ...preview,
+          definition: null,
+          conversionHash: null,
+          blockers: validation.response.issues.map((issue) => ({
+            code: `migration.target.${issue.code}`,
+            message: `Converted v2 workflow is not deployable: ${issue.message}`,
+            nodeId: issue.nodeId,
+            ...(issue.path === undefined ? {} : { path: issue.path }),
+          })),
+          error: "Workflow migration is blocked",
+        };
+      }
+
       const saved = await saveWorkflowDefinitionDraft(dbHandle, {
         definitionId,
-        definition: preview.definition,
+        definition: validation.parsed,
         expectedDraftRevision: body.expectedDraftRevision,
         actor: {
           role: actor.role,

--- a/apps/worker/src/workflow-definition/default-v2.test.ts
+++ b/apps/worker/src/workflow-definition/default-v2.test.ts
@@ -32,7 +32,7 @@ const registryContext: WorkflowBlockRegistryContext = {
 };
 
 describe("built-in Harness Profiles", () => {
-  it("publishes immutable version-one compatibility manifests", () => {
+  it("publishes immutable versioned compatibility manifests", () => {
     const claude = resolveBuiltinHarnessProfile(
       builtinHarnessProfileReference("claude"),
     );
@@ -52,13 +52,13 @@ describe("built-in Harness Profiles", () => {
     });
     expect(codex).toMatchObject({
       profileId: BUILTIN_HARNESS_PROFILE_IDS.codex,
-      version: 1,
+      version: 2,
       harness: {
         provider: "codex",
         cliVersion: "0.144.6",
         protocolVersion: "codex-jsonl-0.144.6",
       },
-      model: { id: "gpt-5-codex" },
+      model: { id: "gpt-5.4" },
     });
     expect(Object.isFrozen(BUILTIN_HARNESS_PROFILE_MANIFESTS)).toBe(true);
     expect(Object.isFrozen(claude?.harness)).toBe(true);
@@ -93,7 +93,7 @@ describe("v2 built-in authoring definitions", () => {
       prompt: "{{prompt:research-plan@1}}",
       harnessProfile: {
         profileId: BUILTIN_HARNESS_PROFILE_IDS.codex,
-        version: 1,
+        version: 2,
       },
     });
     expect(

--- a/apps/worker/src/workflow-definition/models.ts
+++ b/apps/worker/src/workflow-definition/models.ts
@@ -10,7 +10,7 @@ import { RUN_BINDING_SCHEMA } from "./bindings.js";
 
 export const FALLBACK_MODELS = {
   claude: ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"],
-  codex: ["gpt-5-codex", "gpt-5", "gpt-5-mini"],
+  codex: ["gpt-5.4", "gpt-5", "gpt-5-mini"],
 };
 
 export interface AvailableModels {

--- a/apps/worker/src/workflow-definition/prompt-authoring.ts
+++ b/apps/worker/src/workflow-definition/prompt-authoring.ts
@@ -36,6 +36,8 @@ import {
 import {
   dashboardOrganizationId,
   validateHarnessProfileReferences,
+  validateHarnessProfileReferencesWithLoader,
+  type HarnessProfileVersionLoader,
 } from "./harness-profile-runtime.js";
 import {
   validateWorkflowDefinitionCandidate,
@@ -218,6 +220,7 @@ export async function validateWorkflowPromptAuthoringIssues(
   db: Db,
   definition: WorkflowDefinition,
   registryContext?: WorkflowBlockRegistryContext,
+  profileLoader?: HarnessProfileVersionLoader,
 ): Promise<WorkflowDefinitionValidationIssue[]> {
   if (definition.schemaVersion !== 2) return [];
   const context =
@@ -232,15 +235,18 @@ export async function validateWorkflowPromptAuthoringIssues(
   if (!definition.nodes.some((node) => isPromptAuthoringBlock(node))) {
     return promptIssues;
   }
-  const { env } = await import("../../env.js");
-  const organizationId = await dashboardOrganizationId(
-    db,
-    env.DASHBOARD_ORG_SLUG,
-  );
-  const profileIssues = await validateHarnessProfileReferences(db, {
-    definition,
-    organizationId,
-  });
+  const profileIssues = profileLoader
+    ? await validateHarnessProfileReferencesWithLoader(
+        definition,
+        profileLoader,
+      )
+    : await validateHarnessProfileReferences(db, {
+        definition,
+        organizationId: await dashboardOrganizationId(
+          db,
+          (await import("../../env.js")).env.DASHBOARD_ORG_SLUG,
+        ),
+      });
   return dedupeIssues([...promptIssues, ...profileIssues]);
 }
 
@@ -379,6 +385,7 @@ export async function validateWorkflowDefinitionCandidateWithPromptAuthoring(
   db: Db,
   candidate: unknown,
   registryContext?: WorkflowBlockRegistryContext,
+  profileLoader?: HarnessProfileVersionLoader,
 ): Promise<WorkflowDefinitionCandidateValidation> {
   const context =
     registryContext ??
@@ -389,6 +396,7 @@ export async function validateWorkflowDefinitionCandidateWithPromptAuthoring(
     db,
     base.parsed,
     context,
+    profileLoader,
   );
   const issues = dedupeIssues([...base.response.issues, ...promptIssues]);
   return {

--- a/apps/worker/src/workflow-definition/prompt-preview.test.ts
+++ b/apps/worker/src/workflow-definition/prompt-preview.test.ts
@@ -117,7 +117,7 @@ describe("previewWorkflowPromptCandidate", () => {
         expect.objectContaining({
           kind: "profile",
           id: "builtin-codex",
-          version: 1,
+          version: 2,
         }),
         expect.objectContaining({
           kind: "prompt",

--- a/apps/worker/src/workflow-definition/resolve-agent.test.ts
+++ b/apps/worker/src/workflow-definition/resolve-agent.test.ts
@@ -47,13 +47,13 @@ describe("resolveBlockAgent", () => {
         {
           harnessProfile: {
             profileId: "builtin-codex",
-            version: 1,
+            version: 2,
           },
         },
         "claude",
         defaults,
       ),
-    ).toEqual({ kind: "codex", model: "gpt-5-codex" });
+    ).toEqual({ kind: "codex", model: "gpt-5.4" });
   });
 });
 
@@ -85,7 +85,7 @@ describe("requiredAgentKinds", () => {
           params: {
             harnessProfile: {
               profileId: "builtin-codex",
-              version: 1,
+              version: 2,
             },
           },
         }],

--- a/apps/worker/src/workflow-definition/v2-converter.test.ts
+++ b/apps/worker/src/workflow-definition/v2-converter.test.ts
@@ -8,6 +8,7 @@ import type { WorkflowBlockRegistryContext } from "./block-registry.js";
 import {
   convertWorkflowDefinitionV1ToV2,
   deterministicV2ControlEdgeId,
+  workflowV2HarnessProfileTargetKey,
   workflowV2PromptResolutionKey,
 } from "./v2-converter.js";
 
@@ -84,6 +85,37 @@ describe("convertWorkflowDefinitionV1ToV2", () => {
           code: "migration.agent.profile_model_override",
           nodeId: "agent",
           path: "/nodes/1/params/model",
+        }),
+      ]),
+    );
+
+    const materialized = convert(incompatible, {
+      harnessProfiles,
+      harnessProfilesByProviderModel: new Map([
+        [
+          workflowV2HarnessProfileTargetKey("codex", "gpt-custom"),
+          {
+            reference: {
+              profileId: "migration-codex-gpt-custom",
+              version: 1,
+            },
+            modelId: "gpt-custom",
+          },
+        ],
+      ]),
+    });
+    expect(materialized.blockers).toEqual([]);
+    expect(materialized.definition?.nodes[1]?.configuration).toEqual({
+      harnessProfile: {
+        profileId: "migration-codex-gpt-custom",
+        version: 1,
+      },
+    });
+    expect(materialized.conversions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "migration.agent.profile_materialized",
+          nodeId: "agent",
         }),
       ]),
     );

--- a/apps/worker/src/workflow-definition/v2-converter.ts
+++ b/apps/worker/src/workflow-definition/v2-converter.ts
@@ -98,6 +98,13 @@ export interface ConvertWorkflowDefinitionV1ToV2Input {
       }
     >
   >;
+  harnessProfilesByProviderModel?: ReadonlyMap<
+    string,
+    {
+      reference: HarnessProfileReference;
+      modelId: string;
+    }
+  >;
 }
 
 type DiagnosticKind = "conversion" | "warning" | "blocker";
@@ -124,6 +131,13 @@ export function workflowV2PromptResolutionKey(
   const target =
     reference.slug === undefined ? `id:${reference.legacyPromptId}` : `slug:${reference.slug}`;
   return `${target}@${reference.version}`;
+}
+
+export function workflowV2HarnessProfileTargetKey(
+  provider: HarnessProvider,
+  modelId: string,
+): string {
+  return `${provider}\u0000${modelId}`;
 }
 
 export function deterministicV2ControlEdgeId(input: {
@@ -501,27 +515,43 @@ function pinMigratedAgentHarnessProfile(
     configuration.model.trim().length > 0
       ? configuration.model.trim()
       : null;
-  if (explicitModel !== null && explicitModel !== target.modelId) {
+  const exactTarget =
+    explicitModel === null
+      ? target
+      : state.input.harnessProfilesByProviderModel?.get(
+          workflowV2HarnessProfileTargetKey(provider, explicitModel),
+        ) ?? target;
+  if (explicitModel !== null && explicitModel !== exactTarget.modelId) {
     addDiagnostic(
       state,
       "blocker",
       "migration.agent.profile_model_override",
-      `Block "${node.id}" selects model "${explicitModel}", which is not represented by the published ${provider} Harness Profile model "${target.modelId}". Create and select a matching Harness Profile before converting this workflow.`,
+      `Block "${node.id}" selects model "${explicitModel}", which is not represented by the published ${provider} Harness Profile model "${exactTarget.modelId}".`,
       node.id,
       `${nodePath}/params/model`,
+    );
+  }
+  if (exactTarget !== target) {
+    addDiagnostic(
+      state,
+      "conversion",
+      "migration.agent.profile_materialized",
+      `Will create or reuse an exact ${provider} Harness Profile for model "${exactTarget.modelId}".`,
+      node.id,
+      `${nodePath}/configuration/harnessProfile`,
     );
   }
   delete configuration.provider;
   delete configuration.model;
   configuration.harnessProfile = {
-    profileId: target.reference.profileId,
-    version: target.reference.version,
+    profileId: exactTarget.reference.profileId,
+    version: exactTarget.reference.version,
   };
   addDiagnostic(
     state,
     "conversion",
     "migration.agent.profile_pinned",
-    `Pinned block "${node.id}" to Harness Profile "${target.reference.profileId}" version ${target.reference.version}.`,
+    `Pinned block "${node.id}" to Harness Profile "${exactTarget.reference.profileId}" version ${exactTarget.reference.version}.`,
     node.id,
     `${nodePath}/configuration/harnessProfile`,
   );

--- a/apps/worker/src/workflow-definition/v2-migration-harness-profiles.test.ts
+++ b/apps/worker/src/workflow-definition/v2-migration-harness-profiles.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "../db/test-db.js";
+import {
+  harnessProfiles,
+  harnessProfileVersions,
+  organization,
+  user,
+} from "../db/schema.js";
+import {
+  ensureMigratedHarnessProfiles,
+  planMigratedHarnessProfile,
+} from "./v2-migration-harness-profiles.js";
+
+describe("v2 migration Harness Profiles", () => {
+  it("plans a deterministic exact-model profile", () => {
+    const first = planMigratedHarnessProfile({
+      organizationId: "org-a",
+      provider: "codex",
+      modelId: "gpt-custom",
+    });
+    const repeated = planMigratedHarnessProfile({
+      organizationId: "org-a",
+      provider: "codex",
+      modelId: "gpt-custom",
+    });
+    const differentModel = planMigratedHarnessProfile({
+      organizationId: "org-a",
+      provider: "codex",
+      modelId: "gpt-other",
+    });
+
+    expect(repeated).toEqual(first);
+    expect(first.reference).toMatchObject({ version: 1 });
+    expect(first.manifest).toMatchObject({
+      system: false,
+      harness: { provider: "codex" },
+      model: { id: "gpt-custom" },
+    });
+    expect(differentModel.reference.profileId).not.toBe(
+      first.reference.profileId,
+    );
+  });
+
+  it("creates or reuses the same immutable profile idempotently", async () => {
+    const db = await createTestDb();
+    await db
+      .insert(organization)
+      .values({ id: "org-a", name: "Org A", slug: "org-a" });
+    await db.insert(user).values({
+      id: "admin",
+      name: "Admin",
+      email: "admin@example.com",
+      emailVerified: true,
+    });
+    const plan = planMigratedHarnessProfile({
+      organizationId: "org-a",
+      provider: "codex",
+      modelId: "gpt-custom",
+    });
+    const input = {
+      plans: [plan],
+      actor: {
+        organizationId: "org-a",
+        role: "admin" as const,
+        id: "admin",
+      },
+    };
+
+    await ensureMigratedHarnessProfiles(db, input);
+    await ensureMigratedHarnessProfiles(db, input);
+
+    expect(
+      await db
+        .select()
+        .from(harnessProfiles)
+        .where(eq(harnessProfiles.id, plan.reference.profileId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(harnessProfileVersions)
+        .where(
+          eq(
+            harnessProfileVersions.profileId,
+            plan.reference.profileId,
+          ),
+        ),
+    ).toHaveLength(1);
+  });
+});

--- a/apps/worker/src/workflow-definition/v2-migration-harness-profiles.ts
+++ b/apps/worker/src/workflow-definition/v2-migration-harness-profiles.ts
@@ -1,0 +1,208 @@
+import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import { and, eq } from "drizzle-orm";
+import {
+  BUILTIN_HARNESS_PROFILE_MANIFESTS,
+  type HarnessProfileDraftManifestV1,
+  type HarnessProfileManifestV1,
+  type HarnessProfileReference,
+  type HarnessProfileResolvedVersion,
+  type HarnessProvider,
+} from "@shared/contracts";
+import type { Db } from "../db/client.js";
+import {
+  harnessProfiles,
+  harnessProfileVersions,
+} from "../db/schema.js";
+import {
+  canManageHarnessProfiles,
+  type DashboardRole,
+} from "../lib/auth/roles.js";
+import {
+  compileHarnessProfileManifest,
+  hashHarnessProfileManifest,
+} from "../harness-profiles/manifest.js";
+
+export interface MigratedHarnessProfilePlan {
+  organizationId: string;
+  provider: HarnessProvider;
+  modelId: string;
+  reference: HarnessProfileReference;
+  slug: string;
+  draft: HarnessProfileDraftManifestV1;
+  manifest: HarnessProfileManifestV1;
+  manifestHash: string;
+}
+
+export function planMigratedHarnessProfile(input: {
+  organizationId: string;
+  provider: HarnessProvider;
+  modelId: string;
+}): MigratedHarnessProfilePlan {
+  const base =
+    input.provider === "claude"
+      ? BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-claude"]
+      : BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-codex"];
+  const digest = createHash("sha256")
+    .update(
+      JSON.stringify({
+        organizationId: input.organizationId,
+        provider: input.provider,
+        modelId: input.modelId,
+        compatibilityManifestHash: hashHarnessProfileManifest(base),
+      }),
+    )
+    .digest("hex");
+  const profileId = `migration-${digest.slice(0, 32)}`;
+  const slug = `migrated-${input.provider}-${digest.slice(0, 16)}`;
+  const {
+    profileId: _profileId,
+    version: _version,
+    slug: _slug,
+    system: _system,
+    ...baseDraft
+  } = structuredClone(base);
+  const providerName = input.provider === "codex" ? "Codex" : "Claude";
+  const draft: HarnessProfileDraftManifestV1 = {
+    ...baseDraft,
+    displayName: `${providerName} · ${input.modelId}`,
+    description:
+      "Automatically created to preserve a v1 workflow agent configuration.",
+    model: { id: input.modelId, options: {} },
+  };
+  const manifest = compileHarnessProfileManifest({
+    profileId,
+    version: 1,
+    slug,
+    system: false,
+    draft,
+  });
+  return {
+    organizationId: input.organizationId,
+    provider: input.provider,
+    modelId: input.modelId,
+    reference: { profileId, version: 1 },
+    slug,
+    draft,
+    manifest,
+    manifestHash: hashHarnessProfileManifest(manifest),
+  };
+}
+
+export function resolvedMigratedHarnessProfile(
+  plan: MigratedHarnessProfilePlan,
+): HarnessProfileResolvedVersion {
+  return {
+    manifest: structuredClone(plan.manifest),
+    manifestHash: plan.manifestHash,
+    skillArtifacts: [],
+  };
+}
+
+export async function ensureMigratedHarnessProfiles(
+  db: Db,
+  input: {
+    plans: readonly MigratedHarnessProfilePlan[];
+    actor: {
+      organizationId: string;
+      role: DashboardRole;
+      id: string;
+    };
+  },
+): Promise<void> {
+  if (input.plans.length === 0) return;
+  if (!canManageHarnessProfiles(input.actor.role)) {
+    throw new Error("Only owners and admins can create migration profiles.");
+  }
+  for (const plan of input.plans) {
+    if (plan.organizationId !== input.actor.organizationId) {
+      throw new Error("Migration profile belongs to another organization.");
+    }
+    await db
+      .insert(harnessProfiles)
+      .values({
+        id: plan.reference.profileId,
+        organizationId: plan.organizationId,
+        slug: plan.slug,
+        draftManifest: plan.draft,
+        draftRevision: 1,
+        publishedVersion: null,
+        system: false,
+        readOnly: false,
+        createdById: input.actor.id,
+        updatedById: input.actor.id,
+      })
+      .onConflictDoNothing({ target: harnessProfiles.id });
+
+    const [profile] = await db
+      .select()
+      .from(harnessProfiles)
+      .where(
+        and(
+          eq(harnessProfiles.id, plan.reference.profileId),
+          eq(harnessProfiles.organizationId, plan.organizationId),
+        ),
+      )
+      .limit(1);
+    if (
+      !profile ||
+      profile.system ||
+      profile.readOnly ||
+      profile.archivedAt !== null ||
+      profile.slug !== plan.slug ||
+      !isDeepStrictEqual(profile.draftManifest, plan.draft) ||
+      (profile.publishedVersion !== null &&
+        profile.publishedVersion !== plan.reference.version)
+    ) {
+      throw new Error(
+        `Migration Harness Profile "${plan.reference.profileId}" conflicts with existing data.`,
+      );
+    }
+
+    await db
+      .insert(harnessProfileVersions)
+      .values({
+        profileId: plan.reference.profileId,
+        version: plan.reference.version,
+        manifest: plan.manifest,
+        manifestHash: plan.manifestHash,
+        createdById: input.actor.id,
+      })
+      .onConflictDoNothing();
+    const [version] = await db
+      .select()
+      .from(harnessProfileVersions)
+      .where(
+        and(
+          eq(harnessProfileVersions.profileId, plan.reference.profileId),
+          eq(harnessProfileVersions.version, plan.reference.version),
+        ),
+      )
+      .limit(1);
+    if (
+      !version ||
+      version.manifestHash !== plan.manifestHash ||
+      !isDeepStrictEqual(version.manifest, plan.manifest)
+    ) {
+      throw new Error(
+        `Migration Harness Profile "${plan.reference.profileId}" has a conflicting immutable version.`,
+      );
+    }
+
+    if (profile.publishedVersion === null) {
+      await db
+        .update(harnessProfiles)
+        .set({
+          publishedVersion: plan.reference.version,
+          updatedAt: new Date(),
+          updatedById: input.actor.id,
+        })
+        .where(
+          and(
+            eq(harnessProfiles.id, plan.reference.profileId),
+            eq(harnessProfiles.organizationId, plan.organizationId),
+          ),
+        );
+    }
+  }
+}

--- a/apps/worker/src/workflow-definition/v2-migration.ts
+++ b/apps/worker/src/workflow-definition/v2-migration.ts
@@ -5,8 +5,12 @@ import {
   parsePromptReferenceTokens,
   type WorkflowDefinitionV1,
 } from "@shared/contracts";
+import { env } from "../../env.js";
 import type { Db } from "../db/client.js";
-import { getCurrentSystemHarnessProfileReference } from "../harness-profiles/store.js";
+import {
+  getCurrentSystemHarnessProfileReference,
+  resolveHarnessProfileVersion,
+} from "../harness-profiles/store.js";
 import {
   createPromptReferenceLoader,
   getPrompt,
@@ -25,11 +29,24 @@ import { prepareWorkflowV1PromptsForMigration } from "./v2-migration-prompts.js"
 import {
   convertWorkflowDefinitionV1ToV2,
   dedupeWorkflowV2MigrationDiagnostics,
+  workflowV2HarnessProfileTargetKey,
   workflowV2PromptResolutionKey,
+  type ConvertWorkflowDefinitionV1ToV2Input,
   type WorkflowV2MigrationDiagnostic,
   type WorkflowV2MigrationResult,
   type WorkflowV2PromptResolution,
 } from "./v2-converter.js";
+import { dashboardOrganizationId } from "./harness-profile-runtime.js";
+import {
+  planMigratedHarnessProfile,
+  resolvedMigratedHarnessProfile,
+  type MigratedHarnessProfilePlan,
+} from "./v2-migration-harness-profiles.js";
+
+export interface PreparedWorkflowDefinitionV2Migration {
+  result: WorkflowV2MigrationResult;
+  harnessProfiles: MigratedHarnessProfilePlan[];
+}
 
 export async function previewWorkflowDefinitionV2Migration(
   db: Db,
@@ -40,6 +57,18 @@ export async function previewWorkflowDefinitionV2Migration(
     registryContext?: WorkflowBlockRegistryContext;
   },
 ): Promise<WorkflowV2MigrationResult> {
+  return (await prepareWorkflowDefinitionV2Migration(db, input)).result;
+}
+
+export async function prepareWorkflowDefinitionV2Migration(
+  db: Db,
+  input: {
+    definitionId: number;
+    sourceVersion: number;
+    expectedDraftRevision: number;
+    registryContext?: WorkflowBlockRegistryContext;
+  },
+): Promise<PreparedWorkflowDefinitionV2Migration> {
   const definitionRow = await getWorkflowDefinitionRawState(
     db,
     input.definitionId,
@@ -86,19 +115,22 @@ export async function previewWorkflowDefinitionV2Migration(
     }
     upgraded = restoreRawPromptProvenance(source.definition, definition);
   } catch (error) {
-    return blockedMigrationResult(input, {
-      ...preflight,
-      blockers: [
-        ...preflight.blockers,
-        {
-          code: "migration.source.invalid_legacy_shape",
-          message:
-            "The stored source does not match a supported historical v1 workflow shape.",
-          nodeId: null,
-          ...legacyShapeErrorPath(error),
-        },
-      ],
-    });
+    return {
+      result: blockedMigrationResult(input, {
+        ...preflight,
+        blockers: [
+          ...preflight.blockers,
+          {
+            code: "migration.source.invalid_legacy_shape",
+            message:
+              "The stored source does not match a supported historical v1 workflow shape.",
+            nodeId: null,
+            ...legacyShapeErrorPath(error),
+          },
+        ],
+      }),
+      harnessProfiles: [],
+    };
   }
   if (!isDeepStrictEqual(analysisSource, upgraded)) {
     preflight.conversions.push({
@@ -112,16 +144,30 @@ export async function previewWorkflowDefinitionV2Migration(
 
   const registryContext =
     input.registryContext ?? workflowBlockRegistryContextFromEnv();
+  const organizationId = await dashboardOrganizationId(
+    db,
+    env.DASHBOARD_ORG_SLUG,
+  );
   const preparedPrompts = await prepareWorkflowV1PromptsForMigration(
     db,
     upgraded,
   );
-  const converted = await convertWorkflowDefinitionV1ToV2WithPromptResolution(db, {
-    sourceDefinitionId: input.definitionId,
-    sourceVersion: input.sourceVersion,
+  const harnessProfileTargets = await prepareHarnessProfileTargets(db, {
     definition: preparedPrompts.definition,
+    organizationId,
     registryContext,
   });
+  const converted = await convertWorkflowDefinitionV1ToV2WithPromptResolution(
+    db,
+    {
+      sourceDefinitionId: input.definitionId,
+      sourceVersion: input.sourceVersion,
+      definition: preparedPrompts.definition,
+      registryContext,
+      harnessProfiles: harnessProfileTargets.system,
+      harnessProfilesByProviderModel: harnessProfileTargets.exact,
+    },
+  );
   const rawSourceBlocked = preflight.blockers.length > 0;
   const preliminaryBlockers = dedupeWorkflowV2MigrationDiagnostics([
     ...preflight.blockers,
@@ -135,6 +181,20 @@ export async function previewWorkflowDefinitionV2Migration(
         db,
         converted.definition,
         registryContext,
+        ({ profileId, version }) => {
+          const generated = harnessProfileTargets.plans.find(
+            (plan) =>
+              plan.reference.profileId === profileId &&
+              plan.reference.version === version,
+          );
+          return generated
+            ? Promise.resolve(resolvedMigratedHarnessProfile(generated))
+            : resolveHarnessProfileVersion(db, {
+                organizationId,
+                profileId,
+                version,
+              });
+        },
       );
     for (const issue of validation.response.issues) {
       targetBlockers.push({
@@ -154,19 +214,22 @@ export async function previewWorkflowDefinitionV2Migration(
     blockers.length === 0 &&
     converted.definition !== null;
   return {
-    ...converted,
-    // The compatibility copy is used only to discover additional actionable
-    // blockers. Unknown raw fields remain authoritative and can never be
-    // normalized away into an applicable conversion.
-    conversionHash: applicable ? converted.conversionHash : null,
-    definition: applicable ? converted.definition : null,
-    conversions: dedupeWorkflowV2MigrationDiagnostics([
-      ...preflight.conversions,
-      ...preparedPrompts.conversions,
-      ...converted.conversions,
-    ]),
-    warnings: [...preflight.warnings, ...converted.warnings],
-    blockers,
+    result: {
+      ...converted,
+      // The compatibility copy is used only to discover additional actionable
+      // blockers. Unknown raw fields remain authoritative and can never be
+      // normalized away into an applicable conversion.
+      conversionHash: applicable ? converted.conversionHash : null,
+      definition: applicable ? converted.definition : null,
+      conversions: dedupeWorkflowV2MigrationDiagnostics([
+        ...preflight.conversions,
+        ...preparedPrompts.conversions,
+        ...converted.conversions,
+      ]),
+      warnings: [...preflight.warnings, ...converted.warnings],
+      blockers,
+    },
+    harnessProfiles: applicable ? harnessProfileTargets.plans : [],
   };
 }
 
@@ -177,6 +240,8 @@ export async function convertWorkflowDefinitionV1ToV2WithPromptResolution(
     sourceVersion: number;
     definition: WorkflowDefinitionV1;
     registryContext?: WorkflowBlockRegistryContext;
+    harnessProfiles?: ConvertWorkflowDefinitionV1ToV2Input["harnessProfiles"];
+    harnessProfilesByProviderModel?: ConvertWorkflowDefinitionV1ToV2Input["harnessProfilesByProviderModel"];
   },
 ): Promise<WorkflowV2MigrationResult> {
   const [claudeReference, codexReference] = await Promise.all([
@@ -188,7 +253,7 @@ export async function convertWorkflowDefinitionV1ToV2WithPromptResolution(
     registryContext:
       input.registryContext ?? workflowBlockRegistryContextFromEnv(),
     promptResolutions: await resolvePromptVersions(db, input.definition),
-    harnessProfiles: {
+    harnessProfiles: input.harnessProfiles ?? {
       claude: {
         reference: claudeReference,
         modelId:
@@ -200,7 +265,85 @@ export async function convertWorkflowDefinitionV1ToV2WithPromptResolution(
           BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-codex"].model.id,
       },
     },
+    harnessProfilesByProviderModel: input.harnessProfilesByProviderModel,
   });
+}
+
+const MIGRATED_AGENT_BLOCK_TYPES = new Set([
+  "planning_agent",
+  "implementation_agent",
+  "review_agent",
+  "fix_agent",
+  "generic_agent",
+]);
+
+async function prepareHarnessProfileTargets(
+  db: Db,
+  input: {
+    definition: WorkflowDefinitionV1;
+    organizationId: string;
+    registryContext: WorkflowBlockRegistryContext;
+  },
+): Promise<{
+  system: NonNullable<
+    ConvertWorkflowDefinitionV1ToV2Input["harnessProfiles"]
+  >;
+  exact: NonNullable<
+    ConvertWorkflowDefinitionV1ToV2Input["harnessProfilesByProviderModel"]
+  >;
+  plans: MigratedHarnessProfilePlan[];
+}> {
+  const [claudeReference, codexReference] = await Promise.all([
+    getCurrentSystemHarnessProfileReference(db, "claude"),
+    getCurrentSystemHarnessProfileReference(db, "codex"),
+  ]);
+  const system = {
+    claude: {
+      reference: claudeReference,
+      modelId:
+        BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-claude"].model.id,
+    },
+    codex: {
+      reference: codexReference,
+      modelId: BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-codex"].model.id,
+    },
+  };
+  const plansByKey = new Map<string, MigratedHarnessProfilePlan>();
+  for (const node of input.definition.nodes) {
+    if (!MIGRATED_AGENT_BLOCK_TYPES.has(node.type)) continue;
+    const provider =
+      node.params.provider === "claude" || node.params.provider === "codex"
+        ? node.params.provider
+        : input.registryContext.defaultAgent.provider;
+    const modelId =
+      typeof node.params.model === "string" &&
+      node.params.model.trim().length > 0
+        ? node.params.model.trim()
+        : system[provider].modelId;
+    if (modelId === system[provider].modelId) continue;
+    const key = workflowV2HarnessProfileTargetKey(provider, modelId);
+    if (!plansByKey.has(key)) {
+      plansByKey.set(
+        key,
+        planMigratedHarnessProfile({
+          organizationId: input.organizationId,
+          provider,
+          modelId,
+        }),
+      );
+    }
+  }
+  const plans = [...plansByKey.values()];
+  return {
+    system,
+    exact: new Map(
+      plans.map((plan) => [
+        workflowV2HarnessProfileTargetKey(plan.provider, plan.modelId),
+        { reference: plan.reference, modelId: plan.modelId },
+      ]),
+    ),
+    plans,
+  };
 }
 
 async function resolvePromptVersions(

--- a/apps/worker/src/workflows/definition-step.test.ts
+++ b/apps/worker/src/workflows/definition-step.test.ts
@@ -282,7 +282,7 @@ describe("loadWorkflowDefinition", () => {
     expect(
       plan.nodes.find((node) => node.id === "planning")?.params,
     ).toEqual({
-      harnessProfile: { profileId: "builtin-codex", version: 1 },
+      harnessProfile: { profileId: "builtin-codex", version: 2 },
       prompt: "{{prompt:research-plan@1}}",
     });
     expect(
@@ -290,7 +290,7 @@ describe("loadWorkflowDefinition", () => {
         (node) => node.id === "planning",
       )?.configuration,
     ).toEqual({
-      harnessProfile: { profileId: "builtin-codex", version: 1 },
+      harnessProfile: { profileId: "builtin-codex", version: 2 },
       prompt: "{{prompt:research-plan@1}}",
     });
   });


### PR DESCRIPTION
## Summary

- make migration preview model exact Harness Profiles without writing them
- create or reuse the deterministic organization profile only when Apply succeeds
- pin GPT-5.4 workflows to the current built-in Codex profile instead of blocking migration
- publish the Codex built-in profile as immutable version 2 with GPT-5.4 while preserving existing version 1 pins
- keep duplicate-as-v2 behavior aligned with the migration path

## Compatibility

Existing v1 execution is unchanged. Existing v2 definitions pinned to `builtin-codex` version 1 remain pinned to the historical GPT-5-Codex manifest. New authoring uses version 2 with GPT-5.4. No database migration is required; system profile seeding appends the immutable version.

## Verification

- `corepack pnpm --dir apps/worker exec tsc --noEmit`
- migration/profile/converter/default/store/model/agent focused suites: 52 passed
- workflow-definition API suite: 81 passed
- full worker suite: 2,749 passed; its only two failures were stale version-1 expectations, both updated and retested
- affected expectation retest: 29 passed
- `git diff --check`

Jira: https://blazity.atlassian.net/browse/AIW-180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the built-in Codex harness profile to use GPT-5.4.
  * Workflow migrations now prepare and preserve model-specific harness profiles, including custom model selections.
  * Migrated profiles are created consistently and reused when applicable.

* **Bug Fixes**
  * Improved migration validation detects deployment blockers before applying changes and reports clearer blocking details.
  * Existing compatible profiles are now reused instead of creating duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->