### PR TITLE
Add loop-scoped retries and parallel review isolation

### DIFF
--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor.tsx
@@ -64,6 +64,7 @@ import {
   TransformFields,
 } from "./transform-fields";
 import { BranchFields } from "./branch-fields";
+import { LoopFields } from "./loop-fields";
 import { instantiateWorkflowEditorBlockTemplate } from "@/lib/workflow-editor/block-templates";
 import type { WorkflowValidationState } from "@/lib/workflow-editor/validation-controller";
 import { removeSelectionFromGraph } from "@/lib/workflow-editor/graph-edit";
@@ -2441,6 +2442,15 @@ function NodeConfig({
                     configuration as unknown as Record<string, JsonValue>,
                   )
                 }
+              />
+            )}
+            {node.type === "loop" && node.v2 && (
+              <LoopFields
+                configuration={node.v2.configuration}
+                availableValues={availableValues}
+                valuesRefreshing={valuesRefreshing}
+                canEdit={canEdit}
+                onChange={onV2ConfigurationChange}
               />
             )}
           </>

--- a/apps/dashboard/components/cockpit/flow-editor/loop-fields.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/loop-fields.test.tsx
@@ -79,3 +79,52 @@ test("keeps an unavailable carried value visible for repair", () => {
   assert.match(html, /saved value is unavailable/i);
   assert.doesNotMatch(html, /steps\.old\.output/);
 });
+
+test("ignores malformed carry entries and explains invalid names", () => {
+  const html = renderToStaticMarkup(
+    <LoopFields
+      configuration={{
+        carry: [
+          { name: "broken" },
+          {
+            name: "review result",
+            schema: { type: "string" },
+            binding: {
+              kind: "reference",
+              reference: "steps.review.output",
+            },
+          },
+        ],
+      }}
+      availableValues={values}
+      valuesRefreshing={false}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+
+  assert.doesNotMatch(html, /broken/);
+  assert.match(html, /safe value name/i);
+});
+
+test("explains duplicate carry names before deployment", () => {
+  const entry = {
+    name: "review",
+    schema: { type: "string" as const },
+    binding: {
+      kind: "reference" as const,
+      reference: "steps.review.output" as const,
+    },
+  };
+  const html = renderToStaticMarkup(
+    <LoopFields
+      configuration={{ carry: [entry, entry] }}
+      availableValues={values}
+      valuesRefreshing={false}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+
+  assert.match(html, /unique name/i);
+});

--- a/apps/dashboard/components/cockpit/flow-editor/loop-fields.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/loop-fields.test.tsx
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { WorkflowDataCatalogEntry } from "@shared/contracts";
+import { LoopFields } from "./loop-fields";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const values: WorkflowDataCatalogEntry[] = [{
+  reference: "steps.review.output",
+  label: "Security review · Entire output",
+  description: "The complete review result.",
+  schema: {
+    type: "object",
+    properties: {
+      decision: {
+        type: "string",
+        enum: ["approve", "request_changes"],
+      },
+    },
+    required: ["decision"],
+    additionalProperties: false,
+  },
+  source: { kind: "step", nodeId: "review" },
+  presence: "required",
+  availability: { state: "available", guarantee: "Guaranteed." },
+  compatibleInputNames: [],
+}];
+
+test("shows named carried values without exposing canonical references", () => {
+  const html = renderToStaticMarkup(
+    <LoopFields
+      configuration={{
+        maxAttempts: 3,
+        onExhaust: "fail",
+        carry: [{
+          name: "security_review",
+          schema: values[0]!.schema,
+          binding: {
+            kind: "reference",
+            reference: values[0]!.reference,
+          },
+        }],
+      }}
+      availableValues={values}
+      valuesRefreshing={false}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+
+  assert.match(html, /Values for the next retry/);
+  assert.match(html, /security_review/);
+  assert.match(html, /Security review · Entire output/);
+  assert.doesNotMatch(html, /steps\.review\.output/);
+});
+
+test("keeps an unavailable carried value visible for repair", () => {
+  const html = renderToStaticMarkup(
+    <LoopFields
+      configuration={{
+        carry: [{
+          name: "old_review",
+          schema: { type: "string" },
+          binding: {
+            kind: "reference",
+            reference: "steps.old.output",
+          },
+        }],
+      }}
+      availableValues={values}
+      valuesRefreshing={false}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+
+  assert.match(html, /saved value is unavailable/i);
+  assert.doesNotMatch(html, /steps\.old\.output/);
+});

--- a/apps/dashboard/components/cockpit/flow-editor/loop-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/loop-fields.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState } from "react";
+import type {
+  JsonValue,
+  WorkflowDataCatalogEntry,
+  WorkflowLoopCarryV2,
+  WorkflowValueCompatibility,
+} from "@shared/contracts";
+import {
+  WorkflowDataPicker,
+  WorkflowValueChip,
+} from "./workflow-data-picker";
+
+function parseCarry(
+  configuration: Readonly<Record<string, JsonValue>>,
+): WorkflowLoopCarryV2[] {
+  return Array.isArray(configuration.carry)
+    ? configuration.carry as unknown as WorkflowLoopCarryV2[]
+    : [];
+}
+
+function carryCompatibility(
+  entry: WorkflowDataCatalogEntry,
+): WorkflowValueCompatibility {
+  if (entry.availability.state === "unavailable") {
+    return {
+      compatible: false,
+      reason: {
+        code: "graph_unavailable",
+        message: entry.availability.reason,
+      },
+    };
+  }
+  if (
+    entry.presence === "optional" ||
+    entry.presence === "optional_nullable"
+  ) {
+    return {
+      compatible: false,
+      reason: {
+        code: "presence_optional",
+        message: "This value is not present whenever the Loop is reached.",
+      },
+    };
+  }
+  return { compatible: true };
+}
+
+function carryName(
+  entry: WorkflowDataCatalogEntry,
+  existing: readonly WorkflowLoopCarryV2[],
+): string {
+  const base =
+    entry.reference.match(/^steps\.([^.]+)\.output$/)?.[1] ??
+    entry.reference.split(".").at(-1) ??
+    "value";
+  const safe = base
+    .replace(/[^A-Za-z0-9_]/g, "_")
+    .replace(/^[^A-Za-z_]+/, "") || "value";
+  const names = new Set(existing.map((carry) => carry.name));
+  if (!names.has(safe)) return safe;
+  let suffix = 2;
+  while (names.has(`${safe}_${suffix}`)) suffix += 1;
+  return `${safe}_${suffix}`;
+}
+
+export function LoopFields({
+  configuration,
+  availableValues,
+  valuesRefreshing,
+  canEdit,
+  onChange,
+}: {
+  configuration: Readonly<Record<string, JsonValue>>;
+  availableValues: readonly WorkflowDataCatalogEntry[];
+  valuesRefreshing: boolean;
+  canEdit: boolean;
+  onChange: (configuration: Record<string, JsonValue>) => void;
+}) {
+  const [pickerIndex, setPickerIndex] = useState<number | "new" | null>(null);
+  const carry = parseCarry(configuration);
+  const update = (nextCarry: WorkflowLoopCarryV2[]) => {
+    onChange({
+      ...configuration,
+      carry: nextCarry as unknown as JsonValue,
+    });
+  };
+  const selectedReference =
+    typeof pickerIndex === "number" &&
+    carry[pickerIndex]?.binding.kind === "reference"
+      ? carry[pickerIndex].binding.reference
+      : undefined;
+
+  return (
+    <section className="border-b border-neutral-200 px-[14px] py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="m-0 font-mono text-[9px] uppercase tracking-[0.06em] text-neutral-700">
+            Values for the next retry
+          </h3>
+          <p className="m-0 mt-1 font-body text-[11px] leading-[1.45] text-neutral-500">
+            Freeze the current results that Fix should receive in the next Loop pass.
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={!canEdit || valuesRefreshing}
+          onClick={() => setPickerIndex("new")}
+          className="shrink-0 border-none bg-transparent font-mono text-[9px] uppercase tracking-[0.05em] text-mariner disabled:opacity-40"
+        >
+          + Add value
+        </button>
+      </div>
+      <div className="mt-3 space-y-3">
+        {carry.map((item, index) => {
+          const reference =
+            item.binding.kind === "reference"
+              ? item.binding.reference
+              : undefined;
+          const selected =
+            reference === undefined
+              ? null
+              : availableValues.find(
+                  (entry) => entry.reference === reference,
+                ) ?? null;
+          const compatibility = selected
+            ? carryCompatibility(selected)
+            : null;
+          return (
+            <div
+              key={`${item.name}:${index}`}
+              className="space-y-2 rounded-[3px] border border-neutral-200 bg-off-white p-2.5"
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  aria-label={`Carried value ${index + 1} name`}
+                  value={item.name}
+                  disabled={!canEdit}
+                  onChange={(event) => {
+                    const next = [...carry];
+                    next[index] = { ...item, name: event.target.value };
+                    update(next);
+                  }}
+                  className="h-8 min-w-0 flex-1 rounded-[3px] border border-neutral-200 bg-panel px-2 font-mono text-[11px] outline-none disabled:opacity-50"
+                />
+                <button
+                  type="button"
+                  disabled={!canEdit}
+                  aria-label={`Remove carried value ${item.name}`}
+                  onClick={() => update(carry.filter((_, itemIndex) => itemIndex !== index))}
+                  className="size-8 rounded-[3px] border border-neutral-200 bg-panel font-mono text-neutral-500 disabled:opacity-40"
+                >
+                  ×
+                </button>
+              </div>
+              <WorkflowValueChip
+                value={selected}
+                reference={reference}
+                invalidReason={
+                  compatibility?.compatible === false
+                    ? compatibility.reason?.message
+                    : item.binding.kind !== "reference"
+                      ? "Choose one workflow value for this carried result."
+                      : null
+                }
+                disabled={!canEdit || valuesRefreshing}
+                onOpen={() => setPickerIndex(index)}
+              />
+            </div>
+          );
+        })}
+        {carry.length === 0 && (
+          <p className="m-0 rounded-[3px] border border-dashed border-neutral-300 px-3 py-3 font-body text-[11px] text-neutral-500">
+            No values are carried into retries.
+          </p>
+        )}
+      </div>
+      <WorkflowDataPicker
+        open={pickerIndex !== null}
+        entries={availableValues}
+        selectedReference={selectedReference}
+        refreshing={valuesRefreshing}
+        compatibility={carryCompatibility}
+        onClose={() => setPickerIndex(null)}
+        onSelect={(entry) => {
+          if (pickerIndex === "new") {
+            update([
+              ...carry,
+              {
+                name: carryName(entry, carry),
+                schema: structuredClone(entry.schema),
+                binding: {
+                  kind: "reference",
+                  reference: entry.reference,
+                },
+              },
+            ]);
+          } else if (typeof pickerIndex === "number") {
+            const next = [...carry];
+            const current = next[pickerIndex];
+            if (current) {
+              next[pickerIndex] = {
+                ...current,
+                schema: structuredClone(entry.schema),
+                binding: {
+                  kind: "reference",
+                  reference: entry.reference,
+                },
+              };
+              update(next);
+            }
+          }
+          setPickerIndex(null);
+        }}
+      />
+    </section>
+  );
+}

--- a/apps/dashboard/components/cockpit/flow-editor/loop-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/loop-fields.tsx
@@ -7,6 +7,7 @@ import type {
   WorkflowLoopCarryV2,
   WorkflowValueCompatibility,
 } from "@shared/contracts";
+import { isSafeWorkflowInputName } from "@shared/contracts";
 import {
   WorkflowDataPicker,
   WorkflowValueChip,
@@ -15,9 +16,28 @@ import {
 function parseCarry(
   configuration: Readonly<Record<string, JsonValue>>,
 ): WorkflowLoopCarryV2[] {
-  return Array.isArray(configuration.carry)
-    ? configuration.carry as unknown as WorkflowLoopCarryV2[]
-    : [];
+  if (!Array.isArray(configuration.carry)) return [];
+  return configuration.carry.filter((entry) => {
+    if (
+      entry === null ||
+      Array.isArray(entry) ||
+      typeof entry !== "object" ||
+      typeof entry.name !== "string" ||
+      entry.schema === null ||
+      Array.isArray(entry.schema) ||
+      typeof entry.schema !== "object" ||
+      entry.binding === null ||
+      Array.isArray(entry.binding) ||
+      typeof entry.binding !== "object"
+    ) {
+      return false;
+    }
+    return (
+      entry.binding.kind === "reference" ||
+      entry.binding.kind === "reference_list" ||
+      entry.binding.kind === "literal"
+    );
+  }) as unknown as WorkflowLoopCarryV2[];
 }
 
 function carryCompatibility(
@@ -114,6 +134,15 @@ export function LoopFields({
       </div>
       <div className="mt-3 space-y-3">
         {carry.map((item, index) => {
+          const duplicateName = carry.some(
+            (candidate, candidateIndex) =>
+              candidateIndex !== index && candidate.name === item.name,
+          );
+          const nameIssue = !isSafeWorkflowInputName(item.name)
+            ? "Use a safe value name without spaces or reserved fields."
+            : duplicateName
+              ? "Each carried value needs a unique name."
+              : null;
           const reference =
             item.binding.kind === "reference"
               ? item.binding.reference
@@ -133,17 +162,24 @@ export function LoopFields({
               className="space-y-2 rounded-[3px] border border-neutral-200 bg-off-white p-2.5"
             >
               <div className="flex items-center gap-2">
-                <input
-                  aria-label={`Carried value ${index + 1} name`}
-                  value={item.name}
-                  disabled={!canEdit}
-                  onChange={(event) => {
-                    const next = [...carry];
-                    next[index] = { ...item, name: event.target.value };
-                    update(next);
-                  }}
-                  className="h-8 min-w-0 flex-1 rounded-[3px] border border-neutral-200 bg-panel px-2 font-mono text-[11px] outline-none disabled:opacity-50"
-                />
+                <div className="min-w-0 flex-1">
+                  <input
+                    aria-label={`Carried value ${index + 1} name`}
+                    value={item.name}
+                    disabled={!canEdit}
+                    onChange={(event) => {
+                      const next = [...carry];
+                      next[index] = { ...item, name: event.target.value };
+                      update(next);
+                    }}
+                    className="h-8 w-full rounded-[3px] border border-neutral-200 bg-panel px-2 font-mono text-[11px] outline-none disabled:opacity-50"
+                  />
+                  {nameIssue && (
+                    <p className="m-0 mt-1 font-body text-[10px] text-red-700">
+                      {nameIssue}
+                    </p>
+                  )}
+                </div>
                 <button
                   type="button"
                   disabled={!canEdit}

--- a/apps/dashboard/lib/workflow-editor/reference-visitor.test.ts
+++ b/apps/dashboard/lib/workflow-editor/reference-visitor.test.ts
@@ -221,6 +221,47 @@ test("agent prompt tokens and slot bindings remap without touching literals", ()
   });
 });
 
+test("Loop carry bindings remap and remain discoverable", () => {
+  const node: FlowNodeDef = {
+    id: "retry",
+    type: "loop",
+    x: 0,
+    y: 0,
+    params: { maxAttempts: 3, onExhaust: "fail" },
+    inputs: {},
+    v2: {
+      inputs: {},
+      additionalInputs: [],
+      configuration: {
+        maxAttempts: 3,
+        onExhaust: "fail",
+        carry: [{
+          name: "review",
+          schema: { type: "object", properties: {}, additionalProperties: false },
+          binding: {
+            kind: "reference",
+            reference: "steps.review.output",
+          },
+        }],
+      },
+    },
+  };
+
+  const remapped = remapFlowNodeReferences(node, ids);
+  assert.equal(
+    (
+      remapped.v2?.configuration.carry as Array<{
+        binding: { reference: string };
+      }>
+    )[0]?.binding.reference,
+    "steps.review-copy.output",
+  );
+  assert.deepEqual(collectFlowNodeReferences(node), [{
+    reference: "steps.review.output",
+    path: "/configuration/carry/0/binding/reference",
+  }]);
+});
+
 test("reference visiting preserves arbitrary Transform literals and schema source", () => {
   const transform: FlowNodeDef = {
     id: "shape",

--- a/apps/dashboard/lib/workflow-editor/reference-visitor.test.ts
+++ b/apps/dashboard/lib/workflow-editor/reference-visitor.test.ts
@@ -279,6 +279,56 @@ test("Loop carry bindings remap and remain discoverable", () => {
   }]);
 });
 
+test("Loop reference-list carry bindings remap every ordered reference", () => {
+  const node: FlowNodeDef = {
+    id: "retry",
+    type: "loop",
+    x: 0,
+    y: 0,
+    params: { maxAttempts: 3, onExhaust: "fail" },
+    inputs: {},
+    v2: {
+      inputs: {},
+      additionalInputs: [],
+      configuration: {
+        maxAttempts: 3,
+        onExhaust: "fail",
+        carry: [{
+          name: "reviews",
+          schema: { type: "array", items: { type: "object" } },
+          binding: {
+            kind: "reference_list",
+            references: [
+              "steps.review.output",
+              "steps.plan.output",
+            ],
+          },
+        }],
+      },
+    },
+  };
+
+  const remapped = remapFlowNodeReferences(node, ids);
+  assert.deepEqual(
+    (
+      remapped.v2?.configuration.carry as Array<{
+        binding: { references: string[] };
+      }>
+    )[0]?.binding.references,
+    ["steps.review-copy.output", "steps.plan-copy.output"],
+  );
+  assert.deepEqual(collectFlowNodeReferences(node), [
+    {
+      reference: "steps.review.output",
+      path: "/configuration/carry/0/binding/references/0",
+    },
+    {
+      reference: "steps.plan.output",
+      path: "/configuration/carry/0/binding/references/1",
+    },
+  ]);
+});
+
 test("reference visiting preserves arbitrary Transform literals and schema source", () => {
   const transform: FlowNodeDef = {
     id: "shape",

--- a/apps/dashboard/lib/workflow-editor/reference-visitor.ts
+++ b/apps/dashboard/lib/workflow-editor/reference-visitor.ts
@@ -358,6 +358,46 @@ function remapV2Configuration(
       });
     }
   }
+  if (node.type === "loop" && Array.isArray(configuration.carry)) {
+    configuration.carry = configuration.carry.map((entry) => {
+      if (!isJsonRecord(entry) || !isJsonRecord(entry.binding)) {
+        return structuredClone(entry);
+      }
+      const binding = entry.binding;
+      if (
+        binding.kind === "reference" &&
+        typeof binding.reference === "string"
+      ) {
+        return {
+          ...entry,
+          binding: {
+            ...binding,
+            reference: remapWorkflowDataReference(
+              binding.reference,
+              nodeIdMap,
+            ),
+          },
+        };
+      }
+      if (
+        binding.kind === "reference_list" &&
+        Array.isArray(binding.references)
+      ) {
+        return {
+          ...entry,
+          binding: {
+            ...binding,
+            references: binding.references.map((reference) =>
+              typeof reference === "string"
+                ? remapWorkflowDataReference(reference, nodeIdMap)
+                : structuredClone(reference),
+            ),
+          },
+        };
+      }
+      return structuredClone(entry);
+    });
+  }
   if (configuration.promptSlotBindings !== undefined) {
     configuration.promptSlotBindings = remapPromptSlotBindings(
       configuration.promptSlotBindings,
@@ -606,6 +646,33 @@ export function collectFlowNodeReferences(
         }
       });
     }
+  }
+  if (node.type === "loop" && Array.isArray(node.v2.configuration.carry)) {
+    node.v2.configuration.carry.forEach((entry, index) => {
+      if (!isJsonRecord(entry) || !isJsonRecord(entry.binding)) return;
+      const binding = entry.binding;
+      if (
+        binding.kind === "reference" &&
+        typeof binding.reference === "string"
+      ) {
+        found.push({
+          reference: binding.reference,
+          path: `/configuration/carry/${index}/binding/reference`,
+        });
+      } else if (
+        binding.kind === "reference_list" &&
+        Array.isArray(binding.references)
+      ) {
+        binding.references.forEach((reference, referenceIndex) => {
+          if (typeof reference !== "string") return;
+          found.push({
+            reference,
+            path:
+              `/configuration/carry/${index}/binding/references/${referenceIndex}`,
+          });
+        });
+      }
+    });
   }
   if (node.v2.configuration.promptSlotBindings !== undefined) {
     collectPromptSlotBindingReferences(

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -403,6 +403,12 @@ export interface WorkflowBranchConfigurationV2 {
   conditions: WorkflowBranchConditionV2[];
 }
 
+export interface WorkflowLoopCarryV2 {
+  name: string;
+  schema: JsonSchema202012;
+  binding: WorkflowInputBindingV2;
+}
+
 /** Ordered, author-defined input exposed alongside a block's fixed inputs. */
 export interface WorkflowAdditionalInputV2 {
   name: string;

--- a/apps/worker/src/sandbox/disposable-review-workspace.test.ts
+++ b/apps/worker/src/sandbox/disposable-review-workspace.test.ts
@@ -175,9 +175,10 @@ describe("disposable review workspace", () => {
       arthurTaskId: null,
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       ok: true,
       sandboxId: "review-1",
+      sourceFingerprint: expect.any(String),
       repositories: [
         {
           repoPath: "acme/api",

--- a/apps/worker/src/sandbox/disposable-review-workspace.test.ts
+++ b/apps/worker/src/sandbox/disposable-review-workspace.test.ts
@@ -178,7 +178,8 @@ describe("disposable review workspace", () => {
     expect(result).toMatchObject({
       ok: true,
       sandboxId: "review-1",
-      sourceFingerprint: expect.any(String),
+      sourceFingerprint:
+        "9b61a1f46b417353381ac12935b99eef4023fec57990a2b0984072e54bdc52fb",
       repositories: [
         {
           repoPath: "acme/api",

--- a/apps/worker/src/sandbox/disposable-review-workspace.test.ts
+++ b/apps/worker/src/sandbox/disposable-review-workspace.test.ts
@@ -175,7 +175,7 @@ describe("disposable review workspace", () => {
       arthurTaskId: null,
     });
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
       ok: true,
       sandboxId: "review-1",
       sourceFingerprint:

--- a/apps/worker/src/sandbox/disposable-review-workspace.ts
+++ b/apps/worker/src/sandbox/disposable-review-workspace.ts
@@ -11,6 +11,7 @@ import {
   type WorkspaceManifest,
   workspaceManifestSchema,
 } from "./repo-workspace.js";
+import { fingerprintWorkspaceState } from "../workflows/workspace-gate-fingerprint.js";
 
 const PRIMARY_REPOSITORY_EXCLUDES_PATH = "/tmp/aiw-review-primary-git-excludes";
 const PRIMARY_REPOSITORY_EXCLUDES =
@@ -26,6 +27,7 @@ export type DisposableReviewWorkspaceProvisionResult =
   | {
       ok: true;
       sandboxId: string;
+      sourceFingerprint: string;
       repositories: DisposableReviewRepository[];
     }
   | {
@@ -403,6 +405,10 @@ export async function provisionDisposableReviewWorkspaceStep(
     return {
       ok: true,
       sandboxId: sandbox.sandboxId,
+      sourceFingerprint: fingerprintWorkspaceState(
+        manifest,
+        exported.map((repo) => repo.headSha),
+      ),
       repositories: exported.map(({ repoPath, localPath, headSha }) => ({
         repoPath,
         localPath,

--- a/apps/worker/src/workflow-definition/available-values.test.ts
+++ b/apps/worker/src/workflow-definition/available-values.test.ts
@@ -212,6 +212,73 @@ describe("v2 available values", () => {
     expect(references(result, "after")).toContain("run.branchName");
   });
 
+  it("proves same-activation values in an externally entered review retry cycle", () => {
+    const verdict = node("verdict", "branch");
+    verdict.configuration = {
+      combinator: "all",
+      conditions: [{
+        reference: "steps.review.output.body",
+        operator: "equals",
+        value: "approve",
+      }],
+    };
+    const loop = node("retry", "loop");
+    loop.configuration = {
+      maxAttempts: 3,
+      onExhaust: "fail",
+      carry: [{
+        name: "reviewBody",
+        schema: { type: "string" },
+        binding: {
+          kind: "reference",
+          reference: "steps.review.output.body",
+        },
+      }],
+    };
+    const fix = node("fix", "generic_agent", {
+      prompt: {
+        kind: "reference",
+        reference: "steps.retry.output.values.reviewBody",
+      },
+    });
+    const result = analyzeWorkflowV2Bindings(
+      definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("implementation", "generic_agent"),
+          node("review", "generic_agent"),
+          verdict,
+          loop,
+          fix,
+          node("done", "post_ticket_comment"),
+        ],
+        [
+          { id: "trigger-implementation", from: "trigger", to: "implementation" },
+          { id: "implementation-review", from: "implementation", to: "review" },
+          { id: "review-verdict", from: "review", to: "verdict" },
+          { id: "verdict-done", from: "verdict", fromPort: "true", to: "done" },
+          { id: "verdict-loop", from: "verdict", fromPort: "false", to: "retry" },
+          { id: "loop-fix", from: "retry", fromPort: "continue", to: "fix" },
+          { id: "fix-review", from: "fix", to: "review" },
+        ],
+      ),
+      registryContext,
+    );
+
+    expect(references(result, "verdict")).toContain("steps.review.output.body");
+    expect(references(result, "retry")).toContain("steps.review.output.body");
+    expect(references(result, "fix")).toContain(
+      "steps.retry.output.values.reviewBody",
+    );
+    expect(references(result, "fix")).toContain(
+      "steps.implementation.output.body",
+    );
+    expect(references(result, "review")).not.toContain(
+      "steps.fix.output.body",
+    );
+    expect(result.issues).toEqual([]);
+  });
+
   it("derives downstream Transform result paths from its operation", () => {
     const transform = node("shape", "transform");
     transform.configuration = {

--- a/apps/worker/src/workflow-definition/available-values.ts
+++ b/apps/worker/src/workflow-definition/available-values.ts
@@ -594,6 +594,7 @@ function stronglyConnectedComponents(
 ): string[][] {
   const adjacency = new Map(definition.nodes.map((node) => [node.id, [] as string[]]));
   for (const edge of definition.edges) {
+    if (!adjacency.has(edge.to)) continue;
     adjacency.get(edge.from)?.push(edge.to);
   }
 
@@ -751,11 +752,12 @@ function phaseGuaranteesSource(
   sourceId: string,
   consumerId: string,
   starts: readonly string[],
+  phase: "initial" | "retry",
   region: AuthoringLoopRegion,
 ): boolean | null {
   const reachable = reachableFromStarts(starts, region.phaseAdjacency);
   if (!reachable.has(consumerId)) return null;
-  if (sourceId === region.loopNodeId) return starts === region.retryEntryNodeIds;
+  if (sourceId === region.loopNodeId) return phase === "retry";
   if (!reachable.has(sourceId)) return false;
   return !reachableFromStarts(
     starts,
@@ -797,12 +799,14 @@ function loopScopedGuarantee(
       sourceId,
       consumerId,
       region.initialEntryNodeIds,
+      "initial",
       region,
     ),
     phaseGuaranteesSource(
       sourceId,
       consumerId,
       region.retryEntryNodeIds,
+      "retry",
       region,
     ),
   ].filter((value): value is boolean => value !== null);

--- a/apps/worker/src/workflow-definition/available-values.ts
+++ b/apps/worker/src/workflow-definition/available-values.ts
@@ -89,6 +89,58 @@ function contractForNode(
     configurationParams(node),
     registryContext,
   );
+  if (node.type === "loop") {
+    const carries = Array.isArray(node.configuration.carry)
+      ? node.configuration.carry
+      : [];
+    const properties: Record<string, WorkflowValueSchema> = {};
+    for (const carry of carries) {
+      if (
+        carry === null ||
+        Array.isArray(carry) ||
+        typeof carry !== "object" ||
+        typeof carry.name !== "string" ||
+        carry.schema === null ||
+        Array.isArray(carry.schema) ||
+        typeof carry.schema !== "object"
+      ) {
+        continue;
+      }
+      const inspected = inspectJsonSchema202012(
+        carry.schema as JsonSchema202012,
+        { requireClosedObjects: true },
+      );
+      if (inspected.ok) properties[carry.name] = inspected.valueSchema;
+    }
+    if (contract.output.bindingSchema.type !== "object") return contract;
+    const values: WorkflowValueSchema = {
+      type: "object",
+      properties,
+      required: Object.keys(properties),
+      additionalProperties: false,
+    };
+    const output = {
+      ...contract.output.bindingSchema,
+      properties: {
+        ...contract.output.bindingSchema.properties,
+        values,
+      },
+      required: [
+        ...new Set([
+          ...contract.output.bindingSchema.required,
+          "values",
+        ]),
+      ],
+    } satisfies WorkflowValueSchema;
+    return {
+      ...contract,
+      output: {
+        ...contract.output,
+        schema: output,
+        bindingSchema: output,
+      },
+    };
+  }
   if (node.type !== "transform") return contract;
 
   const derived = deriveTransformOutputSchema({
@@ -214,7 +266,7 @@ function contractsForDefinition(
   );
   for (let pass = 0; pass < definition.nodes.length; pass += 1) {
     for (const node of definition.nodes) {
-      if (node.type !== "transform") continue;
+      if (node.type !== "transform" && node.type !== "loop") continue;
       contracts.set(
         node.id,
         contractForNode(
@@ -537,12 +589,12 @@ function resolvedPort(
   return edge.fromPort ?? BLOCK_TYPE_SPECS[source.type].ports[0] ?? null;
 }
 
-function stronglyConnectedNodeIds(definition: WorkflowDefinitionV2): Set<string> {
+function stronglyConnectedComponents(
+  definition: WorkflowDefinitionV2,
+): string[][] {
   const adjacency = new Map(definition.nodes.map((node) => [node.id, [] as string[]]));
-  const selfLoops = new Set<string>();
   for (const edge of definition.edges) {
     adjacency.get(edge.from)?.push(edge.to);
-    if (edge.from === edge.to) selfLoops.add(edge.from);
   }
 
   let nextIndex = 0;
@@ -550,7 +602,7 @@ function stronglyConnectedNodeIds(definition: WorkflowDefinitionV2): Set<string>
   const onStack = new Set<string>();
   const indexById = new Map<string, number>();
   const lowById = new Map<string, number>();
-  const cyclic = new Set<string>();
+  const components: string[][] = [];
 
   const visit = (id: string) => {
     const index = nextIndex++;
@@ -574,15 +626,187 @@ function stronglyConnectedNodeIds(definition: WorkflowDefinitionV2): Set<string>
       component.push(member);
       if (member === id) break;
     }
-    if (component.length > 1 || selfLoops.has(component[0]!)) {
-      for (const member of component) cyclic.add(member);
-    }
+    components.push(component);
   };
 
   for (const node of definition.nodes) {
     if (!indexById.has(node.id)) visit(node.id);
   }
-  return cyclic;
+  return components;
+}
+
+function stronglyConnectedNodeIds(definition: WorkflowDefinitionV2): Set<string> {
+  const selfLoops = new Set(
+    definition.edges
+      .filter((edge) => edge.from === edge.to)
+      .map((edge) => edge.from),
+  );
+  return new Set(
+    stronglyConnectedComponents(definition).flatMap((component) =>
+      component.length > 1 || selfLoops.has(component[0]!)
+        ? component
+        : [],
+    ),
+  );
+}
+
+interface AuthoringLoopRegion {
+  loopNodeId: string;
+  memberNodeIds: ReadonlySet<string>;
+  initialEntryNodeIds: string[];
+  retryEntryNodeIds: string[];
+  phaseAdjacency: ReadonlyMap<string, readonly string[]>;
+  initialGraphAdjacency: ReadonlyMap<string, readonly string[]>;
+  triggerNodeIds: string[];
+}
+
+function authoringLoopRegions(
+  definition: WorkflowDefinitionV2,
+  nodeById: ReadonlyMap<string, WorkflowDefinitionV2Node>,
+): Map<string, AuthoringLoopRegion> {
+  const result = new Map<string, AuthoringLoopRegion>();
+  for (const component of stronglyConnectedComponents(definition)) {
+    const members = new Set(component);
+    const loops = component.filter((id) => nodeById.get(id)?.type === "loop");
+    if (loops.length !== 1) continue;
+    const loopNodeId = loops[0]!;
+    const initialEntryNodeIds = [
+      ...new Set(
+        definition.edges
+          .filter(
+            (edge) =>
+              !members.has(edge.from) &&
+              members.has(edge.to) &&
+              edge.to !== loopNodeId,
+          )
+          .map((edge) => edge.to),
+      ),
+    ];
+    const retryEntryNodeIds = [
+      ...new Set(
+        definition.edges
+          .filter(
+            (edge) =>
+              edge.from === loopNodeId &&
+              edge.fromPort === "continue" &&
+              members.has(edge.to),
+          )
+          .map((edge) => edge.to),
+      ),
+    ];
+    const phaseAdjacency = new Map(
+      component.map((nodeId) => [nodeId, [] as string[]]),
+    );
+    const initialGraphAdjacency = new Map(
+      definition.nodes.map((node) => [node.id, [] as string[]]),
+    );
+    for (const edge of definition.edges) {
+      if (edge.from !== loopNodeId) {
+        initialGraphAdjacency.get(edge.from)?.push(edge.to);
+      }
+      if (
+        edge.from === loopNodeId ||
+        !members.has(edge.from) ||
+        !members.has(edge.to)
+      ) {
+        continue;
+      }
+      phaseAdjacency.get(edge.from)?.push(edge.to);
+    }
+    const region = {
+      loopNodeId,
+      memberNodeIds: members,
+      initialEntryNodeIds,
+      retryEntryNodeIds,
+      phaseAdjacency,
+      initialGraphAdjacency,
+      triggerNodeIds: definition.nodes
+        .filter((node) => isTriggerBlockType(node.type))
+        .map((node) => node.id),
+    };
+    for (const member of component) result.set(member, region);
+  }
+  return result;
+}
+
+function reachableFromStarts(
+  starts: readonly string[],
+  adjacency: ReadonlyMap<string, readonly string[]>,
+  blockedNodeId?: string,
+): Set<string> {
+  const reached = new Set<string>();
+  const queue = starts.filter((nodeId) => nodeId !== blockedNodeId);
+  for (let index = 0; index < queue.length; index += 1) {
+    const current = queue[index]!;
+    if (reached.has(current)) continue;
+    reached.add(current);
+    for (const next of adjacency.get(current) ?? []) {
+      if (next !== blockedNodeId) queue.push(next);
+    }
+  }
+  return reached;
+}
+
+function phaseGuaranteesSource(
+  sourceId: string,
+  consumerId: string,
+  starts: readonly string[],
+  region: AuthoringLoopRegion,
+): boolean | null {
+  const reachable = reachableFromStarts(starts, region.phaseAdjacency);
+  if (!reachable.has(consumerId)) return null;
+  if (sourceId === region.loopNodeId) return starts === region.retryEntryNodeIds;
+  if (!reachable.has(sourceId)) return false;
+  return !reachableFromStarts(
+    starts,
+    region.phaseAdjacency,
+    sourceId,
+  ).has(consumerId);
+}
+
+function loopScopedGuarantee(
+  sourceId: string,
+  consumerId: string,
+  regionsByNodeId: ReadonlyMap<string, AuthoringLoopRegion>,
+): boolean | null {
+  const region = regionsByNodeId.get(consumerId);
+  if (!region) return null;
+  if (!region.memberNodeIds.has(sourceId)) {
+    if (region.initialEntryNodeIds.length === 0) return false;
+    const reachable = reachableFromStarts(
+      region.triggerNodeIds,
+      region.initialGraphAdjacency,
+    );
+    if (
+      !reachable.has(sourceId) ||
+      region.initialEntryNodeIds.some((entryId) => !reachable.has(entryId))
+    ) {
+      return false;
+    }
+    const withoutSource = reachableFromStarts(
+      region.triggerNodeIds,
+      region.initialGraphAdjacency,
+      sourceId,
+    );
+    return region.initialEntryNodeIds.every(
+      (entryId) => !withoutSource.has(entryId),
+    );
+  }
+  const phases = [
+    phaseGuaranteesSource(
+      sourceId,
+      consumerId,
+      region.initialEntryNodeIds,
+      region,
+    ),
+    phaseGuaranteesSource(
+      sourceId,
+      consumerId,
+      region.retryEntryNodeIds,
+      region,
+    ),
+  ].filter((value): value is boolean => value !== null);
+  return phases.length > 0 && phases.every(Boolean);
 }
 
 function activationFormulas(
@@ -847,6 +1071,66 @@ function inputTargets(
       path: `${basePath}/binding`,
     });
   }
+  if (node.type === "loop" && Array.isArray(node.configuration.carry)) {
+    const seenCarry = new Set<string>();
+    for (const [carryIndex, rawCarry] of node.configuration.carry.entries()) {
+      const basePath = `/nodes/${nodeIndex}/configuration/carry/${carryIndex}`;
+      if (
+        rawCarry === null ||
+        Array.isArray(rawCarry) ||
+        typeof rawCarry !== "object" ||
+        typeof rawCarry.name !== "string" ||
+        rawCarry.schema === null ||
+        Array.isArray(rawCarry.schema) ||
+        typeof rawCarry.schema !== "object" ||
+        rawCarry.binding === null ||
+        Array.isArray(rawCarry.binding) ||
+        typeof rawCarry.binding !== "object"
+      ) {
+        continue;
+      }
+      if (
+        !isSafeWorkflowInputName(rawCarry.name) ||
+        seenCarry.has(rawCarry.name)
+      ) {
+        issues.push({
+          code: "loop.carry_name",
+          severity: "error",
+          nodeId: node.id,
+          path: `${basePath}/name`,
+          message: `Loop "${node.id}" has invalid or duplicate carried value "${rawCarry.name}".`,
+        });
+        continue;
+      }
+      seenCarry.add(rawCarry.name);
+      const parsed = inspectJsonSchema202012(
+        rawCarry.schema as JsonSchema202012,
+        { requireClosedObjects: true },
+      );
+      if (!parsed.ok) {
+        for (const issue of parsed.issues) {
+          issues.push({
+            code: `loop.carry_schema.${issue.code}`,
+            severity: "error",
+            nodeId: node.id,
+            path: `${basePath}/schema${issue.path}`,
+            message: issue.message.replace(
+              /^outputSchema/,
+              `Carried value "${rawCarry.name}" schema`,
+            ),
+          });
+        }
+        continue;
+      }
+      targets.push({
+        name: `carry.${rawCarry.name}`,
+        schema: parsed.valueSchema,
+        required: true,
+        binding: rawCarry.binding as WorkflowInputBindingV2,
+        path: `${basePath}/binding`,
+      });
+    }
+  }
   return targets;
 }
 
@@ -1023,6 +1307,7 @@ export function analyzeWorkflowV2Bindings(
     definition.nodes.map((node) => [node.id, reachableFrom(node.id, forward)]),
   );
   const cyclicNodeIds = stronglyConnectedNodeIds(definition);
+  const loopRegionsByNodeId = authoringLoopRegions(definition, nodeById);
   const formulas = activationFormulas(definition, nodeById, cyclicNodeIds);
   const triggers = definition.nodes.filter((node) => isTriggerBlockType(node.type));
   const contracts = contractsForDefinition(definition, registryContext);
@@ -1102,12 +1387,25 @@ export function analyzeWorkflowV2Bindings(
 
     const consumerFormula = formulas.get(consumer.id) ?? emptyFormula();
     for (const source of definition.nodes) {
+      const scopedGuarantee = loopScopedGuarantee(
+        source.id,
+        consumer.id,
+        loopRegionsByNodeId,
+      );
       if (
         source.id === consumer.id ||
         isTriggerBlockType(source.type) ||
-        cyclicNodeIds.has(source.id) ||
         !reachability.get(source.id)?.has(consumer.id) ||
-        !formulaImplies(consumerFormula, formulas.get(source.id) ?? emptyFormula())
+        !(
+          scopedGuarantee ??
+          (
+            !cyclicNodeIds.has(source.id) &&
+            formulaImplies(
+              consumerFormula,
+              formulas.get(source.id) ?? emptyFormula(),
+            )
+          )
+        )
       ) {
         continue;
       }
@@ -1301,6 +1599,7 @@ export function analyzeWorkflowV2Catalog(
     ]),
   );
   const cyclicNodeIds = stronglyConnectedNodeIds(definition);
+  const loopRegionsByNodeId = authoringLoopRegions(definition, nodeById);
   const formulas = activationFormulas(definition, nodeById, cyclicNodeIds);
   const triggers = definition.nodes.filter((node) =>
     isTriggerBlockType(node.type),
@@ -1482,10 +1781,17 @@ export function analyzeWorkflowV2Catalog(
       }
       const contract = contracts.get(source.id)!;
       const guaranteed =
-        !cyclicNodeIds.has(source.id) &&
-        formulaImplies(
-          consumerFormula,
-          formulas.get(source.id) ?? emptyFormula(),
+        loopScopedGuarantee(
+          source.id,
+          consumer.id,
+          loopRegionsByNodeId,
+        ) ??
+        (
+          !cyclicNodeIds.has(source.id) &&
+          formulaImplies(
+            consumerFormula,
+            formulas.get(source.id) ?? emptyFormula(),
+          )
         );
       const availability = guaranteed
         ? ({

--- a/apps/worker/src/workflow-definition/interpreter.ts
+++ b/apps/worker/src/workflow-definition/interpreter.ts
@@ -180,6 +180,8 @@ export type BlockExecutor = (
  * present only when resuming the checkpointed block. */
 export interface BlockExecutionContext {
   attempt?: number;
+  /** V2 activation containing this exact invocation. */
+  activationScopeId?: string;
   clarificationAnswer?: string;
   cancellation?: import("./invocation-context.js").V2InvocationCancellation;
   /** V2 replay-safe diagnostic capture for this exact invocation. */

--- a/apps/worker/src/workflow-definition/schema-v2.test.ts
+++ b/apps/worker/src/workflow-definition/schema-v2.test.ts
@@ -664,6 +664,79 @@ describe("Workflow Definition v2 schema", () => {
     ).toEqual([]);
   });
 
+  it("validates typed Loop carry names, schemas, and bindings", () => {
+    const definition = v2Definition();
+    const retry = loopNode("retry", "continue");
+    retry.configuration.carry = [{
+      name: "ticket_status",
+      schema: { type: "string" },
+      binding: {
+        kind: "reference",
+        reference: "steps.entry.output.status",
+      },
+    }];
+    definition.nodes.push(
+      retry,
+      loopBodyNode("body"),
+      {
+        id: "done",
+        type: "terminate",
+        x: 300,
+        y: 0,
+        configuration: { terminalStatus: "done" },
+        inputs: {},
+        additionalInputs: [],
+      },
+    );
+    definition.edges.push(
+      { id: "ticket-retry", from: "ticket", to: "retry" },
+      {
+        id: "retry-body",
+        from: "retry",
+        fromPort: "continue",
+        to: "body",
+      },
+      { id: "body-retry", from: "body", to: "retry" },
+      {
+        id: "retry-done",
+        from: "retry",
+        fromPort: "exhausted",
+        to: "done",
+      },
+    );
+
+    expect(
+      validateWorkflowDefinitionIssuesForDeployment(
+        definition,
+        registryContext,
+      ),
+    ).toEqual([]);
+
+    retry.configuration.carry = [
+      ...retry.configuration.carry,
+      {
+        name: "ticket_status",
+        schema: { type: "number" },
+        binding: {
+          kind: "reference",
+          reference: "steps.entry.output.status",
+        },
+      },
+    ];
+    expect(
+      validateWorkflowDefinitionIssuesForDeployment(
+        definition,
+        registryContext,
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "loop.carry_name",
+        nodeId: "retry",
+        path: "/nodes/1/configuration/carry/1/name",
+      }),
+    );
+  });
+
   it("keeps invalid non-Transform configuration in drafts but blocks deployment", () => {
     const unknown = v2Definition();
     unknown.nodes[0]!.configuration = { hiddenCommand: "echo unsafe" };

--- a/apps/worker/src/workflow-definition/schema-v2.test.ts
+++ b/apps/worker/src/workflow-definition/schema-v2.test.ts
@@ -748,8 +748,10 @@ describe("Workflow Definition v2 schema", () => {
       ),
     ).toEqual([]);
 
+    const existingCarry = retry.configuration.carry;
+    expect(Array.isArray(existingCarry)).toBe(true);
     retry.configuration.carry = [
-      ...retry.configuration.carry,
+      ...(Array.isArray(existingCarry) ? existingCarry : []),
       {
         name: "ticket_status",
         schema: { type: "number" },
@@ -769,6 +771,48 @@ describe("Workflow Definition v2 schema", () => {
         code: "loop.carry_name",
         nodeId: "retry",
         path: "/nodes/1/configuration/carry/1/name",
+      }),
+    );
+
+    retry.configuration.carry = [{
+      name: "ticket_status",
+      schema: { type: "unsupported" },
+      binding: {
+        kind: "reference",
+        reference: "steps.entry.output.status",
+      },
+    }];
+    expect(
+      validateWorkflowDefinitionIssuesForDeployment(
+        definition,
+        registryContext,
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "loop.carry_schema.unsupported_type",
+        nodeId: "retry",
+        path: "/nodes/1/configuration/carry/0/schema/type",
+      }),
+    );
+
+    retry.configuration.carry = [{
+      name: "ticket_status",
+      schema: { type: "string" },
+      binding: {
+        kind: "literal",
+        value: 42,
+      },
+    }];
+    expect(
+      validateWorkflowDefinitionIssuesForDeployment(
+        definition,
+        registryContext,
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        code: "binding.literal_type",
+        nodeId: "retry",
+        path: "/nodes/1/configuration/carry/0/binding/value",
       }),
     );
   });

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -592,6 +592,18 @@ const v2LoopConfiguration = z
   .object({
     maxAttempts: z.number().int().min(1).max(20),
     onExhaust: z.enum(["fail", "human", "continue"]),
+    carry: z
+      .array(
+        z
+          .object({
+            name: bindingInputName,
+            schema: z.record(z.string(), jsonValueSchema),
+            binding: workflowInputBindingV2Schema,
+          })
+          .strict(),
+      )
+      .max(100)
+      .optional(),
   })
   .strict();
 const v2TerminateConfiguration = z
@@ -1645,6 +1657,7 @@ function validateWorkflowV2ConfigurationIssues(
     const allowedKeys = new Set([
       ...BLOCK_PARAM_KEYS[node.type],
       ...(node.type === "branch" ? ["combinator", "conditions"] : []),
+      ...(node.type === "loop" ? ["carry"] : []),
       ...(isV2PromptAuthoringBlock(node.type)
         ? ["harnessProfile", "promptSlotBindings"]
         : []),

--- a/apps/worker/src/workflow-definition/v2-scheduler.test.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.test.ts
@@ -1087,6 +1087,67 @@ describe("executeV2Graph loop scopes", () => {
     expect(fixInputs).toEqual(["changes-1", "changes-2"]);
   });
 
+  it("rejects duplicate Loop carry names at the runtime safety boundary", async () => {
+    const loop = node("retry", "loop", {
+      maxAttempts: 2,
+      onExhaust: "fail",
+      carry: [
+        {
+          name: "reviewBody",
+          schema: { type: "string" },
+          binding: {
+            kind: "reference",
+            reference: "steps.review.output.body",
+          },
+        },
+        {
+          name: "reviewBody",
+          schema: { type: "string" },
+          binding: {
+            kind: "reference",
+            reference: "steps.review.output.body",
+          },
+        },
+      ],
+    });
+    const result = await executeV2Graph({
+      runId: "duplicate-loop-carry",
+      definition: definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("review", "generic_agent"),
+          loop,
+          node("body", "generic_agent"),
+        ],
+        [
+          { id: "trigger-review", from: "trigger", to: "review" },
+          { id: "review-loop", from: "review", to: "retry" },
+          {
+            id: "loop-body",
+            from: "retry",
+            fromPort: "continue",
+            to: "body",
+          },
+          { id: "body-loop", from: "body", to: "retry" },
+        ],
+      ),
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "ok" },
+      executeBlock: async (current) => ({
+        kind: "next",
+        output: current.id === "review"
+          ? { status: "completed", body: "changes" }
+          : successfulOutput(current),
+      }),
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.executionError).toMatchObject({
+      nodeId: "retry",
+      category: "engine",
+    });
+  });
+
   it("fails the existing waiting owner attempt when a loop body deadlocks", async () => {
     const loopStarts: Array<{
       attempt: number;

--- a/apps/worker/src/workflow-definition/v2-scheduler.test.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.test.ts
@@ -33,12 +33,16 @@ function node(
   configuration: Record<string, JsonValue> = {},
   inputs: Record<string, WorkflowInputBindingV2> = {},
 ): WorkflowDefinitionV2Node {
+  const normalizedConfiguration =
+    type === "generic_agent" && configuration.workspaceMode === undefined
+      ? { ...configuration, workspaceMode: "none" }
+      : configuration;
   return {
     id,
     type,
     x: 0,
     y: 0,
-    configuration,
+    configuration: normalizedConfiguration,
     inputs,
     additionalInputs: [],
   };
@@ -395,6 +399,38 @@ describe("executeV2Graph edge tokens", () => {
 });
 
 describe("executeV2Graph concurrency and failure", () => {
+  it("fails closed when an unsafe workspace overlap bypasses deployment validation", async () => {
+    const result = await executeV2Graph({
+      definition: definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("writer", "implementation_agent"),
+          node("reader", "review_agent"),
+        ],
+        [
+          { id: "trigger-writer", from: "trigger", to: "writer" },
+          { id: "trigger-reader", from: "trigger", to: "reader" },
+        ],
+      ),
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "ok" },
+      executeBlock: async (_current, _steps, _inputs, context) => {
+        await context.cancellation.wait();
+        return {
+          kind: "next",
+          output: { status: "implemented" },
+        };
+      },
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.executionError).toMatchObject({
+      nodeId: "reader",
+      category: "sandbox",
+      phase: "workspace",
+    });
+  });
+
   it("admits at most four block invocations at once", async () => {
     const gates = new Map(
       ["one", "two", "three", "four", "five"].map((id) => [
@@ -945,6 +981,112 @@ describe("executeV2Graph clarification and cancellation", () => {
 });
 
 describe("executeV2Graph loop scopes", () => {
+  it("runs the initial review before Loop and carries the latest result into each retry", async () => {
+    const fixInputs: string[] = [];
+    const reviewScopes: string[] = [];
+    const executionErrors: string[] = [];
+    const review = node("review", "generic_agent");
+    const verdict = node("verdict", "branch", {
+      combinator: "all",
+      conditions: [{
+        reference: "steps.review.output.body",
+        operator: "equals",
+        value: "approve",
+      }],
+    });
+    const loop = node("retry", "loop", {
+      maxAttempts: 3,
+      onExhaust: "fail",
+      carry: [{
+        name: "reviewBody",
+        schema: { type: "string" },
+        binding: {
+          kind: "reference",
+          reference: "steps.review.output.body",
+        },
+      }],
+    });
+    const fix = node(
+      "fix",
+      "generic_agent",
+      {},
+      {
+        prompt: {
+          kind: "reference",
+          reference: "steps.retry.output.values.reviewBody",
+        },
+      },
+    );
+
+    const result = await executeV2Graph({
+      definition: definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          review,
+          verdict,
+          loop,
+          fix,
+          node("done", "generic_agent"),
+        ],
+        [
+          { id: "trigger-review", from: "trigger", to: "review" },
+          { id: "review-verdict", from: "review", to: "verdict" },
+          {
+            id: "verdict-done",
+            from: "verdict",
+            fromPort: "true",
+            to: "done",
+          },
+          {
+            id: "verdict-loop",
+            from: "verdict",
+            fromPort: "false",
+            to: "retry",
+          },
+          {
+            id: "loop-fix",
+            from: "retry",
+            fromPort: "continue",
+            to: "fix",
+          },
+          { id: "fix-review", from: "fix", to: "review" },
+        ],
+      ),
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "ok" },
+      hooks: {
+        onExecutionError({ error }) {
+          executionErrors.push(error.detail ?? error.message);
+        },
+      },
+      executeBlock: async (current, _steps, inputs, context) => {
+        if (current.id === "review") {
+          reviewScopes.push(context.activationScopeId);
+          return {
+            kind: "next",
+            output: {
+              status: "completed",
+              body: context.attempt < 3 ? `changes-${context.attempt}` : "approve",
+            },
+          };
+        }
+        if (current.id === "fix") {
+          fixInputs.push(String(inputs.prompt));
+        }
+        return { kind: "next", output: successfulOutput(current) };
+      },
+    });
+
+    expect(executionErrors).toEqual([]);
+    expect(result.outcome).toBe("completed");
+    expect(reviewScopes).toEqual([
+      "root",
+      "root/loop:retry:1",
+      "root/loop:retry:2",
+    ]);
+    expect(fixInputs).toEqual(["changes-1", "changes-2"]);
+  });
+
   it("fails the existing waiting owner attempt when a loop body deadlocks", async () => {
     const loopStarts: Array<{
       attempt: number;

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -940,6 +940,8 @@ class V2SchedulerRuntime {
             ),
         );
       if (conflictingNode) {
+        // Deployment rejects these graphs. Runtime fails closed as a final
+        // safety boundary if an invalid definition reaches the scheduler.
         const attempt = this.startAttempt(next.scopeId, node.id);
         await this.failNode(
           next.scopeId,
@@ -1285,6 +1287,11 @@ class V2SchedulerRuntime {
       ) {
         throw new V2SchedulerDefinitionError(
           `loop "${node.id}" has an invalid carried value`,
+        );
+      }
+      if (Object.prototype.hasOwnProperty.call(values, carry.name)) {
+        throw new V2SchedulerDefinitionError(
+          `loop "${node.id}" has duplicate carried value "${carry.name}"`,
         );
       }
       const value = resolveWorkflowInputBindingV2(

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -929,7 +929,7 @@ class V2SchedulerRuntime {
       this.checkpoint.readyQueue.shift();
       const nextAccess = workflowWorkspaceAccessOf(node);
       const conflictingNode = [...this.running.keys()]
-        .map((key) => key.slice(key.lastIndexOf("\0") + 1))
+        .map((key) => this.invocationIds(key).nodeId)
         .map((nodeId) => this.graph.nodes.get(nodeId))
         .find(
           (runningNode) =>
@@ -1846,9 +1846,7 @@ class V2SchedulerRuntime {
   private async quiesceRunningSiblings(reason: string): Promise<void> {
     const running = [...this.running.entries()];
     for (const [key] of running) {
-      const separator = key.lastIndexOf("\0");
-      const scopeId = key.slice(0, separator);
-      const nodeId = key.slice(separator + 1);
+      const { scopeId, nodeId } = this.invocationIds(key);
       const state = this.scope(scopeId).nodeStates[nodeId];
       if (!state || state.status !== "running") continue;
       state.status = "cancelled";
@@ -2047,6 +2045,14 @@ class V2SchedulerRuntime {
 
   private invocationKey(scopeId: string, nodeId: string): string {
     return `${scopeId}\0${nodeId}`;
+  }
+
+  private invocationIds(key: string): { scopeId: string; nodeId: string } {
+    const separator = key.lastIndexOf("\0");
+    return {
+      scopeId: key.slice(0, separator),
+      nodeId: key.slice(separator + 1),
+    };
   }
 
   private takeClarificationAnswer(

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -4,6 +4,8 @@ import {
   isTriggerBlockType,
   type BlockOutput,
   type BlockRunState,
+  type JsonSchema202012,
+  type JsonValue,
   type WorkflowParamValue,
   type WorkflowDefinitionV2,
   type WorkflowDefinitionV2ControlEdge,
@@ -31,10 +33,17 @@ import {
   isV2BranchConfiguration,
 } from "./v2-branch.js";
 import {
+  isJsonValue,
+  resolveWorkflowInputBindingV2,
   resolveWorkflowNodeInputsV2,
   type V2BindingResolutionContext,
 } from "./v2-bindings.js";
 import { validateBlockOutputForDefinition } from "./block-registry.js";
+import { validateJsonSchemaValue } from "./json-schema.js";
+import {
+  workflowWorkspaceAccessesConflict,
+  workflowWorkspaceAccessOf,
+} from "./workspace-access.js";
 
 const ROOT_SCOPE_ID = "root";
 const DEFAULT_MAX_CONCURRENCY = 4;
@@ -115,6 +124,7 @@ export interface V2ResolvedControlEdge
 export interface V2LoopRegion {
   loopNodeId: string;
   memberNodeIds: Set<string>;
+  hasExternalBodyEntry: boolean;
 }
 
 export interface V2RuntimeGraph {
@@ -391,6 +401,12 @@ export function buildV2RuntimeGraph(
     loopRegions.set(loopNodeId, {
       loopNodeId,
       memberNodeIds: componentSet,
+      hasExternalBodyEntry: edges.some(
+        (edge) =>
+          !componentSet.has(edge.from) &&
+          componentSet.has(edge.to) &&
+          edge.to !== loopNodeId,
+      ),
     });
     for (const member of component) {
       if (member !== loopNodeId) loopBodyNodeIds.add(member);
@@ -570,9 +586,13 @@ class V2SchedulerRuntime {
         `entry trigger "${this.options.entryTriggerId}" is not present`,
       );
     }
-    const allowedNodeIds = [...this.graph.nodes.keys()].filter(
-      (nodeId) => !this.graph.loopBodyNodeIds.has(nodeId),
-    );
+    const allowedNodeIds = [...this.graph.nodes.keys()].filter((nodeId) => {
+      const region = this.loopRegionContaining(nodeId);
+      return (
+        !this.graph.loopBodyNodeIds.has(nodeId) ||
+        region?.hasExternalBodyEntry === true
+      );
+    });
     const root = this.createScope({
       id: ROOT_SCOPE_ID,
       sequence: 0,
@@ -596,6 +616,19 @@ class V2SchedulerRuntime {
     };
     this.checkpoint = checkpoint;
 
+    // A loop cycle can be entered from an ordinary upstream edge before its
+    // Loop block has run. Resolve each retry-only continue edge as inactive in
+    // the owner scope; inactivity then propagates through that arm until the
+    // externally entered node can resolve normally. Child scopes activate the
+    // same edges explicitly for retries.
+    for (const [loopNodeId, region] of this.graph.loopRegions) {
+      if (!region.hasExternalBodyEntry) continue;
+      for (const edge of this.graph.outgoing.get(loopNodeId) ?? []) {
+        if (edge.port === "continue") {
+          this.setEdgeToken(root.id, edge.id, "inactive");
+        }
+      }
+    }
     for (const edge of this.graph.edges) {
       const sourceLoopRegion = this.loopRegionContaining(edge.from);
       if (
@@ -721,12 +754,46 @@ class V2SchedulerRuntime {
     nodeId: string,
     selectedPort: string | undefined,
   ): void {
+    const scope = this.scope(scopeId);
+    const initialLoopRegion =
+      scope.loop === undefined && scope.parentScopeId === null
+        ? this.loopRegionContaining(nodeId)
+        : undefined;
+    const selectedBoundaryEdgeIds = new Set(
+      initialLoopRegion
+        ? (this.graph.outgoing.get(nodeId) ?? [])
+            .filter(
+              (edge) =>
+                edge.port === selectedPort &&
+                !initialLoopRegion.memberNodeIds.has(edge.to),
+            )
+            .map((edge) => edge.id)
+        : [],
+    );
     for (const edge of this.graph.outgoing.get(nodeId) ?? []) {
+      if (
+        initialLoopRegion &&
+        !initialLoopRegion.memberNodeIds.has(edge.to)
+      ) {
+        // A non-selected exit may be chosen by a later retry. Keep it
+        // unresolved until this initial activation exits the region or the
+        // Loop reaches a terminal transition.
+        continue;
+      }
       this.setEdgeToken(
         scopeId,
         edge.id,
         edge.port === selectedPort ? "active" : "inactive",
       );
+    }
+    if (initialLoopRegion && selectedBoundaryEdgeIds.size > 0) {
+      for (const edge of this.loopBoundaryEdges(initialLoopRegion.loopNodeId)) {
+        this.setEdgeToken(
+          scopeId,
+          edge.id,
+          selectedBoundaryEdgeIds.has(edge.id) ? "active" : "inactive",
+        );
+      }
     }
     this.drainResolutionQueue();
   }
@@ -860,6 +927,32 @@ class V2SchedulerRuntime {
       }
       if (this.running.size >= this.maxConcurrency) return;
       this.checkpoint.readyQueue.shift();
+      const nextAccess = workflowWorkspaceAccessOf(node);
+      const conflictingNode = [...this.running.keys()]
+        .map((key) => key.slice(key.lastIndexOf("\0") + 1))
+        .map((nodeId) => this.graph.nodes.get(nodeId))
+        .find(
+          (runningNode) =>
+            runningNode !== undefined &&
+            workflowWorkspaceAccessesConflict(
+              nextAccess,
+              workflowWorkspaceAccessOf(runningNode),
+            ),
+        );
+      if (conflictingNode) {
+        const attempt = this.startAttempt(next.scopeId, node.id);
+        await this.failNode(
+          next.scopeId,
+          node.id,
+          attempt,
+          runtimeError(
+            `blocks "${conflictingNode.name ?? conflictingNode.id}" and ` +
+              `"${node.name ?? node.id}" attempted unsafe concurrent workspace access`,
+            { category: "sandbox", phase: "workspace" },
+          ).error,
+        );
+        return;
+      }
       this.launchBlock(next.scopeId, node);
     }
   }
@@ -1014,10 +1107,12 @@ class V2SchedulerRuntime {
         continues ? "continue" : undefined,
       );
       if (continues) {
+        const carryValues = this.resolveLoopCarryValues(scopeId, node);
         this.spawnLoopIteration(
           activeLoop.ownerScopeId,
           node,
           activeLoop.iteration + 1,
+          carryValues,
         );
       } else {
         const ownerAttempt =
@@ -1076,7 +1171,12 @@ class V2SchedulerRuntime {
         this.setEdgeToken(scopeId, edge.id, "inactive");
       }
     }
-    this.spawnLoopIteration(scopeId, node, 1);
+    this.spawnLoopIteration(
+      scopeId,
+      node,
+      1,
+      this.resolveLoopCarryValues(scopeId, node),
+    );
   }
 
   private loopMaxAttempts(node: WorkflowDefinitionV2Node): number {
@@ -1097,6 +1197,7 @@ class V2SchedulerRuntime {
     ownerScopeId: string,
     node: WorkflowDefinitionV2Node,
     iteration: number,
+    carryValues: Readonly<Record<string, JsonValue>>,
   ): void {
     const region = this.graph.loopRegions.get(node.id);
     if (!region) {
@@ -1116,7 +1217,11 @@ class V2SchedulerRuntime {
       parentScopeId: ownerScopeId,
       allowedNodeIds: [...region.memberNodeIds],
       outputs: {
-        [node.id]: { status: "ok", attempt: iteration },
+        [node.id]: {
+          status: "ok",
+          attempt: iteration,
+          values: structuredClone(carryValues),
+        },
       },
       loop: {
         loopNodeId: node.id,
@@ -1143,6 +1248,66 @@ class V2SchedulerRuntime {
       );
     }
     this.drainResolutionQueue();
+  }
+
+  private resolveLoopCarryValues(
+    scopeId: string,
+    node: WorkflowDefinitionV2Node,
+  ): Record<string, JsonValue> {
+    const rawCarry = node.configuration.carry;
+    if (rawCarry === undefined) return {};
+    if (!Array.isArray(rawCarry)) {
+      throw new V2SchedulerDefinitionError(
+        `loop "${node.id}" has invalid carried values`,
+      );
+    }
+    const values: Record<string, JsonValue> = {};
+    for (const entry of rawCarry) {
+      if (
+        entry === null ||
+        Array.isArray(entry) ||
+        typeof entry !== "object"
+      ) {
+        throw new V2SchedulerDefinitionError(
+          `loop "${node.id}" has an invalid carried value`,
+        );
+      }
+      const carry = entry as Record<string, unknown>;
+      if (
+        typeof carry.name !== "string" ||
+        carry.name.length === 0 ||
+        carry.schema === null ||
+        Array.isArray(carry.schema) ||
+        typeof carry.schema !== "object" ||
+        carry.binding === null ||
+        Array.isArray(carry.binding) ||
+        typeof carry.binding !== "object"
+      ) {
+        throw new V2SchedulerDefinitionError(
+          `loop "${node.id}" has an invalid carried value`,
+        );
+      }
+      const value = resolveWorkflowInputBindingV2(
+        carry.binding as Parameters<typeof resolveWorkflowInputBindingV2>[0],
+        this.bindingContext(scopeId),
+      );
+      if (!isJsonValue(value)) {
+        throw new Error(
+          `loop "${node.id}" carried value "${carry.name}" is not JSON serializable`,
+        );
+      }
+      const validationIssues = validateJsonSchemaValue(
+        carry.schema as JsonSchema202012,
+        value,
+      );
+      if (validationIssues.length > 0) {
+        throw new Error(
+          `loop "${node.id}" carried value "${carry.name}" does not match its schema`,
+        );
+      }
+      values[carry.name] = structuredClone(value);
+    }
+    return values;
   }
 
   private async exhaustLoop(
@@ -1738,6 +1903,15 @@ class V2SchedulerRuntime {
       if (Object.prototype.hasOwnProperty.call(current.outputs, nodeId)) {
         return current.outputs[nodeId];
       }
+      const currentRegion = current.loop
+        ? this.graph.loopRegions.get(current.loop.loopNodeId)
+        : undefined;
+      if (currentRegion?.memberNodeIds.has(nodeId)) {
+        // A retry may read only values produced in that same child
+        // activation. Falling back to the owner's initial pass would silently
+        // reuse stale review/check output.
+        return undefined;
+      }
       current = current.parentScopeId
         ? this.checkpoint.scopes[current.parentScopeId]
         : undefined;
@@ -1746,17 +1920,10 @@ class V2SchedulerRuntime {
   }
 
   private stepsForScope(scopeId: string): V2StepsRecord {
-    const chain: V2ActivationScopeState[] = [];
-    let current: V2ActivationScopeState | undefined = this.scope(scopeId);
-    while (current) {
-      chain.unshift(current);
-      current = current.parentScopeId
-        ? this.checkpoint.scopes[current.parentScopeId]
-        : undefined;
-    }
     const steps: V2StepsRecord = {};
-    for (const scope of chain) {
-      for (const [nodeId, output] of Object.entries(scope.outputs)) {
+    for (const nodeId of ["entry", ...this.graph.nodes.keys()]) {
+      const output = this.stepOutput(scopeId, nodeId);
+      if (output !== undefined) {
         steps[nodeId] = { output: structuredClone(output) };
       }
     }

--- a/apps/worker/src/workflow-definition/workspace-access.test.ts
+++ b/apps/worker/src/workflow-definition/workspace-access.test.ts
@@ -157,6 +157,9 @@ describe("validateWorkflowV2WorkspaceAccessIssues", () => {
       expect.objectContaining({
         code: "workspace.concurrent_access",
         nodeId: "review",
+        message: expect.stringContaining(
+          '"implementation" (exclusive writer)',
+        ),
       }),
     ]);
   });

--- a/apps/worker/src/workflow-definition/workspace-access.ts
+++ b/apps/worker/src/workflow-definition/workspace-access.ts
@@ -224,7 +224,7 @@ function formulasCanOverlap(
   );
 }
 
-function accessPairConflicts(
+export function workflowWorkspaceAccessesConflict(
   left: WorkflowWorkspaceAccess,
   right: WorkflowWorkspaceAccess,
 ): boolean {
@@ -262,7 +262,7 @@ export function validateWorkflowV2WorkspaceAccessIssues(
     ) {
       const right = definition.nodes[rightIndex]!;
       const rightAccess = workflowWorkspaceAccessOf(right);
-      if (!accessPairConflicts(leftAccess, rightAccess)) continue;
+      if (!workflowWorkspaceAccessesConflict(leftAccess, rightAccess)) continue;
       if (
         reachability.get(left.id)?.has(right.id) ||
         reachability.get(right.id)?.has(left.id)
@@ -283,11 +283,19 @@ export function validateWorkflowV2WorkspaceAccessIssues(
         nodeId: right.id,
         path: `/nodes/${rightIndex}`,
         message:
-          `Blocks "${left.id}" and "${right.id}" can run concurrently while sharing a workspace; ` +
-          "workspace readers and writers must be ordered or placed on mutually exclusive paths.",
+          `Blocks "${left.name ?? left.id}" (${workspaceAccessLabel(leftAccess)}) and ` +
+          `"${right.name ?? right.id}" (${workspaceAccessLabel(rightAccess)}) can run concurrently. ` +
+          "Order them explicitly or place them on mutually exclusive Branch paths.",
       });
     }
   }
 
   return issues;
+}
+
+function workspaceAccessLabel(access: WorkflowWorkspaceAccess): string {
+  if (access === "isolated_review") return "isolated reader";
+  if (access === "shared_write") return "exclusive writer";
+  if (access === "shared_read") return "shared reader";
+  return "no workspace";
 }

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -3277,6 +3277,7 @@ async function agentWorkflowBody(
             });
             ctx.sandboxId = restored.sandboxId;
             invalidateWorkspaceGate(ctx);
+            ctx.reviewSourceFingerprints?.clear();
             ctx.sandboxIds.add(restored.sandboxId);
             const restoredSteps = restoreCheckpointSandboxReferences(
               checkpointSteps,
@@ -3758,6 +3759,7 @@ async function agentWorkflowBody(
           (node.type === "generic_agent" && node.params.workspaceMode !== "none")
         ) {
           invalidateWorkspaceGate(ctx);
+          ctx.reviewSourceFingerprints?.clear();
         }
         // A workspace-enabled generic_agent reuses whatever prepare_workspace
         // attached without routing through a write-ensuring path, so promote its

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -3052,6 +3052,7 @@ async function agentWorkflowBody(
       agentSandboxIds: {},
       harnessRuntimes,
       sandboxIds: new Set<string>(),
+      reviewSourceFingerprints: new Map<string, string>(),
       selectedRepositories: [],
       repositoryContexts: [],
       repositoryDiscovery: null,
@@ -4274,6 +4275,32 @@ async function agentWorkflowBody(
             phaseModels[reviewPhase] = model;
             runPhaseModels[reviewPhase] = model;
             try {
+              if (ctx.schemaVersion === 2) {
+                const activationScopeId =
+                  execution?.activationScopeId ?? "root";
+                const reviewSourceFingerprints =
+                  (ctx.reviewSourceFingerprints ??= new Map<string, string>());
+                const expectedFingerprint =
+                  reviewSourceFingerprints.get(activationScopeId);
+                if (
+                  expectedFingerprint !== undefined &&
+                  expectedFingerprint !== provisioned.sourceFingerprint
+                ) {
+                  return executionError(
+                    "parallel reviews did not receive the same workspace snapshot",
+                    {
+                      category: "sandbox",
+                      phase: "review",
+                      message:
+                        "Parallel reviews could not use one identical workspace snapshot.",
+                    },
+                  );
+                }
+                reviewSourceFingerprints.set(
+                  activationScopeId,
+                  provisioned.sourceFingerprint,
+                );
+              }
               const reviewRuntime = await prepareHarnessAgentInvocationStep(
                 sandboxId,
                 kind,
@@ -4932,6 +4959,7 @@ async function agentWorkflowBody(
           structuredClone(resolvedInputs),
           {
             attempt: invocation.attempt,
+            activationScopeId: invocation.activationScopeId,
             agentArtifactKey: v2AgentArtifactKeys.get(node.id)!,
             cancellation: invocation.cancellation,
             observations: invocation.observations,

--- a/apps/worker/src/workflows/blocks/types.ts
+++ b/apps/worker/src/workflows/blocks/types.ts
@@ -96,6 +96,9 @@ export interface EngineCtx {
    * durable owner child for external cancel/reconcile crash cleanup.
    */
   sandboxIds: Set<string>;
+  /** Exact canonical workspace fingerprint used by parallel Review blocks in
+   * each scheduler activation. All reviewers in one fan-out must match. */
+  reviewSourceFingerprints?: Map<string, string>;
   /** Empty until prepare_workspace selects repositories. */
   selectedRepositories: WorkspaceRepositoryInput[];
   /** Per-repository PR context (full comment bodies, check results, conflicts). */


### PR DESCRIPTION
## Stack

- Base: `codex/aiw-182-187-harness-capabilities` (PR #171)
- Jira: [AIW-185](https://blazity.atlassian.net/browse/AIW-185), [AIW-188](https://blazity.atlassian.net/browse/AIW-188)
- Stack position: 4 of 6

## What changed

- Runs the initial externally entered Review/Checks path in the owner activation and creates a distinct child activation for every retry.
- Adds explicit typed Loop carry values, exposed only to the next retry through the Loop output.
- Prevents retry blocks from reading stale values from an earlier or sibling iteration.
- Makes authoring availability match the runtime activation scopes, including inherited pre-Loop values.
- Adds a visual Loop carry editor and preserves/remaps carry references through copy and paste.
- Allows parallel Review Agents from isolated, read-only disposable workspaces while rejecting unsafe reader/writer and writer/writer overlap at deployment and runtime.
- Verifies that concurrent Review Agents use the identical canonical workspace fingerprint.

## Compatibility

- Workflow Definition v1 behavior is unchanged.
- V2 is pre-release; Loop configuration is extended directly with typed carry data.
- No database migration.

## Verification

- `pnpm typecheck`
- worker suite: 3,134 tests passed
- dashboard suite: 528 tests passed
- installed Workflow SDK suite: 11 tests passed
- focused Loop/catalog/workspace/disposable-review tests passed
- orchestration E2E attempted but could not start because the local checkout does not have its required Jira, GitHub App, database, and deployed-worker environment variables
- `git diff --check`

Browser QA was intentionally not performed.


[AIW-185]: https://blazity.atlassian.net/browse/AIW-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIW-188]: https://blazity.atlassian.net/browse/AIW-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added UI support for configuring Loop node carried values in the flow editor, including safer naming and schema-aware binding selection.
  * Extended Loop carry semantics so carried values are persisted and available across retries.
  * Added schema/deployment validation for Loop carry names, schemas, and bindings.
* **Bug Fixes**
  * Improved workflow reference remapping and reference tracking for Loop carry bindings (single and list forms).
  * Strengthened Loop runtime safety boundaries (loop-scoped output access and duplicate carry detection).
  * Enforced consistent disposable review workspace snapshots for parallel review executions and improved concurrent workspace conflict handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->