### PR TITLE
fix: surface real run failures and keep every step in the deployment

### DIFF
--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -424,6 +424,7 @@ export function TraceDetail({
           runId={runId}
           initialResponse={currentReplay}
           onResponse={handleReplayResponse}
+          normalizeResponse={normalizeReplay}
         />
       ) : (
         <>

--- a/apps/dashboard/components/cockpit/screens/workflow-replay.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-replay.test.tsx
@@ -4,11 +4,13 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type {
+  WorkflowReplayAttemptDetail,
   WorkflowReplayAttemptSummary,
   WorkflowRunReplayResponse,
 } from "@shared/contracts";
 import {
   WorkflowReplay,
+  asDetail,
   compareReplayAttemptActivity,
   countReplayRetries,
   initialReplayNodeId,
@@ -16,8 +18,11 @@ import {
   latestReplayAttempts,
   loadReplayAttemptSummaryTail,
   mergeReplayAttempts,
+  replayAttemptDetailResult,
+  replayAttemptFailureCause,
   replaySelectionForRun,
   selectReplayAttempt,
+  shouldPollAttemptDetail,
   shouldPollReplay,
 } from "./workflow-replay";
 
@@ -458,6 +463,105 @@ test("a live loop owner outranks later terminal iteration attempts", () => {
   assert.equal(
     latestReplayAttempts([iteration, clarification]).get("loop")?.state,
     "waiting_for_clarification",
+  );
+});
+
+// Mirrors the worker's canonical attempt payload from
+// apps/worker/src/routes/api/v1/runs/replay.test.ts: a flat detail whose own
+// `attempt` field is the attempt number rather than a nested envelope.
+const workerAttemptDetail: WorkflowReplayAttemptDetail = {
+  id: 42,
+  nodeId: "review",
+  attempt: 2,
+  activationScopeId: "scope-1",
+  state: "completed",
+  outcome: { kind: "completed", status: "approve" },
+  selectedTransition: { port: "out", edgeIds: ["edge-2"] },
+  startedAt: "2026-07-23T10:00:00.000Z",
+  completedAt: "2026-07-23T10:00:01.000Z",
+  durationMs: 1000,
+  diagnosticId: null,
+  input: null,
+  output: null,
+  logs: null,
+  metadata: null,
+};
+
+test("the flat worker attempt payload parses instead of failing on its attempt number", () => {
+  assert.deepEqual(asDetail(workerAttemptDetail), workerAttemptDetail);
+  assert.deepEqual(
+    replayAttemptDetailResult(200, workerAttemptDetail),
+    { detail: workerAttemptDetail, error: null },
+  );
+  assert.equal(asDetail({ attempt: 2 }), null);
+  assert.equal(asDetail(null), null);
+});
+
+test("an absent attempt detail is an empty state while transport failures alert", () => {
+  // A run that died in a workflow step keeps every envelope null; that is an
+  // empty state, not a fetch failure.
+  const parsed = replayAttemptDetailResult(200, workerAttemptDetail);
+  assert.equal(parsed.error, null);
+  assert.equal(parsed.detail?.logs, null);
+  assert.deepEqual(replayAttemptDetailResult(404, null), {
+    detail: null,
+    error: null,
+  });
+  assert.deepEqual(replayAttemptDetailResult(500, null), {
+    detail: null,
+    error: "Attempt detail is unavailable (500).",
+  });
+  assert.deepEqual(replayAttemptDetailResult(200, { nope: true }), {
+    detail: null,
+    error: "Attempt detail is unavailable.",
+  });
+
+  const html = renderToStaticMarkup(
+    <WorkflowReplay runId="wrun_1" initialResponse={response} />,
+  );
+  assert.match(html, /No sanitized output was captured for this attempt\./);
+  assert.doesNotMatch(html, /Attempt detail is unavailable/);
+  assert.doesNotMatch(html, /role="alert"/);
+});
+
+test("a failed attempt states its outcome and diagnostic id in the header", () => {
+  const html = renderToStaticMarkup(
+    <WorkflowReplay runId="wrun_1" initialResponse={response} />,
+  );
+
+  assert.match(html, /failed: execution_failure/);
+  assert.match(html, /diagnostic diag-1/);
+  assert.equal(
+    replayAttemptFailureCause(attempts[1]),
+    "failed: execution_failure · diagnostic diag-1",
+  );
+  assert.equal(
+    replayAttemptFailureCause({
+      ...attempts[1],
+      outcome: null,
+      diagnosticId: null,
+    }),
+    "cause not recorded",
+  );
+  assert.equal(replayAttemptFailureCause(attempts[0]), null);
+});
+
+test("attempt detail polling stops on a terminal run despite a stale live state", () => {
+  const parked: WorkflowReplayAttemptSummary = {
+    ...attempts[1],
+    state: "waiting_for_clarification",
+  };
+
+  assert.equal(shouldPollAttemptDetail(parked, false), false);
+  assert.equal(shouldPollAttemptDetail(parked, true), true);
+  assert.equal(shouldPollAttemptDetail(attempts[1], true), false);
+  assert.equal(shouldPollAttemptDetail(null, true), false);
+  assert.equal(
+    shouldPollAttemptDetail(
+      parked,
+      shouldPollReplay({ ...response, attempts: [parked] }),
+    ),
+    false,
   );
 });
 

--- a/apps/dashboard/components/cockpit/screens/workflow-replay.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-replay.tsx
@@ -309,22 +309,62 @@ function displayAttempt(attempt: WorkflowReplayAttemptSummary): string {
   return `Attempt ${attempt.attempt} · ${attempt.activationScopeId}`;
 }
 
-function asDetail(value: unknown): WorkflowReplayAttemptDetail | null {
-  const candidate =
-    value &&
-    typeof value === "object" &&
-    "attempt" in value
-      ? (value as { attempt?: unknown }).attempt
-      : value;
+/** The worker route returns the flat attempt detail and the dashboard proxy
+ * forwards that body verbatim, so the payload is validated as it arrives. Its
+ * own `attempt` field is the attempt number, never a nested envelope. */
+export function asDetail(
+  value: unknown,
+): WorkflowReplayAttemptDetail | null {
   if (
-    !candidate ||
-    typeof candidate !== "object" ||
-    !("id" in candidate) ||
-    typeof candidate.id !== "number"
+    !value ||
+    typeof value !== "object" ||
+    !("id" in value) ||
+    typeof value.id !== "number"
   ) {
     return null;
   }
-  return candidate as WorkflowReplayAttemptDetail;
+  return value as WorkflowReplayAttemptDetail;
+}
+
+/** Distinguishes a transport or parse failure, which deserves an alert, from a
+ * detail the run never persisted, which is an ordinary empty state. */
+export function replayAttemptDetailResult(
+  status: number,
+  body: unknown,
+): { detail: WorkflowReplayAttemptDetail | null; error: string | null } {
+  if (status === 404) return { detail: null, error: null };
+  if (status < 200 || status >= 300) {
+    return {
+      detail: null,
+      error: `Attempt detail is unavailable (${status}).`,
+    };
+  }
+  const detail = asDetail(body);
+  return detail
+    ? { detail, error: null }
+    : { detail: null, error: "Attempt detail is unavailable." };
+}
+
+/** Outcome and diagnostic id of a failed attempt, so the panel always states
+ * what failed even when no sanitized agent artifact was captured. Deliberately
+ * omits `outcome.details`, which is free-form and not envelope-sanitized. */
+export function replayAttemptFailureCause(
+  attempt: WorkflowReplayAttemptSummary,
+): string | null {
+  if (attempt.state !== "failed") return null;
+  const cause = attempt.outcome
+    ? `${attempt.outcome.kind}: ${attempt.outcome.status}`
+    : "cause not recorded";
+  return attempt.diagnosticId
+    ? `${cause} · diagnostic ${attempt.diagnosticId}`
+    : cause;
+}
+
+export function shouldPollAttemptDetail(
+  attempt: WorkflowReplayAttemptSummary | null,
+  runIsLive: boolean,
+): boolean {
+  return runIsLive && attempt !== null && isLiveReplayAttempt(attempt);
 }
 
 export function replayEdgeIsActive(
@@ -599,6 +639,7 @@ function AttemptInspector({
   onSelectAttempt,
   followingLatest,
   onFollowLatest,
+  runIsLive,
 }: {
   runId: string;
   attempts: WorkflowReplayAttemptSummary[];
@@ -606,6 +647,7 @@ function AttemptInspector({
   onSelectAttempt: (attempt: WorkflowReplayAttemptSummary) => void;
   followingLatest: boolean;
   onFollowLatest: () => void;
+  runIsLive: boolean;
 }) {
   const [tab, setTab] = React.useState<ReplayTab>("output");
   const [detail, setDetail] =
@@ -626,21 +668,26 @@ function AttemptInspector({
     requestRef.current = controller;
     requestInFlightRef.current = true;
     if (reset) setLoading(true);
-    setError(null);
-    if (reset) setDetail(null);
+    if (reset) {
+      setDetail(null);
+      setError(null);
+    }
     try {
       const response = await fetch(
         `/api/runs/${encodeURIComponent(runId)}/attempts/${encodeURIComponent(String(selectedAttempt.id))}`,
         { cache: "no-store", signal: controller.signal },
       );
-      if (!response.ok) {
-        throw new Error(
-          `Attempt detail is unavailable (${response.status}).`,
-        );
-      }
-      const parsed = asDetail(await response.json());
-      if (!parsed) throw new Error("Attempt detail is unavailable.");
-      setDetail(parsed);
+      const result = replayAttemptDetailResult(
+        response.status,
+        response.ok ? await response.json().catch(() => null) : null,
+      );
+      if (result.error) throw new Error(result.error);
+      // A momentary absence on a background tick (retention expiring mid-run, a
+      // worker redeploy) must not wipe an already rendered panel.
+      if (reset || result.detail !== null) setDetail(result.detail);
+      // Cleared only once a response parsed, so a background tick can never
+      // blank a rendered failure before its replacement arrives.
+      setError(null);
     } catch (cause) {
       if (controller.signal.aborted) return;
       setError(
@@ -662,15 +709,16 @@ function AttemptInspector({
   }, [loadDetail]);
 
   useLivePoll({
-    enabled: selectedAttempt
-      ? isLiveReplayAttempt(selectedAttempt)
-      : false,
+    enabled: shouldPollAttemptDetail(selectedAttempt, runIsLive),
     intervalMs: LIVE_POLL_MS,
     onTick: () => {
       void loadDetail(false);
     },
   });
 
+  const failureCause = selectedAttempt
+    ? replayAttemptFailureCause(selectedAttempt)
+    : null;
   const envelope =
     tab === "input"
       ? detail?.input
@@ -688,7 +736,12 @@ function AttemptInspector({
       title={selectedAttempt ? displayAttempt(selectedAttempt) : "No attempt"}
       action={
         selectedAttempt ? (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {failureCause ? (
+              <span className="font-mono text-[10px] text-fail-fg">
+                {failureCause}
+              </span>
+            ) : null}
             {!followingLatest ? (
               <button
                 type="button"
@@ -777,10 +830,16 @@ export function WorkflowReplay({
   runId,
   initialResponse,
   onResponse,
+  normalizeResponse,
 }: {
   runId: string;
   initialResponse: WorkflowRunReplayResponse;
   onResponse?: (response: WorkflowRunReplayResponse) => void;
+  /** Applies the owner's durable run lifecycle correction to a freshly polled
+   * response, so a lagging replay status cannot re-arm the poll. */
+  normalizeResponse?: (
+    response: WorkflowRunReplayResponse,
+  ) => WorkflowRunReplayResponse;
 }) {
   const [response, setResponse] = React.useState(initialResponse);
   const [loadedOlder, setLoadedOlder] = React.useState(false);
@@ -898,7 +957,8 @@ export function WorkflowReplay({
         { cache: "no-store" },
       );
       if (!result.ok) return;
-      const fresh = (await result.json()) as WorkflowRunReplayResponse;
+      const polled = (await result.json()) as WorkflowRunReplayResponse;
+      const fresh = normalizeResponse ? normalizeResponse(polled) : polled;
       onResponse?.(fresh);
       setGraphAttempts((current) =>
         mergeReplayAttempts(current, fresh.attempts),
@@ -928,10 +988,12 @@ export function WorkflowReplay({
     } finally {
       refreshInFlightRef.current = false;
     }
-  }, [loadedOlder, onResponse, runId]);
+  }, [loadedOlder, normalizeResponse, onResponse, runId]);
+
+  const runIsLive = shouldPollReplay(response);
 
   useLivePoll({
-    enabled: shouldPollReplay(response),
+    enabled: runIsLive,
     intervalMs: LIVE_POLL_MS,
     onTick: () => {
       void refreshLiveReplay();
@@ -1054,6 +1116,7 @@ export function WorkflowReplay({
         runId={runId}
         attempts={attemptsForNode}
         selectedAttempt={selectedAttempt}
+        runIsLive={runIsLive}
         followingLatest={followLatest}
         onFollowLatest={() => {
           setFollowLatest(true);

--- a/apps/worker/src/lib/cancel-run.test.ts
+++ b/apps/worker/src/lib/cancel-run.test.ts
@@ -165,6 +165,7 @@ describe("cancelRun", () => {
       { db: true },
       "run-1",
       "Cancelled via Slack /ai-workflow cancel",
+      { kind: "cancellation" },
     );
   });
 

--- a/apps/worker/src/lib/cancel-run.ts
+++ b/apps/worker/src/lib/cancel-run.ts
@@ -273,7 +273,9 @@ async function persistCancelReason(
       import("../db/client.js"),
       import("./telemetry/run-telemetry.js"),
     ]);
-    await recordRunStatusReason(getDb(), runId, reason);
+    await recordRunStatusReason(getDb(), runId, reason, {
+      kind: "cancellation",
+    });
   } catch (error) {
     logger.warn(
       { subjectKey, runId, error: (error as Error).message },

--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -455,23 +455,39 @@ describe("recordRunStatusReason", () => {
     expect(merged.workflowId).toBe("wf_agent");
   });
 
-  it("keeps the first recorded reason so a later cancellation cannot mask it", async () => {
-    // A failing run records its concrete cause, then its own backlog move fires
-    // the webhook that cancels the orphan with a generic bookkeeping message.
-    // The trace screen renders this field as the run's error, so the real cause
-    // has to survive.
-    await recordRunStatusReason(
-      db,
-      "wrun_1",
-      "The workspace environment could not complete this block. (promoteRepositoryWriteScopeStep failed: Not Found)",
-    );
-    await recordRunStatusReason(
-      db,
-      "wrun_1",
-      "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
-    );
-    expect((await row("wrun_1")).statusReason).toBe(
-      "The workspace environment could not complete this block. (promoteRepositoryWriteScopeStep failed: Not Found)",
+  it("lets the concrete failure reason win in either write order", async () => {
+    // The trace screen renders this field as the run's error, so a generic
+    // cancellation must never mask the concrete cause. The two writers race in
+    // both directions: a failing run's own backlog move fires the webhook that
+    // cancels the orphan, and the reconciler can retire a run just before its
+    // failure lands.
+    const failure =
+      "The workspace environment could not complete this block. (promoteRepositoryWriteScopeStep failed: Not Found)";
+    const cancellation =
+      "Orphaned run cancelled by reconciler: ticket no longer in the AI column";
+
+    await recordRunStatusReason(db, "wrun_fail_first", failure, {
+      kind: "failure",
+    });
+    await recordRunStatusReason(db, "wrun_fail_first", cancellation, {
+      kind: "cancellation",
+    });
+    expect((await row("wrun_fail_first")).statusReason).toBe(failure);
+
+    await recordRunStatusReason(db, "wrun_cancel_first", cancellation, {
+      kind: "cancellation",
+    });
+    await recordRunStatusReason(db, "wrun_cancel_first", failure, {
+      kind: "failure",
+    });
+    expect((await row("wrun_cancel_first")).statusReason).toBe(failure);
+  });
+
+  it("defaults to filling only a null reason", async () => {
+    await recordRunStatusReason(db, "wrun_default", "First bookkeeping note");
+    await recordRunStatusReason(db, "wrun_default", "Later bookkeeping note");
+    expect((await row("wrun_default")).statusReason).toBe(
+      "First bookkeeping note",
     );
   });
 });

--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -455,10 +455,24 @@ describe("recordRunStatusReason", () => {
     expect(merged.workflowId).toBe("wf_agent");
   });
 
-  it("overwrites a previously recorded reason", async () => {
-    await recordRunStatusReason(db, "wrun_1", "first reason");
-    await recordRunStatusReason(db, "wrun_1", "final reason");
-    expect((await row("wrun_1")).statusReason).toBe("final reason");
+  it("keeps the first recorded reason so a later cancellation cannot mask it", async () => {
+    // A failing run records its concrete cause, then its own backlog move fires
+    // the webhook that cancels the orphan with a generic bookkeeping message.
+    // The trace screen renders this field as the run's error, so the real cause
+    // has to survive.
+    await recordRunStatusReason(
+      db,
+      "wrun_1",
+      "The workspace environment could not complete this block. (promoteRepositoryWriteScopeStep failed: Not Found)",
+    );
+    await recordRunStatusReason(
+      db,
+      "wrun_1",
+      "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
+    );
+    expect((await row("wrun_1")).statusReason).toBe(
+      "The workspace environment could not complete this block. (promoteRepositoryWriteScopeStep failed: Not Found)",
+    );
   });
 });
 

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -322,11 +322,21 @@ export async function recordBlockStatuses(
  * runId + statusReason and the later snapshot/usage writes fill in the rest.
  * Callers wrap this in try/catch — recording the reason must never affect the
  * operation that produced it.
+ *
+ * Precedence is explicit rather than positional, because the two writers race
+ * in both orders: a failing run's own backlog move fires the webhook that
+ * cancels the orphan, and the reconciler can equally retire a run just before
+ * its failure lands. A "failure" reason is the concrete cause and always wins;
+ * a "cancellation" reason is bookkeeping and only fills a still-null field, or
+ * the trace screen would never say why the run actually failed.
  */
+export type RunStatusReasonKind = "failure" | "cancellation";
+
 export async function recordRunStatusReason(
   db: Db,
   runId: string,
   reason: string,
+  options: { kind: RunStatusReasonKind } = { kind: "cancellation" },
 ): Promise<void> {
   await db
     .insert(workflowRuns)
@@ -334,12 +344,10 @@ export async function recordRunStatusReason(
     .onConflictDoUpdate({
       target: workflowRuns.runId,
       set: {
-        // First reason wins. The concrete cause is recorded when the run fails;
-        // a later generic cancellation (for example the reconciler retiring an
-        // orphaned run after the failure moved its ticket out of the AI column)
-        // must not overwrite it, or the trace screen shows only the bookkeeping
-        // message and never says why the run actually failed.
-        statusReason: sql`coalesce(${workflowRuns.statusReason}, excluded.status_reason)`,
+        statusReason:
+          options.kind === "failure"
+            ? sql`excluded.status_reason`
+            : sql`coalesce(${workflowRuns.statusReason}, excluded.status_reason)`,
         updatedAt: sql`now()`,
       },
     });

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -334,7 +334,12 @@ export async function recordRunStatusReason(
     .onConflictDoUpdate({
       target: workflowRuns.runId,
       set: {
-        statusReason: sql`excluded.status_reason`,
+        // First reason wins. The concrete cause is recorded when the run fails;
+        // a later generic cancellation (for example the reconciler retiring an
+        // orphaned run after the failure moved its ticket out of the AI column)
+        // must not overwrite it, or the trace screen shows only the bookkeeping
+        // message and never says why the run actually failed.
+        statusReason: sql`coalesce(${workflowRuns.statusReason}, excluded.status_reason)`,
         updatedAt: sql`now()`,
       },
     });

--- a/apps/worker/src/run-observability/store.test.ts
+++ b/apps/worker/src/run-observability/store.test.ts
@@ -777,6 +777,94 @@ describe("replay queries and retention", () => {
     ).toBe(false);
   });
 
+  it("presents stale live attempts as cancelled once the run is terminal", async () => {
+    await capture("run-terminal-projection");
+    const [parked, failed] = await db
+      .insert(workflowBlockAttempts)
+      .values([
+        {
+          runId: "run-terminal-projection",
+          organizationId: "org-replay",
+          nodeId: "clarify",
+          attempt: 1,
+          activationScopeId: "root",
+          state: "waiting_for_clarification" as const,
+          startedAt: new Date("2026-07-23T10:00:01.000Z"),
+          completedAt: new Date("2026-07-23T10:00:01.500Z"),
+          durationMs: 500,
+        },
+        {
+          runId: "run-terminal-projection",
+          organizationId: "org-replay",
+          nodeId: "agent",
+          attempt: 1,
+          activationScopeId: "root",
+          state: "failed" as const,
+          outcome: { kind: "failed" as const, status: "execution_error" },
+          startedAt: new Date("2026-07-23T10:00:02.000Z"),
+          completedAt: new Date("2026-07-23T10:00:03.000Z"),
+          durationMs: 1000,
+        },
+      ])
+      .returning({ id: workflowBlockAttempts.id });
+    const now = new Date("2026-07-23T11:00:00.000Z");
+    const replayAt = (attemptId: number) =>
+      getRunReplayAttempt({
+        db,
+        runId: "run-terminal-projection",
+        organizationId: "org-replay",
+        attemptId,
+        now,
+      });
+    const summaryState = async (attemptId: number) => {
+      const replay = await getRunReplay({
+        db,
+        runId: "run-terminal-projection",
+        organizationId: "org-replay",
+        now,
+      });
+      return replay.attempts.find((attempt) => attempt.id === attemptId)
+        ?.state;
+    };
+
+    await db
+      .update(workflowRuns)
+      .set({ status: "awaiting" })
+      .where(eq(workflowRuns.runId, "run-terminal-projection"));
+    expect(await summaryState(parked!.id)).toBe(
+      "waiting_for_clarification",
+    );
+    expect((await replayAt(parked!.id))?.state).toBe(
+      "waiting_for_clarification",
+    );
+
+    await db
+      .update(workflowRuns)
+      .set({ status: "failed" })
+      .where(eq(workflowRuns.runId, "run-terminal-projection"));
+    expect(await summaryState(parked!.id)).toBe("cancelled");
+    expect((await replayAt(parked!.id))?.state).toBe("cancelled");
+    expect(await summaryState(failed!.id)).toBe("failed");
+    expect((await replayAt(failed!.id))?.state).toBe("failed");
+    expect((await replayAt(failed!.id))?.outcome).toEqual({
+      kind: "failed",
+      status: "execution_error",
+    });
+
+    const stored = await db
+      .select({
+        id: workflowBlockAttempts.id,
+        state: workflowBlockAttempts.state,
+      })
+      .from(workflowBlockAttempts)
+      .where(eq(workflowBlockAttempts.runId, "run-terminal-projection"))
+      .orderBy(asc(workflowBlockAttempts.id));
+    expect(stored).toEqual([
+      { id: parked!.id, state: "waiting_for_clarification" },
+      { id: failed!.id, state: "failed" },
+    ]);
+  });
+
   it("enforces tenant scope and reports not captured, expired, and cleanup state", async () => {
     await db.insert(workflowRuns).values({ runId: "historical" });
     expect(

--- a/apps/worker/src/run-observability/store.ts
+++ b/apps/worker/src/run-observability/store.ts
@@ -306,15 +306,45 @@ function applyReplayAttemptObservations(
   return next;
 }
 
+const TERMINAL_RUN_STATUSES: readonly string[] = [
+  "success",
+  "failed",
+  "blocked",
+];
+
+const STALE_LIVE_ATTEMPT_STATES: readonly ReplayAttemptState[] = [
+  "running",
+  "waiting_loop",
+  "waiting_for_clarification",
+];
+
+function isTerminalRunStatus(status: string | null | undefined): boolean {
+  return !!status && TERMINAL_RUN_STATUSES.includes(status);
+}
+
+/** The scheduler drops parked and in-flight attempts from its in-memory map
+ * when a run ends, so those rows keep their last live state forever. Present
+ * them as cancelled once the durable run status is terminal. Read-time only:
+ * the stored row is never rewritten. */
+function displayAttemptState(
+  state: ReplayAttemptState,
+  runIsTerminal: boolean,
+): ReplayAttemptState {
+  return runIsTerminal && STALE_LIVE_ATTEMPT_STATES.includes(state)
+    ? "cancelled"
+    : state;
+}
+
 function mapAttemptSummary(
   row: typeof workflowBlockAttempts.$inferSelect,
+  runIsTerminal: boolean,
 ): WorkflowReplayAttemptSummary {
   return {
     id: row.id,
     nodeId: row.nodeId,
     attempt: row.attempt,
     activationScopeId: row.activationScopeId,
-    state: row.state,
+    state: displayAttemptState(row.state, runIsTerminal),
     outcome: row.outcome,
     selectedTransition: row.selectedTransition,
     startedAt: row.startedAt.toISOString(),
@@ -326,9 +356,10 @@ function mapAttemptSummary(
 
 function mapAttemptDetail(
   row: typeof workflowBlockAttempts.$inferSelect,
+  runIsTerminal: boolean,
 ): WorkflowReplayAttemptDetail {
   return {
-    ...mapAttemptSummary(row),
+    ...mapAttemptSummary(row, runIsTerminal),
     input: row.inputEnvelope,
     output: row.outputEnvelope,
     logs: row.logEnvelope,
@@ -950,11 +981,9 @@ export async function getRunReplay(
     )
     .limit(1);
   const availability = await getRunReplayAvailability({ ...input, now });
+  const runIsTerminal = isTerminalRunStatus(run?.status);
   const mayAdvance =
-    availability !== "expired" &&
-    run !== undefined &&
-    (!run?.status ||
-      !["success", "failed", "blocked"].includes(run.status));
+    availability !== "expired" && run !== undefined && !runIsTerminal;
   if (availability !== "available") {
     return {
       availability,
@@ -1028,7 +1057,7 @@ export async function getRunReplay(
             capturedAt: observation.capturedAt.toISOString(),
             expiresAt: observation.expiresAt.toISOString(),
           },
-    attempts: page.map(mapAttemptSummary),
+    attempts: page.map((row) => mapAttemptSummary(row, runIsTerminal)),
     nextCursor:
       hasNextPage && page.length > 0
         ? replayCursor(page[page.length - 1]!.id)
@@ -1041,18 +1070,32 @@ export async function getRunReplayAttempt(
 ): Promise<WorkflowReplayAttemptDetail | null> {
   const availability = await getRunReplayAvailability(input);
   if (availability !== "available") return null;
-  const [row] = await input.db
-    .select()
-    .from(workflowBlockAttempts)
-    .where(
-      and(
-        eq(workflowBlockAttempts.id, input.attemptId),
-        eq(workflowBlockAttempts.runId, input.runId),
-        eq(workflowBlockAttempts.organizationId, input.organizationId),
-      ),
-    )
-    .limit(1);
-  return row ? mapAttemptDetail(row) : null;
+  const [[run], [row]] = await Promise.all([
+    input.db
+      .select({ status: workflowRuns.status })
+      .from(workflowRuns)
+      .where(
+        and(
+          eq(workflowRuns.runId, input.runId),
+          eq(workflowRuns.replayOrganizationId, input.organizationId),
+        ),
+      )
+      .limit(1),
+    input.db
+      .select()
+      .from(workflowBlockAttempts)
+      .where(
+        and(
+          eq(workflowBlockAttempts.id, input.attemptId),
+          eq(workflowBlockAttempts.runId, input.runId),
+          eq(workflowBlockAttempts.organizationId, input.organizationId),
+        ),
+      )
+      .limit(1),
+  ]);
+  return row
+    ? mapAttemptDetail(row, isTerminalRunStatus(run?.status))
+    : null;
 }
 
 export async function deleteExpiredRunObservations(

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -1574,6 +1574,34 @@ async function markRunFailedOnSelfMoveStep(runId: string): Promise<void> {
 markRunFailedOnSelfMoveStep.maxRetries = 0;
 
 /**
+ * Persist the concrete reason a run failed so the trace screen can state it.
+ * Without this the only durable reason a failed run ever carried was written by
+ * a later cancellation (the reconciler retiring the orphan after the failure
+ * moved its ticket out of the AI column), which reads as bookkeeping and hides
+ * the real cause. Best-effort: reporting must never change the failure outcome.
+ */
+async function recordRunFailureReasonStep(
+  runId: string,
+  reason: string,
+): Promise<void> {
+  "use step";
+  const [{ getDb }, { recordRunStatusReason }, { logger }] = await Promise.all([
+    import("../db/client.js"),
+    import("../lib/telemetry/run-telemetry.js"),
+    import("../lib/logger.js"),
+  ]);
+  try {
+    await recordRunStatusReason(getDb(), runId, reason.slice(0, 2_000));
+  } catch (error) {
+    logger.warn(
+      { runId, err: error instanceof Error ? error.message : String(error) },
+      "run_failure_reason_unconfirmed",
+    );
+  }
+}
+recordRunFailureReasonStep.maxRetries = 0;
+
+/**
  * Records the run's "success" status before its success-finalizing AI Review
  * move fires the self-triggered "ticket left the AI column" webhook, so that
  * webhook cannot cancel the run out of a genuine success. See
@@ -3271,6 +3299,9 @@ async function agentWorkflowBody(
         // recording "failed" first keeps the outcome correct even if the cancel
         // still lands.
         await markRunFailedOnSelfMoveStep(workflowRunId);
+        // Record why before the backlog move: the move fires the webhook that
+        // cancels this run, and that cancellation writes its own generic reason.
+        await recordRunFailureReasonStep(workflowRunId, reason);
         const usageReport = usageReportOrUndefined();
         const knownPhase = FAILURE_PHASES.has(phase) ? (phase as NotifyPhase) : undefined;
         const { handleWorkflowFailureExit } = await import("./workflow-failure-exit.js");

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -1591,7 +1591,9 @@ async function recordRunFailureReasonStep(
     import("../lib/logger.js"),
   ]);
   try {
-    await recordRunStatusReason(getDb(), runId, reason.slice(0, 2_000));
+    await recordRunStatusReason(getDb(), runId, reason.slice(0, 2_000), {
+      kind: "failure",
+    });
   } catch (error) {
     logger.warn(
       { runId, err: error instanceof Error ? error.message : String(error) },

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -3353,6 +3353,10 @@ async function agentWorkflowBody(
         // Persist "failed" before this backlog move fires the self-triggered
         // "ticket left the AI column" webhook (same race as failureExit).
         await markRunFailedOnSelfMoveStep(workflowRunId);
+        await recordRunFailureReasonStep(
+          workflowRunId,
+          postComment ?? `Terminated by workflow: ${params.terminalStatus}`,
+        );
         await moveTicketStep(ticketId, backlogMoveTarget(), transitionOwner);
         await notifyTicket(ticket.identifier, {
           kind: "failed",

--- a/apps/worker/src/workflows/clarification-snapshot-steps.ts
+++ b/apps/worker/src/workflows/clarification-snapshot-steps.ts
@@ -116,8 +116,11 @@ try {
 `;
 
 // NOTE: this is a JS template literal, so bash's escaped parens must be written
-// as \\( \\) — a single \( collapses to a bare ( in the emitted string, which
-// is a bash syntax error ("syntax error near unexpected token `('").
+// as \\( \\). A single \( collapses to a bare ( in the emitted string, which is
+// a bash syntax error ("syntax error near unexpected token '('").
+// Never write a backtick in a comment in a file that declares steps: the builder
+// masks template literals before it strips comments, so one comment backtick
+// flips backtick parity and hides every "use step" directive below it.
 export const SCRUB_CREDENTIALS_SCRIPT = `set -eu
 find /tmp -maxdepth 1 -type f -name 'agent-env*.sh' -delete
 rm -rf "$HOME/.codex" "$HOME/.claude" "$HOME/.config/claude" "$HOME/.config/claude-code"
@@ -254,8 +257,8 @@ async function withinSnapshotDeadline<T>(
 
 /**
  * Scrub and snapshot a workspace as one replay-safe Workflow step. The SDK can
- * return from snapshot() while the source is still `snapshotting`, so the step
- * does not return checkpoint metadata until Sandbox.get reports `stopped`.
+ * return from snapshot() while the source is still "snapshotting", so the step
+ * does not return checkpoint metadata until Sandbox.get reports "stopped".
  */
 export async function snapshotClarificationSandboxStep(
   input: SnapshotClarificationSandboxInput,

--- a/apps/worker/src/workflows/repository-promotion.test.ts
+++ b/apps/worker/src/workflows/repository-promotion.test.ts
@@ -437,6 +437,31 @@ describe("repository write-scope promotion", () => {
     expect(controller.recordOwnedBranch).toHaveBeenCalled();
   });
 
+  it("refuses an owned branch that reappeared between the probe and the create", async () => {
+    const { sandbox, controller } = setup({
+      ownedBranch: { branchName: "blazebot/aiw-147" },
+      remoteBranchSha: null,
+      createResult: "existing",
+    });
+
+    await expect(
+      promoteRepositoryWriteScope({
+        sandbox,
+        manifest,
+        writeRepositories: [
+          { provider: "github", repoPath: "acme/api", rationale: "implementation" },
+        ],
+        branchName: "blazebot/aiw-147",
+        controller,
+        providers,
+      }),
+    ).rejects.toThrow("its head is unknown");
+
+    // Nothing may be checked out against an assumed head: publication leases
+    // that SHA, so the run must stop before the implementation phase.
+    expect(controller.getBranchSha).not.toHaveBeenCalled();
+  });
+
   it("rejects an unknown write repository", async () => {
     const { sandbox, controller } = setup();
 

--- a/apps/worker/src/workflows/repository-promotion.test.ts
+++ b/apps/worker/src/workflows/repository-promotion.test.ts
@@ -152,6 +152,39 @@ describe("repository write-scope promotion", () => {
     );
   });
 
+  it("records the created branch head without re-reading the fresh ref", async () => {
+    // GitHub's ref API can 404 for a moment after createRef. This step has no
+    // retries, so re-reading the branch it had just created failed healthy runs.
+    // The created head is exactly researchBaseSha, so no provider read is needed.
+    const { sandbox, controller } = setup();
+    controller.getBranchSha = vi.fn(async () => {
+      throw new Error("Not Found - https://docs.github.com/rest/git/refs");
+    });
+
+    const result = await promoteRepositoryWriteScope({
+      sandbox,
+      manifest,
+      writeRepositories: [
+        { provider: "github", repoPath: "acme/api", rationale: "implementation" },
+      ],
+      branchName: "ai-workflow/awp-22",
+      controller,
+      providers,
+    });
+
+    expect(controller.getBranchSha).not.toHaveBeenCalled();
+    expect(controller.createBranchIfMissing).toHaveBeenCalledWith(
+      expect.objectContaining({ repoPath: "acme/api" }),
+      "ai-workflow/awp-22",
+      "base-sha",
+    );
+    expect(result.repositories[0]).toMatchObject({
+      access: "write",
+      expectedRemoteSha: "base-sha",
+      preAgentSha: "base-sha",
+    });
+  });
+
   it("never resets a same-named foreign branch", async () => {
     const { sandbox, controller } = setup({ remoteBranchSha: "foreign-sha" });
 

--- a/apps/worker/src/workflows/repository-promotion.ts
+++ b/apps/worker/src/workflows/repository-promotion.ts
@@ -255,10 +255,16 @@ export async function promoteRepositoryWriteScope(input: {
         );
       }
     }
-    const expectedRemoteSha = await input.controller.getBranchSha(
-      repository,
-      input.branchName,
-    );
+    // Create and reset just wrote this branch at researchBaseSha, so that SHA is
+    // already known. Re-reading the ref here made every promotion depend on the
+    // provider serving a ref it had just accepted: GitHub's ref API can still
+    // 404 for a second or two after createRef, and this step has no retries, so
+    // a transient read killed otherwise healthy runs. Only the reuse path, which
+    // targets a branch an earlier run published, has to ask the provider.
+    const expectedRemoteSha =
+      candidate.action === "reuse"
+        ? await input.controller.getBranchSha(repository, input.branchName)
+        : repository.researchBaseSha!;
     // The reuse path targets a branch an earlier run created, whose head can be
     // absent from this sandbox clone (it only carries the research checkout).
     // Fetch that branch, with credentials supplied inline so nothing persists,

--- a/apps/worker/src/workflows/repository-promotion.ts
+++ b/apps/worker/src/workflows/repository-promotion.ts
@@ -242,16 +242,28 @@ export async function promoteRepositoryWriteScope(input: {
         input.branchName,
         repository.researchBaseSha!,
       );
-      if (created === "existing" && candidate.recordsNewOwnership) {
-        // A concurrent run of the SAME ticket created this workflow-generated
-        // branch in the tiny window after our pre-mutation probe found it
-        // absent. Both runs upsert the same (ticketKey, provider, repoPath)
-        // ledger row, so deleting it here would orphan the remote branch the
-        // winning run legitimately owns and brick every later run of the
-        // ticket. Keep the row and fail this run: the next run reconciles the
-        // now-existing owned branch through the normal reuse path.
+      if (created === "existing") {
+        if (candidate.recordsNewOwnership) {
+          // A concurrent run of the SAME ticket created this workflow-generated
+          // branch in the tiny window after our pre-mutation probe found it
+          // absent. Both runs upsert the same (ticketKey, provider, repoPath)
+          // ledger row, so deleting it here would orphan the remote branch the
+          // winning run legitimately owns and brick every later run of the
+          // ticket. Keep the row and fail this run: the next run reconciles the
+          // now-existing owned branch through the normal reuse path.
+          throw new Error(
+            `Repository ${repository.provider}:${repository.repoPath} branch ${input.branchName} was created by a concurrent promotion of the same ticket`,
+          );
+        }
+        // The branch we already own was absent from the probe yet present at
+        // create, so its head is whatever the other writer left there, not the
+        // researchBaseSha the assignment below would assume. Publication leases
+        // that SHA, so continuing only trades a wrong assumption for a rejected
+        // push after the whole implementation phase. Fail now; the next run
+        // sees the branch and reconciles it through the reuse path, which reads
+        // the real head.
         throw new Error(
-          `Repository ${repository.provider}:${repository.repoPath} branch ${input.branchName} was created by a concurrent promotion of the same ticket`,
+          `Repository ${repository.provider}:${repository.repoPath} branch ${input.branchName} reappeared after the ownership probe; its head is unknown`,
         );
       }
     }

--- a/apps/worker/src/workflows/step-registration-coverage.test.ts
+++ b/apps/worker/src/workflows/step-registration-coverage.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const workerRoot = fileURLToPath(new URL("../../", import.meta.url));
+const scannedRoots = ["src", "workflow-test-fixtures"];
+
+/**
+ * Workflow directives on their own line, matched on the raw source. The builder
+ * decides which files contribute steps and workflows by content-testing every
+ * source file with its own detector, and that detector masks template literals
+ * before it strips comments. A stray backtick in a comment therefore inverts
+ * backtick parity and silently hides every directive below it, so this test
+ * compares the raw truth against what the builder actually sees.
+ */
+const workflowDirectives = [
+  {
+    linePattern: /^[ \t]*(['"])use step\1;?[ \t]*$/m,
+    detectorFlag: "hasUseStep",
+    declares: "steps",
+    consequence:
+      'the file is dropped from the step bundle while the workflow bundle still emits proxies for it, and every step in it fails at runtime with "is not registered in the current deployment"',
+  },
+  {
+    linePattern: /^[ \t]*(['"])use workflow\1;?[ \t]*$/m,
+    detectorFlag: "hasUseWorkflow",
+    declares: "a workflow",
+    consequence:
+      "the file is left out of the workflow bundle entirely, and the workflow disappears from the deployment with no way to start it",
+  },
+] as const;
+
+describe("step registration coverage", () => {
+  it("keeps every step and workflow file discoverable by the workflow builder", async () => {
+    const detectWorkflowPatterns = await loadBuilderDirectiveDetector();
+    const sources = typescriptFiles(workerRoot, scannedRoots).map((path) => ({
+      path,
+      source: readFileSync(path, "utf8"),
+    }));
+
+    for (const directive of workflowDirectives) {
+      const declaring = sources.filter(({ source }) =>
+        directive.linePattern.test(source),
+      );
+      expect(declaring.length).toBeGreaterThan(0);
+
+      for (const { path, source } of declaring) {
+        expect(
+          detectWorkflowPatterns(source)[directive.detectorFlag],
+          `${path} declares ${directive.declares} that the workflow builder's own detector cannot see: ${directive.consequence}.`,
+        ).toBe(true);
+      }
+    }
+
+    const declaringAny = sources.filter(({ source }) =>
+      workflowDirectives.some(({ linePattern }) => linePattern.test(source)),
+    );
+    for (const { path, source } of declaringAny) {
+      expect(
+        (source.match(/`/g) ?? []).length % 2,
+        `${path} declares steps or a workflow and has an odd number of backticks. The builder masks template literals before stripping comments, so a single backtick inside a comment pairs with the next real template literal and masks every directive below it.`,
+      ).toBe(0);
+    }
+  });
+});
+
+/**
+ * The builder detector is the authority on discovery, so assert against it
+ * rather than a local copy. @workflow/builders is a transitive dependency of the
+ * workflow SDK and is not resolvable from this package directly, but the
+ * @workflow/vitest install this suite already depends on pulls in the same
+ * version the nitro build uses.
+ */
+async function loadBuilderDirectiveDetector(): Promise<
+  (source: string) => { hasUseStep: boolean; hasUseWorkflow: boolean }
+> {
+  const buildersEntry = createRequire(
+    createRequire(import.meta.url).resolve("@workflow/vitest"),
+  ).resolve("@workflow/builders");
+  const builders = await import(pathToFileURL(buildersEntry).href);
+  return builders.detectWorkflowPatterns;
+}
+
+function typescriptFiles(root: string, relativeDirs: string[]): string[] {
+  return relativeDirs.flatMap((dir) => walkTypescriptFiles(join(root, dir)));
+}
+
+function walkTypescriptFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return walkTypescriptFiles(path);
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}

--- a/apps/worker/src/workflows/workflow-import-boundary.test.ts
+++ b/apps/worker/src/workflows/workflow-import-boundary.test.ts
@@ -1,10 +1,27 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { readFileSync, readdirSync } from "node:fs";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildWorkflowTests } from "@workflow/vitest";
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const workerRoot = fileURLToPath(new URL("../../", import.meta.url));
+const scannedRoots = ["src", "workflow-test-fixtures"];
+
+// Keep the patterns in sync with step-registration-coverage.test.ts, which
+// asserts the same sets against the builder's own detector without a build.
+const workflowDirectives = [
+  {
+    linePattern: /^[ \t]*(['"])use step\1;?[ \t]*$/m,
+    debugList: "stepFiles",
+    declares: "steps",
+  },
+  {
+    linePattern: /^[ \t]*(['"])use workflow\1;?[ \t]*$/m,
+    debugList: "workflowFiles",
+    declares: "a workflow",
+  },
+] as const;
 
 describe("workflow import boundary", () => {
   it(
@@ -14,12 +31,39 @@ describe("workflow import boundary", () => {
         join(workerRoot, ".workflow-import-boundary-"),
       );
       try {
+        const outDir = join(outputRoot, "bundles");
         await buildWorkflowTests({
           cwd: workerRoot,
           rootDir: workerRoot,
           dataDir: join(outputRoot, "data"),
-          outDir: join(outputRoot, "bundles"),
+          outDir,
         });
+
+        // Discovery is content-based, so a file the builder fails to recognize is
+        // dropped from the bundle without any build error: its steps then fail at
+        // runtime with "is not registered in the current deployment", and its
+        // workflows vanish from the deployment entirely. The steps bundle debug
+        // file carries both discovered lists, so assert them in the same build.
+        const debug = JSON.parse(
+          await readFile(join(outDir, "steps.mjs.debug.json"), "utf8"),
+        ) as Record<string, string[]>;
+
+        for (const { linePattern, debugList, declares } of workflowDirectives) {
+          const bundled = new Set(
+            await Promise.all(
+              (debug[debugList] ?? []).map((file) => realpath(file)),
+            ),
+          );
+          const declared = await Promise.all(
+            directiveFiles(linePattern).map((file) => realpath(file)),
+          );
+
+          expect(declared.length, `no file declares ${declares}`).toBeGreaterThan(0);
+          expect(
+            declared.filter((file) => !bundled.has(file)),
+            `these files declare ${declares} but are missing from the builder's ${debugList}`,
+          ).toEqual([]);
+        }
       } finally {
         await rm(outputRoot, { recursive: true, force: true });
       }
@@ -27,3 +71,17 @@ describe("workflow import boundary", () => {
     30_000,
   );
 });
+
+function directiveFiles(linePattern: RegExp): string[] {
+  return scannedRoots
+    .flatMap((dir) => typescriptFiles(join(workerRoot, dir)))
+    .filter((path) => linePattern.test(readFileSync(path, "utf8")));
+}
+
+function typescriptFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return typescriptFiles(path);
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}


### PR DESCRIPTION
## Why

End-to-end runs of real tickets against the new main (Jira project AWP, repo `Blazity/ai-workflow-prod`, plus a GitLab repo for the mixed-provider cases) surfaced five production defects. Four of them were invisible in the dashboard, which is what made the last release hard to debug: a run would die and the trace screen would only say `Orphaned run cancelled by reconciler`.

## What this fixes

**1. A single stray backtick in a comment silently deleted a step from the deployment.** Every run that asked a clarification question after the workspace was prepared died instantly with `Step ".../clarification-snapshot-steps//snapshotClarificationSandboxStep" is not registered in the current deployment`. This killed four consecutive production runs regardless of ticket content.

The workflow builder masks template literals *before* stripping comments (`@workflow/builders/dist/transform-utils.js`), so an unbalanced backtick inside a comment can make the region containing the `"use step"` directive look like a template literal. The directive becomes invisible, the file is dropped from the step bundle, and the manifest still references its steps. Fixed by balancing the comment, and guarded by two new tests so this class of bug fails in CI instead of production:

- `step-registration-coverage.test.ts` asserts the builder's own detector can see every `"use step"` and `"use workflow"` directive in the tree, plus backtick parity per file.
- `workflow-import-boundary.test.ts` additionally asserts every directive file appears in the builder's `stepFiles`/`workflowFiles`.

Both directives are covered because the same trigger in a `"use workflow"` file would remove an entire workflow from the deployment.

**2. Branch promotion read the SHA of a branch it had just created.** The GitHub ref API returns 404 for a second or two after `createRef`, and the step runs with `maxRetries: 0`, so the whole run failed. Promotion now uses the `researchBaseSha` it already created the branch from, and only reads the remote for the reuse path.

**3. The concrete failure reason was never persisted.** A failing run moves its ticket out of the AI column, which fires the webhook that cancels the now-orphaned run, and the cancellation reason overwrote the real cause. The workflow now records its failure reason before the backlog move, and `recordRunStatusReason` takes an explicit reason kind: a failure reason always wins, a cancellation reason only fills a still-null field. Precedence no longer depends on which writer happens to be first.

**4. A failed run displayed a `WAITING_FOR_CLARIFICATION` badge.** Attempt rows keep their last live state, so a run killed mid-attempt kept `running`/`waiting_for_clarification` forever. The replay store now projects stale live attempt states to `cancelled` at read time when the run itself is terminal. `awaiting` is deliberately excluded, since that is a legitimately parked run.

**5. `Attempt detail is unavailable` on every attempt of every run, plus background flicker.** The client unwrapped a `{ attempt: ... }` envelope that no producer emits, and `attempt` in the real payload is the attempt *number*, so every parse failed. Alongside that: a genuine 404 is now an ordinary empty state rather than an alert, background polling can no longer blank an already-rendered panel or its error, the panel shows the attempt outcome and diagnostic id even when no sanitized artifact was captured, and the trace screen's lifecycle correction is applied to polled responses so a lagging status cannot re-arm the poll.

## Verification

- `apps/worker`: 98 tests across the touched files (`store`, `run-telemetry`, `cancel-run`, replay route, both step guards, `clarification-snapshot-steps`).
- `apps/dashboard`: full suite, 520 passing.
- Both typechecks clean.
- Fresh `nitro build`: 136 steps, 9 workflows, and every step id referenced by the flow bundle is registered in the step bundle. Before the fix, three ids from the snapshot module were missing.
- Each fix has a RED proof: the guards fail on a planted backtick (verified for both directive kinds), and the telemetry test fails in the cancellation-then-failure order with the old positional rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow replays now show clearer attempt outcomes, including failure reasons and diagnostic details.
  * Stale in-progress attempts are displayed as cancelled when the overall run reaches a terminal state.
  * Replay polling now stops appropriately for completed runs and attempts.

* **Bug Fixes**
  * Preserved specific failure reasons instead of replacing them with generic cancellation messages.
  * Improved replay response handling during transient refreshes to prevent existing details from disappearing.
  * Improved repository branch verification during promotion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->