### PR TITLE
Unify workflow value compatibility and Open PR outputs

### DIFF
--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
@@ -117,6 +117,32 @@ test("v2 bindings use worker labels and compatibility without client graph trave
   assert.match(html, /Add typed input/);
 });
 
+test("an incompatible saved binding remains visible with its exact reason", () => {
+  const html = renderToStaticMarkup(
+    <V2BindingFields
+      node={{
+        ...node,
+        inputs: {
+          plan: {
+            kind: "reference",
+            reference: "steps.review.output.decision",
+          },
+        },
+      }}
+      contract={contract}
+      availableValues={availableValues}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+
+  assert.match(html, /Review · decision/);
+  assert.match(
+    html,
+    /This value has a different type than the selected input\./,
+  );
+});
+
 test("v2 additional-input authoring accepts safe dotted names", () => {
   const existingNames = new Set(["checks.unit"]);
 

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
@@ -143,6 +143,66 @@ test("an incompatible saved binding remains visible with its exact reason", () =
   );
 });
 
+test("array inputs expose ordered workflow value list authoring", () => {
+  const listContract: WorkflowBlockContract = {
+    ...contract,
+    inputs: {
+      reviews: {
+        required: true,
+        schema: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+    },
+  };
+  const listValues: WorkflowDataCatalogEntry[] = [
+    {
+      ...availableValues[0]!,
+      reference: "steps.security.output.review",
+      label: "Security review · Entire output",
+      compatibleInputNames: [],
+      compatibleListInputNames: ["reviews"],
+    },
+    {
+      ...availableValues[0]!,
+      reference: "steps.quality.output.review",
+      label: "Quality review · Entire output",
+      compatibleInputNames: [],
+      compatibleListInputNames: ["reviews"],
+    },
+  ];
+  const html = renderToStaticMarkup(
+    <V2BindingFields
+      node={{
+        ...node,
+        inputs: {
+          reviews: {
+            kind: "reference_list",
+            references: listValues.map((value) => value.reference),
+          },
+        },
+        additionalInputs: [],
+      }}
+      contract={listContract}
+      availableValues={listValues}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+
+  assert.match(html, /Workflow value list/);
+  assert.match(html, /Security review · Entire output/);
+  assert.match(html, /Quality review · Entire output/);
+  assert.match(html, /Add workflow value/);
+  assert.match(html, /Move steps\.security\.output\.review down/);
+  assert.match(html, /Move steps\.quality\.output\.review up/);
+  assert.doesNotMatch(
+    html,
+    /This value has a different type than the selected list item\./,
+  );
+});
+
 test("v2 additional-input authoring accepts safe dotted names", () => {
   const existingNames = new Set(["checks.unit"]);
 

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
@@ -195,8 +195,9 @@ test("array inputs expose ordered workflow value list authoring", () => {
   assert.match(html, /Security review · Entire output/);
   assert.match(html, /Quality review · Entire output/);
   assert.match(html, /Add workflow value/);
-  assert.match(html, /Move steps\.security\.output\.review down/);
-  assert.match(html, /Move steps\.quality\.output\.review up/);
+  assert.match(html, /Move Security review · Entire output down/);
+  assert.match(html, /Move Quality review · Entire output up/);
+  assert.doesNotMatch(html, /steps\.security\.output\.review/);
   assert.doesNotMatch(
     html,
     /This value has a different type than the selected list item\./,

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/workflow-editor/binding-options";
 import { JsonSchemaEditor } from "./json-schema-editor";
 import {
+  compatibilityInvalidReason,
   inputCompatibility,
   inputListItemCompatibility,
   WorkflowDataPicker,
@@ -389,11 +390,7 @@ function V2BindingEditor({
         <WorkflowValueChip
           value={currentReference ?? null}
           reference={binding.reference}
-          invalidReason={
-            currentCompatibility?.compatible === false
-              ? currentCompatibility.reason?.message
-              : null
-          }
+          invalidReason={compatibilityInvalidReason(currentCompatibility)}
           disabled={!canEdit}
           onOpen={openReferencePicker}
           onClear={() => onChange(undefined)}
@@ -418,11 +415,7 @@ function V2BindingEditor({
                   <WorkflowValueChip
                     value={value ?? null}
                     reference={reference}
-                    invalidReason={
-                      itemCompatibility?.compatible === false
-                        ? itemCompatibility.reason?.message
-                        : null
-                    }
+                    invalidReason={compatibilityInvalidReason(itemCompatibility)}
                     disabled={!canEdit}
                     onOpen={() => openListPicker(index)}
                     onClear={() =>

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
@@ -322,6 +322,9 @@ function V2BindingEditor({
     binding?.kind === "reference"
       ? availableValues.find((value) => value.reference === binding.reference)
       : undefined;
+  const currentCompatibility = currentReference
+    ? compatibility(currentReference)
+    : null;
   const literalDefault = initialLiteralForSchema(inputSchema);
 
   return (
@@ -350,6 +353,11 @@ function V2BindingEditor({
         <WorkflowValueChip
           value={currentReference ?? null}
           reference={binding.reference}
+          invalidReason={
+            currentCompatibility?.compatible === false
+              ? currentCompatibility.reason?.message
+              : null
+          }
           disabled={!canEdit}
           onOpen={() => setPickerOpen(true)}
           onClear={() => onChange(undefined)}

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
@@ -408,6 +408,7 @@ function V2BindingEditor({
             const itemCompatibility = value
               ? listItemCompatibility(value)
               : null;
+            const moveLabel = value?.label ?? "saved workflow value";
             return (
               <div
                 key={`${reference}-${index}`}
@@ -439,7 +440,7 @@ function V2BindingEditor({
                     type="button"
                     disabled={!canEdit || index === 0}
                     onClick={() => moveListReference(index, index - 1)}
-                    aria-label={`Move ${reference} up`}
+                    aria-label={`Move ${moveLabel} up`}
                     className="h-5 w-7 border border-neutral-200 bg-panel font-mono text-[10px] text-neutral-600 disabled:opacity-30"
                   >
                     ↑
@@ -450,7 +451,7 @@ function V2BindingEditor({
                       !canEdit || index === binding.references.length - 1
                     }
                     onClick={() => moveListReference(index, index + 1)}
-                    aria-label={`Move ${reference} down`}
+                    aria-label={`Move ${moveLabel} down`}
                     className="h-5 w-7 border border-t-0 border-neutral-200 bg-panel font-mono text-[10px] text-neutral-600 disabled:opacity-30"
                   >
                     ↓

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
@@ -23,6 +23,7 @@ import {
 import { JsonSchemaEditor } from "./json-schema-editor";
 import {
   inputCompatibility,
+  inputListItemCompatibility,
   WorkflowDataPicker,
   WorkflowValueChip,
 } from "./workflow-data-picker";
@@ -314,8 +315,16 @@ function V2BindingEditor({
   onChange: (binding: WorkflowInputBindingV2 | undefined) => void;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerMode, setPickerMode] = useState<"reference" | "reference_list">(
+    "reference",
+  );
+  const [listEditIndex, setListEditIndex] = useState<number | null>(null);
   const compatibility = useMemo(
     () => inputCompatibility(inputName),
+    [inputName],
+  );
+  const listItemCompatibility = useMemo(
+    () => inputListItemCompatibility(inputName),
     [inputName],
   );
   const currentReference =
@@ -326,6 +335,27 @@ function V2BindingEditor({
     ? compatibility(currentReference)
     : null;
   const literalDefault = initialLiteralForSchema(inputSchema);
+  const acceptsReferenceList =
+    inputSchema.type === "array" ||
+    (Array.isArray(inputSchema.type) && inputSchema.type.includes("array"));
+  const openReferencePicker = () => {
+    setPickerMode("reference");
+    setListEditIndex(null);
+    setPickerOpen(true);
+  };
+  const openListPicker = (index: number | null) => {
+    setPickerMode("reference_list");
+    setListEditIndex(index);
+    setPickerOpen(true);
+  };
+  const moveListReference = (from: number, to: number) => {
+    if (binding?.kind !== "reference_list") return;
+    const references = [...binding.references];
+    const [reference] = references.splice(from, 1);
+    if (!reference) return;
+    references.splice(to, 0, reference);
+    onChange({ kind: "reference_list", references });
+  };
 
   return (
     <div className="space-y-1.5">
@@ -336,7 +366,10 @@ function V2BindingEditor({
         onChange={(event) => {
           if (event.target.value === "") onChange(undefined);
           else if (event.target.value === "reference") {
-            setPickerOpen(true);
+            openReferencePicker();
+          } else if (event.target.value === "reference_list") {
+            onChange({ kind: "reference_list", references: [] });
+            openListPicker(null);
           } else {
             onChange({ kind: "literal", value: literalDefault });
           }
@@ -347,6 +380,9 @@ function V2BindingEditor({
         <option value="reference">
           Workflow value
         </option>
+        {(acceptsReferenceList || binding?.kind === "reference_list") && (
+          <option value="reference_list">Workflow value list</option>
+        )}
         <option value="literal">Literal value</option>
       </select>
       {binding?.kind === "reference" && (
@@ -359,21 +395,110 @@ function V2BindingEditor({
               : null
           }
           disabled={!canEdit}
-          onOpen={() => setPickerOpen(true)}
+          onOpen={openReferencePicker}
           onClear={() => onChange(undefined)}
         />
+      )}
+      {binding?.kind === "reference_list" && (
+        <div className="space-y-2">
+          {binding.references.map((reference, index) => {
+            const value = availableValues.find(
+              (candidate) => candidate.reference === reference,
+            );
+            const itemCompatibility = value
+              ? listItemCompatibility(value)
+              : null;
+            return (
+              <div
+                key={`${reference}-${index}`}
+                className="flex items-start gap-1.5"
+              >
+                <div className="min-w-0 flex-1">
+                  <WorkflowValueChip
+                    value={value ?? null}
+                    reference={reference}
+                    invalidReason={
+                      itemCompatibility?.compatible === false
+                        ? itemCompatibility.reason?.message
+                        : null
+                    }
+                    disabled={!canEdit}
+                    onOpen={() => openListPicker(index)}
+                    onClear={() =>
+                      onChange({
+                        kind: "reference_list",
+                        references: binding.references.filter(
+                          (_, candidate) => candidate !== index,
+                        ),
+                      })
+                    }
+                  />
+                </div>
+                <div className="flex shrink-0 flex-col">
+                  <button
+                    type="button"
+                    disabled={!canEdit || index === 0}
+                    onClick={() => moveListReference(index, index - 1)}
+                    aria-label={`Move ${reference} up`}
+                    className="h-5 w-7 border border-neutral-200 bg-panel font-mono text-[10px] text-neutral-600 disabled:opacity-30"
+                  >
+                    ↑
+                  </button>
+                  <button
+                    type="button"
+                    disabled={
+                      !canEdit || index === binding.references.length - 1
+                    }
+                    onClick={() => moveListReference(index, index + 1)}
+                    aria-label={`Move ${reference} down`}
+                    className="h-5 w-7 border border-t-0 border-neutral-200 bg-panel font-mono text-[10px] text-neutral-600 disabled:opacity-30"
+                  >
+                    ↓
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+          <button
+            type="button"
+            disabled={!canEdit}
+            onClick={() => openListPicker(null)}
+            className="min-h-9 w-full rounded-[3px] border border-dashed border-neutral-300 bg-panel px-3 text-left font-body text-[12px] text-mariner disabled:opacity-50"
+          >
+            ＋ Add workflow value
+          </button>
+        </div>
       )}
       <WorkflowDataPicker
         open={pickerOpen}
         entries={availableValues}
         selectedReference={
-          binding?.kind === "reference" ? binding.reference : undefined
+          pickerMode === "reference"
+            ? binding?.kind === "reference"
+              ? binding.reference
+              : undefined
+            : binding?.kind === "reference_list" &&
+                listEditIndex !== null
+              ? binding.references[listEditIndex]
+              : undefined
         }
-        compatibility={compatibility}
+        compatibility={
+          pickerMode === "reference" ? compatibility : listItemCompatibility
+        }
         refreshing={valuesRefreshing}
         onClose={() => setPickerOpen(false)}
         onSelect={(entry) => {
-          onChange({ kind: "reference", reference: entry.reference });
+          if (pickerMode === "reference") {
+            onChange({ kind: "reference", reference: entry.reference });
+          } else {
+            const references =
+              binding?.kind === "reference_list"
+                ? [...binding.references]
+                : [];
+            if (listEditIndex === null) references.push(entry.reference);
+            else references[listEditIndex] = entry.reference;
+            onChange({ kind: "reference_list", references });
+          }
           setPickerOpen(false);
         }}
       />

--- a/apps/dashboard/components/cockpit/flow-editor/branch-fields.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/branch-fields.test.tsx
@@ -60,6 +60,51 @@ test("preserves an unavailable selected value without raw reference text", () =>
   assert.doesNotMatch(html, /steps\.old\.output\.value/);
 });
 
+test("allows optional values only for presence operators", () => {
+  const optionalValues: WorkflowDataCatalogEntry[] = [{
+    ...values[0]!,
+    presence: "optional",
+  }];
+  const comparisonHtml = renderToStaticMarkup(
+    <BranchFields
+      configuration={{
+        combinator: "all",
+        conditions: [{
+          reference: "steps.review.output.decision",
+          operator: "equals",
+          value: "approve",
+        }],
+      }}
+      availableValues={optionalValues}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+  const presenceHtml = renderToStaticMarkup(
+    <BranchFields
+      configuration={{
+        combinator: "all",
+        conditions: [{
+          reference: "steps.review.output.decision",
+          operator: "has_value",
+        }],
+      }}
+      availableValues={optionalValues}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+
+  assert.match(
+    comparisonHtml,
+    /This value is not present on every path that reaches this block\./,
+  );
+  assert.doesNotMatch(
+    presenceHtml,
+    /This value is not present on every path that reaches this block\./,
+  );
+});
+
 test("offers replacement for an obsolete pre-release configuration", () => {
   const html = renderToStaticMarkup(
     <BranchFields

--- a/apps/dashboard/components/cockpit/flow-editor/branch-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/branch-fields.tsx
@@ -11,6 +11,7 @@ import type {
 } from "@shared/contracts";
 import { evaluateWorkflowValueCompatibility } from "@shared/contracts";
 import {
+  compatibilityInvalidReason,
   WorkflowDataPicker,
   WorkflowValueChip,
 } from "./workflow-data-picker";
@@ -91,10 +92,13 @@ function ReferencePicker({
   const [open, setOpen] = useState(false);
   const selected =
     entries.find((entry) => entry.reference === condition.reference) ?? null;
+  const allowMissing =
+    condition.operator === "has_value" ||
+    condition.operator === "has_no_value";
   const selectedCompatibility = selected
     ? evaluateWorkflowValueCompatibility(selected, {
         kind: "branch",
-        allowMissing: true,
+        allowMissing,
       })
     : null;
   return (
@@ -102,11 +106,7 @@ function ReferencePicker({
       <WorkflowValueChip
         value={selected}
         reference={condition.reference}
-        invalidReason={
-          selectedCompatibility?.compatible === false
-            ? selectedCompatibility.reason?.message
-            : null
-        }
+        invalidReason={compatibilityInvalidReason(selectedCompatibility)}
         disabled={disabled}
         onOpen={() => setOpen(true)}
       />
@@ -118,7 +118,7 @@ function ReferencePicker({
         compatibility={(entry) =>
           evaluateWorkflowValueCompatibility(entry, {
             kind: "branch",
-            allowMissing: true,
+            allowMissing,
           })
         }
         onClose={() => setOpen(false)}

--- a/apps/dashboard/components/cockpit/flow-editor/branch-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/branch-fields.tsx
@@ -9,6 +9,7 @@ import type {
   WorkflowDataCatalogEntry,
   WorkflowDataReferenceV2,
 } from "@shared/contracts";
+import { evaluateWorkflowValueCompatibility } from "@shared/contracts";
 import {
   WorkflowDataPicker,
   WorkflowValueChip,
@@ -90,11 +91,22 @@ function ReferencePicker({
   const [open, setOpen] = useState(false);
   const selected =
     entries.find((entry) => entry.reference === condition.reference) ?? null;
+  const selectedCompatibility = selected
+    ? evaluateWorkflowValueCompatibility(selected, {
+        kind: "branch",
+        allowMissing: true,
+      })
+    : null;
   return (
     <>
       <WorkflowValueChip
         value={selected}
         reference={condition.reference}
+        invalidReason={
+          selectedCompatibility?.compatible === false
+            ? selectedCompatibility.reason?.message
+            : null
+        }
         disabled={disabled}
         onOpen={() => setOpen(true)}
       />
@@ -104,11 +116,10 @@ function ReferencePicker({
         selectedReference={condition.reference}
         refreshing={refreshing}
         compatibility={(entry) =>
-          schemaTypes(entry).some((type) =>
-            ["string", "number", "integer", "boolean", "null"].includes(type),
-          )
-            ? { compatible: true }
-            : { compatible: false, reason: "Branch conditions require a scalar value." }
+          evaluateWorkflowValueCompatibility(entry, {
+            kind: "branch",
+            allowMissing: true,
+          })
         }
         onClose={() => setOpen(false)}
         onSelect={(entry) => {

--- a/apps/dashboard/components/cockpit/flow-editor/transform-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/transform-fields.tsx
@@ -8,6 +8,7 @@ import type {
   WorkflowDataCatalogEntry,
   WorkflowDataReferenceV2,
 } from "@shared/contracts";
+import { evaluateWorkflowValueCompatibility } from "@shared/contracts";
 import { JsonSchemaEditor } from "./json-schema-editor";
 import {
   WorkflowDataPicker,
@@ -85,11 +86,28 @@ function SourcePicker({
 }) {
   const [open, setOpen] = useState(false);
   const selected = entries.find((entry) => entry.reference === value) ?? null;
+  const destination =
+    accepts === "any"
+      ? ({ kind: "build_object" } as const)
+      : ({
+          kind:
+            accepts === "text"
+              ? "transform_text"
+              : "transform_number",
+        } as const);
+  const selectedCompatibility = selected
+    ? evaluateWorkflowValueCompatibility(selected, destination)
+    : null;
   return (
     <>
       <WorkflowValueChip
         value={selected}
         reference={value}
+        invalidReason={
+          selectedCompatibility?.compatible === false
+            ? selectedCompatibility.reason?.message
+            : null
+        }
         disabled={disabled}
         onOpen={() => setOpen(true)}
       />
@@ -99,12 +117,7 @@ function SourcePicker({
         selectedReference={value}
         refreshing={refreshing}
         compatibility={(entry) => {
-          if (accepts === "any") return { compatible: true };
-          const expected = accepts === "text" ? "string" : "number";
-          return types(entry).includes(expected) ||
-            (expected === "number" && types(entry).includes("integer"))
-            ? { compatible: true }
-            : { compatible: false, reason: `This operation requires ${accepts}.` };
+          return evaluateWorkflowValueCompatibility(entry, destination);
         }}
         onClose={() => setOpen(false)}
         onSelect={(entry) => {

--- a/apps/dashboard/components/cockpit/flow-editor/transform-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/transform-fields.tsx
@@ -11,6 +11,7 @@ import type {
 import { evaluateWorkflowValueCompatibility } from "@shared/contracts";
 import { JsonSchemaEditor } from "./json-schema-editor";
 import {
+  compatibilityInvalidReason,
   WorkflowDataPicker,
   WorkflowValueChip,
 } from "./workflow-data-picker";
@@ -103,11 +104,7 @@ function SourcePicker({
       <WorkflowValueChip
         value={selected}
         reference={value}
-        invalidReason={
-          selectedCompatibility?.compatible === false
-            ? selectedCompatibility.reason?.message
-            : null
-        }
+        invalidReason={compatibilityInvalidReason(selectedCompatibility)}
         disabled={disabled}
         onOpen={() => setOpen(true)}
       />

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
@@ -11,13 +11,15 @@ import type {
   JsonSchema202012,
   WorkflowDataCatalogEntry,
   WorkflowDataReferenceV2,
+  WorkflowValueCompatibility,
 } from "@shared/contracts";
+import { evaluateWorkflowValueCompatibility } from "@shared/contracts";
 
 type PickerTab = "steps" | "run";
 
 export type WorkflowDataCompatibility = (
   entry: WorkflowDataCatalogEntry,
-) => { compatible: true } | { compatible: false; reason: string };
+) => WorkflowValueCompatibility;
 
 function schemaType(schema: JsonSchema202012): string {
   if (Array.isArray(schema.enum) && schema.enum.length > 0) return "enum";
@@ -65,61 +67,36 @@ function availableReason(
     return entry.availability.reason;
   }
   const result = compatibility(entry);
-  return result.compatible ? null : result.reason;
+  return result.compatible ? null : result.reason?.message ?? "This value cannot be used here.";
 }
 
 export function textTemplateCompatibility(
   entry: WorkflowDataCatalogEntry,
-):
-  | { compatible: true }
-  | { compatible: false; reason: string } {
-  if (
-    entry.presence !== "required" ||
-    (Array.isArray(entry.schema.type) &&
-      entry.schema.type.includes("null"))
-  ) {
-    return {
-      compatible: false,
-      reason: "This value may be missing or null when the block runs.",
-    };
-  }
-  const types = Array.isArray(entry.schema.type)
-    ? entry.schema.type
-    : [entry.schema.type];
-  const stringEnum =
-    Array.isArray(entry.schema.enum) &&
-    entry.schema.enum.length > 0 &&
-    entry.schema.enum.every((value) => typeof value === "string");
-  if (!types.includes("string") && !stringEnum) {
-    return {
-      compatible: false,
-      reason: "Only guaranteed text values can be inserted into text.",
-    };
-  }
-  return { compatible: true };
+): WorkflowValueCompatibility {
+  return evaluateWorkflowValueCompatibility(entry, { kind: "mixed_text" });
 }
 
 export function inputCompatibility(
   inputName: string,
 ): WorkflowDataCompatibility {
   return (entry) =>
-    entry.compatibleInputNames.includes(inputName)
-      ? { compatible: true }
-      : {
-          compatible: false,
-          reason: "This value is not compatible with this input.",
-        };
+    evaluateWorkflowValueCompatibility(entry, {
+      kind: "typed_input",
+      inputName,
+    });
 }
 
 export function WorkflowValueChip({
   value,
   reference,
+  invalidReason,
   disabled,
   onOpen,
   onClear,
 }: {
   value: WorkflowDataCatalogEntry | null;
   reference?: WorkflowDataReferenceV2;
+  invalidReason?: string | null;
   disabled?: boolean;
   onOpen: () => void;
   onClear?: () => void;
@@ -145,6 +122,7 @@ export function WorkflowValueChip({
     );
   }
   return (
+    <div className="space-y-1">
     <div className="flex min-h-10 overflow-hidden rounded-[3px] border border-neutral-200 bg-panel">
       <button
         type="button"
@@ -180,6 +158,12 @@ export function WorkflowValueChip({
         </button>
       )}
     </div>
+      {invalidReason && (
+        <p className="m-0 font-body text-[10px] leading-[1.35] text-red-700">
+          {invalidReason}
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -203,7 +187,6 @@ export function WorkflowDataPicker({
   const [query, setQuery] = useState("");
   const [tab, setTab] = useState<PickerTab>("steps");
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
-  const [unavailableOpen, setUnavailableOpen] = useState(false);
   const dialogRef = useRef<HTMLElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -246,9 +229,11 @@ export function WorkflowDataPicker({
   }, [entries, open, selectedReference]);
 
   const normalizedQuery = query.trim().toLowerCase();
-  const visibleEntries = useMemo(
-    () =>
-      entries.filter((entry) => {
+  const visibleEntries = useMemo(() => {
+    const seen = new Set<string>();
+    return entries.filter((entry) => {
+        if (seen.has(entry.reference)) return false;
+        seen.add(entry.reference);
         const expectedTab = entry.source.kind === "run" ? "run" : "steps";
         return (
           expectedTab === tab &&
@@ -256,31 +241,16 @@ export function WorkflowDataPicker({
             .toLowerCase()
             .includes(normalizedQuery)
         );
-      }),
-    [entries, normalizedQuery, tab],
-  );
-  const available = visibleEntries.filter(
-    (entry) => availableReason(entry, compatibility) === null,
-  );
-  const unavailable = visibleEntries
-    .map((entry) => ({
-      entry,
-      reason: availableReason(entry, compatibility),
-    }))
-    .filter(
-      (
-        item,
-      ): item is { entry: WorkflowDataCatalogEntry; reason: string } =>
-        item.reason !== null,
-    );
+      });
+  }, [entries, normalizedQuery, tab]);
   const grouped = useMemo(() => {
     const groups = new Map<string, WorkflowDataCatalogEntry[]>();
-    for (const entry of available) {
+    for (const entry of visibleEntries) {
       const key = sourceKey(entry);
       groups.set(key, [...(groups.get(key) ?? []), entry]);
     }
     return groups;
-  }, [available]);
+  }, [visibleEntries]);
 
   if (!open || typeof document === "undefined") return null;
   return createPortal(
@@ -388,20 +358,27 @@ export function WorkflowDataPicker({
                 </button>
                 {isExpanded && (
                   <div className="pb-2 pl-9">
-                    {values.map((entry) => (
+                    {values.map((entry) => {
+                      const reason = availableReason(entry, compatibility);
+                      return (
                       <button
                         key={entry.reference}
                         type="button"
                         data-picker-value
                         disabled={refreshing}
+                        aria-disabled={reason !== null ? "true" : undefined}
                         aria-current={
                           selectedReference === entry.reference
                             ? "true"
                             : undefined
                         }
-                        onClick={() => onSelect(entry)}
+                        onClick={() => {
+                          if (reason === null) onSelect(entry);
+                        }}
                         className={`flex w-full items-start gap-3 rounded-[3px] border-none px-3 py-2 text-left disabled:opacity-50 ${
-                          selectedReference === entry.reference
+                          reason !== null
+                            ? "bg-off-white text-neutral-500"
+                            : selectedReference === entry.reference
                             ? "bg-mariner-100"
                             : "bg-transparent hover:bg-off-white"
                         }`}
@@ -411,58 +388,22 @@ export function WorkflowDataPicker({
                             {fieldName(entry)}
                           </strong>
                           <small className="block font-body text-[10px] leading-[1.4] text-neutral-500">
-                            {entry.description}
+                            {reason ?? entry.description}
                           </small>
                         </span>
                         <span className="rounded-full bg-off-white px-2 py-0.5 font-mono text-[8px] uppercase text-neutral-500">
                           {schemaType(entry.schema)}
                         </span>
                       </button>
-                    ))}
+                    )})}
                   </div>
                 )}
               </div>
             );
           })}
-          {grouped.size === 0 && unavailable.length === 0 && (
+          {grouped.size === 0 && (
             <div className="px-3 py-8 text-center font-body text-[12px] text-neutral-500">
               No workflow values match this search.
-            </div>
-          )}
-          {unavailable.length > 0 && (
-            <div className="mt-2 border-t border-neutral-200 pt-2">
-              <button
-                type="button"
-                aria-expanded={unavailableOpen}
-                onClick={() => setUnavailableOpen((current) => !current)}
-                className="flex w-full items-center gap-2 border-none bg-transparent px-2 py-2 font-body text-[11px] text-neutral-600"
-              >
-                <span aria-hidden>⚠</span>
-                Unavailable
-                <span className="rounded-full bg-off-white px-1.5 font-mono text-[9px]">
-                  {unavailable.length}
-                </span>
-                <span className="ml-auto font-mono text-[10px]">
-                  {unavailableOpen ? "▴" : "▾"}
-                </span>
-              </button>
-              {unavailableOpen && (
-                <div className="space-y-1 px-2 pb-2">
-                  {unavailable.map(({ entry, reason }) => (
-                    <div
-                      key={entry.reference}
-                      className="rounded-[3px] bg-off-white px-3 py-2"
-                    >
-                      <strong className="block font-body text-[11px] font-medium text-neutral-700">
-                        {entry.label}
-                      </strong>
-                      <small className="block font-body text-[10px] leading-[1.4] text-neutral-500">
-                        {reason}
-                      </small>
-                    </div>
-                  ))}
-                </div>
-              )}
             </div>
           )}
         </div>

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
@@ -21,6 +21,14 @@ export type WorkflowDataCompatibility = (
   entry: WorkflowDataCatalogEntry,
 ) => WorkflowValueCompatibility;
 
+export function compatibilityInvalidReason(
+  compatibility: WorkflowValueCompatibility | null | undefined,
+): string | null {
+  return !compatibility || compatibility.compatible
+    ? null
+    : compatibility.reason.message;
+}
+
 function schemaType(schema: JsonSchema202012): string {
   if (Array.isArray(schema.enum) && schema.enum.length > 0) return "enum";
   const values = Array.isArray(schema.type)
@@ -67,7 +75,7 @@ function availableReason(
     return entry.availability.reason;
   }
   const result = compatibility(entry);
-  return result.compatible ? null : result.reason?.message ?? "This value cannot be used here.";
+  return compatibilityInvalidReason(result);
 }
 
 export function textTemplateCompatibility(
@@ -387,7 +395,7 @@ export function WorkflowDataPicker({
                         }}
                         className={`flex w-full items-start gap-3 rounded-[3px] border-none px-3 py-2 text-left disabled:opacity-50 ${
                           reason !== null
-                            ? "bg-off-white text-neutral-500"
+                            ? "cursor-not-allowed bg-off-white text-neutral-500"
                             : selectedReference === entry.reference
                             ? "bg-mariner-100"
                             : "bg-transparent hover:bg-off-white"

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
@@ -86,6 +86,16 @@ export function inputCompatibility(
     });
 }
 
+export function inputListItemCompatibility(
+  inputName: string,
+): WorkflowDataCompatibility {
+  return (entry) =>
+    evaluateWorkflowValueCompatibility(entry, {
+      kind: "typed_list_item",
+      inputName,
+    });
+}
+
 export function WorkflowValueChip({
   value,
   reference,

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-text-template-editor.test.ts
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-text-template-editor.test.ts
@@ -44,17 +44,18 @@ test("mixed text accepts required numbers and explains optional values precisely
     }),
     { compatible: true },
   );
+  const optional = textTemplateCompatibility({
+    reference: "steps.maybe.output.count",
+    label: "Maybe · count",
+    description: "Optional count.",
+    schema: { type: "number" },
+    source: { kind: "step", nodeId: "maybe" },
+    presence: "optional",
+    availability: { state: "available", guarantee: "Guaranteed." },
+    compatibleInputNames: [],
+  });
   assert.equal(
-    textTemplateCompatibility({
-      reference: "steps.maybe.output.count",
-      label: "Maybe · count",
-      description: "Optional count.",
-      schema: { type: "number" },
-      source: { kind: "step", nodeId: "maybe" },
-      presence: "optional",
-      availability: { state: "available", guarantee: "Guaranteed." },
-      compatibleInputNames: [],
-    }).reason?.code,
+    optional.compatible ? null : optional.reason.code,
     "presence_optional",
   );
 });

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-text-template-editor.test.ts
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-text-template-editor.test.ts
@@ -4,6 +4,7 @@ import {
   textTemplateDocument,
   textTemplateValue,
 } from "./workflow-text-template-editor.tsx";
+import { textTemplateCompatibility } from "./workflow-data-picker.tsx";
 
 test("plain text templates preserve lines and canonical workflow tokens", () => {
   const value = [
@@ -27,4 +28,33 @@ test("plain text templates leave malformed tokens as literal text", () => {
   const value = "Keep {{data:steps.plan.output.value open";
 
   assert.equal(textTemplateValue(textTemplateDocument(value)), value);
+});
+
+test("mixed text accepts required numbers and explains optional values precisely", () => {
+  assert.deepEqual(
+    textTemplateCompatibility({
+      reference: "steps.open.output.prNumber",
+      label: "Open pull request · prNumber",
+      description: "Primary pull request number.",
+      schema: { type: "number" },
+      source: { kind: "step", nodeId: "open" },
+      presence: "required",
+      availability: { state: "available", guarantee: "Guaranteed." },
+      compatibleInputNames: [],
+    }),
+    { compatible: true },
+  );
+  assert.equal(
+    textTemplateCompatibility({
+      reference: "steps.maybe.output.count",
+      label: "Maybe · count",
+      description: "Optional count.",
+      schema: { type: "number" },
+      source: { kind: "step", nodeId: "maybe" },
+      presence: "optional",
+      availability: { state: "available", guarantee: "Guaranteed." },
+      compatibleInputNames: [],
+    }).reason?.code,
+    "presence_optional",
+  );
 });

--- a/apps/dashboard/lib/workflow-editor/reference-visitor.test.ts
+++ b/apps/dashboard/lib/workflow-editor/reference-visitor.test.ts
@@ -139,6 +139,17 @@ test("one node visitor remaps v2 bindings and a typed Branch AST", () => {
             reference: "steps.plan.output.plan",
           },
         },
+        {
+          name: "reviewResults",
+          schema: { type: "array", items: { type: "unknown" } },
+          binding: {
+            kind: "reference_list",
+            references: [
+              "steps.review.output",
+              "steps.plan.output",
+            ],
+          },
+        },
       ],
       configuration: {
         combinator: "all",
@@ -169,6 +180,12 @@ test("one node visitor remaps v2 bindings and a typed Branch AST", () => {
       ? remapped.v2.additionalInputs[0].binding.reference
       : null,
     "steps.plan-copy.output.plan",
+  );
+  assert.deepEqual(
+    remapped.v2?.additionalInputs[1]?.binding.kind === "reference_list"
+      ? remapped.v2.additionalInputs[1].binding.references
+      : null,
+    ["steps.review-copy.output", "steps.plan-copy.output"],
   );
   assert.deepEqual(remapped.v2?.configuration, {
     combinator: "all",
@@ -331,6 +348,17 @@ test("collects every serialized reference with an exact relative path", () => {
             reference: "steps.review.output.decision",
           },
         },
+        {
+          name: "reviewResults",
+          schema: { type: "array", items: { type: "unknown" } },
+          binding: {
+            kind: "reference_list",
+            references: [
+              "steps.security.output",
+              "steps.quality.output",
+            ],
+          },
+        },
       ],
       configuration: {
         combinator: "all",
@@ -359,6 +387,14 @@ test("collects every serialized reference with an exact relative path", () => {
     {
       reference: "steps.review.output.decision",
       path: "/additionalInputs/0/binding/reference",
+    },
+    {
+      reference: "steps.security.output",
+      path: "/additionalInputs/1/binding/references/0",
+    },
+    {
+      reference: "steps.quality.output",
+      path: "/additionalInputs/1/binding/references/1",
     },
     {
       reference: "steps.review.output.ok",

--- a/apps/dashboard/lib/workflow-editor/reference-visitor.test.ts
+++ b/apps/dashboard/lib/workflow-editor/reference-visitor.test.ts
@@ -122,6 +122,13 @@ test("one node visitor remaps v2 bindings and a typed Branch AST", () => {
           kind: "reference",
           reference: "steps.review.output.decision",
         },
+        reviews: {
+          kind: "reference_list",
+          references: [
+            "steps.review.output",
+            "steps.plan.output",
+          ],
+        },
       },
       additionalInputs: [
         {
@@ -150,6 +157,12 @@ test("one node visitor remaps v2 bindings and a typed Branch AST", () => {
       ? remapped.v2.inputs.review.reference
       : null,
     "steps.review-copy.output.decision",
+  );
+  assert.deepEqual(
+    remapped.v2?.inputs.reviews?.kind === "reference_list"
+      ? remapped.v2.inputs.reviews.references
+      : null,
+    ["steps.review-copy.output", "steps.plan-copy.output"],
   );
   assert.equal(
     remapped.v2?.additionalInputs[0]?.binding.kind === "reference"
@@ -301,6 +314,13 @@ test("collects every serialized reference with an exact relative path", () => {
           kind: "reference",
           reference: "steps.plan.output.plan",
         },
+        reviews: {
+          kind: "reference_list",
+          references: [
+            "steps.security.output",
+            "steps.quality.output",
+          ],
+        },
       },
       additionalInputs: [
         {
@@ -327,6 +347,14 @@ test("collects every serialized reference with an exact relative path", () => {
     {
       reference: "steps.plan.output.plan",
       path: "/inputs/fixed/reference",
+    },
+    {
+      reference: "steps.security.output",
+      path: "/inputs/reviews/references/0",
+    },
+    {
+      reference: "steps.quality.output",
+      path: "/inputs/reviews/references/1",
     },
     {
       reference: "steps.review.output.decision",

--- a/apps/dashboard/lib/workflow-editor/reference-visitor.ts
+++ b/apps/dashboard/lib/workflow-editor/reference-visitor.ts
@@ -189,15 +189,28 @@ function remapBinding(
   binding: WorkflowInputBindingV2,
   nodeIdMap: ReadonlyMap<string, string>,
 ): WorkflowInputBindingV2 {
-  return binding.kind === "reference"
-    ? {
+  if (binding.kind === "reference") {
+    return {
         ...binding,
         reference: remapWorkflowDataReference(
           binding.reference,
           nodeIdMap,
         ) as WorkflowDataReferenceV2,
-      }
-    : structuredClone(binding);
+      };
+  }
+  if (binding.kind === "reference_list") {
+    return {
+      ...binding,
+      references: binding.references.map(
+        (reference) =>
+          remapWorkflowDataReference(
+            reference,
+            nodeIdMap,
+          ) as WorkflowDataReferenceV2,
+      ),
+    };
+  }
+  return structuredClone(binding);
 }
 
 function isJsonRecord(
@@ -520,6 +533,13 @@ export function collectFlowNodeReferences(
         reference: binding.reference,
         path: `/inputs/${pointerSegment(name)}/reference`,
       });
+    } else if (binding.kind === "reference_list") {
+      binding.references.forEach((reference, index) => {
+        found.push({
+          reference,
+          path: `/inputs/${pointerSegment(name)}/references/${index}`,
+        });
+      });
     }
   }
   node.v2.additionalInputs.forEach((input, index) => {
@@ -527,6 +547,13 @@ export function collectFlowNodeReferences(
       found.push({
         reference: input.binding.reference,
         path: `/additionalInputs/${index}/binding/reference`,
+      });
+    } else if (input.binding.kind === "reference_list") {
+      input.binding.references.forEach((reference, referenceIndex) => {
+        found.push({
+          reference,
+          path: `/additionalInputs/${index}/binding/references/${referenceIndex}`,
+        });
       });
     }
   });

--- a/apps/shared/contracts/api.ts
+++ b/apps/shared/contracts/api.ts
@@ -393,6 +393,8 @@ export interface WorkflowDataCatalogEntry {
   presence: WorkflowDataCatalogPresence;
   availability: WorkflowDataCatalogAvailability;
   compatibleInputNames: string[];
+  /** Array input names whose item schema can accept this value. */
+  compatibleListInputNames?: string[];
   example?: JsonValue;
 }
 

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -373,6 +373,10 @@ export type WorkflowDataReferenceV2 =
 
 export type WorkflowInputBindingV2 =
   | { kind: "reference"; reference: WorkflowDataReferenceV2 }
+  | {
+      kind: "reference_list";
+      references: WorkflowDataReferenceV2[];
+    }
   | { kind: "literal"; value: JsonValue };
 
 export type WorkflowBranchOperatorV2 =

--- a/apps/shared/contracts/index.ts
+++ b/apps/shared/contracts/index.ts
@@ -9,3 +9,4 @@ export * from "./harness-profiles.js";
 export * from "./run-replay.js";
 export * from "./default-prompts.js";
 export * from "./default-agent-prompt-references.js";
+export * from "./workflow-value-compatibility.js";

--- a/apps/shared/contracts/workflow-value-compatibility.ts
+++ b/apps/shared/contracts/workflow-value-compatibility.ts
@@ -19,6 +19,7 @@ export interface WorkflowValueCompatibility {
 export type WorkflowValueDestination =
   | { kind: "mixed_text" }
   | { kind: "typed_input"; inputName: string }
+  | { kind: "typed_list_item"; inputName: string }
   | { kind: "branch"; allowMissing?: boolean }
   | { kind: "transform_text" }
   | { kind: "transform_number" }
@@ -93,6 +94,14 @@ export function evaluateWorkflowValueCompatibility(
       : incompatible(
           "type_mismatch",
           "This value has a different type than the selected input.",
+        );
+  }
+  if (destination.kind === "typed_list_item") {
+    return entry.compatibleListInputNames?.includes(destination.inputName)
+      ? { compatible: true }
+      : incompatible(
+          "type_mismatch",
+          "This value has a different type than the selected list item.",
         );
   }
 

--- a/apps/shared/contracts/workflow-value-compatibility.ts
+++ b/apps/shared/contracts/workflow-value-compatibility.ts
@@ -1,0 +1,134 @@
+import type { WorkflowDataCatalogEntry } from "./api.js";
+import type { JsonSchema202012 } from "./domain.js";
+
+export type WorkflowValueCompatibilityReasonCode =
+  | "graph_unavailable"
+  | "presence_optional"
+  | "nullable"
+  | "type_mismatch"
+  | "unsupported_destination";
+
+export interface WorkflowValueCompatibility {
+  compatible: boolean;
+  reason?: {
+    code: WorkflowValueCompatibilityReasonCode;
+    message: string;
+  };
+}
+
+export type WorkflowValueDestination =
+  | { kind: "mixed_text" }
+  | { kind: "typed_input"; inputName: string }
+  | { kind: "branch"; allowMissing?: boolean }
+  | { kind: "transform_text" }
+  | { kind: "transform_number" }
+  | { kind: "build_object" };
+
+function schemaTypes(schema: JsonSchema202012): Set<string> {
+  const raw = Array.isArray(schema.type) ? schema.type : [schema.type];
+  const types = new Set(raw.filter((type): type is string => typeof type === "string"));
+  if (
+    types.size === 0 &&
+    Array.isArray(schema.enum) &&
+    schema.enum.length > 0
+  ) {
+    for (const value of schema.enum) {
+      if (value === null) types.add("null");
+      else if (typeof value === "number") types.add("number");
+      else if (typeof value === "string") types.add("string");
+      else if (typeof value === "boolean") types.add("boolean");
+    }
+  }
+  return types;
+}
+
+function incompatible(
+  code: WorkflowValueCompatibilityReasonCode,
+  message: string,
+): WorkflowValueCompatibility {
+  return { compatible: false, reason: { code, message } };
+}
+
+export function evaluateWorkflowValueCompatibility(
+  entry: WorkflowDataCatalogEntry,
+  destination: WorkflowValueDestination,
+): WorkflowValueCompatibility {
+  if (entry.availability.state === "unavailable") {
+    return incompatible("graph_unavailable", entry.availability.reason);
+  }
+
+  if (destination.kind === "build_object") return { compatible: true };
+  const types = schemaTypes(entry.schema);
+  if (destination.kind === "branch" && destination.allowMissing) {
+    const scalar = [...types].every((type) =>
+      ["string", "number", "integer", "boolean", "null"].includes(type),
+    );
+    return scalar && types.size > 0
+      ? { compatible: true }
+      : incompatible(
+          "unsupported_destination",
+          "Branch conditions require a text, number, boolean, or null value.",
+        );
+  }
+
+  if (
+    entry.presence === "optional" ||
+    entry.presence === "optional_nullable"
+  ) {
+    return incompatible(
+      "presence_optional",
+      "This value is not present on every path that reaches this block.",
+    );
+  }
+  if (entry.presence === "nullable") {
+    return incompatible(
+      "nullable",
+      "This value can be null when the block runs.",
+    );
+  }
+
+  if (destination.kind === "typed_input") {
+    return entry.compatibleInputNames.includes(destination.inputName)
+      ? { compatible: true }
+      : incompatible(
+          "type_mismatch",
+          "This value has a different type than the selected input.",
+        );
+  }
+
+  if (destination.kind === "mixed_text") {
+    return types.has("string") ||
+      types.has("number") ||
+      types.has("integer")
+      ? { compatible: true }
+      : incompatible(
+          "type_mismatch",
+          "Only text and number values can be inserted into text.",
+        );
+  }
+  if (destination.kind === "transform_text") {
+    return types.has("string")
+      ? { compatible: true }
+      : incompatible("type_mismatch", "This operation requires a text value.");
+  }
+  if (destination.kind === "transform_number") {
+    return types.has("number") || types.has("integer")
+      ? { compatible: true }
+      : incompatible("type_mismatch", "This operation requires a number value.");
+  }
+  if (destination.kind === "branch") {
+    const scalar = [...types].every((type) =>
+      ["string", "number", "integer", "boolean"].includes(type),
+    );
+    return scalar && types.size > 0
+      ? { compatible: true }
+      : incompatible(
+          "unsupported_destination",
+          "Branch comparisons require a text, number, or boolean value.",
+        );
+  }
+  return incompatible(
+    "unsupported_destination",
+    "This value cannot be used here.",
+  );
+}

--- a/apps/shared/contracts/workflow-value-compatibility.ts
+++ b/apps/shared/contracts/workflow-value-compatibility.ts
@@ -8,13 +8,15 @@ export type WorkflowValueCompatibilityReasonCode =
   | "type_mismatch"
   | "unsupported_destination";
 
-export interface WorkflowValueCompatibility {
-  compatible: boolean;
-  reason?: {
-    code: WorkflowValueCompatibilityReasonCode;
-    message: string;
-  };
-}
+export type WorkflowValueCompatibility =
+  | { compatible: true }
+  | {
+      compatible: false;
+      reason: {
+        code: WorkflowValueCompatibilityReasonCode;
+        message: string;
+      };
+    };
 
 export type WorkflowValueDestination =
   | { kind: "mixed_text" }

--- a/apps/worker/src/workflow-definition/available-values.test.ts
+++ b/apps/worker/src/workflow-definition/available-values.test.ts
@@ -730,6 +730,27 @@ describe("v2 binding validation", () => {
       registryContext,
     );
     expect(valid.issues).toEqual([]);
+    const catalog = analyzeWorkflowV2Catalog(
+      definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("first", "planning_agent"),
+          node("second", "planning_agent"),
+          consumer,
+        ],
+        [
+          { id: "to-first", from: "trigger", to: "first" },
+          { id: "to-second", from: "first", to: "second" },
+          { id: "to-consumer", from: "second", to: "consumer" },
+        ],
+      ),
+      registryContext,
+    );
+    const firstPlan = catalog.catalogByNode.consumer?.find(
+      (entry) => entry.reference === "steps.first.output.plan",
+    );
+    expect(firstPlan?.compatibleInputNames).not.toContain("reviews");
+    expect(firstPlan?.compatibleListInputNames).toContain("reviews");
 
     const invalid = node("invalid", "post_ticket_comment", {
       body: {

--- a/apps/worker/src/workflow-definition/available-values.test.ts
+++ b/apps/worker/src/workflow-definition/available-values.test.ts
@@ -435,6 +435,44 @@ describe("v2 authoring catalog", () => {
       availability: { state: "available" },
     });
   });
+
+  it("exposes required Open PR fields and distinguishes whole and nested output labels", () => {
+    const result = analyzeWorkflowV2Catalog(
+      definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("open", "open_pr"),
+          node("message", "send_slack_message"),
+        ],
+        [
+          { id: "to-open", from: "trigger", to: "open" },
+          { id: "to-message", from: "open", to: "message" },
+        ],
+      ),
+      registryContext,
+    );
+    const catalog = result.catalogByNode.message ?? [];
+
+    expect(
+      catalog.find(
+        (entry) => entry.reference === "steps.open.output.prNumber",
+      ),
+    ).toMatchObject({
+      presence: "required",
+      schema: { type: "number" },
+    });
+    expect(
+      catalog.find(
+        (entry) => entry.reference === "steps.open.output.prUrl",
+      ),
+    ).toMatchObject({
+      presence: "required",
+      schema: { type: "string" },
+    });
+    expect(
+      catalog.find((entry) => entry.reference === "steps.open.output")?.label,
+    ).toBe("Open PR/MR · Entire output");
+  });
 });
 
 describe("v2 binding validation", () => {
@@ -658,5 +696,68 @@ describe("v2 binding validation", () => {
       catalogValue(result, "finalize", "steps.checks.output.status")
         .compatibleInputNames,
     ).toContain("checks.lint");
+  });
+
+  it("validates ordered reference lists only for compatible array items", () => {
+    const consumer = node("consumer", "generic_agent");
+    consumer.additionalInputs = [
+      {
+        name: "reviews",
+        schema: { type: "array", items: { type: "string" } },
+        binding: {
+          kind: "reference_list",
+          references: [
+            "steps.first.output.plan",
+            "steps.second.output.plan",
+          ],
+        },
+      },
+    ];
+    const valid = analyzeWorkflowV2Bindings(
+      definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("first", "planning_agent"),
+          node("second", "planning_agent"),
+          consumer,
+        ],
+        [
+          { id: "to-first", from: "trigger", to: "first" },
+          { id: "to-second", from: "first", to: "second" },
+          { id: "to-consumer", from: "second", to: "consumer" },
+        ],
+      ),
+      registryContext,
+    );
+    expect(valid.issues).toEqual([]);
+
+    const invalid = node("invalid", "post_ticket_comment", {
+      body: {
+        kind: "reference_list",
+        references: ["steps.first.output.plan"],
+      },
+    });
+    expect(
+      analyzeWorkflowV2Bindings(
+        definition(
+          [
+            node("trigger", "trigger_ticket_ai"),
+            node("first", "planning_agent"),
+            invalid,
+          ],
+          [
+            { id: "to-first", from: "trigger", to: "first" },
+            { id: "to-invalid", from: "first", to: "invalid" },
+          ],
+        ),
+        registryContext,
+      ).issues,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "binding.reference_list_destination",
+        }),
+      ]),
+    );
   });
 });

--- a/apps/worker/src/workflow-definition/available-values.ts
+++ b/apps/worker/src/workflow-definition/available-values.ts
@@ -793,6 +793,19 @@ function targetCompatibility(
     .map((target) => target.name);
 }
 
+function targetListCompatibility(
+  source: WorkflowValueSchema,
+  targets: readonly InputTarget[],
+): string[] {
+  return targets
+    .filter(
+      (target) =>
+        target.schema.type === "array" &&
+        isWorkflowSchemaAssignable(source, target.schema.items),
+    )
+    .map((target) => target.name);
+}
+
 function inputTargets(
   node: WorkflowDefinitionV2Node,
   nodeIndex: number,
@@ -1262,6 +1275,7 @@ function catalogEntry(
     presence: input.presence,
     availability: input.availability,
     compatibleInputNames: input.compatibleInputNames,
+    compatibleListInputNames: input.compatibleListInputNames,
     ...(example === undefined ? {} : { example }),
   };
 }
@@ -1368,6 +1382,10 @@ export function analyzeWorkflowV2Catalog(
             commonTriggerOutput,
             targets,
           ),
+          compatibleListInputNames: targetListCompatibility(
+            commonTriggerOutput,
+            targets,
+          ),
         }),
       );
       for (const candidate of catalogSchemaPaths(commonTriggerOutput)) {
@@ -1392,6 +1410,10 @@ export function analyzeWorkflowV2Catalog(
               guarantee: "Every possible active trigger exposes this field.",
             },
             compatibleInputNames: targetCompatibility(
+              candidate.schema,
+              targets,
+            ),
+            compatibleListInputNames: targetListCompatibility(
               candidate.schema,
               targets,
             ),
@@ -1467,6 +1489,7 @@ export function analyzeWorkflowV2Catalog(
               "Branch on Run info → Trigger ID or Trigger type first.",
           },
           compatibleInputNames: targetCompatibility(schema, targets),
+          compatibleListInputNames: targetListCompatibility(schema, targets),
         }),
       );
     }
@@ -1520,6 +1543,10 @@ export function analyzeWorkflowV2Catalog(
             contract.output.bindingSchema,
             targets,
           ),
+          compatibleListInputNames: targetListCompatibility(
+            contract.output.bindingSchema,
+            targets,
+          ),
         }),
       );
       for (const candidate of catalogSchemaPaths(
@@ -1540,6 +1567,10 @@ export function analyzeWorkflowV2Catalog(
             presence: candidate.presence,
             availability,
             compatibleInputNames: targetCompatibility(
+              candidate.schema,
+              targets,
+            ),
+            compatibleListInputNames: targetListCompatibility(
               candidate.schema,
               targets,
             ),
@@ -1567,6 +1598,10 @@ export function analyzeWorkflowV2Catalog(
             guarantee: "Run information is always available.",
           },
           compatibleInputNames: targetCompatibility(
+            candidate.schema,
+            targets,
+          ),
+          compatibleListInputNames: targetListCompatibility(
             candidate.schema,
             targets,
           ),

--- a/apps/worker/src/workflow-definition/available-values.ts
+++ b/apps/worker/src/workflow-definition/available-values.ts
@@ -940,6 +940,48 @@ function validateBindings(
         }
         continue;
       }
+      if (target.binding.kind === "reference_list") {
+        if (target.schema.type !== "array") {
+          issues.push({
+            code: "binding.reference_list_destination",
+            severity: "error",
+            nodeId: node.id,
+            path: target.path,
+            message: `Block "${node.id}" input "${target.name}" accepts a reference list only when its schema is an array.`,
+          });
+          continue;
+        }
+        for (const [referenceIndex, reference] of target.binding.references.entries()) {
+          const available = availableByReference.get(reference);
+          const parsedSource = available
+            ? inspectJsonSchema202012(available.schema)
+            : null;
+          if (!available) {
+            issues.push({
+              code: "binding.unavailable_reference",
+              severity: "error",
+              nodeId: node.id,
+              path: `${target.path}/references/${referenceIndex}`,
+              message: `Block "${node.id}" input "${target.name}" references "${reference}", which is not guaranteed when the block runs.`,
+            });
+          } else if (
+            !parsedSource?.ok ||
+            !isWorkflowSchemaAssignable(
+              parsedSource.valueSchema,
+              target.schema.items,
+            )
+          ) {
+            issues.push({
+              code: "binding.reference_type",
+              severity: "error",
+              nodeId: node.id,
+              path: `${target.path}/references/${referenceIndex}`,
+              message: `Block "${node.id}" input "${target.name}" cannot include "${reference}" because it is incompatible with the array item type.`,
+            });
+          }
+        }
+        continue;
+      }
       const available = availableByReference.get(target.binding.reference);
       if (!available) {
         issues.push({
@@ -1305,7 +1347,7 @@ export function analyzeWorkflowV2Catalog(
       entries.push(
         catalogEntry({
           reference: "steps.entry.output",
-          label: `${triggerLabel} · output`,
+          label: `${triggerLabel} · Entire output`,
           description: "Complete output from the trigger that started this run.",
           valueSchema: commonTriggerOutput,
           source: {
@@ -1333,7 +1375,7 @@ export function analyzeWorkflowV2Catalog(
         entries.push(
           catalogEntry({
             reference: `steps.entry.output.${path}`,
-            label: `${triggerLabel} · ${path}`,
+            label: `${triggerLabel} · ${path === "output" ? "Output" : path}`,
             description:
               candidate.schema.description ??
               "Value supplied by every possible trigger.",
@@ -1465,7 +1507,7 @@ export function analyzeWorkflowV2Catalog(
       entries.push(
         catalogEntry({
           reference: `steps.${source.id}.output`,
-          label: `${source.name ?? contract.presentation.label} · output`,
+          label: `${source.name ?? contract.presentation.label} · Entire output`,
           description: contract.presentation.description,
           valueSchema: contract.output.bindingSchema,
           source: sourceDetails,
@@ -1487,7 +1529,9 @@ export function analyzeWorkflowV2Catalog(
         entries.push(
           catalogEntry({
             reference: `steps.${source.id}.output.${path}`,
-            label: `${source.name ?? contract.presentation.label} · ${path}`,
+            label: `${source.name ?? contract.presentation.label} · ${
+              path === "output" ? "Output" : path
+            }`,
             description:
               candidate.schema.description ??
               contract.presentation.description,

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -688,7 +688,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       prUrl: stringType(),
       prNumber: numberType(),
     }),
-    normalOutputRequired: ["prs"],
+    normalOutputRequired: ["prs", "prUrl", "prNumber"],
     statusVariants: ["ok"],
   },
   update_ticket_status: {

--- a/apps/worker/src/workflow-definition/prompt-authoring.test.ts
+++ b/apps/worker/src/workflow-definition/prompt-authoring.test.ts
@@ -459,4 +459,60 @@ describe("v2 prompt authoring validation", () => {
       ]),
     );
   });
+
+  it("allows Open PR numbers in mixed text and rejects whole object outputs", async () => {
+    const definition: WorkflowDefinitionV2 = {
+      schemaVersion: 2,
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger_ticket_ai",
+          x: 0,
+          y: 0,
+          configuration: {},
+          inputs: {},
+          additionalInputs: [],
+        },
+        {
+          id: "open",
+          type: "open_pr",
+          x: 100,
+          y: 0,
+          configuration: {},
+          inputs: {},
+          additionalInputs: [],
+        },
+        {
+          id: "message",
+          type: "send_slack_message",
+          x: 200,
+          y: 0,
+          configuration: {
+            message:
+              "PR #{{data:steps.open.output.prNumber}} {{data:steps.open.output}}",
+          },
+          inputs: {},
+          additionalInputs: [],
+        },
+      ],
+      edges: [
+        { id: "to-open", from: "trigger", to: "open" },
+        { id: "to-message", from: "open", to: "message" },
+      ],
+    };
+
+    const issues = await validateWorkflowPromptAuthoringIssuesWithLoader(
+      definition,
+      registryContext,
+      vi.fn(),
+    );
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        code: "prompt_data_type_mismatch",
+        nodeId: "message",
+        message: "Only text and number values can be inserted into text.",
+      }),
+    ]);
+  });
 });

--- a/apps/worker/src/workflow-definition/prompt-authoring.test.ts
+++ b/apps/worker/src/workflow-definition/prompt-authoring.test.ts
@@ -515,4 +515,60 @@ describe("v2 prompt authoring validation", () => {
       }),
     ]);
   });
+
+  it("applies mixed-text compatibility to Agent prompt data tokens", async () => {
+    const definition: WorkflowDefinitionV2 = {
+      schemaVersion: 2,
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger_ticket_ai",
+          x: 0,
+          y: 0,
+          configuration: {},
+          inputs: {},
+          additionalInputs: [],
+        },
+        {
+          id: "open",
+          type: "open_pr",
+          x: 100,
+          y: 0,
+          configuration: {},
+          inputs: {},
+          additionalInputs: [],
+        },
+        {
+          id: "agent",
+          type: "generic_agent",
+          x: 200,
+          y: 0,
+          configuration: {
+            prompt: "Review {{data:steps.open.output}}",
+          },
+          inputs: {},
+          additionalInputs: [],
+        },
+      ],
+      edges: [
+        { id: "to-open", from: "trigger", to: "open" },
+        { id: "to-agent", from: "open", to: "agent" },
+      ],
+    };
+
+    const issues = await validateWorkflowPromptAuthoringIssuesWithLoader(
+      definition,
+      registryContext,
+      vi.fn(),
+    );
+
+    expect(issues).toEqual([
+      expect.objectContaining({
+        code: "prompt_data_type_mismatch",
+        nodeId: "agent",
+        path: "/nodes/2/configuration/prompt",
+        message: "Only text and number values can be inserted into text.",
+      }),
+    ]);
+  });
 });

--- a/apps/worker/src/workflow-definition/prompt-authoring.ts
+++ b/apps/worker/src/workflow-definition/prompt-authoring.ts
@@ -105,6 +105,34 @@ export function promptSlotBindingsForV2Node(
   );
 }
 
+function promptDataTokenIssue(
+  reference: string,
+  catalogByReference: ReadonlyMap<string, WorkflowDataCatalogEntry>,
+  availableByReference: { has(reference: string): boolean },
+): { code: string; message: string } | null {
+  const catalogEntry = catalogByReference.get(
+    reference as WorkflowDataCatalogEntry["reference"],
+  );
+  if (catalogEntry) {
+    const compatibility = evaluateWorkflowValueCompatibility(
+      catalogEntry,
+      { kind: "mixed_text" },
+    );
+    if (compatibility.compatible) return null;
+    return {
+      code: `prompt_data_${compatibility.reason.code}`,
+      message: compatibility.reason.message,
+    };
+  }
+  return availableByReference.has(reference)
+    ? null
+    : {
+        code: "prompt_data_unavailable",
+        message:
+          `Prompt data reference "${reference}" is not guaranteed when this block runs.`,
+      };
+}
+
 /**
  * Resolves one unsaved/pinned v2 prompt and runs the same compiler used before
  * execution. Catalog checks happen before example substitution so preview
@@ -154,26 +182,17 @@ export async function resolveNodePromptAuthoring(
     (input.catalogValues ?? []).map((value) => [value.reference, value]),
   );
   for (const token of parsePromptDataTokens(text)) {
-    const catalogEntry = catalogByReference.get(token.reference);
-    if (catalogEntry) {
-      const compatibility = evaluateWorkflowValueCompatibility(
-        catalogEntry,
-        { kind: "mixed_text" },
-      );
-      if (compatibility.compatible) continue;
+    const issue = promptDataTokenIssue(
+      token.reference,
+      catalogByReference,
+      availableByReference,
+    );
+    if (issue) {
       issues.push(nodeIssue(
         input,
-        `prompt_data_${compatibility.reason?.code ?? "incompatible"}`,
+        issue.code,
         field,
-        compatibility.reason?.message ??
-          `Prompt data reference "${token.reference}" cannot be inserted into text.`,
-      ));
-    } else if (!availableByReference.has(token.reference)) {
-      issues.push(nodeIssue(
-        input,
-        "prompt_data_unavailable",
-        field,
-        `Prompt data reference "${token.reference}" is not guaranteed when this block runs.`,
+        issue.message,
       ));
     }
   }
@@ -376,26 +395,17 @@ async function validateNonAgentPromptAuthoring(
       }
       const dataTokens = parsePromptDataTokens(resolved.text);
       for (const token of dataTokens) {
-        const catalogEntry = catalogByReference.get(token.reference);
-        if (catalogEntry) {
-          const compatibility = evaluateWorkflowValueCompatibility(
-            catalogEntry,
-            { kind: "mixed_text" },
-          );
-          if (compatibility.compatible) continue;
+        const issue = promptDataTokenIssue(
+          token.reference,
+          catalogByReference,
+          availableByReference,
+        );
+        if (issue) {
           issues.push(nodeIssue(
             input,
-            `prompt_data_${compatibility.reason?.code ?? "incompatible"}`,
+            issue.code,
             value.path,
-            compatibility.reason?.message ??
-              `Prompt data reference "${token.reference}" cannot be inserted into text.`,
-          ));
-        } else if (!availableByReference.has(token.reference)) {
-          issues.push(nodeIssue(
-            input,
-            "prompt_data_unavailable",
-            value.path,
-            `Prompt data reference "${token.reference}" is not guaranteed when this block runs.`,
+            issue.message,
           ));
         }
       }

--- a/apps/worker/src/workflow-definition/prompt-authoring.ts
+++ b/apps/worker/src/workflow-definition/prompt-authoring.ts
@@ -150,14 +150,32 @@ export async function resolveNodePromptAuthoring(
   const availableByReference = new Map(
     input.availableValues.map((value) => [value.reference, value]),
   );
+  const catalogByReference = new Map(
+    (input.catalogValues ?? []).map((value) => [value.reference, value]),
+  );
   for (const token of parsePromptDataTokens(text)) {
-    if (availableByReference.has(token.reference)) continue;
-    issues.push(nodeIssue(
-      input,
-      "prompt_data_unavailable",
-      field,
-      `Prompt data reference "${token.reference}" is not guaranteed when this block runs.`,
-    ));
+    const catalogEntry = catalogByReference.get(token.reference);
+    if (catalogEntry) {
+      const compatibility = evaluateWorkflowValueCompatibility(
+        catalogEntry,
+        { kind: "mixed_text" },
+      );
+      if (compatibility.compatible) continue;
+      issues.push(nodeIssue(
+        input,
+        `prompt_data_${compatibility.reason?.code ?? "incompatible"}`,
+        field,
+        compatibility.reason?.message ??
+          `Prompt data reference "${token.reference}" cannot be inserted into text.`,
+      ));
+    } else if (!availableByReference.has(token.reference)) {
+      issues.push(nodeIssue(
+        input,
+        "prompt_data_unavailable",
+        field,
+        `Prompt data reference "${token.reference}" is not guaranteed when this block runs.`,
+      ));
+    }
   }
 
   const bindings = promptSlotBindingsForV2Node(input.node);
@@ -271,6 +289,7 @@ export async function validateWorkflowPromptAuthoringIssuesWithLoader(
         node,
         nodeIndex,
         availableValues,
+        catalogValues: catalog.catalogByNode[node.id] ?? [],
         loadPromptReference,
       });
       issues.push(...result.issues);

--- a/apps/worker/src/workflow-definition/prompt-authoring.ts
+++ b/apps/worker/src/workflow-definition/prompt-authoring.ts
@@ -4,10 +4,12 @@ import {
   isPromptSlotBinding,
   parsePromptDataTokens,
   parsePromptSlotTokens,
+  evaluateWorkflowValueCompatibility,
   type PromptSlotBinding,
   type PromptSlotDefinition,
   type ResolvedPromptReference,
   type WorkflowAvailableValue,
+  type WorkflowDataCatalogEntry,
   type WorkflowDefinition,
   type WorkflowDefinitionV2,
   type WorkflowDefinitionV2Node,
@@ -27,7 +29,10 @@ import {
   type PromptReferenceLoader,
 } from "../workflows/prompt-references.js";
 import { VARIABLE_PARAM_KEYS } from "../workflows/prompt-vars.js";
-import { analyzeWorkflowV2Bindings } from "./available-values.js";
+import {
+  analyzeWorkflowV2Bindings,
+  analyzeWorkflowV2Catalog,
+} from "./available-values.js";
 import { isWorkflowSchemaAssignable } from "./bindings.js";
 import type { WorkflowBlockRegistryContext } from "./block-registry.js";
 import {
@@ -64,6 +69,7 @@ export interface ResolveNodePromptAuthoringInput {
   node: WorkflowDefinitionV2Node;
   nodeIndex: number;
   availableValues: readonly WorkflowAvailableValue[];
+  catalogValues?: readonly WorkflowDataCatalogEntry[];
   loadPromptReference: PromptReferenceLoader;
   profileSource?: EffectivePromptProfileSource | null;
   repositorySources?: readonly EffectivePromptRepositorySource[];
@@ -256,6 +262,7 @@ export async function validateWorkflowPromptAuthoringIssuesWithLoader(
   loadPromptReference: PromptReferenceLoader,
 ): Promise<WorkflowDefinitionValidationIssue[]> {
   const analysis = analyzeWorkflowV2Bindings(definition, registryContext);
+  const catalog = analyzeWorkflowV2Catalog(definition, registryContext);
   const issues: WorkflowDefinitionValidationIssue[] = [];
   for (const [nodeIndex, node] of definition.nodes.entries()) {
     const availableValues = analysis.availableValuesByNode[node.id] ?? [];
@@ -275,6 +282,7 @@ export async function validateWorkflowPromptAuthoringIssuesWithLoader(
           node,
           nodeIndex,
           availableValues,
+          catalogValues: catalog.catalogByNode[node.id] ?? [],
           loadPromptReference,
         }),
       );
@@ -289,6 +297,9 @@ async function validateNonAgentPromptAuthoring(
   const issues: WorkflowDefinitionValidationIssue[] = [];
   const availableByReference = new Set(
     input.availableValues.map((value) => value.reference),
+  );
+  const catalogByReference = new Map(
+    (input.catalogValues ?? []).map((value) => [value.reference, value]),
   );
   for (const field of VARIABLE_PARAM_KEYS[input.node.type] ?? []) {
     const authored = input.node.configuration[field];
@@ -346,13 +357,28 @@ async function validateNonAgentPromptAuthoring(
       }
       const dataTokens = parsePromptDataTokens(resolved.text);
       for (const token of dataTokens) {
-        if (availableByReference.has(token.reference)) continue;
-        issues.push(nodeIssue(
-          input,
-          "prompt_data_unavailable",
-          value.path,
-          `Prompt data reference "${token.reference}" is not guaranteed when this block runs.`,
-        ));
+        const catalogEntry = catalogByReference.get(token.reference);
+        if (catalogEntry) {
+          const compatibility = evaluateWorkflowValueCompatibility(
+            catalogEntry,
+            { kind: "mixed_text" },
+          );
+          if (compatibility.compatible) continue;
+          issues.push(nodeIssue(
+            input,
+            `prompt_data_${compatibility.reason?.code ?? "incompatible"}`,
+            value.path,
+            compatibility.reason?.message ??
+              `Prompt data reference "${token.reference}" cannot be inserted into text.`,
+          ));
+        } else if (!availableByReference.has(token.reference)) {
+          issues.push(nodeIssue(
+            input,
+            "prompt_data_unavailable",
+            value.path,
+            `Prompt data reference "${token.reference}" is not guaranteed when this block runs.`,
+          ));
+        }
       }
       const residual = removePromptDataTokens(resolved.text, dataTokens);
       if (residual.includes("{{") || residual.includes("}}")) {

--- a/apps/worker/src/workflow-definition/schema-v2.test.ts
+++ b/apps/worker/src/workflow-definition/schema-v2.test.ts
@@ -764,6 +764,73 @@ describe("Workflow Definition v2 schema", () => {
       }),
     ]);
 
+    const conditionallyUnavailable = branchingDefinition({
+      reference: "steps.checks.output.ok",
+      operator: "has_value",
+    });
+    conditionallyUnavailable.nodes.splice(1, 0, {
+      id: "route",
+      type: "branch",
+      x: 50,
+      y: 0,
+      configuration: {
+        combinator: "all",
+        conditions: [
+          {
+            reference: "steps.entry.output.ticketKey",
+            operator: "has_value",
+          },
+        ],
+      },
+      inputs: {},
+      additionalInputs: [],
+    });
+    conditionallyUnavailable.edges = [
+      { id: "ticket-route", from: "ticket", to: "route" },
+      {
+        id: "route-checks",
+        from: "route",
+        fromPort: "true",
+        to: "checks",
+      },
+      {
+        id: "route-decision",
+        from: "route",
+        fromPort: "false",
+        to: "decision",
+      },
+      { id: "checks-decision", from: "checks", to: "decision" },
+      {
+        id: "decision-success",
+        from: "decision",
+        fromPort: "true",
+        to: "success",
+      },
+      {
+        id: "decision-failure",
+        from: "decision",
+        fromPort: "false",
+        to: "failure",
+      },
+    ];
+    expect(
+      validateWorkflowDefinitionIssuesForDeployment(
+        conditionallyUnavailable,
+        registryContext,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "invalid_configuration",
+          nodeId: "decision",
+          path: "/nodes/3/configuration/conditions/0/reference",
+          message: expect.stringContaining(
+            "This step can be skipped on a path that reaches the current block.",
+          ),
+        }),
+      ]),
+    );
+
     const incompatible = branchingDefinition({
       reference: "steps.checks.output.ok",
       operator: "equals",

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -1952,7 +1952,7 @@ function validateWorkflowV2BranchConditionIssues(
       if (!compatibility.compatible) {
         addIssue(
           [...path, "reference"],
-          compatibility.reason?.message ?? "the selected value cannot be compared.",
+          compatibility.reason.message,
         );
         continue;
       }
@@ -2041,7 +2041,7 @@ function validateWorkflowV2TransformReferenceIssues(
         if (!compatibility.compatible) {
           add(
             [...path, "reference"],
-            compatibility.reason?.message ?? "this value is not available.",
+            compatibility.reason.message,
           );
           continue;
         }
@@ -2068,7 +2068,7 @@ function validateWorkflowV2TransformReferenceIssues(
     if (!compatibility.compatible) {
       add(
         ["source"],
-        compatibility.reason?.message ?? "this value is not compatible.",
+        compatibility.reason.message,
       );
       continue;
     }

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -27,6 +27,7 @@ import {
   isWorkflowAddressablePathSegment,
   resolveBuiltinHarnessProfile,
   wirablePorts,
+  evaluateWorkflowValueCompatibility,
 } from "@shared/contracts";
 import { parseCondition } from "@shared/conditions";
 import { paramsSchema as prepareWorkspaceParams } from "../workflows/blocks/prepare-workspace.js";
@@ -441,6 +442,22 @@ const workflowInputBindingV2Schema = z.discriminatedUnion(
               "Reference must use steps.entry.output.*, steps.<nodeId>.output.*, or run.*.",
           },
         ),
+      })
+      .strict(),
+    z
+      .object({
+        kind: z.literal("reference_list"),
+        references: z
+          .array(
+            z.custom<WorkflowDataReferenceV2>(
+              (value) => isWorkflowDataReferenceV2(value),
+              {
+                message:
+                  "Reference must use steps.entry.output.*, steps.<nodeId>.output.*, or run.*.",
+              },
+            ),
+          )
+          .min(1),
       })
       .strict(),
     z.object({ kind: z.literal("literal"), value: jsonValueSchema }).strict(),
@@ -1859,12 +1876,10 @@ function validateWorkflowV2BranchConditionIssues(
     for (const [conditionIndex, condition] of parsed.data.conditions.entries()) {
       const path = ["conditions", conditionIndex] as const;
       const entry = catalog.get(condition.reference);
-      if (!entry || entry.availability.state !== "available") {
+      if (!entry) {
         addIssue(
           [...path, "reference"],
-          entry?.availability.state === "unavailable"
-            ? entry.availability.reason
-            : `reference "${condition.reference}" is not available when this Branch runs.`,
+          `reference "${condition.reference}" is not available when this Branch runs.`,
         );
         continue;
       }
@@ -1876,6 +1891,16 @@ function validateWorkflowV2BranchConditionIssues(
         if (condition.value !== undefined) {
           addIssue([...path, "value"], "presence conditions do not accept a comparison value.");
         }
+        continue;
+      }
+      const compatibility = evaluateWorkflowValueCompatibility(entry, {
+        kind: "branch",
+      });
+      if (!compatibility.compatible) {
+        addIssue(
+          [...path, "reference"],
+          compatibility.reason?.message ?? "the selected value cannot be compared.",
+        );
         continue;
       }
       if (condition.value === undefined) {
@@ -1940,12 +1965,10 @@ function validateWorkflowV2TransformReferenceIssues(
       path: readonly (string | number)[],
     ): WorkflowDataCatalogEntry | null => {
       const entry = catalog.get(reference);
-      if (!entry || entry.availability.state !== "available") {
+      if (!entry) {
         add(
           path,
-          entry?.availability.state === "unavailable"
-            ? entry.availability.reason
-            : `reference "${reference}" is not available when this Transform runs.`,
+          `reference "${reference}" is not available when this Transform runs.`,
         );
         return null;
       }
@@ -1958,7 +1981,18 @@ function validateWorkflowV2TransformReferenceIssues(
         if (field.value.kind !== "reference") continue;
         const path = ["fields", fieldIndex, "value"] as const;
         const entry = resolve(field.value.reference, [...path, "reference"]);
-        if (!entry || field.value.defaultValue === undefined) continue;
+        if (!entry) continue;
+        const compatibility = evaluateWorkflowValueCompatibility(entry, {
+          kind: "build_object",
+        });
+        if (!compatibility.compatible) {
+          add(
+            [...path, "reference"],
+            compatibility.reason?.message ?? "this value is not available.",
+          );
+          continue;
+        }
+        if (field.value.defaultValue === undefined) continue;
         const optional =
           entry.presence !== "required" ||
           comparableTypesForSchema(entry.schema)?.has("null") === true;
@@ -1972,6 +2006,19 @@ function validateWorkflowV2TransformReferenceIssues(
     }
     const entry = resolve(config.source, ["source"]);
     if (!entry) continue;
+    const compatibility = evaluateWorkflowValueCompatibility(entry, {
+      kind:
+        config.operation === "number_to_text"
+          ? "transform_number"
+          : "transform_text",
+    });
+    if (!compatibility.compatible) {
+      add(
+        ["source"],
+        compatibility.reason?.message ?? "this value is not compatible.",
+      );
+      continue;
+    }
     const types = comparableTypesForSchema(entry.schema);
     const requiresText =
       config.operation === "trim_text" ||

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -1932,6 +1932,10 @@ function validateWorkflowV2BranchConditionIssues(
         );
         continue;
       }
+      if (entry.availability.state === "unavailable") {
+        addIssue([...path, "reference"], entry.availability.reason);
+        continue;
+      }
       const types = comparableTypesForSchema(entry.schema);
       const presence =
         condition.operator === "has_value" ||

--- a/apps/worker/src/workflow-definition/v2-bindings.test.ts
+++ b/apps/worker/src/workflow-definition/v2-bindings.test.ts
@@ -118,6 +118,40 @@ describe("v2 data bindings", () => {
     );
   });
 
+  it("serializes numbers into mixed text without locale-dependent formatting", () => {
+    const numericContext: V2BindingResolutionContext = {
+      ...context,
+      getStepOutput(nodeId) {
+        return nodeId === "open" ? { status: "ok", prNumber: 1234.5 } : undefined;
+      },
+    };
+    expect(
+      resolveWorkflowPromptDataTokensV2(
+        "Pull request #{{data:steps.open.output.prNumber}}",
+        numericContext,
+      ),
+    ).toBe("Pull request #1234.5");
+  });
+
+  it("materializes reference lists in authored order", () => {
+    expect(
+      resolveWorkflowNodeInputsV2(
+        node({
+          reviews: {
+            kind: "reference_list",
+            references: [
+              "steps.plan.output.plan.title",
+              "steps.entry.output.ticket.key",
+            ],
+          },
+        }),
+        context,
+      ),
+    ).toEqual({
+      reviews: ["Implement scheduler", "AIW-120"],
+    });
+  });
+
   it("fails instead of leaking an unresolved canonical prompt token", () => {
     expect(() =>
       resolveWorkflowPromptDataTokensV2(

--- a/apps/worker/src/workflow-definition/v2-bindings.ts
+++ b/apps/worker/src/workflow-definition/v2-bindings.ts
@@ -139,6 +139,11 @@ export function resolveWorkflowInputBindingV2(
   context: V2BindingResolutionContext,
 ): unknown {
   if (binding.kind === "literal") return cloneJsonValue(binding.value);
+  if (binding.kind === "reference_list") {
+    return binding.references.map((reference) =>
+      resolveWorkflowDataReferenceV2(reference, context),
+    );
+  }
   return resolveWorkflowDataReferenceV2(binding.reference, context);
 }
 

--- a/apps/worker/src/workflow-definition/workflow-value-compatibility.test.ts
+++ b/apps/worker/src/workflow-definition/workflow-value-compatibility.test.ts
@@ -77,4 +77,24 @@ describe("workflow value compatibility", () => {
       }).reason?.code,
     ).toBe("presence_optional");
   });
+
+  it("distinguishes whole-input compatibility from array-item compatibility", () => {
+    const listItem = entry({
+      compatibleInputNames: [],
+      compatibleListInputNames: ["reviews"],
+    });
+
+    expect(
+      evaluateWorkflowValueCompatibility(listItem, {
+        kind: "typed_input",
+        inputName: "reviews",
+      }).reason?.code,
+    ).toBe("type_mismatch");
+    expect(
+      evaluateWorkflowValueCompatibility(listItem, {
+        kind: "typed_list_item",
+        inputName: "reviews",
+      }),
+    ).toEqual({ compatible: true });
+  });
 });

--- a/apps/worker/src/workflow-definition/workflow-value-compatibility.test.ts
+++ b/apps/worker/src/workflow-definition/workflow-value-compatibility.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   evaluateWorkflowValueCompatibility,
   type WorkflowDataCatalogEntry,
+  type WorkflowValueCompatibility,
 } from "@shared/contracts";
 
 function entry(
@@ -20,6 +21,12 @@ function entry(
   };
 }
 
+function reasonCode(
+  compatibility: WorkflowValueCompatibility,
+): string | null {
+  return compatibility.compatible ? null : compatibility.reason.code;
+}
+
 describe("workflow value compatibility", () => {
   it("allows guaranteed numbers and text in mixed text", () => {
     expect(
@@ -35,33 +42,41 @@ describe("workflow value compatibility", () => {
 
   it("reports graph, presence, nullability, and type separately", () => {
     expect(
-      evaluateWorkflowValueCompatibility(
-        entry({
-          availability: {
-            state: "unavailable",
-            reason: "The step is not guaranteed on this path.",
-          },
-        }),
-        { kind: "mixed_text" },
-      ).reason?.code,
+      reasonCode(
+        evaluateWorkflowValueCompatibility(
+          entry({
+            availability: {
+              state: "unavailable",
+              reason: "The step is not guaranteed on this path.",
+            },
+          }),
+          { kind: "mixed_text" },
+        ),
+      ),
     ).toBe("graph_unavailable");
     expect(
-      evaluateWorkflowValueCompatibility(
-        entry({ presence: "optional" }),
-        { kind: "mixed_text" },
-      ).reason?.code,
+      reasonCode(
+        evaluateWorkflowValueCompatibility(
+          entry({ presence: "optional" }),
+          { kind: "mixed_text" },
+        ),
+      ),
     ).toBe("presence_optional");
     expect(
-      evaluateWorkflowValueCompatibility(
-        entry({ presence: "nullable", schema: { type: ["number", "null"] } }),
-        { kind: "mixed_text" },
-      ).reason?.code,
+      reasonCode(
+        evaluateWorkflowValueCompatibility(
+          entry({ presence: "nullable", schema: { type: ["number", "null"] } }),
+          { kind: "mixed_text" },
+        ),
+      ),
     ).toBe("nullable");
     expect(
-      evaluateWorkflowValueCompatibility(
-        entry({ schema: { type: "object" } }),
-        { kind: "mixed_text" },
-      ).reason?.code,
+      reasonCode(
+        evaluateWorkflowValueCompatibility(
+          entry({ schema: { type: "object" } }),
+          { kind: "mixed_text" },
+        ),
+      ),
     ).toBe("type_mismatch");
   });
 
@@ -72,10 +87,73 @@ describe("workflow value compatibility", () => {
       }),
     ).toEqual({ compatible: true });
     expect(
-      evaluateWorkflowValueCompatibility(entry({ presence: "optional" }), {
-        kind: "transform_number",
-      }).reason?.code,
+      reasonCode(
+        evaluateWorkflowValueCompatibility(entry({ presence: "optional" }), {
+          kind: "transform_number",
+        }),
+      ),
     ).toBe("presence_optional");
+  });
+
+  it("covers typed, text-transform, and build-object destinations", () => {
+    expect(
+      evaluateWorkflowValueCompatibility(
+        entry({ compatibleInputNames: ["score"] }),
+        { kind: "typed_input", inputName: "score" },
+      ),
+    ).toEqual({ compatible: true });
+    expect(
+      reasonCode(
+        evaluateWorkflowValueCompatibility(entry(), {
+          kind: "typed_input",
+          inputName: "score",
+        }),
+      ),
+    ).toBe("type_mismatch");
+    expect(
+      evaluateWorkflowValueCompatibility(
+        entry({ schema: { type: "string" } }),
+        { kind: "transform_text" },
+      ),
+    ).toEqual({ compatible: true });
+    expect(
+      reasonCode(
+        evaluateWorkflowValueCompatibility(entry(), {
+          kind: "transform_text",
+        }),
+      ),
+    ).toBe("type_mismatch");
+    expect(
+      evaluateWorkflowValueCompatibility(
+        entry({ presence: "optional", schema: { type: "object" } }),
+        { kind: "build_object" },
+      ),
+    ).toEqual({ compatible: true });
+  });
+
+  it("gates Branch presence handling on allowMissing", () => {
+    const optional = entry({ presence: "optional" });
+    expect(
+      evaluateWorkflowValueCompatibility(optional, {
+        kind: "branch",
+        allowMissing: true,
+      }),
+    ).toEqual({ compatible: true });
+    expect(
+      reasonCode(
+        evaluateWorkflowValueCompatibility(optional, {
+          kind: "branch",
+        }),
+      ),
+    ).toBe("presence_optional");
+    expect(
+      reasonCode(
+        evaluateWorkflowValueCompatibility(
+          entry({ schema: { type: "object" } }),
+          { kind: "branch", allowMissing: true },
+        ),
+      ),
+    ).toBe("unsupported_destination");
   });
 
   it("distinguishes whole-input compatibility from array-item compatibility", () => {
@@ -85,10 +163,12 @@ describe("workflow value compatibility", () => {
     });
 
     expect(
-      evaluateWorkflowValueCompatibility(listItem, {
-        kind: "typed_input",
-        inputName: "reviews",
-      }).reason?.code,
+      reasonCode(
+        evaluateWorkflowValueCompatibility(listItem, {
+          kind: "typed_input",
+          inputName: "reviews",
+        }),
+      ),
     ).toBe("type_mismatch");
     expect(
       evaluateWorkflowValueCompatibility(listItem, {

--- a/apps/worker/src/workflow-definition/workflow-value-compatibility.test.ts
+++ b/apps/worker/src/workflow-definition/workflow-value-compatibility.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateWorkflowValueCompatibility,
+  type WorkflowDataCatalogEntry,
+} from "@shared/contracts";
+
+function entry(
+  overrides: Partial<WorkflowDataCatalogEntry> = {},
+): WorkflowDataCatalogEntry {
+  return {
+    reference: "steps.open.output.prNumber",
+    label: "Open pull request · prNumber",
+    description: "Primary pull request number.",
+    schema: { type: "number" },
+    source: { kind: "step", nodeId: "open" },
+    presence: "required",
+    availability: { state: "available", guarantee: "Guaranteed." },
+    compatibleInputNames: [],
+    ...overrides,
+  };
+}
+
+describe("workflow value compatibility", () => {
+  it("allows guaranteed numbers and text in mixed text", () => {
+    expect(
+      evaluateWorkflowValueCompatibility(entry(), { kind: "mixed_text" }),
+    ).toEqual({ compatible: true });
+    expect(
+      evaluateWorkflowValueCompatibility(
+        entry({ schema: { type: "string", enum: ["approved"] } }),
+        { kind: "mixed_text" },
+      ),
+    ).toEqual({ compatible: true });
+  });
+
+  it("reports graph, presence, nullability, and type separately", () => {
+    expect(
+      evaluateWorkflowValueCompatibility(
+        entry({
+          availability: {
+            state: "unavailable",
+            reason: "The step is not guaranteed on this path.",
+          },
+        }),
+        { kind: "mixed_text" },
+      ).reason?.code,
+    ).toBe("graph_unavailable");
+    expect(
+      evaluateWorkflowValueCompatibility(
+        entry({ presence: "optional" }),
+        { kind: "mixed_text" },
+      ).reason?.code,
+    ).toBe("presence_optional");
+    expect(
+      evaluateWorkflowValueCompatibility(
+        entry({ presence: "nullable", schema: { type: ["number", "null"] } }),
+        { kind: "mixed_text" },
+      ).reason?.code,
+    ).toBe("nullable");
+    expect(
+      evaluateWorkflowValueCompatibility(
+        entry({ schema: { type: "object" } }),
+        { kind: "mixed_text" },
+      ).reason?.code,
+    ).toBe("type_mismatch");
+  });
+
+  it("uses the same required source rule for scalar Transforms", () => {
+    expect(
+      evaluateWorkflowValueCompatibility(entry(), {
+        kind: "transform_number",
+      }),
+    ).toEqual({ compatible: true });
+    expect(
+      evaluateWorkflowValueCompatibility(entry({ presence: "optional" }), {
+        kind: "transform_number",
+      }).reason?.code,
+    ).toBe("presence_optional");
+  });
+});

--- a/apps/worker/src/workflows/agent-block-outputs.test.ts
+++ b/apps/worker/src/workflows/agent-block-outputs.test.ts
@@ -135,5 +135,18 @@ describe("specialized workflow block outputs", () => {
         requireNormalOutput: true,
       }),
     ).toEqual([]);
+    expect(
+      validateBlockOutputForDefinition(
+        "open_pr",
+        {},
+        { status: "ok", prs: output.prs },
+        { requireNormalOutput: true },
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("prUrl"),
+        expect.stringContaining("prNumber"),
+      ]),
+    );
   });
 });

--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -1045,11 +1045,13 @@
         open_pr: runtimeContract(["title", "body"], {
           requiredInputs: typedPaths("object[]", "repositories"),
           optionalInputs: typedPaths("string", "title", "body"),
-          requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("object[]", "prs")],
-          optionalOutputs: [
+          requiredOutputs: [
+            ...STATUS_OUTPUT,
+            ...typedPaths("object[]", "prs"),
             ...typedPaths("string", "prUrl"),
             ...typedPaths("number", "prNumber"),
           ],
+          optionalOutputs: [],
           statuses: ["ok"],
         }),
         update_ticket_status: runtimeContract(["target"], {


### PR DESCRIPTION
## Stack

- Base: #168 (`codex/aiw-184-189-run-start-lifecycle`)
- Jira: [AIW-183](https://blazity.atlassian.net/browse/AIW-183)
- Migration: none

## Behavior

- Makes successful Open PR outputs (`prs`, `prUrl`, and `prNumber`) guaranteed and consistently selectable.
- Uses one shared compatibility decision across catalog generation, picker presentation, deployment validation, Branch, Transform, typed inputs, and mixed text.
- Allows guaranteed numbers and integers in mixed-text fields using locale-independent string formatting, without introducing text-to-number coercion.
- Keeps unavailable values beside their source step with an exact reason instead of moving them into a global bucket.
- Distinguishes an entire step result from a nested field named Output and deduplicates canonical references.
- Adds ordered multi-reference bindings for array inputs and materializes them in authored order.
- Preserves invalid existing bindings until the user explicitly replaces or removes them.

## Compatibility

Workflow Definition v1 remains unchanged. This tightens pre-release v2 contracts only.

## Verification

- Focused Open PR/catalog/compatibility/picker/runtime/reference-list regressions pass.
- Repository-wide `pnpm typecheck` passes.
- Repository-wide `pnpm test` passes: dashboard 522/522; worker 3,119/3,119.
- No database migration.

[AIW-183]: https://blazity.atlassian.net/browse/AIW-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `reference_list` bindings to select, resolve, and reorder multiple workflow values for array inputs.
  * Updated workflow value pickers to surface item-level compatibility and list authoring controls during selection.
* **Bug Fixes**
  * Improved compatibility handling across branch and transform validations, including consistent “why” messaging and blocking incompatible selections.
  * Enhanced prompt authoring validation to use workflow catalog compatibility when available.
* **Documentation**
  * Updated the `open_pr` contract documentation to require `prUrl` and `prNumber`.
* **Tests**
  * Expanded test coverage for `reference_list`, compatibility evaluation, prompt authoring validation, and workflow v2 remapping/resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->