### PR TITLE
AIW-182 AIW-187: capability-driven Harness Profiles

### DIFF
--- a/apps/dashboard/app/api/harness-capabilities/handler.test.ts
+++ b/apps/dashboard/app/api/harness-capabilities/handler.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { handleHarnessCapabilitiesGet } from "./handler";
+
+test("capability proxy forwards only normalized supported query values", async () => {
+  const paths: string[] = [];
+  const response = await handleHarnessCapabilitiesGet(
+    new Request(
+      "https://dashboard.test/api/harness-capabilities?provider=codex&cliVersion=0.144.6&refresh=1&unsafe=value",
+    ),
+    async (path, init) => {
+      paths.push(`${init?.method}:${path}`);
+      return Response.json({ stale: false }, { status: 200 });
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.deepEqual(paths, [
+    "GET:/api/v1/harness-capabilities?provider=codex&cliVersion=0.144.6&refresh=true",
+  ]);
+});
+
+test("capability proxy rejects invalid requests and preserves worker failures", async () => {
+  let forwarded = false;
+  const invalid = await handleHarnessCapabilitiesGet(
+    new Request(
+      "https://dashboard.test/api/harness-capabilities?provider=other&cliVersion=latest",
+    ),
+    async () => {
+      forwarded = true;
+      return Response.json({});
+    },
+  );
+  assert.equal(invalid.status, 400);
+  assert.equal(forwarded, false);
+
+  const failure = await handleHarnessCapabilitiesGet(
+    new Request(
+      "https://dashboard.test/api/harness-capabilities?provider=claude&cliVersion=2.1.216",
+    ),
+    async () => Response.json({ error: "Unavailable" }, { status: 503 }),
+  );
+  assert.equal(failure.status, 503);
+  assert.deepEqual(await failure.json(), { error: "Unavailable" });
+
+  const timeout = await handleHarnessCapabilitiesGet(
+    new Request(
+      "https://dashboard.test/api/harness-capabilities?provider=claude&cliVersion=2.1.216",
+    ),
+    async () => {
+      throw new DOMException("timed out", "TimeoutError");
+    },
+  );
+  assert.equal(timeout.status, 504);
+});

--- a/apps/dashboard/app/api/harness-capabilities/handler.ts
+++ b/apps/dashboard/app/api/harness-capabilities/handler.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+
+type WorkerProxy = (path: string, init?: RequestInit) => Promise<Response>;
+
+export async function handleHarnessCapabilitiesGet(
+  request: Request,
+  workerProxy: WorkerProxy,
+) {
+  const source = new URL(request.url);
+  const provider = source.searchParams.get("provider");
+  const cliVersion = source.searchParams.get("cliVersion");
+  const refresh = source.searchParams.get("refresh");
+  if (
+    (provider !== "claude" && provider !== "codex") ||
+    !cliVersion ||
+    !/^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/.test(cliVersion)
+  ) {
+    return NextResponse.json(
+      { error: "Invalid capability request" },
+      { status: 400, headers: { "cache-control": "no-store" } },
+    );
+  }
+  const query = new URLSearchParams({ provider, cliVersion });
+  if (refresh === "1" || refresh === "true") {
+    query.set("refresh", "true");
+  }
+  try {
+    const response = await workerProxy(
+      `/api/v1/harness-capabilities?${query.toString()}`,
+      { method: "GET" },
+    );
+    return NextResponse.json(await response.json().catch(() => ({})), {
+      status: response.status,
+      headers: { "cache-control": "no-store" },
+    });
+  } catch (error) {
+    const candidate = error as { name?: unknown; code?: unknown };
+    if (candidate.name === "TimeoutError" || candidate.code === 23) {
+      return NextResponse.json(
+        { error: "Worker request timed out" },
+        { status: 504, headers: { "cache-control": "no-store" } },
+      );
+    }
+    throw error;
+  }
+}

--- a/apps/dashboard/app/api/harness-capabilities/route.ts
+++ b/apps/dashboard/app/api/harness-capabilities/route.ts
@@ -1,0 +1,6 @@
+import { proxyWorker } from "@/lib/api/proxy";
+import { handleHarnessCapabilitiesGet } from "./handler";
+
+export function GET(request: Request) {
+  return handleHarnessCapabilitiesGet(request, proxyWorker);
+}

--- a/apps/dashboard/components/cockpit/flow-editor/agent-harness-profile.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/agent-harness-profile.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { FlowNodeDef } from "@/lib/flows";
 import type {
-  HarnessProfileManifestV1,
+  HarnessProfileManifest,
   HarnessProfileReference,
   JsonValue,
   WorkflowEditorOptions,
@@ -93,7 +93,7 @@ function ManifestDetails({
   manifestHash,
 }: {
   node: FlowNodeDef;
-  manifest: HarnessProfileManifestV1;
+  manifest: HarnessProfileManifest;
   manifestHash: string;
 }) {
   const capabilities = previewHarnessCapabilities({
@@ -139,9 +139,28 @@ function ManifestDetails({
             ? "repository instructions (required)"
             : "repository instructions omitted (unsupported)"}
           {manifest.context.includeWorkflowData ? ", workflow data" : ""}
-          {" · "}compaction: provider default (fixed)
+          {" · "}compaction:{" "}
+          {manifest.schemaVersion === 1
+            ? "provider default"
+            : manifest.compaction.mode === "model_default"
+              ? "model default"
+              : manifest.compaction.mode === "disabled"
+                ? "disabled"
+                : `${manifest.compaction.thresholdPercent}% (${manifest.compaction.thresholdTokens} tokens)`}
         </div>
-        <div>Model options: provider default (fixed)</div>
+        <div>
+          Reasoning:{" "}
+          {manifest.schemaVersion === 1
+            ? "provider default"
+            : manifest.model.reasoning.effectiveEffort}
+          {manifest.schemaVersion === 2
+            ? ` · speed: ${manifest.model.serviceTier}${
+                manifest.model.verbosity
+                  ? ` · verbosity: ${manifest.model.verbosity}`
+                  : ""
+              }`
+            : ""}
+        </div>
         <div>
           {limitLabel("duration", manifest.limits.maxDurationMs, " ms")}
           {" · "}

--- a/apps/dashboard/components/cockpit/harness-profiles/profile-editor.tsx
+++ b/apps/dashboard/components/cockpit/harness-profiles/profile-editor.tsx
@@ -8,6 +8,7 @@ import { SkillImport } from "./skill-import";
 import {
   canEditProfile,
   isProfileSlug,
+  newProfileDraft,
   upgradeProfileDraft,
   withHarnessProvider,
 } from "@/lib/harness-profiles/editor";
@@ -23,7 +24,7 @@ import type {
   HarnessProfileSkillReference,
   HarnessSkillArtifact,
 } from "@shared/contracts";
-import { HARNESS_TOOL_IDS } from "@shared/contracts";
+import { HARNESS_TOOL_IDS, stableJson } from "@shared/contracts";
 
 const inputClass =
   "h-[30px] w-full rounded-[3px] border border-neutral-200 bg-white px-2 font-mono text-[11px] text-coal outline-none focus:border-mariner disabled:bg-app-bg disabled:opacity-70";
@@ -314,8 +315,7 @@ export function ProfileEditor({
         capabilities.models.some(
           (model) =>
             model.id === draft.model.id &&
-            JSON.stringify(model) ===
-              JSON.stringify(draft.model.capability),
+            stableJson(model) === stableJson(draft.model.capability),
         )) &&
     draft.context.includeRepositoryInstructions &&
     (draft.compaction.mode !== "custom_threshold" ||
@@ -400,6 +400,57 @@ export function ProfileEditor({
       },
       compaction: { mode: "model_default" },
     }));
+  }
+
+  async function switchProvider(provider: HarnessProvider) {
+    if (provider === draft.harness.provider) return;
+    if (draft.schemaVersion === 1) {
+      const next = withHarnessProvider(draft, provider);
+      if (!next) return;
+      setDraft(next);
+      setHomeFilesSource(JSON.stringify(next.homeFiles, null, 2));
+      setHomeFilesError(false);
+      return;
+    }
+
+    const baseline = newProfileDraft(provider);
+    const query = new URLSearchParams({
+      provider,
+      cliVersion: baseline.harness.cliVersion,
+    });
+    setCapabilityLoading(true);
+    setCapabilityError(null);
+    try {
+      const response = await fetch(
+        `/api/harness-capabilities?${query.toString()}`,
+        { cache: "no-store" },
+      );
+      if (!response.ok) throw new Error(await readErrorMessage(response));
+      const targetCapabilities =
+        (await response.json()) as HarnessCapabilitiesResponse;
+      const next = withHarnessProvider(
+        draft,
+        provider,
+        targetCapabilities,
+      );
+      if (!next) {
+        throw new Error(
+          "The target provider capabilities do not include its default model.",
+        );
+      }
+      setCapabilities(targetCapabilities);
+      setDraft(next);
+      setHomeFilesSource(JSON.stringify(next.homeFiles, null, 2));
+      setHomeFilesError(false);
+    } catch (nextError) {
+      setCapabilityError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Harness capabilities are unavailable.",
+      );
+    } finally {
+      setCapabilityLoading(false);
+    }
   }
 
   function discardLocalChanges() {
@@ -1014,19 +1065,12 @@ export function ProfileEditor({
                   { value: "claude", label: "Claude" },
                 ]}
                 value={draft.harness.provider}
-                disabled={!editable}
+                disabled={!editable || capabilityLoading}
                 ariaLabel="Harness provider"
                 onChange={(providerValue) => {
                   const provider =
                     providerValue === "claude" ? "claude" : "codex";
-                  setDraft((current) => {
-                    const next = withHarnessProvider(current, provider);
-                    setHomeFilesSource(
-                      JSON.stringify(next.homeFiles, null, 2),
-                    );
-                    setHomeFilesError(false);
-                    return next;
-                  });
+                  void switchProvider(provider);
                 }}
               />
             </Field>
@@ -1329,8 +1373,13 @@ export function ProfileEditor({
               ) : (
                 <div className="flex flex-col gap-2">
                   <Listbox
-                    options={draft.model.capability.compactionModes.map(
-                      (modeValue) => ({
+                    options={draft.model.capability.compactionModes
+                      .filter(
+                        (modeValue) =>
+                          modeValue !== "custom_threshold" ||
+                          draft.model.capability.contextWindowTokens !== null,
+                      )
+                      .map((modeValue) => ({
                         value: modeValue,
                         label:
                           modeValue === "model_default"
@@ -1338,8 +1387,7 @@ export function ProfileEditor({
                             : modeValue === "custom_threshold"
                               ? "Custom threshold"
                               : "Disabled",
-                      }),
-                    )}
+                      }))}
                     value={draft.compaction.mode}
                     disabled={!editable || capabilities?.stale !== false}
                     ariaLabel="Compaction"
@@ -1362,20 +1410,19 @@ export function ProfileEditor({
                               }
                             : current,
                         );
-                      } else if (
-                        draft.model.capability.contextWindowTokens !== null
-                      ) {
+                      } else {
                         const thresholdPercent = 80;
                         setDraft((current) =>
-                          current.schemaVersion === 2
+                          current.schemaVersion === 2 &&
+                          current.model.capability.contextWindowTokens !== null
                             ? {
                                 ...current,
                                 compaction: {
                                   mode: "custom_threshold",
                                   thresholdPercent,
                                   thresholdTokens: Math.floor(
-                                    (draft.model.capability
-                                      .contextWindowTokens! *
+                                    (current.model.capability
+                                      .contextWindowTokens *
                                       thresholdPercent) /
                                       100,
                                   ),

--- a/apps/dashboard/components/cockpit/harness-profiles/profile-editor.tsx
+++ b/apps/dashboard/components/cockpit/harness-profiles/profile-editor.tsx
@@ -8,11 +8,16 @@ import { SkillImport } from "./skill-import";
 import {
   canEditProfile,
   isProfileSlug,
+  upgradeProfileDraft,
   withHarnessProvider,
 } from "@/lib/harness-profiles/editor";
+import { readErrorMessage } from "@/lib/api/error-message";
 import type {
+  HarnessCapabilitiesResponse,
+  HarnessModelCapability,
   HarnessProvider,
   HarnessProfileDetailResponse,
+  HarnessProfileDraftManifest,
   HarnessProfileDraftManifestV1,
   HarnessProfileDto,
   HarnessProfileSkillReference,
@@ -44,7 +49,7 @@ export interface ProfileEditorProps {
   canManageProfiles: boolean;
   busy: ProfileAction | null;
   error: string | null;
-  onSave: (draft: HarnessProfileDraftManifestV1) => Promise<void>;
+  onSave: (draft: HarnessProfileDraftManifest) => Promise<void>;
   onPublish: () => Promise<void>;
   onFork: (slug: string) => Promise<void>;
   onArchive: () => Promise<void>;
@@ -183,7 +188,7 @@ export function ProfileEditor({
   initialMode = "overview",
 }: ProfileEditorProps) {
   const profile = detail.profile;
-  const [draft, setDraft] = useState<HarnessProfileDraftManifestV1>(() =>
+  const [draft, setDraft] = useState<HarnessProfileDraftManifest>(() =>
     structuredClone(profile.draft),
   );
   const [homeFilesSource, setHomeFilesSource] = useState(() =>
@@ -212,6 +217,11 @@ export function ProfileEditor({
   const [importedArtifacts, setImportedArtifacts] = useState<
     Map<string, HarnessSkillArtifact>
   >(new Map());
+  const [capabilities, setCapabilities] =
+    useState<HarnessCapabilitiesResponse | null>(null);
+  const [capabilityError, setCapabilityError] = useState<string | null>(null);
+  const [capabilityLoading, setCapabilityLoading] = useState(false);
+  const [modelSearch, setModelSearch] = useState("");
 
   useEffect(() => {
     setDraft(structuredClone(profile.draft));
@@ -226,6 +236,59 @@ export function ProfileEditor({
     setEditSection("general");
     setImportedArtifacts(new Map());
   }, [profile.id, profile.draftRevision, profile.draft]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setCapabilityLoading(true);
+    setCapabilityError(null);
+    const query = new URLSearchParams({
+      provider: draft.harness.provider,
+      cliVersion: draft.harness.cliVersion,
+    });
+    void fetch(`/api/harness-capabilities?${query.toString()}`, {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(await readErrorMessage(response));
+        return response.json() as Promise<HarnessCapabilitiesResponse>;
+      })
+      .then((next) => {
+        if (!controller.signal.aborted) setCapabilities(next);
+      })
+      .catch((nextError: unknown) => {
+        if (
+          !controller.signal.aborted &&
+          !(nextError instanceof DOMException && nextError.name === "AbortError")
+        ) {
+          setCapabilities(null);
+          setCapabilityError(
+            nextError instanceof Error
+              ? nextError.message
+              : "Harness capabilities are unavailable.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setCapabilityLoading(false);
+      });
+    return () => controller.abort();
+  }, [draft.harness.cliVersion, draft.harness.provider]);
+
+  useEffect(() => {
+    if (
+      mode !== "edit" ||
+      draft.schemaVersion !== 1 ||
+      !capabilities ||
+      capabilities.stale ||
+      capabilities.provider !== draft.harness.provider ||
+      capabilities.cliVersion !== draft.harness.cliVersion
+    ) {
+      return;
+    }
+    const upgraded = upgradeProfileDraft(draft, capabilities);
+    if (upgraded) setDraft(upgraded);
+  }, [capabilities, draft, mode]);
 
   const editable = canEditProfile(profile, detail.canManageProfile);
   const hasCompleteRuntimeToolSet =
@@ -243,9 +306,27 @@ export function ProfileEditor({
     draft.harness.protocolVersion.trim() !== "" &&
     draft.model.id.trim() !== "" &&
     draft.model.id.trim().length <= 200 &&
-    Object.keys(draft.model.options).length === 0 &&
+    (draft.schemaVersion === 1
+      ? Object.keys(draft.model.options).length === 0
+      : capabilities !== null &&
+        !capabilities.stale &&
+        capabilities.catalogHash === draft.model.catalogHash &&
+        capabilities.models.some(
+          (model) =>
+            model.id === draft.model.id &&
+            JSON.stringify(model) ===
+              JSON.stringify(draft.model.capability),
+        )) &&
     draft.context.includeRepositoryInstructions &&
-    draft.compaction.mode === "provider_default" &&
+    (draft.compaction.mode !== "custom_threshold" ||
+      (draft.schemaVersion === 2 &&
+        draft.model.capability.contextWindowTokens !== null &&
+        draft.compaction.thresholdTokens ===
+          Math.floor(
+            (draft.model.capability.contextWindowTokens *
+              draft.compaction.thresholdPercent) /
+              100,
+          ))) &&
     draft.workspace.mode === "managed" &&
     hasCompleteRuntimeToolSet &&
     draft.mcpIntegrations.length === 0 &&
@@ -268,13 +349,57 @@ export function ProfileEditor({
         draft.limits.maxCostUsd <= 100_000));
   const published = detail.published;
   const usage = detail.usage ?? [];
+  const catalogModels =
+    capabilities?.provider === draft.harness.provider &&
+    capabilities.cliVersion === draft.harness.cliVersion
+      ? capabilities.models
+      : [];
+  const filteredModels = catalogModels.filter((model) => {
+    const query = modelSearch.trim().toLowerCase();
+    return (
+      query === "" ||
+      model.id.toLowerCase().includes(query) ||
+      model.name.toLowerCase().includes(query) ||
+      model.description?.toLowerCase().includes(query)
+    );
+  });
 
   useEffect(() => {
     onDirtyChange?.(dirty);
   }, [dirty, onDirtyChange]);
 
-  function update(next: Partial<HarnessProfileDraftManifestV1>) {
-    setDraft((current) => ({ ...current, ...next }));
+  function update(next: Partial<HarnessProfileDraftManifest>) {
+    setDraft(
+      (current) =>
+        ({ ...current, ...next }) as HarnessProfileDraftManifest,
+    );
+  }
+
+  function selectModel(model: HarnessModelCapability) {
+    if (!capabilities || capabilities.stale) return;
+    const effort =
+      model.defaultReasoningEffort ?? model.reasoningEfforts[0]?.id;
+    const serviceTier =
+      model.defaultServiceTier ?? model.serviceTiers[0]?.id;
+    if (!effort || !serviceTier) return;
+    setDraft((current) => ({
+      ...current,
+      schemaVersion: 2,
+      model: {
+        id: model.id,
+        reasoning: {
+          selection: "model_default",
+          effectiveEffort: effort,
+        },
+        serviceTier,
+        ...(model.defaultVerbosity
+          ? { verbosity: model.defaultVerbosity }
+          : {}),
+        capability: structuredClone(model),
+        catalogHash: capabilities.catalogHash,
+      },
+      compaction: { mode: "model_default" },
+    }));
   }
 
   function discardLocalChanges() {
@@ -503,7 +628,24 @@ export function ProfileEditor({
                       "Workflow data",
                       draft.context.includeWorkflowData ? "Included" : "Excluded",
                     ],
-                    ["Compaction", "Provider default"],
+                    [
+                      "Compaction",
+                      draft.schemaVersion === 1
+                        ? "Provider default"
+                        : draft.compaction.mode === "model_default"
+                          ? "Model default"
+                          : draft.compaction.mode === "disabled"
+                            ? "Disabled"
+                            : `${draft.compaction.thresholdPercent}% · ${draft.compaction.thresholdTokens} tokens`,
+                    ],
+                    [
+                      "Reasoning",
+                      draft.schemaVersion === 1
+                        ? "Provider default"
+                        : draft.model.reasoning.selection === "model_default"
+                          ? `Model default · ${draft.model.reasoning.effectiveEffort}`
+                          : draft.model.reasoning.effectiveEffort,
+                    ],
                   ],
                 },
                 {
@@ -928,33 +1070,195 @@ export function ProfileEditor({
               />
             </Field>
             <Field label="Model">
-              <input
-                aria-label="Model"
-                value={draft.model.id}
-                maxLength={200}
-                disabled={!editable}
-                onChange={(event) =>
-                  setDraft((current) => ({
-                    ...current,
-                    model: { ...current.model, id: event.target.value },
-                  }))
-                }
-                className={inputClass}
-              />
+              <div className="flex flex-col gap-1">
+                <input
+                  aria-label="Search models"
+                  value={modelSearch}
+                  onChange={(event) => setModelSearch(event.target.value)}
+                  placeholder="Search models…"
+                  disabled={!editable || capabilityLoading}
+                  className={inputClass}
+                />
+                <Listbox
+                  options={[
+                    ...(!catalogModels.some(
+                      (model) => model.id === draft.model.id,
+                    )
+                      ? [
+                          {
+                            value: draft.model.id,
+                            label: `${draft.model.id} · unavailable`,
+                            hint:
+                              "Historical selection; choose a current model before publishing.",
+                          },
+                        ]
+                      : []),
+                    ...filteredModels.map((model) => ({
+                      value: model.id,
+                      label: model.name,
+                      hint: model.id,
+                    })),
+                  ]}
+                  value={draft.model.id}
+                  disabled={
+                    !editable ||
+                    capabilityLoading ||
+                    !capabilities ||
+                    capabilities.stale
+                  }
+                  ariaLabel="Model"
+                  onChange={(modelId) => {
+                    const model = catalogModels.find(
+                      (candidate) => candidate.id === modelId,
+                    );
+                    if (model) selectModel(model);
+                  }}
+                />
+              </div>
             </Field>
-            <div className="sm:col-span-2">
+            {draft.schemaVersion === 1 && (
               <Field
                 label="Model options"
-                hint="No configurable model options are supported by the current code-owned runtime catalog."
+                hint="Historical v1 versions retain provider-default model options."
               >
                 <input
                   aria-label="Model options"
-                  value="Provider default"
+                  value={
+                    Object.keys(draft.model.options).length === 0
+                      ? "Provider default"
+                      : "Unsupported historical options"
+                  }
                   disabled
                   className={inputClass}
                 />
               </Field>
-            </div>
+            )}
+            {capabilityLoading && (
+              <div className="sm:col-span-2 font-body text-[11px] text-neutral-500">
+                Loading capabilities…
+              </div>
+            )}
+            {capabilityError && (
+              <div
+                role="alert"
+                className="sm:col-span-2 rounded-[3px] border border-red-200 bg-red-50 px-3 py-2 font-body text-[11px] text-red-700"
+              >
+                {capabilityError}
+              </div>
+            )}
+            {capabilities?.stale && (
+              <div className="sm:col-span-2 rounded-[3px] border border-amber-200 bg-amber-50 px-3 py-2 font-body text-[11px] text-amber-800">
+                Showing the last safe capability catalog. Refresh must
+                succeed before this profile can be published.
+              </div>
+            )}
+            {draft.schemaVersion === 2 && (
+              <>
+                <Field label="Reasoning effort">
+                  <Listbox
+                    options={[
+                      {
+                        value: "model_default",
+                        label: `Model default · ${draft.model.capability.defaultReasoningEffort ?? draft.model.reasoning.effectiveEffort}`,
+                      },
+                      ...draft.model.capability.reasoningEfforts.map(
+                        (effort) => ({
+                          value: effort.id,
+                          label: effort.name,
+                          hint: effort.description ?? undefined,
+                        }),
+                      ),
+                    ]}
+                    value={draft.model.reasoning.selection}
+                    disabled={!editable || capabilities?.stale !== false}
+                    ariaLabel="Reasoning effort"
+                    onChange={(selection) => {
+                      const effectiveEffort =
+                        selection === "model_default"
+                          ? draft.model.capability.defaultReasoningEffort
+                          : selection;
+                      if (!effectiveEffort) return;
+                      setDraft((current) =>
+                        current.schemaVersion === 2
+                          ? {
+                              ...current,
+                              model: {
+                                ...current.model,
+                                reasoning: {
+                                  selection,
+                                  effectiveEffort,
+                                },
+                              },
+                            }
+                          : current,
+                      );
+                    }}
+                  />
+                </Field>
+                <Field label="Speed">
+                  <Listbox
+                    options={draft.model.capability.serviceTiers.map(
+                      (tier) => ({
+                        value: tier.id,
+                        label: tier.name,
+                        hint: tier.description ?? undefined,
+                      }),
+                    )}
+                    value={draft.model.serviceTier}
+                    disabled={!editable || capabilities?.stale !== false}
+                    ariaLabel="Service tier"
+                    onChange={(serviceTier) =>
+                      setDraft((current) =>
+                        current.schemaVersion === 2
+                          ? {
+                              ...current,
+                              model: { ...current.model, serviceTier },
+                            }
+                          : current,
+                      )
+                    }
+                  />
+                </Field>
+                {draft.model.capability.verbosityOptions.length > 0 && (
+                  <Field label="Response verbosity">
+                    <Listbox
+                      options={draft.model.capability.verbosityOptions.map(
+                        (verbosity) => ({
+                          value: verbosity.id,
+                          label: verbosity.name,
+                          hint: verbosity.description ?? undefined,
+                        }),
+                      )}
+                      value={draft.model.verbosity ?? ""}
+                      disabled={!editable || capabilities?.stale !== false}
+                      ariaLabel="Response verbosity"
+                      onChange={(verbosity) =>
+                        setDraft((current) =>
+                          current.schemaVersion === 2
+                            ? {
+                                ...current,
+                                model: { ...current.model, verbosity },
+                              }
+                            : current,
+                        )
+                      }
+                    />
+                  </Field>
+                )}
+                <Field label="Context window">
+                  <input
+                    aria-label="Context window"
+                    value={
+                      draft.model.capability.contextWindowTokens === null
+                        ? "Not advertised"
+                        : `${draft.model.capability.contextWindowTokens.toLocaleString()} tokens`
+                    }
+                    disabled
+                    className={inputClass}
+                  />
+                </Field>
+              </>
+            )}
           </div>
         </CkCard>
 
@@ -1009,14 +1313,121 @@ export function ProfileEditor({
             />
             <Field
               label="Compaction"
-              hint="Fixed until a provider adapter can enforce another mode."
+              hint={
+                draft.schemaVersion === 1
+                  ? "Historical v1 versions retain provider-default behavior."
+                  : "Custom thresholds are stored as both a percentage and the exact provider-native token value."
+              }
             >
-              <input
-                aria-label="Compaction"
-                value="Provider default"
-                disabled
-                className={inputClass}
-              />
+              {draft.schemaVersion === 1 ? (
+                <input
+                  aria-label="Compaction"
+                  value="Provider default"
+                  disabled
+                  className={inputClass}
+                />
+              ) : (
+                <div className="flex flex-col gap-2">
+                  <Listbox
+                    options={draft.model.capability.compactionModes.map(
+                      (modeValue) => ({
+                        value: modeValue,
+                        label:
+                          modeValue === "model_default"
+                            ? "Model default"
+                            : modeValue === "custom_threshold"
+                              ? "Custom threshold"
+                              : "Disabled",
+                      }),
+                    )}
+                    value={draft.compaction.mode}
+                    disabled={!editable || capabilities?.stale !== false}
+                    ariaLabel="Compaction"
+                    onChange={(compactionMode) => {
+                      if (compactionMode === "model_default") {
+                        setDraft((current) =>
+                          current.schemaVersion === 2
+                            ? {
+                                ...current,
+                                compaction: { mode: "model_default" },
+                              }
+                            : current,
+                        );
+                      } else if (compactionMode === "disabled") {
+                        setDraft((current) =>
+                          current.schemaVersion === 2
+                            ? {
+                                ...current,
+                                compaction: { mode: "disabled" },
+                              }
+                            : current,
+                        );
+                      } else if (
+                        draft.model.capability.contextWindowTokens !== null
+                      ) {
+                        const thresholdPercent = 80;
+                        setDraft((current) =>
+                          current.schemaVersion === 2
+                            ? {
+                                ...current,
+                                compaction: {
+                                  mode: "custom_threshold",
+                                  thresholdPercent,
+                                  thresholdTokens: Math.floor(
+                                    (draft.model.capability
+                                      .contextWindowTokens! *
+                                      thresholdPercent) /
+                                      100,
+                                  ),
+                                },
+                              }
+                            : current,
+                        );
+                      }
+                    }}
+                  />
+                  {draft.compaction.mode === "custom_threshold" && (
+                    <label className="flex flex-col gap-1">
+                      <span className="font-body text-[10px] text-neutral-500">
+                        Compact at {draft.compaction.thresholdPercent}% (
+                        {draft.compaction.thresholdTokens.toLocaleString()}{" "}
+                        tokens)
+                      </span>
+                      <input
+                        aria-label="Compaction threshold percentage"
+                        type="range"
+                        min={1}
+                        max={99}
+                        value={draft.compaction.thresholdPercent}
+                        disabled={!editable || capabilities?.stale !== false}
+                        onChange={(event) => {
+                          const thresholdPercent = Number(
+                            event.target.value,
+                          );
+                          const contextWindow =
+                            draft.model.capability.contextWindowTokens;
+                          if (contextWindow === null) return;
+                          setDraft((current) =>
+                            current.schemaVersion === 2
+                              ? {
+                                  ...current,
+                                  compaction: {
+                                    mode: "custom_threshold",
+                                    thresholdPercent,
+                                    thresholdTokens: Math.floor(
+                                      (contextWindow * thresholdPercent) / 100,
+                                    ),
+                                  },
+                                }
+                              : current,
+                          );
+                        }}
+                        className="w-full accent-mariner"
+                      />
+                    </label>
+                  )}
+                </div>
+              )}
             </Field>
           </div>
         </CkCard>

--- a/apps/dashboard/components/cockpit/screens/harness-profiles.tsx
+++ b/apps/dashboard/components/cockpit/screens/harness-profiles.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/harness-profiles/selection";
 import type {
   HarnessProfileDetailResponse,
-  HarnessProfileDraftManifestV1,
+  HarnessProfileDraftManifest,
   HarnessProfileDto,
   HarnessProfileMutationResponse,
   HarnessProfilePublishResponse,
@@ -52,7 +52,7 @@ function NewProfilePanel({
   onCancel: () => void;
   onCreate: (
     slug: string,
-    draft: HarnessProfileDraftManifestV1,
+    draft: HarnessProfileDraftManifest,
   ) => Promise<void>;
 }) {
   const sources = profiles.filter((profile) => profile.archivedAt === null);
@@ -61,7 +61,7 @@ function NewProfilePanel({
   const [provider, setProvider] = useState<"codex" | "claude">("codex");
   const [sourceId, setSourceId] = useState("");
 
-  function buildDraft(): HarnessProfileDraftManifestV1 {
+  function buildDraft(): HarnessProfileDraftManifest {
     const source = sources.find((profile) => profile.id === sourceId);
     const base = source
       ? structuredClone(source.draft)
@@ -350,7 +350,7 @@ export function HarnessProfilesScreen({
     }
   }
 
-  async function saveDraft(draft: HarnessProfileDraftManifestV1) {
+  async function saveDraft(draft: HarnessProfileDraftManifest) {
     if (!detail) return;
     setBusy("save");
     setError(null);
@@ -382,7 +382,7 @@ export function HarnessProfilesScreen({
 
   async function createProfile(
     slug: string,
-    draft: HarnessProfileDraftManifestV1,
+    draft: HarnessProfileDraftManifest,
   ) {
     if (!confirmDiscard()) return;
     setBusy("create");

--- a/apps/dashboard/lib/harness-profiles/capabilities.ts
+++ b/apps/dashboard/lib/harness-profiles/capabilities.ts
@@ -1,6 +1,6 @@
 import type {
   HarnessProfileCapabilities,
-  HarnessProfileManifestV1,
+  HarnessProfileManifest,
   HarnessToolId,
   WorkflowBlockType,
 } from "@shared/contracts";
@@ -20,7 +20,7 @@ function uniqueSorted(values: string[]): string[] {
 export function previewHarnessCapabilities(input: {
   nodeType: WorkflowBlockType;
   workspaceMode?: unknown;
-  manifest: HarnessProfileManifestV1;
+  manifest: HarnessProfileManifest;
 }): HarnessProfileCapabilities {
   const requestedTools = uniqueSorted(input.manifest.tools);
   const tools = requestedTools.filter(

--- a/apps/dashboard/lib/harness-profiles/editor.test.ts
+++ b/apps/dashboard/lib/harness-profiles/editor.test.ts
@@ -6,12 +6,14 @@ import {
   draftFromManifest,
   isProfileSlug,
   newProfileDraft,
+  upgradeProfileDraft,
   upsertProfile,
   withHarnessProvider,
 } from "./editor";
 import {
   BUILTIN_HARNESS_PROFILE_IDS,
   BUILTIN_HARNESS_PROFILE_MANIFESTS,
+  type HarnessCapabilitiesResponse,
   type HarnessProfileDto,
 } from "@shared/contracts";
 
@@ -79,6 +81,9 @@ test("switching providers applies one complete code-owned harness contract", () 
     },
     "claude",
   );
+  assert.ok(next);
+  assert.equal(next.schemaVersion, 1);
+  if (next.schemaVersion !== 1) throw new Error("Expected a v1 draft");
   assert.deepEqual(next.harness, {
     provider: "claude",
     packageName: "@anthropic-ai/claude-code",
@@ -91,6 +96,60 @@ test("switching providers applies one complete code-owned harness contract", () 
     { path: "CLAUDE.md", content: "Shared instructions", mode: 0o644 },
   ]);
   assert.deepEqual(next.credentialReferences, ["anthropic"]);
+});
+
+test("switching a v2 profile requires fresh target capabilities and remains v2", () => {
+  const capabilities = (
+    provider: "codex" | "claude",
+    modelId: string,
+  ): HarnessCapabilitiesResponse => {
+    const baseline = newProfileDraft(provider);
+    return {
+      ...baseline.harness,
+      provider,
+      models: [
+        {
+          id: modelId,
+          name: modelId,
+          description: null,
+          contextWindowTokens: 200_000,
+          reasoningEfforts: [
+            { id: "high", name: "High", description: null },
+          ],
+          defaultReasoningEffort: "high",
+          serviceTiers: [
+            { id: "standard", name: "Standard", description: null },
+          ],
+          defaultServiceTier: "standard",
+          verbosityOptions: [],
+          defaultVerbosity: null,
+          compactionModes: ["model_default", "custom_threshold"],
+        },
+      ],
+      catalogHash: `${provider}-catalog`,
+      fetchedAt: "2026-07-28T00:00:00.000Z",
+      stale: false,
+      refreshFailure: null,
+    };
+  };
+  const codexDraft = newProfileDraft("codex");
+  const v2 = upgradeProfileDraft(
+    codexDraft,
+    capabilities("codex", codexDraft.model.id),
+  );
+  assert.ok(v2);
+
+  assert.equal(withHarnessProvider(v2, "claude"), null);
+  const claudeDraft = newProfileDraft("claude");
+  const switched = withHarnessProvider(
+    v2,
+    "claude",
+    capabilities("claude", claudeDraft.model.id),
+  );
+  assert.ok(switched);
+  assert.equal(switched.schemaVersion, 2);
+  assert.equal(switched.harness.provider, "claude");
+  assert.equal(switched.model.id, claudeDraft.model.id);
 });
 
 test("profile slugs match the worker-owned public constraint", () => {

--- a/apps/dashboard/lib/harness-profiles/editor.ts
+++ b/apps/dashboard/lib/harness-profiles/editor.ts
@@ -1,14 +1,17 @@
 import type {
+  HarnessCapabilitiesResponse,
+  HarnessProfileDraftManifest,
   HarnessProfileDraftManifestV1,
+  HarnessProfileDraftManifestV2,
   HarnessProfileDto,
-  HarnessProfileManifestV1,
+  HarnessProfileManifest,
   HarnessProvider,
 } from "@shared/contracts";
 import { BUILTIN_HARNESS_PROFILE_MANIFESTS } from "@shared/contracts";
 
 export function draftFromManifest(
-  manifest: HarnessProfileManifestV1,
-): HarnessProfileDraftManifestV1 {
+  manifest: HarnessProfileManifest,
+): HarnessProfileDraftManifest {
   const {
     profileId: _profileId,
     version: _version,
@@ -28,7 +31,9 @@ export function newProfileDraft(
   if (!manifest) {
     throw new Error(`Missing built-in ${provider} compatibility profile`);
   }
-  const draft = draftFromManifest(manifest);
+  const draft = draftFromManifest(
+    manifest,
+  ) as HarnessProfileDraftManifestV1;
   return {
     ...draft,
     displayName: `Custom ${draft.displayName}`,
@@ -37,20 +42,54 @@ export function newProfileDraft(
 }
 
 export function withHarnessProvider(
-  draft: HarnessProfileDraftManifestV1,
+  draft: HarnessProfileDraftManifest,
   provider: HarnessProvider,
 ): HarnessProfileDraftManifestV1 {
   const baseline = newProfileDraft(provider);
   return {
     ...draft,
+    schemaVersion: 1,
     harness: baseline.harness,
     model: baseline.model,
+    compaction: baseline.compaction,
     homeFiles: draft.homeFiles.map((file) => ({
       ...file,
       path: provider === "codex" ? "AGENTS.md" : "CLAUDE.md",
       mode: 0o644,
     })),
     credentialReferences: baseline.credentialReferences,
+  };
+}
+
+export function upgradeProfileDraft(
+  draft: HarnessProfileDraftManifestV1,
+  capabilities: HarnessCapabilitiesResponse,
+): HarnessProfileDraftManifestV2 | null {
+  const model = capabilities.models.find(
+    (candidate) => candidate.id === draft.model.id,
+  );
+  const effort =
+    model?.defaultReasoningEffort ?? model?.reasoningEfforts[0]?.id;
+  const serviceTier =
+    model?.defaultServiceTier ?? model?.serviceTiers[0]?.id;
+  if (!model || !effort || !serviceTier) return null;
+  return {
+    ...structuredClone(draft),
+    schemaVersion: 2,
+    model: {
+      id: model.id,
+      reasoning: {
+        selection: "model_default",
+        effectiveEffort: effort,
+      },
+      serviceTier,
+      ...(model.defaultVerbosity
+        ? { verbosity: model.defaultVerbosity }
+        : {}),
+      capability: structuredClone(model),
+      catalogHash: capabilities.catalogHash,
+    },
+    compaction: { mode: "model_default" },
   };
 }
 

--- a/apps/dashboard/lib/harness-profiles/editor.ts
+++ b/apps/dashboard/lib/harness-profiles/editor.ts
@@ -7,7 +7,10 @@ import type {
   HarnessProfileManifest,
   HarnessProvider,
 } from "@shared/contracts";
-import { BUILTIN_HARNESS_PROFILE_MANIFESTS } from "@shared/contracts";
+import {
+  BUILTIN_HARNESS_PROFILE_MANIFESTS,
+  buildHarnessProfileDraftV2,
+} from "@shared/contracts";
 
 export function draftFromManifest(
   manifest: HarnessProfileManifest,
@@ -31,9 +34,10 @@ export function newProfileDraft(
   if (!manifest) {
     throw new Error(`Missing built-in ${provider} compatibility profile`);
   }
-  const draft = draftFromManifest(
-    manifest,
-  ) as HarnessProfileDraftManifestV1;
+  const draft = draftFromManifest(manifest);
+  if (draft.schemaVersion !== 1) {
+    throw new Error("Built-in compatibility profiles must use schema v1");
+  }
   return {
     ...draft,
     displayName: `Custom ${draft.displayName}`,
@@ -44,9 +48,10 @@ export function newProfileDraft(
 export function withHarnessProvider(
   draft: HarnessProfileDraftManifest,
   provider: HarnessProvider,
-): HarnessProfileDraftManifestV1 {
+  capabilities?: HarnessCapabilitiesResponse,
+): HarnessProfileDraftManifest | null {
   const baseline = newProfileDraft(provider);
-  return {
+  const targetDraft: HarnessProfileDraftManifestV1 = {
     ...draft,
     schemaVersion: 1,
     harness: baseline.harness,
@@ -59,38 +64,23 @@ export function withHarnessProvider(
     })),
     credentialReferences: baseline.credentialReferences,
   };
+  if (draft.schemaVersion === 1) return targetDraft;
+  if (
+    !capabilities ||
+    capabilities.stale ||
+    capabilities.provider !== provider ||
+    capabilities.cliVersion !== baseline.harness.cliVersion
+  ) {
+    return null;
+  }
+  return buildHarnessProfileDraftV2(targetDraft, capabilities);
 }
 
 export function upgradeProfileDraft(
   draft: HarnessProfileDraftManifestV1,
   capabilities: HarnessCapabilitiesResponse,
 ): HarnessProfileDraftManifestV2 | null {
-  const model = capabilities.models.find(
-    (candidate) => candidate.id === draft.model.id,
-  );
-  const effort =
-    model?.defaultReasoningEffort ?? model?.reasoningEfforts[0]?.id;
-  const serviceTier =
-    model?.defaultServiceTier ?? model?.serviceTiers[0]?.id;
-  if (!model || !effort || !serviceTier) return null;
-  return {
-    ...structuredClone(draft),
-    schemaVersion: 2,
-    model: {
-      id: model.id,
-      reasoning: {
-        selection: "model_default",
-        effectiveEffort: effort,
-      },
-      serviceTier,
-      ...(model.defaultVerbosity
-        ? { verbosity: model.defaultVerbosity }
-        : {}),
-      capability: structuredClone(model),
-      catalogHash: capabilities.catalogHash,
-    },
-    compaction: { mode: "model_default" },
-  };
+  return buildHarnessProfileDraftV2(draft, capabilities);
 }
 
 export function isProfileSlug(value: string): boolean {

--- a/apps/dashboard/lib/workflow-editor/serialize.test.ts
+++ b/apps/dashboard/lib/workflow-editor/serialize.test.ts
@@ -387,6 +387,44 @@ test("round-trips the flat v2 Branch condition list without loss", () => {
   );
 });
 
+test("a pinned v2 Harness Profile is the sole serialized agent source", () => {
+  const nodes = flowNodes([
+    {
+      id: "agent",
+      type: "implementation_agent",
+      x: 10,
+      y: 20,
+      params: {
+        provider: "codex",
+        model: "stale-display-model",
+        prompt: "Implement the ticket.",
+      },
+      v2: {
+        configuration: {
+          harnessProfile: {
+            profileId: "profile-1",
+            version: 3,
+          },
+          provider: "claude",
+          model: "corrupt-stored-model",
+          prompt: "Implement the ticket.",
+        },
+        inputs: {},
+        additionalInputs: [],
+      },
+    },
+  ]);
+
+  const serialized = serializeWorkflowDefinition(nodes, [], {}, 2);
+  assert.deepEqual(serialized.nodes[0]?.configuration, {
+    harnessProfile: {
+      profileId: "profile-1",
+      version: 3,
+    },
+    prompt: "Implement the ticket.",
+  });
+});
+
 test("clears display-valued v2 configuration without deleting nested JSON", () => {
   const original: WorkflowDefinitionV2 = {
     schemaVersion: 2,

--- a/apps/dashboard/lib/workflow-editor/serialize.ts
+++ b/apps/dashboard/lib/workflow-editor/serialize.ts
@@ -1,6 +1,7 @@
 import {
   BLOCK_PARAM_KEYS,
   isHarnessProfileReference,
+  isV2AgentBlockType,
 } from "@shared/contracts";
 import type {
   WorkflowDefinition,
@@ -141,7 +142,7 @@ export function serializeWorkflowDefinition(
         }
       }
       if (
-        isV2AgentBlock(node.type) &&
+        isV2AgentBlockType(node.type) &&
         isHarnessProfileReference(
           serialized.configuration.harnessProfile,
         )
@@ -170,16 +171,6 @@ export function serializeWorkflowDefinition(
     }),
   };
   return definition;
-}
-
-function isV2AgentBlock(type: FlowNodeDef["type"]): boolean {
-  return (
-    type === "planning_agent" ||
-    type === "implementation_agent" ||
-    type === "review_agent" ||
-    type === "fix_agent" ||
-    type === "generic_agent"
-  );
 }
 
 /** Semantic comparison/storage form: node movement is deliberately ignored. */

--- a/apps/dashboard/lib/workflow-editor/serialize.ts
+++ b/apps/dashboard/lib/workflow-editor/serialize.ts
@@ -1,4 +1,7 @@
-import { BLOCK_PARAM_KEYS } from "@shared/contracts";
+import {
+  BLOCK_PARAM_KEYS,
+  isHarnessProfileReference,
+} from "@shared/contracts";
 import type {
   WorkflowDefinition,
   WorkflowEdgeGeometry,
@@ -124,6 +127,15 @@ export function serializeWorkflowDefinition(
           delete serialized.configuration[key];
         }
       }
+      if (
+        isV2AgentBlock(node.type) &&
+        isHarnessProfileReference(
+          serialized.configuration.harnessProfile,
+        )
+      ) {
+        delete serialized.configuration.provider;
+        delete serialized.configuration.model;
+      }
       return serialized;
     }),
     edges: edges.map((edge, index) => {
@@ -145,6 +157,16 @@ export function serializeWorkflowDefinition(
     }),
   };
   return definition;
+}
+
+function isV2AgentBlock(type: FlowNodeDef["type"]): boolean {
+  return (
+    type === "planning_agent" ||
+    type === "implementation_agent" ||
+    type === "review_agent" ||
+    type === "fix_agent" ||
+    type === "generic_agent"
+  );
 }
 
 /** Semantic comparison/storage form: node movement is deliberately ignored. */

--- a/apps/shared/contracts/harness-profiles.ts
+++ b/apps/shared/contracts/harness-profiles.ts
@@ -75,6 +75,87 @@ export interface HarnessProfileDraftManifestV1 {
   credentialReferences: string[];
 }
 
+export type HarnessReasoningEffort =
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max";
+
+export interface HarnessCapabilityOption {
+  id: string;
+  name: string;
+  description: string | null;
+}
+
+export interface HarnessModelCapability {
+  id: string;
+  name: string;
+  description: string | null;
+  contextWindowTokens: number | null;
+  reasoningEfforts: HarnessCapabilityOption[];
+  defaultReasoningEffort: string | null;
+  serviceTiers: HarnessCapabilityOption[];
+  defaultServiceTier: string | null;
+  verbosityOptions: HarnessCapabilityOption[];
+  defaultVerbosity: string | null;
+  compactionModes: Array<
+    "model_default" | "custom_threshold" | "disabled"
+  >;
+}
+
+export interface HarnessCapabilityCatalog {
+  provider: HarnessProvider;
+  packageName: string;
+  cliVersion: string;
+  protocolVersion: string;
+  models: HarnessModelCapability[];
+}
+
+export interface HarnessCapabilitiesResponse
+  extends HarnessCapabilityCatalog {
+  catalogHash: string;
+  fetchedAt: string;
+  stale: boolean;
+  refreshFailure: {
+    occurredAt: string;
+    message: string;
+  } | null;
+}
+
+export interface HarnessProfileDraftManifestV2
+  extends Omit<
+    HarnessProfileDraftManifestV1,
+    "schemaVersion" | "model" | "compaction"
+  > {
+  schemaVersion: 2;
+  model: {
+    id: string;
+    reasoning: {
+      selection: "model_default" | string;
+      effectiveEffort: string;
+    };
+    serviceTier: string;
+    verbosity?: string;
+    capability: HarnessModelCapability;
+    catalogHash: string;
+  };
+  compaction:
+    | { mode: "model_default" }
+    | {
+        mode: "custom_threshold";
+        thresholdPercent: number;
+        thresholdTokens: number;
+      }
+    | { mode: "disabled" };
+}
+
+export type HarnessProfileDraftManifest =
+  | HarnessProfileDraftManifestV1
+  | HarnessProfileDraftManifestV2;
+
 /**
  * Complete non-secret manifest used by the code-owned PR4 compatibility
  * profiles. PR5 persists this same contract as an immutable profile version.
@@ -87,6 +168,18 @@ export interface HarnessProfileManifestV1
   system: boolean;
 }
 
+export interface HarnessProfileManifestV2
+  extends HarnessProfileDraftManifestV2 {
+  profileId: string;
+  version: number;
+  slug: string;
+  system: boolean;
+}
+
+export type HarnessProfileManifest =
+  | HarnessProfileManifestV1
+  | HarnessProfileManifestV2;
+
 export interface HarnessProfileDto {
   id: string;
   organizationId: string | null;
@@ -97,7 +190,7 @@ export interface HarnessProfileDto {
   draftRevision: number;
   draftRestoredFromVersion: number | null;
   publishedVersion: number | null;
-  draft: HarnessProfileDraftManifestV1;
+  draft: HarnessProfileDraftManifest;
   createdAt: string;
   updatedAt: string;
   createdById: string;
@@ -107,7 +200,7 @@ export interface HarnessProfileDto {
 export interface HarnessProfileVersionDto {
   profileId: string;
   version: number;
-  manifest: HarnessProfileManifestV1;
+  manifest: HarnessProfileManifest;
   manifestHash: string;
   createdAt: string;
   createdById: string;
@@ -115,7 +208,7 @@ export interface HarnessProfileVersionDto {
 }
 
 export interface HarnessProfileResolvedVersion {
-  manifest: HarnessProfileManifestV1;
+  manifest: HarnessProfileManifest;
   manifestHash: string;
   skillArtifacts: HarnessResolvedSkillArtifact[];
 }
@@ -125,19 +218,19 @@ export interface HarnessRunManifestRecord {
   reference: HarnessProfileReference;
   manifestHash: string;
   manifest: {
-    schemaVersion: 1;
+    schemaVersion: 1 | 2;
     profileId: string;
     version: number;
     slug: string;
     displayName: string;
     system: boolean;
-    harness: HarnessProfileManifestV1["harness"];
-    model: HarnessProfileManifestV1["model"];
-    context: HarnessProfileManifestV1["context"];
-    compaction: HarnessProfileManifestV1["compaction"];
-    subagents: HarnessProfileManifestV1["subagents"];
-    limits: HarnessProfileManifestV1["limits"];
-    workspace: HarnessProfileManifestV1["workspace"];
+    harness: HarnessProfileManifest["harness"];
+    model: HarnessProfileManifest["model"];
+    context: HarnessProfileManifest["context"];
+    compaction: HarnessProfileManifest["compaction"];
+    subagents: HarnessProfileManifest["subagents"];
+    limits: HarnessProfileManifest["limits"];
+    workspace: HarnessProfileManifest["workspace"];
     instructionsSha256: string;
     homeFiles: {
       count: number;

--- a/apps/shared/contracts/harness-profiles.ts
+++ b/apps/shared/contracts/harness-profiles.ts
@@ -134,7 +134,8 @@ export interface HarnessProfileDraftManifestV2
   model: {
     id: string;
     reasoning: {
-      selection: "model_default" | string;
+      /** "model_default" or an exact provider-advertised effort ID. */
+      selection: string;
       effectiveEffort: string;
     };
     serviceTier: string;
@@ -180,6 +181,52 @@ export type HarnessProfileManifest =
   | HarnessProfileManifestV1
   | HarnessProfileManifestV2;
 
+export function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
+    .join(",")}}`;
+}
+
+export function buildHarnessProfileDraftV2(
+  draft: HarnessProfileDraftManifestV1,
+  capabilities: HarnessCapabilitiesResponse,
+): HarnessProfileDraftManifestV2 | null {
+  const model = capabilities.models.find(
+    (candidate) => candidate.id === draft.model.id,
+  );
+  const effectiveEffort =
+    model?.defaultReasoningEffort ?? model?.reasoningEfforts[0]?.id;
+  const serviceTier =
+    model?.defaultServiceTier ?? model?.serviceTiers[0]?.id;
+  if (!model || !effectiveEffort || !serviceTier) return null;
+  return {
+    ...structuredClone(draft),
+    schemaVersion: 2,
+    model: {
+      id: model.id,
+      reasoning: {
+        selection: "model_default",
+        effectiveEffort,
+      },
+      serviceTier,
+      ...(model.defaultVerbosity
+        ? { verbosity: model.defaultVerbosity }
+        : {}),
+      capability: structuredClone(model),
+      catalogHash: capabilities.catalogHash,
+    },
+    compaction: { mode: "model_default" },
+  };
+}
+
 export interface HarnessProfileDto {
   id: string;
   organizationId: string | null;
@@ -213,35 +260,46 @@ export interface HarnessProfileResolvedVersion {
   skillArtifacts: HarnessResolvedSkillArtifact[];
 }
 
+interface HarnessRunManifestCommon {
+  profileId: string;
+  version: number;
+  slug: string;
+  displayName: string;
+  system: boolean;
+  harness: HarnessProfileManifest["harness"];
+  context: HarnessProfileManifest["context"];
+  subagents: HarnessProfileManifest["subagents"];
+  limits: HarnessProfileManifest["limits"];
+  workspace: HarnessProfileManifest["workspace"];
+  instructionsSha256: string;
+  homeFiles: {
+    count: number;
+    totalBytes: number;
+    sha256: string;
+  };
+  skills: HarnessProfileSkillReference[];
+  tools: string[];
+  mcpIntegrations: string[];
+  credentialReferences: string[];
+}
+
+type HarnessRunManifest =
+  | (HarnessRunManifestCommon & {
+      schemaVersion: 1;
+      model: HarnessProfileManifestV1["model"];
+      compaction: HarnessProfileManifestV1["compaction"];
+    })
+  | (HarnessRunManifestCommon & {
+      schemaVersion: 2;
+      model: HarnessProfileManifestV2["model"];
+      compaction: HarnessProfileManifestV2["compaction"];
+    });
+
 export interface HarnessRunManifestRecord {
   nodeId: string;
   reference: HarnessProfileReference;
   manifestHash: string;
-  manifest: {
-    schemaVersion: 1 | 2;
-    profileId: string;
-    version: number;
-    slug: string;
-    displayName: string;
-    system: boolean;
-    harness: HarnessProfileManifest["harness"];
-    model: HarnessProfileManifest["model"];
-    context: HarnessProfileManifest["context"];
-    compaction: HarnessProfileManifest["compaction"];
-    subagents: HarnessProfileManifest["subagents"];
-    limits: HarnessProfileManifest["limits"];
-    workspace: HarnessProfileManifest["workspace"];
-    instructionsSha256: string;
-    homeFiles: {
-      count: number;
-      totalBytes: number;
-      sha256: string;
-    };
-    skills: HarnessProfileSkillReference[];
-    tools: string[];
-    mcpIntegrations: string[];
-    credentialReferences: string[];
-  };
+  manifest: HarnessRunManifest;
   skills: Array<{
     artifactHash: string;
     name: string;

--- a/apps/shared/contracts/workflow-graph.ts
+++ b/apps/shared/contracts/workflow-graph.ts
@@ -82,6 +82,20 @@ export const TRIGGER_BLOCK_TYPES: readonly WorkflowBlockType[] = (
   Object.keys(BLOCK_TYPE_SPECS) as WorkflowBlockType[]
 ).filter((type) => BLOCK_TYPE_SPECS[type].category === "trigger");
 
+export const V2_AGENT_BLOCK_TYPES = [
+  "planning_agent",
+  "implementation_agent",
+  "review_agent",
+  "fix_agent",
+  "generic_agent",
+] as const satisfies readonly WorkflowBlockType[];
+
+export function isV2AgentBlockType(
+  type: WorkflowBlockType,
+): type is (typeof V2_AGENT_BLOCK_TYPES)[number] {
+  return (V2_AGENT_BLOCK_TYPES as readonly WorkflowBlockType[]).includes(type);
+}
+
 /** True when a block type can start a run (its category is "trigger"). */
 export function isTriggerBlockType(type: WorkflowBlockType): boolean {
   return BLOCK_TYPE_SPECS[type].category === "trigger";

--- a/apps/worker/drizzle/0031_capability_cache.sql
+++ b/apps/worker/drizzle/0031_capability_cache.sql
@@ -14,5 +14,4 @@ CREATE TABLE "harness_capability_catalogs" (
 );
 --> statement-breakpoint
 ALTER TABLE "harness_capability_catalogs" ADD CONSTRAINT "harness_capability_catalogs_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE UNIQUE INDEX "harness_capability_catalogs_scope_unique" ON "harness_capability_catalogs" USING btree ("organization_id","provider","cli_version");--> statement-breakpoint
-CREATE INDEX "harness_capability_catalogs_organization_idx" ON "harness_capability_catalogs" USING btree ("organization_id");
+CREATE UNIQUE INDEX "harness_capability_catalogs_scope_unique" ON "harness_capability_catalogs" USING btree ("organization_id","provider","cli_version");

--- a/apps/worker/drizzle/0031_capability_cache.sql
+++ b/apps/worker/drizzle/0031_capability_cache.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "harness_capability_catalogs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"cli_version" text NOT NULL,
+	"catalog" jsonb NOT NULL,
+	"catalog_hash" text NOT NULL,
+	"fetched_at" timestamp with time zone NOT NULL,
+	"last_refresh_failed_at" timestamp with time zone,
+	"last_refresh_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "harness_capability_catalogs_provider_check" CHECK ("harness_capability_catalogs"."provider" in ('claude', 'codex'))
+);
+--> statement-breakpoint
+ALTER TABLE "harness_capability_catalogs" ADD CONSTRAINT "harness_capability_catalogs_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "harness_capability_catalogs_scope_unique" ON "harness_capability_catalogs" USING btree ("organization_id","provider","cli_version");--> statement-breakpoint
+CREATE INDEX "harness_capability_catalogs_organization_idx" ON "harness_capability_catalogs" USING btree ("organization_id");

--- a/apps/worker/drizzle/meta/0031_snapshot.json
+++ b/apps/worker/drizzle/meta/0031_snapshot.json
@@ -508,21 +508,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "harness_capability_catalogs_organization_idx": {
-          "name": "harness_capability_catalogs_organization_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {

--- a/apps/worker/drizzle/meta/0031_snapshot.json
+++ b/apps/worker/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,4479 @@
+{
+  "id": "1de397db-1e74-4a91-95be-5375bb0fbdba",
+  "prevId": "23fd0ace-cd0e-44c9-a7a8-5b285b8feb34",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_capability_catalogs": {
+      "name": "harness_capability_catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_hash": {
+          "name": "catalog_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "harness_capability_catalogs_scope_unique": {
+          "name": "harness_capability_catalogs_scope_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_capability_catalogs_organization_idx": {
+          "name": "harness_capability_catalogs_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_capability_catalogs_organization_id_organization_id_fk": {
+          "name": "harness_capability_catalogs_organization_id_organization_id_fk",
+          "tableFrom": "harness_capability_catalogs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_capability_catalogs_provider_check": {
+          "name": "harness_capability_catalogs_provider_check",
+          "value": "\"harness_capability_catalogs\".\"provider\" in ('claude', 'codex')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_started_at": {
+          "name": "entry_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_deadline_at": {
+          "name": "startup_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_startup_watchdog_idx": {
+          "name": "workflow_runs_startup_watchdog_idx",
+          "columns": [
+            {
+              "expression": "startup_deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_runs\".\"entry_started_at\" is null and coalesce(\"workflow_runs\".\"status\", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memory_documents": {
+      "name": "agent_memory_documents",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memory_documents_ticket_key_idx": {
+          "name": "agent_memory_documents_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_documents_updated_at_idx": {
+          "name": "agent_memory_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_memory_documents_subject_key_doc_path_pk": {
+          "name": "agent_memory_documents_subject_key_doc_path_pk",
+          "columns": [
+            "subject_key",
+            "doc_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1785173470525,
       "tag": "0030_startup_watchdog",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1785177193738,
+      "tag": "0031_capability_cache",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/harness-capability-cache-migration.test.ts
+++ b/apps/worker/src/db/harness-capability-cache-migration.test.ts
@@ -1,12 +1,18 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { PGlite } from "@electric-sql/pglite";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+const openClients: PGlite[] = [];
+
+afterEach(async () => {
+  await Promise.all(openClients.splice(0).map((client) => client.close()));
+});
 
 async function migrateThrough(lastPrefix: string): Promise<PGlite> {
   const client = new PGlite();
+  openClients.push(client);
   const files = readdirSync(migrationsDir)
     .filter(
       (file) => file.endsWith(".sql") && file.slice(0, 4) <= lastPrefix,
@@ -47,14 +53,11 @@ describe("0031 Harness capability cache migration", () => {
         AND tablename = 'harness_capability_catalogs'
     `);
     expect(indexes.rows.map(({ indexname }) => indexname)).toEqual(
-      expect.arrayContaining([
-        "harness_capability_catalogs_scope_unique",
-        "harness_capability_catalogs_organization_idx",
-      ]),
+      expect.arrayContaining(["harness_capability_catalogs_scope_unique"]),
     );
   });
 
-  it("upgrades an existing database without changing stored profile versions", async () => {
+  it("upgrades an existing database without changing stored profile drafts", async () => {
     const client = await migrateThrough("0030");
     await client.exec(`
       INSERT INTO organization (id, name, slug)
@@ -79,13 +82,30 @@ describe("0031 Harness capability cache migration", () => {
     await client.exec(
       readFileSync(`${migrationsDir}0031_capability_cache.sql`, "utf8"),
     );
-    const rows = await client.query<{ id: string; slug: string }>(`
-      SELECT id, slug
+    const rows = await client.query<{
+      id: string;
+      slug: string;
+      draft_manifest: unknown;
+    }>(`
+      SELECT id, slug, draft_manifest
       FROM harness_profiles
       WHERE id = 'profile-existing'
     `);
     expect(rows.rows).toEqual([
-      { id: "profile-existing", slug: "existing-profile" },
+      {
+        id: "profile-existing",
+        slug: "existing-profile",
+        draft_manifest: {},
+      },
+    ]);
+    const capabilityTable = await client.query<{ table_name: string }>(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name = 'harness_capability_catalogs'
+    `);
+    expect(capabilityTable.rows).toEqual([
+      { table_name: "harness_capability_catalogs" },
     ]);
   });
 });

--- a/apps/worker/src/db/harness-capability-cache-migration.test.ts
+++ b/apps/worker/src/db/harness-capability-cache-migration.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it } from "vitest";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+
+async function migrateThrough(lastPrefix: string): Promise<PGlite> {
+  const client = new PGlite();
+  const files = readdirSync(migrationsDir)
+    .filter(
+      (file) => file.endsWith(".sql") && file.slice(0, 4) <= lastPrefix,
+    )
+    .sort();
+  for (const file of files) {
+    await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+  }
+  return client;
+}
+
+describe("0031 Harness capability cache migration", () => {
+  it("creates the organization-scoped capability cache and indexes", async () => {
+    const client = await migrateThrough("0031");
+    const columns = await client.query<{ column_name: string }>(`
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'harness_capability_catalogs'
+      ORDER BY column_name
+    `);
+    expect(columns.rows.map(({ column_name }) => column_name)).toEqual(
+      expect.arrayContaining([
+        "organization_id",
+        "provider",
+        "cli_version",
+        "catalog",
+        "catalog_hash",
+        "fetched_at",
+        "last_refresh_failed_at",
+        "last_refresh_error",
+      ]),
+    );
+    const indexes = await client.query<{ indexname: string }>(`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'harness_capability_catalogs'
+    `);
+    expect(indexes.rows.map(({ indexname }) => indexname)).toEqual(
+      expect.arrayContaining([
+        "harness_capability_catalogs_scope_unique",
+        "harness_capability_catalogs_organization_idx",
+      ]),
+    );
+  });
+
+  it("upgrades an existing database without changing stored profile versions", async () => {
+    const client = await migrateThrough("0030");
+    await client.exec(`
+      INSERT INTO organization (id, name, slug)
+      VALUES ('org-existing', 'Existing organization', 'existing-org');
+      INSERT INTO harness_profiles (
+        id,
+        organization_id,
+        slug,
+        draft_manifest,
+        created_by_id,
+        updated_by_id
+      )
+      VALUES (
+        'profile-existing',
+        'org-existing',
+        'existing-profile',
+        '{}'::jsonb,
+        'admin',
+        'admin'
+      )
+    `);
+    await client.exec(
+      readFileSync(`${migrationsDir}0031_capability_cache.sql`, "utf8"),
+    );
+    const rows = await client.query<{ id: string; slug: string }>(`
+      SELECT id, slug
+      FROM harness_profiles
+      WHERE id = 'profile-existing'
+    `);
+    expect(rows.rows).toEqual([
+      { id: "profile-existing", slug: "existing-profile" },
+    ]);
+  });
+});

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -19,8 +19,9 @@ import {
 } from "drizzle-orm/pg-core";
 import type {
   BlockRunState,
-  HarnessProfileDraftManifestV1,
-  HarnessProfileManifestV1,
+  HarnessCapabilityCatalog,
+  HarnessProfileDraftManifest,
+  HarnessProfileManifest,
   HarnessRunManifestRecord,
   PromptSlotDefinition,
   ReplayAttemptOutcome,
@@ -722,7 +723,7 @@ export const harnessProfileVersions = pgTable(
         onDelete: "restrict",
       }),
     version: integer("version").notNull(),
-    manifest: jsonb("manifest").$type<HarnessProfileManifestV1>().notNull(),
+    manifest: jsonb("manifest").$type<HarnessProfileManifest>().notNull(),
     manifestHash: text("manifest_hash").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
@@ -749,7 +750,7 @@ export const harnessProfiles = pgTable(
     }),
     slug: text("slug").notNull(),
     draftManifest: jsonb("draft_manifest")
-      .$type<HarnessProfileDraftManifestV1>()
+      .$type<HarnessProfileDraftManifest>()
       .notNull(),
     draftRevision: integer("draft_revision").notNull().default(1),
     draftRestoredFromVersion: integer("draft_restored_from_version"),
@@ -794,6 +795,50 @@ export const harnessProfiles = pgTable(
       ],
       name: "harness_profiles_published_version_fk",
     }).onDelete("restrict"),
+  ],
+);
+
+/**
+ * Organization-scoped, non-secret provider capability discovery cache.
+ * Catalog rows are keyed by the exact CLI version used by an immutable
+ * Harness Profile so a stale but safe catalog can still be inspected.
+ */
+export const harnessCapabilityCatalogs = pgTable(
+  "harness_capability_catalogs",
+  {
+    id: serial("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    cliVersion: text("cli_version").notNull(),
+    catalog: jsonb("catalog").$type<HarnessCapabilityCatalog>().notNull(),
+    catalogHash: text("catalog_hash").notNull(),
+    fetchedAt: timestamp("fetched_at", { withTimezone: true }).notNull(),
+    lastRefreshFailedAt: timestamp("last_refresh_failed_at", {
+      withTimezone: true,
+    }),
+    lastRefreshError: text("last_refresh_error"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("harness_capability_catalogs_scope_unique").on(
+      t.organizationId,
+      t.provider,
+      t.cliVersion,
+    ),
+    index("harness_capability_catalogs_organization_idx").on(
+      t.organizationId,
+    ),
+    check(
+      "harness_capability_catalogs_provider_check",
+      sql`${t.provider} in ('claude', 'codex')`,
+    ),
   ],
 );
 

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -832,9 +832,6 @@ export const harnessCapabilityCatalogs = pgTable(
       t.provider,
       t.cliVersion,
     ),
-    index("harness_capability_catalogs_organization_idx").on(
-      t.organizationId,
-    ),
     check(
       "harness_capability_catalogs_provider_check",
       sql`${t.provider} in ('claude', 'codex')`,

--- a/apps/worker/src/harness-profiles/capability-catalog.test.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.test.ts
@@ -145,6 +145,89 @@ describe("Harness capability catalog", () => {
     ).rejects.toMatchObject({ statusCode: 409 });
   });
 
+  it("coalesces forced refreshes and throttles repeated discovery", async () => {
+    let releaseDiscovery: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    const discover = vi.fn(async () => {
+      await blocked;
+      return CATALOG;
+    });
+    const input = {
+      organizationId: "org-a",
+      provider: "codex" as const,
+      cliVersion: "0.144.6",
+      refresh: true,
+      dependencies: {
+        now: () => new Date("2026-07-27T10:00:00.000Z"),
+        discoverCodex: discover,
+      },
+    };
+
+    const first = getHarnessCapabilities(db, input);
+    const concurrent = getHarnessCapabilities(db, input);
+    releaseDiscovery?.();
+    await Promise.all([first, concurrent]);
+    expect(discover).toHaveBeenCalledTimes(1);
+
+    await getHarnessCapabilities(db, {
+      ...input,
+      dependencies: {
+        ...input.dependencies,
+        now: () => new Date("2026-07-27T10:00:29.999Z"),
+      },
+    });
+    expect(discover).toHaveBeenCalledTimes(1);
+
+    await getHarnessCapabilities(db, {
+      ...input,
+      dependencies: {
+        ...input.dependencies,
+        now: () => new Date("2026-07-27T10:00:30.000Z"),
+      },
+    });
+    expect(discover).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not misreport persistence failures as discovery failures", async () => {
+    await getHarnessCapabilities(db, {
+      organizationId: "org-a",
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: {
+        now: () => new Date("2026-07-27T10:00:00.000Z"),
+        discoverCodex: async () => CATALOG,
+      },
+    });
+    const persistenceError = new Error("database write failed");
+    const failingDb = new Proxy(db, {
+      get(target, property) {
+        if (property === "insert") {
+          return () => {
+            throw persistenceError;
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as Db;
+
+    await expect(
+      getHarnessCapabilities(failingDb, {
+        organizationId: "org-a",
+        provider: "codex",
+        cliVersion: "0.144.6",
+        refresh: true,
+        dependencies: {
+          now: () => new Date("2026-07-27T10:00:30.000Z"),
+          discoverCodex: async () => CATALOG,
+        },
+      }),
+    ).rejects.toBe(persistenceError);
+  });
+
   it("hashes normalized provider data deterministically and upgrades only a present model", () => {
     const manifest =
       BUILTIN_HARNESS_PROFILE_MANIFESTS[
@@ -250,6 +333,21 @@ describe("Harness capability catalog", () => {
         "custom_threshold",
         "disabled",
       ],
+    });
+
+    expect(
+      normalizeClaudeModel({
+        id: "claude-invalid-default",
+        capabilities: {
+          effort: {
+            supported_efforts: ["medium"],
+            default_effort: "high",
+          },
+        },
+      }),
+    ).toMatchObject({
+      reasoningEfforts: [{ id: "medium" }],
+      defaultReasoningEffort: "medium",
     });
   });
 });

--- a/apps/worker/src/harness-profiles/capability-catalog.test.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  HarnessCapabilityCatalog,
+  HarnessProfileDraftManifestV1,
+} from "@shared/contracts";
+import {
+  BUILTIN_HARNESS_PROFILE_IDS,
+  BUILTIN_HARNESS_PROFILE_MANIFESTS,
+} from "@shared/contracts";
+import type { Db } from "../db/client.js";
+import { organization } from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+import {
+  getHarnessCapabilities,
+  HarnessCapabilityCatalogError,
+  hashHarnessCapabilityCatalog,
+  normalizeClaudeModel,
+  requireFreshHarnessCapabilities,
+  upgradeHarnessDraftToHistoricalV2,
+  upgradeHarnessDraftToV2,
+} from "./capability-catalog.js";
+
+const CATALOG: HarnessCapabilityCatalog = {
+  provider: "codex",
+  packageName: "@openai/codex",
+  cliVersion: "0.144.6",
+  protocolVersion: "codex-jsonl-0.144.6",
+  models: [
+    {
+      id: "gpt-current",
+      name: "GPT Current",
+      description: "Current Codex model",
+      contextWindowTokens: 200_000,
+      reasoningEfforts: [
+        { id: "medium", name: "Medium", description: null },
+        { id: "high", name: "High", description: null },
+      ],
+      defaultReasoningEffort: "medium",
+      serviceTiers: [
+        { id: "standard", name: "Standard", description: null },
+        { id: "fast", name: "Fast", description: null },
+      ],
+      defaultServiceTier: "standard",
+      verbosityOptions: [
+        { id: "medium", name: "Medium", description: null },
+      ],
+      defaultVerbosity: "medium",
+      compactionModes: ["model_default", "custom_threshold"],
+    },
+  ],
+};
+
+let db: Db;
+
+beforeEach(async () => {
+  db = await createTestDb();
+  await db.insert(organization).values([
+    { id: "org-a", name: "Organization A", slug: "capability-org-a" },
+    { id: "org-b", name: "Organization B", slug: "capability-org-b" },
+  ]);
+});
+
+describe("Harness capability catalog", () => {
+  it("caches a live catalog for fifteen minutes and keeps organizations isolated", async () => {
+    const discover = vi.fn(async () => CATALOG);
+    const first = await getHarnessCapabilities(db, {
+      organizationId: "org-a",
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: {
+        now: () => new Date("2026-07-27T10:00:00.000Z"),
+        discoverCodex: discover,
+      },
+    });
+    const cached = await getHarnessCapabilities(db, {
+      organizationId: "org-a",
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: {
+        now: () => new Date("2026-07-27T10:14:59.999Z"),
+        discoverCodex: discover,
+      },
+    });
+
+    expect(discover).toHaveBeenCalledTimes(1);
+    expect(cached).toEqual(first);
+    await expect(
+      getHarnessCapabilities(db, {
+        organizationId: "org-b",
+        provider: "codex",
+        cliVersion: "0.144.6",
+        refresh: false,
+        dependencies: {
+          now: () => new Date("2026-07-27T10:01:00.000Z"),
+          discoverCodex: async () => {
+            throw new Error("offline");
+          },
+        },
+      }),
+    ).rejects.toBeInstanceOf(HarnessCapabilityCatalogError);
+  });
+
+  it("returns an expired cache as stale when live discovery fails", async () => {
+    await getHarnessCapabilities(db, {
+      organizationId: "org-a",
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: {
+        now: () => new Date("2026-07-27T10:00:00.000Z"),
+        discoverCodex: async () => CATALOG,
+      },
+    });
+    const stale = await getHarnessCapabilities(db, {
+      organizationId: "org-a",
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: {
+        now: () => new Date("2026-07-27T10:15:00.000Z"),
+        discoverCodex: async () => {
+          throw new Error("offline");
+        },
+      },
+    });
+
+    expect(stale.stale).toBe(true);
+    expect(stale.refreshFailure?.message).toBe(
+      "Capability discovery failed.",
+    );
+    await expect(
+      requireFreshHarnessCapabilities(db, {
+        organizationId: "org-a",
+        provider: "codex",
+        cliVersion: "0.144.6",
+        dependencies: {
+          now: () => new Date("2026-07-27T10:16:00.000Z"),
+          discoverCodex: async () => {
+            throw new Error("offline");
+          },
+        },
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("hashes normalized provider data deterministically and upgrades only a present model", () => {
+    const manifest =
+      BUILTIN_HARNESS_PROFILE_MANIFESTS[
+        BUILTIN_HARNESS_PROFILE_IDS.codex
+      ];
+    const {
+      profileId: _profileId,
+      version: _version,
+      slug: _slug,
+      system: _system,
+      ...draft
+    } = structuredClone(manifest);
+    const response = {
+      ...CATALOG,
+      catalogHash: hashHarnessCapabilityCatalog(CATALOG),
+      fetchedAt: "2026-07-27T10:00:00.000Z",
+      stale: false,
+      refreshFailure: null,
+    };
+
+    expect(hashHarnessCapabilityCatalog(structuredClone(CATALOG))).toBe(
+      response.catalogHash,
+    );
+    expect(() =>
+      upgradeHarnessDraftToV2(
+        draft as HarnessProfileDraftManifestV1,
+        response,
+      ),
+    ).toThrow(/no longer available/);
+
+    const matching = structuredClone(response);
+    matching.models[0]!.id = draft.model.id;
+    const upgraded = upgradeHarnessDraftToV2(
+      draft as HarnessProfileDraftManifestV1,
+      matching,
+    );
+    expect(upgraded).toMatchObject({
+      schemaVersion: 2,
+      model: {
+        id: draft.model.id,
+        reasoning: {
+          selection: "model_default",
+          effectiveEffort: "medium",
+        },
+        serviceTier: "standard",
+      },
+      compaction: { mode: "model_default" },
+    });
+
+    const historical = upgradeHarnessDraftToHistoricalV2(
+      draft as HarnessProfileDraftManifestV1,
+    );
+    expect(historical).toMatchObject({
+      schemaVersion: 2,
+      model: {
+        id: draft.model.id,
+        reasoning: { effectiveEffort: "none" },
+        serviceTier: "standard",
+        capability: {
+          contextWindowTokens: null,
+          compactionModes: ["model_default"],
+        },
+      },
+    });
+    expect(historical.model.catalogHash).not.toBe(response.catalogHash);
+  });
+
+  it("fills Claude CLI-only effort and compaction controls without inventing model metadata", () => {
+    expect(
+      normalizeClaudeModel({
+        id: "claude-current",
+        display_name: "Claude Current",
+      }),
+    ).toMatchObject({
+      id: "claude-current",
+      contextWindowTokens: null,
+      reasoningEfforts: [
+        { id: "low" },
+        { id: "medium" },
+        { id: "high" },
+      ],
+      defaultReasoningEffort: "high",
+      compactionModes: ["model_default", "disabled"],
+    });
+
+    expect(
+      normalizeClaudeModel({
+        id: "claude-advertised",
+        capabilities: {
+          effort: {
+            supported_efforts: ["medium"],
+            default_effort: "medium",
+          },
+          max_input_tokens: 200_000,
+        },
+      }),
+    ).toMatchObject({
+      reasoningEfforts: [{ id: "medium" }],
+      defaultReasoningEffort: "medium",
+      contextWindowTokens: 200_000,
+      compactionModes: [
+        "model_default",
+        "custom_threshold",
+        "disabled",
+      ],
+    });
+  });
+});

--- a/apps/worker/src/harness-profiles/capability-catalog.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.ts
@@ -1,0 +1,732 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { and, eq } from "drizzle-orm";
+import type {
+  HarnessCapabilitiesResponse,
+  HarnessCapabilityCatalog,
+  HarnessCapabilityOption,
+  HarnessModelCapability,
+  HarnessProfileDraftManifestV1,
+  HarnessProfileDraftManifestV2,
+  HarnessProvider,
+} from "@shared/contracts";
+import type { Db } from "../db/client.js";
+import { harnessCapabilityCatalogs } from "../db/schema.js";
+import {
+  HARNESS_PROVIDER_CONTRACTS,
+  stableJson,
+} from "./manifest.js";
+
+export const HARNESS_CAPABILITY_CACHE_TTL_MS = 15 * 60 * 1_000;
+export const HARNESS_CAPABILITY_DISCOVERY_TIMEOUT_MS = 10_000;
+
+export class HarnessCapabilityCatalogError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface HarnessCapabilityDiscoveryDependencies {
+  now?: () => Date;
+  discoverClaude?: (
+    cliVersion: string,
+    signal: AbortSignal,
+  ) => Promise<HarnessCapabilityCatalog>;
+  discoverCodex?: (
+    cliVersion: string,
+    signal: AbortSignal,
+  ) => Promise<HarnessCapabilityCatalog>;
+}
+
+type CachedCatalog = typeof harnessCapabilityCatalogs.$inferSelect;
+
+export async function getHarnessCapabilities(
+  db: Db,
+  input: {
+    organizationId: string;
+    provider: HarnessProvider;
+    cliVersion: string;
+    refresh: boolean;
+    dependencies?: HarnessCapabilityDiscoveryDependencies;
+  },
+): Promise<HarnessCapabilitiesResponse> {
+  const providerContract = HARNESS_PROVIDER_CONTRACTS[input.provider];
+  if (
+    !(providerContract.cliVersions as readonly string[]).includes(
+      input.cliVersion,
+    )
+  ) {
+    throw new HarnessCapabilityCatalogError(
+      400,
+      "CLI version is not in the code-owned Harness Profile catalog.",
+    );
+  }
+
+  const now = input.dependencies?.now?.() ?? new Date();
+  const cached = await readCachedCatalog(db, input);
+  if (
+    !input.refresh &&
+    cached &&
+    now.getTime() - cached.fetchedAt.getTime() <
+      HARNESS_CAPABILITY_CACHE_TTL_MS
+  ) {
+    return responseFromCache(cached, false);
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    HARNESS_CAPABILITY_DISCOVERY_TIMEOUT_MS,
+  );
+  try {
+    const discover =
+      input.provider === "claude"
+        ? (input.dependencies?.discoverClaude ?? discoverClaudeCapabilities)
+        : (input.dependencies?.discoverCodex ?? discoverCodexCapabilities);
+    const catalog = normalizeCatalog(
+      await discover(input.cliVersion, controller.signal),
+    );
+    const catalogHash = hashHarnessCapabilityCatalog(catalog);
+    const [row] = await db
+      .insert(harnessCapabilityCatalogs)
+      .values({
+        organizationId: input.organizationId,
+        provider: input.provider,
+        cliVersion: input.cliVersion,
+        catalog,
+        catalogHash,
+        fetchedAt: now,
+        lastRefreshFailedAt: null,
+        lastRefreshError: null,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          harnessCapabilityCatalogs.organizationId,
+          harnessCapabilityCatalogs.provider,
+          harnessCapabilityCatalogs.cliVersion,
+        ],
+        set: {
+          catalog,
+          catalogHash,
+          fetchedAt: now,
+          lastRefreshFailedAt: null,
+          lastRefreshError: null,
+          updatedAt: now,
+        },
+      })
+      .returning();
+    return responseFromCache(row!, false);
+  } catch (error) {
+    const failureMessage = safeDiscoveryFailure(error);
+    if (cached) {
+      const [row] = await db
+        .update(harnessCapabilityCatalogs)
+        .set({
+          lastRefreshFailedAt: now,
+          lastRefreshError: failureMessage,
+          updatedAt: now,
+        })
+        .where(eq(harnessCapabilityCatalogs.id, cached.id))
+        .returning();
+      return responseFromCache(row ?? cached, true);
+    }
+    throw new HarnessCapabilityCatalogError(
+      503,
+      "Harness capabilities are temporarily unavailable.",
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function requireFreshHarnessCapabilities(
+  db: Db,
+  input: {
+    organizationId: string;
+    provider: HarnessProvider;
+    cliVersion: string;
+    dependencies?: HarnessCapabilityDiscoveryDependencies;
+  },
+): Promise<HarnessCapabilitiesResponse> {
+  const response = await getHarnessCapabilities(db, {
+    ...input,
+    refresh: true,
+  });
+  if (response.stale) {
+    throw new HarnessCapabilityCatalogError(
+      409,
+      "Refresh Harness capabilities before publishing this profile.",
+    );
+  }
+  return response;
+}
+
+export function hashHarnessCapabilityCatalog(
+  catalog: HarnessCapabilityCatalog,
+): string {
+  return createHash("sha256").update(stableJson(catalog)).digest("hex");
+}
+
+export function upgradeHarnessDraftToV2(
+  draft: HarnessProfileDraftManifestV1,
+  capabilities: HarnessCapabilitiesResponse,
+): HarnessProfileDraftManifestV2 {
+  const model = capabilities.models.find(
+    (candidate) => candidate.id === draft.model.id,
+  );
+  if (!model) {
+    throw new HarnessCapabilityCatalogError(
+      409,
+      `Model "${draft.model.id}" is no longer available. Select a current model before publishing.`,
+    );
+  }
+  const effectiveEffort =
+    model.defaultReasoningEffort ?? model.reasoningEfforts[0]?.id;
+  if (!effectiveEffort) {
+    throw new HarnessCapabilityCatalogError(
+      409,
+      `Model "${draft.model.id}" does not advertise a usable reasoning effort.`,
+    );
+  }
+  const serviceTier =
+    model.defaultServiceTier ?? model.serviceTiers[0]?.id;
+  if (!serviceTier) {
+    throw new HarnessCapabilityCatalogError(
+      409,
+      `Model "${draft.model.id}" does not advertise a usable service tier.`,
+    );
+  }
+  return {
+    ...structuredClone(draft),
+    schemaVersion: 2,
+    model: {
+      id: model.id,
+      reasoning: {
+        selection: "model_default",
+        effectiveEffort,
+      },
+      serviceTier,
+      ...(model.defaultVerbosity
+        ? { verbosity: model.defaultVerbosity }
+        : {}),
+      capability: structuredClone(model),
+      catalogHash: capabilities.catalogHash,
+    },
+    compaction: { mode: "model_default" },
+  };
+}
+
+/**
+ * Converts an immutable v1 selection into an inspectable v2 draft without
+ * inventing current provider capabilities. The placeholder can never be
+ * published unchanged because publication refreshes and compares the live
+ * catalog hash and exact model snapshot.
+ */
+export function upgradeHarnessDraftToHistoricalV2(
+  draft: HarnessProfileDraftManifestV1,
+): HarnessProfileDraftManifestV2 {
+  const capability: HarnessModelCapability = {
+    id: draft.model.id,
+    name: draft.model.id,
+    description:
+      "Historical provider-default selection. Choose a current model before publishing.",
+    contextWindowTokens: null,
+    reasoningEfforts: [
+      {
+        id: "none",
+        name: "Provider default",
+        description: null,
+      },
+    ],
+    defaultReasoningEffort: "none",
+    serviceTiers: [
+      { id: "standard", name: "Standard", description: null },
+    ],
+    defaultServiceTier: "standard",
+    verbosityOptions: [],
+    defaultVerbosity: null,
+    compactionModes: ["model_default"],
+  };
+  const historicalCatalog: HarnessCapabilityCatalog = {
+    provider: draft.harness.provider,
+    packageName: draft.harness.packageName,
+    cliVersion: draft.harness.cliVersion,
+    protocolVersion: draft.harness.protocolVersion,
+    models: [capability],
+  };
+  return {
+    ...structuredClone(draft),
+    schemaVersion: 2,
+    model: {
+      id: draft.model.id,
+      reasoning: {
+        selection: "model_default",
+        effectiveEffort: "none",
+      },
+      serviceTier: "standard",
+      capability,
+      catalogHash: hashHarnessCapabilityCatalog(historicalCatalog),
+    },
+    compaction: { mode: "model_default" },
+  };
+}
+
+async function readCachedCatalog(
+  db: Db,
+  input: {
+    organizationId: string;
+    provider: HarnessProvider;
+    cliVersion: string;
+  },
+): Promise<CachedCatalog | null> {
+  const [row] = await db
+    .select()
+    .from(harnessCapabilityCatalogs)
+    .where(
+      and(
+        eq(
+          harnessCapabilityCatalogs.organizationId,
+          input.organizationId,
+        ),
+        eq(harnessCapabilityCatalogs.provider, input.provider),
+        eq(harnessCapabilityCatalogs.cliVersion, input.cliVersion),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+function responseFromCache(
+  row: CachedCatalog,
+  stale: boolean,
+): HarnessCapabilitiesResponse {
+  return {
+    ...structuredClone(row.catalog),
+    catalogHash: row.catalogHash,
+    fetchedAt: row.fetchedAt.toISOString(),
+    stale,
+    refreshFailure:
+      row.lastRefreshFailedAt && row.lastRefreshError
+        ? {
+            occurredAt: row.lastRefreshFailedAt.toISOString(),
+            message: row.lastRefreshError,
+          }
+        : null,
+  };
+}
+
+function normalizeCatalog(
+  catalog: HarnessCapabilityCatalog,
+): HarnessCapabilityCatalog {
+  if (catalog.models.length === 0) {
+    throw new Error("Provider returned no models.");
+  }
+  const modelIds = new Set<string>();
+  const models = catalog.models.map((model) => {
+    if (!model.id.trim() || modelIds.has(model.id)) {
+      throw new Error("Provider returned an invalid model catalog.");
+    }
+    modelIds.add(model.id);
+    return {
+      ...structuredClone(model),
+      reasoningEfforts: uniqueOptions(model.reasoningEfforts),
+      serviceTiers: uniqueOptions(model.serviceTiers),
+      verbosityOptions: uniqueOptions(model.verbosityOptions),
+      compactionModes: [...new Set(model.compactionModes)],
+    };
+  });
+  return {
+    provider: catalog.provider,
+    packageName: catalog.packageName,
+    cliVersion: catalog.cliVersion,
+    protocolVersion: catalog.protocolVersion,
+    models,
+  };
+}
+
+function uniqueOptions(
+  options: HarnessCapabilityOption[],
+): HarnessCapabilityOption[] {
+  const seen = new Set<string>();
+  return options.filter((option) => {
+    if (!option.id.trim() || seen.has(option.id)) return false;
+    seen.add(option.id);
+    return true;
+  });
+}
+
+async function discoverClaudeCapabilities(
+  cliVersion: string,
+  signal: AbortSignal,
+): Promise<HarnessCapabilityCatalog> {
+  const { env } = await import("../../env.js");
+  if (
+    !env.ANTHROPIC_API_KEY ||
+    env.ANTHROPIC_API_KEY.startsWith("sk-ant-oat")
+  ) {
+    throw new Error("Anthropic Models API credentials are unavailable.");
+  }
+  const models: HarnessModelCapability[] = [];
+  let afterId: string | undefined;
+  do {
+    const url = new URL("https://api.anthropic.com/v1/models");
+    url.searchParams.set("limit", "1000");
+    if (afterId) url.searchParams.set("after_id", afterId);
+    const response = await fetch(url, {
+      headers: {
+        "x-api-key": env.ANTHROPIC_API_KEY,
+        "anthropic-version": "2023-06-01",
+      },
+      signal,
+    });
+    if (!response.ok) {
+      throw new Error("Anthropic model discovery failed.");
+    }
+    const body = (await response.json()) as {
+      data?: unknown[];
+      has_more?: boolean;
+      last_id?: string;
+    };
+    for (const raw of body.data ?? []) {
+      const normalized = normalizeClaudeModel(raw);
+      if (normalized) models.push(normalized);
+    }
+    afterId =
+      body.has_more === true && typeof body.last_id === "string"
+        ? body.last_id
+        : undefined;
+  } while (afterId);
+
+  return {
+    provider: "claude",
+    packageName: HARNESS_PROVIDER_CONTRACTS.claude.packageName,
+    cliVersion,
+    protocolVersion:
+      HARNESS_PROVIDER_CONTRACTS.claude.protocolVersions[0],
+    models,
+  };
+}
+
+export function normalizeClaudeModel(
+  raw: unknown,
+  cliVersion = HARNESS_PROVIDER_CONTRACTS.claude.cliVersions[0],
+): HarnessModelCapability | null {
+  const record = objectRecord(raw);
+  const id = stringValue(record.id);
+  if (!id) return null;
+  const displayName = stringValue(record.display_name) ?? id;
+  const capabilities = objectRecord(record.capabilities);
+  const effort = objectRecord(capabilities.effort);
+  const advertisedEfforts =
+    stringArray(effort.supported_efforts) ??
+    stringArray(capabilities.supported_efforts) ??
+    [];
+  const supportedEfforts =
+    advertisedEfforts.length > 0
+      ? advertisedEfforts
+      : claudeCliReasoningEfforts(cliVersion);
+  const efforts = supportedEfforts.map(optionFromId);
+  const defaultEffort =
+    stringValue(effort.default_effort) ??
+    (supportedEfforts.includes("high")
+      ? "high"
+      : (supportedEfforts[0] ?? "none"));
+  const contextWindow =
+    positiveInteger(record.max_input_tokens) ??
+    positiveInteger(capabilities.max_input_tokens);
+  return {
+    id,
+    name: displayName,
+    description: stringValue(record.description),
+    contextWindowTokens: contextWindow,
+    reasoningEfforts: efforts,
+    defaultReasoningEffort: defaultEffort,
+    serviceTiers: [optionFromId("standard")],
+    defaultServiceTier: "standard",
+    verbosityOptions: [],
+    defaultVerbosity: null,
+    compactionModes: [
+      "model_default",
+      ...(contextWindow === null ? [] : ["custom_threshold" as const]),
+      "disabled",
+    ],
+  };
+}
+
+function claudeCliReasoningEfforts(cliVersion: string): string[] {
+  return (HARNESS_PROVIDER_CONTRACTS.claude.cliVersions as readonly string[])
+    .includes(cliVersion)
+    ? ["low", "medium", "high"]
+    : ["none"];
+}
+
+async function discoverCodexCapabilities(
+  cliVersion: string,
+  signal: AbortSignal,
+): Promise<HarnessCapabilityCatalog> {
+  const rawModels = await readCodexAppServerModels(cliVersion, signal);
+  return {
+    provider: "codex",
+    packageName: HARNESS_PROVIDER_CONTRACTS.codex.packageName,
+    cliVersion,
+    protocolVersion:
+      HARNESS_PROVIDER_CONTRACTS.codex.protocolVersions[0],
+    models: rawModels
+      .map(normalizeCodexModel)
+      .filter((model): model is HarnessModelCapability => model !== null),
+  };
+}
+
+async function readCodexAppServerModels(
+  cliVersion: string,
+  signal: AbortSignal,
+): Promise<unknown[]> {
+  const { env } = await import("../../env.js");
+  const isolatedHome = await mkdtemp(join(tmpdir(), "aiw-codex-models-"));
+  const child = spawn(
+    "npx",
+    [
+      "--yes",
+      `@openai/codex@${cliVersion}`,
+      "app-server",
+      "--listen",
+      "stdio://",
+    ],
+    {
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: isolatedHome,
+        CODEX_HOME: join(isolatedHome, ".codex"),
+        ...(env.CODEX_API_KEY
+          ? { OPENAI_API_KEY: env.CODEX_API_KEY }
+          : {}),
+        ...(env.CODEX_CHATGPT_OAUTH_TOKEN
+          ? { CODEX_ACCESS_TOKEN: env.CODEX_CHATGPT_OAUTH_TOKEN }
+          : {}),
+      },
+      stdio: ["pipe", "pipe", "ignore"],
+    },
+  );
+  const lines = createInterface({ input: child.stdout });
+  const responses = new Map<
+    string,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+  const failPending = (error: Error) => {
+    for (const pending of responses.values()) pending.reject(error);
+    responses.clear();
+  };
+  lines.on("line", (line) => {
+    try {
+      const value = JSON.parse(line) as { id?: unknown; result?: unknown };
+      const id = String(value.id ?? "");
+      const pending = responses.get(id);
+      if (!pending) return;
+      responses.delete(id);
+      pending.resolve(value.result);
+    } catch {
+      // App-server notifications and non-JSON diagnostics are ignored.
+    }
+  });
+  child.once("error", failPending);
+  child.once("exit", (code) => {
+    if (code !== 0) failPending(new Error("Codex app-server exited."));
+  });
+  const abort = () => {
+    child.kill("SIGKILL");
+    failPending(new Error("Codex capability discovery timed out."));
+  };
+  signal.addEventListener("abort", abort, { once: true });
+
+  let requestId = 0;
+  const request = (method: string, params: unknown): Promise<unknown> => {
+    const id = String(++requestId);
+    return new Promise((resolve, reject) => {
+      responses.set(id, { resolve, reject });
+      child.stdin.write(`${JSON.stringify({ id, method, params })}\n`);
+    });
+  };
+
+  try {
+    await request("initialize", {
+      clientInfo: { name: "ai-workflow", version: "1" },
+      capabilities: {},
+    });
+    child.stdin.write(
+      `${JSON.stringify({ method: "initialized", params: {} })}\n`,
+    );
+    const models: unknown[] = [];
+    let cursor: string | null = null;
+    do {
+      const result = objectRecord(
+        await request("model/list", {
+          includeHidden: false,
+          limit: 100,
+          cursor,
+        }),
+      );
+      const page = Array.isArray(result.data)
+        ? result.data
+        : Array.isArray(result.models)
+          ? result.models
+          : [];
+      models.push(...page);
+      cursor =
+        stringValue(result.nextCursor) ??
+        stringValue(result.next_cursor) ??
+        null;
+    } while (cursor);
+    return models;
+  } finally {
+    signal.removeEventListener("abort", abort);
+    child.kill("SIGTERM");
+    lines.close();
+    await rm(isolatedHome, { recursive: true, force: true });
+  }
+}
+
+function normalizeCodexModel(raw: unknown): HarnessModelCapability | null {
+  const record = objectRecord(raw);
+  const id =
+    stringValue(record.id) ??
+    stringValue(record.model) ??
+    stringValue(record.slug);
+  if (!id) return null;
+  const rawEfforts = Array.isArray(record.supportedReasoningEfforts)
+    ? record.supportedReasoningEfforts
+    : Array.isArray(record.supported_reasoning_efforts)
+      ? record.supported_reasoning_efforts
+      : [];
+  const reasoningEfforts = rawEfforts
+    .map((entry) => {
+      const option = objectRecord(entry);
+      const effort =
+        stringValue(option.reasoningEffort) ??
+        stringValue(option.reasoning_effort) ??
+        stringValue(option.id);
+      return effort
+        ? {
+            id: effort,
+            name: titleCase(effort),
+            description: stringValue(option.description),
+          }
+        : null;
+    })
+    .filter((option): option is HarnessCapabilityOption => option !== null);
+  if (reasoningEfforts.length === 0) {
+    reasoningEfforts.push(optionFromId("none"));
+  }
+  const defaultReasoning =
+    stringValue(record.defaultReasoningEffort) ??
+    stringValue(record.default_reasoning_effort) ??
+    reasoningEfforts[0]?.id ??
+    null;
+
+  const tierIds = new Set<string>(["standard"]);
+  for (const value of [
+    ...(stringArray(record.serviceTiers) ?? []),
+    ...(stringArray(record.service_tiers) ?? []),
+  ]) {
+    tierIds.add(value);
+  }
+  for (const entry of Array.isArray(record.additionalSpeedTiers)
+    ? record.additionalSpeedTiers
+    : []) {
+    const option = objectRecord(entry);
+    const id =
+      stringValue(option.serviceTier) ??
+      stringValue(option.id) ??
+      stringValue(option.slug);
+    if (id) tierIds.add(id);
+  }
+  const contextWindow =
+    positiveInteger(record.contextWindow) ??
+    positiveInteger(record.context_window) ??
+    positiveInteger(record.contextWindowTokens);
+  const supportsVerbosity =
+    record.supportsVerbosity === true ||
+    record.supports_verbosity === true ||
+    Array.isArray(record.supportedVerbosity);
+  const verbosityIds = supportsVerbosity
+    ? (stringArray(record.supportedVerbosity) ?? ["low", "medium", "high"])
+    : [];
+  return {
+    id,
+    name:
+      stringValue(record.displayName) ??
+      stringValue(record.display_name) ??
+      id,
+    description: stringValue(record.description),
+    contextWindowTokens: contextWindow,
+    reasoningEfforts,
+    defaultReasoningEffort: defaultReasoning,
+    serviceTiers: [...tierIds].map(optionFromId),
+    defaultServiceTier:
+      stringValue(record.defaultServiceTier) ??
+      stringValue(record.default_service_tier) ??
+      "standard",
+    verbosityOptions: verbosityIds.map(optionFromId),
+    defaultVerbosity:
+      stringValue(record.defaultVerbosity) ??
+      stringValue(record.default_verbosity) ??
+      (verbosityIds.includes("medium") ? "medium" : (verbosityIds[0] ?? null)),
+    compactionModes: [
+      "model_default",
+      ...(contextWindow === null ? [] : ["custom_threshold" as const]),
+    ],
+  };
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function stringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value
+    .map(stringValue)
+    .filter((entry): entry is string => entry !== null);
+}
+
+function positiveInteger(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value > 0
+    ? value
+    : null;
+}
+
+function optionFromId(id: string): HarnessCapabilityOption {
+  return { id, name: titleCase(id), description: null };
+}
+
+function titleCase(value: string): string {
+  return value
+    .replaceAll("_", " ")
+    .replaceAll("-", " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function safeDiscoveryFailure(error: unknown): string {
+  if (
+    error instanceof DOMException &&
+    (error.name === "AbortError" || error.name === "TimeoutError")
+  ) {
+    return "Capability discovery timed out.";
+  }
+  return "Capability discovery failed.";
+}

--- a/apps/worker/src/harness-profiles/capability-catalog.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.ts
@@ -274,7 +274,14 @@ export function upgradeHarnessDraftToV2(
       `Model "${draft.model.id}" does not advertise a usable service tier.`,
     );
   }
-  return buildHarnessProfileDraftV2(draft, capabilities)!;
+  const upgraded = buildHarnessProfileDraftV2(draft, capabilities);
+  if (!upgraded) {
+    throw new HarnessCapabilityCatalogError(
+      409,
+      `Model "${draft.model.id}" is not compatible with the current capability catalog.`,
+    );
+  }
+  return upgraded;
 }
 
 /**
@@ -681,8 +688,14 @@ async function readCodexAppServerModels(
       },
     );
     const models: unknown[] = [];
+    const seenCursors = new Set<string>();
+    let pages = 0;
     let cursor: string | null = null;
     do {
+      pages++;
+      if (pages > 50) {
+        throw new Error("Codex app-server returned too many model pages.");
+      }
       const result = objectRecord(
         await request("model/list", {
           includeHidden: false,
@@ -700,6 +713,14 @@ async function readCodexAppServerModels(
         stringValue(result.nextCursor) ??
         stringValue(result.next_cursor) ??
         null;
+      if (cursor !== null) {
+        if (seenCursors.has(cursor)) {
+          throw new Error(
+            "Codex app-server returned a repeated page cursor.",
+          );
+        }
+        seenCursors.add(cursor);
+      }
     } while (cursor);
     return models;
   } finally {

--- a/apps/worker/src/harness-profiles/capability-catalog.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.ts
@@ -14,8 +14,10 @@ import type {
   HarnessProfileDraftManifestV2,
   HarnessProvider,
 } from "@shared/contracts";
+import { buildHarnessProfileDraftV2 } from "@shared/contracts";
 import type { Db } from "../db/client.js";
 import { harnessCapabilityCatalogs } from "../db/schema.js";
+import { logger } from "../lib/logger.js";
 import {
   HARNESS_PROVIDER_CONTRACTS,
   stableJson,
@@ -23,6 +25,12 @@ import {
 
 export const HARNESS_CAPABILITY_CACHE_TTL_MS = 15 * 60 * 1_000;
 export const HARNESS_CAPABILITY_DISCOVERY_TIMEOUT_MS = 10_000;
+export const HARNESS_CAPABILITY_REFRESH_THROTTLE_MS = 30_000;
+
+const inFlightRefreshes = new Map<
+  string,
+  Promise<HarnessCapabilitiesResponse>
+>();
 
 export class HarnessCapabilityCatalogError extends Error {
   constructor(
@@ -57,6 +65,37 @@ export async function getHarnessCapabilities(
     dependencies?: HarnessCapabilityDiscoveryDependencies;
   },
 ): Promise<HarnessCapabilitiesResponse> {
+  const refreshKey = [
+    input.organizationId,
+    input.provider,
+    input.cliVersion,
+  ].join(":");
+  if (input.refresh) {
+    const existing = inFlightRefreshes.get(refreshKey);
+    if (existing) return existing;
+    const pending = getHarnessCapabilitiesInternal(db, input);
+    inFlightRefreshes.set(refreshKey, pending);
+    try {
+      return await pending;
+    } finally {
+      if (inFlightRefreshes.get(refreshKey) === pending) {
+        inFlightRefreshes.delete(refreshKey);
+      }
+    }
+  }
+  return getHarnessCapabilitiesInternal(db, input);
+}
+
+async function getHarnessCapabilitiesInternal(
+  db: Db,
+  input: {
+    organizationId: string;
+    provider: HarnessProvider;
+    cliVersion: string;
+    refresh: boolean;
+    dependencies?: HarnessCapabilityDiscoveryDependencies;
+  },
+): Promise<HarnessCapabilitiesResponse> {
   const providerContract = HARNESS_PROVIDER_CONTRACTS[input.provider];
   if (
     !(providerContract.cliVersions as readonly string[]).includes(
@@ -72,6 +111,14 @@ export async function getHarnessCapabilities(
   const now = input.dependencies?.now?.() ?? new Date();
   const cached = await readCachedCatalog(db, input);
   if (
+    input.refresh &&
+    cached &&
+    now.getTime() - cached.fetchedAt.getTime() <
+      HARNESS_CAPABILITY_REFRESH_THROTTLE_MS
+  ) {
+    return responseFromCache(cached, false);
+  }
+  if (
     !input.refresh &&
     cached &&
     now.getTime() - cached.fetchedAt.getTime() <
@@ -85,47 +132,40 @@ export async function getHarnessCapabilities(
     () => controller.abort(),
     HARNESS_CAPABILITY_DISCOVERY_TIMEOUT_MS,
   );
+  const discoveryStartedAt = Date.now();
+  let catalog: HarnessCapabilityCatalog;
   try {
     const discover =
       input.provider === "claude"
         ? (input.dependencies?.discoverClaude ?? discoverClaudeCapabilities)
         : (input.dependencies?.discoverCodex ?? discoverCodexCapabilities);
-    const catalog = normalizeCatalog(
+    catalog = normalizeCatalog(
       await discover(input.cliVersion, controller.signal),
     );
-    const catalogHash = hashHarnessCapabilityCatalog(catalog);
-    const [row] = await db
-      .insert(harnessCapabilityCatalogs)
-      .values({
-        organizationId: input.organizationId,
+    logger.info(
+      {
+        event: "harness_capability_discovery",
+        organization_id: input.organizationId,
         provider: input.provider,
-        cliVersion: input.cliVersion,
-        catalog,
-        catalogHash,
-        fetchedAt: now,
-        lastRefreshFailedAt: null,
-        lastRefreshError: null,
-        updatedAt: now,
-      })
-      .onConflictDoUpdate({
-        target: [
-          harnessCapabilityCatalogs.organizationId,
-          harnessCapabilityCatalogs.provider,
-          harnessCapabilityCatalogs.cliVersion,
-        ],
-        set: {
-          catalog,
-          catalogHash,
-          fetchedAt: now,
-          lastRefreshFailedAt: null,
-          lastRefreshError: null,
-          updatedAt: now,
-        },
-      })
-      .returning();
-    return responseFromCache(row!, false);
+        cli_version: input.cliVersion,
+        duration_ms: Date.now() - discoveryStartedAt,
+        model_count: catalog.models.length,
+      },
+      "Harness capability discovery completed",
+    );
   } catch (error) {
     const failureMessage = safeDiscoveryFailure(error);
+    logger.warn(
+      {
+        event: "harness_capability_discovery",
+        organization_id: input.organizationId,
+        provider: input.provider,
+        cli_version: input.cliVersion,
+        duration_ms: Date.now() - discoveryStartedAt,
+        failure: failureMessage,
+      },
+      "Harness capability discovery failed",
+    );
     if (cached) {
       const [row] = await db
         .update(harnessCapabilityCatalogs)
@@ -145,6 +185,38 @@ export async function getHarnessCapabilities(
   } finally {
     clearTimeout(timer);
   }
+
+  const catalogHash = hashHarnessCapabilityCatalog(catalog);
+  const [row] = await db
+    .insert(harnessCapabilityCatalogs)
+    .values({
+      organizationId: input.organizationId,
+      provider: input.provider,
+      cliVersion: input.cliVersion,
+      catalog,
+      catalogHash,
+      fetchedAt: now,
+      lastRefreshFailedAt: null,
+      lastRefreshError: null,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        harnessCapabilityCatalogs.organizationId,
+        harnessCapabilityCatalogs.provider,
+        harnessCapabilityCatalogs.cliVersion,
+      ],
+      set: {
+        catalog,
+        catalogHash,
+        fetchedAt: now,
+        lastRefreshFailedAt: null,
+        lastRefreshError: null,
+        updatedAt: now,
+      },
+    })
+    .returning();
+  return responseFromCache(row!, false);
 }
 
 export async function requireFreshHarnessCapabilities(
@@ -188,40 +260,21 @@ export function upgradeHarnessDraftToV2(
       `Model "${draft.model.id}" is no longer available. Select a current model before publishing.`,
     );
   }
-  const effectiveEffort =
-    model.defaultReasoningEffort ?? model.reasoningEfforts[0]?.id;
-  if (!effectiveEffort) {
+  if (
+    !(model.defaultReasoningEffort ?? model.reasoningEfforts[0]?.id)
+  ) {
     throw new HarnessCapabilityCatalogError(
       409,
       `Model "${draft.model.id}" does not advertise a usable reasoning effort.`,
     );
   }
-  const serviceTier =
-    model.defaultServiceTier ?? model.serviceTiers[0]?.id;
-  if (!serviceTier) {
+  if (!(model.defaultServiceTier ?? model.serviceTiers[0]?.id)) {
     throw new HarnessCapabilityCatalogError(
       409,
       `Model "${draft.model.id}" does not advertise a usable service tier.`,
     );
   }
-  return {
-    ...structuredClone(draft),
-    schemaVersion: 2,
-    model: {
-      id: model.id,
-      reasoning: {
-        selection: "model_default",
-        effectiveEffort,
-      },
-      serviceTier,
-      ...(model.defaultVerbosity
-        ? { verbosity: model.defaultVerbosity }
-        : {}),
-      capability: structuredClone(model),
-      catalogHash: capabilities.catalogHash,
-    },
-    compaction: { mode: "model_default" },
-  };
+  return buildHarnessProfileDraftV2(draft, capabilities)!;
 }
 
 /**
@@ -335,11 +388,29 @@ function normalizeCatalog(
       throw new Error("Provider returned an invalid model catalog.");
     }
     modelIds.add(model.id);
+    const reasoningEfforts = uniqueOptions(model.reasoningEfforts);
+    const serviceTiers = uniqueOptions(model.serviceTiers);
+    const verbosityOptions = uniqueOptions(model.verbosityOptions);
+    assertDefaultInOptions(
+      model.defaultReasoningEffort,
+      reasoningEfforts,
+      "reasoning effort",
+    );
+    assertDefaultInOptions(
+      model.defaultServiceTier,
+      serviceTiers,
+      "service tier",
+    );
+    assertDefaultInOptions(
+      model.defaultVerbosity,
+      verbosityOptions,
+      "verbosity",
+    );
     return {
       ...structuredClone(model),
-      reasoningEfforts: uniqueOptions(model.reasoningEfforts),
-      serviceTiers: uniqueOptions(model.serviceTiers),
-      verbosityOptions: uniqueOptions(model.verbosityOptions),
+      reasoningEfforts,
+      serviceTiers,
+      verbosityOptions,
       compactionModes: [...new Set(model.compactionModes)],
     };
   });
@@ -350,6 +421,19 @@ function normalizeCatalog(
     protocolVersion: catalog.protocolVersion,
     models,
   };
+}
+
+function assertDefaultInOptions(
+  defaultId: string | null,
+  options: HarnessCapabilityOption[],
+  label: string,
+): void {
+  if (
+    defaultId !== null &&
+    !options.some((option) => option.id === defaultId)
+  ) {
+    throw new Error(`Provider returned an invalid default ${label}.`);
+  }
 }
 
 function uniqueOptions(
@@ -434,11 +518,13 @@ export function normalizeClaudeModel(
       ? advertisedEfforts
       : claudeCliReasoningEfforts(cliVersion);
   const efforts = supportedEfforts.map(optionFromId);
+  const advertisedDefault = stringValue(effort.default_effort);
   const defaultEffort =
-    stringValue(effort.default_effort) ??
-    (supportedEfforts.includes("high")
-      ? "high"
-      : (supportedEfforts[0] ?? "none"));
+    advertisedDefault && supportedEfforts.includes(advertisedDefault)
+      ? advertisedDefault
+      : supportedEfforts.includes("high")
+        ? "high"
+        : (supportedEfforts[0] ?? "none");
   const contextWindow =
     positiveInteger(record.max_input_tokens) ??
     positiveInteger(capabilities.max_input_tokens);
@@ -537,8 +623,11 @@ async function readCodexAppServerModels(
     }
   });
   child.once("error", failPending);
-  child.once("exit", (code) => {
-    if (code !== 0) failPending(new Error("Codex app-server exited."));
+  child.once("exit", () => {
+    failPending(new Error("Codex app-server exited."));
+  });
+  child.stdin.once("error", () => {
+    failPending(new Error("Codex app-server input closed."));
   });
   const abort = () => {
     child.kill("SIGKILL");
@@ -550,8 +639,24 @@ async function readCodexAppServerModels(
   const request = (method: string, params: unknown): Promise<unknown> => {
     const id = String(++requestId);
     return new Promise((resolve, reject) => {
+      if (
+        child.exitCode !== null ||
+        child.stdin.destroyed ||
+        child.stdin.writableEnded
+      ) {
+        reject(new Error("Codex app-server is not running."));
+        return;
+      }
       responses.set(id, { resolve, reject });
-      child.stdin.write(`${JSON.stringify({ id, method, params })}\n`);
+      child.stdin.write(
+        `${JSON.stringify({ id, method, params })}\n`,
+        (error) => {
+          if (!error) return;
+          responses.delete(id);
+          reject(new Error("Codex app-server input failed."));
+          failPending(new Error("Codex app-server input failed."));
+        },
+      );
     });
   };
 
@@ -560,8 +665,20 @@ async function readCodexAppServerModels(
       clientInfo: { name: "ai-workflow", version: "1" },
       capabilities: {},
     });
+    if (
+      child.exitCode !== null ||
+      child.stdin.destroyed ||
+      child.stdin.writableEnded
+    ) {
+      throw new Error("Codex app-server is not running.");
+    }
     child.stdin.write(
       `${JSON.stringify({ method: "initialized", params: {} })}\n`,
+      (error) => {
+        if (error) {
+          failPending(new Error("Codex app-server input failed."));
+        }
+      },
     );
     const models: unknown[] = [];
     let cursor: string | null = null;

--- a/apps/worker/src/harness-profiles/manifest.test.ts
+++ b/apps/worker/src/harness-profiles/manifest.test.ts
@@ -221,5 +221,29 @@ describe("harness profile manifest validation", () => {
         ]),
       );
     }
+
+    const disabledCodex = structuredClone(value) as Record<string, any>;
+    disabledCodex.compaction = { mode: "disabled" };
+    try {
+      parseHarnessProfileDraftManifest(disabledCodex);
+      expect.unreachable();
+    } catch (error) {
+      expect(issuePaths(error)).toContain("/compaction/mode");
+    }
+
+    const claude = structuredClone(value) as Record<string, any>;
+    claude.harness = structuredClone(
+      BUILTIN_HARNESS_PROFILE_MANIFESTS[
+        BUILTIN_HARNESS_PROFILE_IDS.claude
+      ].harness,
+    );
+    claude.credentialReferences = ["anthropic"];
+    claude.compaction = { mode: "model_default" };
+    try {
+      parseHarnessProfileDraftManifest(claude);
+      expect.unreachable();
+    } catch (error) {
+      expect(issuePaths(error)).toContain("/model/verbosity");
+    }
   });
 });

--- a/apps/worker/src/harness-profiles/manifest.test.ts
+++ b/apps/worker/src/harness-profiles/manifest.test.ts
@@ -33,7 +33,9 @@ function issuePaths(error: unknown): string[] {
 
 describe("harness profile manifest validation", () => {
   it("accepts a code-owned provider contract and hashes it deterministically", () => {
-    const parsed = parseHarnessProfileDraftManifest(draft());
+    const parsed = parseHarnessProfileDraftManifest(
+      draft(),
+    ) as HarnessProfileDraftManifestV1;
     const first = compileHarnessProfileManifest({
       profileId: "profile",
       version: 1,
@@ -141,5 +143,83 @@ describe("harness profile manifest validation", () => {
     expect(() => parseHarnessProfileDraftManifest(value)).toThrow(
       HarnessProfileManifestError,
     );
+  });
+
+  it("accepts a v2 capability snapshot and requires every selected setting to be advertised", () => {
+    const value = {
+      ...draft(),
+      schemaVersion: 2 as const,
+      model: {
+        id: "gpt-5.4",
+        reasoning: {
+          selection: "model_default",
+          effectiveEffort: "high",
+        },
+        serviceTier: "standard",
+        verbosity: "medium",
+        catalogHash: "a".repeat(64),
+        capability: {
+          id: "gpt-5.4",
+          name: "GPT-5.4",
+          description: null,
+          contextWindowTokens: 200_000,
+          reasoningEfforts: [
+            { id: "medium", name: "Medium", description: null },
+            { id: "high", name: "High", description: null },
+          ],
+          defaultReasoningEffort: "high",
+          serviceTiers: [
+            { id: "standard", name: "Standard", description: null },
+            { id: "fast", name: "Fast", description: null },
+          ],
+          defaultServiceTier: "standard",
+          verbosityOptions: [
+            { id: "medium", name: "Medium", description: null },
+          ],
+          defaultVerbosity: "medium",
+          compactionModes: [
+            "model_default" as const,
+            "custom_threshold" as const,
+          ],
+        },
+      },
+      compaction: {
+        mode: "custom_threshold" as const,
+        thresholdPercent: 80,
+        thresholdTokens: 160_000,
+      },
+    };
+
+    expect(parseHarnessProfileDraftManifest(value)).toMatchObject({
+      schemaVersion: 2,
+      model: {
+        reasoning: { effectiveEffort: "high" },
+        serviceTier: "standard",
+        verbosity: "medium",
+      },
+      compaction: {
+        mode: "custom_threshold",
+        thresholdTokens: 160_000,
+      },
+    });
+
+    const invalid = structuredClone(value);
+    invalid.model.serviceTier = "unadvertised";
+    invalid.model.reasoning.effectiveEffort = "low";
+    invalid.compaction.thresholdTokens = 123;
+    expect(() => parseHarnessProfileDraftManifest(invalid)).toThrow(
+      HarnessProfileManifestError,
+    );
+    try {
+      parseHarnessProfileDraftManifest(invalid);
+    } catch (error) {
+      expect(issuePaths(error)).toEqual(
+        expect.arrayContaining([
+          "/model/reasoning",
+          "/model/serviceTier",
+          "/compaction/thresholdTokens",
+        ]),
+      );
+    }
   });
 });

--- a/apps/worker/src/harness-profiles/manifest.ts
+++ b/apps/worker/src/harness-profiles/manifest.ts
@@ -13,6 +13,7 @@ import type {
 import {
   HARNESS_MCP_INTEGRATION_IDS,
   HARNESS_TOOL_IDS,
+  stableJson,
 } from "@shared/contracts";
 import { z } from "zod";
 
@@ -398,11 +399,38 @@ const draftManifestV2Schema = z
   })
   .strict()
   .superRefine((manifest, context) => {
+    const {
+      displayName,
+      description,
+      harness,
+      homeFiles,
+      context: manifestContext,
+      subagents,
+      limits,
+      workspace,
+      instructions,
+      skills,
+      tools,
+      mcpIntegrations,
+      credentialReferences,
+    } = manifest;
     const commonValidation = draftManifestSchema.safeParse({
-      ...manifest,
       schemaVersion: 1,
+      displayName,
+      description,
+      harness,
       model: { id: manifest.model.id, options: {} },
+      homeFiles,
+      context: manifestContext,
       compaction: { mode: "provider_default" },
+      subagents,
+      limits,
+      workspace,
+      instructions,
+      skills,
+      tools,
+      mcpIntegrations,
+      credentialReferences,
     });
     if (!commonValidation.success) {
       for (const issue of commonValidation.error.issues) {
@@ -655,19 +683,7 @@ export function hashHarnessProfileManifest(
   return createHash("sha256").update(stableJson(manifest)).digest("hex");
 }
 
-export function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map(stableJson).join(",")}]`;
-  }
-  const record = value as Record<string, unknown>;
-  return `{${Object.keys(record)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${stableJson(record[key])}`)
-    .join(",")}}`;
-}
+export { stableJson } from "@shared/contracts";
 
 function escapePointerSegment(segment: PropertyKey): string {
   return String(segment).replaceAll("~", "~0").replaceAll("/", "~1");

--- a/apps/worker/src/harness-profiles/manifest.ts
+++ b/apps/worker/src/harness-profiles/manifest.ts
@@ -1,8 +1,13 @@
 import { createHash } from "node:crypto";
 import { posix } from "node:path";
 import type {
+  HarnessModelCapability,
+  HarnessProfileDraftManifest,
   HarnessProfileDraftManifestV1,
+  HarnessProfileDraftManifestV2,
+  HarnessProfileManifest,
   HarnessProfileManifestV1,
+  HarnessProfileManifestV2,
   JsonValue,
 } from "@shared/contracts";
 import {
@@ -20,7 +25,7 @@ export const HARNESS_CREDENTIAL_IDS = [
   "slack",
 ] as const;
 
-const PROVIDER_CONTRACTS = {
+export const HARNESS_PROVIDER_CONTRACTS = {
   claude: {
     packageName: "@anthropic-ai/claude-code",
     cliVersions: ["2.1.216"],
@@ -46,6 +51,7 @@ const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
 
 const boundedString = (max: number) => z.string().trim().min(1).max(max);
 const artifactHashSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const catalogHashSchema = z.string().regex(/^[a-f0-9]{64}$/);
 
 const draftManifestSchema = z
   .object({
@@ -125,7 +131,8 @@ const draftManifestSchema = z
   })
   .strict()
   .superRefine((manifest, context) => {
-    const providerContract = PROVIDER_CONTRACTS[manifest.harness.provider];
+    const providerContract =
+      HARNESS_PROVIDER_CONTRACTS[manifest.harness.provider];
     if (manifest.harness.packageName !== providerContract.packageName) {
       context.addIssue({
         code: "custom",
@@ -268,6 +275,278 @@ const draftManifestSchema = z
     );
   });
 
+const capabilityOptionSchema = z
+  .object({
+    id: boundedString(80),
+    name: boundedString(120),
+    description: z.string().max(2_000).nullable(),
+  })
+  .strict();
+
+const modelCapabilitySchema: z.ZodType<HarnessModelCapability> = z
+  .object({
+    id: boundedString(200),
+    name: boundedString(200),
+    description: z.string().max(4_000).nullable(),
+    contextWindowTokens: z.number().int().positive().nullable(),
+    reasoningEfforts: z.array(capabilityOptionSchema).max(20),
+    defaultReasoningEffort: boundedString(80).nullable(),
+    serviceTiers: z.array(capabilityOptionSchema).min(1).max(20),
+    defaultServiceTier: boundedString(80).nullable(),
+    verbosityOptions: z.array(capabilityOptionSchema).max(20),
+    defaultVerbosity: boundedString(80).nullable(),
+    compactionModes: z
+      .array(
+        z.enum(["model_default", "custom_threshold", "disabled"]),
+      )
+      .min(1)
+      .max(3),
+  })
+  .strict();
+
+const draftManifestV2Schema = z
+  .object({
+    schemaVersion: z.literal(2),
+    displayName: boundedString(120),
+    description: z.string().trim().max(2_000),
+    harness: z
+      .object({
+        provider: z.enum(["claude", "codex"]),
+        packageName: boundedString(200),
+        cliVersion: boundedString(80),
+        protocolVersion: boundedString(120),
+      })
+      .strict(),
+    model: z
+      .object({
+        id: boundedString(200),
+        reasoning: z
+          .object({
+            selection: boundedString(80),
+            effectiveEffort: boundedString(80),
+          })
+          .strict(),
+        serviceTier: boundedString(80),
+        verbosity: boundedString(80).optional(),
+        capability: modelCapabilitySchema,
+        catalogHash: catalogHashSchema,
+      })
+      .strict(),
+    homeFiles: z
+      .array(
+        z
+          .object({
+            path: boundedString(300),
+            content: z.string().max(1024 * 1024),
+            mode: z.literal(0o644),
+          })
+          .strict(),
+      )
+      .max(100),
+    context: z
+      .object({
+        includeRepositoryInstructions: z.literal(true),
+        includeWorkflowData: z.boolean(),
+      })
+      .strict(),
+    compaction: z.discriminatedUnion("mode", [
+      z.object({ mode: z.literal("model_default") }).strict(),
+      z
+        .object({
+          mode: z.literal("custom_threshold"),
+          thresholdPercent: z.number().int().min(1).max(99),
+          thresholdTokens: z.number().int().positive(),
+        })
+        .strict(),
+      z.object({ mode: z.literal("disabled") }).strict(),
+    ]),
+    subagents: z
+      .object({
+        enabled: z.boolean(),
+        maxConcurrent: z.number().int().min(0).max(16),
+      })
+      .strict(),
+    limits: z
+      .object({
+        maxDurationMs: z.number().int().positive().max(86_400_000).nullable(),
+        maxTokens: z.number().int().positive().max(10_000_000).nullable(),
+        maxCostUsd: z.number().finite().positive().max(100_000).nullable(),
+      })
+      .strict(),
+    workspace: z
+      .object({
+        mode: z.literal("managed"),
+        preserveAcrossBlocks: z.boolean(),
+      })
+      .strict(),
+    instructions: z.string().max(100_000),
+    skills: z
+      .array(
+        z
+          .object({
+            artifactHash: artifactHashSchema,
+            name: boundedString(120),
+          })
+          .strict(),
+      )
+      .max(100),
+    tools: z.array(z.enum(HARNESS_TOOL_IDS)).max(HARNESS_TOOL_IDS.length),
+    mcpIntegrations: z.array(z.string()).max(0),
+    credentialReferences: z
+      .array(z.enum(HARNESS_CREDENTIAL_IDS))
+      .max(HARNESS_CREDENTIAL_IDS.length),
+  })
+  .strict()
+  .superRefine((manifest, context) => {
+    const commonValidation = draftManifestSchema.safeParse({
+      ...manifest,
+      schemaVersion: 1,
+      model: { id: manifest.model.id, options: {} },
+      compaction: { mode: "provider_default" },
+    });
+    if (!commonValidation.success) {
+      for (const issue of commonValidation.error.issues) {
+        context.addIssue({
+          code: "custom",
+          path: issue.path,
+          message: issue.message,
+        });
+      }
+    }
+
+    const capability = manifest.model.capability;
+    if (capability.id !== manifest.model.id) {
+      context.addIssue({
+        code: "custom",
+        path: ["model", "capability", "id"],
+        message: "Capability snapshot does not match the selected model",
+      });
+    }
+    addDuplicateIssues(
+      capability.reasoningEfforts.map((option) => option.id),
+      ["model", "capability", "reasoningEfforts"],
+      "Reasoning effort",
+      context,
+    );
+    addDuplicateIssues(
+      capability.serviceTiers.map((option) => option.id),
+      ["model", "capability", "serviceTiers"],
+      "Service tier",
+      context,
+    );
+    addDuplicateIssues(
+      capability.verbosityOptions.map((option) => option.id),
+      ["model", "capability", "verbosityOptions"],
+      "Verbosity option",
+      context,
+    );
+    addDuplicateIssues(
+      capability.compactionModes,
+      ["model", "capability", "compactionModes"],
+      "Compaction mode",
+      context,
+    );
+
+    const effortIds = new Set(
+      capability.reasoningEfforts.map((option) => option.id),
+    );
+    const selectedEffort =
+      manifest.model.reasoning.selection === "model_default"
+        ? capability.defaultReasoningEffort
+        : manifest.model.reasoning.selection;
+    if (
+      selectedEffort === null ||
+      !effortIds.has(selectedEffort) ||
+      manifest.model.reasoning.effectiveEffort !== selectedEffort
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["model", "reasoning"],
+        message:
+          "Reasoning selection must resolve to an effort advertised by the selected model",
+      });
+    }
+
+    if (
+      !capability.serviceTiers.some(
+        (option) => option.id === manifest.model.serviceTier,
+      )
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["model", "serviceTier"],
+        message: "Service tier is not supported by the selected model",
+      });
+    }
+
+    if (
+      (capability.verbosityOptions.length === 0 &&
+        manifest.model.verbosity !== undefined) ||
+      (manifest.model.verbosity !== undefined &&
+        !capability.verbosityOptions.some(
+          (option) => option.id === manifest.model.verbosity,
+        ))
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["model", "verbosity"],
+        message: "Verbosity is not supported by the selected model",
+      });
+    }
+
+    if (!capability.compactionModes.includes(manifest.compaction.mode)) {
+      context.addIssue({
+        code: "custom",
+        path: ["compaction", "mode"],
+        message: "Compaction mode is not supported by the selected model",
+      });
+    }
+    if (manifest.compaction.mode === "custom_threshold") {
+      if (capability.contextWindowTokens === null) {
+        context.addIssue({
+          code: "custom",
+          path: ["compaction"],
+          message:
+            "Custom compaction requires a known model context window",
+        });
+      } else {
+        const expectedTokens = Math.floor(
+          (capability.contextWindowTokens *
+            manifest.compaction.thresholdPercent) /
+            100,
+        );
+        if (manifest.compaction.thresholdTokens !== expectedTokens) {
+          context.addIssue({
+            code: "custom",
+            path: ["compaction", "thresholdTokens"],
+            message:
+              "Derived compaction token threshold does not match the selected percentage",
+          });
+        }
+      }
+    }
+    if (
+      manifest.harness.provider === "codex" &&
+      manifest.compaction.mode === "disabled"
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["compaction", "mode"],
+        message: "Codex does not support disabling compaction",
+      });
+    }
+    if (
+      manifest.harness.provider === "claude" &&
+      manifest.model.verbosity !== undefined
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["model", "verbosity"],
+        message: "Claude does not support response verbosity",
+      });
+    }
+  });
+
 function addDuplicateIssues(
   values: readonly string[],
   path: Array<string | number>,
@@ -313,8 +592,14 @@ export class HarnessProfileManifestError extends Error {
 
 export function parseHarnessProfileDraftManifest(
   value: unknown,
-): HarnessProfileDraftManifestV1 {
-  const parsed = draftManifestSchema.safeParse(value);
+): HarnessProfileDraftManifest {
+  const parsed =
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as { schemaVersion?: unknown }).schemaVersion === 2
+      ? draftManifestV2Schema.safeParse(value)
+      : draftManifestSchema.safeParse(value);
   if (!parsed.success) {
     throw new HarnessProfileManifestError(
       "Invalid harness profile manifest",
@@ -333,7 +618,28 @@ export function compileHarnessProfileManifest(input: {
   slug: string;
   system: boolean;
   draft: HarnessProfileDraftManifestV1;
-}): HarnessProfileManifestV1 {
+}): HarnessProfileManifestV1;
+export function compileHarnessProfileManifest(input: {
+  profileId: string;
+  version: number;
+  slug: string;
+  system: boolean;
+  draft: HarnessProfileDraftManifestV2;
+}): HarnessProfileManifestV2;
+export function compileHarnessProfileManifest(input: {
+  profileId: string;
+  version: number;
+  slug: string;
+  system: boolean;
+  draft: HarnessProfileDraftManifest;
+}): HarnessProfileManifest;
+export function compileHarnessProfileManifest(input: {
+  profileId: string;
+  version: number;
+  slug: string;
+  system: boolean;
+  draft: HarnessProfileDraftManifest;
+}): HarnessProfileManifest {
   return {
     ...structuredClone(input.draft),
     profileId: input.profileId,
@@ -344,7 +650,7 @@ export function compileHarnessProfileManifest(input: {
 }
 
 export function hashHarnessProfileManifest(
-  manifest: HarnessProfileManifestV1,
+  manifest: HarnessProfileManifest,
 ): string {
   return createHash("sha256").update(stableJson(manifest)).digest("hex");
 }

--- a/apps/worker/src/harness-profiles/store.test.ts
+++ b/apps/worker/src/harness-profiles/store.test.ts
@@ -408,7 +408,11 @@ describe("organization profiles", () => {
         actor: ADMIN,
         capabilityDependencies,
       }),
-    ).rejects.toMatchObject({ statusCode: 409 });
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      message:
+        "Harness capabilities changed. Review the current model settings before publishing.",
+    });
     const currentDraft = upgradeHarnessDraftToV2(draft(), {
       ...liveCapabilities,
       catalogHash: hashHarnessCapabilityCatalog(liveCapabilities),
@@ -429,6 +433,7 @@ describe("organization profiles", () => {
       capabilityDependencies,
     });
     expect(third.version.version).toBe(3);
+    expect(third.version.restoredFromVersion).toBe(1);
 
     const fork = await forkHarnessProfile(db, {
       profileId: created.id,

--- a/apps/worker/src/harness-profiles/store.test.ts
+++ b/apps/worker/src/harness-profiles/store.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { beforeEach, describe, expect, it } from "vitest";
 import { and, eq } from "drizzle-orm";
 import type {
+  HarnessCapabilityCatalog,
   HarnessProfileDraftManifestV1,
   HarnessProfileManifestV1,
 } from "@shared/contracts";
@@ -23,6 +24,10 @@ import {
 import { createTestDb } from "../db/test-db.js";
 import { DashboardAuthError } from "../lib/auth/users-read.js";
 import { hashHarnessSkillArtifact } from "./skill-artifact.js";
+import {
+  hashHarnessCapabilityCatalog,
+  upgradeHarnessDraftToV2,
+} from "./capability-catalog.js";
 import {
   archiveHarnessProfile,
   createHarnessProfile,
@@ -89,6 +94,43 @@ function catalogWithCodex(
         BUILTIN_HARNESS_PROFILE_IDS.claude
       ],
     [BUILTIN_HARNESS_PROFILE_IDS.codex]: manifest,
+  };
+}
+
+function capabilityCatalogFor(
+  profileDraft: HarnessProfileDraftManifestV1,
+): HarnessCapabilityCatalog {
+  return {
+    provider: profileDraft.harness.provider,
+    packageName: profileDraft.harness.packageName,
+    cliVersion: profileDraft.harness.cliVersion,
+    protocolVersion: profileDraft.harness.protocolVersion,
+    models: [
+      {
+        id: profileDraft.model.id,
+        name: profileDraft.model.id,
+        description: null,
+        contextWindowTokens: 200_000,
+        reasoningEfforts: [
+          { id: "medium", name: "Medium", description: null },
+        ],
+        defaultReasoningEffort: "medium",
+        serviceTiers: [
+          { id: "standard", name: "Standard", description: null },
+        ],
+        defaultServiceTier: "standard",
+        verbosityOptions:
+          profileDraft.harness.provider === "codex"
+            ? [{ id: "medium", name: "Medium", description: null }]
+            : [],
+        defaultVerbosity:
+          profileDraft.harness.provider === "codex" ? "medium" : null,
+        compactionModes:
+          profileDraft.harness.provider === "codex"
+            ? ["model_default", "custom_threshold"]
+            : ["model_default", "custom_threshold", "disabled"],
+      },
+    ],
   };
 }
 
@@ -165,7 +207,9 @@ describe("system profile seeding", () => {
       (version) => version.profileId === "builtin-codex",
     );
     const nextCodex: HarnessProfileManifestV1 = {
-      ...structuredClone(currentCodex!.manifest),
+      ...structuredClone(
+        currentCodex!.manifest as HarnessProfileManifestV1,
+      ),
       version: currentCodex!.version + 1,
       instructions: "Updated code-owned instructions",
     };
@@ -308,6 +352,10 @@ describe("organization profiles", () => {
   });
 
   it("publishes immutable versions, restores drafts, forks, and preserves pinned archives", async () => {
+    const liveCapabilities = capabilityCatalogFor(draft());
+    const capabilityDependencies = {
+      discoverCodex: async () => liveCapabilities,
+    };
     const created = await createHarnessProfile(db, {
       slug: "lifecycle",
       draft: draft(),
@@ -342,6 +390,7 @@ describe("organization profiles", () => {
       profileId: created.id,
       expectedRevision: changedDraft.draftRevision,
       actor: ADMIN,
+      capabilityDependencies,
     });
     expect(second.version.version).toBe(2);
 
@@ -352,20 +401,39 @@ describe("organization profiles", () => {
       actor: ADMIN,
     });
     expect(restored.draftRestoredFromVersion).toBe(1);
-    const third = await publishHarnessProfile(db, {
+    await expect(
+      publishHarnessProfile(db, {
+        profileId: created.id,
+        expectedRevision: restored.draftRevision,
+        actor: ADMIN,
+        capabilityDependencies,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    const currentDraft = upgradeHarnessDraftToV2(draft(), {
+      ...liveCapabilities,
+      catalogHash: hashHarnessCapabilityCatalog(liveCapabilities),
+      fetchedAt: new Date().toISOString(),
+      stale: false,
+      refreshFailure: null,
+    });
+    const reviewedRestore = await updateHarnessProfileDraft(db, {
       profileId: created.id,
       expectedRevision: restored.draftRevision,
+      draft: currentDraft,
       actor: ADMIN,
     });
-    expect(third.version).toMatchObject({
-      version: 3,
-      restoredFromVersion: 1,
+    const third = await publishHarnessProfile(db, {
+      profileId: created.id,
+      expectedRevision: reviewedRestore.draftRevision,
+      actor: ADMIN,
+      capabilityDependencies,
     });
+    expect(third.version.version).toBe(3);
 
     const fork = await forkHarnessProfile(db, {
       profileId: created.id,
       slug: "lifecycle-fork",
-      expectedRevision: restored.draftRevision,
+      expectedRevision: reviewedRestore.draftRevision,
       actor: ADMIN,
     });
     expect(fork.id).not.toBe(created.id);
@@ -373,7 +441,7 @@ describe("organization profiles", () => {
 
     const archived = await archiveHarnessProfile(db, {
       profileId: created.id,
-      expectedRevision: restored.draftRevision,
+      expectedRevision: reviewedRestore.draftRevision,
       actor: ADMIN,
     });
     expect(archived.archivedAt).not.toBeNull();

--- a/apps/worker/src/harness-profiles/store.ts
+++ b/apps/worker/src/harness-profiles/store.ts
@@ -17,8 +17,9 @@ import {
 import type {
   BuiltinHarnessProfileId,
   HarnessProfileDetailResponse,
-  HarnessProfileDraftManifestV1,
+  HarnessProfileDraftManifest,
   HarnessProfileDto,
+  HarnessProfileManifest,
   HarnessProfileManifestV1,
   HarnessProfileReference,
   HarnessProfileResolvedVersion,
@@ -51,7 +52,14 @@ import {
   HarnessProfileManifestError,
   hashHarnessProfileManifest,
   parseHarnessProfileDraftManifest,
+  stableJson,
 } from "./manifest.js";
+import {
+  HarnessCapabilityCatalogError,
+  requireFreshHarnessCapabilities,
+  upgradeHarnessDraftToHistoricalV2,
+  type HarnessCapabilityDiscoveryDependencies,
+} from "./capability-catalog.js";
 import {
   HarnessSkillArtifactIntegrityError,
   verifyHarnessSkillArtifact,
@@ -145,7 +153,7 @@ function assertPositiveRevision(value: number): void {
   }
 }
 
-function normalizeDraft(value: unknown): HarnessProfileDraftManifestV1 {
+function normalizeDraft(value: unknown): HarnessProfileDraftManifest {
   try {
     return parseHarnessProfileDraftManifest(value);
   } catch (error) {
@@ -159,8 +167,8 @@ function normalizeDraft(value: unknown): HarnessProfileDraftManifestV1 {
 }
 
 function draftFromManifest(
-  manifest: HarnessProfileManifestV1,
-): HarnessProfileDraftManifestV1 {
+  manifest: HarnessProfileManifest,
+): HarnessProfileDraftManifest {
   const {
     profileId: _profileId,
     version: _version,
@@ -695,6 +703,7 @@ export async function publishHarnessProfile(
     profileId: string;
     expectedRevision: number;
     actor: HarnessProfileActor;
+    capabilityDependencies?: HarnessCapabilityDiscoveryDependencies;
   },
 ): Promise<{
   profile: HarnessProfileDto;
@@ -705,6 +714,40 @@ export async function publishHarnessProfile(
   assertPositiveRevision(input.expectedRevision);
   const profile = await getWritableProfileForRevision(db, input);
   const draft = normalizeDraft(profile.draftManifest);
+  if (draft.schemaVersion === 2) {
+    let capabilities;
+    try {
+      capabilities = await requireFreshHarnessCapabilities(db, {
+        organizationId: input.actor.organizationId,
+        provider: draft.harness.provider,
+        cliVersion: draft.harness.cliVersion,
+        dependencies: input.capabilityDependencies,
+      });
+    } catch (error) {
+      if (error instanceof HarnessCapabilityCatalogError) {
+        throw new HarnessProfileStoreError(error.statusCode, error.message);
+      }
+      throw error;
+    }
+    if (capabilities.catalogHash !== draft.model.catalogHash) {
+      throw new HarnessProfileStoreError(
+        409,
+        "Harness capabilities changed. Review the current model settings before publishing.",
+      );
+    }
+    const model = capabilities.models.find(
+      (candidate) => candidate.id === draft.model.id,
+    );
+    if (
+      !model ||
+      stableJson(model) !== stableJson(draft.model.capability)
+    ) {
+      throw new HarnessProfileStoreError(
+        409,
+        "The selected model capability snapshot is no longer current.",
+      );
+    }
+  }
   const artifacts = await getHarnessSkillArtifactsByHashes(db, {
     organizationId: input.actor.organizationId,
     artifactHashes: draft.skills.map((skill) => skill.artifactHash),
@@ -907,10 +950,14 @@ export async function restoreHarnessProfileVersion(
   if (!source) {
     throw new HarnessProfileStoreError(404, "Profile version not found");
   }
+  let restoredDraft = draftFromManifest(source.manifest);
+  if (restoredDraft.schemaVersion === 1) {
+    restoredDraft = upgradeHarnessDraftToHistoricalV2(restoredDraft);
+  }
   const [updated] = await db
     .update(harnessProfiles)
     .set({
-      draftManifest: draftFromManifest(source.manifest),
+      draftManifest: restoredDraft,
       draftRevision: sql`${harnessProfiles.draftRevision} + 1`,
       draftRestoredFromVersion: source.version,
       updatedAt: new Date(),
@@ -957,9 +1004,13 @@ export async function forkHarnessProfile(
   if (source.draftRevision !== input.expectedRevision) {
     throw new HarnessProfileStoreError(409, "Profile draft revision conflict");
   }
+  let draft = normalizeDraft(source.draftManifest);
+  if (draft.schemaVersion === 1) {
+    draft = upgradeHarnessDraftToHistoricalV2(draft);
+  }
   return createHarnessProfile(db, {
     slug: input.slug,
-    draft: source.draftManifest,
+    draft,
     actor: input.actor,
   });
 }

--- a/apps/worker/src/harness-profiles/store.ts
+++ b/apps/worker/src/harness-profiles/store.ts
@@ -678,7 +678,6 @@ export async function updateHarnessProfileDraft(
     .set({
       draftManifest: draft,
       draftRevision: sql`${harnessProfiles.draftRevision} + 1`,
-      draftRestoredFromVersion: null,
       updatedAt: new Date(),
       updatedById: input.actor.id,
     })

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -303,13 +303,17 @@ async function runFixAgent(
             endpoint: env.GENAI_ENGINE_TRACE_ENDPOINT,
           }
         : undefined;
+    const effectiveModel =
+      runtime.manifest.schemaVersion === 2
+        ? runtime.manifest.model.id
+        : model;
     await adapter.configure(sandbox, {
       ...resolveRuntimeCredentials(runtime.manifest, {
         anthropicApiKey: env.ANTHROPIC_API_KEY,
         codexApiKey: env.CODEX_API_KEY,
         codexChatGptOauthToken: env.CODEX_CHATGPT_OAUTH_TOKEN,
       }),
-      model,
+      model: effectiveModel,
       arthur,
       runtime: runtime.paths,
       ...(runtime.modelSettings
@@ -321,9 +325,13 @@ async function runFixAgent(
   await adapter.setCommitGuard(sandbox, true, runtime?.paths);
   const phase = `pre-pr-fix-${fixCycle}`;
   const paths = adapter.artifactPaths(phase);
+  const effectiveModel =
+    runtime?.manifest.schemaVersion === 2
+      ? runtime.manifest.model.id
+      : model;
   const script = adapter.buildPhaseScript({
     phase,
-    model,
+    model: effectiveModel,
     paths,
     ...(runtime
       ? {

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -257,7 +257,11 @@ async function runFixAgent(
   failure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
 }> {
   const { createAgentAdapter } = await import("../sandbox/agents/index.js");
-  const adapter = createAgentAdapter(agentKind, runtime?.cliSpec);
+  const effectiveAgentKind =
+    runtime?.manifest.schemaVersion === 2
+      ? runtime.manifest.harness.provider
+      : agentKind;
+  const adapter = createAgentAdapter(effectiveAgentKind, runtime?.cliSpec);
   if (runtime) {
     const { env } = await import("../../env.js");
     const { getDb } = await import("../db/client.js");

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -312,6 +312,9 @@ async function runFixAgent(
       model,
       arthur,
       runtime: runtime.paths,
+      ...(runtime.modelSettings
+        ? { modelSettings: runtime.modelSettings }
+        : {}),
       legacyDynamicSkills: false,
     });
   }
@@ -322,7 +325,14 @@ async function runFixAgent(
     phase,
     model,
     paths,
-    ...(runtime ? { runtime: runtime.paths } : {}),
+    ...(runtime
+      ? {
+          runtime: runtime.paths,
+          ...(runtime.modelSettings
+            ? { modelSettings: runtime.modelSettings }
+            : {}),
+        }
+      : {}),
   });
   await sandbox.writeFiles([
     {

--- a/apps/worker/src/routes/api/v1/harness-capabilities.get.ts
+++ b/apps/worker/src/routes/api/v1/harness-capabilities.get.ts
@@ -1,0 +1,70 @@
+import {
+  createError,
+  defineEventHandler,
+  getQuery,
+  setResponseHeader,
+} from "h3";
+import type {
+  HarnessCapabilitiesResponse,
+  HarnessProvider,
+} from "@shared/contracts";
+import { getDb } from "../../../db/client.js";
+import {
+  getHarnessCapabilities,
+  HarnessCapabilityCatalogError,
+} from "../../../harness-profiles/capability-catalog.js";
+import {
+  requireDashboardActor,
+  toHttpError,
+} from "../../../lib/auth/request-context.js";
+
+export default defineEventHandler(
+  async (event): Promise<HarnessCapabilitiesResponse | undefined> => {
+    try {
+      setResponseHeader(event, "Cache-Control", "private, no-store");
+      const actor = await requireDashboardActor(event);
+      const query = getQuery(event);
+      const provider = parseProvider(query.provider);
+      const cliVersion = parseCliVersion(query.cliVersion);
+      const refresh =
+        query.refresh === "1" || query.refresh === "true";
+      return await getHarnessCapabilities(getDb(), {
+        organizationId: actor.organizationId,
+        provider,
+        cliVersion,
+        refresh,
+      });
+    } catch (error) {
+      if (error instanceof HarnessCapabilityCatalogError) {
+        throw createError({
+          statusCode: error.statusCode,
+          statusMessage: error.message,
+        });
+      }
+      toHttpError(error);
+    }
+  },
+);
+
+function parseProvider(value: unknown): HarnessProvider {
+  if (value !== "claude" && value !== "codex") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "provider must be claude or codex",
+    });
+  }
+  return value;
+}
+
+function parseCliVersion(value: unknown): string {
+  if (
+    typeof value !== "string" ||
+    !/^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/.test(value)
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "cliVersion must be an exact version",
+    });
+  }
+  return value;
+}

--- a/apps/worker/src/sandbox/agents/claude.test.ts
+++ b/apps/worker/src/sandbox/agents/claude.test.ts
@@ -355,6 +355,27 @@ describe("ClaudeAgentAdapter.extractUsage", () => {
 });
 
 describe("ClaudeAgentAdapter.buildPhaseScript", () => {
+  it("materializes pinned effort and a custom auto-compact percentage", () => {
+    const paths = adapter.artifactPaths("research");
+    const script = adapter.buildPhaseScript({
+      phase: "research",
+      model: "claude-opus-4-6",
+      paths,
+      modelSettings: {
+        reasoningEffort: "high",
+        serviceTier: "standard",
+        compaction: {
+          mode: "custom_threshold",
+          thresholdPercent: 82,
+          thresholdTokens: 164_000,
+        },
+      },
+    });
+
+    expect(script).toContain("--effort 'high'");
+    expect(script).toContain("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=82");
+  });
+
   it("research phase emits a script that sources agent-env.sh and invokes claude", () => {
     const paths = adapter.artifactPaths("research");
     const s = adapter.buildPhaseScript({ phase: "research", model: "claude-opus-4-6", paths });
@@ -553,6 +574,52 @@ describe("ClaudeAgentAdapter.configure", () => {
 
     const claudeEnv = writtenFiles(writeFiles).find((f: any) => f.path === AGENT_ENV_CLAUDE_PATH);
     expect(claudeEnv.content.toString("utf8")).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+  });
+
+  it("installs the pinned disabled-compaction hook in an isolated v2 home", async () => {
+    const runCommand = vi.fn().mockResolvedValue({ exitCode: 0 });
+    const writeFiles = vi.fn().mockResolvedValue(undefined);
+    const sandbox = { runCommand, writeFiles } as any;
+    const runtime = {
+      manifestHash: "c".repeat(64),
+      rootDir: `/tmp/aiw-harness/${"c".repeat(64)}`,
+      homeDir: `/tmp/aiw-harness/${"c".repeat(64)}/home`,
+      cliDir: `/tmp/aiw-harness/${"c".repeat(64)}/cli`,
+      executablePath: `/tmp/aiw-harness/${"c".repeat(64)}/cli/node_modules/.bin/claude`,
+      envPath: `/tmp/aiw-harness/${"c".repeat(64)}/credentials.sh`,
+    };
+
+    await adapter.configure(sandbox, {
+      model: "claude-opus-4-6",
+      anthropicApiKey: "sk-ant-test",
+      runtime,
+      legacyDynamicSkills: false,
+      modelSettings: {
+        reasoningEffort: "high",
+        serviceTier: "standard",
+        compaction: { mode: "disabled" },
+      },
+    });
+
+    expect(
+      runCommand.mock.calls.some(
+        ([command, args]) =>
+          command === "bash" &&
+          typeof args?.[1] === "string" &&
+          args[1].includes("disable-auto-compact.sh"),
+      ),
+    ).toBe(true);
+    expect(
+      runCommand.mock.calls.some(
+        ([, args]) =>
+          Array.isArray(args) &&
+          args.some(
+            (argument) =>
+              typeof argument === "string" &&
+              argument.includes("PreCompact"),
+          ),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/apps/worker/src/sandbox/agents/claude.ts
+++ b/apps/worker/src/sandbox/agents/claude.ts
@@ -106,6 +106,44 @@ export class ClaudeAgentAdapter implements AgentAdapter {
         this.cliSpec,
         "Claude onboarding setup",
       );
+      if (opts.modelSettings) {
+        if (
+          opts.modelSettings.serviceTier !== "standard" ||
+          opts.modelSettings.verbosity !== undefined
+        ) {
+          throw runtimePreparationError(
+            this.cliSpec,
+            "The pinned Claude model settings are not supported.",
+          );
+        }
+        if (opts.modelSettings.compaction.mode === "disabled") {
+          const disableAutoCompact = await sandbox.runCommand("bash", [
+            "-c",
+            withRuntimeHome(
+              opts.runtime,
+              [
+                "mkdir -p \"$HOME/.claude\"",
+                "cat > \"$HOME/.claude/disable-auto-compact.sh\" <<'SCRIPT'",
+                "#!/bin/bash",
+                "echo 'Automatic compaction is disabled by the pinned Harness Profile.' >&2",
+                "exit 2",
+                "SCRIPT",
+                "chmod 700 \"$HOME/.claude/disable-auto-compact.sh\"",
+              ].join("\n"),
+            ),
+          ]);
+          await requireProviderSetup(
+            disableAutoCompact,
+            this.cliSpec,
+            "Claude compaction setup",
+          );
+          await this.mergeSettings(
+            sandbox,
+            { autoCompact: "disable" },
+            opts.runtime,
+          );
+        }
+      }
     }
 
     // V1 retains the historical skills.sh compatibility setup. V2 profile
@@ -157,13 +195,23 @@ export class ClaudeAgentAdapter implements AgentAdapter {
   }
 
   buildPhaseScript(opts: PhaseScriptOpts): string {
-    const { paths, jsonSchema, model, phase, runtime } = opts;
+    const {
+      paths,
+      jsonSchema,
+      model,
+      modelSettings,
+      phase,
+      runtime,
+    } = opts;
     const safePhase = sanitizePhase(phase);
     let claudeFlags = `--print --model ${shellQuote(model)} --dangerously-skip-permissions --output-format json`;
     if (runtime) {
       // Profile subagents are clipped until a versioned concurrency contract is
       // available. Enforce the current declaration instead of only reporting it.
       claudeFlags += " --disallowedTools Task";
+    }
+    if (modelSettings) {
+      claudeFlags += ` --effort ${shellQuote(modelSettings.reasoningEffort)}`;
     }
     if (jsonSchema) {
       const escapedSchema = jsonSchema.replace(/'/g, "'\\''");
@@ -177,6 +225,7 @@ rm -f ${paths.sentinel} ${paths.stdout} ${paths.stderr} ${paths.exitCode}
 # --- Select immutable profile runtime and source runtime-only credentials ---
 ${runtime ? `export HOME=${shellQuote(runtime.homeDir)}` : ""}
 [ -f ${runtime ? shellQuote(runtime.envPath) : "/tmp/agent-env.sh"} ] && source ${runtime ? shellQuote(runtime.envPath) : "/tmp/agent-env.sh"}
+${modelSettings?.compaction.mode === "custom_threshold" ? `export CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=${modelSettings.compaction.thresholdPercent}` : ""}
 
 # --- Phase: ${safePhase} ---
 cat ${paths.input} | ${runtime ? shellQuote(runtime.executablePath) : "claude"} \\
@@ -509,7 +558,11 @@ touch ${paths.sentinel}
   /** Merge-aware writer for ~/.claude/settings.json. */
   private async mergeSettings(
     sandbox: RunnableSandbox,
-    opts: { commitGuard?: "enable" | "disable"; arthur?: "install" },
+    opts: {
+      commitGuard?: "enable" | "disable";
+      arthur?: "install";
+      autoCompact?: "disable";
+    },
     runtime?: AgentRuntimePaths,
   ): Promise<void> {
     const arthurEvents = JSON.stringify(ARTHUR_HOOK_EVENTS);
@@ -545,6 +598,9 @@ touch ${paths.sentinel}
         for (const [event, arg] of arthurEvents) {
           upsertHook(event, '', 'python3 "$HOME/.claude/hooks/claude_code_tracer.py" ' + arg);
         }
+      }
+      if (opts.autoCompact === 'disable') {
+        upsertHook('PreCompact', 'auto', 'bash "$HOME/.claude/disable-auto-compact.sh"');
       }
       fs.writeFileSync(settingsPath, JSON.stringify(s, null, 2));
     `;

--- a/apps/worker/src/sandbox/agents/codex.test.ts
+++ b/apps/worker/src/sandbox/agents/codex.test.ts
@@ -201,6 +201,32 @@ describe("CodexAgentAdapter.extractUsage", () => {
 });
 
 describe("CodexAgentAdapter.buildPhaseScript", () => {
+  it("materializes every pinned v2 model setting explicitly", () => {
+    const paths = adapter.artifactPaths("impl");
+    const script = adapter.buildPhaseScript({
+      phase: "impl",
+      model: "gpt-5.4",
+      paths,
+      modelSettings: {
+        reasoningEffort: "high",
+        serviceTier: "fast",
+        verbosity: "low",
+        compaction: {
+          mode: "custom_threshold",
+          thresholdPercent: 80,
+          thresholdTokens: 160_000,
+        },
+      },
+    });
+
+    expect(script).toContain('model_reasoning_effort="high"');
+    expect(script).toContain('service_tier="fast"');
+    expect(script).toContain('model_verbosity="low"');
+    expect(script).toContain(
+      "model_auto_compact_token_limit=160000",
+    );
+  });
+
   it("research phase uses -o and accepts --output-schema when supplied", () => {
     const paths = adapter.artifactPaths("research");
     const baseScript = adapter.buildPhaseScript({ phase: "research", model: "gpt-5-codex", paths });

--- a/apps/worker/src/sandbox/agents/codex.ts
+++ b/apps/worker/src/sandbox/agents/codex.ts
@@ -72,6 +72,14 @@ export class CodexAgentAdapter implements AgentAdapter {
         "Codex authentication credentials were not configured.",
       );
     }
+    if (
+      opts.modelSettings?.compaction.mode === "disabled"
+    ) {
+      throw runtimePreparationError(
+        this.cliSpec,
+        "The pinned Codex compaction mode is not supported.",
+      );
+    }
 
     // 1) auth env file. Codex CLI auto-reads OPENAI_API_KEY when no auth.json
     // exists; we additionally run `codex login --with-api-key` below to
@@ -191,7 +199,14 @@ export class CodexAgentAdapter implements AgentAdapter {
   }
 
   buildPhaseScript(opts: PhaseScriptOpts): string {
-    const { paths, jsonSchema, model, phase, runtime } = opts;
+    const {
+      paths,
+      jsonSchema,
+      model,
+      modelSettings,
+      phase,
+      runtime,
+    } = opts;
     const safePhase = sanitizePhase(phase);
 
     // --dangerously-bypass-approvals-and-sandbox over --full-auto: --full-auto
@@ -205,6 +220,22 @@ export class CodexAgentAdapter implements AgentAdapter {
       `--json`,
       `-c features.codex_hooks=true`,
       ...(runtime ? [`-c features.multi_agent=false`] : []),
+      ...(modelSettings
+        ? [
+            `-c ${shellQuote(`model_reasoning_effort="${modelSettings.reasoningEffort}"`)}`,
+            `-c ${shellQuote(`service_tier="${modelSettings.serviceTier}"`)}`,
+            ...(modelSettings.verbosity
+              ? [
+                  `-c ${shellQuote(`model_verbosity="${modelSettings.verbosity}"`)}`,
+                ]
+              : []),
+            ...(modelSettings.compaction.mode === "custom_threshold"
+              ? [
+                  `-c ${shellQuote(`model_auto_compact_token_limit=${modelSettings.compaction.thresholdTokens}`)}`,
+                ]
+              : []),
+          ]
+        : []),
       `-o ${paths.structuredOutput}`,
     ];
 

--- a/apps/worker/src/sandbox/agents/types.ts
+++ b/apps/worker/src/sandbox/agents/types.ts
@@ -310,7 +310,22 @@ export interface ConfigureOpts {
    * omits this and retains its historical shared-home compatibility behavior.
    */
   runtime?: AgentRuntimePaths;
+  modelSettings?: AgentModelRuntimeSettings;
   legacyDynamicSkills?: boolean;
+}
+
+export interface AgentModelRuntimeSettings {
+  reasoningEffort: string;
+  serviceTier: string;
+  verbosity?: string;
+  compaction:
+    | { mode: "model_default" }
+    | {
+        mode: "custom_threshold";
+        thresholdPercent: number;
+        thresholdTokens: number;
+      }
+    | { mode: "disabled" };
 }
 
 export interface AgentRuntimePaths {
@@ -415,6 +430,7 @@ export interface PhaseScriptOpts {
   /** When set, the phase requests schema-validated structured output. */
   jsonSchema?: string;
   runtime?: AgentRuntimePaths;
+  modelSettings?: AgentModelRuntimeSettings;
 }
 
 export interface AgentAdapter {

--- a/apps/worker/src/sandbox/harness-runtime.test.ts
+++ b/apps/worker/src/sandbox/harness-runtime.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import type {
+  HarnessProfileManifestV1,
   HarnessProfileResolvedVersion,
   HarnessResolvedSkillArtifact,
 } from "@shared/contracts";
@@ -59,12 +60,10 @@ function resolvedSkillArtifact(
 }
 
 function resolvedCodex(
-  overrides: Partial<
-    HarnessProfileResolvedVersion["manifest"]
-  > = {},
+  overrides: Partial<HarnessProfileManifestV1> = {},
   skillArtifacts: HarnessResolvedSkillArtifact[] = [],
 ): HarnessProfileResolvedVersion {
-  const manifest = {
+  const manifest: HarnessProfileManifestV1 = {
     ...structuredClone(
       BUILTIN_HARNESS_PROFILE_MANIFESTS[
         BUILTIN_HARNESS_PROFILE_IDS.codex

--- a/apps/worker/src/sandbox/harness-runtime.test.ts
+++ b/apps/worker/src/sandbox/harness-runtime.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import type {
   HarnessProfileManifestV1,
+  HarnessProfileManifestV2,
   HarnessProfileResolvedVersion,
   HarnessResolvedSkillArtifact,
 } from "@shared/contracts";
@@ -81,6 +82,54 @@ function resolvedCodex(
   };
 }
 
+function resolvedCodexV2(): HarnessProfileResolvedVersion {
+  const v1 = resolvedCodex().manifest as HarnessProfileManifestV1;
+  const manifest: HarnessProfileManifestV2 = {
+    ...structuredClone(v1),
+    schemaVersion: 2,
+    model: {
+      id: "gpt-5.4",
+      reasoning: {
+        selection: "high",
+        effectiveEffort: "high",
+      },
+      serviceTier: "fast",
+      verbosity: "low",
+      catalogHash: "a".repeat(64),
+      capability: {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        description: null,
+        contextWindowTokens: 200_000,
+        reasoningEfforts: [
+          { id: "high", name: "High", description: null },
+        ],
+        defaultReasoningEffort: "high",
+        serviceTiers: [
+          { id: "standard", name: "Standard", description: null },
+          { id: "fast", name: "Fast", description: null },
+        ],
+        defaultServiceTier: "standard",
+        verbosityOptions: [
+          { id: "low", name: "Low", description: null },
+        ],
+        defaultVerbosity: "low",
+        compactionModes: ["model_default", "custom_threshold"],
+      },
+    },
+    compaction: {
+      mode: "custom_threshold",
+      thresholdPercent: 80,
+      thresholdTokens: 160_000,
+    },
+  };
+  return {
+    manifest,
+    manifestHash: hashHarnessProfileManifest(manifest),
+    skillArtifacts: [],
+  };
+}
+
 describe("Harness Profile runtime resolution", () => {
   it("uses exact manifest-hash paths and records clipped capabilities safely", () => {
     const resolved = resolvedCodex({
@@ -110,6 +159,29 @@ describe("Harness Profile runtime resolution", () => {
     expect(runtime.safeManifest.manifestHash).toBe(resolved.manifestHash);
     expect(runtime.safeManifest).not.toHaveProperty(
       "skills.0.files.0.contentBase64",
+    );
+  });
+
+  it("maps v2 model settings without aliasing the manifest", () => {
+    const resolved = resolvedCodexV2();
+    const runtime = resolveHarnessRuntime({
+      nodeId: "implementation",
+      nodeType: "implementation_agent",
+      resolved,
+    });
+
+    expect(runtime.modelSettings).toEqual({
+      reasoningEffort: "high",
+      serviceTier: "fast",
+      verbosity: "low",
+      compaction: {
+        mode: "custom_threshold",
+        thresholdPercent: 80,
+        thresholdTokens: 160_000,
+      },
+    });
+    expect(runtime.modelSettings?.compaction).not.toBe(
+      resolved.manifest.compaction,
     );
   });
 

--- a/apps/worker/src/sandbox/harness-runtime.ts
+++ b/apps/worker/src/sandbox/harness-runtime.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type {
   HarnessProfileCapabilities,
-  HarnessProfileManifestV1,
+  HarnessProfileManifest,
   HarnessProfileResolvedVersion,
   HarnessResolvedSkillArtifact,
   HarnessRunManifestRecord,
@@ -13,6 +13,7 @@ import {
   HARNESS_TOOL_IDS,
 } from "@shared/contracts";
 import type {
+  AgentModelRuntimeSettings,
   AgentRuntimePaths,
   RunnableSandbox,
   SerializableAgentCliSpec,
@@ -85,10 +86,11 @@ const TOOL_ENVELOPE: Record<
 };
 
 export interface ResolvedHarnessRuntime {
-  manifest: HarnessProfileManifestV1;
+  manifest: HarnessProfileManifest;
   manifestHash: string;
   cliSpec: SerializableAgentCliSpec;
   paths: AgentRuntimePaths;
+  modelSettings?: AgentModelRuntimeSettings;
   capabilities: HarnessProfileCapabilities;
   safeManifest: HarnessRunManifestRecord;
   /**
@@ -154,16 +156,32 @@ export function resolveHarnessRuntime(input: {
     manifestHash,
     cliSpec,
     paths,
+    ...(manifest.schemaVersion === 2
+      ? { modelSettings: modelSettingsFromManifest(manifest) }
+      : {}),
     capabilities,
     safeManifest,
     legacyDynamicSkills: input.legacyDynamicSkills === true,
   };
 }
 
+function modelSettingsFromManifest(
+  manifest: Extract<HarnessProfileManifest, { schemaVersion: 2 }>,
+): AgentModelRuntimeSettings {
+  return {
+    reasoningEffort: manifest.model.reasoning.effectiveEffort,
+    serviceTier: manifest.model.serviceTier,
+    ...(manifest.model.verbosity
+      ? { verbosity: manifest.model.verbosity }
+      : {}),
+    compaction: structuredClone(manifest.compaction),
+  };
+}
+
 export function resolveHarnessCapabilities(input: {
   nodeType: WorkflowBlockType;
   workspaceMode?: unknown;
-  manifest: HarnessProfileManifestV1;
+  manifest: HarnessProfileManifest;
 }): HarnessProfileCapabilities {
   if (!AGENT_BLOCK_TYPES.has(input.nodeType)) {
     throw new Error(`Block type "${input.nodeType}" has no harness safety envelope.`);
@@ -223,7 +241,7 @@ export function resolveHarnessCapabilities(input: {
 }
 
 export function resolveRuntimeCredentials(
-  manifest: HarnessProfileManifestV1,
+  manifest: HarnessProfileManifest,
   source: RuntimeCredentialSource,
 ): ResolvedRuntimeCredentials {
   const references = uniqueSorted(manifest.credentialReferences);
@@ -430,7 +448,7 @@ export async function materializePinnedHarnessFiles(
 }
 
 function profileCliSpec(
-  manifest: HarnessProfileManifestV1,
+  manifest: HarnessProfileManifest,
 ): SerializableAgentCliSpec {
   const supported = AGENT_CLI_SPEC_CATALOG.find(
     (candidate) =>
@@ -456,9 +474,9 @@ function profileCliSpec(
   };
 }
 
-function validateManifestIdentity(manifest: HarnessProfileManifestV1): void {
+function validateManifestIdentity(manifest: HarnessProfileManifest): void {
   if (
-    manifest.schemaVersion !== 1 ||
+    (manifest.schemaVersion !== 1 && manifest.schemaVersion !== 2) ||
     !manifest.profileId ||
     !Number.isInteger(manifest.version) ||
     manifest.version < 1
@@ -468,10 +486,7 @@ function validateManifestIdentity(manifest: HarnessProfileManifestV1): void {
   if (!manifest.model.id.trim()) {
     throw new Error("Harness Profile model is missing.");
   }
-  if (
-    manifest.workspace.mode !== "managed" ||
-    manifest.compaction.mode !== "provider_default"
-  ) {
+  if (manifest.workspace.mode !== "managed") {
     throw new Error("Harness Profile contains an unsupported runtime mode.");
   }
   const declaredTools = uniqueSorted(manifest.tools);
@@ -484,7 +499,10 @@ function validateManifestIdentity(manifest: HarnessProfileManifestV1): void {
       "Harness Profile tool subsets are not supported by the current provider runtimes.",
     );
   }
-  if (Object.keys(manifest.model.options).length > 0) {
+  if (
+    manifest.schemaVersion === 1 &&
+    Object.keys(manifest.model.options).length > 0
+  ) {
     throw new Error(
       "Harness Profile model options are not supported by the current runtime.",
     );
@@ -492,7 +510,7 @@ function validateManifestIdentity(manifest: HarnessProfileManifestV1): void {
 }
 
 function validatePinnedArtifacts(
-  manifest: HarnessProfileManifestV1,
+  manifest: HarnessProfileManifest,
   artifacts: readonly HarnessResolvedSkillArtifact[],
 ): void {
   const expected = new Map(
@@ -521,7 +539,7 @@ function validatePinnedArtifacts(
 
 function buildSafeRunHarnessManifest(input: {
   nodeId: string;
-  manifest: HarnessProfileManifestV1;
+  manifest: HarnessProfileManifest;
   manifestHash: string;
   skillArtifacts: readonly HarnessResolvedSkillArtifact[];
   capabilities: HarnessProfileCapabilities;
@@ -562,7 +580,7 @@ function buildSafeRunHarnessManifest(input: {
     },
     manifestHash: input.manifestHash,
     manifest: {
-      schemaVersion: 1,
+      schemaVersion: input.manifest.schemaVersion,
       profileId: input.manifest.profileId,
       version: input.manifest.version,
       slug: input.manifest.slug,

--- a/apps/worker/src/sandbox/harness-runtime.ts
+++ b/apps/worker/src/sandbox/harness-runtime.ts
@@ -572,6 +572,45 @@ function buildSafeRunHarnessManifest(input: {
     ),
     ...(input.capabilities.subagents.clipped ? ["subagents"] : []),
   ];
+  const manifestCommon = {
+    profileId: input.manifest.profileId,
+    version: input.manifest.version,
+    slug: input.manifest.slug,
+    displayName: input.manifest.displayName,
+    system: input.manifest.system,
+    harness: structuredClone(input.manifest.harness),
+    context: structuredClone(input.manifest.context),
+    subagents: structuredClone(input.manifest.subagents),
+    limits: structuredClone(input.manifest.limits),
+    workspace: structuredClone(input.manifest.workspace),
+    instructionsSha256: sha256(input.manifest.instructions),
+    homeFiles: {
+      count: input.manifest.homeFiles.length,
+      totalBytes: input.manifest.homeFiles.reduce(
+        (total, file) => total + Buffer.byteLength(file.content),
+        0,
+      ),
+      sha256: sha256(JSON.stringify(homeFileProvenance)),
+    },
+    skills: structuredClone(input.manifest.skills),
+    tools: [...input.manifest.tools],
+    mcpIntegrations: [...input.manifest.mcpIntegrations],
+    credentialReferences: [...input.manifest.credentialReferences],
+  };
+  const safeManifest =
+    input.manifest.schemaVersion === 1
+      ? {
+          ...manifestCommon,
+          schemaVersion: 1 as const,
+          model: structuredClone(input.manifest.model),
+          compaction: structuredClone(input.manifest.compaction),
+        }
+      : {
+          ...manifestCommon,
+          schemaVersion: 2 as const,
+          model: structuredClone(input.manifest.model),
+          compaction: structuredClone(input.manifest.compaction),
+        };
   return {
     nodeId: input.nodeId,
     reference: {
@@ -579,34 +618,7 @@ function buildSafeRunHarnessManifest(input: {
       version: input.manifest.version,
     },
     manifestHash: input.manifestHash,
-    manifest: {
-      schemaVersion: input.manifest.schemaVersion,
-      profileId: input.manifest.profileId,
-      version: input.manifest.version,
-      slug: input.manifest.slug,
-      displayName: input.manifest.displayName,
-      system: input.manifest.system,
-      harness: structuredClone(input.manifest.harness),
-      model: structuredClone(input.manifest.model),
-      context: structuredClone(input.manifest.context),
-      compaction: structuredClone(input.manifest.compaction),
-      subagents: structuredClone(input.manifest.subagents),
-      limits: structuredClone(input.manifest.limits),
-      workspace: structuredClone(input.manifest.workspace),
-      instructionsSha256: sha256(input.manifest.instructions),
-      homeFiles: {
-        count: input.manifest.homeFiles.length,
-        totalBytes: input.manifest.homeFiles.reduce(
-          (total, file) => total + Buffer.byteLength(file.content),
-          0,
-        ),
-        sha256: sha256(JSON.stringify(homeFileProvenance)),
-      },
-      skills: structuredClone(input.manifest.skills),
-      tools: [...input.manifest.tools],
-      mcpIntegrations: [...input.manifest.mcpIntegrations],
-      credentialReferences: [...input.manifest.credentialReferences],
-    },
+    manifest: safeManifest,
     skills: input.manifest.skills.map((skill) => {
       const artifact = input.skillArtifacts.find(
         (candidate) => candidate.artifactHash === skill.artifactHash,

--- a/apps/worker/src/workflow-definition/schema-v2.test.ts
+++ b/apps/worker/src/workflow-definition/schema-v2.test.ts
@@ -848,4 +848,34 @@ describe("Workflow Definition v2 schema", () => {
     const definition = v2Definition();
     expect(upgradeStoredWorkflowDefinition(definition)).toEqual(definition);
   });
+
+  it("normalizes duplicate agent provider and model fields to the pinned profile", () => {
+    const definition = v2Definition();
+    definition.nodes.push({
+      id: "agent",
+      type: "implementation_agent",
+      x: 100,
+      y: 0,
+      configuration: {
+        harnessProfile: {
+          profileId: "profile-1",
+          version: 2,
+        },
+        provider: "claude",
+        model: "stale-model",
+        prompt: "Implement the ticket.",
+      },
+      inputs: {},
+      additionalInputs: [],
+    });
+
+    const parsed = workflowDefinitionV2Schema.parse(definition);
+    expect(parsed.nodes[1]?.configuration).toEqual({
+      harnessProfile: {
+        profileId: "profile-1",
+        version: 2,
+      },
+      prompt: "Implement the ticket.",
+    });
+  });
 });

--- a/apps/worker/src/workflow-definition/schema-v2.test.ts
+++ b/apps/worker/src/workflow-definition/schema-v2.test.ts
@@ -981,4 +981,28 @@ describe("Workflow Definition v2 schema", () => {
       prompt: "Implement the ticket.",
     });
   });
+
+  it("preserves agent provider and model fields without a pinned profile", () => {
+    const definition = v2Definition();
+    definition.nodes.push({
+      id: "agent",
+      type: "implementation_agent",
+      x: 100,
+      y: 0,
+      configuration: {
+        provider: "claude",
+        model: "claude-opus-4-6",
+        prompt: "Implement the ticket.",
+      },
+      inputs: {},
+      additionalInputs: [],
+    });
+
+    const parsed = workflowDefinitionV2Schema.parse(definition);
+    expect(parsed.nodes[1]?.configuration).toEqual({
+      provider: "claude",
+      model: "claude-opus-4-6",
+      prompt: "Implement the ticket.",
+    });
+  });
 });

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -731,7 +731,7 @@ const workflowDefinitionV2ControlEdgeSchema = z
   })
   .strict();
 
-export const workflowDefinitionV2Schema = z
+const workflowDefinitionV2ParsedSchema = z
   .object({
     schemaVersion: z.literal(2),
     budgets: executionBudgetsSchema.optional(),
@@ -758,10 +758,58 @@ export const workflowDefinitionV2Schema = z
     }
   });
 
+export const workflowDefinitionV2Schema = z.preprocess(
+  normalizeV2AgentProfileConfiguration,
+  workflowDefinitionV2ParsedSchema,
+);
+
 export const workflowDefinitionSchema = z.union([
   workflowDefinitionV1Schema,
   workflowDefinitionV2Schema,
 ]);
+
+function normalizeV2AgentProfileConfiguration(value: unknown): unknown {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    (value as { schemaVersion?: unknown }).schemaVersion !== 2
+  ) {
+    return value;
+  }
+  const definition = structuredClone(
+    value as Record<string, unknown>,
+  ) as Record<string, unknown>;
+  if (!Array.isArray(definition.nodes)) return definition;
+  definition.nodes = definition.nodes.map((rawNode) => {
+    if (
+      rawNode === null ||
+      typeof rawNode !== "object" ||
+      Array.isArray(rawNode)
+    ) {
+      return rawNode;
+    }
+    const node = rawNode as Record<string, unknown>;
+    if (
+      typeof node.type !== "string" ||
+      !isV2PromptAuthoringBlock(node.type as WorkflowBlockType) ||
+      node.configuration === null ||
+      typeof node.configuration !== "object" ||
+      Array.isArray(node.configuration)
+    ) {
+      return node;
+    }
+    const configuration = node.configuration as Record<string, unknown>;
+    if (!isHarnessProfileReference(configuration.harnessProfile)) {
+      return node;
+    }
+    const normalized = { ...configuration };
+    delete normalized.provider;
+    delete normalized.model;
+    return { ...node, configuration: normalized };
+  });
+  return definition;
+}
 
 // Ordinary version reads deliberately do not apply current block-param or
 // graph rules: operators must be able to open and repair an old invalid graph.

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -24,6 +24,7 @@ import {
   PROMPT_SLOT_NAME_PATTERN,
   isHarnessProfileReference,
   isTriggerBlockType,
+  isV2AgentBlockType,
   isWorkflowAddressablePathSegment,
   resolveBuiltinHarnessProfile,
   wirablePorts,
@@ -822,11 +823,10 @@ function normalizeV2AgentProfileConfiguration(value: unknown): unknown {
   ) {
     return value;
   }
-  const definition = structuredClone(
-    value as Record<string, unknown>,
-  ) as Record<string, unknown>;
-  if (!Array.isArray(definition.nodes)) return definition;
-  definition.nodes = definition.nodes.map((rawNode) => {
+  const definition = value as Record<string, unknown>;
+  if (!Array.isArray(definition.nodes)) return value;
+  let changed = false;
+  const nodes = definition.nodes.map((rawNode) => {
     if (
       rawNode === null ||
       typeof rawNode !== "object" ||
@@ -837,7 +837,7 @@ function normalizeV2AgentProfileConfiguration(value: unknown): unknown {
     const node = rawNode as Record<string, unknown>;
     if (
       typeof node.type !== "string" ||
-      !isV2PromptAuthoringBlock(node.type as WorkflowBlockType) ||
+      !isV2AgentBlockType(node.type as WorkflowBlockType) ||
       node.configuration === null ||
       typeof node.configuration !== "object" ||
       Array.isArray(node.configuration)
@@ -851,9 +851,10 @@ function normalizeV2AgentProfileConfiguration(value: unknown): unknown {
     const normalized = { ...configuration };
     delete normalized.provider;
     delete normalized.model;
+    changed = true;
     return { ...node, configuration: normalized };
   });
-  return definition;
+  return changed ? { ...definition, nodes } : value;
 }
 
 // Ordinary version reads deliberately do not apply current block-param or
@@ -1694,7 +1695,7 @@ function validateWorkflowV2ConfigurationIssues(
     const allowedKeys = new Set([
       ...BLOCK_PARAM_KEYS[node.type],
       ...(node.type === "branch" ? ["combinator", "conditions"] : []),
-      ...(isV2PromptAuthoringBlock(node.type)
+      ...(isV2AgentBlockType(node.type)
         ? ["harnessProfile", "promptSlotBindings"]
         : []),
       ...(node.type === "generic_agent" || node.type === "call_llm"
@@ -1721,7 +1722,7 @@ function validateWorkflowV2ConfigurationIssues(
     if (parsed.success) {
       const profileReference = node.configuration.harnessProfile;
       if (
-        isV2PromptAuthoringBlock(node.type) &&
+        isV2AgentBlockType(node.type) &&
         isHarnessProfileReference(profileReference)
       ) {
         if (
@@ -1757,23 +1758,6 @@ function validateWorkflowV2ConfigurationIssues(
     }
   }
   return issues;
-}
-
-function isV2PromptAuthoringBlock(
-  type: WorkflowBlockType,
-): type is
-  | "planning_agent"
-  | "implementation_agent"
-  | "review_agent"
-  | "fix_agent"
-  | "generic_agent" {
-  return (
-    type === "planning_agent" ||
-    type === "implementation_agent" ||
-    type === "review_agent" ||
-    type === "fix_agent" ||
-    type === "generic_agent"
-  );
 }
 
 function v2ConfigurationParams(

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -1285,7 +1285,14 @@ async function planPhaseStep(
     model,
     paths,
     jsonSchema,
-    ...(runtime ? { runtime: runtime.paths } : {}),
+    ...(runtime
+      ? {
+          runtime: runtime.paths,
+          ...(runtime.modelSettings
+            ? { modelSettings: runtime.modelSettings }
+            : {}),
+        }
+      : {}),
   });
   return { paths, script };
 }

--- a/apps/worker/src/workflows/blocks/agent-sandbox.ts
+++ b/apps/worker/src/workflows/blocks/agent-sandbox.ts
@@ -205,6 +205,9 @@ export async function prepareHarnessAgentInvocationStep(
       model,
       arthur,
       runtime: runtime.paths,
+      ...(runtime.modelSettings
+        ? { modelSettings: runtime.modelSettings }
+        : {}),
       legacyDynamicSkills: false,
     });
     return { ok: true, value: undefined };

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -102,7 +102,14 @@ async function blockFixAgentPlanPhaseStep(
     model,
     paths,
     jsonSchema,
-    ...(runtime ? { runtime: runtime.paths } : {}),
+    ...(runtime
+      ? {
+          runtime: runtime.paths,
+          ...(runtime.modelSettings
+            ? { modelSettings: runtime.modelSettings }
+            : {}),
+        }
+      : {}),
   });
   return { paths, script };
 }

--- a/apps/worker/src/workflows/blocks/generic-agent.ts
+++ b/apps/worker/src/workflows/blocks/generic-agent.ts
@@ -102,9 +102,13 @@ async function blockGenericAgentPlanPhaseStep(
   const { createAgentAdapter } = await import("../../sandbox/agents/index.js");
   const adapter = createAgentAdapter(agentKind, runtime?.cliSpec);
   const paths = adapter.artifactPaths(phase);
+  const effectiveModel =
+    runtime?.manifest.schemaVersion === 2
+      ? runtime.manifest.model.id
+      : model;
   const script = adapter.buildPhaseScript({
     phase,
-    model,
+    model: effectiveModel,
     paths,
     jsonSchema,
     ...(runtime

--- a/apps/worker/src/workflows/blocks/generic-agent.ts
+++ b/apps/worker/src/workflows/blocks/generic-agent.ts
@@ -107,7 +107,14 @@ async function blockGenericAgentPlanPhaseStep(
     model,
     paths,
     jsonSchema,
-    ...(runtime ? { runtime: runtime.paths } : {}),
+    ...(runtime
+      ? {
+          runtime: runtime.paths,
+          ...(runtime.modelSettings
+            ? { modelSettings: runtime.modelSettings }
+            : {}),
+        }
+      : {}),
   });
   return { paths, script };
 }

--- a/apps/worker/src/workflows/blocks/prepare-workspace.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.ts
@@ -315,6 +315,9 @@ async function blockPrepareWorkspaceProvisionStep(
     return {
       model: runtime.manifest.model.id,
       runtime: runtime.paths,
+      ...(runtime.modelSettings
+        ? { modelSettings: runtime.modelSettings }
+        : {}),
       legacyDynamicSkills: false,
     };
   };


### PR DESCRIPTION
## Stack

- Base: `codex/aiw-183-workflow-values` (PR #169)
- Jira: AIW-182, AIW-187
- Migration: `0031_capability_cache.sql`

## What changed

- Adds organization-scoped, cached capability discovery for the exact pinned Codex and Claude CLI versions.
- Adds searchable model selection and capability-driven reasoning, speed, verbosity, context-window, and compaction controls.
- Publishes immutable v2 Harness Profile manifests with an exact capability snapshot and catalog hash.
- Keeps existing v1 profile versions on historical provider-default behavior while upgrading mutable restored and forked drafts.
- Materializes all selected model settings explicitly in the Claude and Codex runtime adapters.
- Makes the exact pinned Harness Profile the sole provider/model source for v2 agent blocks, including copy, restore, and serialization paths.

## Compatibility and rollout

- Existing immutable Harness Profile v1 versions and Workflow Definition v1 remain unchanged.
- A stale capability cache remains inspectable but cannot publish a profile.
- Publishing requires a successful fresh discovery whose hash and model snapshot exactly match the draft.
- New cache data is isolated by organization, provider, and pinned CLI version.

## Verification

- Dashboard: 525/525 tests passed.
- Worker focused capability/profile/runtime/schema suites: 148/148 passed.
- Worker full suite: 3,126 passed; four unrelated PGlite setup hooks timed out under full-suite contention, then all affected files passed in isolation (89/89).
- Repository `pnpm typecheck`: passed.
- Migration tested both from a fresh database and as an upgrade from migration 0030.
- `git diff --check`: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Harness profiles now support schema v2 using live, cached capability catalogs for both Claude and Codex, including catalog hashing and freshness/refresh behavior.
  * The harness profile editor is now schema-aware: searchable model selection, reasoning effort/effective effort, service tier, optional verbosity, and compaction controls (default/custom-threshold/disabled where supported).
  * A dedicated harness-capabilities API powers editor/runtime upgrades for pinned harness profiles.
* **Bug Fixes**
  * Publishing and workflow execution now enforce stronger validation to prevent stale or mismatched model/capability selections.
  * Capability requests now return consistent error statuses (including timeout-to-504 behavior) and avoid caching invalid responses.
* **Chores**
  * Added database-backed storage for capability catalogs plus migration and coverage updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->