### PR TITLE
AIW-179: Fix GitHub skill discovery timeouts

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -51,12 +51,14 @@
     "re2-wasm": "^1.0.2",
     "resend": "^6.16.0",
     "svix": "^1.96.1",
+    "tar-stream": "^3.1.8",
     "workflow": "4.6.0",
     "yaml": "^2.9.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.5.1",
+    "@types/tar-stream": "^3.1.4",
     "@workflow/vitest": "4.0.12",
     "@workflow/world-postgres": "4.3.0",
     "dotenv": "^17.4.2",

--- a/apps/worker/src/harness-profiles/github-skills.test.ts
+++ b/apps/worker/src/harness-profiles/github-skills.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { gzipSync } from "node:zlib";
+import { pack } from "tar-stream";
 import type { Db } from "../db/client.js";
 import {
   harnessSkillArtifactFiles,
@@ -8,6 +10,7 @@ import {
 import { createTestDb } from "../db/test-db.js";
 import {
   discoverGitHubSkills,
+  extractRepositoryFiles,
   HarnessSkillImportError,
   importGitHubSkills,
   parseGitHubSkillLocator,
@@ -64,11 +67,22 @@ class FakeRepository implements GitHubSkillRepository {
     return tree;
   }
 
-  async getBlob(input: { sha: string }): Promise<Buffer> {
-    this.calls.push(`blob:${input.sha}`);
-    const blob = this.blobs.get(input.sha);
-    if (!blob) throw new Error("missing blob");
-    return Buffer.from(blob);
+  async getFiles(input: {
+    commitSha: string;
+    paths: string[];
+  }): Promise<Map<string, Buffer>> {
+    this.calls.push(`files:${input.commitSha}:${input.paths.length}`);
+    const resolved = this.commits.get(input.commitSha);
+    if (!resolved) throw new Error("missing commit");
+    const tree = this.trees.get(resolved.treeSha);
+    if (!tree) throw new Error("missing tree");
+    const files = new Map<string, Buffer>();
+    for (const path of input.paths) {
+      const entry = tree.entries.find((candidate) => candidate.path === path);
+      const blob = entry ? this.blobs.get(entry.sha) : undefined;
+      if (blob) files.set(path, Buffer.from(blob));
+    }
+    return files;
   }
 }
 
@@ -198,7 +212,7 @@ describe("GitHub skill discovery", () => {
     ]);
   });
 
-  it("fails before blob fan-out when discovery exceeds the candidate cap", async () => {
+  it("fails before snapshot download when discovery exceeds the candidate cap", async () => {
     const repository = new FakeRepository();
     repository.trees.set(TREE_ONE, {
       truncated: false,
@@ -213,9 +227,37 @@ describe("GitHub skill discovery", () => {
     await expect(
       discoverGitHubSkills({ repository, source: "acme/skills" }),
     ).rejects.toMatchObject({ statusCode: 422 });
-    expect(repository.calls.some((call) => call.startsWith("blob:"))).toBe(
+    expect(repository.calls.some((call) => call.startsWith("files:"))).toBe(
       false,
     );
+  });
+
+  it("loads many skill documents from one exact-commit snapshot", async () => {
+    const repository = new FakeRepository();
+    const entries: GitHubSkillTreeEntry[] = [];
+    for (let index = 0; index < 41; index += 1) {
+      const sha = index.toString(16).padStart(40, "0");
+      const content = validSkill(`skill-${index}`, `Skill ${index}`);
+      repository.blobs.set(sha, content);
+      entries.push({
+        path: `skills/engineering/skill-${index}/SKILL.md`,
+        mode: "100644",
+        type: "blob",
+        sha,
+        size: content.byteLength,
+      });
+    }
+    repository.trees.set(TREE_ONE, { entries, truncated: false });
+
+    const discovered = await discoverGitHubSkills({
+      repository,
+      source: "acme/skills",
+    });
+
+    expect(discovered.skills).toHaveLength(41);
+    expect(
+      repository.calls.filter((call) => call.startsWith("files:")),
+    ).toEqual([`files:${COMMIT_ONE}:41`]);
   });
 
   it("prefers conventional skill directories and falls back to recursive discovery", async () => {
@@ -281,6 +323,55 @@ describe("GitHub skill discovery", () => {
       message:
         "GitHub repository could not be read with the organization installation",
     });
+  });
+});
+
+describe("GitHub repository snapshots", () => {
+  it("extracts requested files from one tarball and ignores unrelated files", async () => {
+    const archive = pack();
+    archive.entry(
+      { name: "acme-skills-commit/skills/review/SKILL.md" },
+      validSkill(),
+    );
+    archive.entry(
+      { name: "acme-skills-commit/large-unrelated.bin" },
+      Buffer.alloc(2 * 1024 * 1024),
+    );
+    archive.finalize();
+    const chunks: Buffer[] = [];
+    for await (const chunk of archive) chunks.push(Buffer.from(chunk));
+
+    const files = await extractRepositoryFiles(
+      gzipSync(Buffer.concat(chunks)),
+      new Set(["skills/review/SKILL.md"]),
+    );
+
+    expect([...files.keys()]).toEqual(["skills/review/SKILL.md"]);
+  });
+
+  it("rejects snapshots with multiple root directories", async () => {
+    const archive = pack();
+    archive.entry(
+      { name: "first-root/skills/review/SKILL.md" },
+      validSkill(),
+    );
+    archive.entry(
+      { name: "second-root/skills/other/SKILL.md" },
+      validSkill("other", "Other"),
+    );
+    archive.finalize();
+    const chunks: Buffer[] = [];
+    for await (const chunk of archive) chunks.push(Buffer.from(chunk));
+
+    await expect(
+      extractRepositoryFiles(
+        gzipSync(Buffer.concat(chunks)),
+        new Set([
+          "skills/review/SKILL.md",
+          "skills/other/SKILL.md",
+        ]),
+      ),
+    ).rejects.toMatchObject({ statusCode: 422 });
   });
 });
 

--- a/apps/worker/src/harness-profiles/github-skills.ts
+++ b/apps/worker/src/harness-profiles/github-skills.ts
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
 import { posix } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
 import type {
   HarnessSkillArtifact,
   HarnessSkillArtifactFile,
@@ -8,6 +11,7 @@ import type {
 } from "@shared/contracts";
 import { HARNESS_SKILL_IMPORT_LIMITS } from "@shared/contracts";
 import { and, eq, sql } from "drizzle-orm";
+import { extract } from "tar-stream";
 import type { Db } from "../db/client.js";
 import {
   harnessSkillArtifactFiles,
@@ -22,6 +26,7 @@ import {
 } from "./skill-artifact.js";
 
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
+const MAX_REPOSITORY_ARCHIVE_BYTES = 50 * 1024 * 1024;
 // Keep repository discovery compatible with the conventional-first behavior
 // of https://github.com/vercel-labs/skills while limiting the catalog to the
 // harnesses AI Workflow can materialize.
@@ -58,11 +63,12 @@ export interface GitHubSkillRepository {
     repository: string;
     treeSha: string;
   }): Promise<{ entries: GitHubSkillTreeEntry[]; truncated: boolean }>;
-  getBlob(input: {
+  getFiles(input: {
     owner: string;
     repository: string;
-    sha: string;
-  }): Promise<Buffer>;
+    commitSha: string;
+    paths: string[];
+  }): Promise<Map<string, Buffer>>;
 }
 
 export interface ParsedGitHubSkillLocator {
@@ -148,21 +154,159 @@ export function createGitHubSkillRepository(
         truncated: response.data.truncated === true,
       };
     },
-    async getBlob(input) {
-      const response = await octokit.git.getBlob({
+    async getFiles(input) {
+      const response = await octokit.repos.downloadTarballArchive({
         owner: input.owner,
         repo: input.repository,
-        file_sha: input.sha,
+        ref: input.commitSha,
       });
-      if (response.data.encoding !== "base64") {
+      const archive = toArchiveBuffer(response.data);
+      if (archive.byteLength > MAX_REPOSITORY_ARCHIVE_BYTES) {
         throw new HarnessSkillImportError(
-          422,
-          "GitHub returned a blob with an unsupported encoding",
+          413,
+          "GitHub repository snapshot exceeds the 50 MiB download limit",
         );
       }
-      return Buffer.from(response.data.content.replaceAll("\n", ""), "base64");
+      return extractRepositoryFiles(archive, new Set(input.paths));
     },
   };
+}
+
+function toArchiveBuffer(data: unknown): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  if (ArrayBuffer.isView(data)) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  }
+  throw new HarnessSkillImportError(
+    422,
+    "GitHub returned a repository snapshot in an unsupported format",
+  );
+}
+
+export async function extractRepositoryFiles(
+  archive: Buffer,
+  wantedPaths: Set<string>,
+): Promise<Map<string, Buffer>> {
+  const files = new Map<string, Buffer>();
+  let rootDirectory: string | null = null;
+  let validationError: HarnessSkillImportError | null = null;
+  const extractor = extract();
+
+  extractor.on("entry", (header, stream, next) => {
+    if (validationError) {
+      stream.on("end", next);
+      stream.resume();
+      return;
+    }
+    let repositoryPath: string;
+    try {
+      if (header.name.includes("\\") || header.name.includes("\0")) {
+        throw new HarnessSkillImportError(
+          422,
+          "GitHub repository snapshot contains an unsafe path",
+        );
+      }
+      const segments = header.name.split("/").filter(Boolean);
+      const [root, ...relativeSegments] = segments;
+      if (!root) {
+        throw new HarnessSkillImportError(
+          422,
+          "GitHub repository snapshot is missing its root directory",
+        );
+      }
+      if (rootDirectory === null) rootDirectory = root;
+      if (rootDirectory !== root) {
+        throw new HarnessSkillImportError(
+          422,
+          "GitHub repository snapshot contains multiple root directories",
+        );
+      }
+      repositoryPath = normalizeRepositoryPath(
+        relativeSegments.join("/"),
+        true,
+      );
+    } catch (error) {
+      validationError =
+        error instanceof HarnessSkillImportError
+          ? error
+          : new HarnessSkillImportError(
+              422,
+              "GitHub repository snapshot contains an unsafe path",
+            );
+      stream.on("end", next);
+      stream.resume();
+      return;
+    }
+
+    if (
+      repositoryPath === "" ||
+      header.type !== "file" ||
+      !wantedPaths.has(repositoryPath)
+    ) {
+      stream.on("end", next);
+      stream.resume();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    let size = 0;
+    stream.on("data", (chunk: Buffer) => {
+      if (validationError) return;
+      size += chunk.byteLength;
+      if (size > HARNESS_SKILL_IMPORT_LIMITS.maxFileBytes) {
+        validationError = new HarnessSkillImportError(
+          413,
+          `File "${repositoryPath}" is too large`,
+        );
+        return;
+      }
+      chunks.push(Buffer.from(chunk));
+    });
+    stream.on("error", (error) => extractor.destroy(error));
+    stream.on("end", () => {
+      if (validationError) {
+        next();
+        return;
+      }
+      if (files.has(repositoryPath)) {
+        validationError = new HarnessSkillImportError(
+          422,
+          `GitHub repository snapshot contains duplicate file "${repositoryPath}"`,
+        );
+        next();
+        return;
+      }
+      files.set(repositoryPath, Buffer.concat(chunks, size));
+      next();
+    });
+  });
+
+  try {
+    await pipeline(Readable.from([archive]), createGunzip(), extractor);
+  } catch (error) {
+    if (error instanceof HarnessSkillImportError) throw error;
+    throw new HarnessSkillImportError(
+      422,
+      "GitHub repository snapshot could not be unpacked safely",
+    );
+  }
+  if (validationError) throw validationError;
+  return files;
+}
+
+function requireSnapshotFile(
+  files: Map<string, Buffer>,
+  path: string,
+): Buffer {
+  const content = files.get(path);
+  if (!content) {
+    throw new HarnessSkillImportError(
+      422,
+      `GitHub repository snapshot is missing "${path}"`,
+    );
+  }
+  return content;
 }
 
 export function parseGitHubSkillLocator(
@@ -283,15 +427,20 @@ export async function discoverGitHubSkills(input: {
     );
   }
 
+  const contents =
+    candidates.length === 0
+      ? new Map<string, Buffer>()
+      : await readProvider(() =>
+          input.repository.getFiles({
+            owner: locator.owner,
+            repository: locator.repository,
+            commitSha: resolved.commitSha,
+            paths: candidates.map((candidate) => candidate.path),
+          }),
+        );
   const skills: HarnessSkillDiscoveryResponse["skills"] = [];
   for (const candidate of candidates) {
-    const content = await readProvider(() =>
-      input.repository.getBlob({
-        owner: locator.owner,
-        repository: locator.repository,
-        sha: candidate.sha,
-      }),
-    );
+    const content = requireSnapshotFile(contents, candidate.path);
     try {
       assertFileSize(content.byteLength);
       const metadata = parseSkillMetadata(content);
@@ -386,13 +535,35 @@ export async function importGitHubSkills(
   }
   validateTreeEntries(tree.entries);
 
+  const wantedPaths = [
+    ...new Set(
+      tree.entries
+        .filter(
+          (entry) =>
+            entry.type === "blob" &&
+            (entry.mode === "100644" || entry.mode === "100755") &&
+            selectedPaths.some((selectedPath) =>
+              pathWithin(selectedPath, entry.path),
+            ),
+        )
+        .map((entry) => entry.path),
+    ),
+  ];
+  const contents = await readProvider(() =>
+    input.repository.getFiles({
+      owner: source.owner,
+      repository: source.repository,
+      commitSha: resolved.commitSha,
+      paths: wantedPaths,
+    }),
+  );
   const artifacts: HarnessSkillArtifact[] = [];
   const names = new Set<string>();
   for (const selectedPath of selectedPaths) {
     const artifact = await buildArtifact({
-      repository: input.repository,
       source: { ...source, path: selectedPath },
       entries: tree.entries,
+      contents,
     });
     if (names.has(artifact.name)) {
       throw new HarnessSkillImportError(
@@ -472,9 +643,9 @@ interface BuiltArtifact {
 }
 
 async function buildArtifact(input: {
-  repository: GitHubSkillRepository;
   source: HarnessSkillArtifact["source"];
   entries: GitHubSkillTreeEntry[];
+  contents: Map<string, Buffer>;
 }): Promise<BuiltArtifact> {
   const selected = input.entries.filter((entry) =>
     pathWithin(input.source.path, entry.path),
@@ -541,13 +712,7 @@ async function buildArtifact(input: {
   for (const entry of nonTrees.sort((left, right) =>
     left.path.localeCompare(right.path),
   )) {
-    const content = await readProvider(() =>
-      input.repository.getBlob({
-        owner: input.source.owner,
-        repository: input.source.repository,
-        sha: entry.sha,
-      }),
-    );
+    const content = requireSnapshotFile(input.contents, entry.path);
     assertFileSize(content.byteLength, entry.path);
     if (entry.size !== undefined && content.byteLength !== entry.size) {
       throw new HarnessSkillImportError(

--- a/apps/worker/src/routes/api/v1/harness-profiles.test.ts
+++ b/apps/worker/src/routes/api/v1/harness-profiles.test.ts
@@ -104,8 +104,14 @@ class ApiSkillRepository implements GitHubSkillRepository {
     return { entries: this.entries, truncated: false };
   }
 
-  async getBlob(): Promise<Buffer> {
-    return Buffer.from(this.skill);
+  async getFiles(input: {
+    paths: string[];
+  }): Promise<Map<string, Buffer>> {
+    return new Map(
+      input.paths
+        .filter((path) => path === this.entries[0]!.path)
+        .map((path) => [path, Buffer.from(this.skill)]),
+    );
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       svix:
         specifier: ^1.96.1
         version: 1.96.1
+      tar-stream:
+        specifier: ^3.1.8
+        version: 3.1.8
       workflow:
         specifier: 4.6.0
         version: 4.6.0(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.17(@nestjs/common@11.1.17(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.0)(@swc/cli@0.8.0(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(magicast@0.5.2)(next@15.5.18(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
@@ -180,6 +183,9 @@ importers:
       '@electric-sql/pglite':
         specifier: ^0.5.1
         version: 0.5.1
+      '@types/tar-stream':
+        specifier: ^3.1.4
+        version: 3.1.4
       '@workflow/vitest':
         specifier: 4.0.12
         version: 4.0.12(@opentelemetry/api@1.9.0)(vite@7.3.1(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(vitest@3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -2341,6 +2347,9 @@ packages:
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -7538,6 +7547,10 @@ snapshots:
   '@types/retry@0.12.0': {}
 
   '@types/semver@7.7.1': {}
+
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/unist@3.0.3': {}
 


### PR DESCRIPTION
## Summary

Fix the GitHub skill discovery timeout exposed during manual review of AIW-179.

The previous implementation fetched every candidate `SKILL.md` through a separate sequential GitHub API request. A repository with 41 skills therefore exceeded the dashboard's 10-second worker timeout even though cloning the repository took under a second.

This follow-up:

- resolves the default branch and exact commit as before;
- keeps the recursive tree request for file modes, sizes, symlinks, submodules, and unsafe-path validation;
- downloads one authenticated exact-commit tarball snapshot;
- extracts only the files required for discovery or the selected imports;
- retains exact-SHA pinning and all existing artifact integrity checks;
- rejects oversized or malformed snapshots safely.

This follows the `vercel-labs/skills` transport model: fetch the repository once, then discover locally.

## Manual reproduction

`mattpocock/skills` contains 41 `SKILL.md` files. Its public snapshot is 167 KiB, downloaded in under one second, and the new parser extracted all 41 files in 8 ms locally.

## Verification

- Focused Harness Profile and GitHub skill suites: 27 tests passed.
- Full worker suite: 237 files / 2,773 tests passed.
- Worker and dashboard TypeScript checks passed.
- Live snapshot parser check: 41 requested / 41 extracted in 8 ms.
- `git diff --check` passed.

No database migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GitHub skill discovery and importing by retrieving repository files in a single snapshot.
  * Added support for extracting only the required files from repository archives.
  * Added safeguards for oversized, malformed, unsafe, or duplicate archive contents.

* **Performance**
  * Reduced the number of repository file requests when discovering and importing multiple skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->