### PR TITLE
AIW-140: ingest PR review comments without duplicate or recursive runs

### DIFF
--- a/apps/worker/drizzle/0028_semantic_key.sql
+++ b/apps/worker/drizzle/0028_semantic_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "trigger_deliveries" ADD COLUMN "semantic_key" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "trigger_deliveries_semantic_key_idx" ON "trigger_deliveries" USING btree ("provider","semantic_key") WHERE "trigger_deliveries"."semantic_key" is not null;

--- a/apps/worker/drizzle/meta/0028_snapshot.json
+++ b/apps/worker/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,4200 @@
+{
+  "id": "03ad243e-928a-4129-93c2-3e7ac7592d92",
+  "prevId": "47016a00-9a2a-4d3d-bc9c-bce9658fb1cf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1784908074098,
       "tag": "0027_married_retro_girl",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1785145357799,
+      "tag": "0028_semantic_key",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/env.test.ts
+++ b/apps/worker/env.test.ts
@@ -237,7 +237,7 @@ describe("env", () => {
     const { env, getVcsBotLogin } = await import("./env.js");
 
     expect(env.GITHUB_BOT_LOGIN).toBe("GitHub-App[Bot]");
-    expect(getVcsBotLogin("github")).toBe("github-app[bot]");
+    expect(getVcsBotLogin("github")).toBe("github-app");
   });
 
   it("uses the legacy bot login only for an unambiguous single provider", async () => {
@@ -263,7 +263,7 @@ describe("env", () => {
 
     const { getVcsBotLogin } = await import("./env.js");
 
-    expect(getVcsBotLogin("github")).toBe("github-app[bot]");
+    expect(getVcsBotLogin("github")).toBe("github-app");
     expect(getVcsBotLogin("gitlab")).toBeUndefined();
   });
 

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -229,7 +229,7 @@ export class GitHubAdapter
     if (state !== "open" && state !== "closed" && state !== "merged") {
       throw new Error(`GitHub PR #${prId} has unsupported lifecycle state ${String(state)}`);
     }
-    return { headSha: data.head.sha, baseRef, state };
+    return { headSha: data.head.sha, headRef: data.head.ref, baseRef, state };
   }
 
   async getManualDispatchPullRequest(

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -384,6 +384,7 @@ export class GitLabAdapter implements
         : undefined;
     return {
       headSha,
+      ...(mr.source_branch ? { headRef: mr.source_branch } : {}),
       baseRef,
       state,
       ...(typeof headPipelineId === "number" ? { headPipelineId } : {}),

--- a/apps/worker/src/adapters/vcs/types.ts
+++ b/apps/worker/src/adapters/vcs/types.ts
@@ -6,6 +6,9 @@ export interface PullRequest {
 
 export interface PullRequestHead {
   headSha: string;
+  /** Provider-authoritative source branch (GitHub head / GitLab source). Comment
+   * events carry no branch name, so binding adopts this instead. */
+  headRef?: string;
   /** Provider-authoritative target branch (GitHub base / GitLab target). */
   baseRef: string;
   /** Provider-neutral current PR/MR lifecycle state. */

--- a/apps/worker/src/db/queries/workflow-owned-branches.test.ts
+++ b/apps/worker/src/db/queries/workflow-owned-branches.test.ts
@@ -550,4 +550,62 @@ describe("workflow-owned branch records", () => {
       }),
     ).resolves.toBeNull();
   });
+
+  it("matches a confirmed PR by head and target when the branch name is unknown", async () => {
+    // issue_comment events carry no branch name. The published-head-SHA and
+    // target-branch checks alone still prove workflow ownership.
+    const db = await createTestDb();
+    await upsertWorkflowOwnedBranch(db, {
+      ticketKey: "AIW-140",
+      provider: "github",
+      repoPath: "acme/web",
+      branchName: "blazebot/aiw-140",
+      publishedHeadSha: "published-sha",
+      targetBranch: "main",
+      pr: {
+        id: 88,
+        url: "https://github.com/acme/web/pull/88",
+        branch: "blazebot/aiw-140",
+      },
+    });
+
+    await expect(
+      findWorkflowOwnedPullRequest(db, {
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 88,
+        branchName: "",
+        publishedHeadSha: "published-sha",
+        baseBranch: "main",
+      }),
+    ).resolves.toMatchObject({ ticketKey: "AIW-140", pr: { id: 88 } });
+  });
+
+  it("does not match an unknown-branch lookup when the head sha differs", async () => {
+    const db = await createTestDb();
+    await upsertWorkflowOwnedBranch(db, {
+      ticketKey: "AIW-140",
+      provider: "github",
+      repoPath: "acme/web",
+      branchName: "blazebot/aiw-140",
+      publishedHeadSha: "published-sha",
+      targetBranch: "main",
+      pr: {
+        id: 88,
+        url: "https://github.com/acme/web/pull/88",
+        branch: "blazebot/aiw-140",
+      },
+    });
+
+    await expect(
+      findWorkflowOwnedPullRequest(db, {
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 88,
+        branchName: "",
+        publishedHeadSha: "human-push",
+        baseBranch: "main",
+      }),
+    ).resolves.toBeNull();
+  });
 });

--- a/apps/worker/src/db/queries/workflow-owned-branches.ts
+++ b/apps/worker/src/db/queries/workflow-owned-branches.ts
@@ -116,7 +116,12 @@ export async function findWorkflowOwnedPullRequest(
         eq(workflowOwnedBranches.provider, input.provider),
         eq(workflowOwnedBranches.repoPath, input.repoPath),
         eq(workflowOwnedBranches.prId, input.prNumber),
-        eq(workflowOwnedBranches.prBranchName, input.branchName),
+        // issue_comment events cannot know the PR branch name. Dropping only the
+        // branch equality still leaves the published-head-SHA and target-branch
+        // checks below, which prove the workflow itself published this head.
+        input.branchName
+          ? eq(workflowOwnedBranches.prBranchName, input.branchName)
+          : undefined,
         or(
           eq(workflowOwnedBranches.prPublishedHeadSha, input.publishedHeadSha),
           and(

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -92,6 +92,9 @@ export const triggerDeliveries = pgTable(
     provider: text("provider").notNull(),
     deliveryId: text("delivery_id").notNull(),
     producer: text("producer").notNull(),
+    /** Stable identity of the human action behind this delivery. One review's
+     * fan-out of N webhooks shares one key so it accepts exactly one run. */
+    semanticKey: text("semantic_key"),
     triggerType: text("trigger_type").notNull(),
     subjectKey: text("subject_key").notNull(),
     ticketKey: text("ticket_key"),
@@ -109,6 +112,9 @@ export const triggerDeliveries = pgTable(
     uniqueIndex("trigger_deliveries_one_pending_per_subject_idx")
       .on(t.subjectKey)
       .where(sql`${t.pending} = true`),
+    uniqueIndex("trigger_deliveries_semantic_key_idx")
+      .on(t.provider, t.semanticKey)
+      .where(sql`${t.semanticKey} is not null`),
     foreignKey({
       columns: [t.definitionId, t.definitionVersion],
       foreignColumns: [

--- a/apps/worker/src/lib/dispatch-pr-trigger-coalesce.test.ts
+++ b/apps/worker/src/lib/dispatch-pr-trigger-coalesce.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ActiveRunEntry,
   RunRegistryAdapter,
   RunReservation,
 } from "../adapters/run-registry/types.js";
+import type { Db } from "../db/client.js";
+import {
+  workflowDefinitions,
+  workflowDefinitionVersions,
+} from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
 import { claimSubjectRun } from "./dispatch.js";
+import {
+  acceptTriggerDelivery,
+  coalescePendingTrigger,
+  completeTriggerDelivery,
+  listPendingTriggersForSubject,
+  type AcceptedTriggerDelivery,
+} from "./trigger-delivery-store.js";
 
 vi.mock("../../env.js", () => ({
   env: { JIRA_PROJECT_KEY: "PROJ", COLUMN_AI: "AI" },
@@ -120,5 +133,101 @@ describe("PR trigger coalescing with owner-CAS", () => {
     });
     expect(await runRegistry.release(subject.subjectKey, predecessorOwner, "run-1")).toBe(false);
     expect(await runRegistry.get(subject.subjectKey)).not.toBeNull();
+  });
+});
+
+describe("PR trigger semantic dedup at the coalesce boundary", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await db.insert(workflowDefinitions).values({
+      id: 7,
+      name: "Coalesce test",
+      createdById: "test",
+      createdByLabel: "Test",
+    });
+    await db.insert(workflowDefinitionVersions).values({
+      definitionId: 7,
+      version: 11,
+      definition: {},
+      createdById: "test",
+      createdByLabel: "Test",
+    });
+  });
+
+  function prReview(
+    deliveryId: string,
+    semanticKey: string,
+  ): AcceptedTriggerDelivery {
+    return {
+      delivery: {
+        provider: "github",
+        producer: "human",
+        deliveryId,
+        semanticKey,
+      },
+      triggerType: "trigger_pr_review",
+      scope: "workflow_owned",
+      subjectKey: subject.subjectKey,
+      ticketKey: null,
+      definitionId: 7,
+      definitionVersion: 11,
+      pr: {
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 7,
+        prUrl: "https://github.com/acme/app/pull/7",
+        headRef: "feature/x",
+        headSha: "sha-1",
+        baseRef: "main",
+        title: "Review me",
+        author: "alice",
+        isDraft: false,
+        review: { state: "commented", author: "human", body: "fix this" },
+      },
+    };
+  }
+
+  // Faithful model of dispatchTriggerEvent's accept-then-coalesce decision
+  // (dispatch-trigger.ts:148-153 and :288): a duplicate (semantic or exact)
+  // short-circuits without ever coalescing; a fresh delivery either becomes the
+  // run on an idle subject or coalesces into the one pending successor while the
+  // subject is busy.
+  async function dispatch(
+    accepted: AcceptedTriggerDelivery,
+    subjectBusy: boolean,
+  ): Promise<"started" | "coalesced" | "deduped"> {
+    const durable = await acceptTriggerDelivery(db, accepted);
+    if (!durable.inserted) return "deduped";
+    if (subjectBusy) {
+      await coalescePendingTrigger(db, durable.stored);
+      return "coalesced";
+    }
+    await completeTriggerDelivery(db, "github", accepted.delivery.deliveryId, {
+      result: "started",
+      runId: `run-${accepted.delivery.deliveryId}`,
+    });
+    return "started";
+  }
+
+  it("accepts one run for a review fan-out and queues no successor", async () => {
+    const results = [
+      await dispatch(prReview("d-review", "review:99"), false),
+      await dispatch(prReview("d-c1", "review:99"), true),
+      await dispatch(prReview("d-c2", "review:99"), true),
+    ];
+    expect(results).toEqual(["started", "deduped", "deduped"]);
+    expect(await listPendingTriggersForSubject(db, subject.subjectKey)).toHaveLength(0);
+  });
+
+  it("still coalesces two independent comments into at most one successor", async () => {
+    const results = [
+      await dispatch(prReview("d-1", "comment:1"), false),
+      await dispatch(prReview("d-2", "comment:2"), true),
+      await dispatch(prReview("d-3", "comment:3"), true),
+    ];
+    expect(results).toEqual(["started", "coalesced", "coalesced"]);
+    expect(await listPendingTriggersForSubject(db, subject.subjectKey)).toHaveLength(1);
   });
 });

--- a/apps/worker/src/lib/trigger-current-pull-request.test.ts
+++ b/apps/worker/src/lib/trigger-current-pull-request.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PullRequestHead } from "../adapters/vcs/types.js";
+
+// bindCurrentPullRequest is a pure function, but the module also imports
+// createRepositoryVCS (-> env.js). Mock the runtime so the import chain never
+// validates environment variables during this unit test.
+vi.mock("./vcs-runtime.js", () => ({
+  createRepositoryVCS: vi.fn(),
+}));
+
+const { bindCurrentPullRequest } = await import("./trigger-current-pull-request.js");
+type TriggerEvent = import("./trigger-events.js").TriggerEvent;
+
+function reviewEvent(overrides: Partial<TriggerEvent["pr"]> = {}): TriggerEvent {
+  return {
+    delivery: { provider: "github", producer: "human", deliveryId: "d1" },
+    triggerType: "trigger_pr_review",
+    pr: {
+      provider: "github",
+      repoPath: "acme/app",
+      prNumber: 7,
+      prUrl: "https://github.com/acme/app/pull/7",
+      headRef: "",
+      headSha: "",
+      baseRef: "",
+      title: "Fix things",
+      author: "human",
+      isDraft: false,
+      review: { state: "commented", author: "human", body: "please fix" },
+      ...overrides,
+    },
+  };
+}
+
+const openHead: PullRequestHead = {
+  headSha: "live-sha",
+  baseRef: "main",
+  state: "open",
+};
+
+describe("bindCurrentPullRequest", () => {
+  it("adopts the current head and base for a review with empty head/base", () => {
+    const bound = bindCurrentPullRequest(reviewEvent(), openHead);
+
+    expect(bound).not.toBeNull();
+    expect(bound?.pr.headSha).toBe("live-sha");
+    expect(bound?.pr.baseRef).toBe("main");
+    // headRef has no provider equivalent in PullRequestHead and stays as-is.
+    expect(bound?.pr.headRef).toBe("");
+  });
+
+  it("keeps a non-empty matching head/base for a review", () => {
+    const bound = bindCurrentPullRequest(
+      reviewEvent({ headSha: "live-sha", baseRef: "main" }),
+      openHead,
+    );
+
+    expect(bound?.pr.headSha).toBe("live-sha");
+    expect(bound?.pr.baseRef).toBe("main");
+  });
+
+  it("rejects a review whose non-empty head no longer matches the current head", () => {
+    const bound = bindCurrentPullRequest(
+      reviewEvent({ headSha: "stale-sha", baseRef: "main" }),
+      openHead,
+    );
+
+    expect(bound).toBeNull();
+  });
+
+  it("rejects a review on a PR that is no longer open", () => {
+    const bound = bindCurrentPullRequest(reviewEvent(), { ...openHead, state: "merged" });
+
+    expect(bound).toBeNull();
+  });
+
+  it("still rejects a non-review trigger that carries an empty base ref", () => {
+    const event: TriggerEvent = {
+      delivery: { provider: "github", producer: "bot", deliveryId: "d2" },
+      triggerType: "trigger_pr_created",
+      pr: { ...reviewEvent().pr, baseRef: "", headSha: "live-sha", review: undefined },
+    };
+
+    expect(bindCurrentPullRequest(event, openHead)).toBeNull();
+  });
+});

--- a/apps/worker/src/lib/trigger-current-pull-request.test.ts
+++ b/apps/worker/src/lib/trigger-current-pull-request.test.ts
@@ -34,19 +34,33 @@ function reviewEvent(overrides: Partial<TriggerEvent["pr"]> = {}): TriggerEvent 
 
 const openHead: PullRequestHead = {
   headSha: "live-sha",
+  headRef: "blazebot/aiw-1",
   baseRef: "main",
   state: "open",
 };
 
 describe("bindCurrentPullRequest", () => {
-  it("adopts the current head and base for a review with empty head/base", () => {
+  it("adopts the current head, branch and base for a review with empty facts", () => {
     const bound = bindCurrentPullRequest(reviewEvent(), openHead);
 
     expect(bound).not.toBeNull();
     expect(bound?.pr.headSha).toBe("live-sha");
     expect(bound?.pr.baseRef).toBe("main");
-    // headRef has no provider equivalent in PullRequestHead and stays as-is.
-    expect(bound?.pr.headRef).toBe("");
+    // headRef feeds the agent's checkout branch, so it must be rehydrated too.
+    expect(bound?.pr.headRef).toBe("blazebot/aiw-1");
+  });
+
+  it("rejects a review when neither the event nor the provider knows the branch", () => {
+    // Fail closed: dispatching would hand the agent an empty branch to check out.
+    const bound = bindCurrentPullRequest(reviewEvent(), { ...openHead, headRef: undefined });
+
+    expect(bound).toBeNull();
+  });
+
+  it("prefers the event's own branch over the provider read", () => {
+    const bound = bindCurrentPullRequest(reviewEvent({ headRef: "from-payload" }), openHead);
+
+    expect(bound?.pr.headRef).toBe("from-payload");
   });
 
   it("keeps a non-empty matching head/base for a review", () => {

--- a/apps/worker/src/lib/trigger-current-pull-request.ts
+++ b/apps/worker/src/lib/trigger-current-pull-request.ts
@@ -36,11 +36,20 @@ export function bindCurrentPullRequest<T extends TriggerEvent>(
 ): T | null {
   if (!current) return null;
   const { pr } = event;
-  if (current.baseRef !== pr.baseRef) return null;
+  // Review triggers are about the PR, not a specific head. A comment event may
+  // carry no base ref (issue_comment), so an empty pr.baseRef means "unknown,
+  // adopt the provider-authoritative value" rather than "stale".
+  const isReview = event.triggerType === "trigger_pr_review";
+  if (current.baseRef !== pr.baseRef && !(isReview && pr.baseRef === "")) return null;
   const expectedState =
     event.triggerType === "trigger_pr_merged" ? "merged" : "open";
   if (current.state !== expectedState) return null;
   if (pr.provider === "github") {
+    if (isReview) {
+      // Empty pr.headSha (issue_comment) is unknown, not stale: adopt current.
+      if (pr.headSha && pr.headSha !== current.headSha) return null;
+      return { ...event, pr: { ...pr, headSha: current.headSha, baseRef: current.baseRef } };
+    }
     if (current.headSha !== pr.headSha) return null;
     if (event.triggerType !== "trigger_pr_checks_failed") return event;
     const failedChecks = (pr.failedChecks ?? []).filter((failed) =>

--- a/apps/worker/src/lib/trigger-current-pull-request.ts
+++ b/apps/worker/src/lib/trigger-current-pull-request.ts
@@ -48,7 +48,15 @@ export function bindCurrentPullRequest<T extends TriggerEvent>(
     if (isReview) {
       // Empty pr.headSha (issue_comment) is unknown, not stale: adopt current.
       if (pr.headSha && pr.headSha !== current.headSha) return null;
-      return { ...event, pr: { ...pr, headSha: current.headSha, baseRef: current.baseRef } };
+      // headRef feeds the agent's checkout branch and the owned-branch lookups,
+      // so an unknown one must come from the provider read. Fail closed rather
+      // than dispatch a run that would check out an empty branch name.
+      const headRef = pr.headRef || current.headRef || "";
+      if (!headRef) return null;
+      return {
+        ...event,
+        pr: { ...pr, headRef, headSha: current.headSha, baseRef: current.baseRef },
+      };
     }
     if (current.headSha !== pr.headSha) return null;
     if (event.triggerType !== "trigger_pr_checks_failed") return event;

--- a/apps/worker/src/lib/trigger-delivery-store.test.ts
+++ b/apps/worker/src/lib/trigger-delivery-store.test.ts
@@ -75,6 +75,14 @@ function delivery(
   };
 }
 
+function reviewFanout(
+  deliveryId: string,
+  semanticKey: string,
+): AcceptedTriggerDelivery {
+  const base = delivery(deliveryId, { triggerType: "trigger_pr_review" });
+  return { ...base, delivery: { ...base.delivery, semanticKey } };
+}
+
 describe("provider event inbox", () => {
   it("deduplicates provider retries without changing the original version pin", async () => {
     expect((await acceptTriggerDelivery(db, delivery())).inserted).toBe(true);
@@ -191,5 +199,54 @@ describe("provider event inbox", () => {
       pending: false,
       result: { result: "started", runId: "run-1" },
     });
+  });
+
+  it("accepts one review fan-out: a shared semantic key returns the winner's envelope", async () => {
+    const winner = await acceptTriggerDelivery(db, reviewFanout("d-review", "review:99"));
+    expect(winner.inserted).toBe(true);
+
+    const sibling = await acceptTriggerDelivery(db, reviewFanout("d-comment", "review:99"));
+    expect(sibling.inserted).toBe(false);
+    expect(sibling.stored.delivery.deliveryId).toBe("d-review");
+    expect(sibling.stored.delivery.semanticKey).toBe("review:99");
+  });
+
+  it("resolves the semantic winner even after it has a result recorded", async () => {
+    await acceptTriggerDelivery(db, reviewFanout("d-review", "review:100"));
+    await completeTriggerDelivery(db, "github", "d-review", {
+      result: "started",
+      runId: "run-9",
+    });
+
+    const sibling = await acceptTriggerDelivery(db, reviewFanout("d-comment", "review:100"));
+    expect(sibling.inserted).toBe(false);
+    expect(sibling.stored).toMatchObject({
+      delivery: { deliveryId: "d-review" },
+      result: { result: "started", runId: "run-9" },
+    });
+  });
+
+  it("inserts separately when semantic keys differ", async () => {
+    const first = await acceptTriggerDelivery(db, reviewFanout("d-1", "review:1"));
+    const second = await acceptTriggerDelivery(db, reviewFanout("d-2", "review:2"));
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(true);
+  });
+
+  it("never conflicts two deliveries that carry no semantic key", async () => {
+    const first = await acceptTriggerDelivery(db, delivery("d-1"));
+    const second = await acceptTriggerDelivery(db, delivery("d-2"));
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(true);
+  });
+
+  it("replays the original by delivery id even when a semantic key is set", async () => {
+    await acceptTriggerDelivery(db, reviewFanout("d-review", "review:7"));
+    const replay = await acceptTriggerDelivery(
+      db,
+      reviewFanout("d-review", "review:7"),
+    );
+    expect(replay.inserted).toBe(false);
+    expect(replay.stored.delivery.deliveryId).toBe("d-review");
   });
 });

--- a/apps/worker/src/lib/trigger-delivery-store.ts
+++ b/apps/worker/src/lib/trigger-delivery-store.ts
@@ -34,7 +34,10 @@ export interface StoredTriggerDelivery extends AcceptedTriggerDelivery {
 }
 
 /** Insert one fully authenticated and normalized provider event. Provider
- * retries return the first stored envelope and can never change its pin. */
+ * retries return the first stored envelope and can never change its pin. A
+ * delivery whose semantic key already exists returns the semantic winner's
+ * envelope instead: the loser's delivery id is never recorded, and provider
+ * redeliveries of the loser keep resolving to the same winner. */
 export async function acceptTriggerDelivery(
   db: Db,
   accepted: AcceptedTriggerDelivery,
@@ -48,6 +51,7 @@ export async function acceptTriggerDelivery(
       provider: accepted.delivery.provider,
       deliveryId: accepted.delivery.deliveryId,
       producer: accepted.delivery.producer,
+      semanticKey: accepted.delivery.semanticKey ?? null,
       triggerType: accepted.triggerType,
       subjectKey: accepted.subjectKey,
       ticketKey: accepted.ticketKey,
@@ -56,16 +60,22 @@ export async function acceptTriggerDelivery(
       definitionVersion: accepted.definitionVersion,
       payload: accepted,
     })
-    .onConflictDoNothing({
-      target: [triggerDeliveries.provider, triggerDeliveries.deliveryId],
-    })
+    .onConflictDoNothing()
     .returning();
   if (rows[0]) return { inserted: true, stored: mapDelivery(rows[0]) };
-  const stored = await getTriggerDelivery(
-    db,
-    accepted.delivery.provider,
-    accepted.delivery.deliveryId,
-  );
+  const stored =
+    (await getTriggerDelivery(
+      db,
+      accepted.delivery.provider,
+      accepted.delivery.deliveryId,
+    )) ??
+    (accepted.delivery.semanticKey
+      ? await getTriggerDeliveryBySemanticKey(
+          db,
+          accepted.delivery.provider,
+          accepted.delivery.semanticKey,
+        )
+      : null);
   if (!stored) throw new Error("trigger delivery disappeared after unique conflict");
   return { inserted: false, stored };
 }
@@ -120,6 +130,26 @@ export async function getTriggerDelivery(
       and(
         eq(triggerDeliveries.provider, provider),
         eq(triggerDeliveries.deliveryId, deliveryId),
+      ),
+    )
+    .limit(1);
+  return rows[0] ? mapDelivery(rows[0]) : null;
+}
+
+/** Resolve the delivery that owns a semantic key (the winner of a
+ * semantic-key conflict). */
+export async function getTriggerDeliveryBySemanticKey(
+  db: Db,
+  provider: "github" | "gitlab",
+  semanticKey: string,
+): Promise<StoredTriggerDelivery | null> {
+  const rows = await db
+    .select()
+    .from(triggerDeliveries)
+    .where(
+      and(
+        eq(triggerDeliveries.provider, provider),
+        eq(triggerDeliveries.semanticKey, semanticKey),
       ),
     )
     .limit(1);
@@ -349,6 +379,7 @@ function mapDelivery(row: typeof triggerDeliveries.$inferSelect): StoredTriggerD
       deliveryId: row.deliveryId,
       producer: row.producer,
       ...(payload.delivery.source ? { source: payload.delivery.source } : {}),
+      ...(row.semanticKey ? { semanticKey: row.semanticKey } : {}),
     },
     triggerType: row.triggerType as PrTriggerType,
     subjectKey: row.subjectKey,

--- a/apps/worker/src/lib/trigger-events.test.ts
+++ b/apps/worker/src/lib/trigger-events.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { normalizeGitHubEvent, normalizeGitLabEvent } from "./trigger-events.js";
+import { AI_WORKFLOW_COMMENT_MARKER } from "./vcs-bot-identity.js";
 
 const options = {
   gateCheckNames: [
@@ -340,6 +341,315 @@ describe("normalizeGitHubEvent", () => {
     expect(evt).toBeNull();
   });
 
+  it("adds a semantic key derived from the review id", () => {
+    const evt = normalizeGitHubEvent(
+      "pull_request_review",
+      {
+        action: "submitted",
+        repository: githubRepo(),
+        pull_request: githubPr(),
+        review: { id: 321, state: "changes_requested", user: { login: "human" }, body: "please fix" },
+      },
+      options,
+    );
+    expect(evt?.delivery.semanticKey).toBe("review:321");
+  });
+
+  const commentOptions = { ...options, reviewStates: ["commented"] as const };
+
+  it("maps a pull_request_review_comment created to a commented review", () => {
+    const evt = normalizeGitHubEvent(
+      "pull_request_review_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        pull_request: githubPr({ user: { login: "human" } }),
+        comment: {
+          id: 555,
+          pull_request_review_id: 999,
+          user: { login: "human", type: "User" },
+          body: "please fix the null check",
+        },
+      },
+      commentOptions,
+    );
+    expect(evt).toEqual({
+      delivery: {
+        provider: "github",
+        producer: "human",
+        deliveryId: "github-delivery-1",
+        semanticKey: "review:999",
+      },
+      triggerType: "trigger_pr_review",
+      pr: {
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 7,
+        prUrl: "https://github.com/acme/app/pull/7",
+        headRef: "blazebot/aiw-1",
+        headSha: "abc123",
+        baseRef: "main",
+        title: "Fix things",
+        author: "human",
+        isDraft: false,
+        review: {
+          state: "commented",
+          author: "human",
+          body: "please fix the null check",
+        },
+      },
+    });
+  });
+
+  it("falls back to comment:<id> when the review-comment has no parent review id", () => {
+    const evt = normalizeGitHubEvent(
+      "pull_request_review_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        pull_request: githubPr(),
+        comment: { id: 555, user: { login: "human", type: "User" }, body: "x" },
+      },
+      commentOptions,
+    );
+    expect(evt?.delivery.semanticKey).toBe("comment:555");
+  });
+
+  it("ignores non-created review-comment actions", () => {
+    for (const action of ["edited", "deleted"]) {
+      expect(
+        normalizeGitHubEvent(
+          "pull_request_review_comment",
+          {
+            action,
+            repository: githubRepo(),
+            pull_request: githubPr(),
+            comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+          },
+          commentOptions,
+        ),
+      ).toBeNull();
+    }
+  });
+
+  it("drops a review-comment authored by the bot itself", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request_review_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          pull_request: githubPr(),
+          comment: { id: 1, user: { login: "blazebot[bot]", type: "User" }, body: "self" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops a review-comment from any Bot-type account", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request_review_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          pull_request: githubPr(),
+          comment: { id: 1, user: { login: "dependabot", type: "Bot" }, body: "ci noise" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops a review-comment carrying the AI Workflow marker", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request_review_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          pull_request: githubPr(),
+          comment: {
+            id: 1,
+            user: { login: "human", type: "User" },
+            body: `looks good ${AI_WORKFLOW_COMMENT_MARKER}`,
+          },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops a review-comment when reviewStates is not opted into commented", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request_review_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          pull_request: githubPr(),
+          comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+        },
+        options,
+      ),
+    ).toBeNull();
+  });
+
+  it("maps an issue_comment on a PR to a commented review", () => {
+    const evt = normalizeGitHubEvent(
+      "issue_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        issue: {
+          number: 7,
+          title: "Fix things",
+          user: { login: "author-person" },
+          pull_request: { html_url: "https://github.com/acme/app/pull/7" },
+        },
+        comment: { id: 777, user: { login: "human", type: "User" }, body: "conversation feedback" },
+      },
+      commentOptions,
+    );
+    expect(evt).toEqual({
+      delivery: {
+        provider: "github",
+        producer: "human",
+        deliveryId: "github-delivery-1",
+        semanticKey: "comment:777",
+      },
+      triggerType: "trigger_pr_review",
+      pr: {
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 7,
+        prUrl: "https://github.com/acme/app/pull/7",
+        headRef: "",
+        headSha: "",
+        baseRef: "",
+        title: "Fix things",
+        author: "author-person",
+        isDraft: false,
+        review: {
+          state: "commented",
+          author: "human",
+          body: "conversation feedback",
+        },
+      },
+    });
+  });
+
+  it("derives the PR url from the repo when issue.pull_request omits html_url", () => {
+    const evt = normalizeGitHubEvent(
+      "issue_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+        comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+      },
+      commentOptions,
+    );
+    expect(evt?.pr.prUrl).toBe("https://github.com/acme/app/pull/7");
+  });
+
+  it("ignores an issue_comment on a plain issue (no pull_request)", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "bug", user: { login: "author-person" } },
+          comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores non-created issue_comment actions", () => {
+    for (const action of ["edited", "deleted"]) {
+      expect(
+        normalizeGitHubEvent(
+          "issue_comment",
+          {
+            action,
+            repository: githubRepo(),
+            issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+            comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+          },
+          commentOptions,
+        ),
+      ).toBeNull();
+    }
+  });
+
+  it("drops an issue_comment authored by the bot itself", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+          comment: { id: 1, user: { login: "blazebot[bot]", type: "User" }, body: "self" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops an issue_comment from any Bot-type account", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+          comment: { id: 1, user: { login: "dependabot", type: "Bot" }, body: "ci noise" },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops an issue_comment carrying the AI Workflow marker", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+          comment: {
+            id: 1,
+            user: { login: "human", type: "User" },
+            body: `looks good ${AI_WORKFLOW_COMMENT_MARKER}`,
+          },
+        },
+        commentOptions,
+      ),
+    ).toBeNull();
+  });
+
+  it("drops an issue_comment when reviewStates is not opted into commented", () => {
+    expect(
+      normalizeGitHubEvent(
+        "issue_comment",
+        {
+          action: "created",
+          repository: githubRepo(),
+          issue: { number: 7, title: "t", user: { login: "a" }, pull_request: {} },
+          comment: { id: 1, user: { login: "human", type: "User" }, body: "x" },
+        },
+        options,
+      ),
+    ).toBeNull();
+  });
+
   it("ignores unrelated events", () => {
     expect(normalizeGitHubEvent("push", { repository: githubRepo() }, options)).toBeNull();
   });
@@ -556,6 +866,23 @@ describe("normalizeGitLabEvent", () => {
         botUsername: "  GitLab-Bot  ",
         reviewStates: ["commented"],
       }),
+    ).toBeNull();
+  });
+
+  it("adds a semantic key derived from the GitLab note id", () => {
+    const note = notePayload();
+    note.object_attributes.id = 4321;
+    const evt = normalizeGitLabEvent("Note Hook", note, {
+      reviewStates: ["commented"],
+    });
+    expect(evt?.delivery.semanticKey).toBe("note:4321");
+  });
+
+  it("drops a GitLab note carrying the AI Workflow marker", () => {
+    const note = notePayload();
+    note.object_attributes.note = `looks good ${AI_WORKFLOW_COMMENT_MARKER}`;
+    expect(
+      normalizeGitLabEvent("Note Hook", note, { reviewStates: ["commented"] }),
     ).toBeNull();
   });
 

--- a/apps/worker/src/lib/trigger-events.test.ts
+++ b/apps/worker/src/lib/trigger-events.test.ts
@@ -415,6 +415,29 @@ describe("normalizeGitHubEvent", () => {
     expect(evt?.delivery.semanticKey).toBe("comment:555");
   });
 
+  it("keys a reply on the comment, not the review it hangs off", () => {
+    // A reply may reuse its thread's pull_request_review_id. Keying it on that
+    // review would coalesce it into the already-consumed submission and drop
+    // the reply silently, so replies always get their own key.
+    const evt = normalizeGitHubEvent(
+      "pull_request_review_comment",
+      {
+        action: "created",
+        repository: githubRepo(),
+        pull_request: githubPr(),
+        comment: {
+          id: 777,
+          in_reply_to_id: 555,
+          pull_request_review_id: 999,
+          user: { login: "human", type: "User" },
+          body: "still broken",
+        },
+      },
+      commentOptions,
+    );
+    expect(evt?.delivery.semanticKey).toBe("comment:777");
+  });
+
   it("ignores non-created review-comment actions", () => {
     for (const action of ["edited", "deleted"]) {
       expect(

--- a/apps/worker/src/lib/trigger-events.ts
+++ b/apps/worker/src/lib/trigger-events.ts
@@ -157,12 +157,16 @@ export function normalizeGitHubEvent(
     if (hasAiWorkflowCommentMarker(comment.body)) return null;
     // GitHub wraps inline comments in a review container, so the N sibling
     // comments and their parent review submission share one semantic key.
+    // A reply is its own human action and must never coalesce into the review
+    // it hangs off, whose key was already consumed by that submission.
     const semanticKey =
-      typeof comment.pull_request_review_id === "number"
-        ? `review:${comment.pull_request_review_id}`
-        : typeof comment.id === "number"
-          ? `comment:${comment.id}`
-          : undefined;
+      typeof comment.in_reply_to_id === "number" && typeof comment.id === "number"
+        ? `comment:${comment.id}`
+        : typeof comment.pull_request_review_id === "number"
+          ? `review:${comment.pull_request_review_id}`
+          : typeof comment.id === "number"
+            ? `comment:${comment.id}`
+            : undefined;
     return {
       delivery: {
         ...githubDelivery(options.deliveryId, comment.user?.login),

--- a/apps/worker/src/lib/trigger-events.ts
+++ b/apps/worker/src/lib/trigger-events.ts
@@ -1,5 +1,5 @@
 import type { PrTriggerPayload } from "../workflows/agent-input.js";
-import { vcsLoginsMatch } from "./vcs-bot-identity.js";
+import { hasAiWorkflowCommentMarker, vcsLoginsMatch } from "./vcs-bot-identity.js";
 import { isManagedGateCheckName } from "./workflow-naming.js";
 
 export {
@@ -20,6 +20,10 @@ export interface TriggerEvent {
     /** Provider event source, such as GitLab's merge_request_event pipeline source. */
     source?: string;
     deliveryId: string;
+    /** Stable identity of the human action behind this delivery, used for
+     * semantic dedup so one review's fan-out of N webhooks starts one run.
+     * Derived here at normalization; a later stage consumes it. */
+    semanticKey?: string;
   };
   triggerType: PrTriggerType;
   pr: PrTriggerPayload;
@@ -125,7 +129,10 @@ export function normalizeGitHubEvent(
     if (!allowedStates.includes(review.state)) return null;
     if (vcsLoginsMatch(review.user?.login, options.botLogin)) return null;
     return {
-      delivery: githubDelivery(options.deliveryId, review.user?.login),
+      delivery: {
+        ...githubDelivery(options.deliveryId, review.user?.login),
+        ...(typeof review.id === "number" ? { semanticKey: `review:${review.id}` } : {}),
+      },
       triggerType: "trigger_pr_review",
       pr: {
         ...mapGitHubPullRequest(pr, repo),
@@ -133,6 +140,83 @@ export function normalizeGitHubEvent(
           state: review.state as "changes_requested" | "commented",
           author: review.user?.login ?? "unknown",
           body: review.body ?? "",
+        },
+      },
+    };
+  }
+
+  if (eventName === "pull_request_review_comment") {
+    if (body?.action !== "created") return null;
+    const comment = body?.comment;
+    const pr = body?.pull_request;
+    if (!comment || !pr) return null;
+    const allowedStates = options.reviewStates ?? DEFAULT_REVIEW_STATES;
+    if (!allowedStates.includes("commented")) return null;
+    if (vcsLoginsMatch(comment.user?.login, options.botLogin)) return null;
+    if (comment.user?.type === "Bot") return null;
+    if (hasAiWorkflowCommentMarker(comment.body)) return null;
+    // GitHub wraps inline comments in a review container, so the N sibling
+    // comments and their parent review submission share one semantic key.
+    const semanticKey =
+      typeof comment.pull_request_review_id === "number"
+        ? `review:${comment.pull_request_review_id}`
+        : typeof comment.id === "number"
+          ? `comment:${comment.id}`
+          : undefined;
+    return {
+      delivery: {
+        ...githubDelivery(options.deliveryId, comment.user?.login),
+        ...(semanticKey ? { semanticKey } : {}),
+      },
+      triggerType: "trigger_pr_review",
+      pr: {
+        ...mapGitHubPullRequest(pr, repo),
+        review: {
+          state: "commented",
+          author: comment.user?.login ?? "unknown",
+          body: comment.body ?? "",
+        },
+      },
+    };
+  }
+
+  if (eventName === "issue_comment") {
+    if (body?.action !== "created") return null;
+    const comment = body?.comment;
+    const issue = body?.issue;
+    // issue.pull_request is only present when the issue is a PR conversation.
+    if (!comment || !issue?.pull_request) return null;
+    const allowedStates = options.reviewStates ?? DEFAULT_REVIEW_STATES;
+    if (!allowedStates.includes("commented")) return null;
+    if (vcsLoginsMatch(comment.user?.login, options.botLogin)) return null;
+    if (comment.user?.type === "Bot") return null;
+    if (hasAiWorkflowCommentMarker(comment.body)) return null;
+    const semanticKey =
+      typeof comment.id === "number" ? `comment:${comment.id}` : undefined;
+    return {
+      delivery: {
+        ...githubDelivery(options.deliveryId, comment.user?.login),
+        ...(semanticKey ? { semanticKey } : {}),
+      },
+      triggerType: "trigger_pr_review",
+      pr: {
+        // issue_comment carries no pull_request object, so head facts are
+        // unknown here. Dispatch binds the authoritative values before
+        // acceptance, mirroring the GitLab Pipeline Hook empty-head pattern.
+        provider: "github",
+        repoPath: `${repo.owner.login}/${repo.name}`,
+        prNumber: issue.number,
+        prUrl: issue.pull_request.html_url ?? `${repo.html_url}/pull/${issue.number}`,
+        headRef: "",
+        headSha: "",
+        baseRef: "",
+        title: issue.title ?? "",
+        author: issue.user?.login ?? "unknown",
+        isDraft: false,
+        review: {
+          state: "commented",
+          author: comment.user?.login ?? "unknown",
+          body: comment.body ?? "",
         },
       },
     };
@@ -199,14 +283,18 @@ export function normalizeGitLabEvent(
       attrs.noteable_type !== "MergeRequest" ||
       attrs.system === true ||
       attrs.internal === true ||
-      attrs.confidential === true
+      attrs.confidential === true ||
+      hasAiWorkflowCommentMarker(attrs.note)
     ) {
       return null;
     }
     const allowedStates = options.reviewStates ?? DEFAULT_REVIEW_STATES;
     if (!allowedStates.includes("commented")) return null;
     return {
-      delivery: gitLabDelivery(options.deliveryId, producer),
+      delivery: {
+        ...gitLabDelivery(options.deliveryId, producer),
+        ...(typeof attrs.id === "number" ? { semanticKey: `note:${attrs.id}` } : {}),
+      },
       triggerType: "trigger_pr_review",
       pr: {
         ...mapGitLabMergeRequest(mr, project),

--- a/apps/worker/src/lib/vcs-bot-identity.test.ts
+++ b/apps/worker/src/lib/vcs-bot-identity.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { resolveVcsBotLogin } from "./vcs-bot-identity.js";
+import {
+  AI_WORKFLOW_COMMENT_MARKER,
+  hasAiWorkflowCommentMarker,
+  normalizeVcsLogin,
+  resolveVcsBotLogin,
+  vcsLoginsMatch,
+} from "./vcs-bot-identity.js";
 
 describe("resolveVcsBotLogin", () => {
   it("trims and case-normalizes a provider-specific login", () => {
@@ -7,7 +13,7 @@ describe("resolveVcsBotLogin", () => {
       resolveVcsBotLogin("github", ["github"], {
         github: "  GitHub-App[Bot]  ",
       }),
-    ).toBe("github-app[bot]");
+    ).toBe("github-app");
   });
 
   it("treats whitespace-only values as unset and falls back only when unambiguous", () => {
@@ -23,5 +29,76 @@ describe("resolveVcsBotLogin", () => {
         legacy: "   ",
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("normalizeVcsLogin", () => {
+  it("strips a single trailing [bot] suffix after lowercasing", () => {
+    expect(normalizeVcsLogin("Blazebot[bot]")).toBe("blazebot");
+    expect(normalizeVcsLogin("BlazeBot[Bot]")).toBe("blazebot");
+  });
+
+  it("strips only one trailing [bot] suffix", () => {
+    expect(normalizeVcsLogin("x[bot][bot]")).toBe("x[bot]");
+  });
+
+  it("does not strip a [bot] token that is not a trailing suffix", () => {
+    expect(normalizeVcsLogin("[bot]x")).toBe("[bot]x");
+  });
+
+  it("returns undefined for a bare [bot] input", () => {
+    expect(normalizeVcsLogin("[bot]")).toBeUndefined();
+  });
+
+  it("returns undefined for empty, whitespace and null-ish input", () => {
+    expect(normalizeVcsLogin("")).toBeUndefined();
+    expect(normalizeVcsLogin("   ")).toBeUndefined();
+    expect(normalizeVcsLogin(null)).toBeUndefined();
+    expect(normalizeVcsLogin(undefined)).toBeUndefined();
+  });
+});
+
+describe("vcsLoginsMatch", () => {
+  it("matches when the actual login carries a [bot] suffix but the configured one does not", () => {
+    expect(vcsLoginsMatch("blazebot[bot]", "blazebot")).toBe(true);
+  });
+
+  it("matches when the configured login carries a [bot] suffix but the actual one does not", () => {
+    expect(vcsLoginsMatch("blazebot", "blazebot[bot]")).toBe(true);
+  });
+
+  it("matches case-insensitively across the [bot] suffix", () => {
+    expect(vcsLoginsMatch("BlazeBot[Bot]", "blazebot")).toBe(true);
+  });
+
+  it("does not match a bare [bot] against a bare [bot]", () => {
+    expect(vcsLoginsMatch("[bot]", "[bot]")).toBe(false);
+  });
+
+  it("does not match unrelated logins", () => {
+    expect(vcsLoginsMatch("alice", "bob")).toBe(false);
+    expect(vcsLoginsMatch("alice[bot]", "bob")).toBe(false);
+  });
+
+  it("returns false when either side is undefined", () => {
+    expect(vcsLoginsMatch(undefined, "blazebot")).toBe(false);
+    expect(vcsLoginsMatch("blazebot", null)).toBe(false);
+  });
+});
+
+describe("hasAiWorkflowCommentMarker", () => {
+  it("returns true when the body contains the marker", () => {
+    expect(
+      hasAiWorkflowCommentMarker(`Some review feedback\n${AI_WORKFLOW_COMMENT_MARKER}`),
+    ).toBe(true);
+  });
+
+  it("returns false when the body does not contain the marker", () => {
+    expect(hasAiWorkflowCommentMarker("Some review feedback")).toBe(false);
+  });
+
+  it("returns false for null and undefined bodies", () => {
+    expect(hasAiWorkflowCommentMarker(null)).toBe(false);
+    expect(hasAiWorkflowCommentMarker(undefined)).toBe(false);
   });
 });

--- a/apps/worker/src/lib/vcs-bot-identity.ts
+++ b/apps/worker/src/lib/vcs-bot-identity.ts
@@ -1,5 +1,7 @@
 import type { VcsProviderKind } from "@shared/contracts";
 
+const BOT_LOGIN_SUFFIX = "[bot]";
+
 export interface VcsBotLoginConfig {
   github?: string;
   gitlab?: string;
@@ -30,6 +32,16 @@ export function vcsLoginsMatch(
 }
 
 export function normalizeVcsLogin(login: string | null | undefined): string | undefined {
-  const normalized = login?.trim().toLowerCase();
-  return normalized ? normalized : undefined;
+  const lowercased = login?.trim().toLowerCase();
+  if (!lowercased) return undefined;
+  const stripped = lowercased.endsWith(BOT_LOGIN_SUFFIX)
+    ? lowercased.slice(0, -BOT_LOGIN_SUFFIX.length)
+    : lowercased;
+  return stripped ? stripped : undefined;
+}
+
+export const AI_WORKFLOW_COMMENT_MARKER = "<!-- ai-workflow:bot -->";
+
+export function hasAiWorkflowCommentMarker(body: string | null | undefined): boolean {
+  return typeof body === "string" && body.includes(AI_WORKFLOW_COMMENT_MARKER);
 }

--- a/apps/worker/src/routes/webhooks/github.post.test.ts
+++ b/apps/worker/src/routes/webhooks/github.post.test.ts
@@ -392,6 +392,87 @@ describe("POST /webhooks/github", () => {
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
 
+  it("dispatches a pull_request_review_comment through the trigger path", async () => {
+    mockDispatchTriggerEvent.mockResolvedValueOnce({ result: "started", runId: "run_rc" });
+    const body = {
+      action: "created",
+      repository: repo(),
+      pull_request: {
+        number: 7,
+        html_url: "https://github.com/acme/app/pull/7",
+        head: { ref: "blazebot/aiw-1", sha: "abc123" },
+        base: { ref: "main" },
+        title: "Fix",
+        user: { login: "human" },
+        draft: false,
+      },
+      comment: {
+        id: 5,
+        pull_request_review_id: 9,
+        user: { login: "human", type: "User" },
+        body: "please fix",
+      },
+    };
+
+    const response = await makeApp()(makeRequest(body, "pull_request_review_comment"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "dispatched", runId: "run_rc" });
+    expect(mockDispatchTriggerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggerType: "trigger_pr_review",
+        pr: expect.objectContaining({
+          review: expect.objectContaining({ state: "commented" }),
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
+  it("dispatches an issue_comment on a PR through the trigger path", async () => {
+    mockDispatchTriggerEvent.mockResolvedValueOnce({ result: "started", runId: "run_ic" });
+    const body = {
+      action: "created",
+      repository: repo(),
+      issue: {
+        number: 7,
+        title: "Fix",
+        user: { login: "author-person" },
+        pull_request: { html_url: "https://github.com/acme/app/pull/7" },
+      },
+      comment: { id: 77, user: { login: "human", type: "User" }, body: "conversation feedback" },
+    };
+
+    const response = await makeApp()(makeRequest(body, "issue_comment"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "dispatched", runId: "run_ic" });
+    expect(mockDispatchTriggerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggerType: "trigger_pr_review",
+        pr: expect.objectContaining({
+          prNumber: 7,
+          review: expect.objectContaining({ state: "commented" }),
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
+  it("ignores an unrelated event without dispatching or gating", async () => {
+    const response = await makeApp()(makeRequest({ repository: repo() }, "workflow_run"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "event_workflow_run",
+    });
+    expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
   it("matches the configured repo case-insensitively", async () => {
     // GitHub org/repo slugs are case-insensitive: payload "acme/app" must match
     // a configured "Acme/App" instead of dropping as other_repo.

--- a/apps/worker/src/routes/webhooks/github.post.ts
+++ b/apps/worker/src/routes/webhooks/github.post.ts
@@ -74,11 +74,14 @@ export default defineEventHandler(async (event) => {
   // Normalize every structurally supported review state here. The dispatcher
   // applies provider/state selectors from the same immutable definition
   // snapshot that it pins, avoiding a load-then-deploy race in this route.
+  // Comment events (inline diff + PR conversation) can only ever be "commented".
   const botLogin = getVcsBotLogin("github");
   const reviewStates =
     ghEvent === "pull_request_review"
       ? ["changes_requested", "commented"] as const
-      : undefined;
+      : ghEvent === "pull_request_review_comment" || ghEvent === "issue_comment"
+        ? ["commented"] as const
+        : undefined;
   const evt = normalizeGitHubEvent(ghEvent, body, {
     gateCheckNames,
     deliveryId,

--- a/apps/worker/src/workflows/blocks/io-blocks.edge.test.ts
+++ b/apps/worker/src/workflows/blocks/io-blocks.edge.test.ts
@@ -53,6 +53,7 @@ import type {
 } from "../../sandbox/repo-workspace.js";
 import { emptyPrePrCheckConfig } from "../../pre-pr-checks/config.js";
 import { isRepoAllowed, filterAllowedRepositories } from "../../lib/repo-allowlist.js";
+import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 import {
   createRepositoryDirectory,
   createRepositoryDirectoryForProviders,
@@ -74,6 +75,8 @@ const activeOwner = {
   ownerToken: "owner-1",
   runId: "run-1",
 };
+
+const marked = (body: string) => `${body}\n\n${AI_WORKFLOW_COMMENT_MARKER}`;
 
 function setAllowlist(value: string | undefined): void {
   if (value === undefined) delete process.env.AGENT_ALLOWED_REPOS;
@@ -452,8 +455,8 @@ describe("post_pr_comment edge cases", () => {
 
     expect(result.kind).toBe("next");
     expect(postPRComment).toHaveBeenCalledTimes(2);
-    expect(postPRComment).toHaveBeenCalledWith(7, "LGTM");
-    expect(postPRComment).toHaveBeenCalledWith(9, "LGTM");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("LGTM"));
+    expect(postPRComment).toHaveBeenCalledWith(9, marked("LGTM"));
   });
 
   it("does not infer a missing publication target from the trigger payload", async () => {

--- a/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
@@ -13,9 +13,12 @@ vi.mock("../../lib/vcs-runtime.js", () => ({
   createRepositoryVCS: mocks.createRepositoryVCS,
 }));
 
+import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 import type { WorkspacePublicationResult } from "../workspace-publication.js";
 import { execute, paramsSchema } from "./post-pr-comment.js";
 import { makeCtx, makeNode, makePrPayload, runControlErrorCases } from "./test-support.js";
+
+const marked = (body: string) => `${body}\n\n${AI_WORKFLOW_COMMENT_MARKER}`;
 
 function publication(): WorkspacePublicationResult {
   return {
@@ -101,7 +104,7 @@ describe("post_pr_comment execute", () => {
     );
 
     expect(postPRComment).toHaveBeenCalledTimes(1);
-    expect(postPRComment).toHaveBeenCalledWith(7, "LGTM");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("LGTM"));
     expect(result).toEqual({
       kind: "next",
       output: {
@@ -111,6 +114,53 @@ describe("post_pr_comment execute", () => {
         ],
       },
     });
+  });
+
+  it("appends the bot marker to the posted body", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: null });
+    mockFreshVcs(postPRComment);
+
+    await execute(
+      makeNode("post_pr_comment", { body: "LGTM" }),
+      {},
+      makeCtx({ publication: publication() }),
+    );
+
+    const [, postedBody] = postPRComment.mock.calls[0] as [number, string];
+    expect(postedBody.endsWith(AI_WORKFLOW_COMMENT_MARKER)).toBe(true);
+  });
+
+  it("does not double-mark a body that already carries the marker", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: null });
+    mockFreshVcs(postPRComment);
+
+    const preMarked = marked("LGTM");
+    await execute(
+      makeNode("post_pr_comment", { body: preMarked }),
+      {},
+      makeCtx({ publication: publication() }),
+    );
+
+    expect(postPRComment).toHaveBeenCalledWith(7, preMarked);
+    const [, postedBody] = postPRComment.mock.calls[0] as [number, string];
+    expect(postedBody.split(AI_WORKFLOW_COMMENT_MARKER)).toHaveLength(2);
+  });
+
+  it("rejects an empty body before appending the marker", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: null });
+    mockFreshVcs(postPRComment);
+
+    const result = await execute(
+      makeNode("post_pr_comment", { body: "" }),
+      {},
+      makeCtx({ publication: publication() }),
+    );
+
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("requires a body");
+    }
+    expect(postPRComment).not.toHaveBeenCalled();
   });
 
   it("prefers a resolved body over the static param", async () => {
@@ -124,7 +174,7 @@ describe("post_pr_comment execute", () => {
       { body: " Bound " },
     );
 
-    expect(postPRComment).toHaveBeenCalledWith(7, "Bound");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("Bound"));
   });
 
   it("comments every PR when target is all", async () => {
@@ -182,7 +232,7 @@ describe("post_pr_comment execute", () => {
       repoPath: "acme/api",
       baseBranch: "main",
     });
-    expect(postPRComment).toHaveBeenCalledWith(7, "checks are red");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("checks are red"));
     expect(result.kind).toBe("next");
   });
 
@@ -295,7 +345,7 @@ describe("post_pr_comment execute", () => {
     );
 
     expect(result.kind).toBe("next");
-    expect(postPRComment).toHaveBeenCalledWith(7, "merged");
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("merged"));
   });
 
   it("returns an execution error without publishing partial comments", async () => {

--- a/apps/worker/src/workflows/blocks/post-pr-comment.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 import type { VcsProvider } from "../../adapters/vcs/repository-directory.js";
 import type { PullRequestHead } from "../../adapters/vcs/types.js";
 import type { ActiveRunOwner } from "../../lib/active-run-owner.js";
+import {
+  AI_WORKFLOW_COMMENT_MARKER,
+  hasAiWorkflowCommentMarker,
+} from "../../lib/vcs-bot-identity.js";
 import { isRunControlError } from "../run-control-error.js";
 import {
   executionError,
@@ -45,6 +49,12 @@ async function blockPostPrCommentStep(
   const comments: PostPrCommentsResult["comments"] = [];
   const errors: string[] = [];
 
+  // Every comment we post carries the marker so that even a misconfigured bot
+  // login cannot let our own comments re-trigger the workflow (AIW-140).
+  const markedBody = hasAiWorkflowCommentMarker(body)
+    ? body
+    : `${body}\n\n${AI_WORKFLOW_COMMENT_MARKER}`;
+
   for (const target of targets) {
     try {
       if (!isRepoAllowed(target.repoPath)) {
@@ -58,7 +68,7 @@ async function blockPostPrCommentStep(
       const current = await vcs.getPRHead(target.prId);
       assertCurrentPrCommentTarget(target, current);
       await assertActiveRunOwner(db, owner);
-      const { url } = await vcs.postPRComment(target.prId, body);
+      const { url } = await vcs.postPRComment(target.prId, markedBody);
       comments.push({
         provider: target.provider,
         repoPath: target.repoPath,


### PR DESCRIPTION
Jira: **AIW-181** Deliver remaining PR review-comment ingestion criteria from AIW-140 (parent AIW-118 Workflow editor and runtime improvements).

Replaces #138, which went stale against `main` (~50 commits of AIW-147 multi-repo, harness profiles and status reasons landed since). This branch is a clean re-cut off current `main` with the superseded work dropped.

## Why a follow-up ticket exists

AIW-140 is closed as Done, but its acceptance criteria are not met on `main`. The Jira comment linking "PR #140" as the implementation points at *AIW-120: Implement the Workflow Definition v2 runtime* (a different ticket, branch `codex/aiw-120-v2-runtime`). That PR did deliver one AC, the safe diagnostic ID, via `lib/ingestion-diagnostic.ts`. The rest was never implemented. AIW-140 stays closed and AIW-181 tracks the remainder, rather than reopening a ticket someone else closed.

Verified against `main` at `e77720a`:

| Acceptance criterion | Before | After |
|---|---|---|
| A human PR review comment reaches the correct run and target block | No: `trigger-events.ts` normalized only `pull_request`, `check_run`, `pull_request_review` | Yes |
| Legacy and v2 paths have coverage | Partial: v2 only; legacy via the AIW-141 AI-column path | Unchanged (legacy stays on AI-column by design) |
| Duplicate deliveries do not create duplicate runs | Partial: exact redelivery only; one review + N inline comments started N+1 runs | Yes |
| AI Workflow-authored feedback cannot create a bot loop | No: `[bot]` suffix never stripped, no comment marker | Yes |
| An ingestion failure is observable without exposing unsafe internals | Yes, from AIW-120 | Untouched |

## What changed

- **Comment ingestion.** GitHub inline diff comments (`pull_request_review_comment`) and PR conversation comments (`issue_comment` on a PR) now normalize to `trigger_pr_review` events with state `commented`, mirroring the GitLab Note Hook. Both were previously dropped at the webhook route.
- **Head-fact adoption.** `issue_comment` carries no head SHA, refs, or branch name. `bindCurrentPullRequest` treats an empty head/base on a review trigger as "unknown, adopt the provider-authoritative value" rather than "stale" (the existing GitLab Pipeline Hook pattern), and the workflow-owned PR lookup can match without a branch name while still enforcing the published-head SHA and target branch.
- **Semantic dedup.** One human action fanning out to N+1 webhooks (a review submission plus its N inline comments) now dedupes to exactly one accepted delivery, via a nullable `semantic_key` column with a partial unique index. Keys are `review:<id>` / `comment:<id>` / `note:<id>`, derived at normalization. Exact-redelivery behavior is unchanged.
- **Bot-loop hardening, layered.** `normalizeVcsLogin` strips the GitHub App `[bot]` suffix, so a `GITHUB_BOT_LOGIN` of `blazebot` now matches the real author `blazebot[bot]` (a silent guard miss today). Comments from `Bot`-type accounts never trigger. Every PR/MR comment the workflow posts carries an invisible `<!-- ai-workflow:bot -->` marker that ingestion rejects, so even a misconfigured bot login cannot cause recursion.

Opt-in is unchanged and fail-safe: `selectedReviewStates` (already on `main`) keeps `commented` only when the definition explicitly declares `on: ["commented"]` **and** a bot login is configured. A definition without `on` still resolves to `["changes_requested"]`, so comment events are rejected by default.

## Dropped from #138

The commit `9d0632b7 return safe diagnostic id on failed webhook ingestion` is **not** carried over. `main` independently landed a better design in AIW-120: `AIW-DIAG-ingest-<uuid>` IDs from `recordIngestionFailure`, persisted to a column and surfaced in the UI as run status reasons. The #138 version echoed the raw provider delivery id into `ignored` webhook responses. Keeping both would have left two competing diagnostic-ID schemes. Dropping it also removed 2 of the 3 code conflicts, so this branch's only manual resolution was an import merge in `trigger-events.ts`.

Also corrected from #138's description: it claimed a stale expectation in `workflow-owned-branches.test.ts` was red on `main`. That was true against `main` at `43c4f94`, but `6dd44d2 Align workflow branch fixture with query output` fixed it independently. This branch's changes to that file are purely additive (2 new coverage tests, no existing assertion touched).

## Migration ordering, needs coordination with #164

This branch adds `0028_semantic_key`. **Open PR #164 also claims `0028`.** Both snapshots have `prevId = 47016a00` (0027), so they are siblings, not a chain: hand-renumbering one to `0029` would leave a broken snapshot chain and the next `drizzle-kit generate` would emit a spurious `CREATE TABLE` for whichever table the skipped snapshot introduced.

Whichever PR merges second must rebase and regenerate rather than renumber:

```
git rm apps/worker/drizzle/0028_semantic_key.sql apps/worker/drizzle/meta/0028_snapshot.json
git checkout main -- apps/worker/drizzle/meta/_journal.json
pnpm --filter worker db:generate --name semantic_key
```

#164 is `CLEAN` and ready now, so the expectation is that it lands first and this branch regenerates to `0029`.

## Verification

- Full `apps/worker` suite: **790 files, 2982 tests, 0 failures**. `pnpm --filter worker typecheck` clean.
- Independently confirmed each "gap" claim by grepping `origin/main` rather than trusting #138's description; one claim (the red test) did not survive that check and is corrected above.
- New coverage: normalization of both event types including every guard case (bot author, `Bot` type, marker, missing opt-in), head-fact adoption in `bindCurrentPullRequest`, branchless owned-PR lookup, semantic-dedup winner/replay semantics, review fan-out coalescing (one review + N inline comments = one run, no pending successor), `[bot]` suffix matching, and marker append/no-double-append.
- **Pending: live smoke on a deployed tenant** (signed webhook to fix run). Never done for #138 either.

## Known follow-ups, out of scope

`trigger_deliveries` pruning (no TTL today), filtering the bot's own comments out of `{{pr_review_feedback}}` context (prompt pollution, not a loop), webhook-triggered remediation for definition-less legacy installs, and GitLab formal Request Changes detection (AIW-116).
