### PR TITLE
feat: pin repositories to a workflow

### DIFF
--- a/apps/dashboard/app/api/repositories/route.test.ts
+++ b/apps/dashboard/app/api/repositories/route.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { handleRepositoriesGet } from "../pre-pr-checks/handler.ts";
+
+test("GET forwards to the worker repository catalog and re-serializes it", async () => {
+  const repositories = [
+    {
+      provider: "github",
+      repoPath: "Blazity/ai-workflow",
+      name: "ai-workflow",
+      owner: "Blazity",
+      defaultBranch: "main",
+      private: true,
+      archived: false,
+    },
+  ];
+  const res = await handleRepositoriesGet(async (path, init) => {
+    assert.equal(path, "/api/v1/repositories");
+    assert.equal(init?.method ?? "GET", "GET");
+    return Response.json({ repositories }, { status: 200 });
+  });
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { repositories });
+});
+
+test("GET propagates a worker failure status instead of inventing a catalog", async () => {
+  const res = await handleRepositoriesGet(async () =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  );
+
+  assert.equal(res.status, 403);
+  assert.deepEqual(await res.json(), { error: "Forbidden" });
+});
+
+test("GET maps worker timeouts to 504", async () => {
+  const res = await handleRepositoriesGet(async () => {
+    throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+  });
+
+  assert.equal(res.status, 504);
+  assert.deepEqual(await res.json(), { error: "Worker request timed out" });
+});

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor-validation.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor-validation.test.tsx
@@ -5,10 +5,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type {
   WorkflowBlockContract,
   WorkflowEditorOptions,
+  WorkflowRepositoryScope,
 } from "@shared/contracts";
 import type { FlowNodeDef } from "@/lib/flows";
 import type { WorkflowValidationState } from "@/lib/workflow-editor/validation-controller";
 import { FlowEditor } from "./flow-editor";
+import { RepositoryCatalogProvider } from "./repository-catalog-context";
+import { MAX_PINNED_REPOSITORIES } from "@/lib/workflow-editor/repository-scope";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
@@ -159,7 +162,9 @@ function renderEditor(
       {...editorInteractionProps}
       schemaVersion={1}
       limits={{}}
+      repositoryScope={{}}
       onLimitsChange={() => undefined}
+      onRepositoryScopeChange={() => undefined}
       onNodesChange={() => undefined}
       onEdgesChange={() => undefined}
       canEdit
@@ -255,7 +260,9 @@ test("a runnable deployed trigger shows the circular play button beside the node
       {...editorInteractionProps}
       schemaVersion={1}
       limits={{}}
+      repositoryScope={{}}
       onLimitsChange={() => undefined}
+      onRepositoryScopeChange={() => undefined}
       onNodesChange={() => undefined}
       onEdgesChange={() => undefined}
       canEdit
@@ -349,7 +356,9 @@ test("a selected v2 Transform exposes the seven-action editor without generic in
       {...editorInteractionProps}
       schemaVersion={2}
       limits={{}}
+      repositoryScope={{}}
       onLimitsChange={() => undefined}
+      onRepositoryScopeChange={() => undefined}
       onNodesChange={() => undefined}
       onEdgesChange={() => undefined}
       canEdit
@@ -431,7 +440,9 @@ function renderSelectedBranch(schemaVersion: 1 | 2): string {
       {...editorInteractionProps}
       schemaVersion={schemaVersion}
       limits={{}}
+      repositoryScope={{}}
       onLimitsChange={() => undefined}
+      onRepositoryScopeChange={() => undefined}
       onNodesChange={() => undefined}
       onEdgesChange={() => undefined}
       canEdit
@@ -511,7 +522,9 @@ function renderSelectedOpenPr(schemaVersion: 1 | 2): string {
       {...editorInteractionProps}
       schemaVersion={schemaVersion}
       limits={{}}
+      repositoryScope={{}}
       onLimitsChange={() => undefined}
+      onRepositoryScopeChange={() => undefined}
       onNodesChange={() => undefined}
       onEdgesChange={() => undefined}
       canEdit
@@ -548,4 +561,89 @@ function renderSelectedOpenPr(schemaVersion: 1 | 2): string {
 test("v2 canvas never exposes an execution-failure port", () => {
   assert.match(renderSelectedOpenPr(1), />failed<\/span>/);
   assert.doesNotMatch(renderSelectedOpenPr(2), />failed<\/span>/);
+});
+
+function renderEditorWithRepositoryPin(
+  repositoryScope: WorkflowRepositoryScope,
+  canEdit: boolean,
+): string {
+  return renderToStaticMarkup(
+    <RepositoryCatalogProvider
+      initial={{
+        status: "ready",
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "Blazity/ai-workflow",
+            name: "ai-workflow",
+            owner: "Blazity",
+            defaultBranch: "main",
+            private: true,
+            archived: false,
+          },
+        ],
+      }}
+    >
+      <FlowEditor
+        nodes={[node]}
+        edges={[]}
+        {...editorInteractionProps}
+        schemaVersion={1}
+        limits={{}}
+        repositoryScope={repositoryScope}
+        onLimitsChange={() => undefined}
+        onRepositoryScopeChange={() => undefined}
+        onNodesChange={() => undefined}
+        onEdgesChange={() => undefined}
+        canEdit={canEdit}
+        dirty={false}
+        saveEnabled
+        saving={false}
+        error={null}
+        validation={{
+          status: "valid",
+          issues: [],
+          nodeContracts: { entry: triggerContract },
+          availableValuesByNode: {},
+        }}
+        onSave={() => undefined}
+        headerTitle="Ticket workflow"
+        headerVersionBadge="draft"
+        options={options}
+      />
+    </RepositoryCatalogProvider>,
+  );
+}
+
+test("the repository scope bar sits directly under the execution limits bar", () => {
+  const html = renderEditorWithRepositoryPin(
+    { repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow" }] },
+    true,
+  );
+
+  assert.match(html, /Execution limits[\s\S]*Repositories/);
+  assert.match(html, /Pinned for every ticket/);
+  assert.match(html, /Blazity\/ai-workflow/);
+  assert.match(html, new RegExp(`1 / ${MAX_PINNED_REPOSITORIES}`));
+  assert.match(html, /\+ Add repository/);
+});
+
+test("an unpinned workflow renders the bar without implying a binding", () => {
+  const html = renderEditorWithRepositoryPin({}, true);
+
+  assert.match(html, /No repository pinned/);
+  assert.match(html, new RegExp(`0 / ${MAX_PINNED_REPOSITORIES}`));
+  assert.doesNotMatch(html, /inherits/);
+});
+
+test("a read-only editor disables the repository scope controls", () => {
+  const html = renderEditorWithRepositoryPin(
+    { repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow" }] },
+    false,
+  );
+
+  assert.match(html, /disabled=""[^>]*aria-label="Remove Blazity\/ai-workflow"/);
+  assert.match(html, /disabled=""[^>]*>\+ Add repository/);
+  assert.match(html, /aria-pressed="false" disabled=""[^>]*>GitHub/);
+  assert.match(html, /aria-pressed="false" disabled=""[^>]*>GitLab/);
 });

--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
@@ -25,6 +25,7 @@ import type {
   WorkflowExecutionBudgets,
   WorkflowInputBindingV2,
   WorkflowParamValue,
+  WorkflowRepositoryScope,
 } from "@shared/contracts";
 import { FAILURE_PORT, isTriggerBlockType } from "@shared/contracts";
 import { useIsMobileViewport } from "@/lib/use-media-query";
@@ -72,6 +73,7 @@ import {
   setExecutionLimit,
   type WorkflowExecutionLimitKey,
 } from "@/lib/workflow-editor/execution-limits";
+import { RepositoryScopeBar } from "./repository-scope-bar";
 import {
   groupValidationIssues,
   NodeValidationErrors,
@@ -1322,7 +1324,9 @@ export function FlowEditor({
   edgeGeometry,
   schemaVersion,
   limits,
+  repositoryScope,
   onLimitsChange,
+  onRepositoryScopeChange,
   onNodesChange,
   onNodePositionsChange,
   onEdgesChange,
@@ -1366,7 +1370,9 @@ export function FlowEditor({
   edgeGeometry: Record<string, WorkflowEdgeGeometry>;
   schemaVersion: 1 | 2;
   limits: WorkflowExecutionBudgets;
+  repositoryScope: WorkflowRepositoryScope;
   onLimitsChange: (limits: WorkflowExecutionBudgets) => void;
+  onRepositoryScopeChange: (scope: WorkflowRepositoryScope) => void;
   onNodesChange: React.Dispatch<React.SetStateAction<FlowNodeDef[]>>;
   onNodePositionsChange: React.Dispatch<
     React.SetStateAction<FlowNodeDef[]>
@@ -1638,9 +1644,9 @@ export function FlowEditor({
   const previewDefinition = useMemo<WorkflowDefinitionV2 | null>(
     () =>
       schemaVersion === 2
-        ? serializeWorkflowDefinition(nodes, edges, limits, 2)
+        ? serializeWorkflowDefinition(nodes, edges, limits, 2, repositoryScope)
         : null,
-    [edges, limits, nodes, schemaVersion],
+    [edges, limits, nodes, repositoryScope, schemaVersion],
   );
 
   const addNode = (item: PaletteItem, at?: Point) => {
@@ -2088,6 +2094,11 @@ export function FlowEditor({
         </div>
       </div>
       <ExecutionLimitsBar limits={limits} canEdit={canEdit} onChange={onLimitsChange} />
+      <RepositoryScopeBar
+        scope={repositoryScope}
+        canEdit={canEdit}
+        onChange={onRepositoryScopeChange}
+      />
       {displayedError && (
         <div
           role="alert"

--- a/apps/dashboard/components/cockpit/flow-editor/repository-catalog-context.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-catalog-context.test.tsx
@@ -133,6 +133,28 @@ test("a stale failure never downgrades a newer successful catalog", async () => 
   await act(async () => harness.renderer.unmount());
 });
 
+test("a 200 with an unusable body is an error, not a ready empty catalog", async () => {
+  for (const body of [
+    {},
+    { repositories: null },
+    { repositories: "Blazity/a" },
+    { error: "wrong shape" },
+    null,
+  ]) {
+    const harness = await mount([Promise.resolve(Response.json(body))]);
+
+    await act(async () => undefined);
+
+    assert.equal(
+      harness.state().status,
+      "error",
+      `body ${JSON.stringify(body)} must not read as ready`,
+    );
+    assert.deepEqual(harness.state().repositories, []);
+    await act(async () => harness.renderer.unmount());
+  }
+});
+
 test("a failed catalog fetch reports the error state", async () => {
   const harness = await mount([
     Promise.resolve(Response.json({ error: "nope" }, { status: 503 })),

--- a/apps/dashboard/components/cockpit/flow-editor/repository-catalog-context.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-catalog-context.test.tsx
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import type { RepositoryOption } from "@shared/contracts";
+import {
+  RepositoryCatalogProvider,
+  useRepositoryCatalog,
+  type RepositoryCatalogState,
+} from "./repository-catalog-context";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function repository(repoPath: string): RepositoryOption {
+  return {
+    provider: "github",
+    repoPath,
+    name: repoPath.split("/")[1],
+    owner: repoPath.split("/")[0],
+    defaultBranch: "main",
+    private: true,
+    archived: false,
+  };
+}
+
+function deferred<T>() {
+  let settle!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    settle = resolve;
+  });
+  return { promise, settle };
+}
+
+interface Harness {
+  renderer: ReactTestRenderer;
+  state: () => RepositoryCatalogState;
+  urls: string[];
+}
+
+async function mount(responses: Array<Promise<Response>>): Promise<Harness> {
+  const urls: string[] = [];
+  const queue = [...responses];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string) => {
+    urls.push(String(url));
+    const next = queue.shift();
+    assert.notEqual(next, undefined, "an unexpected extra request was made");
+    return next!;
+  }) as typeof globalThis.fetch;
+
+  let captured!: RepositoryCatalogState;
+  function Probe() {
+    captured = useRepositoryCatalog();
+    return null;
+  }
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <RepositoryCatalogProvider>
+        <Probe />
+      </RepositoryCatalogProvider>,
+    );
+  });
+  renderer.unmount = ((original) => () => {
+    globalThis.fetch = originalFetch;
+    original.call(renderer);
+  })(renderer.unmount);
+  return { renderer, state: () => captured, urls };
+}
+
+test("the provider fetches the catalog once on mount", async () => {
+  const harness = await mount([
+    Promise.resolve(Response.json({ repositories: [repository("Blazity/a")] })),
+  ]);
+
+  await act(async () => undefined);
+
+  assert.deepEqual(harness.urls, ["/api/repositories"]);
+  assert.equal(harness.state().status, "ready");
+  assert.deepEqual(
+    harness.state().repositories.map((option) => option.repoPath),
+    ["Blazity/a"],
+  );
+  await act(async () => harness.renderer.unmount());
+});
+
+test("a stale catalog response never replaces a newer one", async () => {
+  const first = deferred<Response>();
+  const second = deferred<Response>();
+  const harness = await mount([first.promise, second.promise]);
+
+  // Refresh supersedes the in-flight mount request.
+  await act(async () => harness.state().refresh());
+  assert.deepEqual(harness.urls, ["/api/repositories", "/api/repositories"]);
+
+  await act(async () => {
+    second.settle(Response.json({ repositories: [repository("Blazity/new")] }));
+  });
+  await act(async () => {
+    first.settle(Response.json({ repositories: [repository("Blazity/stale")] }));
+  });
+
+  assert.equal(harness.state().status, "ready");
+  assert.deepEqual(
+    harness.state().repositories.map((option) => option.repoPath),
+    ["Blazity/new"],
+    "the superseded response must not overwrite the newer catalog",
+  );
+  await act(async () => harness.renderer.unmount());
+});
+
+test("a stale failure never downgrades a newer successful catalog", async () => {
+  const first = deferred<Response>();
+  const second = deferred<Response>();
+  const harness = await mount([first.promise, second.promise]);
+
+  await act(async () => harness.state().refresh());
+  await act(async () => {
+    second.settle(Response.json({ repositories: [repository("Blazity/new")] }));
+  });
+  await act(async () => {
+    first.settle(Response.json({ error: "boom" }, { status: 500 }));
+  });
+
+  assert.equal(harness.state().status, "ready");
+  assert.deepEqual(
+    harness.state().repositories.map((option) => option.repoPath),
+    ["Blazity/new"],
+  );
+  await act(async () => harness.renderer.unmount());
+});
+
+test("a failed catalog fetch reports the error state", async () => {
+  const harness = await mount([
+    Promise.resolve(Response.json({ error: "nope" }, { status: 503 })),
+  ]);
+
+  await act(async () => undefined);
+
+  assert.equal(harness.state().status, "error");
+  assert.deepEqual(harness.state().repositories, []);
+  await act(async () => harness.renderer.unmount());
+});
+
+test("an injected catalog renders without any request", async () => {
+  const urls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((url: string) => {
+    urls.push(String(url));
+    return Promise.reject(new Error("must not fetch"));
+  }) as typeof globalThis.fetch;
+
+  let captured!: RepositoryCatalogState;
+  function Probe() {
+    captured = useRepositoryCatalog();
+    return null;
+  }
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <RepositoryCatalogProvider
+        initial={{ status: "ready", repositories: [repository("Blazity/given")] }}
+      >
+        <Probe />
+      </RepositoryCatalogProvider>,
+    );
+  });
+
+  assert.deepEqual(urls, []);
+  assert.equal(captured.status, "ready");
+  assert.deepEqual(
+    captured.repositories.map((option) => option.repoPath),
+    ["Blazity/given"],
+  );
+  await act(async () => renderer.unmount());
+  globalThis.fetch = originalFetch;
+});

--- a/apps/dashboard/components/cockpit/flow-editor/repository-catalog-context.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-catalog-context.tsx
@@ -43,11 +43,19 @@ export function RepositoryCatalogProvider({
     fetch("/api/repositories", { cache: "no-store" })
       .then((response) => {
         if (!response.ok) throw new Error(String(response.status));
-        return response.json() as Promise<RepositoriesResponse>;
+        return response.json() as Promise<unknown>;
       })
       .then((result) => {
         if (id !== listRequestId.current) return;
-        setRepositories(result.repositories);
+        // A 200 carrying an unexpected body is as unusable as a bad status:
+        // every consumer maps over `repositories`, so anything but an array has
+        // to fail rather than land as a `ready` catalog that throws on render.
+        const repositories = (result as Partial<RepositoriesResponse> | null)
+          ?.repositories;
+        if (!Array.isArray(repositories)) {
+          throw new Error("malformed repository catalog");
+        }
+        setRepositories(repositories);
         setStatus("ready");
       })
       .catch(() => {

--- a/apps/dashboard/components/cockpit/flow-editor/repository-catalog-context.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-catalog-context.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+
+import type { RepositoriesResponse, RepositoryOption } from "@shared/contracts";
+
+export type RepositoryCatalogStatus = "loading" | "ready" | "error";
+
+export interface RepositoryCatalogState {
+  status: RepositoryCatalogStatus;
+  repositories: RepositoryOption[];
+  refresh: () => void;
+}
+
+const noop = () => {};
+const RepositoryCatalogContext = createContext<RepositoryCatalogState>({
+  status: "loading",
+  repositories: [],
+  refresh: noop,
+});
+
+export function RepositoryCatalogProvider({
+  children,
+  initial,
+}: {
+  children: React.ReactNode;
+  initial?: {
+    status: RepositoryCatalogStatus;
+    repositories: RepositoryOption[];
+  };
+}) {
+  const [status, setStatus] = useState<RepositoryCatalogStatus>(
+    initial?.status ?? "loading",
+  );
+  const [repositories, setRepositories] = useState<RepositoryOption[]>(
+    initial?.repositories ?? [],
+  );
+  const listRequestId = useRef(0);
+
+  const refresh = useCallback(() => {
+    const id = ++listRequestId.current;
+    setStatus("loading");
+    fetch("/api/repositories", { cache: "no-store" })
+      .then((response) => {
+        if (!response.ok) throw new Error(String(response.status));
+        return response.json() as Promise<RepositoriesResponse>;
+      })
+      .then((result) => {
+        if (id !== listRequestId.current) return;
+        setRepositories(result.repositories);
+        setStatus("ready");
+      })
+      .catch(() => {
+        if (id !== listRequestId.current) return;
+        setStatus("error");
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!initial) refresh();
+  }, [initial, refresh]);
+
+  return (
+    <RepositoryCatalogContext.Provider value={{ status, repositories, refresh }}>
+      {children}
+    </RepositoryCatalogContext.Provider>
+  );
+}
+
+export function useRepositoryCatalog(): RepositoryCatalogState {
+  return useContext(RepositoryCatalogContext);
+}

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
@@ -1,0 +1,473 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import {
+  act,
+  create,
+  type ReactTestInstance,
+  type ReactTestRenderer,
+} from "react-test-renderer";
+
+import type {
+  RepositoryOption,
+  WorkflowRepositoryScope,
+} from "@shared/contracts";
+import {
+  RepositoryScopeBar,
+  RepositoryScopePicker,
+} from "./repository-scope-bar";
+import {
+  RepositoryCatalogProvider,
+  type RepositoryCatalogStatus,
+} from "./repository-catalog-context";
+import { Listbox } from "@/components/cockpit/listbox";
+import {
+  MAX_PINNED_REPOSITORIES,
+  type PinnedRepository,
+} from "@/lib/workflow-editor/repository-scope";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+function gh(repoPath: string, defaultBranch = "main", archived = false): RepositoryOption {
+  const [owner, ...rest] = repoPath.split("/");
+  return {
+    provider: "github",
+    repoPath,
+    name: rest.join("/"),
+    owner,
+    defaultBranch,
+    private: true,
+    archived,
+  };
+}
+
+function gl(repoPath: string, defaultBranch = "main"): RepositoryOption {
+  const segments = repoPath.split("/");
+  return {
+    provider: "gitlab",
+    repoPath,
+    name: segments[segments.length - 1],
+    owner: segments.slice(0, -1).join("/"),
+    defaultBranch,
+    private: true,
+    archived: false,
+  };
+}
+
+const CATALOG: RepositoryOption[] = [
+  gh("Blazity/ai-workflow-prod"),
+  gh("Blazity/ai-workflow-demo"),
+  gh("Blazity/next-enterprise"),
+  gh("Blazity/legacy-portal", "master", true),
+  gl("filipmaszota3/ai-workflow-integration-test"),
+  gl("acme-group/platform/billing-core", "develop"),
+];
+
+function nodeText(node: ReactTestInstance): string {
+  return node.children
+    .flatMap((child) => (typeof child === "string" ? [child] : [nodeText(child)]))
+    .join("");
+}
+
+function byAriaLabel(root: ReactTestInstance, label: string): ReactTestInstance {
+  const matches = root.findAll(
+    (node) => typeof node.type === "string" && node.props["aria-label"] === label,
+  );
+  assert.equal(matches.length, 1, `expected exactly one element labelled ${label}`);
+  return matches[0];
+}
+
+function hasAriaLabel(root: ReactTestInstance, label: string): boolean {
+  return root.findAll(
+    (node) => typeof node.type === "string" && node.props["aria-label"] === label,
+  ).length > 0;
+}
+
+function buttonWithText(root: ReactTestInstance, text: string): ReactTestInstance {
+  const matches = root
+    .findAll((node) => node.type === "button")
+    .filter((node) => nodeText(node).includes(text));
+  assert.equal(matches.length, 1, `expected exactly one button containing ${text}`);
+  return matches[0];
+}
+
+interface PickerConfig {
+  scope?: WorkflowRepositoryScope;
+  canEdit?: boolean;
+  status?: RepositoryCatalogStatus;
+  repositories?: RepositoryOption[];
+}
+
+async function mountPicker(config: PickerConfig = {}) {
+  const {
+    scope = {},
+    canEdit = true,
+    status = "ready" as RepositoryCatalogStatus,
+    repositories = CATALOG,
+  } = config;
+  const added: PinnedRepository[][] = [];
+  const closes: number[] = [];
+  const element = (open: boolean) => (
+    <RepositoryCatalogProvider initial={{ status, repositories }}>
+      <RepositoryScopePicker
+        open={open}
+        scope={scope}
+        canEdit={canEdit}
+        onAdd={(repos) => added.push(repos)}
+        onClose={() => closes.push(1)}
+      />
+    </RepositoryCatalogProvider>
+  );
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(element(true));
+  });
+  const root = () => renderer.root;
+  return {
+    renderer,
+    added,
+    closes,
+    setOpen: async (open: boolean) => {
+      await act(async () => renderer.update(element(open)));
+    },
+    setFilter: async (value: string) => {
+      const input = byAriaLabel(root(), "Filter repositories");
+      await act(async () => input.props.onChange({ target: { value } }));
+    },
+    toggle: async (repoPath: string, checked: boolean) => {
+      const box = byAriaLabel(root(), `Pin ${repoPath}`);
+      await act(async () => box.props.onChange({ target: { checked } }));
+    },
+    checkboxDisabled: (repoPath: string) =>
+      byAriaLabel(root(), `Pin ${repoPath}`).props.disabled === true,
+    typeManualPath: async (value: string) => {
+      const input = byAriaLabel(root(), "Repository path");
+      await act(async () => input.props.onChange({ target: { value } }));
+    },
+    chooseManualProvider: async (provider: string) => {
+      const listbox = root().findByType(Listbox);
+      await act(async () => listbox.props.onChange(provider));
+    },
+    clickManualAdd: async () => {
+      await act(async () => buttonWithText(root(), "Add").props.onClick());
+    },
+    commit: async () => {
+      await act(async () => buttonWithText(root(), "Add").props.onClick());
+    },
+    close: async () => {
+      await act(async () =>
+        byAriaLabel(root(), "Close the repository picker").props.onClick(),
+      );
+    },
+    addLabel: () => nodeText(buttonWithText(root(), "Add")),
+    addDisabled: () => buttonWithText(root(), "Add").props.disabled === true,
+    manualOffered: () => hasAriaLabel(root(), "Repository path"),
+  };
+}
+
+async function mountBar(config: PickerConfig = {}) {
+  const {
+    scope = {},
+    canEdit = true,
+    status = "ready" as RepositoryCatalogStatus,
+    repositories = CATALOG,
+  } = config;
+  let current: WorkflowRepositoryScope = scope;
+  const changes: WorkflowRepositoryScope[] = [];
+  const element = () => (
+    <RepositoryCatalogProvider initial={{ status, repositories }}>
+      <RepositoryScopeBar
+        scope={current}
+        canEdit={canEdit}
+        onChange={(next) => {
+          current = next;
+          changes.push(next);
+        }}
+      />
+    </RepositoryCatalogProvider>
+  );
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(element());
+  });
+  const root = () => renderer.root;
+  /** Feed the new scope back in, the way the editor re-renders on a change. */
+  const rerender = async () => {
+    await act(async () => renderer.update(element()));
+  };
+  return {
+    renderer,
+    changes,
+    scope: () => current,
+    rerender,
+    removeChip: async (repoPath: string) => {
+      await act(async () =>
+        byAriaLabel(root(), `Remove ${repoPath}`).props.onClick(),
+      );
+      await rerender();
+    },
+    toggleProvider: async (label: string) => {
+      await act(async () => buttonWithText(root(), label).props.onClick());
+      await rerender();
+    },
+    openPicker: async () => {
+      await act(async () =>
+        buttonWithText(root(), "+ Add repository").props.onClick(),
+      );
+    },
+    text: () => nodeText(root().findAll((node) => node.type === "div")[0]),
+  };
+}
+
+test("a selection made under one filter survives a later filter", async () => {
+  const picker = await mountPicker();
+
+  await picker.setFilter("prod");
+  await picker.toggle("Blazity/ai-workflow-prod", true);
+  await picker.setFilter("billing");
+  await picker.toggle("acme-group/platform/billing-core", true);
+
+  assert.equal(picker.addLabel(), "Add 2 repositories");
+  await picker.commit();
+
+  assert.deepEqual(picker.added, [
+    [
+      { provider: "github", repoPath: "Blazity/ai-workflow-prod" },
+      { provider: "gitlab", repoPath: "acme-group/platform/billing-core" },
+    ],
+  ]);
+  assert.equal(picker.closes.length, 1);
+  await act(async () => picker.renderer.unmount());
+});
+
+test("an enabled add button never silently does nothing", async () => {
+  const picker = await mountPicker();
+
+  await picker.setFilter("prod");
+  await picker.toggle("Blazity/ai-workflow-prod", true);
+  await picker.setFilter("nothing-matches-this");
+
+  assert.equal(picker.addLabel(), "Add 1 repository");
+  assert.equal(picker.addDisabled(), false);
+  await picker.commit();
+
+  assert.deepEqual(picker.added, [
+    [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
+  ]);
+  await act(async () => picker.renderer.unmount());
+});
+
+test("unchecking a row before committing drops it from the addition", async () => {
+  const picker = await mountPicker();
+
+  await picker.toggle("Blazity/ai-workflow-prod", true);
+  await picker.toggle("Blazity/ai-workflow-demo", true);
+  await picker.toggle("Blazity/ai-workflow-prod", false);
+  await picker.commit();
+
+  assert.deepEqual(picker.added, [
+    [{ provider: "github", repoPath: "Blazity/ai-workflow-demo" }],
+  ]);
+  await act(async () => picker.renderer.unmount());
+});
+
+test("dismissing the picker discards an uncommitted selection", async () => {
+  const picker = await mountPicker();
+
+  await picker.setFilter("prod");
+  await picker.toggle("Blazity/ai-workflow-prod", true);
+  assert.equal(picker.addLabel(), "Add 1 repository");
+
+  await picker.close();
+  await picker.setOpen(false);
+  await picker.setOpen(true);
+
+  assert.equal(picker.addLabel(), "Add repositories");
+  assert.equal(picker.addDisabled(), true);
+  assert.equal(
+    byAriaLabel(picker.renderer.root, "Filter repositories").props.value,
+    "",
+  );
+  assert.deepEqual(picker.added, []);
+  await act(async () => picker.renderer.unmount());
+});
+
+test("the picker refuses to select past the remaining slots", async () => {
+  const pinned = Array.from(
+    { length: MAX_PINNED_REPOSITORIES - 1 },
+    (_value, index) => ({
+      provider: "github" as const,
+      repoPath: `Blazity/filler-${index}`,
+    }),
+  );
+  const picker = await mountPicker({ scope: { repositories: pinned } });
+
+  await picker.toggle("Blazity/ai-workflow-prod", true);
+
+  assert.equal(picker.checkboxDisabled("Blazity/ai-workflow-demo"), true);
+  await picker.commit();
+
+  assert.deepEqual(picker.added, [
+    [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
+  ]);
+  await act(async () => picker.renderer.unmount());
+});
+
+test("manual entry pins the exact trimmed path for the chosen provider", async () => {
+  const picker = await mountPicker({ status: "error", repositories: [] });
+
+  await picker.chooseManualProvider("gitlab");
+  await picker.typeManualPath("  acme-group/platform/billing-core  ");
+  await picker.clickManualAdd();
+
+  assert.deepEqual(picker.added, [
+    [{ provider: "gitlab", repoPath: "acme-group/platform/billing-core" }],
+  ]);
+  assert.equal(picker.closes.length, 1);
+  await act(async () => picker.renderer.unmount());
+});
+
+test("manual entry refuses a blank path and an already-pinned repository", async () => {
+  const picker = await mountPicker({
+    status: "error",
+    repositories: [],
+    scope: { repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }] },
+  });
+
+  await picker.typeManualPath("   ");
+  await picker.clickManualAdd();
+  assert.deepEqual(picker.added, []);
+
+  await picker.typeManualPath("blazity/AI-WORKFLOW-PROD");
+  await picker.clickManualAdd();
+  assert.deepEqual(picker.added, []);
+
+  await act(async () => picker.renderer.unmount());
+});
+
+test("an empty but healthy catalog still offers manual entry", async () => {
+  const picker = await mountPicker({ status: "ready", repositories: [] });
+
+  assert.equal(picker.manualOffered(), true);
+  await picker.typeManualPath("Blazity/ai-workflow-prod");
+  await picker.clickManualAdd();
+
+  assert.deepEqual(picker.added, [
+    [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
+  ]);
+  await act(async () => picker.renderer.unmount());
+});
+
+test("removing a chip hands back a scope without that repository", async () => {
+  const bar = await mountBar({
+    scope: {
+      repositories: [
+        { provider: "github", repoPath: "Blazity/ai-workflow-prod" },
+        { provider: "gitlab", repoPath: "acme-group/platform/billing-core" },
+      ],
+    },
+  });
+
+  await bar.removeChip("Blazity/ai-workflow-prod");
+
+  assert.deepEqual(bar.scope(), {
+    repositories: [
+      { provider: "gitlab", repoPath: "acme-group/platform/billing-core" },
+    ],
+  });
+
+  await bar.removeChip("acme-group/platform/billing-core");
+  assert.deepEqual(bar.scope(), {});
+  await act(async () => bar.renderer.unmount());
+});
+
+test("toggling a provider pill pins it and toggling again clears the key", async () => {
+  const bar = await mountBar();
+
+  await bar.toggleProvider("GitHub");
+  assert.deepEqual(bar.scope(), { providers: ["github"] });
+
+  await bar.toggleProvider("GitLab");
+  assert.deepEqual(bar.scope(), { providers: ["github", "gitlab"] });
+
+  await bar.toggleProvider("GitHub");
+  assert.deepEqual(bar.scope(), { providers: ["gitlab"] });
+
+  await bar.toggleProvider("GitLab");
+  assert.deepEqual(bar.scope(), {});
+  await act(async () => bar.renderer.unmount());
+});
+
+test("a provider pin that excludes a pinned repository is named, not asserted", async () => {
+  const bar = await mountBar({
+    scope: {
+      repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
+      providers: ["gitlab"],
+    },
+  });
+
+  const shown = bar.text();
+  assert.match(shown, /Provider mismatch/);
+  assert.match(shown, /Blazity\/ai-workflow-prod \(GitHub\)/);
+  assert.match(shown, /Deployment rejects this until the two agree/);
+  assert.match(shown, /inherits 1 repo, provider mismatch/);
+  assert.doesNotMatch(shown, /inherits 1 repo, GitLab/);
+  await act(async () => bar.renderer.unmount());
+});
+
+test("adding the excluded provider clears the mismatch", async () => {
+  const bar = await mountBar({
+    scope: {
+      repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
+      providers: ["gitlab"],
+    },
+  });
+
+  await bar.toggleProvider("GitHub");
+
+  assert.deepEqual(bar.scope(), {
+    repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
+    providers: ["github", "gitlab"],
+  });
+  assert.doesNotMatch(bar.text(), /Provider mismatch/);
+  assert.match(bar.text(), /inherits 1 repo, GitHub \+ GitLab/);
+  await act(async () => bar.renderer.unmount());
+});
+
+test("the picker adds through the bar and lands in the scope", async () => {
+  const bar = await mountBar();
+
+  await bar.openPicker();
+  const box = byAriaLabel(bar.renderer.root, "Pin Blazity/ai-workflow-prod");
+  await act(async () => box.props.onChange({ target: { checked: true } }));
+  await act(async () =>
+    buttonWithText(bar.renderer.root, "Add 1 repository").props.onClick(),
+  );
+
+  assert.deepEqual(bar.scope(), {
+    repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
+  });
+  await act(async () => bar.renderer.unmount());
+});
+
+test("a read-only bar wires no handler at all", async () => {
+  const bar = await mountBar({
+    scope: {
+      repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
+      providers: ["github"],
+    },
+    canEdit: false,
+  });
+
+  const remove = byAriaLabel(bar.renderer.root, "Remove Blazity/ai-workflow-prod");
+  const provider = buttonWithText(bar.renderer.root, "GitHub");
+  const add = buttonWithText(bar.renderer.root, "+ Add repository");
+
+  assert.equal(remove.props.disabled, true);
+  assert.equal(provider.props.disabled, true);
+  assert.equal(add.props.disabled, true);
+  assert.deepEqual(bar.changes, []);
+  await act(async () => bar.renderer.unmount());
+});

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
@@ -112,6 +112,7 @@ async function mountPicker(config: PickerConfig = {}) {
   const element = (open: boolean) => (
     <RepositoryCatalogProvider initial={{ status, repositories }}>
       <RepositoryScopePicker
+        id="test-picker"
         open={open}
         scope={scope}
         canEdit={canEdit}
@@ -164,6 +165,67 @@ async function mountPicker(config: PickerConfig = {}) {
     addLabel: () => nodeText(buttonWithText(root(), "Add")),
     addDisabled: () => buttonWithText(root(), "Add").props.disabled === true,
     manualOffered: () => hasAriaLabel(root(), "Repository path"),
+    text: () => nodeText(root().findByType(RepositoryScopePicker)),
+  };
+}
+
+/**
+ * Picker over a live-fetching provider, so `Refresh catalog` really replaces the
+ * catalog the way it does in the editor.
+ */
+async function mountLivePicker(
+  catalogs: RepositoryOption[][],
+  scope: WorkflowRepositoryScope = {},
+) {
+  const queue = [...catalogs];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (() => {
+    const next = queue.shift();
+    assert.notEqual(next, undefined, "an unexpected extra catalog request was made");
+    return Promise.resolve(Response.json({ repositories: next }));
+  }) as typeof globalThis.fetch;
+
+  const added: PinnedRepository[][] = [];
+  const closes: number[] = [];
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <RepositoryCatalogProvider>
+        <RepositoryScopePicker
+          id="test-picker"
+          open
+          scope={scope}
+          canEdit
+          onAdd={(repos) => added.push(repos)}
+          onClose={() => closes.push(1)}
+        />
+      </RepositoryCatalogProvider>,
+    );
+  });
+  await act(async () => undefined);
+  const root = () => renderer.root;
+  return {
+    added,
+    closes,
+    toggle: async (repoPath: string, checked: boolean) => {
+      const box = byAriaLabel(root(), `Pin ${repoPath}`);
+      await act(async () => box.props.onChange({ target: { checked } }));
+    },
+    refresh: async () => {
+      await act(async () =>
+        buttonWithText(root(), "Refresh catalog").props.onClick(),
+      );
+      await act(async () => undefined);
+    },
+    commit: async () => {
+      await act(async () => buttonWithText(root(), "Add").props.onClick());
+    },
+    addLabel: () => nodeText(buttonWithText(root(), "Add")),
+    addDisabled: () => buttonWithText(root(), "Add").props.disabled === true,
+    unmount: async () => {
+      await act(async () => renderer.unmount());
+      globalThis.fetch = originalFetch;
+    },
   };
 }
 
@@ -329,7 +391,7 @@ test("manual entry pins the exact trimmed path for the chosen provider", async (
   await act(async () => picker.renderer.unmount());
 });
 
-test("manual entry refuses a blank path and an already-pinned repository", async () => {
+test("manual entry disables its button instead of silently refusing", async () => {
   const picker = await mountPicker({
     status: "error",
     repositories: [],
@@ -337,13 +399,50 @@ test("manual entry refuses a blank path and an already-pinned repository", async
   });
 
   await picker.typeManualPath("   ");
+  assert.equal(picker.addDisabled(), true);
   await picker.clickManualAdd();
   assert.deepEqual(picker.added, []);
 
+  // Same provider and path in a different case is the same repository.
   await picker.typeManualPath("blazity/AI-WORKFLOW-PROD");
+  assert.equal(
+    picker.addDisabled(),
+    true,
+    "an already-pinned path must not sit under an enabled button",
+  );
+  assert.match(picker.text(), /is already pinned for GitHub/);
   await picker.clickManualAdd();
   assert.deepEqual(picker.added, []);
 
+  // The same path under the other provider is a different repository.
+  await picker.chooseManualProvider("gitlab");
+  assert.equal(picker.addDisabled(), false);
+  await picker.clickManualAdd();
+  assert.deepEqual(picker.added, [
+    [{ provider: "gitlab", repoPath: "blazity/AI-WORKFLOW-PROD" }],
+  ]);
+
+  await act(async () => picker.renderer.unmount());
+});
+
+test("manual entry states the workspace limit instead of a dead button", async () => {
+  const picker = await mountPicker({
+    status: "error",
+    repositories: [],
+    scope: {
+      repositories: Array.from({ length: MAX_PINNED_REPOSITORIES }, (_value, index) => ({
+        provider: "github" as const,
+        repoPath: `Blazity/filler-${index}`,
+      })),
+    },
+  });
+
+  await picker.typeManualPath("Blazity/ai-workflow-prod");
+
+  assert.equal(picker.addDisabled(), true);
+  assert.match(picker.text(), new RegExp(`already holds ${MAX_PINNED_REPOSITORIES} repositories`));
+  await picker.clickManualAdd();
+  assert.deepEqual(picker.added, []);
   await act(async () => picker.renderer.unmount());
 });
 
@@ -358,6 +457,48 @@ test("an empty but healthy catalog still offers manual entry", async () => {
     [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
   ]);
   await act(async () => picker.renderer.unmount());
+});
+
+test("a refresh that retires a checked row leaves no phantom in the count", async () => {
+  const picker = await mountLivePicker([
+    [gh("Blazity/ai-workflow-prod"), gh("Blazity/ai-workflow-demo")],
+    [gh("Blazity/next-enterprise")],
+  ]);
+
+  await picker.toggle("Blazity/ai-workflow-prod", true);
+  assert.equal(picker.addLabel(), "Add 1 repository");
+
+  await picker.refresh();
+
+  assert.equal(
+    picker.addLabel(),
+    "Add repositories",
+    "a row the refreshed catalog no longer offers must not still be counted",
+  );
+  assert.equal(picker.addDisabled(), true);
+  await picker.unmount();
+});
+
+test("a refresh keeps the checked rows that survive it", async () => {
+  const picker = await mountLivePicker([
+    [gh("Blazity/ai-workflow-prod"), gh("Blazity/ai-workflow-demo")],
+    [gh("Blazity/ai-workflow-demo"), gh("Blazity/next-enterprise")],
+  ]);
+
+  await picker.toggle("Blazity/ai-workflow-prod", true);
+  await picker.toggle("Blazity/ai-workflow-demo", true);
+  assert.equal(picker.addLabel(), "Add 2 repositories");
+
+  await picker.refresh();
+
+  assert.equal(picker.addLabel(), "Add 1 repository");
+  await picker.commit();
+
+  assert.deepEqual(picker.added, [
+    [{ provider: "github", repoPath: "Blazity/ai-workflow-demo" }],
+  ]);
+  assert.equal(picker.closes.length, 1);
+  await picker.unmount();
 });
 
 test("removing a chip hands back a scope without that repository", async () => {
@@ -449,6 +590,36 @@ test("the picker adds through the bar and lands in the scope", async () => {
   assert.deepEqual(bar.scope(), {
     repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
   });
+  await act(async () => bar.renderer.unmount());
+});
+
+test("the toggle announces the picker it controls", async () => {
+  const bar = await mountBar();
+  const toggle = () => buttonWithText(bar.renderer.root, "+ Add repository");
+  const controls = toggle().props["aria-controls"];
+
+  assert.equal(typeof controls, "string");
+  assert.notEqual(controls, "");
+  assert.equal(toggle().props["aria-expanded"], false);
+  assert.equal(
+    bar.renderer.root.findAll(
+      (node) => typeof node.type === "string" && node.props.id === controls,
+    ).length,
+    0,
+    "nothing is expanded yet",
+  );
+
+  await bar.openPicker();
+
+  assert.equal(
+    buttonWithText(bar.renderer.root, "Done").props["aria-expanded"],
+    true,
+  );
+  const section = bar.renderer.root.findAll(
+    (node) => typeof node.type === "string" && node.props.id === controls,
+  );
+  assert.equal(section.length, 1, "aria-controls resolves to the opened section");
+  assert.equal(section[0].props["aria-label"], "Add pinned repositories");
   await act(async () => bar.renderer.unmount());
 });
 

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx
@@ -85,6 +85,7 @@ function renderPicker(
   return renderToStaticMarkup(
     <RepositoryCatalogProvider initial={{ status, repositories }}>
       <RepositoryScopePicker
+        id="test-picker"
         open
         scope={scope}
         canEdit={canEdit}
@@ -286,6 +287,7 @@ test("a closed picker renders nothing", () => {
   const html = renderToStaticMarkup(
     <RepositoryCatalogProvider initial={{ status: "ready", repositories: catalog }}>
       <RepositoryScopePicker
+        id="test-picker"
         open={false}
         scope={{}}
         canEdit

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type {
+  RepositoryOption,
+  WorkflowRepositoryScope,
+} from "@shared/contracts";
+import {
+  RepositoryScopeBar,
+  RepositoryScopePicker,
+} from "./repository-scope-bar";
+import {
+  RepositoryCatalogProvider,
+  type RepositoryCatalogStatus,
+} from "./repository-catalog-context";
+import { MAX_PINNED_REPOSITORIES } from "@/lib/workflow-editor/repository-scope";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+/** Visible text only, so assertions never depend on class strings or tag order. */
+function text(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&#x27;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function option(overrides: Partial<RepositoryOption> = {}): RepositoryOption {
+  return {
+    provider: "github",
+    repoPath: "Blazity/ai-workflow",
+    name: "ai-workflow",
+    owner: "Blazity",
+    defaultBranch: "main",
+    private: true,
+    archived: false,
+    ...overrides,
+  };
+}
+
+const catalog = [
+  option(),
+  option({
+    provider: "gitlab",
+    repoPath: "group/app",
+    name: "app",
+    owner: "group",
+    defaultBranch: "trunk",
+  }),
+  option({
+    repoPath: "Blazity/legacy",
+    name: "legacy",
+    defaultBranch: "master",
+    archived: true,
+  }),
+];
+
+function renderBar(
+  scope: WorkflowRepositoryScope,
+  canEdit = true,
+  status: RepositoryCatalogStatus = "ready",
+  repositories: RepositoryOption[] = catalog,
+): string {
+  return renderToStaticMarkup(
+    <RepositoryCatalogProvider initial={{ status, repositories }}>
+      <RepositoryScopeBar
+        scope={scope}
+        canEdit={canEdit}
+        onChange={() => undefined}
+      />
+    </RepositoryCatalogProvider>,
+  );
+}
+
+function renderPicker(
+  scope: WorkflowRepositoryScope,
+  canEdit = true,
+  status: RepositoryCatalogStatus = "ready",
+  repositories: RepositoryOption[] = catalog,
+): string {
+  return renderToStaticMarkup(
+    <RepositoryCatalogProvider initial={{ status, repositories }}>
+      <RepositoryScopePicker
+        open
+        scope={scope}
+        canEdit={canEdit}
+        onAdd={() => undefined}
+        onClose={() => undefined}
+      />
+    </RepositoryCatalogProvider>,
+  );
+}
+
+test("an unpinned workflow states that every ticket still resolves its own repository", () => {
+  const html = renderBar({});
+
+  assert.match(html, /Repositories/);
+  assert.match(html, /Pinned for every ticket/);
+  assert.match(html, /No repository pinned: every ticket resolves its own/);
+  assert.match(html, new RegExp(`0 / ${MAX_PINNED_REPOSITORIES}`));
+  assert.match(html, /No provider pinned: the run picks the provider itself/);
+});
+
+test("a pinned repository shows its provider, default branch, and inherited providers", () => {
+  const html = renderBar({
+    repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow" }],
+  });
+
+  // The chip reads path, then provider, then default branch. The provider is
+  // lowercase in the DOM and uppercased by CSS.
+  assert.match(text(html), /Blazity\/ai-workflow github main/);
+  assert.match(text(html), new RegExp(`1 / ${MAX_PINNED_REPOSITORIES}`));
+  assert.match(html, /aria-label="Remove Blazity\/ai-workflow"/);
+  assert.match(html, /Inherited from the pinned repositories: GitHub\./);
+  assert.match(html, /inherits 1 repo, GitHub/);
+  assert.match(html, /never asks which repository to use/);
+  assert.doesNotMatch(html, /unverified/);
+});
+
+test("a provider-only pin does not claim the run resolves repositories freely", () => {
+  const html = renderBar({ providers: ["github", "gitlab"] });
+
+  assert.match(
+    html,
+    /No repository pinned: every ticket resolves its own within the pinned providers\./,
+  );
+  assert.doesNotMatch(html, /as it does today/);
+});
+
+test("both providers pinned reads as the multi-repo binding", () => {
+  const html = renderBar({
+    repositories: [
+      { provider: "github", repoPath: "Blazity/ai-workflow" },
+      { provider: "gitlab", repoPath: "group/app" },
+    ],
+    providers: ["github", "gitlab"],
+  });
+
+  assert.match(html, /inherits 2 repos, GitHub \+ GitLab/);
+  assert.match(html, /aria-pressed="true"[^>]*>GitHub</);
+  assert.match(html, /aria-pressed="true"[^>]*>GitLab</);
+  assert.match(html, /Both makes a run multi-repo/);
+});
+
+test("a pinned repository the catalog does not return stays selected with a warning", () => {
+  const html = renderBar({
+    repositories: [{ provider: "github", repoPath: "Blazity/private-thing" }],
+  });
+
+  assert.match(html, /Blazity\/private-thing/);
+  assert.match(html, /unverified/);
+  assert.match(html, /The catalog does not list Blazity\/private-thing/);
+  assert.match(html, /kept exactly as saved/);
+  assert.match(html, /outside the server allowlist/);
+  assert.match(html, /cached for 60 seconds/);
+  assert.match(html, /aria-label="Remove Blazity\/private-thing"/);
+});
+
+test("a still-loading catalog never accuses a saved pin of being missing", () => {
+  const html = renderBar(
+    { repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }] },
+    true,
+    "loading",
+    [],
+  );
+
+  assert.match(html, /Blazity\/ai-workflow-prod/);
+  assert.match(html, /Checking the pinned repositories against the catalog…/);
+  assert.doesNotMatch(html, /unverified/);
+  assert.doesNotMatch(html, /The catalog does not list/);
+});
+
+test("an archived pin is kept but its reason is stated", () => {
+  const html = renderBar({
+    repositories: [{ provider: "github", repoPath: "Blazity/legacy" }],
+  });
+
+  assert.match(html, /Archived in the provider: Blazity\/legacy/);
+  assert.match(html, /cannot open changes there/);
+  assert.doesNotMatch(html, /unverified/);
+});
+
+test("read-only mode disables every control in the bar", () => {
+  const html = renderBar(
+    {
+      repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow" }],
+      providers: ["github"],
+    },
+    false,
+  );
+
+  const buttons = html.match(/<button[^>]*>/g) ?? [];
+  assert.equal(buttons.length > 0, true);
+  for (const button of buttons) {
+    assert.match(button, /disabled=""/);
+  }
+  assert.match(html, /Blazity\/ai-workflow/);
+});
+
+test("a catalog outage still explains that pins survive and can be entered by path", () => {
+  const html = renderBar({}, true, "error", []);
+
+  assert.match(html, /The repository catalog is unavailable/);
+  assert.match(html, /Saved pins are preserved/);
+  assert.match(html, /entered by exact path/);
+});
+
+test("the picker offers only catalog repositories, with disabled reasons", () => {
+  const html = renderPicker({
+    repositories: [{ provider: "gitlab", repoPath: "group/app" }],
+  });
+
+  assert.match(html, /aria-label="Add pinned repositories"/);
+  assert.match(html, /aria-label="Filter repositories"/);
+  assert.match(html, /aria-label="Pin Blazity\/ai-workflow"/);
+  assert.match(html, /Already pinned/);
+  assert.match(html, /Archived in the provider/);
+  assert.match(html, /trunk/);
+  assert.match(html, /master/);
+  assert.match(
+    html,
+    new RegExp(`${MAX_PINNED_REPOSITORIES - 1} of ${MAX_PINNED_REPOSITORIES} slots left`),
+  );
+  assert.match(html, /cached for 60 seconds/);
+  assert.match(html, /Refresh catalog/);
+});
+
+test("a pinned repository absent from the catalog is never offered by the picker", () => {
+  const html = renderPicker({
+    repositories: [{ provider: "github", repoPath: "Blazity/private-thing" }],
+  });
+
+  assert.doesNotMatch(html, /Blazity\/private-thing/);
+});
+
+test("the picker reports no slots left once the workspace limit is reached", () => {
+  const html = renderPicker({
+    repositories: Array.from({ length: MAX_PINNED_REPOSITORIES }, (_value, index) => ({
+      provider: "github" as const,
+      repoPath: `owner/repo-${index}`,
+    })),
+  });
+
+  assert.match(html, new RegExp(`0 of ${MAX_PINNED_REPOSITORIES} slots left`));
+  assert.match(html, new RegExp(`Limit of ${MAX_PINNED_REPOSITORIES} reached`));
+});
+
+test("an empty catalog is not reported as a filter miss and is not a dead end", () => {
+  const html = renderPicker({}, true, "ready", []);
+
+  assert.match(html, /The catalog returned no repositories/);
+  assert.doesNotMatch(html, /matches this filter/);
+  // Nothing to filter or select, so only the exact-path fallback is offered.
+  assert.match(html, /aria-label="Repository path"/);
+  assert.doesNotMatch(html, /aria-label="Filter repositories"/);
+  assert.doesNotMatch(html, /Add repositories<\/button>/);
+});
+
+test("a catalog outage degrades the picker to exact owner/repo entry", () => {
+  const html = renderPicker({}, true, "error", []);
+
+  assert.match(html, /role="alert"/);
+  assert.match(html, /cannot be browsed/);
+  assert.match(html, /aria-label="Repository path"/);
+  assert.match(html, /placeholder="owner\/repo"/);
+  assert.match(
+    html,
+    /aria-label="Provider for the manually entered repository"/,
+  );
+  assert.doesNotMatch(html, /aria-label="Filter repositories"/);
+});
+
+test("a loading catalog says so instead of looking like an empty workspace", () => {
+  const html = renderPicker({}, true, "loading", []);
+
+  assert.match(html, /Loading repositories…/);
+  assert.doesNotMatch(html, /aria-label="Filter repositories"/);
+  assert.doesNotMatch(html, /owner\/repo/);
+});
+
+test("a closed picker renders nothing", () => {
+  const html = renderToStaticMarkup(
+    <RepositoryCatalogProvider initial={{ status: "ready", repositories: catalog }}>
+      <RepositoryScopePicker
+        open={false}
+        scope={{}}
+        canEdit
+        onAdd={() => undefined}
+        onClose={() => undefined}
+      />
+    </RepositoryCatalogProvider>,
+  );
+
+  assert.equal(html, "");
+});
+
+/** Attribute order is React's to choose, so assert on the whole tag. */
+function controlTag(html: string, attribute: string): string {
+  const match = html.match(new RegExp(`<(?:input|button)[^>]*${attribute}[^>]*>`));
+  assert.notEqual(match, null, `no control carries ${attribute}`);
+  return match![0];
+}
+
+test("read-only mode disables the picker inputs", () => {
+  const html = renderPicker({}, false);
+
+  assert.match(controlTag(html, 'aria-label="Filter repositories"'), /disabled=""/);
+  assert.match(
+    controlTag(html, 'aria-label="Pin Blazity/ai-workflow"'),
+    /disabled=""/,
+  );
+});

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 
 import type {
   RepositoryOption,
@@ -85,12 +85,15 @@ interface CatalogEntry {
 }
 
 export function RepositoryScopePicker({
+  id,
   open,
   scope,
   canEdit,
   onAdd,
   onClose,
 }: {
+  /** Target of the toggle's aria-controls. */
+  id: string;
   open: boolean;
   scope: WorkflowRepositoryScope;
   canEdit: boolean;
@@ -136,6 +139,18 @@ export function RepositoryScopePicker({
   const catalogEmpty =
     catalog.status === "ready" && catalog.repositories.length === 0;
 
+  // The manual button has the same duty as the commit button: never sit enabled
+  // over a path that cannot be added.
+  const manualRepoPath = manualPath.trim();
+  const manualAlreadyPinned =
+    manualRepoPath !== "" &&
+    isRepositoryPinned(scope, {
+      provider: manualProvider,
+      repoPath: manualRepoPath,
+    });
+  const manualAddable =
+    canEdit && manualRepoPath !== "" && remaining > 0 && !manualAlreadyPinned;
+
   // Dismissing abandons the selection. The closed picker stays mounted, so
   // without this a reopen would show a stale count and add repositories the
   // operator picked in a session they already walked away from.
@@ -144,6 +159,16 @@ export function RepositoryScopePicker({
     setSelected([]);
     setFilter("");
   }, [open]);
+
+  // A refresh can retire a row that is still checked. Drop keys the current
+  // catalog no longer offers, so the count and the button never promise a
+  // repository that can no longer be resolved and added.
+  useEffect(() => {
+    setSelected((current) => {
+      const kept = current.filter((key) => catalogByKey.has(key));
+      return kept.length === current.length ? current : kept;
+    });
+  }, [catalogByKey]);
 
   if (!open) return null;
 
@@ -166,17 +191,15 @@ export function RepositoryScopePicker({
   }
 
   function commitManual() {
-    const repoPath = manualPath.trim();
-    if (repoPath === "" || remaining <= 0) return;
-    const repository = { provider: manualProvider, repoPath };
-    if (isRepositoryPinned(scope, repository)) return;
-    onAdd([repository]);
+    if (!manualAddable) return;
+    onAdd([{ provider: manualProvider, repoPath: manualRepoPath }]);
     setManualPath("");
     onClose();
   }
 
   return (
     <section
+      id={id}
       aria-label="Add pinned repositories"
       className="rounded-[3px] border border-neutral-200 bg-panel px-3 py-2.5"
     >
@@ -331,12 +354,24 @@ export function RepositoryScopePicker({
             <button
               type="button"
               onClick={commitManual}
-              disabled={!canEdit || manualPath.trim() === "" || remaining <= 0}
+              disabled={!manualAddable}
               className="appearance-none rounded-[3px] border border-neutral-300 bg-panel px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-coal cursor-pointer disabled:cursor-default disabled:opacity-40"
             >
               Add
             </button>
           </div>
+          {manualAlreadyPinned && (
+            <div className="pt-1.5 font-body text-[10px] text-amber-800">
+              {manualRepoPath} is already pinned for{" "}
+              {providerLabel(manualProvider)}.
+            </div>
+          )}
+          {manualRepoPath !== "" && remaining <= 0 && (
+            <div className="pt-1.5 font-body text-[10px] text-amber-800">
+              The pin already holds {MAX_PINNED_REPOSITORIES} repositories, the
+              workspace limit.
+            </div>
+          )}
         </div>
       )}
     </section>
@@ -354,6 +389,7 @@ export function RepositoryScopeBar({
 }) {
   const catalog = useRepositoryCatalog();
   const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerId = useId();
 
   const pinned = pinnedRepositories(scope);
   const catalogByKey = useMemo(
@@ -415,6 +451,8 @@ export function RepositoryScopeBar({
         </span>
         <button
           type="button"
+          aria-expanded={pickerOpen}
+          aria-controls={pickerId}
           onClick={() => setPickerOpen((open) => !open)}
           disabled={!canEdit || atLimit}
           className="appearance-none rounded-[3px] border border-neutral-300 bg-panel px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.04em] text-coal cursor-pointer hover:bg-app-bg disabled:cursor-default disabled:opacity-40"
@@ -519,6 +557,7 @@ export function RepositoryScopeBar({
       )}
 
       <RepositoryScopePicker
+        id={pickerId}
         open={pickerOpen}
         scope={scope}
         canEdit={canEdit}

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx
@@ -1,0 +1,530 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type {
+  RepositoryOption,
+  VcsProviderKind,
+  WorkflowRepositoryScope,
+} from "@shared/contracts";
+import { Listbox } from "@/components/cockpit/listbox";
+import {
+  addPinnedRepositories,
+  contradictingPinnedRepositories,
+  describeRepositoryScope,
+  effectiveScopeProviders,
+  isRepositoryPinned,
+  isRepositoryScopeEmpty,
+  MAX_PINNED_REPOSITORIES,
+  PINNABLE_PROVIDERS,
+  pinnedRepositories,
+  providerLabel,
+  removePinnedRepository,
+  repositoryKey,
+  togglePinnedProvider,
+  type PinnedRepository,
+} from "@/lib/workflow-editor/repository-scope";
+import { useRepositoryCatalog } from "./repository-catalog-context";
+
+const CATALOG_CACHE_NOTE =
+  "The repository catalog is cached for 60 seconds, so access granted a moment ago can still be missing here.";
+
+/** Bordered so it reads both on the grey bar chips and on the white picker rows. */
+const providerPillClass =
+  "rounded-[3px] border border-neutral-200 bg-panel px-[5px] py-[1px] font-mono text-[10px] uppercase text-neutral-500";
+
+function ProviderPill({ provider }: { provider: VcsProviderKind }) {
+  return <span className={providerPillClass}>{provider}</span>;
+}
+
+function RepositoryChip({
+  repository,
+  defaultBranch,
+  unknown,
+  canEdit,
+  onRemove,
+}: {
+  repository: PinnedRepository;
+  defaultBranch: string | null;
+  unknown: boolean;
+  canEdit: boolean;
+  onRemove: () => void;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-pill border px-2 py-0.5 font-mono text-[10px] ${
+        unknown
+          ? "border-amber-300 bg-amber-50 text-amber-800"
+          : "border-neutral-200 bg-app-bg text-neutral-800"
+      }`}
+    >
+      {repository.repoPath}
+      <ProviderPill provider={repository.provider} />
+      {defaultBranch !== null && defaultBranch !== "" && (
+        <span className="font-mono text-[9px] text-neutral-500">{defaultBranch}</span>
+      )}
+      {unknown && (
+        <span className="font-mono text-[9px] uppercase text-amber-700">unverified</span>
+      )}
+      <button
+        type="button"
+        disabled={!canEdit}
+        aria-label={`Remove ${repository.repoPath}`}
+        onClick={onRemove}
+        className="appearance-none border-none bg-transparent cursor-pointer text-neutral-500 hover:text-coal disabled:cursor-default disabled:opacity-40"
+      >
+        ×
+      </button>
+    </span>
+  );
+}
+
+interface CatalogEntry {
+  option: RepositoryOption;
+  disabledReason: string | null;
+}
+
+export function RepositoryScopePicker({
+  open,
+  scope,
+  canEdit,
+  onAdd,
+  onClose,
+}: {
+  open: boolean;
+  scope: WorkflowRepositoryScope;
+  canEdit: boolean;
+  onAdd: (repositories: PinnedRepository[]) => void;
+  onClose: () => void;
+}) {
+  const catalog = useRepositoryCatalog();
+  const [filter, setFilter] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [manualProvider, setManualProvider] = useState<VcsProviderKind>("github");
+  const [manualPath, setManualPath] = useState("");
+
+  const remaining = MAX_PINNED_REPOSITORIES - pinnedRepositories(scope).length;
+  const catalogByKey = useMemo(
+    () =>
+      new Map(
+        catalog.repositories.map((option) => [repositoryKey(option), option]),
+      ),
+    [catalog.repositories],
+  );
+  const entries = useMemo<CatalogEntry[]>(() => {
+    const query = filter.trim().toLowerCase();
+    return catalog.repositories
+      .filter((option) => option.repoPath.toLowerCase().includes(query))
+      .map((option) => {
+        const key = repositoryKey(option);
+        const pinned = isRepositoryPinned(scope, option);
+        const atLimit = !selected.includes(key) && selected.length >= remaining;
+        return {
+          option,
+          disabledReason: pinned
+            ? "Already pinned"
+            : option.archived
+              ? "Archived in the provider"
+              : atLimit
+                ? `Limit of ${MAX_PINNED_REPOSITORIES} reached`
+                : null,
+        };
+      });
+  }, [catalog.repositories, filter, remaining, scope, selected]);
+
+  /** A 200 with an empty list is reachable, and it must not strand the operator. */
+  const catalogEmpty =
+    catalog.status === "ready" && catalog.repositories.length === 0;
+
+  // Dismissing abandons the selection. The closed picker stays mounted, so
+  // without this a reopen would show a stale count and add repositories the
+  // operator picked in a session they already walked away from.
+  useEffect(() => {
+    if (open) return;
+    setSelected([]);
+    setFilter("");
+  }, [open]);
+
+  if (!open) return null;
+
+  function commitSelected() {
+    // Resolve against the whole catalog, never the filtered rows: `selected`
+    // accumulates across filter changes, so filtering by `entries` would drop
+    // everything picked under an earlier filter.
+    const additions = selected
+      .map((key) => catalogByKey.get(key))
+      .filter((option): option is RepositoryOption => option !== undefined)
+      .map((option) => ({
+        provider: option.provider,
+        repoPath: option.repoPath,
+      }));
+    if (additions.length === 0) return;
+    onAdd(additions);
+    setSelected([]);
+    setFilter("");
+    onClose();
+  }
+
+  function commitManual() {
+    const repoPath = manualPath.trim();
+    if (repoPath === "" || remaining <= 0) return;
+    const repository = { provider: manualProvider, repoPath };
+    if (isRepositoryPinned(scope, repository)) return;
+    onAdd([repository]);
+    setManualPath("");
+    onClose();
+  }
+
+  return (
+    <section
+      aria-label="Add pinned repositories"
+      className="rounded-[3px] border border-neutral-200 bg-panel px-3 py-2.5"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.06em] text-neutral-700">
+          Add repositories
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={catalog.refresh}
+            className="appearance-none border-none bg-transparent p-0 font-body text-[10px] font-semibold text-mariner cursor-pointer"
+          >
+            Refresh catalog
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close the repository picker"
+            className="appearance-none border-none bg-transparent p-0 font-body text-[10px] text-neutral-500 cursor-pointer"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {catalog.status === "loading" && (
+        <div className="pt-2 font-body text-[10px] text-neutral-500">
+          Loading repositories…
+        </div>
+      )}
+
+      {catalog.status === "ready" && !catalogEmpty && (
+        <>
+          <input
+            value={filter}
+            disabled={!canEdit}
+            onChange={(event) => setFilter(event.target.value)}
+            placeholder="Filter repositories…"
+            aria-label="Filter repositories"
+            className="mt-2 h-[28px] w-full rounded-[3px] border border-neutral-200 bg-white px-2 font-mono text-[11px] text-coal outline-none focus:border-mariner disabled:opacity-60"
+          />
+          <div className="mt-2 max-h-[220px] overflow-y-auto rounded-[3px] border border-neutral-200">
+            {entries.length === 0 ? (
+              <div className="px-2 py-6 text-center font-body text-[10px] text-neutral-500">
+                No repository in the catalog matches this filter.
+              </div>
+            ) : (
+              entries.map(({ option, disabledReason }) => {
+                const key = repositoryKey(option);
+                const checked = selected.includes(key);
+                return (
+                  <label
+                    key={key}
+                    className={`flex items-center gap-2 border-b border-neutral-100 px-2 py-1.5 last:border-b-0 ${
+                      disabledReason === null
+                        ? "cursor-pointer bg-panel"
+                        : "cursor-default bg-app-bg"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      disabled={!canEdit || disabledReason !== null}
+                      aria-label={`Pin ${option.repoPath}`}
+                      onChange={(event) =>
+                        setSelected((current) =>
+                          event.target.checked
+                            ? [...current, key]
+                            : current.filter((entry) => entry !== key),
+                        )
+                      }
+                      className="size-3 accent-mariner"
+                    />
+                    <span
+                      className={`min-w-0 flex-1 truncate font-mono text-[11px] ${
+                        disabledReason === null ? "text-coal" : "text-neutral-500"
+                      }`}
+                    >
+                      {option.repoPath}
+                    </span>
+                    <ProviderPill provider={option.provider} />
+                    <span className="font-mono text-[9px] text-neutral-500">
+                      {option.defaultBranch === "" ? "no default branch" : option.defaultBranch}
+                    </span>
+                    {disabledReason !== null && (
+                      <span className="font-body text-[10px] text-neutral-500">
+                        {disabledReason}
+                      </span>
+                    )}
+                  </label>
+                );
+              })
+            )}
+          </div>
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <span className="font-body text-[10px] text-neutral-500">
+              {remaining} of {MAX_PINNED_REPOSITORIES} slots left. {CATALOG_CACHE_NOTE}
+            </span>
+            <button
+              type="button"
+              onClick={commitSelected}
+              disabled={!canEdit || selected.length === 0}
+              className="appearance-none rounded-[3px] border border-mariner bg-mariner px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-white cursor-pointer disabled:cursor-default disabled:opacity-40"
+            >
+              {selected.length === 0
+                ? "Add repositories"
+                : `Add ${selected.length} ${
+                    selected.length === 1 ? "repository" : "repositories"
+                  }`}
+            </button>
+          </div>
+        </>
+      )}
+
+      {(catalog.status === "error" || catalogEmpty) && (
+        <div className="pt-2">
+          {catalog.status === "error" ? (
+            <div role="alert" className="font-body text-[10px] text-red-600">
+              The repository catalog is unavailable, so it cannot be browsed. Enter an
+              exact owner/repo the workspace already has access to.
+            </div>
+          ) : (
+            <div className="font-body text-[10px] text-neutral-600">
+              The catalog returned no repositories, so there is nothing to browse. If
+              the workspace can reach one it does not list, enter its exact
+              owner/repo.
+            </div>
+          )}
+          <div className="mt-2 flex items-center gap-2">
+            <div className="w-[110px]">
+              <Listbox
+                options={PINNABLE_PROVIDERS.map((provider) => ({
+                  value: provider,
+                  label: providerLabel(provider),
+                  hint: provider === "github" ? "github.com" : "gitlab",
+                }))}
+                value={manualProvider}
+                disabled={!canEdit}
+                ariaLabel="Provider for the manually entered repository"
+                onChange={(value) => setManualProvider(value as VcsProviderKind)}
+              />
+            </div>
+            <input
+              value={manualPath}
+              disabled={!canEdit}
+              onChange={(event) => setManualPath(event.target.value)}
+              placeholder="owner/repo"
+              aria-label="Repository path"
+              className="h-[28px] flex-1 rounded-[3px] border border-neutral-200 bg-white px-2 font-mono text-[11px] text-coal outline-none focus:border-mariner disabled:opacity-60"
+            />
+            <button
+              type="button"
+              onClick={commitManual}
+              disabled={!canEdit || manualPath.trim() === "" || remaining <= 0}
+              className="appearance-none rounded-[3px] border border-neutral-300 bg-panel px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-coal cursor-pointer disabled:cursor-default disabled:opacity-40"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function RepositoryScopeBar({
+  scope,
+  canEdit,
+  onChange,
+}: {
+  scope: WorkflowRepositoryScope;
+  canEdit: boolean;
+  onChange: (scope: WorkflowRepositoryScope) => void;
+}) {
+  const catalog = useRepositoryCatalog();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const pinned = pinnedRepositories(scope);
+  const catalogByKey = useMemo(
+    () =>
+      new Map(
+        catalog.repositories.map((option) => [repositoryKey(option), option]),
+      ),
+    [catalog.repositories],
+  );
+  /** Only a settled catalog can prove a pin is missing, so a pending one never warns. */
+  const catalogSettled = catalog.status === "ready";
+  const unknownPins = catalogSettled
+    ? pinned.filter((repository) => !catalogByKey.has(repositoryKey(repository)))
+    : [];
+  const archivedPins = pinned.filter(
+    (repository) => catalogByKey.get(repositoryKey(repository))?.archived === true,
+  );
+  const atLimit = pinned.length >= MAX_PINNED_REPOSITORIES;
+  const providers = effectiveScopeProviders(scope);
+  const contradictingPins = contradictingPinnedRepositories(scope);
+
+  return (
+    <div className="flex flex-col gap-2 px-6 py-2 border-b border-neutral-200 bg-app-bg">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="min-w-[110px]">
+          <div className="font-mono text-[9px] font-semibold tracking-[0.06em] uppercase text-neutral-700">
+            Repositories
+          </div>
+          <div className="font-body text-[10px] text-neutral-500">
+            Pinned for every ticket
+          </div>
+        </div>
+        {pinned.length === 0 ? (
+          <span className="font-body text-[10px] text-neutral-500">
+            {(scope.providers?.length ?? 0) === 0
+              ? "No repository pinned: every ticket resolves its own, as it does today."
+              : "No repository pinned: every ticket resolves its own within the pinned providers."}
+          </span>
+        ) : (
+          pinned.map((repository) => {
+            const option = catalogByKey.get(repositoryKey(repository));
+            return (
+              <RepositoryChip
+                key={repositoryKey(repository)}
+                repository={repository}
+                defaultBranch={option?.defaultBranch ?? null}
+                unknown={catalogSettled && option === undefined}
+                canEdit={canEdit}
+                onRemove={() => onChange(removePinnedRepository(scope, repository))}
+              />
+            );
+          })
+        )}
+        <span
+          title={`${MAX_PINNED_REPOSITORIES} pinned repositories is the workspace limit.`}
+          className="font-mono text-[10px] text-neutral-600"
+        >
+          {pinned.length} / {MAX_PINNED_REPOSITORIES}
+        </span>
+        <button
+          type="button"
+          onClick={() => setPickerOpen((open) => !open)}
+          disabled={!canEdit || atLimit}
+          className="appearance-none rounded-[3px] border border-neutral-300 bg-panel px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.04em] text-coal cursor-pointer hover:bg-app-bg disabled:cursor-default disabled:opacity-40"
+        >
+          {pickerOpen ? "Done" : "+ Add repository"}
+        </button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="min-w-[110px]">
+          <div className="font-mono text-[9px] font-semibold tracking-[0.06em] uppercase text-neutral-700">
+            Providers
+          </div>
+          <div className="font-body text-[10px] text-neutral-500">
+            Both makes a run multi-repo
+          </div>
+        </div>
+        {PINNABLE_PROVIDERS.map((provider) => {
+          const active = (scope.providers ?? []).includes(provider);
+          return (
+            <button
+              key={provider}
+              type="button"
+              aria-pressed={active}
+              disabled={!canEdit}
+              onClick={() => onChange(togglePinnedProvider(scope, provider))}
+              className={`appearance-none rounded-pill border px-2.5 py-0.5 font-mono text-[10px] cursor-pointer disabled:cursor-default disabled:opacity-40 ${
+                active
+                  ? "border-mariner bg-mariner-100 text-mariner"
+                  : "border-neutral-200 bg-panel text-neutral-600"
+              }`}
+            >
+              {providerLabel(provider)}
+            </button>
+          );
+        })}
+        {(scope.providers?.length ?? 0) === 0 && (
+          <span className="font-body text-[10px] text-neutral-500">
+            {pinned.length === 0
+              ? "No provider pinned: the run picks the provider itself."
+              : `Inherited from the pinned repositories: ${providers
+                  .map(providerLabel)
+                  .join(" + ")}.`}
+          </span>
+        )}
+        {contradictingPins.length > 0 && (
+          <span
+            role="status"
+            className="rounded-[3px] border border-amber-300 bg-amber-50 px-2 py-0.5 font-body text-[10px] text-amber-800"
+          >
+            Provider mismatch:{" "}
+            {contradictingPins
+              .map((r) => `${r.repoPath} (${providerLabel(r.provider)})`)
+              .join(", ")}{" "}
+            {contradictingPins.length === 1 ? "is" : "are"} pinned but excluded by
+            the selected providers. Deployment rejects this until the two agree.
+          </span>
+        )}
+      </div>
+
+      {unknownPins.length > 0 && (
+        <div
+          role="status"
+          className="rounded-[3px] border border-amber-300 bg-amber-50 px-2.5 py-1.5 font-body text-[10px] text-amber-800"
+        >
+          The catalog does not list {unknownPins.map((r) => r.repoPath).join(", ")}.
+          The pin is kept exactly as saved. Access may have been revoked, the
+          repository may sit outside the server allowlist, or the catalog may be
+          stale. {CATALOG_CACHE_NOTE}
+        </div>
+      )}
+
+      {archivedPins.length > 0 && (
+        <div
+          role="status"
+          className="rounded-[3px] border border-amber-300 bg-amber-50 px-2.5 py-1.5 font-body text-[10px] text-amber-800"
+        >
+          Archived in the provider: {archivedPins.map((r) => r.repoPath).join(", ")}.
+          The pin is kept, but the workflow cannot open changes there.
+        </div>
+      )}
+
+      {catalog.status === "loading" && pinned.length > 0 && (
+        <div className="font-body text-[10px] text-neutral-500">
+          Checking the pinned repositories against the catalog…
+        </div>
+      )}
+
+      {catalog.status === "error" && !pickerOpen && (
+        <div role="status" className="font-body text-[10px] text-red-600">
+          The repository catalog is unavailable. Saved pins are preserved, and new
+          ones can be entered by exact path.
+        </div>
+      )}
+
+      {!isRepositoryScopeEmpty(scope) && (
+        <div className="font-body text-[10px] text-neutral-500">
+          Every ticket entering this workflow inherits{" "}
+          {describeRepositoryScope(scope)}. The run never asks which repository to
+          use, and the pull request trigger filter follows this pin.
+        </div>
+      )}
+
+      <RepositoryScopePicker
+        open={pickerOpen}
+        scope={scope}
+        canEdit={canEdit}
+        onAdd={(repositories) => onChange(addPinnedRepositories(scope, repositories))}
+        onClose={() => setPickerOpen(false)}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
@@ -28,6 +28,7 @@ import {
   type WorkflowEdgeGeometry,
   type WorkflowExecutionBudgets,
   type WorkflowEditorOptions,
+  type WorkflowRepositoryScope,
 } from "@shared/contracts";
 import { FlowEditor } from "@/components/cockpit/flow-editor/flow-editor";
 import {
@@ -37,6 +38,7 @@ import {
 } from "@/components/cockpit/flow-editor/workflow-migration-drawer";
 import { PromptLibraryProvider } from "@/components/cockpit/flow-editor/prompt-library-context";
 import { HarnessProfileCatalogProvider } from "@/components/cockpit/flow-editor/harness-profile-context";
+import { RepositoryCatalogProvider } from "@/components/cockpit/flow-editor/repository-catalog-context";
 import { Listbox } from "@/components/cockpit/listbox";
 import { ManualDispatchModal } from "@/components/cockpit/manual-dispatch-modal";
 import {
@@ -72,6 +74,10 @@ import {
 } from "@/lib/workflow-editor/editor-actions";
 import { executionLimitsFromDefinition } from "@/lib/workflow-editor/execution-limits";
 import {
+  describeRepositoryScope,
+  repositoryScopeFromDefinition,
+} from "@/lib/workflow-editor/repository-scope";
+import {
   createEditorResponseGuard,
   type EditorResponseGuard,
 } from "@/lib/workflow-editor/response-guard";
@@ -94,6 +100,7 @@ interface WorkflowEditorDocument {
   nodes: FlowNodeDef[];
   edges: FlowEdgeDef[];
   budgets: WorkflowExecutionBudgets;
+  repositoryScope: WorkflowRepositoryScope;
   edgeGeometry: Record<string, WorkflowEdgeGeometry>;
 }
 
@@ -105,6 +112,7 @@ function semanticKeyForDefinition(definition: WorkflowDefinition): string {
       flow.edges,
       executionLimitsFromDefinition(definition),
       definition.schemaVersion,
+      repositoryScopeFromDefinition(definition),
     ),
   );
 }
@@ -119,6 +127,7 @@ function semanticKeyForDocument(
       document.edges,
       document.budgets,
       schemaVersion,
+      document.repositoryScope,
     ),
   );
 }
@@ -181,6 +190,7 @@ export function WorkflowEditorScreen({
           nodes: seedFlow.nodes,
           edges: seedFlow.edges,
           budgets: executionLimitsFromDefinition(seed),
+          repositoryScope: repositoryScopeFromDefinition(seed),
           edgeGeometry: structuredClone(initialDetail.layout.edges),
         },
         {
@@ -190,7 +200,8 @@ export function WorkflowEditorScreen({
         },
       ),
   );
-  const { nodes, edges, budgets, edgeGeometry } = editorHistory.present;
+  const { nodes, edges, budgets, repositoryScope, edgeGeometry } =
+    editorHistory.present;
   const [layoutBaseline, setLayoutBaseline] = useState(() => JSON.stringify(initialDetail.layout));
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -301,6 +312,11 @@ export function WorkflowEditorScreen({
       applyEditorDocument((current) => ({ ...current, budgets: next })),
     [applyEditorDocument],
   );
+  const changeRepositoryScope = useCallback(
+    (next: WorkflowRepositoryScope) =>
+      applyEditorDocument((current) => ({ ...current, repositoryScope: next })),
+    [applyEditorDocument],
+  );
   const changeEdgeGeometry = useCallback<
     React.Dispatch<
       React.SetStateAction<Record<string, WorkflowEdgeGeometry>>
@@ -409,8 +425,15 @@ export function WorkflowEditorScreen({
 
   const selectedMeta = metas.find((m) => m.id === selectedId);
   const semanticDefinition = useMemo(
-    () => serializeSemanticWorkflowDefinition(nodes, edges, budgets, schemaVersion),
-    [budgets, edges, nodes, schemaVersion],
+    () =>
+      serializeSemanticWorkflowDefinition(
+        nodes,
+        edges,
+        budgets,
+        schemaVersion,
+        repositoryScope,
+      ),
+    [budgets, edges, nodes, repositoryScope, schemaVersion],
   );
   const semanticDefinitionRef = useRef(semanticDefinition);
   semanticDefinitionRef.current = semanticDefinition;
@@ -611,6 +634,7 @@ export function WorkflowEditorScreen({
       edges,
       budgets,
       schemaVersion,
+      repositoryScope,
     );
     setBusy("save");
     setError(null);
@@ -657,6 +681,7 @@ export function WorkflowEditorScreen({
       edges,
       budgets,
       schemaVersion,
+      repositoryScope,
     );
     setBusy("migration-save");
     setError(null);
@@ -841,6 +866,7 @@ export function WorkflowEditorScreen({
       edges,
       budgets,
       schemaVersion,
+      repositoryScope,
     );
     const candidateKey = validationTargetKey;
     setBusy("deploy");
@@ -981,6 +1007,7 @@ export function WorkflowEditorScreen({
       nodes: flow.nodes,
       edges: flow.edges,
       budgets: executionLimitsFromDefinition(definition),
+      repositoryScope: repositoryScopeFromDefinition(definition),
       edgeGeometry: structuredClone(detail.layout.edges),
     };
     setSchemaVersion(flow.schemaVersion);
@@ -1130,6 +1157,7 @@ export function WorkflowEditorScreen({
     `rounded-full border px-2 py-0.5 font-mono text-[10px] font-semibold tracking-[0.04em] uppercase ${
       enabled ? "border-mariner text-mariner" : "border-neutral-200 text-neutral-600"
     }`;
+  const repositoryScopeSummary = describeRepositoryScope(repositoryScope);
 
   const triggerLabel = (type: WorkflowDefinitionMeta["triggerTypes"][number]) =>
     options.blockRegistry[type]?.presentation.label ?? type;
@@ -1142,6 +1170,7 @@ export function WorkflowEditorScreen({
 
   return (
     <HarnessProfileCatalogProvider>
+    <RepositoryCatalogProvider>
     <PromptLibraryProvider>
     <div className="flex flex-col h-full min-h-0">
       {deployed === null && (
@@ -1176,8 +1205,10 @@ export function WorkflowEditorScreen({
           edges={edges}
           schemaVersion={schemaVersion}
           limits={budgets}
+          repositoryScope={repositoryScope}
           edgeGeometry={edgeGeometry}
           onLimitsChange={changeBudgets}
+          onRepositoryScopeChange={changeRepositoryScope}
           onNodesChange={changeNodes}
           onNodePositionsChange={changeNodePositions}
           onEdgesChange={changeEdges}
@@ -1216,6 +1247,14 @@ export function WorkflowEditorScreen({
           headerVersionBadge={deployed ? `deployed v${deployed.version}` : "not deployed"}
           headerInlineExtra={
             <>
+              {repositoryScopeSummary !== null && (
+                <span
+                  title="Repositories pinned to this workflow. Every ticket entering it inherits them."
+                  className="rounded-full border border-neutral-300 bg-panel px-2 py-0.5 font-mono text-[10px] font-semibold tracking-[0.04em] text-neutral-700"
+                >
+                  {repositoryScopeSummary}
+                </span>
+              )}
               {migrationVisibility.showLegacyStatus && (
                 <span
                   title="Legacy v1 workflows keep FAILED ports for compatibility. Migrate to v2 to make execution errors fail the whole workflow automatically."
@@ -1577,6 +1616,7 @@ export function WorkflowEditorScreen({
       </div>
     </div>
     </PromptLibraryProvider>
+    </RepositoryCatalogProvider>
     </HarnessProfileCatalogProvider>
   );
 }

--- a/apps/dashboard/lib/workflow-editor/repository-scope.test.ts
+++ b/apps/dashboard/lib/workflow-editor/repository-scope.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  addPinnedRepositories,
+  contradictingPinnedRepositories,
+  describeRepositoryScope,
+  effectiveScopeProviders,
+  isRepositoryScopeEmpty,
+  MAX_PINNED_REPOSITORIES,
+  normalizeRepositoryScope,
+  removePinnedRepository,
+  repositoryScopeFromDefinition,
+  togglePinnedProvider,
+} from "./repository-scope.ts";
+
+test("a definition without a pin seeds an empty scope", () => {
+  const scope = repositoryScopeFromDefinition({
+    schemaVersion: 1,
+    nodes: [],
+    edges: [],
+  });
+  assert.deepEqual(scope, {});
+  assert.equal(isRepositoryScopeEmpty(scope), true);
+});
+
+test("an explicitly empty pin is indistinguishable from no pin", () => {
+  const scope = repositoryScopeFromDefinition({
+    schemaVersion: 1,
+    repositoryScope: { repositories: [], providers: [] },
+    nodes: [],
+    edges: [],
+  });
+  assert.deepEqual(scope, {});
+  assert.equal(isRepositoryScopeEmpty(scope), true);
+});
+
+test("a saved pin round-trips with its stored casing and canonical provider order", () => {
+  const scope = repositoryScopeFromDefinition({
+    schemaVersion: 2,
+    repositoryScope: {
+      repositories: [{ provider: "gitlab", repoPath: "Group/Sub/App" }],
+      providers: ["gitlab", "github"],
+    },
+    nodes: [],
+    edges: [],
+  });
+  assert.deepEqual(scope, {
+    repositories: [{ provider: "gitlab", repoPath: "Group/Sub/App" }],
+    providers: ["github", "gitlab"],
+  });
+});
+
+test("duplicate repositories collapse case-insensitively and keep the first casing", () => {
+  const scope = normalizeRepositoryScope({
+    repositories: [
+      { provider: "github", repoPath: "Blazity/ai-workflow" },
+      { provider: "github", repoPath: "blazity/AI-Workflow" },
+      { provider: "gitlab", repoPath: "blazity/ai-workflow" },
+      { provider: "github", repoPath: "   " },
+    ],
+  });
+  assert.deepEqual(scope.repositories, [
+    { provider: "github", repoPath: "Blazity/ai-workflow" },
+    { provider: "gitlab", repoPath: "blazity/ai-workflow" },
+  ]);
+});
+
+test("the workspace limit caps a pin instead of growing past it", () => {
+  const many = Array.from({ length: 12 }, (_value, index) => ({
+    provider: "github" as const,
+    repoPath: `owner/repo-${index}`,
+  }));
+  const scope = addPinnedRepositories({}, many);
+  assert.equal(scope.repositories?.length, MAX_PINNED_REPOSITORIES);
+  assert.equal(scope.repositories?.at(-1)?.repoPath, "owner/repo-7");
+
+  const overflowed = addPinnedRepositories(scope, [
+    { provider: "github", repoPath: "owner/late" },
+  ]);
+  assert.equal(overflowed.repositories?.length, MAX_PINNED_REPOSITORIES);
+  assert.equal(
+    overflowed.repositories?.some((repo) => repo.repoPath === "owner/late"),
+    false,
+  );
+});
+
+test("removing the last repository leaves no empty collection behind", () => {
+  const pinned = addPinnedRepositories({}, [
+    { provider: "github", repoPath: "owner/repo" },
+  ]);
+  const cleared = removePinnedRepository(pinned, {
+    provider: "github",
+    repoPath: "OWNER/REPO",
+  });
+  assert.deepEqual(cleared, {});
+});
+
+test("providers toggle to a canonical order and clear to an absent key", () => {
+  const gitlabOnly = togglePinnedProvider({}, "gitlab");
+  assert.deepEqual(gitlabOnly, { providers: ["gitlab"] });
+
+  const both = togglePinnedProvider(gitlabOnly, "github");
+  assert.deepEqual(both, { providers: ["github", "gitlab"] });
+
+  const backToGitlab = togglePinnedProvider(both, "github");
+  assert.deepEqual(backToGitlab, { providers: ["gitlab"] });
+  assert.deepEqual(togglePinnedProvider(backToGitlab, "gitlab"), {});
+});
+
+test("providers are inherited from pinned repositories when not pinned explicitly", () => {
+  const scope = addPinnedRepositories({}, [
+    { provider: "gitlab", repoPath: "group/app" },
+    { provider: "github", repoPath: "owner/repo" },
+  ]);
+  assert.deepEqual(effectiveScopeProviders(scope), ["github", "gitlab"]);
+  assert.deepEqual(
+    effectiveScopeProviders({ ...scope, providers: ["github"] }),
+    ["github"],
+  );
+});
+
+test("a provider pin that excludes a pinned repository is reported as contradicting", () => {
+  const github = { provider: "github" as const, repoPath: "Blazity/ai-workflow-prod" };
+  const gitlab = { provider: "gitlab" as const, repoPath: "acme-group/platform/billing-core" };
+
+  assert.deepEqual(
+    contradictingPinnedRepositories({ repositories: [github, gitlab] }),
+    [],
+    "no provider pin excludes nothing",
+  );
+  assert.deepEqual(
+    contradictingPinnedRepositories({
+      repositories: [github, gitlab],
+      providers: ["gitlab"],
+    }),
+    [github],
+  );
+  assert.deepEqual(
+    contradictingPinnedRepositories({
+      repositories: [github, gitlab],
+      providers: ["github", "gitlab"],
+    }),
+    [],
+  );
+});
+
+test("the toolbar summary never asserts a provider its own repositories contradict", () => {
+  const scope = {
+    repositories: [{ provider: "github" as const, repoPath: "Blazity/ai-workflow-prod" }],
+    providers: ["gitlab" as const],
+  };
+
+  assert.equal(describeRepositoryScope(scope), "1 repo, provider mismatch");
+  assert.equal(
+    describeRepositoryScope({ ...scope, providers: ["github", "gitlab"] }),
+    "1 repo, GitHub + GitLab",
+  );
+});
+
+test("the toolbar summary names the repository count and the effective providers", () => {
+  assert.equal(describeRepositoryScope({}), null);
+  assert.equal(
+    describeRepositoryScope(
+      addPinnedRepositories({}, [{ provider: "github", repoPath: "owner/repo" }]),
+    ),
+    "1 repo, GitHub",
+  );
+  assert.equal(
+    describeRepositoryScope(
+      addPinnedRepositories({}, [
+        { provider: "github", repoPath: "owner/repo" },
+        { provider: "gitlab", repoPath: "group/app" },
+      ]),
+    ),
+    "2 repos, GitHub + GitLab",
+  );
+  assert.equal(
+    describeRepositoryScope({ providers: ["github", "gitlab"] }),
+    "GitHub + GitLab",
+  );
+});

--- a/apps/dashboard/lib/workflow-editor/repository-scope.ts
+++ b/apps/dashboard/lib/workflow-editor/repository-scope.ts
@@ -1,0 +1,176 @@
+import type {
+  VcsProviderKind,
+  WorkflowDefinition,
+  WorkflowRepositoryScope,
+} from "@shared/contracts";
+
+export interface PinnedRepository {
+  provider: VcsProviderKind;
+  repoPath: string;
+}
+
+/** Workspace ceiling on pinned repositories; the worker rejects a larger pin. */
+export const MAX_PINNED_REPOSITORIES = 8;
+
+export const PINNABLE_PROVIDERS: readonly VcsProviderKind[] = ["github", "gitlab"];
+
+/** `repoPath` is stored in the case the operator picked; matching ignores case. */
+export function sameRepository(a: PinnedRepository, b: PinnedRepository): boolean {
+  return (
+    a.provider === b.provider &&
+    a.repoPath.toLowerCase() === b.repoPath.toLowerCase()
+  );
+}
+
+export function repositoryKey(repository: PinnedRepository): string {
+  return `${repository.provider}:${repository.repoPath.toLowerCase()}`;
+}
+
+/**
+ * Collapses a scope to the exact shape the definition contract allows: unique
+ * repositories capped at the workspace limit, providers in a stable order, and
+ * absent keys instead of empty collections so an unpinned workflow serializes
+ * identically to one that never had a pin.
+ */
+export function normalizeRepositoryScope(
+  scope: WorkflowRepositoryScope,
+): WorkflowRepositoryScope {
+  const repositories: PinnedRepository[] = [];
+  for (const candidate of scope.repositories ?? []) {
+    const repoPath = candidate.repoPath.trim();
+    if (repoPath === "") continue;
+    const repository = { provider: candidate.provider, repoPath };
+    if (repositories.some((kept) => sameRepository(kept, repository))) continue;
+    if (repositories.length >= MAX_PINNED_REPOSITORIES) break;
+    repositories.push(repository);
+  }
+  const providers = PINNABLE_PROVIDERS.filter((provider) =>
+    (scope.providers ?? []).includes(provider),
+  );
+  return {
+    ...(repositories.length > 0 ? { repositories } : {}),
+    ...(providers.length > 0 ? { providers } : {}),
+  };
+}
+
+export function repositoryScopeFromDefinition(
+  definition: WorkflowDefinition,
+): WorkflowRepositoryScope {
+  return normalizeRepositoryScope(definition.repositoryScope ?? {});
+}
+
+export function isRepositoryScopeEmpty(scope: WorkflowRepositoryScope): boolean {
+  return (
+    (scope.repositories?.length ?? 0) === 0 && (scope.providers?.length ?? 0) === 0
+  );
+}
+
+export function pinnedRepositories(
+  scope: WorkflowRepositoryScope,
+): readonly PinnedRepository[] {
+  return scope.repositories ?? [];
+}
+
+export function isRepositoryPinned(
+  scope: WorkflowRepositoryScope,
+  repository: PinnedRepository,
+): boolean {
+  return pinnedRepositories(scope).some((pinned) =>
+    sameRepository(pinned, repository),
+  );
+}
+
+export function addPinnedRepositories(
+  scope: WorkflowRepositoryScope,
+  repositories: readonly PinnedRepository[],
+): WorkflowRepositoryScope {
+  return normalizeRepositoryScope({
+    ...scope,
+    repositories: [...pinnedRepositories(scope), ...repositories],
+  });
+}
+
+export function removePinnedRepository(
+  scope: WorkflowRepositoryScope,
+  repository: PinnedRepository,
+): WorkflowRepositoryScope {
+  return normalizeRepositoryScope({
+    ...scope,
+    repositories: pinnedRepositories(scope).filter(
+      (pinned) => !sameRepository(pinned, repository),
+    ),
+  });
+}
+
+export function togglePinnedProvider(
+  scope: WorkflowRepositoryScope,
+  provider: VcsProviderKind,
+): WorkflowRepositoryScope {
+  const current = scope.providers ?? [];
+  return normalizeRepositoryScope({
+    ...scope,
+    providers: current.includes(provider)
+      ? current.filter((kept) => kept !== provider)
+      : [...current, provider],
+  });
+}
+
+export function providerLabel(provider: VcsProviderKind): string {
+  return provider === "github" ? "GitHub" : "GitLab";
+}
+
+/**
+ * Pinned repositories an explicit provider pin excludes. Deployment rejects such
+ * a scope, so the editor has to name the offenders rather than quietly asserting
+ * a provider set the pinned repositories contradict. An absent or empty provider
+ * pin excludes nothing.
+ */
+export function contradictingPinnedRepositories(
+  scope: WorkflowRepositoryScope,
+): readonly PinnedRepository[] {
+  const providers = scope.providers ?? [];
+  if (providers.length === 0) return [];
+  return pinnedRepositories(scope).filter(
+    (repository) => !providers.includes(repository.provider),
+  );
+}
+
+/**
+ * Providers a run inherits: the explicit pin when the operator set one, and
+ * otherwise the providers implied by the pinned repositories.
+ */
+export function effectiveScopeProviders(
+  scope: WorkflowRepositoryScope,
+): VcsProviderKind[] {
+  const pinned = scope.providers ?? [];
+  if (pinned.length > 0) {
+    return PINNABLE_PROVIDERS.filter((provider) => pinned.includes(provider));
+  }
+  return PINNABLE_PROVIDERS.filter((provider) =>
+    pinnedRepositories(scope).some(
+      (repository) => repository.provider === provider,
+    ),
+  );
+}
+
+/**
+ * Toolbar summary, for example "2 repos, GitHub + GitLab". Null means no pin.
+ * A scope whose providers exclude one of its own repositories reports the
+ * mismatch instead of a provider set, so the summary can never contradict the
+ * repository chips it sits above.
+ */
+export function describeRepositoryScope(
+  scope: WorkflowRepositoryScope,
+): string | null {
+  if (isRepositoryScopeEmpty(scope)) return null;
+  const count = pinnedRepositories(scope).length;
+  const repositories = count === 0 ? null : `${count} ${count === 1 ? "repo" : "repos"}`;
+  if (contradictingPinnedRepositories(scope).length > 0) {
+    return [repositories, "provider mismatch"].filter((part) => part !== null).join(", ");
+  }
+  const providers = effectiveScopeProviders(scope)
+    .map(providerLabel)
+    .join(" + ");
+  const parts = [repositories, providers === "" ? null : providers];
+  return parts.filter((part) => part !== null).join(", ");
+}

--- a/apps/dashboard/lib/workflow-editor/serialize.test.ts
+++ b/apps/dashboard/lib/workflow-editor/serialize.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   BLOCK_PARAM_KEYS,
+  type WorkflowDefinition,
   type WorkflowDefinitionV2,
 } from "@shared/contracts";
 import {
@@ -10,6 +11,7 @@ import {
   serializeWorkflowLayout,
   serializeWorkflowLayoutWithBaseline,
 } from "./serialize.ts";
+import { repositoryScopeFromDefinition } from "./repository-scope.ts";
 import {
   toFlowDefinition,
   type FlowEdgeDef,
@@ -799,3 +801,125 @@ test("preserves execution budgets when saving graph edits", () => {
 
   assert.deepEqual(out.budgets, budgets);
 });
+
+const pinnedNodes = flowNodes([
+  { id: "trigger", type: "trigger_ticket_ai", x: 10, y: 20, params: {} },
+]);
+const pinnedScope = {
+  repositories: [
+    { provider: "github" as const, repoPath: "Blazity/ai-workflow" },
+    { provider: "gitlab" as const, repoPath: "group/app" },
+  ],
+  providers: ["github" as const, "gitlab" as const],
+};
+
+/** Mirrors how the editor keys a saved draft against the live document. */
+function semanticKey(definition: WorkflowDefinition): string {
+  const flow = toFlowDefinition(definition);
+  return JSON.stringify(
+    serializeSemanticWorkflowDefinition(
+      flow.nodes,
+      flow.edges,
+      definition.budgets ?? {},
+      definition.schemaVersion,
+      repositoryScopeFromDefinition(definition),
+    ),
+  );
+}
+
+for (const schemaVersion of [1, 2] as const) {
+  test(`a repository pin survives both v${schemaVersion} serializers`, () => {
+    const saved = serializeWorkflowDefinition(
+      pinnedNodes,
+      [],
+      {},
+      schemaVersion,
+      pinnedScope,
+    );
+    const semantic = serializeSemanticWorkflowDefinition(
+      pinnedNodes,
+      [],
+      {},
+      schemaVersion,
+      pinnedScope,
+    );
+
+    assert.deepEqual(saved.repositoryScope, pinnedScope);
+    assert.deepEqual(semantic.repositoryScope, pinnedScope);
+    assert.deepEqual(
+      repositoryScopeFromDefinition(saved),
+      repositoryScopeFromDefinition(semantic),
+    );
+  });
+
+  test(`an unpinned v${schemaVersion} definition omits repositoryScope from both serializers`, () => {
+    const saved = serializeWorkflowDefinition(pinnedNodes, [], {}, schemaVersion);
+    const semantic = serializeSemanticWorkflowDefinition(
+      pinnedNodes,
+      [],
+      {},
+      schemaVersion,
+      { repositories: [], providers: [] },
+    );
+
+    assert.equal("repositoryScope" in saved, false);
+    assert.equal("repositoryScope" in semantic, false);
+  });
+
+  test(`opening a v${schemaVersion} definition without a pin never reports unsaved changes`, () => {
+    const draft = serializeWorkflowDefinition(pinnedNodes, [], {}, schemaVersion);
+    const documentKey = JSON.stringify(
+      serializeSemanticWorkflowDefinition(
+        pinnedNodes,
+        [],
+        {},
+        schemaVersion,
+        repositoryScopeFromDefinition(draft),
+      ),
+    );
+
+    assert.equal(documentKey, semanticKey(draft));
+  });
+
+  test(`opening a v${schemaVersion} pin stored out of order never reports unsaved changes`, () => {
+    const draft = {
+      ...serializeWorkflowDefinition(pinnedNodes, [], {}, schemaVersion),
+      repositoryScope: {
+        repositories: [
+          { provider: "github" as const, repoPath: "Blazity/ai-workflow" },
+        ],
+        providers: ["gitlab" as const, "github" as const],
+      },
+    };
+    const documentKey = JSON.stringify(
+      serializeSemanticWorkflowDefinition(
+        pinnedNodes,
+        [],
+        {},
+        schemaVersion,
+        repositoryScopeFromDefinition(draft),
+      ),
+    );
+
+    assert.equal(documentKey, semanticKey(draft));
+  });
+
+  test(`changing a v${schemaVersion} pin changes the semantic definition`, () => {
+    const before = serializeSemanticWorkflowDefinition(
+      pinnedNodes,
+      [],
+      {},
+      schemaVersion,
+      pinnedScope,
+    );
+    const after = serializeSemanticWorkflowDefinition(
+      pinnedNodes,
+      [],
+      {},
+      schemaVersion,
+      { ...pinnedScope, repositories: [pinnedScope.repositories[0]] },
+    );
+
+    assert.notDeepEqual(after, before);
+  });
+}

--- a/apps/dashboard/lib/workflow-editor/serialize.ts
+++ b/apps/dashboard/lib/workflow-editor/serialize.ts
@@ -7,6 +7,7 @@ import type {
   WorkflowDefinitionV2,
   WorkflowExecutionBudgets,
   WorkflowParamValue,
+  WorkflowRepositoryScope,
 } from "@shared/contracts";
 import {
   fromFlowDefinitionV1Node,
@@ -16,6 +17,10 @@ import {
   type FlowNodeDef,
 } from "@/lib/flows";
 import { canOmitFromPort } from "./edges";
+import {
+  isRepositoryScopeEmpty,
+  normalizeRepositoryScope,
+} from "./repository-scope";
 
 // The canonical param-key allowlist lives in @shared/contracts (BLOCK_PARAM_KEYS).
 // Import it rather than keeping a dashboard copy so the two can never drift (a
@@ -43,31 +48,38 @@ export function serializeWorkflowDefinition(
   edges: readonly FlowEdgeDef[],
   budgets: WorkflowExecutionBudgets,
   schemaVersion: 1,
+  repositoryScope?: WorkflowRepositoryScope,
 ): WorkflowDefinitionV1;
 export function serializeWorkflowDefinition(
   nodes: readonly FlowNodeDef[],
   edges: readonly FlowEdgeDef[],
   budgets: WorkflowExecutionBudgets,
   schemaVersion: 2,
+  repositoryScope?: WorkflowRepositoryScope,
 ): WorkflowDefinitionV2;
 export function serializeWorkflowDefinition(
   nodes: readonly FlowNodeDef[],
   edges: readonly FlowEdgeDef[],
   budgets: WorkflowExecutionBudgets,
   schemaVersion: 1 | 2,
+  repositoryScope?: WorkflowRepositoryScope,
 ): WorkflowDefinition;
 export function serializeWorkflowDefinition(
   nodes: readonly FlowNodeDef[],
   edges: readonly FlowEdgeDef[],
   budgets: WorkflowExecutionBudgets = {},
   schemaVersion: 1 | 2 = 1,
+  repositoryScope: WorkflowRepositoryScope = {},
 ): WorkflowDefinition {
   const typeById = new Map(nodes.map((node) => [node.id, node.type]));
   const hasBudgets = Object.values(budgets).some((value) => value !== undefined);
+  const scope = normalizeRepositoryScope(repositoryScope);
+  const pin = isRepositoryScopeEmpty(scope) ? {} : { repositoryScope: scope };
   if (schemaVersion === 1) {
     const definition: WorkflowDefinitionV1 = {
       schemaVersion: 1,
       ...(hasBudgets ? { budgets: { ...budgets } } : {}),
+      ...pin,
       nodes: nodes.map((node) => {
         const serialized = fromFlowDefinitionV1Node({
           ...node,
@@ -107,6 +119,7 @@ export function serializeWorkflowDefinition(
   const definition: WorkflowDefinitionV2 = {
     schemaVersion: 2,
     ...(hasBudgets ? { budgets: { ...budgets } } : {}),
+    ...pin,
     nodes: nodes.map((node) => {
       const serialized = fromFlowDefinitionV2Node({
         ...node,
@@ -158,26 +171,36 @@ export function serializeSemanticWorkflowDefinition(
   edges: readonly FlowEdgeDef[],
   budgets: WorkflowExecutionBudgets,
   schemaVersion: 1,
+  repositoryScope?: WorkflowRepositoryScope,
 ): WorkflowDefinitionV1;
 export function serializeSemanticWorkflowDefinition(
   nodes: readonly FlowNodeDef[],
   edges: readonly FlowEdgeDef[],
   budgets: WorkflowExecutionBudgets,
   schemaVersion: 2,
+  repositoryScope?: WorkflowRepositoryScope,
 ): WorkflowDefinitionV2;
 export function serializeSemanticWorkflowDefinition(
   nodes: readonly FlowNodeDef[],
   edges: readonly FlowEdgeDef[],
   budgets: WorkflowExecutionBudgets,
   schemaVersion: 1 | 2,
+  repositoryScope?: WorkflowRepositoryScope,
 ): WorkflowDefinition;
 export function serializeSemanticWorkflowDefinition(
   nodes: readonly FlowNodeDef[],
   edges: readonly FlowEdgeDef[],
   budgets: WorkflowExecutionBudgets = {},
   schemaVersion: 1 | 2 = 1,
+  repositoryScope: WorkflowRepositoryScope = {},
 ): WorkflowDefinition {
-  const definition = serializeWorkflowDefinition(nodes, edges, budgets, schemaVersion);
+  const definition = serializeWorkflowDefinition(
+    nodes,
+    edges,
+    budgets,
+    schemaVersion,
+    repositoryScope,
+  );
   if (definition.schemaVersion === 1) {
     return {
       ...definition,

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -487,9 +487,25 @@ export type WorkflowRunBudgetFailure =
       reason: string;
     };
 
+/**
+ * Repositories pinned to a workflow definition by the operator, so every ticket
+ * entering the workflow inherits them instead of resolving its own. Distinct from
+ * `ApprovalRequest.repositoryScope`, which is the per-run scope resolved and
+ * approved for one ticket: this is the definition-level pin chosen up front.
+ *
+ * Both sub-fields are optional, and an absent or fully empty scope means the
+ * default behavior (the run resolves repositories itself). `repoPath` is stored
+ * in the case the operator picked; all matching against it is case-insensitive.
+ */
+export interface WorkflowRepositoryScope {
+  repositories?: Array<{ provider: VcsProviderKind; repoPath: string }>;
+  providers?: VcsProviderKind[];
+}
+
 export interface WorkflowDefinitionV1 {
   schemaVersion: 1;
   budgets?: WorkflowExecutionBudgets;
+  repositoryScope?: WorkflowRepositoryScope;
   nodes: WorkflowDefinitionV1Node[];
   edges: WorkflowDefinitionV1Edge[];
 }
@@ -497,6 +513,7 @@ export interface WorkflowDefinitionV1 {
 export interface WorkflowDefinitionV2 {
   schemaVersion: 2;
   budgets?: WorkflowExecutionBudgets;
+  repositoryScope?: WorkflowRepositoryScope;
   nodes: WorkflowDefinitionV2Node[];
   edges: WorkflowDefinitionV2ControlEdge[];
 }

--- a/apps/worker/.gitignore
+++ b/apps/worker/.gitignore
@@ -2,3 +2,6 @@
 .vercel
 .env*.local
 /.swc
+
+# Scratch bundle dirs from the workflow import boundary guard
+.workflow-import-boundary-*

--- a/apps/worker/src/adapters/vcs/repository-directory.test.ts
+++ b/apps/worker/src/adapters/vcs/repository-directory.test.ts
@@ -14,6 +14,8 @@ vi.mock("../../lib/github-auth.js", () => ({
 import {
   createRepositoryDirectory,
   createRepositoryDirectoryForProviders,
+  filterPinnedRepositories,
+  isRepositoryWithinPinnedScope,
 } from "./repository-directory.js";
 
 const mockFetch = vi.fn();
@@ -221,5 +223,67 @@ describe("createRepositoryDirectory", () => {
       expect.objectContaining({ provider: "github", repoPath: "acme/web" }),
       expect.objectContaining({ provider: "gitlab", repoPath: "acme/api" }),
     ]);
+  });
+});
+
+describe("definition repository pin", () => {
+  const listed = [
+    { provider: "github" as const, repoPath: "Acme/Web" },
+    { provider: "github" as const, repoPath: "acme/api" },
+    { provider: "gitlab" as const, repoPath: "acme/web" },
+  ];
+
+  it("returns the listing untouched for an absent or empty scope", () => {
+    expect(filterPinnedRepositories(listed, undefined)).toBe(listed);
+    expect(filterPinnedRepositories(listed, {})).toBe(listed);
+    expect(
+      filterPinnedRepositories(listed, { repositories: [], providers: [] }),
+    ).toBe(listed);
+  });
+
+  it("intersects on a case-insensitive provider-scoped key", () => {
+    expect(
+      filterPinnedRepositories(listed, {
+        repositories: [{ provider: "github", repoPath: "acme/web" }],
+      }),
+    ).toEqual([{ provider: "github", repoPath: "Acme/Web" }]);
+  });
+
+  it("applies the provider filter and the repository filter together", () => {
+    expect(
+      filterPinnedRepositories(listed, {
+        providers: ["gitlab"],
+        repositories: [
+          { provider: "github", repoPath: "acme/web" },
+          { provider: "gitlab", repoPath: "acme/web" },
+        ],
+      }),
+    ).toEqual([{ provider: "gitlab", repoPath: "acme/web" }]);
+  });
+
+  // The pin is an intersection over what the server already offered: it can only
+  // remove entries, never add one the listing did not contain.
+  it("never admits a repository outside the listing", () => {
+    expect(
+      filterPinnedRepositories(listed, {
+        repositories: [{ provider: "github", repoPath: "acme/secret" }],
+      }),
+    ).toEqual([]);
+  });
+
+  it("answers the single-subject question from the same filter", () => {
+    const scope = {
+      providers: ["github" as const],
+      repositories: [{ provider: "github" as const, repoPath: "Acme/Web" }],
+    };
+    expect(
+      isRepositoryWithinPinnedScope(scope, { provider: "github", repoPath: "acme/WEB" }),
+    ).toBe(true);
+    expect(
+      isRepositoryWithinPinnedScope(scope, { provider: "gitlab", repoPath: "acme/web" }),
+    ).toBe(false);
+    expect(
+      isRepositoryWithinPinnedScope(undefined, { provider: "gitlab", repoPath: "x/y" }),
+    ).toBe(true);
   });
 });

--- a/apps/worker/src/adapters/vcs/repository-directory.ts
+++ b/apps/worker/src/adapters/vcs/repository-directory.ts
@@ -1,3 +1,4 @@
+import type { WorkflowRepositoryScope } from "@shared/contracts";
 import type { VcsConfig, VcsProviderConfig } from "../../../env.js";
 import { buildOctokit } from "../../lib/github-auth.js";
 import { filterAllowedRepositories } from "../../lib/repo-allowlist.js";
@@ -39,6 +40,49 @@ export function createRepositoryDirectoryForProviders(
       return lists.flat();
     },
   };
+}
+
+/**
+ * Intersect a repository listing with the repositories pinned to a workflow
+ * definition. Composes AFTER filterAllowedRepositories and can only remove
+ * entries the server already offered: it never fetches, never builds a path, and
+ * never re-admits an entry the allowlist dropped, so a pin can never widen
+ * access. An absent or fully empty scope returns the input untouched, which is
+ * what keeps a workflow without a pin on exactly its pre-pin behavior.
+ */
+export function filterPinnedRepositories<
+  T extends { provider: VcsProvider; repoPath: string },
+>(repositories: T[], scope: WorkflowRepositoryScope | undefined): T[] {
+  const providers = scope?.providers ?? [];
+  const pinned = scope?.repositories ?? [];
+  let filtered = repositories;
+  if (providers.length > 0) {
+    filtered = filtered.filter((repository) => providers.includes(repository.provider));
+  }
+  if (pinned.length > 0) {
+    const keys = new Set(pinned.map(pinnedRepositoryKey));
+    filtered = filtered.filter((repository) => keys.has(pinnedRepositoryKey(repository)));
+  }
+  return filtered;
+}
+
+/** Whether one repository identity survives the pin. Derived from the filter so
+ *  trigger admission and repository selection can never drift apart. */
+export function isRepositoryWithinPinnedScope(
+  scope: WorkflowRepositoryScope | undefined,
+  repository: { provider: VcsProvider; repoPath: string },
+): boolean {
+  return filterPinnedRepositories([repository], scope).length === 1;
+}
+
+/** A pinned repoPath is stored in the case the operator picked, so every
+ *  comparison lowercases it, exactly like repositoryKey in
+ *  pre-sandbox/steps/repo-selection.ts and repositoryCatalogKey. */
+function pinnedRepositoryKey(repository: {
+  provider: VcsProvider;
+  repoPath: string;
+}): string {
+  return `${repository.provider}:${repository.repoPath.toLowerCase()}`;
 }
 
 class GitHubRepositoryDirectory implements RepositoryDirectory {

--- a/apps/worker/src/lib/dispatch-trigger.test.ts
+++ b/apps/worker/src/lib/dispatch-trigger.test.ts
@@ -25,7 +25,10 @@ vi.mock("../../env.js", () => ({
   getVcsBotLogin: vi.fn((provider: "github" | "gitlab") =>
     provider === "github" ? testEnv.GITHUB_BOT_LOGIN : testEnv.GITLAB_BOT_LOGIN),
 }));
-vi.mock("../adapters/vcs/repository-directory.js", () => ({
+// The pin predicate is a pure helper in the same module and stays real; only the
+// network-backed directory is stubbed.
+vi.mock("../adapters/vcs/repository-directory.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../adapters/vcs/repository-directory.js")>()),
   createRepositoryDirectoryForProviders: vi.fn(() => ({ listRepositories: vi.fn(() => []) })),
 }));
 const mockStart = vi.fn();
@@ -64,6 +67,7 @@ beforeEach(async () => {
 function enabled(
   params: Record<string, unknown> = { scope: "any" },
   triggerType: TriggerEvent["triggerType"] = "trigger_pr_created",
+  repositoryScope?: Record<string, unknown>,
 ) {
   return {
     definition: { id: 5, name: "PR flow" },
@@ -72,6 +76,7 @@ function enabled(
       version: 12,
       definition: {
         schemaVersion: 1,
+        ...(repositoryScope ? { repositoryScope } : {}),
         nodes: [{ id: "trigger", type: triggerType, x: 0, y: 0, params, inputs: {} }],
         edges: [],
       },
@@ -339,6 +344,57 @@ describe("provider trigger dispatch", () => {
       runId: "run-2",
     });
     expect(mockStart).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores an any-scope PR outside the definition pin without writing an inbox row", async () => {
+    mockGetEnabled.mockResolvedValue(
+      enabled({ scope: "any" }, "trigger_pr_created", {
+        repositories: [{ provider: "github", repoPath: "acme/other" }],
+      }),
+    );
+    const { dispatchTriggerEvent } = await import("./dispatch-trigger.js");
+
+    await expect(dispatchTriggerEvent(event(), deps())).resolves.toEqual({
+      result: "ignored_provider",
+    });
+    expect(mockStart).not.toHaveBeenCalled();
+    await expect(getTriggerDelivery(db, "github", "delivery-1")).resolves.toBeNull();
+  });
+
+  it("accepts an any-scope PR inside the definition pin, matching case-insensitively", async () => {
+    mockGetEnabled.mockResolvedValue(
+      enabled({ scope: "any" }, "trigger_pr_created", {
+        repositories: [{ provider: "github", repoPath: "Acme/App" }],
+      }),
+    );
+    const { dispatchTriggerEvent } = await import("./dispatch-trigger.js");
+
+    await expect(dispatchTriggerEvent(event(), deps())).resolves.toEqual({
+      result: "started",
+      runId: "run-pr",
+    });
+  });
+
+  it("still accepts a workflow-owned PR outside the definition pin", async () => {
+    await upsertWorkflowOwnedBranch(db, {
+      ticketKey: "AIW-1",
+      provider: "github",
+      repoPath: "acme/app",
+      branchName: "feature/owned",
+      publishedHeadSha: "abc123",
+      targetBranch: "main",
+      pr: { id: 7, url: "https://github.com/acme/app/pull/7", branch: "feature/owned" },
+    });
+    mockGetEnabled.mockResolvedValue(
+      enabled({ scope: "workflow_owned" }, "trigger_pr_created", {
+        repositories: [{ provider: "github", repoPath: "acme/other" }],
+      }),
+    );
+    const { dispatchTriggerEvent } = await import("./dispatch-trigger.js");
+
+    await expect(dispatchTriggerEvent(event(), deps())).resolves.toMatchObject({
+      result: "started",
+    });
   });
 
   it("filters untrusted CI producers before accepting a delivery", async () => {

--- a/apps/worker/src/lib/dispatch-trigger.ts
+++ b/apps/worker/src/lib/dispatch-trigger.ts
@@ -142,6 +142,26 @@ export async function dispatchTriggerEvent(
       );
       return { result: "ignored_provider" };
     }
+    // Definition-level repository pin, a different concept from the
+    // provider-configured repositoryScope read further down. It runs before
+    // acceptTriggerDelivery so a filtered event leaves no inbox row behind.
+    const pinnedScope = enabled.current.definition.repositoryScope;
+    if (pinnedScope) {
+      const { isRepositoryWithinPinnedScope } = await import(
+        "../adapters/vcs/repository-directory.js"
+      );
+      if (!isRepositoryWithinPinnedScope(pinnedScope, event.pr)) {
+        logger.info(
+          { provider: event.pr.provider, repoPath: event.pr.repoPath, scope },
+          "trigger_repo_outside_definition_pin",
+        );
+        // Only "any" scope is filtered. A workflow_owned delivery still has to
+        // pass the ownership proof in resolveSubjectIdentity below, and gating it
+        // on the pin as well would strand every open workflow pull request the
+        // moment an operator edits the pin.
+        if (scope === "any") return { result: "ignored_provider" };
+      }
+    }
 
     const eligibleEvent = selectEligibleEvent(event, params);
     if (!eligibleEvent) return { result: "ignored_untrusted_event" };

--- a/apps/worker/src/manual-dispatch/resolve.test.ts
+++ b/apps/worker/src/manual-dispatch/resolve.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ManualDispatchPullRequestSnapshot } from "../adapters/vcs/types.js";
 import type { PrTriggerPayload } from "../workflows/agent-input.js";
 
@@ -21,9 +21,41 @@ vi.mock("../../env.js", () => ({
   getVcsBotLogin: () => "workflow-bot",
 }));
 
-const { parsePullRequestUrl, selectManualTriggerEvent } = await import(
-  "./resolve.js"
-);
+const mocks = vi.hoisted(() => ({
+  getDeployedWorkflowDefinitionVersion: vi.fn(),
+  getManualDispatchPullRequest: vi.fn(),
+  isConfiguredTriggerRepository: vi.fn(),
+  findWorkflowOwnedPullRequest: vi.fn(),
+  hasDispatchBlockingApprovalForTicket: vi.fn(),
+}));
+
+vi.mock("../workflow-definition/store.js", () => ({
+  getDeployedWorkflowDefinitionVersion: mocks.getDeployedWorkflowDefinitionVersion,
+  getWorkflowDefinitionVersion: vi.fn(),
+}));
+vi.mock("../lib/vcs-runtime.js", () => ({
+  createRepositoryVCS: () => ({
+    getManualDispatchPullRequest: mocks.getManualDispatchPullRequest,
+  }),
+}));
+// Only the provider-reachability probe is stubbed; the trigger-eligibility
+// helpers this module shares with automatic dispatch stay real.
+vi.mock("../lib/dispatch-trigger.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/dispatch-trigger.js")>()),
+  isConfiguredTriggerRepository: mocks.isConfiguredTriggerRepository,
+}));
+vi.mock("../db/queries/workflow-owned-branches.js", () => ({
+  findWorkflowOwnedPullRequest: mocks.findWorkflowOwnedPullRequest,
+}));
+vi.mock("../approvals/store.js", () => ({
+  hasDispatchBlockingApprovalForTicket: mocks.hasDispatchBlockingApprovalForTicket,
+}));
+vi.mock("../post-pr-gate/config.js", () => ({
+  loadPostPrGateConfig: () => ({ postPrGate: { steps: [] } }),
+}));
+
+const { parsePullRequestUrl, resolveManualDispatch, selectManualTriggerEvent } =
+  await import("./resolve.js");
 
 const pr: PrTriggerPayload = {
   provider: "github",
@@ -159,5 +191,104 @@ describe("manual pull request input", () => {
       author: "human-reviewer",
       body: "Cover the retry path.",
     });
+  });
+});
+
+describe("manual dispatch against a definition repository pin", () => {
+  const definitionDb = {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => [{ name: "PR flow" }] }),
+      }),
+    }),
+  } as unknown as Parameters<typeof resolveManualDispatch>[0]["db"];
+
+  const issueTracker = {
+    fetchTicket: vi.fn().mockResolvedValue({ identifier: "AIW-1" }),
+  } as unknown as Parameters<typeof resolveManualDispatch>[0]["issueTracker"];
+
+  function deployed(
+    scope: "any" | "workflow_owned",
+    repositoryScope: Record<string, unknown>,
+  ) {
+    return {
+      definitionId: 5,
+      version: 12,
+      definition: {
+        schemaVersion: 1,
+        repositoryScope,
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger_pr_created",
+            x: 0,
+            y: 0,
+            params: { scope },
+            inputs: {},
+          },
+        ],
+        edges: [],
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getManualDispatchPullRequest.mockResolvedValue(snapshot());
+    mocks.isConfiguredTriggerRepository.mockResolvedValue(true);
+    mocks.hasDispatchBlockingApprovalForTicket.mockResolvedValue(false);
+    mocks.findWorkflowOwnedPullRequest.mockResolvedValue({ ticketKey: "AIW-1" });
+  });
+
+  it("rejects an any-scope pull request outside the pin", async () => {
+    mocks.getDeployedWorkflowDefinitionVersion.mockResolvedValue(
+      deployed("any", { repositories: [{ provider: "github", repoPath: "acme/other" }] }),
+    );
+
+    await expect(
+      resolveManualDispatch({
+        db: definitionDb,
+        issueTracker,
+        definitionId: 5,
+        triggerNodeId: "trigger",
+        dispatchInput: { kind: "pull_request", url: pr.prUrl },
+      }),
+    ).rejects.toThrow("outside the repositories pinned to this workflow");
+  });
+
+  it("accepts an any-scope pull request inside the pin, matching case-insensitively", async () => {
+    mocks.getDeployedWorkflowDefinitionVersion.mockResolvedValue(
+      deployed("any", { repositories: [{ provider: "github", repoPath: "Acme/API" }] }),
+    );
+
+    await expect(
+      resolveManualDispatch({
+        db: definitionDb,
+        issueTracker,
+        definitionId: 5,
+        triggerNodeId: "trigger",
+        dispatchInput: { kind: "pull_request", url: pr.prUrl },
+      }),
+    ).resolves.toMatchObject({
+      inputPayload: { scope: "any", pr: expect.objectContaining({ repoPath: "acme/api" }) },
+    });
+  });
+
+  it("still accepts a workflow-owned pull request outside the pin", async () => {
+    mocks.getDeployedWorkflowDefinitionVersion.mockResolvedValue(
+      deployed("workflow_owned", {
+        repositories: [{ provider: "github", repoPath: "acme/other" }],
+      }),
+    );
+
+    await expect(
+      resolveManualDispatch({
+        db: definitionDb,
+        issueTracker,
+        definitionId: 5,
+        triggerNodeId: "trigger",
+        dispatchInput: { kind: "pull_request", url: pr.prUrl },
+      }),
+    ).resolves.toMatchObject({ ticketKey: "AIW-1" });
   });
 });

--- a/apps/worker/src/manual-dispatch/resolve.ts
+++ b/apps/worker/src/manual-dispatch/resolve.ts
@@ -9,6 +9,7 @@ import {
   IssueTrackerNotFoundError,
   type IssueTrackerAdapter,
 } from "../adapters/issue-tracker/types.js";
+import { isRepositoryWithinPinnedScope } from "../adapters/vcs/repository-directory.js";
 import {
   hasManualDispatchPrCapability,
   type ManualDispatchPullRequestSnapshot,
@@ -303,6 +304,24 @@ async function resolvePullRequestDispatch(
       422,
       "not_eligible",
       "This repository is outside the configured allowlist.",
+    );
+  }
+  // Mirrors the automatic trigger gate in dispatch-trigger.ts, including its
+  // workflow_owned exemption: that scope proves ownership below instead, so a pin
+  // edit must not strand an open workflow pull request.
+  const pinnedScope = deployed.definition.definition.repositoryScope;
+  if (
+    scope === "any" &&
+    pinnedScope &&
+    !isRepositoryWithinPinnedScope(pinnedScope, {
+      provider: parsed.provider,
+      repoPath: parsed.repoPath,
+    })
+  ) {
+    throw new ManualDispatchError(
+      422,
+      "not_eligible",
+      "This repository is outside the repositories pinned to this workflow.",
     );
   }
   const pr = snapshotToPayload(parsed.provider, parsed.repoPath, snapshot);

--- a/apps/worker/src/pre-sandbox/runner.ts
+++ b/apps/worker/src/pre-sandbox/runner.ts
@@ -36,6 +36,7 @@ export async function executePreSandboxPhase(
   const promptAdditions = emptyPromptAdditions();
   let selectedRepositories: RunPreSandboxPhaseResult["selectedRepositories"];
   let repositoryDiscovery: RunPreSandboxPhaseResult["repositoryDiscovery"];
+  let repositoryScopeNarrowing: RunPreSandboxPhaseResult["repositoryScopeNarrowing"];
 
   for (const step of config.preSandbox.steps) {
     const handler = registry[step.uses];
@@ -56,6 +57,7 @@ export async function executePreSandboxPhase(
           context: {
             ticket: selectTicketFields(input.ticket, step),
             run: input.run,
+            ...(input.repositoryScope ? { repositoryScope: input.repositoryScope } : {}),
           },
           config: step.with,
           step,
@@ -73,6 +75,9 @@ export async function executePreSandboxPhase(
       if (result.repositoryDiscovery) {
         repositoryDiscovery = result.repositoryDiscovery;
       }
+      if (result.repositoryScopeNarrowing) {
+        repositoryScopeNarrowing = result.repositoryScopeNarrowing;
+      }
 
       if (result.status === "halt") {
         return {
@@ -83,6 +88,7 @@ export async function executePreSandboxPhase(
           promptAdditions,
           selectedRepositories,
           repositoryDiscovery,
+          repositoryScopeNarrowing,
         };
       }
     } catch (err) {
@@ -107,6 +113,7 @@ export async function executePreSandboxPhase(
     promptAdditions,
     selectedRepositories,
     repositoryDiscovery,
+    repositoryScopeNarrowing,
   };
 }
 

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
@@ -1,20 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RepositoryMetadata } from "../../adapters/vcs/repository-directory.js";
 
-const mocks = vi.hoisted(() => ({
-  listRepositories: vi.fn(),
-  getConfiguredVcsProviders: vi.fn(),
-  getDb: vi.fn(),
-  listWorkflowOwnedBranchesForTicket: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const listRepositories = vi.fn();
+  return {
+    listRepositories,
+    createRepositoryDirectoryForProviders: vi.fn(() => ({ listRepositories })),
+    getConfiguredVcsProviders: vi.fn(),
+    getDb: vi.fn(),
+    listWorkflowOwnedBranchesForTicket: vi.fn(),
+  };
+});
 
-vi.mock("../../adapters/vcs/repository-directory.js", () => ({
+// The pin filter is a pure helper in the same module and stays real: mocking it
+// would hide the intersection this suite is asserting.
+vi.mock("../../adapters/vcs/repository-directory.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../adapters/vcs/repository-directory.js")
+  >()),
   createRepositoryDirectory: vi.fn(() => ({
     listRepositories: mocks.listRepositories,
   })),
-  createRepositoryDirectoryForProviders: vi.fn(() => ({
-    listRepositories: mocks.listRepositories,
-  })),
+  createRepositoryDirectoryForProviders: mocks.createRepositoryDirectoryForProviders,
 }));
 
 vi.mock("../../../env.js", () => ({
@@ -287,6 +294,233 @@ describe("selectRepositoriesFromMetadata", () => {
     ).toThrow("Accessible repository catalog exceeds 200 entries");
   });
 
+  it("attaches every pinned repository without discovery or clarification", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      repositoryScope: {
+        repositories: [
+          { provider: "github", repoPath: "acme/api" },
+          { provider: "github", repoPath: "acme/web" },
+        ],
+      },
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories).toEqual([
+      expect.objectContaining({
+        repoPath: "acme/web",
+        selectedRationale: "pinned to this workflow",
+      }),
+      expect.objectContaining({
+        repoPath: "acme/api",
+        selectedRationale: "pinned to this workflow",
+      }),
+    ]);
+  });
+
+  it("matches a pinned repository stored in a different case", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Update copy",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      repositoryScope: {
+        repositories: [{ provider: "github", repoPath: "Acme/Web" }],
+      },
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories.map((repo) => repo.repoPath)).toEqual(["acme/web"]);
+  });
+
+  it("does not apply the initial-match limit to an explicit pin", () => {
+    const many = Array.from({ length: 5 }, (_, index) => ({
+      ...repos[0],
+      repoPath: `acme/repo-${index}`,
+      name: `repo-${index}`,
+    }));
+
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Improve overall reliability",
+      repositories: many,
+      workflowOwnedBranches: [],
+      repositoryScope: {
+        repositories: many.map((repo) => ({
+          provider: "github" as const,
+          repoPath: repo.repoPath,
+        })),
+      },
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories).toHaveLength(5);
+  });
+
+  it("attaches a workflow-owned branch outside the pin alongside the pinned repositories", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Address review feedback",
+      repositories: repos,
+      workflowOwnedBranches: [
+        {
+          provider: "github",
+          repoPath: "acme/web",
+          branch: { branchName: "blazebot/aiw-45" },
+        },
+      ],
+      repositoryScope: {
+        repositories: [{ provider: "github", repoPath: "acme/api" }],
+      },
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories).toEqual([
+      expect.objectContaining({
+        repoPath: "acme/web",
+        selectedRationale: "workflow-owned branch for this ticket",
+        workflowOwnedBranch: expect.objectContaining({ branchName: "blazebot/aiw-45" }),
+      }),
+      expect.objectContaining({
+        repoPath: "acme/api",
+        selectedRationale: "pinned to this workflow",
+      }),
+    ]);
+  });
+
+  it("clarifies by name when one pinned repository is unusable", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: [repos[0], { ...repos[1], archived: true }],
+      workflowOwnedBranches: [],
+      repositoryScope: {
+        repositories: [
+          { provider: "github", repoPath: "acme/web" },
+          { provider: "github", repoPath: "acme/api" },
+        ],
+      },
+    });
+
+    expect(selected.status).toBe("clarification_needed");
+    if (selected.status !== "clarification_needed") {
+      throw new Error("expected clarification");
+    }
+    expect(selected.questions[0]).toContain("github:acme/api");
+    expect(selected.questions[0]).not.toContain("acme/web");
+  });
+
+  it("clarifies instead of discovering when no pinned repository is usable", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      repositoryScope: {
+        repositories: [{ provider: "github", repoPath: "acme/warehouse" }],
+      },
+    });
+
+    expect(selected).toMatchObject({
+      status: "clarification_needed",
+      questions: [expect.stringContaining("github:acme/warehouse")],
+    });
+  });
+
+  // The allowlist is applied by the repository directory, so an excluded
+  // repository never reaches selection. The pin must not be able to bring it back.
+  it("cannot resurrect a pinned repository the allowlist dropped", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix acme/secret",
+      repositories: [repos[0]],
+      workflowOwnedBranches: [],
+      repositoryScope: {
+        repositories: [
+          { provider: "github", repoPath: "acme/web" },
+          { provider: "github", repoPath: "acme/secret" },
+        ],
+      },
+    });
+
+    expect(selected.status).toBe("clarification_needed");
+    if (selected.status !== "clarification_needed") {
+      throw new Error("expected clarification");
+    }
+    expect(selected.questions[0]).toContain("github:acme/secret");
+  });
+
+  it("never lists another provider's repositories under a provider pin", () => {
+    const mixed = [
+      repos[0],
+      { ...repos[1], provider: "gitlab" as const, repoPath: "acme/api" },
+    ];
+
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix the billing callback in acme/api.",
+      repositories: mixed,
+      workflowOwnedBranches: [],
+      repositoryScope: { providers: ["gitlab"] },
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories).toEqual([
+      expect.objectContaining({ provider: "gitlab", repoPath: "acme/api" }),
+    ]);
+  });
+
+  it("narrows the discovery catalog to the pinned providers", () => {
+    const mixed = [
+      repos[0],
+      { ...repos[1], provider: "gitlab" as const, repoPath: "acme/billing" },
+      { ...repos[1], provider: "gitlab" as const, repoPath: "acme/payments" },
+    ];
+
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Improve overall reliability",
+      repositories: mixed,
+      workflowOwnedBranches: [],
+      repositoryScope: { providers: ["gitlab"] },
+    });
+
+    expect(selected).toMatchObject({
+      status: "discovery_needed",
+      catalog: [
+        expect.objectContaining({ provider: "gitlab", repoPath: "acme/billing" }),
+        expect.objectContaining({ provider: "gitlab", repoPath: "acme/payments" }),
+      ],
+    });
+  });
+
+  // Invariant: an absent pin must leave every existing path byte for byte intact.
+  it("keeps the unpinned path identical when the scope is absent or empty", () => {
+    const ticketText = "Fix billing webhook retry behavior";
+    const unpinned = selectRepositoriesFromMetadata({
+      ticketText,
+      repositories: repos,
+      workflowOwnedBranches: [],
+    });
+
+    expect(
+      selectRepositoriesFromMetadata({
+        ticketText,
+        repositories: repos,
+        workflowOwnedBranches: [],
+        repositoryScope: {},
+      }),
+    ).toEqual(unpinned);
+    expect(
+      selectRepositoriesFromMetadata({
+        ticketText,
+        repositories: repos,
+        workflowOwnedBranches: [],
+        repositoryScope: { repositories: [], providers: [] },
+      }),
+    ).toEqual(unpinned);
+    expect(unpinned.status).toBe("discovery_needed");
+  });
+
   it("selects the single usable repository regardless of archived catalog volume", () => {
     const archived = Array.from(
       { length: MAX_ACCESSIBLE_REPOSITORIES + 1 },
@@ -378,6 +612,92 @@ describe("repoSelectionStep", () => {
       }),
     ]);
     expect(result.promptAdditions?.[0]?.content).toContain("github:acme/web");
+  });
+
+  it("queries only the pinned providers and reports the narrowing", async () => {
+    mocks.listRepositories.mockResolvedValueOnce([
+      { ...repos[0], provider: "gitlab", repoPath: "acme/web" },
+      { ...repos[1], provider: "gitlab", repoPath: "acme/api" },
+    ]);
+    mocks.listWorkflowOwnedBranchesForTicket.mockResolvedValueOnce([]);
+
+    const result = await repoSelectionStep({
+      context: {
+        ticket: { identifier: "AIW-45", title: "Update copy" },
+        run: { branchName: "blazebot/aiw-45" },
+        repositoryScope: {
+          providers: ["gitlab"],
+          repositories: [{ provider: "gitlab", repoPath: "acme/api" }],
+        },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", onFailure: "fail" },
+    });
+
+    expect(mocks.createRepositoryDirectoryForProviders).toHaveBeenCalledWith([
+      expect.objectContaining({ kind: "gitlab" }),
+    ]);
+    expect(result.selectedRepositories).toEqual([
+      expect.objectContaining({ provider: "gitlab", repoPath: "acme/api" }),
+    ]);
+    expect(result.repositoryScopeNarrowing).toEqual({
+      catalogSize: 2,
+      scopedCatalogSize: 1,
+    });
+  });
+
+  it("keeps listing a provider that carries a workflow-owned branch for this ticket", async () => {
+    mocks.listRepositories.mockResolvedValueOnce(repos);
+    mocks.listWorkflowOwnedBranchesForTicket.mockResolvedValueOnce([
+      {
+        ticketKey: "AIW-45",
+        provider: "github",
+        repoPath: "acme/web",
+        branchName: "blazebot/aiw-45",
+        pr: null,
+      },
+    ]);
+
+    await repoSelectionStep({
+      context: {
+        ticket: { identifier: "AIW-45", title: "Address review feedback" },
+        run: { branchName: "blazebot/aiw-45" },
+        repositoryScope: { providers: ["gitlab"] },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", onFailure: "fail" },
+    });
+
+    expect(mocks.createRepositoryDirectoryForProviders).toHaveBeenCalledWith([
+      expect.objectContaining({ kind: "github" }),
+      expect.objectContaining({ kind: "gitlab" }),
+    ]);
+  });
+
+  it("reports no narrowing and queries every provider without a pin", async () => {
+    mocks.listRepositories.mockResolvedValueOnce([repos[0]]);
+    mocks.listWorkflowOwnedBranchesForTicket.mockResolvedValueOnce([]);
+
+    const result = await repoSelectionStep({
+      context: {
+        ticket: { identifier: "AIW-45", title: "Update copy" },
+        run: { branchName: "blazebot/aiw-45" },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", onFailure: "fail" },
+    });
+
+    expect(mocks.createRepositoryDirectoryForProviders).toHaveBeenCalledWith([
+      expect.objectContaining({ kind: "github" }),
+      expect.objectContaining({ kind: "gitlab" }),
+    ]);
+    expect(result.repositoryScopeNarrowing).toBeUndefined();
+    expect(result.selectedRepositories).toEqual([
+      expect.objectContaining({
+        repoPath: "acme/web",
+        selectedRationale: "only accessible repository",
+      }),
+    ]);
   });
 
   it("keeps workflow-owned branches provider-scoped when repo paths overlap", () => {

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.ts
@@ -1,9 +1,14 @@
-import type {
-  RepositoryMetadata,
-  SelectedRepository,
-  WorkflowOwnedBranch,
+import type { WorkflowRepositoryScope } from "@shared/contracts";
+import {
+  filterPinnedRepositories,
+  type RepositoryMetadata,
+  type SelectedRepository,
+  type WorkflowOwnedBranch,
 } from "../../adapters/vcs/repository-directory.js";
-import type { PreSandboxStepHandler } from "../types.js";
+import type {
+  PreSandboxRepositoryScopeNarrowing,
+  PreSandboxStepHandler,
+} from "../types.js";
 import {
   buildRepositoryCatalog,
   buildRepositoryCatalogEntries,
@@ -21,9 +26,6 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
   const { getDb } = await import("../../db/client.js");
   const { listWorkflowOwnedBranchesForTicket } = await import("../../db/queries/workflow-owned-branches.js");
   const { getConfiguredVcsProviders } = await import("../../../env.js");
-  const repositories = await createRepositoryDirectoryForProviders(
-    getConfiguredVcsProviders(),
-  ).listRepositories();
   const ticketIdentifier = context.ticket.identifier;
   const workflowOwnedBranches = ticketIdentifier
     ? (await listWorkflowOwnedBranchesForTicket(getDb(), ticketIdentifier)).map((record) => ({
@@ -35,12 +37,22 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
         },
       }))
     : [];
+  const repositoryScope = context.repositoryScope;
+  const repositories = await createRepositoryDirectoryForProviders(
+    listedVcsProviders(
+      getConfiguredVcsProviders(),
+      repositoryScope,
+      workflowOwnedBranches,
+    ),
+  ).listRepositories();
 
   const selected = selectRepositoriesFromMetadata({
     ticketText: ticketText(context.ticket),
     repositories,
     workflowOwnedBranches,
+    ...(repositoryScope ? { repositoryScope } : {}),
   });
+  const narrowing = scopeNarrowing(repositories, repositoryScope);
 
   if (selected.status === "clarification_needed") {
     return {
@@ -48,6 +60,7 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
       outcome: "needs_clarification",
       message: selected.questions[0],
       questions: selected.questions,
+      ...(narrowing ? { repositoryScopeNarrowing: narrowing } : {}),
     };
   }
 
@@ -58,6 +71,7 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
         catalog: selected.catalog,
         mandatoryRepositories: selected.mandatoryRepositories,
       },
+      ...(narrowing ? { repositoryScopeNarrowing: narrowing } : {}),
     };
   }
 
@@ -73,13 +87,52 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
           .join("\n"),
       },
     ],
+    ...(narrowing ? { repositoryScopeNarrowing: narrowing } : {}),
   };
 };
+
+/**
+ * Providers whose listings this run needs. A pin narrows the set so an excluded
+ * provider is never even queried, but a provider carrying an in-flight
+ * workflow-owned branch for this ticket always stays in: losing its listing
+ * would strand that branch's open pull request the moment an operator edits the
+ * pin.
+ */
+function listedVcsProviders<T extends { kind: RepositoryMetadata["provider"] }>(
+  providers: T[],
+  repositoryScope: WorkflowRepositoryScope | undefined,
+  workflowOwnedBranches: WorkflowOwnedBranchSelectionInput[],
+): T[] {
+  const pinned = repositoryScope?.providers ?? [];
+  if (pinned.length === 0) return providers;
+  const owned = new Set(workflowOwnedBranches.map((branch) => branch.provider));
+  return providers.filter(
+    (provider) => pinned.includes(provider.kind) || owned.has(provider.kind),
+  );
+}
+
+function scopeNarrowing(
+  repositories: RepositoryMetadata[],
+  repositoryScope: WorkflowRepositoryScope | undefined,
+): PreSandboxRepositoryScopeNarrowing | null {
+  if (!repositoryScope) return null;
+  if (
+    (repositoryScope.repositories?.length ?? 0) === 0 &&
+    (repositoryScope.providers?.length ?? 0) === 0
+  ) {
+    return null;
+  }
+  return {
+    catalogSize: repositories.length,
+    scopedCatalogSize: filterPinnedRepositories(repositories, repositoryScope).length,
+  };
+}
 
 export function selectRepositoriesFromMetadata(input: {
   ticketText: string;
   repositories: RepositoryMetadata[];
   workflowOwnedBranches: WorkflowOwnedBranchSelectionInput[];
+  repositoryScope?: WorkflowRepositoryScope;
 }):
   | { status: "selected"; repositories: SelectedRepository[] }
   | {
@@ -100,6 +153,10 @@ export function selectRepositoriesFromMetadata(input: {
   );
   const selected = new Map<string, SelectedRepository>();
 
+  // Signal 0 is the definition pin below, but a repository carrying a
+  // workflow-owned branch for this ticket enters first and is never subject to
+  // the pin: dropping it would strand that branch's open pull request the moment
+  // an operator edits the pin.
   for (const owned of input.workflowOwnedBranches) {
     const repo = repositoriesByKey.get(repositoryKey(owned));
     if (!repo) continue;
@@ -112,8 +169,44 @@ export function selectRepositoriesFromMetadata(input: {
     });
   }
 
+  // Pure intersection over what the server already offered, so the pin can only
+  // ever remove candidates. Without a pin this is the input list untouched.
+  const scopedRepositories = filterPinnedRepositories(
+    usableRepositories,
+    input.repositoryScope,
+  );
+  const pinnedRepositories = input.repositoryScope?.repositories ?? [];
+  if (pinnedRepositories.length > 0) {
+    const scopedByKey = new Map(
+      scopedRepositories.map((repo) => [repositoryKey(repo), repo]),
+    );
+    const unavailable = pinnedRepositories
+      .filter((pinned) => !scopedByKey.has(repositoryKey(pinned)))
+      .map((pinned) => `${pinned.provider}:${pinned.repoPath}`);
+    // A pin the server cannot satisfy is surfaced by name. Falling through to
+    // model discovery would silently replace the operator's explicit choice, and
+    // an empty selection would silently resolve the ticket to nothing.
+    if (unavailable.length > 0) {
+      return {
+        status: "clarification_needed",
+        questions: [
+          `Repositories pinned to this workflow are unavailable: ${unavailable.join(", ")}. Restore access to them or update the workflow's pinned repositories.`,
+        ],
+      };
+    }
+    for (const repo of scopedByKey.values()) {
+      const key = repositoryKey(repo);
+      if (!selected.has(key)) {
+        selected.set(key, selectedRepository(repo, "pinned to this workflow"));
+      }
+    }
+    // The initial-match limit below exists for ambiguity between competing
+    // signals. An explicit operator pin is not ambiguous, so it does not apply.
+    return { status: "selected", repositories: [...selected.values()] };
+  }
+
   const ticketText = input.ticketText.toLowerCase();
-  const exactMatches = usableRepositories.filter((repo) =>
+  const exactMatches = scopedRepositories.filter((repo) =>
     mentionsRepositoryPath(ticketText, repo.repoPath),
   );
   for (const repo of exactMatches) {
@@ -135,11 +228,11 @@ export function selectRepositoriesFromMetadata(input: {
     return { status: "selected", repositories: [...selected.values()] };
   }
 
-  if (usableRepositories.length === 1) {
+  if (scopedRepositories.length === 1) {
     return {
       status: "selected",
       repositories: [
-        selectedRepository(usableRepositories[0]!, "only accessible repository"),
+        selectedRepository(scopedRepositories[0]!, "only accessible repository"),
       ],
     };
   }
@@ -148,7 +241,9 @@ export function selectRepositoriesFromMetadata(input: {
   // Deterministic selection above never fails on catalog size.
   return {
     status: "discovery_needed",
-    catalog: buildRepositoryCatalog(input.repositories),
+    catalog: buildRepositoryCatalog(
+      filterPinnedRepositories(input.repositories, input.repositoryScope),
+    ),
     mandatoryRepositories: [...selected.values()],
   };
 }

--- a/apps/worker/src/pre-sandbox/types.ts
+++ b/apps/worker/src/pre-sandbox/types.ts
@@ -1,9 +1,20 @@
+import type { WorkflowRepositoryScope } from "@shared/contracts";
 import type { SelectedRepository } from "../adapters/vcs/repository-directory.js";
 import type { RepositoryCatalogEntry } from "../repository-discovery/catalog.js";
 
 export interface PreSandboxRepositoryDiscovery {
   catalog: RepositoryCatalogEntry[];
   mandatoryRepositories: SelectedRepository[];
+}
+
+/** Telemetry for how much a definition pin reduced what selection could see. */
+export interface PreSandboxRepositoryScopeNarrowing {
+  /** Repositories the provider listing offered this run. A pin that selects
+   *  providers keeps the excluded ones from being queried at all, so this is
+   *  already provider-scoped rather than a server-wide total. */
+  catalogSize: number;
+  /** Repositories left after the pin narrowed that listing. */
+  scopedCatalogSize: number;
 }
 
 export const preSandboxPromptTargets = ["research", "implementation", "review"] as const;
@@ -26,6 +37,7 @@ export type PreSandboxStepResult =
       promptAdditions?: PreSandboxPromptAddition[];
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
+      repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
     }
   | {
       status: "halt";
@@ -35,6 +47,7 @@ export type PreSandboxStepResult =
       promptAdditions?: PreSandboxPromptAddition[];
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
+      repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
     };
 
 export const preSandboxTicketInputFields = [
@@ -59,6 +72,8 @@ export interface PreSandboxStepContext {
   run: {
     branchName: string;
   };
+  /** Repositories pinned to the workflow definition; absent when none are. */
+  repositoryScope?: WorkflowRepositoryScope;
 }
 
 export type PreSandboxOnFailure = "continue" | "fail" | "move_to_backlog";
@@ -92,6 +107,7 @@ export type PreSandboxStepRegistry = Record<string, PreSandboxStepHandler>;
 export interface RunPreSandboxPhaseInput {
   ticket: PreSandboxStepContext["ticket"];
   run: PreSandboxStepContext["run"];
+  repositoryScope?: PreSandboxStepContext["repositoryScope"];
 }
 
 export type RunPreSandboxPhaseResult =
@@ -100,6 +116,7 @@ export type RunPreSandboxPhaseResult =
       promptAdditions: PreSandboxPromptAdditionsByTarget;
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
+      repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
     }
   | {
       status: "halt";
@@ -109,4 +126,5 @@ export type RunPreSandboxPhaseResult =
       promptAdditions: PreSandboxPromptAdditionsByTarget;
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
+      repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
     };

--- a/apps/worker/src/run-observability/agent-observations.ts
+++ b/apps/worker/src/run-observability/agent-observations.ts
@@ -43,10 +43,17 @@ type CollectedTimeoutArtifacts = CollectedPhaseArtifacts & {
 export type RepositoryWorkflowObservation =
   | {
       event: "selection";
-      source: "metadata" | "harness" | "approved" | "pr_trigger";
+      source: "metadata" | "harness" | "approved" | "pr_trigger" | "definition_pin";
+      /** Repositories the provider listing offered this run. Under a pin that
+       *  selects providers, the excluded providers are never queried, so this is
+       *  already provider-scoped rather than a server-wide total. */
       catalogSize: number;
       selectedCount: number;
       confidence?: "high" | "medium";
+      /** Repositories left after the pin narrowed that listing; absent when no
+       *  pin applied. The pin itself stays reproducible from the run's immutable
+       *  definitionId and definitionVersion. */
+      scopedCatalogSize?: number;
     }
   | {
       event: "expansion";

--- a/apps/worker/src/workflow-definition/block-registry.test.ts
+++ b/apps/worker/src/workflow-definition/block-registry.test.ts
@@ -6,6 +6,7 @@ import {
   validateBlockOutputForDefinition,
   workflowBlockDefinitionIssues,
   workflowBlockDeploymentDefinitionIssues,
+  workflowRepositoryScopeIssues,
   type WorkflowBlockRegistryContext,
 } from "./block-registry.js";
 
@@ -695,5 +696,63 @@ describe("workflow block registry", () => {
       });
       expect(schema).not.toHaveProperty("properties.ticketKey");
     }
+  });
+});
+
+describe("definition repository pin validation", () => {
+  it("accepts an absent, empty, or fully configured pin", () => {
+    expect(workflowRepositoryScopeIssues(undefined, context)).toEqual([]);
+    expect(workflowRepositoryScopeIssues({}, context)).toEqual([]);
+    expect(
+      workflowRepositoryScopeIssues(
+        {
+          providers: ["github"],
+          repositories: [{ provider: "github", repoPath: "acme/api" }],
+        },
+        context,
+      ),
+    ).toEqual([]);
+  });
+
+  it("reports pinned providers none of which this server has configured", () => {
+    expect(workflowRepositoryScopeIssues({ providers: ["gitlab"] }, context)).toEqual([
+      "Pinned VCS providers are not configured: gitlab.",
+    ]);
+    expect(
+      workflowRepositoryScopeIssues({ providers: ["github", "gitlab"] }, context),
+    ).toEqual([]);
+  });
+
+  // Provider configuration is environment state: skipping it keeps an
+  // already-deployed pinned definition loadable after that state changes.
+  it("skips the provider check when environment availability is not checked", () => {
+    expect(
+      workflowRepositoryScopeIssues({ providers: ["gitlab"] }, context, {
+        checkEnvironmentAvailability: false,
+      }),
+    ).toEqual([]);
+  });
+
+  // A pinned repository its own provider list excludes can never resolve. It must
+  // surface as an authoring issue instead of being dropped at runtime, so it is
+  // reported even when environment availability is skipped.
+  it("reports a pinned repository excluded by the pinned provider list", () => {
+    const contradiction = {
+      providers: ["github" as const],
+      repositories: [
+        { provider: "github" as const, repoPath: "acme/api" },
+        { provider: "gitlab" as const, repoPath: "acme/shared" },
+      ],
+    };
+    const expected = [
+      "Pinned repositories use providers excluded by the pinned provider list: gitlab:acme/shared.",
+    ];
+
+    expect(workflowRepositoryScopeIssues(contradiction, context)).toEqual(expected);
+    expect(
+      workflowRepositoryScopeIssues(contradiction, context, {
+        checkEnvironmentAvailability: false,
+      }),
+    ).toEqual(expected);
   });
 });

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -12,6 +12,7 @@ import {
   type WorkflowBlockPresentation,
   type WorkflowBlockType,
   type WorkflowParamValue,
+  type WorkflowRepositoryScope,
   type WorkflowValueSchema,
 } from "@shared/contracts";
 import { resolveLlmProvider, type LlmProvider } from "../lib/llm-provider.js";
@@ -973,6 +974,46 @@ function availabilityFor(
     }
   }
   return available;
+}
+
+/**
+ * Definition-level repository pin issues. A pin is not block params, so it
+ * cannot be checked through availabilityFor above and is validated once per
+ * definition instead. Two failures are reported, in the same message style as
+ * the VCS provider check in availabilityFor:
+ *  - none of the pinned providers is configured on this server, so no pinned
+ *    repository could ever resolve. This is environment state, so it is skipped
+ *    with checkEnvironmentAvailability: false, keeping an already-deployed pinned
+ *    definition loadable after provider configuration changes;
+ *  - a pinned repository whose provider its own `providers` list excludes, a
+ *    contradiction in the authored definition itself. It always fails closed, so
+ *    it can never be silently dropped at runtime.
+ */
+export function workflowRepositoryScopeIssues(
+  scope: WorkflowRepositoryScope | undefined,
+  context: WorkflowBlockRegistryContext,
+  options: { checkEnvironmentAvailability?: boolean } = {},
+): string[] {
+  const providers = scope?.providers ?? [];
+  if (providers.length === 0) return [];
+  const issues: string[] = [];
+  if (
+    options.checkEnvironmentAvailability !== false &&
+    !providers.some((provider) => context.vcsProviders.includes(provider))
+  ) {
+    issues.push(`Pinned VCS providers are not configured: ${providers.join(", ")}.`);
+  }
+  const excluded = (scope?.repositories ?? []).filter(
+    (repository) => !providers.includes(repository.provider),
+  );
+  if (excluded.length > 0) {
+    issues.push(
+      `Pinned repositories use providers excluded by the pinned provider list: ${excluded
+        .map((repository) => `${repository.provider}:${repository.repoPath}`)
+        .join(", ")}.`,
+    );
+  }
+  return issues;
 }
 
 function declaredOutputSchema(

--- a/apps/worker/src/workflow-definition/schema-v2.test.ts
+++ b/apps/worker/src/workflow-definition/schema-v2.test.ts
@@ -163,6 +163,42 @@ describe("Workflow Definition v2 schema", () => {
     expect(workflowDefinitionV2Schema.safeParse(v1).success).toBe(false);
   });
 
+  it("round-trips a pinned repository scope and rejects an invalid one", () => {
+    const repositoryScope = {
+      repositories: [
+        { provider: "github" as const, repoPath: "acme/web" },
+        { provider: "gitlab" as const, repoPath: "acme/group/subgroup/api" },
+      ],
+      providers: ["github" as const, "gitlab" as const],
+    };
+
+    expect(
+      workflowDefinitionV2Schema.parse({ ...v2Definition(), repositoryScope }).repositoryScope,
+    ).toEqual(repositoryScope);
+
+    expect(
+      workflowDefinitionV2Schema.safeParse({ ...v2Definition(), repositoryScope: {} }).success,
+    ).toBe(true);
+    expect(
+      workflowDefinitionV2Schema.safeParse({
+        ...v2Definition(),
+        repositoryScope: { repositories: [{ provider: "github", repoPath: "acme" }] },
+      }).success,
+    ).toBe(false);
+    expect(
+      workflowDefinitionV2Schema.safeParse({
+        ...v2Definition(),
+        repositoryPin: { providers: ["github"] },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("parses a v2 definition without a repository scope exactly as before", () => {
+    const parsed = workflowDefinitionV2Schema.parse(v2Definition());
+    expect(parsed.repositoryScope).toBeUndefined();
+    expect("repositoryScope" in parsed).toBe(false);
+  });
+
   it("accepts typed reference and literal bindings plus ordered additional inputs", () => {
     const definition = v2Definition();
     definition.nodes.push({

--- a/apps/worker/src/workflow-definition/schema.test.ts
+++ b/apps/worker/src/workflow-definition/schema.test.ts
@@ -19,6 +19,7 @@ import {
   ANY_SCOPE_BLOCK_POLICY,
   upgradeStoredWorkflowDefinition,
   validateWorkflowDefinitionForDeployment,
+  validateWorkflowDefinitionIssuesForDeployment,
   validateWorkflowGraph,
   workflowDefinitionV2Schema,
   workflowDefinitionV1Schema as workflowDefinitionSchema,
@@ -103,6 +104,232 @@ describe("workflowDefinitionSchema", () => {
         edges: [],
       }).budgets,
     ).toEqual({ maxDurationMs: 30_000, maxTokens: 8_000, maxCostUsd: 1.25 });
+  });
+
+  it("round-trips a pinned repository scope through the v1 schema", () => {
+    const repositoryScope = {
+      repositories: [
+        { provider: "github" as const, repoPath: "acme/web" },
+        { provider: "gitlab" as const, repoPath: "acme/group/subgroup/api" },
+      ],
+      providers: ["github" as const, "gitlab" as const],
+    };
+
+    expect(
+      workflowDefinitionSchema.parse({
+        schemaVersion: 1,
+        repositoryScope,
+        nodes: [],
+        edges: [],
+      }).repositoryScope,
+    ).toEqual(repositoryScope);
+  });
+
+  it("treats an omitted repository scope as today's behavior", () => {
+    expect(
+      workflowDefinitionSchema.parse({ schemaVersion: 1, nodes: [], edges: [] }),
+    ).toEqual({ schemaVersion: 1, nodes: [], edges: [] });
+  });
+
+  it("accepts each repository scope sub-field on its own", () => {
+    expect(
+      workflowDefinitionSchema.parse({
+        schemaVersion: 1,
+        repositoryScope: { repositories: [{ provider: "github", repoPath: "acme/web" }] },
+        nodes: [],
+        edges: [],
+      }).repositoryScope,
+    ).toEqual({ repositories: [{ provider: "github", repoPath: "acme/web" }] });
+
+    expect(
+      workflowDefinitionSchema.parse({
+        schemaVersion: 1,
+        repositoryScope: { providers: ["gitlab"] },
+        nodes: [],
+        edges: [],
+      }).repositoryScope,
+    ).toEqual({ providers: ["gitlab"] });
+  });
+
+  // filterPinnedRepositories in adapters/vcs/repository-directory.ts restricts a
+  // listing only when repositories or providers is non-empty, so every scope this
+  // schema accepts as "no pin" has to reach it carrying neither. Pinned here so a
+  // schema change cannot turn an empty pin into one that matches nothing.
+  it("admits exactly three no-pin spellings, none of them carrying a restriction", () => {
+    const parseScope = (repositoryScope?: unknown) =>
+      workflowDefinitionSchema.parse({
+        schemaVersion: 1,
+        ...(repositoryScope === undefined ? {} : { repositoryScope }),
+        nodes: [],
+        edges: [],
+      }).repositoryScope;
+
+    for (const scope of [parseScope(), parseScope({}), parseScope({ repositories: [] })]) {
+      expect(scope?.repositories?.length ?? 0).toBe(0);
+      expect(scope?.providers?.length ?? 0).toBe(0);
+    }
+
+    expect(parseScope()).toBeUndefined();
+    expect(parseScope({})).toEqual({});
+    expect(parseScope({ repositories: [] })).toEqual({ repositories: [] });
+
+    expect(
+      workflowDefinitionSchema.safeParse({
+        schemaVersion: 1,
+        repositoryScope: { providers: [] },
+        nodes: [],
+        edges: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("caps repoPath length at 200 characters", () => {
+    const pathOfLength = (length: number) => `acme/${"r".repeat(length - "acme/".length)}`;
+    const parseRepoPath = (repoPath: string) =>
+      workflowDefinitionSchema.safeParse({
+        schemaVersion: 1,
+        repositoryScope: { repositories: [{ provider: "github", repoPath }] },
+        nodes: [],
+        edges: [],
+      }).success;
+
+    expect(pathOfLength(200)).toHaveLength(200);
+    expect(parseRepoPath(pathOfLength(200))).toBe(true);
+    expect(parseRepoPath(pathOfLength(201))).toBe(false);
+  });
+
+  it("stores a padded repoPath trimmed", () => {
+    expect(
+      workflowDefinitionSchema.parse({
+        schemaVersion: 1,
+        repositoryScope: { repositories: [{ provider: "github", repoPath: "  acme/web  " }] },
+        nodes: [],
+        edges: [],
+      }).repositoryScope?.repositories,
+    ).toEqual([{ provider: "github", repoPath: "acme/web" }]);
+  });
+
+  it("preserves the repoPath case the operator picked", () => {
+    expect(
+      workflowDefinitionSchema.parse({
+        schemaVersion: 1,
+        repositoryScope: { repositories: [{ provider: "github", repoPath: "Acme/Web" }] },
+        nodes: [],
+        edges: [],
+      }).repositoryScope?.repositories,
+    ).toEqual([{ provider: "github", repoPath: "Acme/Web" }]);
+  });
+
+  it("accepts exactly eight pinned repositories and rejects a ninth", () => {
+    const pin = (count: number) => ({
+      schemaVersion: 1,
+      repositoryScope: {
+        repositories: Array.from({ length: count }, (_unused, index) => ({
+          provider: "github" as const,
+          repoPath: `acme/repo-${index}`,
+        })),
+      },
+      nodes: [],
+      edges: [],
+    });
+
+    expect(workflowDefinitionSchema.safeParse(pin(8)).success).toBe(true);
+    expect(workflowDefinitionSchema.safeParse(pin(9)).success).toBe(false);
+  });
+
+  it("rejects duplicate pinned repositories case-insensitively but keeps the same path on two providers", () => {
+    const withRepositories = (
+      repositories: Array<{ provider: "github" | "gitlab"; repoPath: string }>,
+    ) =>
+      workflowDefinitionSchema.safeParse({
+        schemaVersion: 1,
+        repositoryScope: { repositories },
+        nodes: [],
+        edges: [],
+      }).success;
+
+    expect(
+      withRepositories([
+        { provider: "github", repoPath: "acme/web" },
+        { provider: "github", repoPath: "acme/web" },
+      ]),
+    ).toBe(false);
+    expect(
+      withRepositories([
+        { provider: "github", repoPath: "acme/web" },
+        { provider: "github", repoPath: "Acme/Web" },
+      ]),
+    ).toBe(false);
+    expect(
+      withRepositories([
+        { provider: "github", repoPath: "acme/web" },
+        { provider: "gitlab", repoPath: "acme/web" },
+      ]),
+    ).toBe(true);
+  });
+
+  it.each([
+    { repositories: [{ provider: "github", repoPath: "acme" }] },
+    { repositories: [{ provider: "github", repoPath: "" }] },
+    { repositories: [{ provider: "github", repoPath: "acme/" }] },
+    { repositories: [{ provider: "github", repoPath: "/web" }] },
+    { repositories: [{ provider: "github", repoPath: "acme/we b" }] },
+    { repositories: [{ provider: "svn", repoPath: "acme/web" }] },
+    { repositories: [{ provider: "github", repoPath: "acme/web", extra: 1 }] },
+    { repositories: [{ repoPath: "acme/web" }] },
+    { providers: [] },
+    { providers: ["svn"] },
+    { unexpected: 1 },
+  ])("rejects an invalid repository scope %#", (repositoryScope) => {
+    expect(
+      workflowDefinitionSchema.safeParse({
+        schemaVersion: 1,
+        repositoryScope,
+        nodes: [],
+        edges: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown sibling of repositoryScope at the definition root", () => {
+    expect(
+      workflowDefinitionSchema.safeParse({
+        schemaVersion: 1,
+        repositoryScope: { providers: ["github"] },
+        repositoryPin: { providers: ["github"] },
+        nodes: [],
+        edges: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("preserves a pinned repository scope while upgrading a stored definition", () => {
+    expect(
+      upgradeStoredWorkflowDefinition({
+        schemaVersion: 1,
+        repositoryScope: {
+          repositories: [{ provider: "gitlab", repoPath: "acme/group/api" }],
+          providers: ["gitlab"],
+        },
+        nodes: [],
+        edges: [],
+      }).repositoryScope,
+    ).toEqual({
+      repositories: [{ provider: "gitlab", repoPath: "acme/group/api" }],
+      providers: ["gitlab"],
+    });
+  });
+
+  it("leaves repositoryScope absent when upgrading a stored definition that lacks it", () => {
+    const upgraded = upgradeStoredWorkflowDefinition({
+      schemaVersion: 1,
+      budgets: { maxTokens: 100 },
+      nodes: [],
+      edges: [],
+    });
+
+    expect(upgraded.repositoryScope).toBeUndefined();
+    expect("repositoryScope" in upgraded).toBe(false);
   });
 
   it("removes retired arthur_trace and splices only its normal output", () => {
@@ -1690,6 +1917,120 @@ describe("validateWorkflowGraph rules", () => {
     const definition = graph([node("review", "trigger_pr_review", defaults)], []);
 
     expect(validateWorkflowDefinitionForDeployment(definition, gitlabOnlyContext)).toEqual([]);
+  });
+
+  describe("definition repository pin", () => {
+    const pinned = (
+      repositoryScope: WorkflowDefinitionV1["repositoryScope"],
+    ): WorkflowDefinitionV1 => ({
+      ...graph([node("trigger", "trigger_ticket_ai")], []),
+      ...(repositoryScope ? { repositoryScope } : {}),
+    });
+
+    it("deploys a pin whose providers are configured", () => {
+      expect(
+        validateWorkflowDefinitionForDeployment(
+          pinned({
+            providers: ["github"],
+            repositories: [{ provider: "github", repoPath: "acme/api" }],
+          }),
+          registryContext,
+        ),
+      ).toEqual([]);
+    });
+
+    it("rejects a pin whose providers are all unconfigured", () => {
+      expect(
+        validateWorkflowDefinitionForDeployment(pinned({ providers: ["github"] }), {
+          ...registryContext,
+          vcsProviders: ["gitlab"],
+        }),
+      ).toContain("Pinned VCS providers are not configured: github.");
+    });
+
+    it("rejects a pin contradicting its own provider list, on both schema versions", () => {
+      const contradiction = {
+        providers: ["github" as const],
+        repositories: [{ provider: "gitlab" as const, repoPath: "acme/shared" }],
+      };
+      const message =
+        "Pinned repositories use providers excluded by the pinned provider list: gitlab:acme/shared.";
+
+      expect(
+        validateWorkflowDefinitionForDeployment(pinned(contradiction), registryContext),
+      ).toContain(message);
+      expect(
+        validateWorkflowDefinitionForDeployment(
+          {
+            schemaVersion: 2,
+            repositoryScope: contradiction,
+            nodes: [
+              {
+                id: "trigger",
+                type: "trigger_ticket_ai",
+                x: 0,
+                y: 0,
+                configuration: {},
+                inputs: {},
+                additionalInputs: [],
+              },
+            ],
+            edges: [],
+          },
+          registryContext,
+        ),
+      ).toContain(message);
+    });
+
+    // A stored pinned definition must keep loading when provider configuration
+    // changes under it, but a contradiction inside the definition itself always
+    // fails closed instead of being dropped silently at runtime.
+    it("separates environment availability from the definition-local contradiction", () => {
+      const contradiction = pinned({
+        providers: ["github"],
+        repositories: [{ provider: "gitlab", repoPath: "acme/shared" }],
+      });
+      const gitlabOnly = { ...registryContext, vcsProviders: ["gitlab" as const] };
+
+      expect(
+        validateWorkflowDefinitionForDeployment(pinned({ providers: ["github"] }), gitlabOnly, {
+          checkEnvironmentAvailability: false,
+        }),
+      ).toEqual([]);
+      expect(
+        validateWorkflowDefinitionForDeployment(contradiction, gitlabOnly, {
+          checkEnvironmentAvailability: false,
+        }),
+      ).toEqual([
+        "Pinned repositories use providers excluded by the pinned provider list: gitlab:acme/shared.",
+      ]);
+    });
+
+    it("reports the pin once, with no node and the scope's own path", () => {
+      const issues = validateWorkflowDefinitionIssuesForDeployment(
+        pinned({ providers: ["github"] }),
+        { ...registryContext, vcsProviders: ["gitlab"] },
+      ).filter((issue) => issue.message.startsWith("Pinned VCS providers"));
+
+      expect(issues).toEqual([
+        {
+          code: "deployment",
+          severity: "error",
+          nodeId: null,
+          path: "/repositoryScope",
+          message: "Pinned VCS providers are not configured: github.",
+        },
+      ]);
+    });
+
+    it("leaves a definition without a pin untouched", () => {
+      expect(
+        validateWorkflowDefinitionForDeployment(pinned(undefined), registryContext),
+      ).toEqual([]);
+      expect(
+        validateWorkflowDefinitionForDeployment(pinned({}), registryContext),
+      ).toEqual([]);
+    });
   });
 
   it("allows scope:any only through review-safe, non-mutating blocks", () => {

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -53,6 +53,7 @@ import {
   resolveWorkflowBlockContract,
   workflowBlockDeploymentDefinitionIssues,
   workflowBlockDefinitionIssues,
+  workflowRepositoryScopeIssues,
   type WorkflowBlockRegistryContext,
 } from "./block-registry.js";
 import {
@@ -374,10 +375,53 @@ const executionBudgetsSchema = z
   })
   .strict();
 
+const MAX_PINNED_REPOSITORIES = 8;
+
+// At least one slash, more allowed for nested GitLab group paths. Stricter than
+// REPO_PATH_RE in lib/repo-allowlist.ts: this also rejects inner whitespace, which
+// neither provider permits in a path. Duplicated rather than imported on purpose,
+// because repo-allowlist.ts pulls in the pino logger and this file is reachable
+// from the workflow isolate, where a CJS/node:* import compiles to require() and
+// throws at runtime while local tests stay green.
+const definitionRepoPathSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(/^[^\s/]+(?:\/[^\s/]+)+$/);
+
+// Repositories pinned to the definition. Case is preserved as the operator picked
+// it, so uniqueness compares on the lowercased path the way repositoryKey does in
+// pre-sandbox/steps/repo-selection.ts.
+const repositoryScopeSchema = z
+  .object({
+    repositories: z
+      .array(
+        z
+          .object({ provider: vcsProviders, repoPath: definitionRepoPathSchema })
+          .strict(),
+      )
+      .max(
+        MAX_PINNED_REPOSITORIES,
+        `A workflow cannot pin more than ${MAX_PINNED_REPOSITORIES} repositories.`,
+      )
+      .refine(
+        (repositories) =>
+          new Set(
+            repositories.map((repo) => `${repo.provider}:${repo.repoPath.toLowerCase()}`),
+          ).size === repositories.length,
+        "Pinned repositories must be unique.",
+      )
+      .optional(),
+    providers: vcsProviderSelection.optional(),
+  })
+  .strict();
+
 export const workflowDefinitionV1Schema = z
   .object({
     schemaVersion: z.literal(1),
     budgets: executionBudgetsSchema.optional(),
+    repositoryScope: repositoryScopeSchema.optional(),
     nodes: z.array(nodeSchema).max(MAX_NODES, `Workflow cannot have more than ${MAX_NODES} blocks.`),
     edges: z
       .array(edgeSchema)
@@ -718,6 +762,7 @@ export const workflowDefinitionV2Schema = z
   .object({
     schemaVersion: z.literal(2),
     budgets: executionBudgetsSchema.optional(),
+    repositoryScope: repositoryScopeSchema.optional(),
     nodes: z
       .array(workflowDefinitionV2NodeSchema)
       .max(MAX_NODES, `Workflow cannot have more than ${MAX_NODES} blocks.`),
@@ -784,6 +829,7 @@ const storedWorkflowDefinitionV1 = z
   .object({
     schemaVersion: z.literal(1),
     budgets: executionBudgetsSchema.optional(),
+    repositoryScope: repositoryScopeSchema.optional(),
     nodes: z.array(storedWorkflowNode),
     edges: z.array(edgeSchema),
   })
@@ -1048,6 +1094,9 @@ function upgradeStoredWorkflowDefinitionV1(raw: unknown): WorkflowDefinitionV1 {
   return {
     schemaVersion: 1,
     ...(parsed.budgets === undefined ? {} : { budgets: parsed.budgets }),
+    ...(parsed.repositoryScope === undefined
+      ? {}
+      : { repositoryScope: parsed.repositoryScope }),
     nodes: upgradedNodes,
     edges: publicationUpgraded.edges,
   };
@@ -2340,6 +2389,7 @@ export function validateWorkflowDefinitionIssuesForDeployment(
         catalogAnalysis.catalogByNode,
       ),
       ...validateWorkflowV2WorkspaceAccessIssues(def),
+      ...repositoryScopePinIssues(def, registryContext, options),
     ]);
     return issues;
   }
@@ -2357,6 +2407,7 @@ export function validateWorkflowDefinitionIssuesForDeployment(
       ? []
       : validateWorkspaceCapabilityIssues(def, graphContext)),
     ...validateAnyScopeReviewSafetyIssues(def),
+    ...repositoryScopePinIssues(def, registryContext, options),
   ];
   for (const [nodeIndex, node] of def.nodes.entries()) {
     if (!isWorkflowAddressablePathSegment(node.id)) {
@@ -2411,6 +2462,23 @@ export function validateWorkflowDefinitionIssuesForDeployment(
     }
   }
   return dedupeDeploymentIssues(issues);
+}
+
+/**
+ * The definition-level repository pin belongs to no block, so the node walks
+ * above never see it. Its issues carry `nodeId: null`, the way every other
+ * definition-wide issue does, and flow through the same dedupe as the rest.
+ */
+function repositoryScopePinIssues(
+  def: WorkflowDefinition,
+  registryContext: WorkflowBlockRegistryContext,
+  options: { checkEnvironmentAvailability?: boolean },
+): WorkflowDefinitionValidationIssue[] {
+  return workflowRepositoryScopeIssues(
+    def.repositoryScope,
+    registryContext,
+    options,
+  ).map((message) => deploymentIssue(message, null, "/repositoryScope"));
 }
 
 function deploymentIssue(

--- a/apps/worker/src/workflow-definition/store-v2.test.ts
+++ b/apps/worker/src/workflow-definition/store-v2.test.ts
@@ -77,6 +77,38 @@ describe("v2 workflow definition storage", () => {
       .toMatchObject({ schemaVersion: 2 });
   });
 
+  it("round-trips a pinned repository scope through jsonb storage", async () => {
+    const repositoryScope = {
+      repositories: [
+        { provider: "github" as const, repoPath: "Acme/Web" },
+        { provider: "gitlab" as const, repoPath: "acme/group/api" },
+      ],
+      providers: ["github" as const, "gitlab" as const],
+    };
+    const created = await createWorkflowDefinition(db, {
+      name: "V2 pinned",
+      seed: null,
+      actor: ADMIN,
+    });
+    await saveWorkflowDefinitionDraft(db, {
+      definitionId: created.definition.id,
+      definition: { ...definitionV2(), repositoryScope },
+      expectedDraftRevision: 0,
+      actor: ADMIN,
+    });
+
+    const current = await getCurrentWorkflowDefinitionVersion(db, created.definition.id);
+    expect(current?.definition).toMatchObject({ schemaVersion: 2, repositoryScope });
+
+    const deployed = await deployWorkflowDefinition(db, {
+      definitionId: created.definition.id,
+      expectedDraftRevision: 1,
+      expectedDeployedVersion: null,
+      actor: ADMIN,
+    });
+    expect(deployed.version.definition).toMatchObject({ repositoryScope });
+  });
+
   it("deploys and rolls back valid v2 versions", async () => {
     const created = await createWorkflowDefinition(db, {
       name: "V2 gated",

--- a/apps/worker/src/workflow-definition/store.test.ts
+++ b/apps/worker/src/workflow-definition/store.test.ts
@@ -813,6 +813,45 @@ describe("write-path validation", () => {
     expect((await listWorkflowDefinitionVersionRows(db, d.id)).map((v) => v.version)).toEqual([2, 1]);
   });
 
+  it("rejects deploying a pin whose repositories contradict its own provider list", async () => {
+    const contradictory: WorkflowDefinitionV1 = {
+      ...def(),
+      repositoryScope: {
+        providers: ["github"],
+        repositories: [{ provider: "gitlab", repoPath: "acme/shared" }],
+      },
+    };
+    const created = (
+      await createWorkflowDefinition(db, { name: "Pinned", seed: null, actor: ADMIN })
+    ).definition;
+    // The draft still saves: the pin is an authoring issue reported to the editor,
+    // and only deployment is gated on it.
+    await saveWorkflowDefinitionDraft(db, {
+      definitionId: created.id,
+      definition: contradictory,
+      expectedDraftRevision: 0,
+      actor: ADMIN,
+    });
+
+    await expect(
+      deployWorkflowDefinition(db, {
+        definitionId: created.id,
+        expectedDraftRevision: 1,
+        expectedDeployedVersion: null,
+        actor: ADMIN,
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 422,
+      issues: [
+        expect.objectContaining({
+          nodeId: null,
+          path: "/repositoryScope",
+          message: expect.stringContaining("excluded by the pinned provider list"),
+        }),
+      ],
+    });
+  });
+
   it("checks the role before the graph, so a member never learns the graph is invalid", async () => {
     await expect(
       saveWorkflowDefinitionVersion(db, { definitionId: SEEDED_DEFAULT_ID, definition: invalidDef(), actor: MEMBER }),

--- a/apps/worker/src/workflow-definition/v2-converter.test.ts
+++ b/apps/worker/src/workflow-definition/v2-converter.test.ts
@@ -222,6 +222,104 @@ describe("convertWorkflowDefinitionV1ToV2", () => {
     expect(result.conversionHash).toMatch(/^[a-f0-9]{64}$/);
   });
 
+  it("carries a pinned repository scope into the converted v2 definition", () => {
+    const repositoryScope = {
+      repositories: [
+        { provider: "github" as const, repoPath: "Acme/Web" },
+        { provider: "gitlab" as const, repoPath: "acme/group/api" },
+      ],
+      providers: ["github" as const, "gitlab" as const],
+    };
+    const definition: WorkflowDefinitionV1 = {
+      schemaVersion: 1,
+      repositoryScope,
+      nodes: [
+        node("trigger", "trigger_ticket_ai"),
+        node("finish", "terminate", { terminalStatus: "done" }),
+      ],
+      edges: [{ from: "trigger", to: "finish" }],
+    };
+
+    const result = convert(definition);
+
+    expect(result.blockers).toEqual([]);
+    expect(result.definition?.repositoryScope).toEqual(repositoryScope);
+    expect(result.definition?.repositoryScope).not.toBe(repositoryScope);
+  });
+
+  it("converts a definition without a repository scope without inventing one", () => {
+    const definition: WorkflowDefinitionV1 = {
+      schemaVersion: 1,
+      nodes: [
+        node("trigger", "trigger_ticket_ai"),
+        node("finish", "terminate", { terminalStatus: "done" }),
+      ],
+      edges: [{ from: "trigger", to: "finish" }],
+    };
+
+    const result = convert(definition);
+
+    expect(result.blockers).toEqual([]);
+    expect(result.definition?.repositoryScope).toBeUndefined();
+    expect("repositoryScope" in (result.definition ?? {})).toBe(false);
+  });
+
+  // The pin travels with the definition, so a contradictory one must block the
+  // migration instead of producing a v2 snapshot that only fails at runtime.
+  it("blocks a migration whose pinned repositories contradict its pinned providers", () => {
+    const definition: WorkflowDefinitionV1 = {
+      schemaVersion: 1,
+      repositoryScope: {
+        providers: ["github"],
+        repositories: [{ provider: "gitlab", repoPath: "acme/shared" }],
+      },
+      nodes: [
+        node("trigger", "trigger_ticket_ai"),
+        node("finish", "terminate", { terminalStatus: "done" }),
+      ],
+      edges: [{ from: "trigger", to: "finish" }],
+    };
+
+    const result = convert(definition);
+
+    expect(result.definition).toBeNull();
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "migration.target.deployment",
+          nodeId: null,
+          path: "/repositoryScope",
+          message: expect.stringContaining("excluded by the pinned provider list"),
+        }),
+      ]),
+    );
+  });
+
+  it("blocks an unknown top-level field while allowing repositoryScope", () => {
+    const definition = {
+      schemaVersion: 1,
+      repositoryScope: { providers: ["github" as const] },
+      repositoryPin: { providers: ["github"] },
+      nodes: [
+        node("trigger", "trigger_ticket_ai"),
+        node("finish", "terminate", { terminalStatus: "done" }),
+      ],
+      edges: [{ from: "trigger", to: "finish" }],
+    } as unknown as WorkflowDefinitionV1;
+
+    const result = convert(definition);
+
+    expect(result.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "migration.definition.unknown_configuration",
+          path: "/repositoryPin",
+        }),
+      ]),
+    );
+    expect(result.blockers.map(({ path }) => path)).not.toContain("/repositoryScope");
+  });
+
   it("is byte-deterministic and incorporates exact source identity into ids and hash", () => {
     const definition: WorkflowDefinitionV1 = {
       schemaVersion: 1,

--- a/apps/worker/src/workflow-definition/v2-converter.ts
+++ b/apps/worker/src/workflow-definition/v2-converter.ts
@@ -256,6 +256,9 @@ export function convertWorkflowDefinitionV1ToV2(
     ...(input.definition.budgets === undefined
       ? {}
       : { budgets: structuredClone(input.definition.budgets) }),
+    ...(input.definition.repositoryScope === undefined
+      ? {}
+      : { repositoryScope: structuredClone(input.definition.repositoryScope) }),
     nodes,
     edges,
   };
@@ -301,7 +304,7 @@ export function convertWorkflowDefinitionV1ToV2(
 function inspectDefinitionEnvelope(state: ConversionState): void {
   const definition = state.input.definition as WorkflowDefinitionV1 & Record<string, unknown>;
   for (const key of Object.keys(definition)) {
-    if (!["schemaVersion", "budgets", "nodes", "edges"].includes(key)) {
+    if (!["schemaVersion", "budgets", "repositoryScope", "nodes", "edges"].includes(key)) {
       addDiagnostic(
         state,
         "blocker",

--- a/apps/worker/src/workflow-definition/v2-migration.test.ts
+++ b/apps/worker/src/workflow-definition/v2-migration.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../env.js", () => ({
+  env: {
+    AGENT_KIND: "claude",
+    CLAUDE_MODEL: "claude-test",
+    CODEX_MODEL: "codex-test",
+    ANTHROPIC_API_KEY: "sk-ant-test",
+    CODEX_API_KEY: "sk-codex-test",
+    GITHUB_APP_ID: 1,
+    GITHUB_APP_PRIVATE_KEY: "private-key",
+    GITHUB_INSTALLATION_ID: 2,
+    GITLAB_TOKEN: "gitlab-token",
+    CHAT_SDK_SLACK_TOKEN: "slack-token",
+    CHAT_SDK_CHANNEL_ID: "channel",
+    GENAI_ENGINE_API_KEY: "arthur-key",
+    GENAI_ENGINE_TRACE_ENDPOINT: "https://arthur.example/traces",
+  },
+}));
+
+import { inspectRawWorkflowDefinitionV1Migration } from "./v2-migration.js";
+
+function rawDefinition(extra: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    nodes: [
+      { id: "trigger", type: "trigger_ticket_ai", x: 0, y: 0, params: {}, inputs: {} },
+      { id: "finish", type: "terminate", x: 0, y: 0, params: { terminalStatus: "done" }, inputs: {} },
+    ],
+    edges: [{ from: "trigger", to: "finish" }],
+    ...extra,
+  };
+}
+
+describe("inspectRawWorkflowDefinitionV1Migration", () => {
+  it("does not reject a stored definition carrying a pinned repository scope", () => {
+    const preflight = inspectRawWorkflowDefinitionV1Migration(
+      rawDefinition({
+        repositoryScope: {
+          repositories: [
+            { provider: "github", repoPath: "Acme/Web" },
+            { provider: "gitlab", repoPath: "acme/group/api" },
+          ],
+          providers: ["github", "gitlab"],
+        },
+      }),
+    );
+
+    expect(preflight.blockers).toEqual([]);
+  });
+
+  it("does not reject a stored definition that lacks a repository scope", () => {
+    expect(inspectRawWorkflowDefinitionV1Migration(rawDefinition()).blockers).toEqual([]);
+  });
+
+  it("still rejects an unknown top-level field next to a repository scope", () => {
+    const preflight = inspectRawWorkflowDefinitionV1Migration(
+      rawDefinition({
+        repositoryScope: { providers: ["github"] },
+        repositoryPin: { providers: ["github"] },
+      }),
+    );
+
+    expect(preflight.blockers).toEqual([
+      expect.objectContaining({
+        code: "migration.source.unknown_top_level_field",
+        path: "/repositoryPin",
+      }),
+    ]);
+  });
+});

--- a/apps/worker/src/workflow-definition/v2-migration.ts
+++ b/apps/worker/src/workflow-definition/v2-migration.ts
@@ -410,6 +410,7 @@ interface RawMigrationPreflight {
 const RAW_DEFINITION_FIELDS = new Set([
   "schemaVersion",
   "budgets",
+  "repositoryScope",
   "nodes",
   "edges",
 ]);

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -170,6 +170,7 @@ import type {
   ReplaySanitizedEnvelope,
   ResolvedPromptReference,
   TransformConfiguration,
+  VcsProviderKind,
   WorkflowBlockType,
   WorkflowBlockTypeV1,
   WorkflowDefinition,
@@ -1325,7 +1326,13 @@ async function parseRepositoryDiscoveryStep(
   };
 }
 
-async function listFreshRepositoryCatalogStep() {
+/**
+ * Fresh server-owned catalog for model expansion. A definition pin narrows it by
+ * PROVIDER only: restricting it to the pinned repositories would kill the bounded
+ * expansion a pinned run is explicitly allowed to keep (the shared-components
+ * case), which every downstream gate still bounds.
+ */
+async function listFreshRepositoryCatalogStep(pinnedProviders?: VcsProviderKind[]) {
   "use step";
   const { getConfiguredVcsProviders } = await import("../../env.js");
   const { createRepositoryDirectoryForProviders } = await import(
@@ -1336,11 +1343,21 @@ async function listFreshRepositoryCatalogStep() {
   );
   return buildRepositoryCatalog(
     await createRepositoryDirectoryForProviders(
-      getConfiguredVcsProviders(),
+      pinnedProviderConfigs(getConfiguredVcsProviders(), pinnedProviders),
     ).listRepositories(),
   );
 }
 listFreshRepositoryCatalogStep.maxRetries = 0;
+
+/** Provider-config intersection used by both expansion catalogs. Empty or absent
+ *  pinned providers leave the configured set untouched. */
+function pinnedProviderConfigs<T extends { kind: VcsProviderKind }>(
+  configured: T[],
+  pinnedProviders: VcsProviderKind[] | undefined,
+): T[] {
+  if (!pinnedProviders || pinnedProviders.length === 0) return configured;
+  return configured.filter((provider) => pinnedProviders.includes(provider.kind));
+}
 
 async function attachResearchRepositoriesStep(
   sandboxId: string,
@@ -1425,6 +1442,7 @@ attachResearchRepositoriesStep.maxRetries = 0;
 async function resolveHumanRepositoryExpansionStep(
   answer: string,
   attached: Array<{ provider: "github" | "gitlab"; repoPath: string }>,
+  pinnedProviders?: VcsProviderKind[],
 ): Promise<RepositoryExpansionDecision> {
   "use step";
   const { getConfiguredVcsProviders } = await import("../../env.js");
@@ -1440,7 +1458,7 @@ async function resolveHumanRepositoryExpansionStep(
   );
   const catalog = buildRepositoryCatalog(
     await createRepositoryDirectoryForProviders(
-      getConfiguredVcsProviders(),
+      pinnedProviderConfigs(getConfiguredVcsProviders(), pinnedProviders),
     ).listRepositories(),
   );
   return validateHumanRepositoryExpansion({
@@ -3040,6 +3058,7 @@ async function agentWorkflowBody(
       selectedRepositories: [],
       repositoryContexts: [],
       repositoryDiscovery: null,
+      ...(plan.repositoryScope ? { repositoryScope: plan.repositoryScope } : {}),
       repositoryExpansion: { rounds: 0, priorRequests: [] },
       researchWriteRepositories: [],
       preSandboxAdditions: {
@@ -3540,7 +3559,9 @@ async function agentWorkflowBody(
         );
         const decision = validateRepositoryExpansionRequests({
           requests,
-          catalog: await listFreshRepositoryCatalogStep(),
+          catalog: await listFreshRepositoryCatalogStep(
+            ctx.repositoryScope?.providers,
+          ),
           attached: ctx.selectedRepositories,
           completedRounds: ctx.repositoryExpansion.rounds,
         });
@@ -3625,6 +3646,7 @@ async function agentWorkflowBody(
         }
         if (!ctx.sandboxId) return { kind: "exit", result: noWorkspace("prepare_workspace") };
         if (!repositorySelectionObserved) {
+          const narrowing = ctx.repositoryScopeNarrowing;
           await emitRepositoryWorkflowObservation(execution?.observations, {
             event: "selection",
             source:
@@ -3632,11 +3654,15 @@ async function agentWorkflowBody(
                 ? "approved"
                 : ctx.entry.kind === "pr_trigger"
                   ? "pr_trigger"
-                  : "metadata",
+                  : (ctx.repositoryScope?.repositories?.length ?? 0) > 0
+                    ? "definition_pin"
+                    : "metadata",
             catalogSize:
+              narrowing?.catalogSize ??
               ctx.repositoryDiscovery?.catalog.length ??
               ctx.selectedRepositories.length,
             selectedCount: ctx.selectedRepositories.length,
+            ...(narrowing ? { scopedCatalogSize: narrowing.scopedCatalogSize } : {}),
           });
           repositorySelectionObserved = true;
         }
@@ -3775,7 +3801,11 @@ async function agentWorkflowBody(
             // so the re-run reflects the newly attached repositories.
             const humanExpansion = await applyHumanRepositoryExpansion(ctx, {
               resolve: (answer, attached) =>
-                resolveHumanRepositoryExpansionStep(answer, attached),
+                resolveHumanRepositoryExpansionStep(
+                  answer,
+                  attached,
+                  ctx.repositoryScope?.providers,
+                ),
               attach: (repositories) => {
                 if (!ctx.sandboxId || ctx.workspaceManifest?.version !== 2) {
                   throw new Error(

--- a/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
@@ -62,7 +62,12 @@ vi.mock("../../lib/vcs-runtime.js", () => ({
     getBranchShaIfExists: mocks.getBranchShaIfExists,
   }),
 }));
-vi.mock("../../adapters/vcs/repository-directory.js", () => ({
+// The pin predicate is a pure helper in the same module and stays real; only the
+// network-backed directory is stubbed.
+vi.mock("../../adapters/vcs/repository-directory.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../adapters/vcs/repository-directory.js")
+  >()),
   createRepositoryDirectoryForProviders: () => ({
     listRepositories: mocks.listRepositories,
   }),
@@ -1019,6 +1024,75 @@ describe("prepare_workspace execute", () => {
       expect(result.error.detail).not.toContain("replan required");
     }
     expect(mocks.provisionMultiRepo).not.toHaveBeenCalled();
+  });
+
+  it("requires replanning when the pin no longer covers the approved scope", async () => {
+    mocks.listRepositories.mockResolvedValue([availableApiRepo()]);
+    const result = await execute(
+      makeNode("prepare_workspace"),
+      {},
+      makeCtx({
+        sandboxId: null,
+        entry: approvedScopeEntry(validApprovedScope),
+        repositoryScope: {
+          repositories: [{ provider: "github", repoPath: "acme/web" }],
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain(
+        "outside the repositories pinned to this workflow",
+      );
+      expect(result.error.detail).toContain("replan required");
+    }
+    expect(mocks.getBranchShaIfExists).not.toHaveBeenCalled();
+  });
+
+  it("keeps an approved scope the pin still covers", async () => {
+    mocks.listRepositories.mockResolvedValue([availableApiRepo()]);
+    mocks.blockFetchPrContextsStep.mockResolvedValue(contextsFor(repo));
+    const result = await execute(
+      makeNode("prepare_workspace"),
+      {},
+      makeCtx({
+        sandboxId: null,
+        entry: approvedScopeEntry(validApprovedScope),
+        // Stored in the operator's case; the comparison is case-insensitive.
+        repositoryScope: {
+          repositories: [{ provider: "github", repoPath: "Acme/API" }],
+        },
+      }),
+    );
+
+    expect(result.kind).toBe("next");
+  });
+
+  it("passes the definition pin into the pre-sandbox phase and records its narrowing", async () => {
+    mocks.runPreSandboxPhase.mockResolvedValue({
+      status: "continue",
+      promptAdditions: { research: [], implementation: [], review: [] },
+      selectedRepositories: [repo],
+      repositoryScopeNarrowing: { catalogSize: 4, scopedCatalogSize: 1 },
+    });
+    mocks.blockFetchPrContextsStep.mockResolvedValue(contextsFor(repo));
+    const repositoryScope = {
+      repositories: [{ provider: "github" as const, repoPath: "acme/api" }],
+    };
+    const ctx = makeCtx({ sandboxId: null, repositoryScope });
+
+    await execute(makeNode("prepare_workspace"), {}, ctx);
+
+    expect(mocks.runPreSandboxPhase).toHaveBeenCalledWith({
+      ticket: expect.objectContaining({ identifier: "AWT-1" }),
+      run: { branchName: "blazebot/awt-1" },
+      repositoryScope,
+    });
+    expect(ctx.repositoryScopeNarrowing).toEqual({
+      catalogSize: 4,
+      scopedCatalogSize: 1,
+    });
   });
 
   it("prepares a review-only human PR without creating a workflow branch", async () => {

--- a/apps/worker/src/workflows/blocks/prepare-workspace.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.ts
@@ -25,8 +25,14 @@ import {
 } from "./types.js";
 import type { BlockExecutionContext } from "../../workflow-definition/interpreter.js";
 import type { ResolvedHarnessRuntime } from "../../sandbox/harness-runtime.js";
-import type { PreSandboxRepositoryDiscovery } from "../../pre-sandbox/types.js";
-import type { ApprovedRepositoryScope } from "@shared/contracts";
+import type {
+  PreSandboxRepositoryDiscovery,
+  PreSandboxRepositoryScopeNarrowing,
+} from "../../pre-sandbox/types.js";
+import type {
+  ApprovedRepositoryScope,
+  WorkflowRepositoryScope,
+} from "@shared/contracts";
 
 export const paramsSchema = z.object({}).strict();
 
@@ -40,6 +46,7 @@ interface PreSandboxTicketContext {
     labels: string[];
   };
   run: { branchName: string };
+  repositoryScope?: WorkflowRepositoryScope;
 }
 
 interface WorkspaceAgentRuntime {
@@ -54,6 +61,7 @@ type PreSandboxOutcome =
       promptAdditions?: PreSandboxPromptAdditionsByTarget;
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
+      repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
     }
   | {
       status: "halt";
@@ -63,6 +71,7 @@ type PreSandboxOutcome =
       promptAdditions?: PreSandboxPromptAdditionsByTarget;
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
+      repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
     };
 
 async function blockPrepareWorkspacePreSandboxStep(
@@ -97,6 +106,7 @@ const approvedRepositoryScopeSchema = z.object({
 async function blockApprovedRepositoryScopeStep(
   ticketKey: string,
   scope: ApprovedRepositoryScope,
+  pinnedScope: WorkflowRepositoryScope | null,
 ): Promise<SelectedRepository[]> {
   "use step";
   const parsed = approvedRepositoryScopeSchema.safeParse(scope);
@@ -107,9 +117,8 @@ async function blockApprovedRepositoryScopeStep(
   }
   scope = parsed.data;
   const { getConfiguredVcsProviders } = await import("../../../env.js");
-  const { createRepositoryDirectoryForProviders } = await import(
-    "../../adapters/vcs/repository-directory.js"
-  );
+  const { createRepositoryDirectoryForProviders, isRepositoryWithinPinnedScope } =
+    await import("../../adapters/vcs/repository-directory.js");
   const { createRepositoryVCS } = await import("../../lib/vcs-runtime.js");
   const { getDb } = await import("../../db/client.js");
   const { listWorkflowOwnedBranchesForTicket } = await import(
@@ -133,6 +142,14 @@ async function blockApprovedRepositoryScopeStep(
       throw new Error(`Approved repository scope duplicates ${key}; replan required`);
     }
     seen.add(key);
+    // Here the pin is a control, never a filter. A human already approved this
+    // exact scope, so a pin that no longer covers it must force a replan instead
+    // of silently narrowing what was reviewed and approved.
+    if (pinnedScope && !isRepositoryWithinPinnedScope(pinnedScope, approved)) {
+      throw new Error(
+        `Approved repository ${key} is outside the repositories pinned to this workflow; replan required`,
+      );
+    }
     const current = byKey.get(key);
     if (!current) {
       throw new Error(`Approved repository ${key} is unavailable or no longer allowed; replan required`);
@@ -605,6 +622,7 @@ export async function ensureWorkspace(
       selected = await blockApprovedRepositoryScopeStep(
         ctx.ticket.identifier,
         scope,
+        ctx.repositoryScope ?? null,
       );
       approvedBaselineByKey = new Map(
         scope.repositories.map((repository) => [
@@ -633,7 +651,11 @@ export async function ensureWorkspace(
           labels: ctx.ticket.labels,
         },
         run: { branchName: ctx.branchName },
+        ...(ctx.repositoryScope ? { repositoryScope: ctx.repositoryScope } : {}),
       });
+      if (preSandbox.repositoryScopeNarrowing) {
+        ctx.repositoryScopeNarrowing = preSandbox.repositoryScopeNarrowing;
+      }
       if (preSandbox.status === "halt") {
         if (preSandbox.outcome === "needs_clarification") {
           const parsed = (preSandbox.questions ?? []).filter((q) => q.trim().length > 0);

--- a/apps/worker/src/workflows/blocks/types.ts
+++ b/apps/worker/src/workflows/blocks/types.ts
@@ -1,6 +1,7 @@
 import type {
   WorkflowDefinitionNode,
   WorkflowDefinitionV2Node,
+  WorkflowRepositoryScope,
 } from "@shared/contracts";
 import type {
   BlockExecutionContext,
@@ -28,7 +29,10 @@ import type { AgentWorkflowInput } from "../agent-input.js";
 import type { RunBudgetObservation } from "../run-budget.js";
 import type { WorkspaceGate } from "../workspace-gate.js";
 import type { ResolvedHarnessRuntime } from "../../sandbox/harness-runtime.js";
-import type { PreSandboxRepositoryDiscovery } from "../../pre-sandbox/types.js";
+import type {
+  PreSandboxRepositoryDiscovery,
+  PreSandboxRepositoryScopeNarrowing,
+} from "../../pre-sandbox/types.js";
 import type { ResearchRepository } from "../../sandbox/agents/types.js";
 
 /**
@@ -39,7 +43,7 @@ import type { ResearchRepository } from "../../sandbox/agents/types.js";
  * Mutation contract (executors write back through the shared object):
  * - prepare_workspace sets `sandboxId` (and appends to `sandboxIds`),
  *   `workspaceManifest`, `selectedRepositories`, `repositoryContexts`,
- *   `preSandboxAdditions`, and `arthur.taskId`.
+ *   `preSandboxAdditions`, `repositoryScopeNarrowing`, and `arthur.taskId`.
  * - fetch_pr_context refreshes `repositoryContexts`.
  * - finalize_workspace sets `publication`.
  * All other fields are read-only from the executors' perspective.
@@ -102,6 +106,13 @@ export interface EngineCtx {
   repositoryContexts: SelectedRepositoryPromptContext[];
   /** Server-authored catalog and mandatory scope used for model-assisted selection. */
   repositoryDiscovery: PreSandboxRepositoryDiscovery | null;
+  /** Repositories pinned to the definition, inherited by every run it dispatches.
+   *  Absent when the operator pinned none, which keeps unpinned runs on exactly
+   *  their pre-pin path. */
+  repositoryScope?: WorkflowRepositoryScope;
+  /** Catalog sizes observed when the pin narrowed selection; absent without a
+   *  pin. Telemetry only, never a selection input. */
+  repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
   /** Bounded expansion state retained across planner reruns and clarification replay. */
   repositoryExpansion: {
     rounds: number;

--- a/apps/worker/src/workflows/definition-step.test.ts
+++ b/apps/worker/src/workflows/definition-step.test.ts
@@ -189,6 +189,50 @@ describe("loadWorkflowDefinition", () => {
     expect(plan.budgets).toEqual({ maxDurationMs: 12_000, maxTokens: 500, maxCostUsd: 1.25 });
   });
 
+  it("preserves a pinned repository scope in the loaded plan", async () => {
+    const repositoryScope = {
+      repositories: [
+        { provider: "github" as const, repoPath: "Acme/Web" },
+        { provider: "gitlab" as const, repoPath: "acme/group/api" },
+      ],
+      providers: ["github" as const, "gitlab" as const],
+    };
+    const definition = {
+      ...defaultWorkflowDefinition({ includeReview: false }),
+      repositoryScope,
+    };
+    mockGetEnabled.mockResolvedValue(enabled(definition, 8, 4));
+
+    const plan = await loadWorkflowDefinition();
+
+    expect(plan.repositoryScope).toEqual(repositoryScope);
+  });
+
+  it("leaves repositoryScope absent for a definition without a pin", async () => {
+    mockGetEnabled.mockResolvedValue(
+      enabled(defaultWorkflowDefinition({ includeReview: false }), 8, 4),
+    );
+
+    const plan = await loadWorkflowDefinition();
+
+    expect(plan.repositoryScope).toBeUndefined();
+    expect("repositoryScope" in plan).toBe(false);
+  });
+
+  it("preserves a pinned repository scope on a v2 plan", async () => {
+    const repositoryScope = { providers: ["gitlab" as const] };
+    const definition: WorkflowDefinitionV2 = {
+      ...defaultWorkflowDefinitionV2({ includeReview: false }),
+      repositoryScope,
+    };
+    mockGetEnabled.mockResolvedValue(enabled(definition, 11, 6));
+
+    const plan = await loadWorkflowDefinition();
+
+    expect(plan.schemaVersion).toBe(2);
+    expect(plan.repositoryScope).toEqual(repositoryScope);
+  });
+
   it("reflects reviewEnabled=false for a valid stored definition without a review block", async () => {
     mockGetEnabled.mockResolvedValue(enabled(defaultWorkflowDefinition({ includeReview: false }), 4, 2));
     const plan = await loadWorkflowDefinition();

--- a/apps/worker/src/workflows/definition-step.ts
+++ b/apps/worker/src/workflows/definition-step.ts
@@ -1,5 +1,6 @@
 import type {
   WorkflowExecutionBudgets,
+  WorkflowRepositoryScope,
   WorkflowBlockType,
   WorkflowDefinition,
   WorkflowDefinitionV1,
@@ -26,6 +27,8 @@ export interface LoadedWorkflowPlan {
   edges: WorkflowDefinitionEdge[];
   reviewEnabled: boolean;
   budgets?: WorkflowExecutionBudgets;
+  /** Repositories pinned to the definition, inherited by every run it dispatches. */
+  repositoryScope?: WorkflowRepositoryScope;
 }
 
 interface ZodLikeError extends Error {
@@ -131,6 +134,7 @@ export async function loadWorkflowDefinitionFor(
       edges: normalized.edges,
       reviewEnabled: def.nodes.some((node) => node.type === "review_agent"),
       ...(def.budgets ? { budgets: def.budgets } : {}),
+      ...(def.repositoryScope ? { repositoryScope: def.repositoryScope } : {}),
     };
   };
 

--- a/apps/worker/src/workflows/multi-repo-research.test.ts
+++ b/apps/worker/src/workflows/multi-repo-research.test.ts
@@ -63,6 +63,7 @@ import {
   validateRepositoryExpansionRequests,
 } from "../repository-discovery/runner.js";
 import type { RepositoryCatalogEntry } from "../repository-discovery/catalog.js";
+import { filterPinnedRepositories } from "../adapters/vcs/repository-directory.js";
 import type { WorkspaceManifest } from "../sandbox/repo-workspace.js";
 import { workspaceRepositoryAccess } from "../sandbox/repo-workspace.js";
 import { publishTrustedWorkspaceFromSandbox } from "../sandbox/trusted-workspace-publisher.js";
@@ -232,6 +233,77 @@ describe("multi-repository research workflow scenarios", () => {
       prs: [{ id: 21, repoPath: "acme/shared/contracts" }],
     });
     expect(mocks.createPr).toHaveBeenCalledTimes(1);
+  });
+
+  // A definition pin attaches its repositories from the start but must not close
+  // the shared-owner expansion: the expansion catalog is narrowed by PROVIDER
+  // only, never to the pinned repository list, and every round limit still holds.
+  it("still expands to a non-pinned repository under a definition pin", () => {
+    const pinnedScope = {
+      providers: ["github" as const, "gitlab" as const],
+      repositories: [{ provider: "github" as const, repoPath: "acme/service" }],
+    };
+    const expansionCatalog = filterPinnedRepositories(catalog, {
+      providers: pinnedScope.providers,
+    });
+    expect(expansionCatalog).toHaveLength(catalog.length);
+
+    expect(
+      validateRepositoryExpansionRequests({
+        requests: [
+          {
+            provider: "gitlab",
+            repoPath: "acme/shared/contracts",
+            rationale: "service imports this schema",
+          },
+        ],
+        catalog: expansionCatalog,
+        attached: [{ provider: "github", repoPath: "acme/service" }],
+        completedRounds: 1,
+      }),
+    ).toMatchObject({
+      kind: "attach",
+      repositories: [{ provider: "gitlab", repoPath: "acme/shared/contracts" }],
+    });
+
+    // The pin changes neither the round limit nor the catalog membership rule.
+    expect(
+      validateRepositoryExpansionRequests({
+        requests: [
+          {
+            provider: "gitlab",
+            repoPath: "acme/shared/contracts",
+            rationale: "late request",
+          },
+        ],
+        catalog: expansionCatalog,
+        attached: [{ provider: "github", repoPath: "acme/service" }],
+        completedRounds: 2,
+      }),
+    ).toMatchObject({ kind: "clarification_needed" });
+  });
+
+  it("narrows the expansion catalog to the pinned providers", () => {
+    const gitlabOnly = filterPinnedRepositories(catalog, { providers: ["gitlab"] });
+    expect(gitlabOnly.map((entry) => entry.provider)).toEqual(["gitlab", "gitlab"]);
+
+    expect(
+      validateRepositoryExpansionRequests({
+        requests: [
+          {
+            provider: "github",
+            repoPath: "acme/service",
+            rationale: "excluded provider",
+          },
+        ],
+        catalog: gitlabOnly,
+        attached: [{ provider: "gitlab", repoPath: "acme/service" }],
+        completedRounds: 0,
+      }),
+    ).toMatchObject({
+      kind: "clarification_needed",
+      questions: [expect.stringContaining("unavailable repository github:acme/service")],
+    });
   });
 
   it("turns a third expansion round into targeted clarification", () => {


### PR DESCRIPTION
## Why

Today every ticket entering a workflow resolves its own repository: deterministic signals from the ticket text, then model-driven discovery, then a clarification question to a human. For a team whose work always lands in the same one or two repositories that is a question they answer over and over, and a run that guesses wrong wastes a full cycle. It is worse with closed-source GitLab work, where the ticket text often names nothing the catalog can match.

This adds an operator-level binding: pin repositories to a workflow once, and every ticket entering that workflow inherits them.

## What it does

A new optional definition-level field, modelled 1:1 on the existing `budgets` setting, so it flows through every version, migration, and snapshot path that already exists:

```ts
repositoryScope?: {
  repositories?: Array<{ provider: "github" | "gitlab"; repoPath: string }>;  // max 8, unique case-insensitively
  providers?: Array<"github" | "gitlab">;                                     // non-empty when present
}
```

Absent or empty means exactly today's behavior, byte for byte. No SQL migration: the definition column is already `jsonb`.

**In a run**, the pin is Signal 0 in repository selection, ahead of every existing signal, so a pinned workflow resolves to `selected` and never asks which repository to use. Product decision from the team: pinned repositories are the starting set, not a cage. Research can still expand to other allowed repositories within the existing limits (2 rounds, 3 per round, 8 total), which is what keeps the shared-components case working, so the model-facing catalog is narrowed by **provider only**, never by the repository list.

**On triggers**, PR and MR deliveries outside the pin are ignored before anything is written to the inbox, which is what stops a workflow from waking up on every pull request in the organization. Workflow-owned subjects are deliberately exempt: the ownership check already proves we published that branch, and filtering them would strand every open workflow PR the moment an operator edits a pin.

**In the editor**, a Repositories bar under the execution limits bar, with a picker fed by the existing catalog endpoint, provider pills, and a toolbar chip so the binding is visible without opening the bar. No new endpoint and no new save path.

## Boundaries the pin does not cross

The pin is operator convenience over a security boundary, never a replacement for it. It composes as a pure intersection **after** `filterAllowedRepositories`, so it can only ever narrow what the server already offered. Untouched: the catalog's 200-entry bound and path validation, validation of model answers against the server catalog, expansion limits, the allowlist rechecks before clone, before promotion, and three times before publication, and the eight-repository workspace gate. On the approved-plan path the pin acts as a control only: a pin that no longer covers an approved scope raises the existing "replan required" error rather than silently dropping a repository a human approved.

Deploy-time validation is wired in one place, `validateWorkflowDefinitionIssuesForDeployment`, so the editor, the deploy gate, and the v1-to-v2 migration all see it. Two failures are separated by kind: pinned providers that are not configured on the server are environment state and are skipped where environment checks are, while repositories contradicting the pin's own provider list are definition-local and always fail closed.

## Verification

- `apps/worker`: full suite, **3173 tests, 811 suites, 0 failures**. 41 new tests cover the pin as Signal 0, more than three pinned repositories not tripping the ambiguity clarification, an unusable pinned repository producing a clarification that names it instead of silently falling through to discovery, a workflow-owned branch outside the pin still attaching, the allowlist winning over the pin, provider-only narrowing leaving expansion intact, the contradiction as a validation issue, the migration blocker, case-insensitive matching, and an explicit no-pin regression path.
- `apps/dashboard`: **583 tests, 0 failures**, including a behavior suite that drives the real handlers rather than asserting markup.
- Both typechecks clean. Fresh `nitro build`: 140 steps, 9 workflows, and every step id referenced by the flow bundle is registered in the step bundle.

## Review notes

Two rounds of adversarial review found four defects the tests had missed, all fixed with regression tests: the bar rendered a factually false summary when the pinned providers contradicted a pinned repository, the picker silently dropped selections made under a previous filter, an amber "catalog does not list this" warning flashed on every editor open before the catalog settled, and a healthy-but-empty catalog left the operator with no way to pin anything.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository pinning for workflows, including GitHub and GitLab repository selection.
  * Added repository scope controls, filtering, provider toggles, warnings, and read-only support in the workflow editor.
  * Preserved repository scope through workflow saving, deployment, migration, and schema conversion.
  * Enforced pinned repository scope during trigger handling, manual dispatch, repository discovery, and workspace preparation.
  * Added repository catalog loading, refresh, outage handling, and narrowed-catalog feedback.
* **Bug Fixes**
  * Prevented out-of-scope repositories and pull requests from being selected or dispatched.
  * Added validation for invalid, duplicate, contradictory, or unavailable repository pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->