### PR TITLE
Harden workflow start ownership and recover stalled starts

### DIFF
--- a/apps/worker/drizzle/0030_startup_watchdog.sql
+++ b/apps/worker/drizzle/0030_startup_watchdog.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "workflow_runs" ADD COLUMN "entry_started_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "workflow_runs" ADD COLUMN "startup_deadline_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "workflow_runs" ADD COLUMN "diagnostic_id" text;--> statement-breakpoint
+CREATE INDEX "workflow_runs_startup_watchdog_idx" ON "workflow_runs" USING btree ("startup_deadline_at") WHERE "workflow_runs"."entry_started_at" is null and coalesce("workflow_runs"."status", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled');

--- a/apps/worker/drizzle/meta/0030_snapshot.json
+++ b/apps/worker/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,4336 @@
+{
+  "id": "23fd0ace-cd0e-44c9-a7a8-5b285b8feb34",
+  "prevId": "dfb9e555-eb75-4010-8206-a085fd7c2847",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_started_at": {
+          "name": "entry_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_deadline_at": {
+          "name": "startup_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_startup_watchdog_idx": {
+          "name": "workflow_runs_startup_watchdog_idx",
+          "columns": [
+            {
+              "expression": "startup_deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_runs\".\"entry_started_at\" is null and coalesce(\"workflow_runs\".\"status\", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memory_documents": {
+      "name": "agent_memory_documents",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memory_documents_ticket_key_idx": {
+          "name": "agent_memory_documents_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_documents_updated_at_idx": {
+          "name": "agent_memory_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_memory_documents_subject_key_doc_path_pk": {
+          "name": "agent_memory_documents_subject_key_doc_path_pk",
+          "columns": [
+            "subject_key",
+            "doc_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1785149709194,
       "tag": "0029_silly_dark_beast",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1785173470525,
+      "tag": "0030_startup_watchdog",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,6 +12,7 @@
     "typecheck": "pnpm build:shared && tsc --noEmit",
     "validate:pre-sandbox": "tsx scripts/validate-pre-sandbox-config.ts",
     "capture:agent-protocol-fixtures": "tsx scripts/capture-agent-protocol-fixtures.ts",
+    "cleanup:startup-orphans": "tsx scripts/cleanup-startup-orphans.ts",
     "build:arthur-tracer": "node scripts/build-arthur-tracer.mjs",
     "test:e2e": "pnpm test:e2e:agent && pnpm test:e2e:orchestration && pnpm test:e2e:capacity",
     "test:e2e:agent": "pnpm build:shared && vitest run --config e2e/vitest.e2e.config.ts --project agent",

--- a/apps/worker/scripts/cleanup-startup-orphans.ts
+++ b/apps/worker/scripts/cleanup-startup-orphans.ts
@@ -1,0 +1,115 @@
+import { eq } from "drizzle-orm";
+import { getRun } from "workflow/api";
+import { getWorld } from "workflow/runtime";
+import { getDb } from "../src/db/client.js";
+import { workflowRuns } from "../src/db/schema.js";
+
+const EXPECTED_DEPLOYMENT = "dpl_DuNRZF1V4SRSxTE2D2UREtBSoe3m";
+const RUN_IDS = [
+  "wrun_01KYCYKGBHFQP40X6A00S68YHE",
+  "wrun_01KYCYX2CA2DCYSD20H89B4VQ5",
+  "wrun_01KYCZ81GTA63DXDE4T4K15FFR",
+  "wrun_01KYCZK16XJWRSZ2JBRGRERW9R",
+  "wrun_01KYCZY10SSZ9CDXHZR65ZW7VA",
+  "wrun_01KYD09021YXW8BNT8SQ618B21",
+] as const;
+const TERMINAL = new Set(["completed", "failed", "cancelled"]);
+
+interface Inspection {
+  runId: string;
+  deploymentId: string | null;
+  runStatus: string;
+  firstStepName: string | null;
+  firstStepStatus: string | null;
+  firstStepAttempt: number | null;
+  entryStarted: boolean;
+  eligible: boolean;
+}
+
+async function inspect(runId: string): Promise<Inspection> {
+  const world = getWorld();
+  const [run, steps, rows] = await Promise.all([
+    world.runs.get(runId, { resolveData: "none" }),
+    world.steps.list({
+      runId,
+      resolveData: "none",
+      pagination: { limit: 2 },
+    }),
+    getDb()
+      .select({ entryStartedAt: workflowRuns.entryStartedAt })
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, runId))
+      .limit(1),
+  ]);
+  const first = steps.data[0] ?? null;
+  const deploymentId =
+    "deploymentId" in run && typeof run.deploymentId === "string"
+      ? run.deploymentId
+      : null;
+  const runStatus = String(run.status);
+  const firstStepName =
+    first && "stepName" in first && typeof first.stepName === "string"
+      ? first.stepName
+      : null;
+  const firstStepStatus = first ? String(first.status) : null;
+  const firstStepAttempt =
+    first && typeof first.attempt === "number" ? first.attempt : null;
+  const entryStarted = rows[0]?.entryStartedAt != null;
+  return {
+    runId,
+    deploymentId,
+    runStatus,
+    firstStepName,
+    firstStepStatus,
+    firstStepAttempt,
+    entryStarted,
+    eligible:
+      deploymentId === EXPECTED_DEPLOYMENT &&
+      !TERMINAL.has(runStatus) &&
+      firstStepName?.includes("bindWorkflowCandidateStep") === true &&
+      firstStepStatus === "pending" &&
+      firstStepAttempt === 0 &&
+      !entryStarted,
+  };
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const inspections = await Promise.all(RUN_IDS.map(inspect));
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        mode: apply ? "apply" : "dry-run",
+        expectedDeployment: EXPECTED_DEPLOYMENT,
+        inspections,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  if (!apply) return;
+  const ineligible = inspections.filter((item) => !item.eligible);
+  if (ineligible.length > 0) {
+    throw new Error(
+      `Refusing cleanup: ${ineligible.map((item) => item.runId).join(", ")} failed the exact safety preflight.`,
+    );
+  }
+  for (const item of inspections) {
+    const rechecked = await inspect(item.runId);
+    if (!rechecked.eligible) {
+      throw new Error(
+        `Refusing cleanup: ${item.runId} changed after preflight.`,
+      );
+    }
+    await getRun(item.runId).cancel();
+    const status = await getRun(item.runId).status;
+    if (!TERMINAL.has(status)) {
+      throw new Error(
+        `Cancellation of ${item.runId} was not confirmed (status: ${status}).`,
+      );
+    }
+    process.stdout.write(`${item.runId}: ${status}\n`);
+  }
+}
+
+await main();

--- a/apps/worker/scripts/cleanup-startup-orphans.ts
+++ b/apps/worker/scripts/cleanup-startup-orphans.ts
@@ -14,6 +14,8 @@ const RUN_IDS = [
   "wrun_01KYD09021YXW8BNT8SQ618B21",
 ] as const;
 const TERMINAL = new Set(["completed", "failed", "cancelled"]);
+const CANCELLATION_CONFIRMATION_TIMEOUT_MS = 30_000;
+const CANCELLATION_POLL_INTERVAL_MS = 500;
 
 interface Inspection {
   runId: string;
@@ -73,6 +75,19 @@ async function inspect(runId: string): Promise<Inspection> {
   };
 }
 
+async function waitForTerminalStatus(runId: string): Promise<string> {
+  const run = getRun(runId);
+  const deadline = Date.now() + CANCELLATION_CONFIRMATION_TIMEOUT_MS;
+  let status = await run.status;
+  while (!TERMINAL.has(status) && Date.now() < deadline) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, CANCELLATION_POLL_INTERVAL_MS),
+    );
+    status = await run.status;
+  }
+  return status;
+}
+
 async function main() {
   const apply = process.argv.includes("--apply");
   const inspections = await Promise.all(RUN_IDS.map(inspect));
@@ -102,7 +117,7 @@ async function main() {
       );
     }
     await getRun(item.runId).cancel();
-    const status = await getRun(item.runId).status;
+    const status = await waitForTerminalStatus(item.runId);
     if (!TERMINAL.has(status)) {
       throw new Error(
         `Cancellation of ${item.runId} was not confirmed (status: ${status}).`,

--- a/apps/worker/src/adapters/run-registry/postgres.test.ts
+++ b/apps/worker/src/adapters/run-registry/postgres.test.ts
@@ -5,6 +5,7 @@ import {
   activeRunSandboxes,
   activeRuns,
   clarificationRequests,
+  workflowRuns,
 } from "../../db/schema.js";
 import { createTestDb } from "../../db/test-db.js";
 import { ActiveRunOwnerError } from "../../lib/run-control-errors.js";
@@ -70,6 +71,142 @@ describe("owner-CAS run claims", () => {
     expect(await registry.bindRun(subjectKey, "owner-a", "run-winner")).toBe(true);
     expect(await registry.bindRun(subjectKey, "owner-a", "run-retry")).toBe(false);
     expect(await registry.get(subjectKey)).toMatchObject({ state: "bound", runId: "run-winner" });
+  });
+
+  it("binds a hosted start and writes its watchdog row in one transaction", async () => {
+    await registry.reserve({
+      subjectKey,
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-a",
+      kind: "ticket",
+    });
+
+    await expect(
+      registry.commitStartedRun({
+        subjectKey,
+        ticketKey: "PROJ-1",
+        ownerToken: "owner-a",
+        kind: "ticket",
+        runId: "run-started",
+      }),
+    ).resolves.toBe(true);
+
+    expect(await registry.get(subjectKey)).toMatchObject({
+      state: "bound",
+      runId: "run-started",
+    });
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, "run-started"));
+    expect(row).toMatchObject({
+      status: "running",
+      subjectKey,
+      ticketKey: "PROJ-1",
+      entryStartedAt: null,
+      diagnosticId: null,
+    });
+    expect(row?.startupDeadlineAt?.getTime()).toBeGreaterThan(
+      row?.startedAt?.getTime() ?? 0,
+    );
+  });
+
+  it("accepts dispatcher and workflow-entry startup commits in either order", async () => {
+    const start = {
+      subjectKey,
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-a",
+      kind: "ticket" as const,
+      runId: "run-started",
+    };
+    await registry.reserve(start);
+    expect(await registry.markRunEntryStarted(start)).toBe(true);
+    expect(await registry.commitStartedRun(start)).toBe(true);
+
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, start.runId));
+    expect(row?.entryStartedAt).toBeInstanceOf(Date);
+  });
+
+  it("fills identity and startup fields when another writer inserted the run row first", async () => {
+    const start = {
+      subjectKey,
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-a",
+      kind: "ticket" as const,
+      runId: "run-started",
+    };
+    await registry.reserve(start);
+    await db.insert(workflowRuns).values({
+      runId: start.runId,
+      status: "running",
+    });
+
+    expect(await registry.commitStartedRun(start)).toBe(true);
+
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, start.runId));
+    expect(row).toMatchObject({
+      subjectKey,
+      ticketKey: "PROJ-1",
+      status: "running",
+      entryStartedAt: null,
+    });
+    expect(row?.startedAt).toBeInstanceOf(Date);
+    expect(row?.startupDeadlineAt).toBeInstanceOf(Date);
+  });
+
+  it("does not mark application entry after the startup watchdog claimed the run", async () => {
+    const start = {
+      subjectKey,
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-a",
+      kind: "ticket" as const,
+      runId: "run-started",
+    };
+    await registry.reserve(start);
+    expect(await registry.commitStartedRun(start)).toBe(true);
+    await db
+      .update(workflowRuns)
+      .set({ diagnosticId: "diag_watchdog" })
+      .where(eq(workflowRuns.runId, start.runId));
+
+    expect(await registry.markRunEntryStarted(start)).toBe(false);
+
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, start.runId));
+    expect(row?.entryStartedAt).toBeNull();
+    expect(row?.diagnosticId).toBe("diag_watchdog");
+  });
+
+  it("does not create a watchdog row when start binding loses ownership", async () => {
+    await registry.reserve({
+      subjectKey,
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-winner",
+      kind: "ticket",
+    });
+    await expect(
+      registry.commitStartedRun({
+        subjectKey,
+        ticketKey: "PROJ-1",
+        ownerToken: "owner-loser",
+        kind: "ticket",
+        runId: "run-loser",
+      }),
+    ).resolves.toBe(false);
+    expect(
+      await db
+        .select()
+        .from(workflowRuns)
+        .where(eq(workflowRuns.runId, "run-loser")),
+    ).toEqual([]);
   });
 
   it("does not bind a reservation after its capacity grace expires", async () => {

--- a/apps/worker/src/adapters/run-registry/postgres.test.ts
+++ b/apps/worker/src/adapters/run-registry/postgres.test.ts
@@ -130,6 +130,25 @@ describe("owner-CAS run claims", () => {
     expect(row?.entryStartedAt).toBeInstanceOf(Date);
   });
 
+  it("marks application entry after the dispatcher committed the start", async () => {
+    const start = {
+      subjectKey,
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-a",
+      kind: "ticket" as const,
+      runId: "run-started",
+    };
+    await registry.reserve(start);
+    expect(await registry.commitStartedRun(start)).toBe(true);
+    expect(await registry.markRunEntryStarted(start)).toBe(true);
+
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, start.runId));
+    expect(row?.entryStartedAt).toBeInstanceOf(Date);
+  });
+
   it("fills identity and startup fields when another writer inserted the run row first", async () => {
     const start = {
       subjectKey,
@@ -183,6 +202,24 @@ describe("owner-CAS run claims", () => {
       .where(eq(workflowRuns.runId, start.runId));
     expect(row?.entryStartedAt).toBeNull();
     expect(row?.diagnosticId).toBe("diag_watchdog");
+  });
+
+  it("does not accept a repeated dispatcher commit after the startup watchdog claimed the run", async () => {
+    const start = {
+      subjectKey,
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-a",
+      kind: "ticket" as const,
+      runId: "run-started",
+    };
+    await registry.reserve(start);
+    expect(await registry.commitStartedRun(start)).toBe(true);
+    await db
+      .update(workflowRuns)
+      .set({ diagnosticId: "diag_watchdog" })
+      .where(eq(workflowRuns.runId, start.runId));
+
+    expect(await registry.commitStartedRun(start)).toBe(false);
   });
 
   it("does not create a watchdog row when start binding loses ownership", async () => {

--- a/apps/worker/src/adapters/run-registry/postgres.ts
+++ b/apps/worker/src/adapters/run-registry/postgres.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "../../db/client.js";
 import { ActiveRunOwnerError } from "../../lib/run-control-errors.js";
 import {
@@ -6,6 +6,7 @@ import {
   activeRuns,
   failedTickets,
   threadParents,
+  workflowRuns,
 } from "../../db/schema.js";
 import {
   RESERVATION_BIND_GRACE_MS,
@@ -14,8 +15,12 @@ import {
   type FailedTicketOwner,
   type RunRegistryAdapter,
   type RunReservation,
+  type StartedRunRecord,
   type ThreadStore,
 } from "./types.js";
+
+const STARTUP_DEADLINE_MS = 10 * 60 * 1000;
+class StartedRunIdentityConflictError extends Error {}
 
 export class PostgresRunRegistry implements RunRegistryAdapter, ThreadStore {
   constructor(private db: Db) {}
@@ -35,6 +40,117 @@ export class PostgresRunRegistry implements RunRegistryAdapter, ThreadStore {
     return rows.length > 0;
   }
 
+  async commitStartedRun(started: StartedRunRecord): Promise<boolean> {
+    return this.recordStartedRun(started, false);
+  }
+
+  async markRunEntryStarted(started: StartedRunRecord): Promise<boolean> {
+    return this.recordStartedRun(started, true);
+  }
+
+  private async recordStartedRun(
+    started: StartedRunRecord,
+    markEntryStarted: boolean,
+  ): Promise<boolean> {
+    try {
+      return await this.db.transaction(async (tx) => {
+        const owners = await tx
+          .update(activeRuns)
+          .set({ runId: started.runId, state: "bound", updatedAt: sql`now()` })
+          .where(
+            and(
+              eq(activeRuns.subjectKey, started.subjectKey),
+              eq(activeRuns.ownerToken, started.ownerToken),
+              or(
+                and(
+                  eq(activeRuns.state, "reserved"),
+                  isNull(activeRuns.runId),
+                  sql`${activeRuns.updatedAt} >= now() - (${RESERVATION_BIND_GRACE_MS} * interval '1 millisecond')`,
+                ),
+                and(
+                  eq(activeRuns.state, "bound"),
+                  eq(activeRuns.runId, started.runId),
+                ),
+              ),
+            ),
+          )
+          .returning({ subjectKey: activeRuns.subjectKey });
+        if (owners.length !== 1) return false;
+
+        const inserted = await tx
+          .insert(workflowRuns)
+          .values({
+            runId: started.runId,
+            status: "running",
+            subjectKey: started.subjectKey,
+            ticketKey: started.ticketKey,
+            createdAt: sql`now()`,
+            startedAt: sql`now()`,
+            startupDeadlineAt: sql`now() + (${STARTUP_DEADLINE_MS} * interval '1 millisecond')`,
+            ...(markEntryStarted ? { entryStartedAt: sql`now()` } : {}),
+          })
+          .onConflictDoNothing({ target: workflowRuns.runId })
+          .returning({ runId: workflowRuns.runId });
+        if (inserted.length === 1) return true;
+
+        const existing = await tx
+          .select({
+            subjectKey: workflowRuns.subjectKey,
+            ticketKey: workflowRuns.ticketKey,
+            diagnosticId: workflowRuns.diagnosticId,
+          })
+          .from(workflowRuns)
+          .where(eq(workflowRuns.runId, started.runId))
+          .limit(1);
+        if (
+          (existing[0]?.subjectKey != null &&
+            existing[0].subjectKey !== started.subjectKey) ||
+          (existing[0]?.ticketKey != null &&
+            existing[0].ticketKey !== started.ticketKey) ||
+          (markEntryStarted && existing[0]?.diagnosticId != null)
+        ) {
+          throw new StartedRunIdentityConflictError(
+            `Run ${started.runId} is already attributed to another subject`,
+          );
+        }
+        const updated = await tx
+          .update(workflowRuns)
+          .set({
+            subjectKey: sql`coalesce(${workflowRuns.subjectKey}, ${started.subjectKey})`,
+            ticketKey: sql`coalesce(${workflowRuns.ticketKey}, ${started.ticketKey})`,
+            status: sql`coalesce(${workflowRuns.status}, 'running')`,
+            createdAt: sql`coalesce(${workflowRuns.createdAt}, now())`,
+            startedAt: sql`coalesce(${workflowRuns.startedAt}, now())`,
+            startupDeadlineAt: sql`coalesce(${workflowRuns.startupDeadlineAt}, now() + (${STARTUP_DEADLINE_MS} * interval '1 millisecond'))`,
+            ...(markEntryStarted
+              ? {
+                  entryStartedAt: sql`coalesce(${workflowRuns.entryStartedAt}, now())`,
+                }
+              : {}),
+            updatedAt: sql`now()`,
+          })
+          .where(
+            markEntryStarted
+              ? and(
+                  eq(workflowRuns.runId, started.runId),
+                  isNull(workflowRuns.diagnosticId),
+                )
+              : eq(workflowRuns.runId, started.runId),
+          )
+          .returning({ runId: workflowRuns.runId });
+        if (updated.length !== 1) {
+          throw new StartedRunIdentityConflictError(
+            `Run ${started.runId} startup was already claimed`,
+          );
+        }
+        return true;
+      });
+    } catch (error) {
+      if (error instanceof StartedRunIdentityConflictError) return false;
+      throw error;
+    }
+  }
+
   async bindRun(subjectKey: string, ownerToken: string, runId: string): Promise<boolean> {
     const rows = await this.db
       .update(activeRuns)
@@ -43,9 +159,17 @@ export class PostgresRunRegistry implements RunRegistryAdapter, ThreadStore {
         and(
           eq(activeRuns.subjectKey, subjectKey),
           eq(activeRuns.ownerToken, ownerToken),
-          eq(activeRuns.state, "reserved"),
-          isNull(activeRuns.runId),
-          sql`${activeRuns.updatedAt} >= now() - (${RESERVATION_BIND_GRACE_MS} * interval '1 millisecond')`,
+          or(
+            and(
+              eq(activeRuns.state, "reserved"),
+              isNull(activeRuns.runId),
+              sql`${activeRuns.updatedAt} >= now() - (${RESERVATION_BIND_GRACE_MS} * interval '1 millisecond')`,
+            ),
+            and(
+              eq(activeRuns.state, "bound"),
+              eq(activeRuns.runId, runId),
+            ),
+          ),
         ),
       )
       .returning({ subjectKey: activeRuns.subjectKey });

--- a/apps/worker/src/adapters/run-registry/postgres.ts
+++ b/apps/worker/src/adapters/run-registry/postgres.ts
@@ -1,6 +1,7 @@
 import { and, eq, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "../../db/client.js";
 import { ActiveRunOwnerError } from "../../lib/run-control-errors.js";
+import { STARTUP_DEADLINE_MS } from "../../lib/run-start-constants.js";
 import {
   activeRunSandboxes,
   activeRuns,
@@ -19,7 +20,6 @@ import {
   type ThreadStore,
 } from "./types.js";
 
-const STARTUP_DEADLINE_MS = 10 * 60 * 1000;
 class StartedRunIdentityConflictError extends Error {}
 
 export class PostgresRunRegistry implements RunRegistryAdapter, ThreadStore {
@@ -107,7 +107,7 @@ export class PostgresRunRegistry implements RunRegistryAdapter, ThreadStore {
             existing[0].subjectKey !== started.subjectKey) ||
           (existing[0]?.ticketKey != null &&
             existing[0].ticketKey !== started.ticketKey) ||
-          (markEntryStarted && existing[0]?.diagnosticId != null)
+          existing[0]?.diagnosticId != null
         ) {
           throw new StartedRunIdentityConflictError(
             `Run ${started.runId} is already attributed to another subject`,
@@ -130,12 +130,10 @@ export class PostgresRunRegistry implements RunRegistryAdapter, ThreadStore {
             updatedAt: sql`now()`,
           })
           .where(
-            markEntryStarted
-              ? and(
-                  eq(workflowRuns.runId, started.runId),
-                  isNull(workflowRuns.diagnosticId),
-                )
-              : eq(workflowRuns.runId, started.runId),
+            and(
+              eq(workflowRuns.runId, started.runId),
+              isNull(workflowRuns.diagnosticId),
+            ),
           )
           .returning({ runId: workflowRuns.runId });
         if (updated.length !== 1) {

--- a/apps/worker/src/adapters/run-registry/types.ts
+++ b/apps/worker/src/adapters/run-registry/types.ts
@@ -46,9 +46,24 @@ export interface ActiveRunEntry extends RunReservation {
   updatedAt: number;
 }
 
+export interface StartedRunRecord extends RunReservation {
+  runId: string;
+}
+
 export interface RunRegistryAdapter {
   /** Atomically reserve an unclaimed provider-neutral subject. */
   reserve(reservation: RunReservation): Promise<boolean>;
+  /**
+   * Bind the hosted run returned by start() and create its startup-watchdog
+   * record in one transaction. Repeating the exact owner/run is idempotent.
+   */
+  commitStartedRun(started: StartedRunRecord): Promise<boolean>;
+  /**
+   * Workflow-entry crash-window fallback. It accepts either the unbound
+   * reservation or the exact dispatcher-bound run and records that the first
+   * application step actually began.
+   */
+  markRunEntryStarted(started: StartedRunRecord): Promise<boolean>;
   /** A workflow candidate CAS-binds its fresh reservation; retries, losers, and
    * candidates whose capacity grace expired cannot overwrite it. */
   bindRun(subjectKey: string, ownerToken: string, runId: string): Promise<boolean>;

--- a/apps/worker/src/approvals/dispatch.test.ts
+++ b/apps/worker/src/approvals/dispatch.test.ts
@@ -78,6 +78,8 @@ function makeRegistry(options: {
   });
   return {
     reserve,
+    commitStartedRun: vi.fn(async () => true),
+    markRunEntryStarted: vi.fn(async () => true),
     bindRun: vi.fn(),
     beginParking: vi.fn(),
     finishParking: vi.fn(),

--- a/apps/worker/src/approvals/dispatch.ts
+++ b/apps/worker/src/approvals/dispatch.ts
@@ -28,8 +28,8 @@ export type DispatchPlanApprovedResult =
 /**
  * Starts a trigger_plan_approved run for an approved plan. It uses the same
  * owner-CAS reservation and capacity path as direct ticket dispatch. The
- * workflow candidate binds its own runtime id on entry; this dispatcher never
- * overwrites an owner after start.
+ * dispatcher binds the returned runtime id before reporting success; workflow
+ * entry repeats the exact bind as a crash-window fallback.
  *
  * The optional onClaimed gate runs once the ticket is reserved and before the
  * workflow starts; a caller passes the compare-and-set decision there so the

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -293,6 +293,10 @@ export const workflowRuns = pgTable("workflow_runs", {
   ticketKey: text("ticket_key"),
   ticketTitle: text("ticket_title"),
   ticketUrl: text("ticket_url"),
+  /** Application-owned startup boundary, independent from Workflow world time. */
+  entryStartedAt: timestamp("entry_started_at", { withTimezone: true }),
+  startupDeadlineAt: timestamp("startup_deadline_at", { withTimezone: true }),
+  diagnosticId: text("diagnostic_id"),
   model: text("model"),
   sandboxId: text("sandbox_id"),
   createdAt: timestamp("created_at", { withTimezone: true }),
@@ -355,6 +359,11 @@ export const workflowRuns = pgTable("workflow_runs", {
   index("workflow_runs_subject_key_idx").on(t.subjectKey),
   index("workflow_runs_ticket_key_idx").on(t.ticketKey),
   index("workflow_runs_definition_id_idx").on(t.definitionId),
+  index("workflow_runs_startup_watchdog_idx")
+    .on(t.startupDeadlineAt)
+    .where(
+      sql`${t.entryStartedAt} is null and coalesce(${t.status}, 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')`,
+    ),
 ]);
 
 /**

--- a/apps/worker/src/db/startup-watchdog-migration.test.ts
+++ b/apps/worker/src/db/startup-watchdog-migration.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it } from "vitest";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+
+async function migrateThrough(lastPrefix: string): Promise<PGlite> {
+  const client = new PGlite();
+  const files = readdirSync(migrationsDir)
+    .filter(
+      (file) => file.endsWith(".sql") && file.slice(0, 4) <= lastPrefix,
+    )
+    .sort();
+  for (const file of files) {
+    await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+  }
+  return client;
+}
+
+describe("0030 startup watchdog migration", () => {
+  it("creates the startup metadata and partial nonterminal index", async () => {
+    const client = await migrateThrough("0030");
+    const columns = await client.query<{
+      column_name: string;
+      is_nullable: string;
+    }>(`
+      SELECT column_name, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'workflow_runs'
+        AND column_name IN (
+          'entry_started_at',
+          'startup_deadline_at',
+          'diagnostic_id'
+        )
+      ORDER BY column_name
+    `);
+    expect(columns.rows).toEqual([
+      { column_name: "diagnostic_id", is_nullable: "YES" },
+      { column_name: "entry_started_at", is_nullable: "YES" },
+      { column_name: "startup_deadline_at", is_nullable: "YES" },
+    ]);
+    const indexes = await client.query<{ indexdef: string }>(`
+      SELECT indexdef
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = 'workflow_runs_startup_watchdog_idx'
+    `);
+    expect(indexes.rows[0]?.indexdef).toContain(
+      "WHERE ((entry_started_at IS NULL)",
+    );
+    expect(indexes.rows[0]?.indexdef).toContain("startup_deadline_at");
+  });
+
+  it("upgrades existing runs without manufacturing startup state", async () => {
+    const client = await migrateThrough("0029");
+    await client.exec(`
+      INSERT INTO workflow_runs (run_id, status, updated_at)
+      VALUES ('legacy-run', 'running', now())
+    `);
+    await client.exec(
+      readFileSync(`${migrationsDir}0030_startup_watchdog.sql`, "utf8"),
+    );
+    const rows = await client.query<{
+      run_id: string;
+      status: string;
+      entry_started_at: Date | null;
+      startup_deadline_at: Date | null;
+      diagnostic_id: string | null;
+    }>(`
+      SELECT run_id, status, entry_started_at, startup_deadline_at, diagnostic_id
+      FROM workflow_runs
+      WHERE run_id = 'legacy-run'
+    `);
+    expect(rows.rows).toEqual([
+      {
+        run_id: "legacy-run",
+        status: "running",
+        entry_started_at: null,
+        startup_deadline_at: null,
+        diagnostic_id: null,
+      },
+    ]);
+  });
+});

--- a/apps/worker/src/lib/cancel-run.test.ts
+++ b/apps/worker/src/lib/cancel-run.test.ts
@@ -50,6 +50,8 @@ function active(overrides: Partial<ActiveRunEntry> = {}): ActiveRunEntry {
 function registry(entry: ActiveRunEntry | null = active()): RunRegistryAdapter {
   return {
     reserve: vi.fn(),
+    commitStartedRun: vi.fn(),
+    markRunEntryStarted: vi.fn(),
     bindRun: vi.fn(),
     beginParking: vi.fn(),
     finishParking: vi.fn(),

--- a/apps/worker/src/lib/dispatch-owner-cas.test.ts
+++ b/apps/worker/src/lib/dispatch-owner-cas.test.ts
@@ -9,6 +9,19 @@ vi.mock("../../env.js", () => ({
 }));
 vi.mock("workflow/api", () => ({ start: vi.fn(), getRun: vi.fn() }));
 vi.mock("../workflows/agent.js", () => ({ agentWorkflow: vi.fn() }));
+const recordAndCancelOrphanStartedRun = vi.hoisted(() => vi.fn());
+vi.mock("./run-start-lifecycle.js", () => ({
+  commitHostedStart: async (
+    runRegistry: RunRegistryAdapter,
+    started: Parameters<RunRegistryAdapter["commitStartedRun"]>[0],
+  ) => {
+    if (await runRegistry.commitStartedRun(started)) return true;
+    await recordAndCancelOrphanStartedRun(started);
+    return false;
+  },
+  recordAndCancelOrphanStartedRun: (...args: unknown[]) =>
+    recordAndCancelOrphanStartedRun(...args),
+}));
 
 function registry(): RunRegistryAdapter {
   const entries = new Map<string, ActiveRunEntry>();
@@ -25,6 +38,18 @@ function registry(): RunRegistryAdapter {
       });
       return true;
     }),
+    commitStartedRun: vi.fn(async (started) => {
+      const current = entries.get(started.subjectKey);
+      if (!current || current.ownerToken !== started.ownerToken) return false;
+      entries.set(started.subjectKey, {
+        ...current,
+        state: "bound",
+        runId: started.runId,
+        updatedAt: Date.now(),
+      });
+      return true;
+    }),
+    markRunEntryStarted: vi.fn(async () => false),
     bindRun: vi.fn(async () => false),
     beginParking: vi.fn(async () => false),
     finishParking: vi.fn(async () => false),
@@ -54,10 +79,6 @@ describe("claimSubjectRun", () => {
     const { claimSubjectRun } = await import("./dispatch.js");
     const runRegistry = registry();
     const order: string[] = [];
-    vi.mocked(runRegistry.reserve).mockImplementationOnce(async () => {
-      order.push("reserve");
-      return true;
-    });
     const startWorkflow = vi.fn(async (ownerToken: string) => {
       order.push("start");
       expect(ownerToken).toMatch(/^owner:/);
@@ -80,8 +101,14 @@ describe("claimSubjectRun", () => {
       runId: "run-a",
       ownerToken: expect.stringMatching(/^owner:/),
     });
-    expect(order).toEqual(["reserve", "start"]);
-    expect(runRegistry.bindRun).not.toHaveBeenCalled();
+    expect(order).toEqual(["start"]);
+    expect(runRegistry.commitStartedRun).toHaveBeenCalledWith({
+      subjectKey: "ticket:jira:PROJ-1",
+      ticketKey: "PROJ-1",
+      kind: "ticket",
+      ownerToken: expect.stringMatching(/^owner:/),
+      runId: "run-a",
+    });
   });
 
   it("releases only its unbound reservation when a post-reservation guard bails", async () => {
@@ -140,5 +167,33 @@ describe("claimSubjectRun", () => {
       ),
     ).toEqual({ started: false, reason: "already_claimed" });
     expect(secondStart).not.toHaveBeenCalled();
+  });
+
+  it("cancels the exact orphan candidate and reports a retryable error when binding loses ownership", async () => {
+    const { claimSubjectRun } = await import("./dispatch.js");
+    const runRegistry = registry();
+    vi.mocked(runRegistry.commitStartedRun).mockResolvedValueOnce(false);
+    recordAndCancelOrphanStartedRun.mockResolvedValueOnce(undefined);
+
+    await expect(
+      claimSubjectRun(
+        {
+          subjectKey: "ticket:jira:PROJ-1",
+          ticketKey: "PROJ-1",
+          kind: "ticket",
+        },
+        runRegistry,
+        2,
+        { startWorkflow: async () => "run-orphan" },
+      ),
+    ).resolves.toEqual({ started: false, reason: "error" });
+    expect(recordAndCancelOrphanStartedRun).toHaveBeenCalledWith({
+      subjectKey: "ticket:jira:PROJ-1",
+      ticketKey: "PROJ-1",
+      kind: "ticket",
+      ownerToken: expect.stringMatching(/^owner:/),
+      runId: "run-orphan",
+    });
+    expect(runRegistry.releaseReservation).not.toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/lib/dispatch-owner-cas.test.ts
+++ b/apps/worker/src/lib/dispatch-owner-cas.test.ts
@@ -79,6 +79,11 @@ describe("claimSubjectRun", () => {
     const { claimSubjectRun } = await import("./dispatch.js");
     const runRegistry = registry();
     const order: string[] = [];
+    const reserve = vi.mocked(runRegistry.reserve).getMockImplementation();
+    vi.mocked(runRegistry.reserve).mockImplementation(async (reservation) => {
+      order.push("reserve");
+      return reserve?.(reservation) ?? false;
+    });
     const startWorkflow = vi.fn(async (ownerToken: string) => {
       order.push("start");
       expect(ownerToken).toMatch(/^owner:/);
@@ -101,7 +106,7 @@ describe("claimSubjectRun", () => {
       runId: "run-a",
       ownerToken: expect.stringMatching(/^owner:/),
     });
-    expect(order).toEqual(["start"]);
+    expect(order).toEqual(["reserve", "start"]);
     expect(runRegistry.commitStartedRun).toHaveBeenCalledWith({
       subjectKey: "ticket:jira:PROJ-1",
       ticketKey: "PROJ-1",

--- a/apps/worker/src/lib/dispatch-pr-trigger-coalesce.test.ts
+++ b/apps/worker/src/lib/dispatch-pr-trigger-coalesce.test.ts
@@ -38,6 +38,24 @@ function registry(): RunRegistryAdapter {
       });
       return true;
     }),
+    commitStartedRun: vi.fn(async (started) => {
+      const current = rows.get(started.subjectKey);
+      if (
+        !current ||
+        current.ownerToken !== started.ownerToken ||
+        (current.runId !== null && current.runId !== started.runId)
+      ) {
+        return false;
+      }
+      rows.set(started.subjectKey, {
+        ...current,
+        state: "bound",
+        runId: started.runId,
+        updatedAt: Date.now(),
+      });
+      return true;
+    }),
+    markRunEntryStarted: vi.fn(async () => false),
     bindRun: vi.fn(async (subjectKey, ownerToken, runId) => {
       const current = rows.get(subjectKey);
       if (!current || current.state !== "reserved" || current.ownerToken !== ownerToken) return false;
@@ -96,8 +114,6 @@ describe("PR trigger coalescing with owner-CAS", () => {
       runId: "run-1",
       ownerToken: firstOwner,
     });
-    expect(await runRegistry.bindRun(subject.subjectKey, firstOwner, "run-1")).toBe(true);
-
     const secondStart = vi.fn();
     expect(
       await claimSubjectRun(subject, runRegistry, 3, { startWorkflow: secondStart }),
@@ -125,7 +141,6 @@ describe("PR trigger coalescing with owner-CAS", () => {
         return "run-1";
       },
     });
-    await runRegistry.bindRun(subject.subjectKey, predecessorOwner, "run-1");
     await runRegistry.release(subject.subjectKey, predecessorOwner, "run-1");
 
     await claimSubjectRun(subject, runRegistry, 3, {

--- a/apps/worker/src/lib/dispatch-trigger.test.ts
+++ b/apps/worker/src/lib/dispatch-trigger.test.ts
@@ -310,8 +310,7 @@ describe("provider trigger dispatch", () => {
 
     await dispatchTriggerEvent(event(), deps());
     const owner = await registry.get(subjectKey);
-    expect(owner?.state).toBe("reserved");
-    expect(await registry.bindRun(subjectKey, owner!.ownerToken, "run-1")).toBe(true);
+    expect(owner).toMatchObject({ state: "bound", runId: "run-1" });
     const first = (await listPendingTriggersForSubject(db, subjectKey))[0]!;
     expect(await acknowledgeStartedTriggerDelivery(db, first, "run-1")).toBe(true);
 

--- a/apps/worker/src/lib/dispatch.test.ts
+++ b/apps/worker/src/lib/dispatch.test.ts
@@ -59,6 +59,8 @@ function registry(options: {
       rows.push({ ...reservation, runId: null, state: "reserved", createdAt: now, updatedAt: now });
       return true;
     }),
+    commitStartedRun: vi.fn(async () => true),
+    markRunEntryStarted: vi.fn(async () => true),
     bindRun: vi.fn(),
     beginParking: vi.fn(),
     finishParking: vi.fn(),

--- a/apps/worker/src/lib/dispatch.ts
+++ b/apps/worker/src/lib/dispatch.ts
@@ -136,9 +136,9 @@ export async function dispatchTicket(
 }
 
 /**
- * Reserve before start. The dispatcher never binds the run: every Workflow
- * candidate CAS-binds its own runtime id on entry, so retries and duplicate
- * candidates exit before side effects instead of replacing the winner.
+ * Reserve before start, then atomically bind the returned hosted run and write
+ * its startup-watchdog row before reporting success. The Workflow entry repeats
+ * the exact operation as a crash-window fallback.
  */
 export async function claimSubjectRun(
   subject: ClaimSubject,
@@ -172,6 +172,16 @@ export async function claimSubjectRun(
 
     const runId = await options.startWorkflow(ownerToken);
     started = true;
+    const startedRun = {
+      ...subject,
+      ownerToken,
+      runId,
+    };
+    const { commitHostedStart } = await import("./run-start-lifecycle.js");
+    const committed = await commitHostedStart(runRegistry, startedRun);
+    if (!committed) {
+      throw new Error("Hosted workflow start lost dispatch ownership");
+    }
     return { started: true, runId, ownerToken };
   } catch (error) {
     // Once start returns, the candidate may already have bound. A dispatcher

--- a/apps/worker/src/lib/dispatch.ts
+++ b/apps/worker/src/lib/dispatch.ts
@@ -178,9 +178,8 @@ export async function claimSubjectRun(
       runId,
     };
     const { commitHostedStart } = await import("./run-start-lifecycle.js");
-    const committed = await commitHostedStart(runRegistry, startedRun);
-    if (!committed) {
-      throw new Error("Hosted workflow start lost dispatch ownership");
+    if (!(await commitHostedStart(runRegistry, startedRun))) {
+      return { started: false, reason: "error" };
     }
     return { started: true, runId, ownerToken };
   } catch (error) {

--- a/apps/worker/src/lib/overview/collect-block-statuses.test.ts
+++ b/apps/worker/src/lib/overview/collect-block-statuses.test.ts
@@ -24,6 +24,8 @@ function makeRegistry(
   }));
   return {
     reserve: vi.fn(),
+    commitStartedRun: vi.fn(),
+    markRunEntryStarted: vi.fn(),
     bindRun: vi.fn(),
     beginParking: vi.fn(),
     finishParking: vi.fn(),

--- a/apps/worker/src/lib/overview/collect-live-runs.test.ts
+++ b/apps/worker/src/lib/overview/collect-live-runs.test.ts
@@ -21,6 +21,8 @@ function makeRegistry(
   }));
   return {
     reserve: vi.fn(),
+    commitStartedRun: vi.fn(),
+    markRunEntryStarted: vi.fn(),
     bindRun: vi.fn(),
     beginParking: vi.fn(),
     finishParking: vi.fn(),

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -31,6 +31,13 @@ vi.mock("./cancel-run.js", () => ({
   cancelRun: (...args: any[]) => mockCancelRun(...args),
   cancelSubjectRun: (...args: any[]) => mockCancelSubjectRun(...args),
 }));
+vi.mock("./run-start-lifecycle.js", () => ({
+  reconcileStartupWatchdog: vi.fn().mockResolvedValue({
+    selected: 0,
+    cancelled: 0,
+    retryable: 0,
+  }),
+}));
 vi.mock("../sandbox/stop-ticket-sandboxes.js", () => ({
   stopSandboxesByIds: (...args: any[]) => mockStopSandboxesByIds(...args),
 }));
@@ -55,6 +62,8 @@ function registry(
 ): RunRegistryAdapter {
   return {
     reserve: vi.fn(),
+    commitStartedRun: vi.fn(),
+    markRunEntryStarted: vi.fn(),
     bindRun: vi.fn(),
     handoff: vi.fn(),
     get: vi.fn(async (subjectKey) => entries.find((row) => row.subjectKey === subjectKey) ?? null),

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -13,6 +13,7 @@ import type {
 } from "../adapters/run-registry/types.js";
 import type { Db } from "../db/client.js";
 import { confirmWorkflowStepsDrained } from "./workflow-step-drain.js";
+import { reconcileStartupWatchdog } from "./run-start-lifecycle.js";
 
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 const STALE_RESERVATION_MS = 5 * 60 * 1000;
@@ -35,8 +36,25 @@ export async function reconcileRuns(
   db?: Db,
   terminalReconciliationSubjects?: ReadonlySet<string>,
 ): Promise<{ cancelled: number; cleaned: number }> {
-  const entries = await runRegistry.listAll();
   let cancelled = 0;
+  if (db) {
+    try {
+      const startup = await reconcileStartupWatchdog({
+        db,
+        runRegistry,
+        onSubjectReleased,
+      });
+      cancelled += startup.cancelled;
+    } catch (error) {
+      logger.warn(
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "startup_watchdog_reconciliation_failed",
+      );
+    }
+  }
+  const entries = await runRegistry.listAll();
   let cleaned = 0;
 
   for (const listedEntry of entries) {

--- a/apps/worker/src/lib/run-start-constants.ts
+++ b/apps/worker/src/lib/run-start-constants.ts
@@ -1,0 +1,1 @@
+export const STARTUP_DEADLINE_MS = 10 * 60 * 1000;

--- a/apps/worker/src/lib/run-start-lifecycle.test.ts
+++ b/apps/worker/src/lib/run-start-lifecycle.test.ts
@@ -1,0 +1,169 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
+import type { Db } from "../db/client.js";
+import { activeRuns, workflowRuns } from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+
+const mocks = vi.hoisted(() => ({
+  cancelOwned: vi.fn(),
+  cancelHosted: vi.fn(),
+  hostedStatus: "running",
+  confirmDrained: vi.fn(),
+}));
+
+vi.mock("./cancel-run.js", () => ({
+  cancelSubjectRun: (...args: unknown[]) => mocks.cancelOwned(...args),
+}));
+vi.mock("../../env.js", () => ({ env: {} }));
+vi.mock("./workflow-step-drain.js", () => ({
+  confirmWorkflowStepsDrained: (...args: unknown[]) =>
+    mocks.confirmDrained(...args),
+}));
+vi.mock("workflow/api", () => ({
+  getRun: () => ({
+    cancel: (...args: unknown[]) => mocks.cancelHosted(...args),
+    get status() {
+      return Promise.resolve(mocks.hostedStatus);
+    },
+  }),
+}));
+
+const {
+  reconcileStartupWatchdog,
+  STARTUP_TIMEOUT_REASON,
+} = await import("./run-start-lifecycle.js");
+
+const now = new Date("2026-07-27T12:00:00.000Z");
+let db: Db;
+const registry = {} as RunRegistryAdapter;
+
+beforeEach(async () => {
+  db = await createTestDb();
+  mocks.cancelOwned.mockReset().mockResolvedValue(true);
+  mocks.cancelHosted.mockReset().mockImplementation(async () => {
+    mocks.hostedStatus = "cancelled";
+  });
+  mocks.confirmDrained.mockReset().mockResolvedValue(true);
+  mocks.hostedStatus = "running";
+});
+
+async function insertRun(input: {
+  runId?: string;
+  deadline: Date;
+  entryStartedAt?: Date | null;
+  withOwner?: boolean;
+}) {
+  const runId = input.runId ?? "run-startup";
+  const subjectKey = `ticket:jira:${runId.toUpperCase()}`;
+  await db.insert(workflowRuns).values({
+    runId,
+    status: "running",
+    subjectKey,
+    ticketKey: runId.toUpperCase(),
+    createdAt: new Date(now.getTime() - 11 * 60_000),
+    startedAt: new Date(now.getTime() - 11 * 60_000),
+    startupDeadlineAt: input.deadline,
+    entryStartedAt: input.entryStartedAt ?? null,
+  });
+  if (input.withOwner) {
+    await db.insert(activeRuns).values({
+      subjectKey,
+      ticketKey: runId.toUpperCase(),
+      ownerToken: `owner:${runId}`,
+      runId,
+      state: "bound",
+      runKind: "ticket",
+    });
+  }
+  return { runId, subjectKey };
+}
+
+describe("startup watchdog", () => {
+  it("does not select a run one millisecond before its deadline", async () => {
+    await insertRun({ deadline: new Date(now.getTime() + 1) });
+    await expect(
+      reconcileStartupWatchdog({ db, runRegistry: registry, now }),
+    ).resolves.toEqual({ selected: 0, cancelled: 0, retryable: 0 });
+  });
+
+  it("selects exactly at the ten-minute deadline and closes an orphaned run", async () => {
+    const { runId } = await insertRun({ deadline: now });
+    await expect(
+      reconcileStartupWatchdog({ db, runRegistry: registry, now }),
+    ).resolves.toEqual({ selected: 1, cancelled: 1, retryable: 0 });
+    expect(mocks.cancelHosted).toHaveBeenCalledOnce();
+
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, runId));
+    expect(row).toMatchObject({
+      status: "failed",
+      statusReason: STARTUP_TIMEOUT_REASON,
+    });
+    expect(row?.diagnosticId).toMatch(/^diag_/);
+  });
+
+  it("never applies the startup watchdog after application entry begins", async () => {
+    await insertRun({
+      deadline: new Date(now.getTime() - 60_000),
+      entryStartedAt: new Date(now.getTime() - 30_000),
+    });
+    await expect(
+      reconcileStartupWatchdog({ db, runRegistry: registry, now }),
+    ).resolves.toEqual({ selected: 0, cancelled: 0, retryable: 0 });
+  });
+
+  it("closes the exact active owner before marking the startup failure", async () => {
+    const { runId, subjectKey } = await insertRun({
+      deadline: new Date(now.getTime() - 1),
+      withOwner: true,
+    });
+    await expect(
+      reconcileStartupWatchdog({ db, runRegistry: registry, now }),
+    ).resolves.toEqual({ selected: 1, cancelled: 1, retryable: 0 });
+    expect(mocks.cancelOwned).toHaveBeenCalledWith(
+      subjectKey,
+      { ownerToken: `owner:${runId}`, runId },
+      registry,
+      undefined,
+      STARTUP_TIMEOUT_REASON,
+    );
+  });
+
+  it("keeps cancellation failures retryable and never records a false terminal row", async () => {
+    const { runId } = await insertRun({
+      deadline: new Date(now.getTime() - 1),
+    });
+    mocks.cancelHosted.mockRejectedValueOnce(new Error("provider unavailable"));
+    mocks.hostedStatus = "running";
+
+    await expect(
+      reconcileStartupWatchdog({ db, runRegistry: registry, now }),
+    ).resolves.toEqual({ selected: 1, cancelled: 0, retryable: 1 });
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, runId));
+    expect(row?.status).toBe("running");
+    expect(row?.diagnosticId).toMatch(/^diag_/);
+  });
+
+  it("waits for hosted terminal confirmation after cancellation is accepted", async () => {
+    const { runId } = await insertRun({
+      deadline: new Date(now.getTime() - 1),
+    });
+    mocks.cancelHosted.mockResolvedValueOnce(undefined);
+    mocks.hostedStatus = "running";
+
+    await expect(
+      reconcileStartupWatchdog({ db, runRegistry: registry, now }),
+    ).resolves.toEqual({ selected: 1, cancelled: 0, retryable: 1 });
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, runId));
+    expect(row?.status).toBe("running");
+  });
+});

--- a/apps/worker/src/lib/run-start-lifecycle.test.ts
+++ b/apps/worker/src/lib/run-start-lifecycle.test.ts
@@ -11,11 +11,20 @@ const mocks = vi.hoisted(() => ({
   hostedStatus: "running",
   confirmDrained: vi.fn(),
 }));
+const state = vi.hoisted(() => ({
+  db: undefined as Db | undefined,
+}));
 
 vi.mock("./cancel-run.js", () => ({
   cancelSubjectRun: (...args: unknown[]) => mocks.cancelOwned(...args),
 }));
 vi.mock("../../env.js", () => ({ env: {} }));
+vi.mock("../db/client.js", () => ({
+  getDb: () => {
+    if (!state.db) throw new Error("Test database is not ready");
+    return state.db;
+  },
+}));
 vi.mock("./workflow-step-drain.js", () => ({
   confirmWorkflowStepsDrained: (...args: unknown[]) =>
     mocks.confirmDrained(...args),
@@ -30,6 +39,8 @@ vi.mock("workflow/api", () => ({
 }));
 
 const {
+  commitHostedStart,
+  recordAndCancelOrphanStartedRun,
   reconcileStartupWatchdog,
   STARTUP_TIMEOUT_REASON,
 } = await import("./run-start-lifecycle.js");
@@ -40,12 +51,88 @@ const registry = {} as RunRegistryAdapter;
 
 beforeEach(async () => {
   db = await createTestDb();
+  state.db = db;
   mocks.cancelOwned.mockReset().mockResolvedValue(true);
   mocks.cancelHosted.mockReset().mockImplementation(async () => {
     mocks.hostedStatus = "cancelled";
   });
   mocks.confirmDrained.mockReset().mockResolvedValue(true);
   mocks.hostedStatus = "running";
+});
+
+const started = {
+  subjectKey: "ticket:jira:PROJ-1",
+  ticketKey: "PROJ-1",
+  ownerToken: "owner-a",
+  kind: "ticket" as const,
+  runId: "run-started",
+};
+
+describe("hosted start commit", () => {
+  it("accepts an exact owner/run after an ambiguous commit exception", async () => {
+    const runRegistry = {
+      commitStartedRun: vi.fn().mockRejectedValue(new Error("connection lost")),
+      get: vi.fn().mockResolvedValue({
+        subjectKey: started.subjectKey,
+        ticketKey: started.ticketKey,
+        ownerToken: started.ownerToken,
+        kind: started.kind,
+        runId: started.runId,
+        state: "bound",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    } as unknown as RunRegistryAdapter;
+
+    await expect(commitHostedStart(runRegistry, started)).resolves.toBe(true);
+    expect(mocks.cancelHosted).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel when an ambiguous commit cannot be rechecked", async () => {
+    const runRegistry = {
+      commitStartedRun: vi.fn().mockRejectedValue(new Error("connection lost")),
+      get: vi.fn().mockRejectedValue(new Error("database unavailable")),
+    } as unknown as RunRegistryAdapter;
+
+    await expect(commitHostedStart(runRegistry, started)).rejects.toThrow(
+      "database unavailable",
+    );
+    expect(mocks.cancelHosted).not.toHaveBeenCalled();
+  });
+
+  it("records and cancels a confirmed orphan candidate", async () => {
+    const runRegistry = {
+      commitStartedRun: vi.fn().mockResolvedValue(false),
+    } as unknown as RunRegistryAdapter;
+
+    await expect(commitHostedStart(runRegistry, started)).resolves.toBe(false);
+    expect(mocks.cancelHosted).toHaveBeenCalledOnce();
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, started.runId));
+    expect(row).toMatchObject({
+      status: "failed",
+      statusReason: "Hosted workflow start lost dispatch ownership.",
+    });
+    expect(row?.diagnosticId).toMatch(/^diag_/);
+  });
+
+  it("records direct orphan cleanup after terminal cancellation", async () => {
+    await recordAndCancelOrphanStartedRun({
+      ...started,
+      runId: "run-direct-orphan",
+    });
+
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, "run-direct-orphan"));
+    expect(row).toMatchObject({
+      status: "failed",
+      statusReason: "Hosted workflow start lost dispatch ownership.",
+    });
+  });
 });
 
 async function insertRun(input: {

--- a/apps/worker/src/lib/run-start-lifecycle.ts
+++ b/apps/worker/src/lib/run-start-lifecycle.ts
@@ -10,8 +10,9 @@ import { activeRuns, workflowRuns } from "../db/schema.js";
 import { confirmWorkflowStepsDrained } from "./workflow-step-drain.js";
 import { logger } from "./logger.js";
 import { cancelSubjectRun } from "./cancel-run.js";
+import { STARTUP_DEADLINE_MS } from "./run-start-constants.js";
 
-export const STARTUP_DEADLINE_MS = 10 * 60 * 1000;
+export { STARTUP_DEADLINE_MS } from "./run-start-constants.js";
 export const STARTUP_TIMEOUT_REASON =
   "Workflow did not start within 10 minutes.";
 const LOST_START_OWNERSHIP_REASON =
@@ -46,6 +47,14 @@ export async function commitHostedStart(
       },
       "dispatch_start_commit_failed",
     );
+    const owner = await runRegistry.get(started.subjectKey);
+    if (
+      owner?.ownerToken === started.ownerToken &&
+      owner.runId === started.runId &&
+      owner.state === "bound"
+    ) {
+      return true;
+    }
   }
   await recordAndCancelOrphanStartedRun(started);
   return false;

--- a/apps/worker/src/lib/run-start-lifecycle.ts
+++ b/apps/worker/src/lib/run-start-lifecycle.ts
@@ -1,0 +1,296 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { getRun } from "workflow/api";
+import type {
+  RunRegistryAdapter,
+  StartedRunRecord,
+} from "../adapters/run-registry/types.js";
+import { getDb, type Db } from "../db/client.js";
+import { activeRuns, workflowRuns } from "../db/schema.js";
+import { confirmWorkflowStepsDrained } from "./workflow-step-drain.js";
+import { logger } from "./logger.js";
+import { cancelSubjectRun } from "./cancel-run.js";
+
+export const STARTUP_DEADLINE_MS = 10 * 60 * 1000;
+export const STARTUP_TIMEOUT_REASON =
+  "Workflow did not start within 10 minutes.";
+const LOST_START_OWNERSHIP_REASON =
+  "Hosted workflow start lost dispatch ownership.";
+const STARTUP_WATCHDOG_LIMIT = 50;
+const TERMINAL_LOCAL_STATUSES = [
+  "success",
+  "failed",
+  "blocked",
+  "awaiting",
+  "completed",
+  "cancelled",
+] as const;
+const TERMINAL_HOSTED_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+export async function commitHostedStart(
+  runRegistry: RunRegistryAdapter,
+  started: StartedRunRecord,
+): Promise<boolean> {
+  try {
+    if (await runRegistry.commitStartedRun(started)) return true;
+  } catch (error) {
+    logger.warn(
+      {
+        subjectKey: started.subjectKey,
+        runId: started.runId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "dispatch_start_commit_failed",
+    );
+  }
+  await recordAndCancelOrphanStartedRun(started);
+  return false;
+}
+
+export async function recordAndCancelOrphanStartedRun(
+  started: StartedRunRecord,
+): Promise<void> {
+  const db = getDb();
+  const diagnosticId = diagnosticIdForStartup();
+  try {
+    await db
+      .insert(workflowRuns)
+      .values({
+        runId: started.runId,
+        status: "running",
+        statusReason: LOST_START_OWNERSHIP_REASON,
+        subjectKey: started.subjectKey,
+        ticketKey: started.ticketKey,
+        createdAt: sql`now()`,
+        startedAt: sql`now()`,
+        startupDeadlineAt: sql`now()`,
+        diagnosticId,
+      })
+      .onConflictDoNothing({ target: workflowRuns.runId });
+  } catch (error) {
+    logger.warn(
+      {
+        subjectKey: started.subjectKey,
+        runId: started.runId,
+        diagnosticId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "dispatch_orphan_candidate_record_failed",
+    );
+  }
+  const cancelled = await cancelUnownedHostedRun(started.runId);
+  if (cancelled) {
+    await markStartupFailure(
+      db,
+      started.runId,
+      diagnosticId,
+      LOST_START_OWNERSHIP_REASON,
+    );
+  }
+  logger.warn(
+    {
+      subjectKey: started.subjectKey,
+      runId: started.runId,
+      diagnosticId,
+      cancellationConfirmed: cancelled,
+    },
+    "dispatch_orphan_candidate",
+  );
+}
+
+export interface StartupWatchdogResult {
+  selected: number;
+  cancelled: number;
+  retryable: number;
+}
+
+export async function reconcileStartupWatchdog(input: {
+  db: Db;
+  runRegistry: RunRegistryAdapter;
+  now?: Date;
+  onSubjectReleased?: (subjectKey: string) => Promise<void> | void;
+}): Promise<StartupWatchdogResult> {
+  const now = input.now ?? new Date();
+  const due = await input.db
+    .select({
+      runId: workflowRuns.runId,
+      subjectKey: workflowRuns.subjectKey,
+      ticketKey: workflowRuns.ticketKey,
+      diagnosticId: workflowRuns.diagnosticId,
+      ownerToken: activeRuns.ownerToken,
+      ownerRunId: activeRuns.runId,
+      ownerState: activeRuns.state,
+    })
+    .from(workflowRuns)
+    .leftJoin(
+      activeRuns,
+      and(
+        eq(activeRuns.subjectKey, workflowRuns.subjectKey),
+        eq(activeRuns.runId, workflowRuns.runId),
+      ),
+    )
+    .where(
+      and(
+        isNull(workflowRuns.entryStartedAt),
+        sql`${workflowRuns.startupDeadlineAt} <= ${now}`,
+        sql`coalesce(${workflowRuns.status}, 'running') not in (${sql.join(
+          TERMINAL_LOCAL_STATUSES.map((status) => sql`${status}`),
+          sql`, `,
+        )})`,
+      ),
+    )
+    .limit(STARTUP_WATCHDOG_LIMIT);
+
+  const result: StartupWatchdogResult = {
+    selected: due.length,
+    cancelled: 0,
+    retryable: 0,
+  };
+  for (const row of due) {
+    const diagnosticId = await claimStartupTimeout(
+      input.db,
+      row.runId,
+      now,
+      row.diagnosticId ?? diagnosticIdForStartup(),
+    );
+    if (!diagnosticId) continue;
+    if (!row.subjectKey) {
+      result.retryable++;
+      continue;
+    }
+    const confirmed =
+      row.ownerToken &&
+      row.ownerRunId === row.runId &&
+      row.ownerState !== "reserved"
+        ? await cancelSubjectRun(
+            row.subjectKey,
+            { ownerToken: row.ownerToken, runId: row.runId },
+            input.runRegistry,
+            input.onSubjectReleased,
+            STARTUP_TIMEOUT_REASON,
+          )
+        : await cancelUnownedHostedRun(row.runId);
+    if (!confirmed) {
+      await persistDiagnosticId(input.db, row.runId, diagnosticId);
+      result.retryable++;
+      continue;
+    }
+    await markStartupFailure(input.db, row.runId, diagnosticId);
+    result.cancelled++;
+  }
+  return result;
+}
+
+async function claimStartupTimeout(
+  db: Db,
+  runId: string,
+  now: Date,
+  diagnosticId: string,
+): Promise<string | null> {
+  const rows = await db
+    .update(workflowRuns)
+    .set({
+      diagnosticId: sql`coalesce(${workflowRuns.diagnosticId}, ${diagnosticId})`,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(workflowRuns.runId, runId),
+        isNull(workflowRuns.entryStartedAt),
+        sql`${workflowRuns.startupDeadlineAt} <= ${now}`,
+        sql`coalesce(${workflowRuns.status}, 'running') not in (${sql.join(
+          TERMINAL_LOCAL_STATUSES.map((status) => sql`${status}`),
+          sql`, `,
+        )})`,
+      ),
+    )
+    .returning({ diagnosticId: workflowRuns.diagnosticId });
+  return rows[0]?.diagnosticId ?? null;
+}
+
+async function cancelUnownedHostedRun(runId: string): Promise<boolean> {
+  const run = getRun(runId);
+  try {
+    await run.cancel();
+  } catch (error) {
+    let status: string;
+    try {
+      status = await run.status;
+    } catch (statusError) {
+      logger.warn(
+        {
+          runId,
+          error: error instanceof Error ? error.message : String(error),
+          statusError:
+            statusError instanceof Error
+              ? statusError.message
+              : String(statusError),
+        },
+        "startup_watchdog_cancel_unconfirmed",
+      );
+      return false;
+    }
+    if (!TERMINAL_HOSTED_STATUSES.has(status)) return false;
+  }
+  let status: string;
+  try {
+    status = await run.status;
+  } catch (error) {
+    logger.warn(
+      {
+        runId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "startup_watchdog_status_unconfirmed",
+    );
+    return false;
+  }
+  if (!TERMINAL_HOSTED_STATUSES.has(status)) return false;
+  return confirmWorkflowStepsDrained("startup-watchdog", runId);
+}
+
+async function markStartupFailure(
+  db: Db,
+  runId: string,
+  diagnosticId: string,
+  reason = STARTUP_TIMEOUT_REASON,
+): Promise<void> {
+  await db
+    .update(workflowRuns)
+    .set({
+      status: "failed",
+      statusReason: reason,
+      diagnosticId,
+      completedAt: sql`coalesce(${workflowRuns.completedAt}, now())`,
+      durationSec: sql`coalesce(${workflowRuns.durationSec}, greatest(0, extract(epoch from (now() - coalesce(${workflowRuns.startedAt}, ${workflowRuns.createdAt})))::int))`,
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(workflowRuns.runId, runId),
+        isNull(workflowRuns.entryStartedAt),
+      ),
+    );
+}
+
+async function persistDiagnosticId(
+  db: Db,
+  runId: string,
+  diagnosticId: string,
+): Promise<void> {
+  await db
+    .update(workflowRuns)
+    .set({
+      diagnosticId: sql`coalesce(${workflowRuns.diagnosticId}, ${diagnosticId})`,
+      updatedAt: sql`now()`,
+    })
+    .where(eq(workflowRuns.runId, runId));
+}
+
+function diagnosticIdForStartup(): string {
+  return `diag_${randomUUID()}`;
+}

--- a/apps/worker/src/lib/slack/handlers.test.ts
+++ b/apps/worker/src/lib/slack/handlers.test.ts
@@ -13,6 +13,8 @@ const JIRA_BASE_URL = "https://example.atlassian.net";
 function makeRegistry(overrides: Partial<RunRegistryAdapter> = {}): RunRegistryAdapter {
   return {
     reserve: vi.fn(),
+    commitStartedRun: vi.fn(),
+    markRunEntryStarted: vi.fn(),
     bindRun: vi.fn(),
     beginParking: overrides.beginParking ?? vi.fn(),
     finishParking: overrides.finishParking ?? vi.fn(),

--- a/apps/worker/src/manual-dispatch/service.test.ts
+++ b/apps/worker/src/manual-dispatch/service.test.ts
@@ -51,6 +51,7 @@ const {
 
 let db: Db;
 let runRegistry: {
+  commitStartedRun: ReturnType<typeof vi.fn>;
   get: ReturnType<typeof vi.fn>;
   listAll: ReturnType<typeof vi.fn>;
   listCapacityConsumers: ReturnType<typeof vi.fn>;
@@ -143,6 +144,10 @@ beforeEach(async () => {
     return { runId: `run-${testState.runNumber}` };
   });
   runRegistry = {
+    commitStartedRun: vi.fn().mockImplementation(async () => {
+      testState.order.push("commit");
+      return true;
+    }),
     get: vi.fn().mockResolvedValue(null),
     listAll: vi.fn().mockResolvedValue([]),
     listCapacityConsumers: vi.fn().mockResolvedValue([]),
@@ -180,6 +185,7 @@ describe("manual dispatch durability", () => {
       "resolve",
       "move",
       "start",
+      "commit",
     ]);
     expect(await getManualDispatchRequest(db, request().requestId)).toMatchObject({
       status: "candidate_started",

--- a/apps/worker/src/manual-dispatch/service.ts
+++ b/apps/worker/src/manual-dispatch/service.ts
@@ -431,6 +431,26 @@ async function processManualDispatch(input: {
   try {
     const workflowInput = workflowInputFor(resolved, ownerToken, input.row.requestId);
     const handle = await start(agentWorkflow, [workflowInput]);
+    const startedRun = {
+      subjectKey: resolved.subjectKey,
+      ticketKey: resolved.ticketKey ?? null,
+      ownerToken,
+      runId: handle.runId,
+      kind:
+        resolved.inputKind === "ticket"
+          ? "manual_ticket"
+          : "manual_pr_trigger",
+    } as const;
+    const { commitHostedStart } = await import(
+      "../lib/run-start-lifecycle.js"
+    );
+    const committed = await commitHostedStart(
+      input.adapters.runRegistry,
+      startedRun,
+    );
+    if (!committed) {
+      return { requestId: input.row.requestId, status: "recovering" };
+    }
     const recorded = await markManualDispatchCandidateStarted(
       input.db,
       input.row.requestId,

--- a/apps/worker/src/workflows/agent-input.test.ts
+++ b/apps/worker/src/workflows/agent-input.test.ts
@@ -2,8 +2,48 @@ import { describe, expect, it } from "vitest";
 import {
   normalizeClarificationOrigin,
   restoreClarificationOrigin,
+  runKindForAgentWorkflowInput,
   type AgentWorkflowInput,
 } from "./agent-input.js";
+
+describe("workflow run kind", () => {
+  const ticket = {
+    kind: "ticket",
+    subjectKey: "ticket:jira:PROJ-1",
+    ticketKey: "PROJ-1",
+    ownerToken: "owner",
+  } as const;
+  const prTrigger = {
+    kind: "pr_trigger",
+    triggerType: "trigger_pr_created",
+    subjectKey: "pr:github:acme/api:42",
+    ownerToken: "owner",
+    definitionId: 7,
+    definitionVersion: 12,
+    scope: "any",
+    pr: {
+      provider: "github",
+      repoPath: "acme/api",
+      prNumber: 42,
+      prUrl: "https://github.com/acme/api/pull/42",
+      headRef: "feature/review",
+      headSha: "deadbeef",
+      baseRef: "main",
+      title: "Review me",
+      author: "alice",
+      isDraft: false,
+    },
+  } as const;
+
+  it.each([
+    [ticket, "ticket"],
+    [{ ...ticket, manualDispatchId: "manual-1" }, "manual_ticket"],
+    [prTrigger, "pr_trigger"],
+    [{ ...prTrigger, manualDispatchId: "manual-2" }, "manual_pr_trigger"],
+  ] as const)("maps %s to %s", (entry, expected) => {
+    expect(runKindForAgentWorkflowInput(entry)).toBe(expected);
+  });
+});
 
 describe("clarification origin entries", () => {
   it("restores the full PR trigger context under the successor identity", () => {

--- a/apps/worker/src/workflows/agent-input.ts
+++ b/apps/worker/src/workflows/agent-input.ts
@@ -4,6 +4,7 @@
  * executors can read PR facts without re-fetching them.
  */
 import type { ApprovedRepositoryScope } from "@shared/contracts";
+import type { RunKind } from "../adapters/run-registry/types.js";
 
 export interface PrTriggerPayload {
   provider: "github" | "gitlab";
@@ -119,6 +120,18 @@ export type AgentWorkflowInput =
       approval: { approvalRequestId: string; approver: string; approvedAt: string };
     }
   ;
+
+export function runKindForAgentWorkflowInput(
+  entry: AgentWorkflowInput,
+): RunKind {
+  if (entry.kind === "pr_trigger") {
+    return entry.manualDispatchId ? "manual_pr_trigger" : "pr_trigger";
+  }
+  if (entry.kind === "ticket" && entry.manualDispatchId) {
+    return "manual_ticket";
+  }
+  return "ticket";
+}
 
 export type ClarificationOriginEntry =
   | { kind: "ticket"; ticketKey: string; definitionId?: number; definitionVersion?: WorkflowDefinitionVersionPin }

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -2514,6 +2514,14 @@ export async function agentWorkflow(input: string | AgentWorkflowInput) {
       entry.subjectKey,
       entry.ownerToken,
       workflowRunId,
+      entry.ticketKey ?? null,
+      entry.kind === "pr_trigger"
+        ? entry.manualDispatchId
+          ? "manual_pr_trigger"
+          : "pr_trigger"
+        : entry.kind === "ticket" && entry.manualDispatchId
+          ? "manual_ticket"
+          : "ticket",
     );
     if (!bound) return;
     await acknowledgeManualDispatchStep(entry, workflowRunId);

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -73,6 +73,7 @@ import type {
 import { resolveBlockAgent, resolveRunDefaultKind } from "../workflow-definition/resolve-agent.js";
 import { resolveTicketMoveTarget } from "./ticket-move-target.js";
 import {
+  runKindForAgentWorkflowInput,
   type AgentWorkflowInput,
 } from "./agent-input.js";
 import type { TicketTransitionOwner } from "../lib/ticket-transition.js";
@@ -2515,13 +2516,7 @@ export async function agentWorkflow(input: string | AgentWorkflowInput) {
       entry.ownerToken,
       workflowRunId,
       entry.ticketKey ?? null,
-      entry.kind === "pr_trigger"
-        ? entry.manualDispatchId
-          ? "manual_pr_trigger"
-          : "pr_trigger"
-        : entry.kind === "ticket" && entry.manualDispatchId
-          ? "manual_ticket"
-          : "ticket",
+      runKindForAgentWorkflowInput(entry),
     );
     if (!bound) return;
     await acknowledgeManualDispatchStep(entry, workflowRunId);

--- a/apps/worker/src/workflows/run-ownership-steps.test.ts
+++ b/apps/worker/src/workflows/run-ownership-steps.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ActiveRunOwnerError } from "../lib/run-control-errors.js";
 
-const bindRun = vi.fn();
+const markRunEntryStarted = vi.fn();
 const beginParking = vi.fn();
 const finishParking = vi.fn();
 const getRunOwner = vi.fn();
@@ -29,7 +29,7 @@ const acknowledgeManualDispatch = vi.fn();
 vi.mock("../lib/step-adapters.js", () => ({
   createStepAdapters: () => ({
     runRegistry: {
-      bindRun,
+      markRunEntryStarted,
       beginParking,
       finishParking,
       get: getRunOwner,
@@ -88,7 +88,7 @@ vi.mock("../manual-dispatch/service.js", () => ({
 
 describe("workflow owner steps", () => {
   beforeEach(() => {
-    bindRun.mockReset();
+    markRunEntryStarted.mockReset();
     beginParking.mockReset().mockResolvedValue(true);
     finishParking.mockReset().mockResolvedValue(true);
     getRunOwner.mockReset().mockResolvedValue(null);
@@ -464,11 +464,17 @@ describe("workflow owner steps", () => {
   });
 
   it("lets only the candidate that CAS-binds continue", async () => {
-    bindRun.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    markRunEntryStarted.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     const { bindWorkflowCandidateStep } = await import("./run-ownership-steps.js");
     expect(await bindWorkflowCandidateStep("subject", "owner", "run-a")).toBe(true);
     expect(await bindWorkflowCandidateStep("subject", "owner", "run-b")).toBe(false);
-    expect(bindRun).toHaveBeenNthCalledWith(1, "subject", "owner", "run-a");
+    expect(markRunEntryStarted).toHaveBeenNthCalledWith(1, {
+      subjectKey: "subject",
+      ticketKey: null,
+      kind: "ticket",
+      ownerToken: "owner",
+      runId: "run-a",
+    });
   });
 
   it("crosses the durable parking barrier only after every registered sandbox stop is confirmed", async () => {

--- a/apps/worker/src/workflows/run-ownership-steps.ts
+++ b/apps/worker/src/workflows/run-ownership-steps.ts
@@ -2,10 +2,18 @@ export async function bindWorkflowCandidateStep(
   subjectKey: string,
   ownerToken: string,
   workflowRunId: string,
+  ticketKey: string | null = null,
+  kind: import("../adapters/run-registry/types.js").RunKind = "ticket",
 ): Promise<boolean> {
   "use step";
   const { createStepAdapters } = await import("../lib/step-adapters.js");
-  return createStepAdapters().runRegistry.bindRun(subjectKey, ownerToken, workflowRunId);
+  return createStepAdapters().runRegistry.markRunEntryStarted({
+    subjectKey,
+    ticketKey,
+    kind,
+    ownerToken,
+    runId: workflowRunId,
+  });
 }
 bindWorkflowCandidateStep.maxRetries = 0;
 

--- a/docs/plans/2026-07-27-aiw-182-190-workflow-acceptance-followups.md
+++ b/docs/plans/2026-07-27-aiw-182-190-workflow-acceptance-followups.md
@@ -1,0 +1,215 @@
+# AIW-182–190 workflow acceptance follow-ups
+
+Date: 2026-07-27
+
+This document is the persistent implementation record for the six-PR stack
+approved after the workflow-v2 acceptance review. The locked product decisions
+remain in `2026-07-23-ai-workflow-improvements-decisions.md`.
+
+## Delivery stack
+
+| PR | Branch | Jira | Base | Migration |
+|---|---|---|---|---|
+| 1 | `codex/aiw-184-189-run-start-lifecycle` | AIW-184, AIW-189 | `origin/main` | Startup metadata |
+| 2 | `codex/aiw-183-workflow-values` | AIW-183 | PR 1 | No |
+| 3 | `codex/aiw-182-187-harness-capabilities` | AIW-182, AIW-187 | PR 2 | Capability cache |
+| 4 | `codex/aiw-185-188-loop-parallelism` | AIW-185, AIW-188 | PR 3 | No |
+| 5 | `codex/aiw-186-review-fix-template` | AIW-186 | PR 4 | No |
+| 6 | `codex/aiw-190-post-pr-review` | AIW-190 | PR 5 | PR checks and review publications |
+
+All work uses clean worktrees. No more than three PRs are ready for review at
+once; completed descendants may remain drafts.
+
+## Shared contracts
+
+### Workflow value bindings
+
+V2 supports a single reference, an ordered reference list, or a literal.
+`reference_list` is valid only for array inputs, every member must be guaranteed
+and compatible with the array item schema, and runtime preserves authored
+order.
+
+Catalog generation, picker presentation, deployment validation, Branch,
+Transform, typed inputs, and mixed text share one compatibility decision. Its
+reasons are graph unavailability, optional presence, nullability, type mismatch,
+or an unsupported destination.
+
+### Review Result
+
+Review Agent, Fix Agent, Post PR review, catalog compatibility, and runtime
+validation derive from one code-owned contract:
+
+- decision: `approve` or `request_changes`;
+- findings: file, description, critical or suggestion severity, and optional
+  start/end line;
+- optional feedback.
+
+An end line requires a start line and cannot precede it. Structurally compatible
+custom agent outputs may contain extra fields, but runtime projects only the
+canonical fields.
+
+### Compatibility
+
+- Workflow Definition v1 remains readable and executable unchanged.
+- Pre-release v2 profile serialization, Loop carry data, trigger set, and review
+  actions may change directly.
+- Immutable Harness Profile v1 versions retain their historical
+  provider-default behavior.
+- Duplicate provider/model fields in pre-release v2 drafts normalize to the
+  selected profile.
+
+## PR 1 — Dispatch ownership and startup watchdog
+
+- Reserve the exact subject and owner, start the hosted Workflow, then bind the
+  returned run ID and insert the minimal run row in one transaction.
+- Report `started` only after the transaction commits.
+- Accept an identical dispatcher or workflow-entry bind as idempotent success.
+- If binding loses ownership, record and cancel only the orphan candidate and
+  return a retryable dispatch error.
+- Use the same start boundary for tickets, PR triggers, approvals, and manual
+  dispatch.
+- Add `entry_started_at`, `startup_deadline_at`, `diagnostic_id`, and a partial
+  watchdog index to `workflow_runs`.
+- Give each successful start a deadline exactly ten minutes later.
+- Mark application entry only when the first ownership step actually begins.
+- Reconcile due nonterminal rows whose entry marker is absent, including rows
+  whose active ownership disappeared.
+- Close exact active ownership, cancel the hosted Workflow, drain resources, and
+  retry transient failures. Mark failure only after terminal confirmation.
+- Use the safe reason `Workflow did not start within 10 minutes.` and a
+  diagnostic ID.
+- Provide a dry-run-first cleanup command for the six confirmed production run
+  IDs. Apply mode must re-check the exact deployment, pending first ownership
+  step at attempt zero, missing entry marker, and nonterminal hosted status.
+
+## PR 2 — Open PR outputs and workflow-value compatibility
+
+- Make `prs`, `prUrl`, and `prNumber` required after successful Open PR
+  continuation; missing primary PR data is an execution failure.
+- Mixed text accepts guaranteed required non-null strings, string enums,
+  numbers, and integers. Numeric formatting uses locale-independent
+  `String(number)`.
+- Do not coerce text to numbers or accept booleans, arrays, objects, null, or
+  maybe-missing values.
+- Scalar transforms require guaranteed required non-null values of their
+  expected type. Build object keeps its explicit omission/default behavior.
+- Remove the global Unavailable section. Keep disabled rows in their normal
+  step and schema order with muted presentation and the exact reason.
+- Disabled rows remain searchable and keyboard reachable but cannot be
+  selected.
+- Deduplicate canonical references and distinguish **Entire output** from a
+  nested field named **Output**.
+- Preserve invalid existing bindings until the author removes or replaces them.
+
+## PR 3 — Capability-driven Harness Profiles
+
+- Add an organization-scoped, authenticated, no-store capability endpoint keyed
+  by provider and exact pinned CLI version.
+- Codex discovers the paginated `model/list` catalog from the exact isolated
+  app-server. Claude discovers organization-visible models from the Anthropic
+  Models API; the adapter supplies only capability details the provider cannot
+  expose reliably.
+- Use a ten-second discovery timeout and fifteen-minute fresh-cache window.
+- Return a safe stale organization cache after live failure; return 503 when no
+  cache exists. Stale catalogs cannot publish a profile version.
+- Cache normalized catalogs by organization, provider, and CLI version without
+  credentials or secret-bearing provider payloads.
+- Add manifest v2 while preserving immutable manifest v1 behavior.
+- V2 stores the model, reasoning selection and effective effort, standard or
+  advertised speed tier, supported Codex verbosity, compaction mode and
+  threshold, and the exact capability snapshot/hash used for publication.
+- Context size is read-only. Custom compaction requires known context.
+- Claude supports default, percentage threshold, and disabled compaction.
+  Codex supports default and a percentage-derived token threshold, but not
+  disabled.
+- Runtime applies every published setting explicitly; unsupported settings
+  block publication.
+- Dashboard controls come only from the catalog. Historical unavailable models
+  remain visible and are never silently replaced.
+- The exact pinned Harness Profile version becomes the sole provider/model
+  source for v2 agents across save, restore, duplication, copy/paste, and
+  Undo/Redo.
+
+## PR 4 — Loop-scoped values and parallel Review isolation
+
+- Make authoring availability follow scheduler activation scopes.
+- The initially entered part of a Loop region executes in the owner scope;
+  retries receive separate child activations.
+- A value is available only when its producer precedes the consumer on every
+  relevant path in the same activation. Guaranteed pre-Loop values remain
+  available in descendants.
+- Never fall back to previous or sibling iterations. Unexpected missing
+  current-iteration data fails safely.
+- Add typed explicit Loop carry values. Resolve and freeze them at the boundary,
+  then expose only those values under
+  `steps.<loopId>.output.values.<name>` in the next child activation.
+- Refresh carry on each boundary and never leak arbitrary Loop-child state
+  after exit.
+- Keep three workspace modes: none, isolated reader for Review Agent, and
+  exclusive writer for mutating or not-provably-read-only blocks.
+- Allow reader/reader concurrency; reject reader/writer and writer/writer unless
+  explicitly ordered or mutually exclusive.
+- Fan-out reviewers each receive a disposable read-only workspace from the same
+  immutable fingerprint, without publication credentials or writable remotes.
+- Review sandboxes are never merged into the canonical workspace and are
+  cleaned up on every terminal path.
+
+## PR 5 — Reviewed ticket workflow
+
+- Add fixed `reviewResults: ReviewResult[]` to Fix Agent through
+  `reference_list`; keep external human `reviewFeedback` separate.
+- Revalidate every review result and compile the ordered list into a delimited
+  prompt section.
+- Add the editable **Reviewed ticket workflow** template:
+  ticket trigger, workspace, planning, implementation, three parallel reviews,
+  one visible all-approved Branch, checks/finalization/Open PR on approval, and
+  Loop/Fix/re-review on rejection.
+- Carry the three exact current Review Results through the Loop.
+- Allow three retries after the initial review.
+- Exhaustion sends Slack and terminates the workflow explicitly as failed.
+- Keep every block, prompt, condition, mapping, and connection visible and
+  editable.
+
+## PR 6 — Post-PR checks and review publishing
+
+- Add v2 PR created, PR ready, and PR updated triggers with equivalent GitHub
+  and GitLab normalization.
+- Created includes drafts; Ready covers non-draft open/reopen and draft-to-ready;
+  Updated fires only when the head SHA changes.
+- Manual dispatch resolves the selected deployed trigger against the exact
+  current head.
+- A newer head supersedes the previous review run, closes its pending checks,
+  drains/cancels its exact owner, and prevents stale publication.
+- Add visible Create PR check and Complete PR check actions using an opaque
+  same-run, same-head reference. Provider IDs remain server-side.
+- Persist external checks and review publications/comments with durable retry
+  intent and idempotency.
+- Every terminal path closes pending checks with the appropriate conclusion.
+  Normal workflow completion with an uncompleted check becomes a clear
+  configuration failure.
+- Add Post PR review with a non-empty ordered list of compatible Review Results.
+- Validate and normalize results, hash the publication, fetch the exact diff,
+  publish safe changed-line findings inline, and move unsafe/unlocatable
+  findings into the summary.
+- Approve only when every source approves. GitHub uses one review with inline
+  comments; GitLab uses equivalent discussions, summary note, and supported
+  approval state.
+- Return the combined decision, summary, inline count, and fallback count.
+- Add the editable **Post-PR review** template with PR ready and PR updated
+  triggers, Create check, exact-head workspace, three parallel reviewers, Post
+  review, Branch, and successful/failed check completion.
+- Route normalized events through one coordinator so a workflow definition and
+  the legacy YAML gate can never both claim the same event/head.
+
+## Verification and delivery
+
+Each PR re-checks Jira scope and assignment, moves its tickets to In Progress
+when work starts, links the PR and exact checks, and moves tickets to Review only
+after implementation and automation are green. Tickets reach Done only after
+merge; AIW-189 additionally waits for confirmed production cleanup.
+
+Migrations are tested from a fresh database and from the previous stack
+revision. Each PR runs focused unit/component/integration coverage, repository
+`pnpm test` and `pnpm typecheck`, and the relevant orchestration, capacity,
+harness-profile, and agent E2E suites. Browser QA is left to the user. Newly
+found acceptance bugs become separate Jira follow-ups.


### PR DESCRIPTION
## Jira

- [AIW-184](https://blazity.atlassian.net/browse/AIW-184)
- [AIW-189](https://blazity.atlassian.net/browse/AIW-189)

## What changed

- Centralized the successful hosted Workflow start boundary for ticket, PR-trigger, approval, and manual dispatch. A dispatch is reported as started only after the exact owner/run binding and minimal `workflow_runs` row commit atomically.
- Kept the Workflow entry ownership step as an idempotent crash-window fallback and made it record the first application entry marker.
- Added a ten-minute startup watchdog with exact-owner cancellation, hosted terminal confirmation, resource-drain confirmation, durable diagnostics, and retryable failure behavior.
- Added startup metadata and the bounded partial watchdog index in migration `0030_startup_watchdog`.
- Added a dry-run-first cleanup command for the six confirmed production orphan runs. Apply mode rechecks deployment, pending first step, attempt number, entry marker, and hosted status before cancellation.
- Added the locked six-PR implementation record under `docs/plans`.

## Why

A hosted start could previously return without a durable application-owned run boundary. If the first Workflow step never entered, polling kept the run looking active indefinitely and repeated dispatch attempts could create multiple hosted candidates. This change makes successful start ownership durable before acknowledgment and gives stalled starts a safe, fixed recovery deadline.

## Compatibility and rollout

- Workflow Definition v1 and v2 contracts are unchanged.
- Existing historical runs are not backfilled and therefore are not selected by the new watchdog.
- Apply migration `0030_startup_watchdog` before enabling the reconciler behavior.
- Run `pnpm --filter worker cleanup:startup-orphans` in dry-run mode after deployment; use `--apply` only after every exact preflight passes.
- AIW-189 must remain in Review until that production cleanup is executed and verified.

## Verification

- `pnpm test` — dashboard 520/520; worker 3110/3110.
- `pnpm typecheck` — dashboard and worker pass.
- Focused lifecycle, registry, trigger, reconciliation, and migration suites — 93/93, followed by 56/56 after the final watchdog/entry race guard.
- Fresh-database and upgrade-through-0029 migration tests pass.
- `pnpm test:e2e:capacity` could not start locally because the dedicated E2E deployment, Jira, GitHub App, cron, and database environment variables are not present in this checkout; no test body ran. CI or the configured E2E environment must complete this gate before the PR is marked ready.

[AIW-184]: https://blazity.atlassian.net/browse/AIW-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIW-189]: https://blazity.atlassian.net/browse/AIW-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a startup watchdog for workflow runs that don’t begin within 10 minutes, including diagnostic tracking and deadline-based indexing.
  * Manual and automated dispatches now commit the hosted start lifecycle before reporting success, ensuring consistent recovery states.
  * Added an on-demand cleanup script for potential startup orphans.
* **Bug Fixes**
  * Prevented competing dispatches from claiming/advancing the same run, including stricter lost-ownership handling and retryable watchdog outcomes.
* **Documentation**
  * Added workflow acceptance follow-up implementation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->