### PR TITLE
test(worker): verify mixed GitHub+GitLab multi-repo runs

### DIFF
--- a/.claude/skills/init-vcs/SKILL.md
+++ b/.claude/skills/init-vcs/SKILL.md
@@ -5,7 +5,7 @@ description: Configure or rotate the VCS provider (GitHub or GitLab) for the Bla
 
 # Initialize VCS provider
 
-Branch-on-choice skill. Asks **GitHub or GitLab**, then emits a single paste-template for the chosen provider. The cross-field rule in `env.ts` (`VCS_KIND=github` requires `GITHUB_TOKEN` + `GITHUB_OWNER` + `GITHUB_REPO`; `VCS_KIND=gitlab` requires `GITLAB_TOKEN` + `GITLAB_PROJECT_ID`) is enforced by construction — only the chosen branch's keys are emitted.
+Branch-on-choice skill. Asks **GitHub, GitLab, or both**, then emits a paste-template per chosen provider. Provider credentials are additive in `env.ts`: a deployment may configure GitHub (GitHub App vars), GitLab (`GITLAB_TOKEN` + `GITLAB_PROJECT_ID`), or both at once. `VCS_KIND` is optional and only pins the legacy single-repo helpers; leave it unset in a dual-provider deployment. The cross-field rule (`VCS_KIND=github` requires the GitHub App vars; `VCS_KIND=gitlab` requires `GITLAB_TOKEN`) is enforced by construction.
 
 > If you want full project setup (Jira + VCS + Agent + Slack + Neon + deploy), invoke `init-env` instead. This skill only handles VCS.
 
@@ -22,30 +22,36 @@ Halt.
 
 ## Step 1 — Pick provider
 
-Ask: *"GitHub or GitLab?"*
+Ask: *"GitHub, GitLab, or both?"*
 
-If switching from a previously-configured provider, the user should also remove the old branch's keys from Vercel (`GITHUB_*` if switching to GitLab, vice versa). Print a one-line warning and let them handle it.
+Providers coexist: adding GitLab does NOT require removing `GITHUB_*` keys (and vice versa). A dual-provider deployment lists repositories from both providers in one catalog and a single run can mix them. Only when the user explicitly wants to DROP a provider should they remove that provider's keys; print a one-line note in that case. For "both", also collect per-provider bot logins (`GITHUB_BOT_LOGIN`, `GITLAB_BOT_LOGIN`) instead of the legacy `VCS_BOT_LOGIN`, and leave `VCS_KIND` unset.
 
 ## Step 2 — Emit paste-template
 
 ### GitHub branch
 
-Walk the user through `references/github-pat.md` to mint a token, find owner/repo. Then collect:
+GitHub auth uses a GitHub App (the legacy `GITHUB_TOKEN` PAT flow was removed; see `docs/GITHUB-APP-SETUP.md`). Collect:
 
-- `GITHUB_TOKEN` (PAT with `repo` scope)
+- `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY` (base64), `GITHUB_INSTALLATION_ID`
 - `GITHUB_OWNER` (org or user)
 - `GITHUB_REPO` (just the repo name)
 - `GITHUB_BASE_BRANCH` (default `main`)
+- `GITHUB_WEBHOOK_SECRET` (`openssl rand -hex 32`)
 
 Emit (paste into Vercel → Project Settings → Environment Variables, all three environments):
 
 ```
 VCS_KIND=github
-GITHUB_TOKEN=<value>
+GITHUB_APP_ID=<value>
+GITHUB_APP_PRIVATE_KEY=<base64 PEM>
+GITHUB_INSTALLATION_ID=<value>
 GITHUB_OWNER=<value>
 GITHUB_REPO=<value>
 GITHUB_BASE_BRANCH=main
+GITHUB_WEBHOOK_SECRET=<value>
 ```
+
+(Omit the `VCS_KIND` line when configuring both providers.)
 
 ### GitLab branch
 
@@ -78,5 +84,5 @@ If invoked from `init-env`, return control. If standalone, end.
 
 ## Don'ts
 
-- **Don't emit both branches.** Cross-field validation in `env.ts` will fail at validate time, but emitting both invites the user to paste both, leaving stale keys in Vercel even if validation passes (it does — only one set is *required*, the other is harmless until it's not).
+- **Don't emit both branches unless the user chose "both".** For a single-provider setup, emitting both invites stale keys. For a deliberate dual-provider setup, emit both templates, drop the `VCS_KIND` lines, and add `GITHUB_BOT_LOGIN`/`GITLAB_BOT_LOGIN`.
 - **Don't print the token after collecting it.** Reference by name only.

--- a/SETUP.md
+++ b/SETUP.md
@@ -262,10 +262,10 @@ vercel env add JIRA_API_TOKEN production
 | `JIRA_BASE_URL`, `JIRA_API_TOKEN`, `JIRA_PROJECT_KEY`                                              | Jira credentials (scoped service-account Bearer token) |
 | `COLUMN_AI`, `COLUMN_AI_REVIEW`, `COLUMN_BACKLOG`                                                  | Jira status/display names for polling, webhooks, and fallback transition lookup |
 | `JIRA_BACKLOG_TRANSITION_ID`, `JIRA_AI_REVIEW_TRANSITION_ID`                                       | Optional stable transition IDs for Jira moves; recommended when Jira localizes transition names |
-| `VCS_KIND`                                                                                         | `github` or `gitlab`                                   |
-| `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_INSTALLATION_ID`, `GITHUB_OWNER`, `GITHUB_REPO` | If `VCS_KIND=github` (GitHub App auth)                 |
-| `GITHUB_WEBHOOK_SECRET`                                                                            | If `VCS_KIND=github` — signs `pull_request` webhook deliveries for the post-PR gate. Required in **every** environment (Production, Preview, Development) because the webhook fires on preview deployments too. Generate: `openssl rand -hex 32`. |
-| `GITLAB_TOKEN`, `GITLAB_PROJECT_ID`, `GITLAB_BASE_BRANCH`, `GITLAB_WEBHOOK_SECRET`                  | If `VCS_KIND=gitlab` — GitLab.com token with `api` + `write_repository`, namespace/project path, target branch, and merge request webhook secret. Generate: `openssl rand -hex 32`. |
+| `VCS_KIND`                                                                                         | Optional. Provider credentials are additive: configure GitHub, GitLab, or both in one deployment (a run can then mix repositories from both providers). Set `VCS_KIND` only to pin the legacy single-repo helpers to one provider; leave it unset in dual-provider deployments. |
+| `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_INSTALLATION_ID`, `GITHUB_OWNER`, `GITHUB_REPO` | If GitHub is configured (GitHub App auth)              |
+| `GITHUB_WEBHOOK_SECRET`                                                                            | If GitHub is configured — signs `pull_request` webhook deliveries for the post-PR gate. Required in **every** environment (Production, Preview, Development) because the webhook fires on preview deployments too. Generate: `openssl rand -hex 32`. |
+| `GITLAB_TOKEN`, `GITLAB_PROJECT_ID`, `GITLAB_BASE_BRANCH`, `GITLAB_WEBHOOK_SECRET`                  | If GitLab is configured — GitLab.com token with `api` + `write_repository`, namespace/project path, target branch, and merge request webhook secret. Generate: `openssl rand -hex 32`. |
 | `ANTHROPIC_API_KEY`                                                                                | If `AGENT_KIND=claude` (default)                       |
 | `CODEX_API_KEY` (or `CODEX_CHATGPT_OAUTH_TOKEN`)                                                   | If `AGENT_KIND=codex`                                  |
 | `DATABASE_URL`                                                                                     | Auto-injected by Neon integration                      |
@@ -512,9 +512,9 @@ GENAI_ENGINE_TRACE_ENDPOINT=https://your-arthur-host/api/v1/traces
 
 This enables per-run tracing and the optional `arthur_injection_check` block. The tracer is built into every sandbox via `pnpm build:arthur-tracer` during deploy.
 
-### GitLab instead of GitHub
+### GitLab alongside (or instead of) GitHub
 
-Flip `VCS_KIND=gitlab` and provide `GITLAB_TOKEN`, `GITLAB_PROJECT_ID`, and `GITLAB_WEBHOOK_SECRET`. For GitLab.com setup, see [`docs/GITLAB-SETUP.md`](./docs/GITLAB-SETUP.md). `GITHUB_*` vars become inert.
+Provider credentials are additive. To run GitLab only, provide `GITLAB_TOKEN`, `GITLAB_PROJECT_ID`, and `GITLAB_WEBHOOK_SECRET` (optionally `VCS_KIND=gitlab` to pin the legacy single-repo helpers); `GITHUB_*` vars may be removed. To run BOTH providers in one deployment, keep the GitHub App vars and add the GitLab vars side by side, leave `VCS_KIND` unset, and set per-provider bot logins (`GITHUB_BOT_LOGIN`, `GITLAB_BOT_LOGIN`) instead of the legacy `VCS_BOT_LOGIN`. A dual-provider deployment lists repositories from both providers in one catalog, and a single run can read and modify a mix of GitHub and GitLab repositories, publishing a PR or MR per changed repository. For GitLab.com setup, see [`docs/GITLAB-SETUP.md`](./docs/GITLAB-SETUP.md).
 
 ---
 

--- a/apps/worker/src/adapters/vcs/gitlab.test.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.test.ts
@@ -628,6 +628,52 @@ describe("GitLabAdapter", () => {
     });
   });
 
+  describe("nested namespace project id", () => {
+    function nestedAdapter() {
+      return new GitLabAdapter({
+        token: "glpat-xxxxxxxxxxxx",
+        projectId: "group/subgroup/repo",
+        baseBranch: "main",
+      });
+    }
+
+    it("carries a nested project path through promotion branch and MR operations", async () => {
+      mockBranches.create.mockResolvedValue({});
+      mockBranches.remove.mockResolvedValueOnce({});
+      mockMergeRequests.all.mockResolvedValueOnce([]);
+
+      const adapter = nestedAdapter();
+      await adapter.createBranchIfMissing("feat/test", "main");
+      await adapter.resetOwnedBranch("feat/test", "main");
+      await adapter.findPR("feat/test");
+
+      expect(mockBranches.create).toHaveBeenCalledWith(
+        "group/subgroup/repo",
+        "feat/test",
+        "main",
+      );
+      expect(mockBranches.remove).toHaveBeenCalledWith(
+        "group/subgroup/repo",
+        "feat/test",
+      );
+      expect(mockMergeRequests.all).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: "group/subgroup/repo" }),
+      );
+    });
+
+    it("url-encodes the nested project path in hand-rolled REST gate statuses", async () => {
+      mockFetch.mockResolvedValueOnce(gitLabResponse({}, { status: 201 }));
+
+      const adapter = nestedAdapter();
+      await adapter.createGateStatus("blazebot / code-hygiene", "sha1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://gitlab.com/api/v4/projects/group%2Fsubgroup%2Frepo/statuses/sha1",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
   describe("gate statuses", () => {
     it("creates a GitLab commit status and returns a gate status ref", async () => {
       mockFetch.mockResolvedValueOnce(gitLabResponse({}, { status: 201 }));

--- a/apps/worker/src/sandbox/research-workspace.test.ts
+++ b/apps/worker/src/sandbox/research-workspace.test.ts
@@ -83,6 +83,37 @@ function createConcurrencyTrackingSandbox(initialPaths: string[] = []) {
   };
 }
 
+// Attach verifies each clone's origin against the artifact's cloneUrl. The
+// temp checkout path is a random uuid, so the git origin cannot be keyed on the
+// repository; instead the mock returns the batch's cloneUrls in attach order,
+// which is the artifact order. HEAD is fixed so it matches researchBaseSha.
+function createMixedAttachSandbox(cloneUrls: string[]) {
+  const pendingCloneUrls = [...cloneUrls];
+  const existing = new Set(["/vercel/sandbox/repos"]);
+  const runCommand = vi.fn(async (name: string, args: string[]) => {
+    if (args.includes("get-url")) return command(`${pendingCloneUrls.shift() ?? ""}\n`);
+    if (args.includes("rev-parse")) return command("shared-sha\n");
+    if (name === "realpath") return command(`${args[0]}\n`);
+    if (name === "test" && args[0] === "-L") return command("", 1);
+    if (name === "test" && args[0] === "-e") {
+      return command("", existing.has(args[1]!) ? 0 : 1);
+    }
+    if (name === "mkdir") existing.add(args[0]!);
+    if (name === "mv") {
+      existing.delete(args[0]!);
+      existing.add(args[1]!);
+    }
+    if (name === "rm") {
+      for (const path of args.slice(3)) existing.delete(path);
+    }
+    return command();
+  });
+  return {
+    runCommand,
+    writeFiles: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 const emptyManifest: WorkspaceManifestV2 = { version: 2, repositories: [] };
 const selected = {
   provider: "github" as const,
@@ -373,6 +404,100 @@ describe("materializeResearchRepositories", () => {
     expect(
       sandbox.runCommand.mock.calls.flatMap(([, args]) => args).join(" "),
     ).toContain("AUTHORIZATION");
+  });
+});
+
+describe("mixed-provider research workspace", () => {
+  it("materializes and attaches a github and a gitlab repository in one batch", async () => {
+    const githubRepository: WorkspaceRepositoryInput = {
+      provider: "github",
+      repoPath: "acme/api",
+      defaultBranch: "main",
+      selectedRationale: "primary implementation target",
+    };
+    const gitlabRepository: WorkspaceRepositoryInput = {
+      provider: "gitlab",
+      repoPath: "acme/contracts",
+      defaultBranch: "main",
+      selectedRationale: "shared contract dependency",
+    };
+    const providers = [
+      {
+        kind: "github" as const,
+        host: "https://github.com",
+        getToken: vi.fn().mockResolvedValue("github-token"),
+        commitAuthor: "ai-workflow-blazity",
+        commitEmail: "ai-workflow@blazity.com",
+      },
+      {
+        kind: "gitlab" as const,
+        host: "https://gitlab.com",
+        getToken: vi.fn().mockResolvedValue("gitlab-token"),
+        commitAuthor: "ai-workflow-blazity",
+        commitEmail: "ai-workflow@blazity.com",
+      },
+    ];
+    const materializeSandbox = {
+      runCommand: vi.fn(async (_name: string, args: string[]) => {
+        if (args.includes("rev-parse")) return command("shared-sha\n");
+        return command();
+      }),
+      writeFiles: vi.fn(),
+      readFileToBuffer: vi.fn().mockResolvedValue(Buffer.from("archive")),
+    };
+
+    const artifacts = await materializeResearchRepositories({
+      sandbox: materializeSandbox,
+      repositories: [githubRepository, gitlabRepository],
+      providers,
+    });
+
+    // Each clone reaches its own provider's host with that provider's auth
+    // (github uses x-access-token, gitlab uses oauth2), so credentials never
+    // cross providers.
+    const cloneCalls = materializeSandbox.runCommand.mock.calls.filter(
+      ([name, args]) => name === "git" && (args as string[]).includes("clone"),
+    );
+    const githubClone = cloneCalls.find(([, args]) =>
+      (args as string[]).includes("https://github.com/acme/api.git"),
+    );
+    const gitlabClone = cloneCalls.find(([, args]) =>
+      (args as string[]).includes("https://gitlab.com/acme/contracts.git"),
+    );
+    expect(githubClone?.[1]).toContain(
+      `http.extraHeader=AUTHORIZATION: Basic ${Buffer.from("x-access-token:github-token").toString("base64")}`,
+    );
+    expect(gitlabClone?.[1]).toContain(
+      `http.extraHeader=AUTHORIZATION: Basic ${Buffer.from("oauth2:gitlab-token").toString("base64")}`,
+    );
+
+    const attachSandbox = createMixedAttachSandbox(
+      artifacts.map((materialized) => materialized.cloneUrl),
+    );
+    const manifest = await attachResearchRepositories({
+      sandbox: attachSandbox,
+      manifest: emptyManifest,
+      artifacts,
+    });
+
+    expect(manifest.repositories).toHaveLength(2);
+    const byPath = Object.fromEntries(
+      manifest.repositories.map((repository) => [repository.repoPath, repository]),
+    );
+    expect(byPath["acme/api"]).toMatchObject({
+      provider: "github",
+      slug: "github__acme__api",
+      localPath: "/vercel/sandbox/repos/github__acme__api",
+      access: "read",
+      researchBaseSha: "shared-sha",
+    });
+    expect(byPath["acme/contracts"]).toMatchObject({
+      provider: "gitlab",
+      slug: "gitlab__acme__contracts",
+      localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+      access: "read",
+      researchBaseSha: "shared-sha",
+    });
   });
 });
 

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
@@ -27,15 +27,27 @@ vi.mock("@vercel/sandbox", () => ({
 }));
 vi.mock("./credentials.js", () => ({ getSandboxCredentials: () => ({ teamId: "team" }) }));
 vi.mock("../lib/vcs-runtime.js", () => ({
-  createRepositoryVcsRuntime: vi.fn(() => ({
-    config: {
-      kind: "github",
-      host: "https://github.com",
-      auth: { appId: 1, privateKeyBase64: "pem", installationId: 2 },
-    },
-    getToken: mocks.getToken,
-    vcs: { getBranchSha: mocks.getBranchSha, getPRHead: mocks.getPrHead },
-  })),
+  createRepositoryVcsRuntime: vi.fn((target: { provider: "github" | "gitlab" }) =>
+    target.provider === "gitlab"
+      ? {
+          config: {
+            kind: "gitlab",
+            host: "https://gitlab.com",
+            auth: { token: "glpat" },
+          },
+          getToken: async () => "gitlab-token",
+          vcs: { getBranchSha: mocks.getBranchSha, getPRHead: mocks.getPrHead },
+        }
+      : {
+          config: {
+            kind: "github",
+            host: "https://github.com",
+            auth: { appId: 1, privateKeyBase64: "pem", installationId: 2 },
+          },
+          getToken: mocks.getToken,
+          vcs: { getBranchSha: mocks.getBranchSha, getPRHead: mocks.getPrHead },
+        },
+  ),
 }));
 vi.mock("../../env.js", () => ({ env: { JOB_TIMEOUT_MS: 120_000 } }));
 vi.mock("../lib/step-adapters.js", () => ({
@@ -346,5 +358,87 @@ describe("trusted workspace publisher", () => {
 
     expect(result).toMatchObject({ pushed: true, repositories: [{ pushedHead: "after" }] });
     expect(mocks.createSandbox).not.toHaveBeenCalled();
+  });
+
+  it("pushes a github and a gitlab write repository each with its own provider credentials", async () => {
+    const githubRepo = repository("acme/api", "/vercel/sandbox");
+    const gitlabRepo = {
+      ...repository("acme/contracts", "/vercel/sandbox/repos/gitlab__acme__contracts"),
+      provider: "gitlab" as const,
+    };
+    const mixedManifest: WorkspaceManifest = {
+      version: 1,
+      repositories: [githubRepo, gitlabRepo],
+    };
+    // Preflight, then post-push, once per repository in manifest order.
+    mocks.getBranchSha
+      .mockReset()
+      .mockResolvedValueOnce("before-acme/api")
+      .mockResolvedValueOnce("before-acme/contracts")
+      .mockResolvedValueOnce("after-api")
+      .mockResolvedValueOnce("after-contracts");
+    mocks.sourceCommand.mockImplementation(async (_name: string, args: string[]) => {
+      if (args.includes("rev-parse")) {
+        return command(
+          args.includes(gitlabRepo.localPath) ? "after-contracts" : "after-api",
+        );
+      }
+      return command();
+    });
+    mocks.publisherCommand.mockImplementation(async (_name: string, args: string[]) => {
+      const isGitlab = args.some((arg) => arg.includes("/publisher/1"));
+      if (args.includes("rev-parse") && args.at(-1) === "HEAD") {
+        return command(isGitlab ? "before-acme/contracts" : "before-acme/api");
+      }
+      if (args.includes("rev-parse") && args.at(-1) === "FETCH_HEAD") {
+        return command(isGitlab ? "after-contracts" : "after-api");
+      }
+      return command();
+    });
+
+    const result = await publishTrustedWorkspaceFromSandbox({
+      sourceSandboxId: "source-sandbox",
+      workspaceManifest: mixedManifest,
+      ...owner,
+    });
+
+    const pushes = mocks.publisherCommand.mock.calls.filter(([, args]) =>
+      (args as string[]).includes("push"),
+    );
+    const githubPush = pushes.find(([, args]) =>
+      (args as string[]).includes("https://github.com/acme/api.git"),
+    );
+    const gitlabPush = pushes.find(([, args]) =>
+      (args as string[]).includes("https://gitlab.com/acme/contracts.git"),
+    );
+    // Each push targets its own provider's host, force-with-lease baseline, and
+    // credentials (github via x-access-token, gitlab via oauth2).
+    expect(githubPush?.[1]).toEqual(
+      expect.arrayContaining([
+        `http.extraHeader=AUTHORIZATION: Basic ${Buffer.from("x-access-token:secret").toString("base64")}`,
+        "--force-with-lease=refs/heads/blazebot/AIW-100:before-acme/api",
+      ]),
+    );
+    expect(gitlabPush?.[1]).toEqual(
+      expect.arrayContaining([
+        `http.extraHeader=AUTHORIZATION: Basic ${Buffer.from("oauth2:gitlab-token").toString("base64")}`,
+        "--force-with-lease=refs/heads/blazebot/AIW-100:before-acme/contracts",
+      ]),
+    );
+
+    expect(result.pushed).toBe(true);
+    const byPath = Object.fromEntries(
+      result.repositories.map((repo) => [repo.repoPath, repo]),
+    );
+    expect(byPath["acme/api"]).toMatchObject({
+      provider: "github",
+      pushed: true,
+      pushedHead: "after-api",
+    });
+    expect(byPath["acme/contracts"]).toMatchObject({
+      provider: "gitlab",
+      pushed: true,
+      pushedHead: "after-contracts",
+    });
   });
 });

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
@@ -310,6 +310,52 @@ describe("trusted workspace publisher", () => {
     expect(mocks.createSandbox).not.toHaveBeenCalled();
   });
 
+  it("ignores an untracked file in a write repository and still pushes", async () => {
+    // AWT-1049: the agent left a session-memory file untracked in the write
+    // checkout (nondeterministic: earlier runs committed it). It cannot enter
+    // the commit bundle (HEAD ^expectedRemoteSha), so publication must proceed.
+    mocks.sourceCommand.mockImplementation(async (_name: string, args: string[]) => {
+      if (args.includes("status")) {
+        return args.includes("--untracked-files=all")
+          ? command("?? blazebot/memory/AWT-1049.md")
+          : command();
+      }
+      if (args.includes("rev-parse")) return command("after");
+      return command();
+    });
+
+    const result = await publishTrustedWorkspaceFromSandbox({
+      sourceSandboxId: "source-sandbox",
+      workspaceManifest: manifest,
+      ...owner,
+    });
+
+    expect(result.pushed).toBe(true);
+    expect(result.repositories[0]?.failureKind).toBeUndefined();
+    const writeStatus = mocks.sourceCommand.mock.calls.find(([, args]) =>
+      (args as string[]).includes("status"),
+    );
+    expect(writeStatus?.[1]).toContain("--untracked-files=no");
+    expect(writeStatus?.[1]).not.toContain("--untracked-files=all");
+  });
+
+  it("still fails a write repository with a tracked modification before push", async () => {
+    mocks.sourceCommand.mockImplementation(async (_name: string, args: string[]) => {
+      if (args.includes("status")) return command(" M src/index.ts");
+      if (args.includes("rev-parse")) return command("after");
+      return command();
+    });
+
+    const result = await publishTrustedWorkspaceFromSandbox({
+      sourceSandboxId: "source-sandbox",
+      workspaceManifest: manifest,
+      ...owner,
+    });
+
+    expect(result.repositories[0]).toMatchObject({ failureKind: "dirty_worktree" });
+    expect(mocks.createSandbox).not.toHaveBeenCalled();
+  });
+
   it("preflights every publisher checkout before pushing any repository", async () => {
     const repositories = [
       repository("acme/api", "/vercel/sandbox"),

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.ts
@@ -101,8 +101,8 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
       // Research agents leave untracked build/test artifacts in read-only
       // clones. They cannot enter the publication bundle (it exports commit
       // ranges), so ignore untracked entries here and fail only on tracked
-      // modifications or a moved HEAD. Write repositories keep the stricter
-      // untracked check below unchanged.
+      // modifications or a moved HEAD. The write-repository check below applies
+      // the same tolerance for the same reason.
       const status = await source.runCommand("git", [
         "-C",
         repo.localPath,
@@ -169,12 +169,18 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
       continue;
     }
 
+    // Agent phases (research and implementation) run inside the write checkout
+    // and leave untracked scratch behind, e.g. a session-memory file the agent
+    // did not commit. Publication ships a commit bundle (HEAD ^expectedRemoteSha),
+    // so untracked files physically cannot enter the PR; ignore them and fail
+    // only on tracked modifications or deletions, which are real work that would
+    // be lost if not committed.
     const status = await source.runCommand("git", [
       "-C",
       repo.localPath,
       "status",
       "--porcelain=v1",
-      "--untracked-files=all",
+      "--untracked-files=no",
     ]);
     const dirty = status.exitCode === 0 ? (await status.stdout()).trim() : "";
     if (status.exitCode !== 0 || dirty) {

--- a/apps/worker/src/workflows/repository-promotion.test.ts
+++ b/apps/worker/src/workflows/repository-promotion.test.ts
@@ -421,6 +421,120 @@ describe("repository write-scope promotion", () => {
     ).rejects.toThrow("not attached");
   });
 
+  it("promotes a github and a gitlab write repository in one call, per provider", async () => {
+    const mixedManifest: WorkspaceManifestV2 = {
+      version: 2,
+      repositories: [
+        {
+          provider: "github",
+          repoPath: "acme/api",
+          slug: "github__acme__api",
+          localPath: "/vercel/sandbox/repos/github__acme__api",
+          defaultBranch: "main",
+          branchName: "main",
+          selectedRationale: "ticket",
+          access: "read",
+          researchBaseSha: "gh-base",
+        },
+        {
+          provider: "gitlab",
+          repoPath: "acme/contracts",
+          slug: "gitlab__acme__contracts",
+          localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+          defaultBranch: "main",
+          branchName: "main",
+          selectedRationale: "shared",
+          access: "read",
+          researchBaseSha: "gl-base",
+        },
+      ],
+    };
+    const mixedProviders = [
+      { kind: "github" as const, host: "https://github.com", getToken: async () => "gh-token" },
+      { kind: "gitlab" as const, host: "https://gitlab.com", getToken: async () => "gl-token" },
+    ];
+    // Each repository's checked-out HEAD (and thus preAgentSha) is keyed on its
+    // own localPath, and the provider adapter's SHA on its own provider, so the
+    // two repositories carry distinct baselines through the promotion.
+    const shaForPath = (localPath: string) =>
+      localPath.includes("gitlab__acme__contracts") ? "gl-base" : "gh-base";
+    const shaForRepo = (repository: { provider: string }) =>
+      repository.provider === "gitlab" ? "gl-base" : "gh-base";
+    const sandbox = {
+      runCommand: vi.fn(async (command: string, args: string[]) => {
+        if (command === "git" && args.includes("status")) return commandResult("");
+        if (command === "git" && args.includes("rev-parse")) {
+          const localPath = args[args.indexOf("-C") + 1] ?? "";
+          return commandResult(shaForPath(localPath));
+        }
+        return commandResult();
+      }),
+      writeFiles: vi.fn().mockResolvedValue(undefined),
+    };
+    const controller = {
+      getResearchBranchSha: vi.fn(async (repository) => shaForRepo(repository)),
+      findOwnedBranch: vi.fn().mockResolvedValue(null),
+      getBranchShaIfExists: vi.fn().mockResolvedValue(null),
+      createBranchIfMissing: vi.fn().mockResolvedValue("created"),
+      resetOwnedBranch: vi.fn().mockResolvedValue(undefined),
+      recordOwnedBranch: vi.fn().mockResolvedValue(undefined),
+      assertRepositoryAllowed: vi.fn().mockResolvedValue(undefined),
+      getBranchSha: vi.fn(async (repository) => shaForRepo(repository)),
+    };
+
+    const result = await promoteRepositoryWriteScope({
+      sandbox,
+      manifest: mixedManifest,
+      writeRepositories: [
+        { provider: "github", repoPath: "acme/api", rationale: "implementation" },
+        { provider: "gitlab", repoPath: "acme/contracts", rationale: "implementation" },
+      ],
+      branchName: "blazebot/aiw-147",
+      controller,
+      providers: mixedProviders,
+    });
+
+    // Each repository's branch is created through its own provider's adapter,
+    // cut from that provider's research baseline.
+    expect(controller.createBranchIfMissing).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "github", repoPath: "acme/api" }),
+      "blazebot/aiw-147",
+      "gh-base",
+    );
+    expect(controller.createBranchIfMissing).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "gitlab", repoPath: "acme/contracts" }),
+      "blazebot/aiw-147",
+      "gl-base",
+    );
+    // Ownership is recorded once per repository.
+    expect(controller.recordOwnedBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "github", repoPath: "acme/api" }),
+      "blazebot/aiw-147",
+    );
+    expect(controller.recordOwnedBranch).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "gitlab", repoPath: "acme/contracts" }),
+      "blazebot/aiw-147",
+    );
+
+    const byPath = Object.fromEntries(
+      result.repositories.map((repository) => [repository.repoPath, repository]),
+    );
+    expect(byPath["acme/api"]).toMatchObject({
+      provider: "github",
+      access: "write",
+      branchName: "blazebot/aiw-147",
+      preAgentSha: "gh-base",
+      expectedRemoteSha: "gh-base",
+    });
+    expect(byPath["acme/contracts"]).toMatchObject({
+      provider: "gitlab",
+      access: "write",
+      branchName: "blazebot/aiw-147",
+      preAgentSha: "gl-base",
+      expectedRemoteSha: "gl-base",
+    });
+  });
+
   it("points at an earlier identity-resolution failure when a provider is unconfigured", async () => {
     const { sandbox, controller } = setup();
     const gitlabManifest: WorkspaceManifestV2 = {

--- a/apps/worker/src/workflows/workspace-gate.test.ts
+++ b/apps/worker/src/workflows/workspace-gate.test.ts
@@ -52,6 +52,7 @@ const manifest: WorkspaceManifest = {
 let manifestRaw = JSON.stringify(manifest);
 let heads = new Map<string, string>();
 let dirty = new Set<string>();
+let untracked = new Set<string>();
 
 function commandResult(exitCode: number, stdout = "", stderr = "") {
   return {
@@ -67,7 +68,15 @@ function sandbox() {
       if (cmd === "cat") return commandResult(0, manifestRaw);
       const path = args[1]!;
       if (args.includes("status")) {
-        return commandResult(0, dirty.has(path) ? " M src/index.ts" : "");
+        // Model git faithfully: tracked modifications surface under every
+        // --untracked-files mode, but untracked entries only appear when the
+        // caller asks for them (--untracked-files=all), never under =no.
+        const lines: string[] = [];
+        if (dirty.has(path)) lines.push(" M src/index.ts");
+        if (untracked.has(path) && args.includes("--untracked-files=all")) {
+          lines.push("?? scratch/build.log");
+        }
+        return commandResult(0, lines.join("\n"));
       }
       if (args.includes("rev-parse")) {
         const head = heads.get(path);
@@ -87,6 +96,7 @@ describe("workspace gate", () => {
       ["/vercel/sandbox/repos/gitlab__acme__api", "api-base"],
     ]);
     dirty = new Set();
+    untracked = new Set();
     mocks.getDb.mockReturnValue({ db: true });
     mocks.getCurrentPrePrCheckConfig.mockResolvedValue(null);
     mocks.sandboxGet.mockImplementation(async () => sandbox());
@@ -169,6 +179,35 @@ describe("workspace gate", () => {
         configurationVersion: 7,
       }),
     ).rejects.toThrow("does not match");
+  });
+
+  it("tolerates untracked-only dirt but still fails on tracked modifications", async () => {
+    // A write repo with no in-tree .gitignore (e.g. a bare GitLab repo) surfaces
+    // the untracked build/test scratch that in-workspace research phases leave
+    // behind. That scratch never enters the publication bundle (commit ranges
+    // only), so the gate must record cleanly instead of throwing.
+    untracked.add("/vercel/sandbox/repos/gitlab__acme__api");
+    const gate = await recordSuccessfulWorkspaceGate({
+      sandboxId: "sbx-1",
+      workspaceManifest: manifest,
+      configurationVersion: 7,
+    });
+    expect(gate).toEqual({
+      configurationVersion: 7,
+      fingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+
+    // A tracked, uncommitted modification is real work that would be lost, so it
+    // must still fail the gate.
+    untracked.clear();
+    dirty.add("/vercel/sandbox/repos/gitlab__acme__api");
+    await expect(
+      recordSuccessfulWorkspaceGate({
+        sandboxId: "sbx-1",
+        workspaceManifest: manifest,
+        configurationVersion: 7,
+      }),
+    ).rejects.toThrow("Run Workspace is not clean");
   });
 
   it("does not require a gate when configuration is absent or inapplicable", async () => {

--- a/apps/worker/src/workflows/workspace-gate.ts
+++ b/apps/worker/src/workflows/workspace-gate.ts
@@ -176,12 +176,18 @@ async function inspectWorkspaceForGateStep(
   const repositories: InspectedWorkspaceRepository[] = [];
   const headShas: string[] = [];
   for (const repo of manifest.repositories) {
+    // Research and implementation now run inside the shared code workspace, so
+    // agent phases leave untracked build/test/scratch artifacts behind. Those
+    // never enter the publication bundle (it exports commit ranges), so ignore
+    // untracked entries and fail only on tracked modifications (staged or
+    // unstaged) that would be lost if not committed. This matches the read-check
+    // tolerance in repository-promotion.ts and trusted-workspace-publisher.ts.
     const status = await sandbox.runCommand("git", [
       "-C",
       repo.localPath,
       "status",
       "--porcelain=v1",
-      "--untracked-files=all",
+      "--untracked-files=no",
     ]);
     if (status.exitCode !== 0 || (await status.stdout()).trim().length > 0) {
       throw new Error(`Run Workspace is not clean for ${repo.provider}:${repo.repoPath}`);


### PR DESCRIPTION
## Goal

Close the verification and documentation gaps for mixed GitHub + GitLab deployments on top of AIW-147 multi-repo research. An architecture audit confirmed every runtime path (catalog, discovery, provisioning, expansion attach, write promotion, publication, webhooks, manual dispatch) is already provider-scoped per repository and both providers can be configured additively in one deployment; four seams lacked a positive mixed-provider test and the onboarding docs still framed provider choice as either/or.

## What changed

- **Tests only, no production changes**:
  - `repository-promotion.test.ts`: promotes a GitHub write repo and a GitLab write repo in one call; per-provider branch creation from each repo's own research baseline, per-repo ledger ownership, both flipped to write with their own trusted baselines.
  - `trusted-workspace-publisher.test.ts`: the `createRepositoryVcsRuntime` mock now echoes the requested provider (it previously hardcoded GitHub, masking this whole class); new test pushes a GitHub and a GitLab write repo in one publication, asserting each push uses its own host, force-with-lease baseline, and auth header.
  - `research-workspace.test.ts`: one expansion batch materializes and attaches a GitHub and a GitLab repository, each cloned with its own provider's URL and credentials, both landing in the trusted manifest.
  - `gitlab.test.ts`: nested-namespace project paths (`group/subgroup/repo`) through branch create/reset, MR lookup, and the URL-encoded REST path.
- **Docs**: SETUP.md now states provider credentials are additive (GitHub, GitLab, or both in one deployment; `VCS_KIND` optional, only pins the legacy single-repo helpers; per-provider bot logins in mixed deployments). The `init-vcs` setup skill supports the "both" choice and drops the removed `GITHUB_TOKEN` PAT flow in favor of the GitHub App variables.

## Verification

- Targeted suites (promotion, publisher, research-workspace, gitlab adapter, workspace-publication, multi-repo scenarios): 104 tests green; `pnpm --filter worker typecheck` clean.
- Live mixed smoke evidence on the `ai-workflow-demo` environment is appended below once executed.

## Live mixed smoke evidence (ai-workflow-demo environment, 2026-07-25)

Deployed this branch to the `ai-workflow-demo` custom environment with `AGENT_ALLOWED_REPOS` spanning both providers (`Blazity/ai-workflow-demo` on GitHub + `filipmaszota3/ai-workflow-integration-test` on GitLab):

- **GitLab-only run** (AWT-1047): Jira ticket -> read-only research in the workspace -> ledger-guarded write promotion created `ai-workflow/awt-1047` on GitLab -> implementation -> merge request opened: filipmaszota3/ai-workflow-integration-test!1.
- **Mixed run, the headline scenario** (AWT-1050): ONE ticket requesting a change in both repositories -> one run cloned a GitHub and a GitLab repository into one workspace, promoted write scope on both providers, and published one artifact per repository: GitHub PR Blazity/ai-workflow-demo#310 and GitLab MR filipmaszota3/ai-workflow-integration-test!2, each containing exactly the requested `AUTOMATION.md`.

The smoke surfaced two policy inconsistencies with AIW-147's planning-in-workspace model, both fixed here with RED-first tests:
- the checks-phase workspace gate counted untracked agent scratch as dirt (`--untracked-files=all`); a bare GitLab repo without a `.gitignore` exposed it while the GitHub demo app's `.gitignore` had been masking it;
- the publisher's write-repo preflight had the same strictness and failed a publication over an uncommitted agent session-memory file, even though publication ships commit bundles and untracked files cannot leak into a PR.

Both checks now count tracked modifications and deletions only, matching the read-repo policy.
