### PR TITLE
fix: record the true outcome of runs that reach review

### DIFF
--- a/apps/worker/src/adapters/issue-tracker/jira.test.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.test.ts
@@ -597,6 +597,49 @@ describe("JiraAdapter", () => {
     });
   });
 
+  describe("resolveMoveTargetStatus", () => {
+    it("resolves a transition name to the localized status it lands in", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          transitions: [
+            { id: "3", name: "REVIEW", to: { id: "11418", name: "Weryfikacja" } },
+            { id: "4", name: "DONE", to: { id: "10002", name: "Gotowe" } },
+          ],
+        }),
+      });
+
+      await expect(
+        jiraAdapter().resolveMoveTargetStatus("PROJ-1", "REVIEW"),
+      ).resolves.toEqual({ id: "11418", name: "Weryfikacja" });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null when the target does not resolve from the current status", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          transitions: [{ id: "4", name: "DONE", to: { id: "10002", name: "Gotowe" } }],
+        }),
+      });
+
+      await expect(
+        jiraAdapter().resolveMoveTargetStatus("PROJ-1", "REVIEW"),
+      ).resolves.toBeNull();
+    });
+
+    it("returns null for a matched transition that exposes no destination status", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ transitions: [{ id: "3", name: "REVIEW" }] }),
+      });
+
+      await expect(
+        jiraAdapter().resolveMoveTargetStatus("PROJ-1", "REVIEW"),
+      ).resolves.toBeNull();
+    });
+  });
+
   describe("postComment", () => {
     it("posts ADF-formatted comment and returns a deep link to the new comment", async () => {
       mockFetch.mockResolvedValueOnce({

--- a/apps/worker/src/adapters/issue-tracker/jira.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.ts
@@ -155,6 +155,20 @@ export class JiraAdapter implements IssueTrackerAdapter {
     });
   }
 
+  async resolveMoveTargetStatus(
+    id: string,
+    target: IssueTrackerMoveTarget,
+  ): Promise<{ id: string; name: string } | null> {
+    const data = await this.request(`/rest/api/3/issue/${id}/transitions`);
+    const transitions = (data?.transitions ?? []) as JiraTransition[];
+    const transition = findTransition(transitions, normalizeTransitionTarget(target));
+    const statusId = transition?.to?.id == null ? "" : String(transition.to.id).trim();
+    const statusName =
+      typeof transition?.to?.name === "string" ? transition.to.name.trim() : "";
+    if (!statusId || !statusName) return null;
+    return { id: statusId, name: statusName };
+  }
+
   async listStatuses(): Promise<Array<{ id: string; name: string }>> {
     const groups = await this.request(
       `/rest/api/3/project/${encodeURIComponent(this.projectKey)}/statuses`,

--- a/apps/worker/src/adapters/issue-tracker/types.ts
+++ b/apps/worker/src/adapters/issue-tracker/types.ts
@@ -54,6 +54,21 @@ export interface IssueTrackerAdapter {
    */
   fetchTicket(id: string): Promise<TicketContent>;
   moveTicket(id: string, target: IssueTrackerMoveTarget): Promise<void>;
+  /**
+   * The status a move target actually lands in, resolved through the provider's
+   * own transition metadata using the same matching moveTicket applies.
+   *
+   * A configured target may name a TRANSITION rather than the status it leads
+   * to, and a provider is free to give the two different display names (Jira
+   * localizes statuses but not transitions). Callers that must recognise the
+   * destination therefore cannot compare display names; they resolve it here
+   * and compare status ids. Null when the target does not resolve from where
+   * the ticket currently sits. Optional.
+   */
+  resolveMoveTargetStatus?(
+    id: string,
+    target: IssueTrackerMoveTarget,
+  ): Promise<{ id: string; name: string } | null>;
   /** Statuses configured for the adapter's project, for workflow authoring. */
   listStatuses?(): Promise<Array<{ id: string; name: string }>>;
   /**

--- a/apps/worker/src/lib/ai-review-destination.ts
+++ b/apps/worker/src/lib/ai-review-destination.ts
@@ -1,0 +1,100 @@
+import { env } from "../../env.js";
+import type {
+  IssueTrackerAdapter,
+  IssueTrackerMoveTarget,
+} from "../adapters/issue-tracker/types.js";
+import { logger } from "./logger.js";
+
+/**
+ * The destination a run's own success finalization moves its ticket to. The
+ * provider matches COLUMN_AI_REVIEW against transition names as well as status
+ * names, so the configured value legitimately names either one.
+ */
+export function aiReviewMoveTarget(): IssueTrackerMoveTarget {
+  return env.JIRA_AI_REVIEW_TRANSITION_ID
+    ? { name: env.COLUMN_AI_REVIEW, transitionId: env.JIRA_AI_REVIEW_TRANSITION_ID }
+    : env.COLUMN_AI_REVIEW;
+}
+
+/**
+ * Resolved at most once per process: the answer is project workflow
+ * configuration, identical for every ticket, so it is not per-run state.
+ */
+let resolvedReviewStatusId: string | null = null;
+
+export function resetAiReviewDestinationCache(): void {
+  resolvedReviewStatusId = null;
+}
+
+/**
+ * Whether the status a ticket now sits in IS the review destination, which is
+ * the run's own success path and therefore never an abort.
+ *
+ * Comparing display names is not sufficient. COLUMN_AI_REVIEW may name the
+ * TRANSITION ("REVIEW") while the status it leads to carries a different,
+ * often localized name ("Weryfikacja"), and a name comparison then misses on
+ * every such project: the run's own completion gesture reads as "ticket left
+ * the AI column" and a run that is still publishing gets cancelled. So fall
+ * through to an identity comparison against the transition's resolved
+ * destination status id.
+ *
+ * Costs one provider call, taken only when the free name comparison misses and
+ * only once per process. A target that does not resolve (its transition is not
+ * offered from where the ticket sits now) leaves the name comparison as the
+ * answer, so this can only spare runs the previous check would have cancelled,
+ * never the reverse.
+ */
+export async function isAiReviewDestination(input: {
+  issueTracker: IssueTrackerAdapter;
+  ticketKey: string;
+  statusName: string | null;
+  statusId: string | null;
+}): Promise<boolean> {
+  const configured = env.COLUMN_AI_REVIEW.trim().toLowerCase();
+  if (
+    input.statusName !== null &&
+    input.statusName.trim().toLowerCase() === configured
+  ) {
+    return true;
+  }
+  const statusId = input.statusId?.trim();
+  if (!statusId) return false;
+  const reviewStatusId = await resolveReviewStatusId(
+    input.issueTracker,
+    input.ticketKey,
+  );
+  return reviewStatusId !== null && reviewStatusId === statusId;
+}
+
+async function resolveReviewStatusId(
+  issueTracker: IssueTrackerAdapter,
+  ticketKey: string,
+): Promise<string | null> {
+  if (resolvedReviewStatusId !== null) return resolvedReviewStatusId;
+  if (!issueTracker.resolveMoveTargetStatus) return null;
+  try {
+    const destination = await issueTracker.resolveMoveTargetStatus(
+      ticketKey,
+      aiReviewMoveTarget(),
+    );
+    if (!destination) return null;
+    resolvedReviewStatusId = destination.id;
+    logger.info(
+      {
+        configured: env.COLUMN_AI_REVIEW,
+        statusId: destination.id,
+        statusName: destination.name,
+      },
+      "ai_review_destination_resolved",
+    );
+    return resolvedReviewStatusId;
+  } catch (error) {
+    // Never fail the caller: an unresolved destination just leaves the name
+    // comparison as the answer.
+    logger.warn(
+      { ticketKey, error: (error as Error).message },
+      "ai_review_destination_resolution_failed",
+    );
+    return null;
+  }
+}

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -74,7 +74,14 @@ function registry(
   };
 }
 
-function issueTracker(status = "AI", identifier = "PROJ-1"): IssueTrackerAdapter {
+function issueTracker(
+  status = "AI",
+  identifier = "PROJ-1",
+  extra: {
+    trackerStatusId?: string;
+    reviewDestination?: { id: string; name: string } | null;
+  } = {},
+): IssueTrackerAdapter {
   return {
     fetchTicket: vi.fn().mockResolvedValue({
       id: "ticket-id",
@@ -85,16 +92,21 @@ function issueTracker(status = "AI", identifier = "PROJ-1"): IssueTrackerAdapter
       comments: [],
       labels: [],
       trackerStatus: status,
+      ...(extra.trackerStatusId ? { trackerStatusId: extra.trackerStatusId } : {}),
     }),
     moveTicket: vi.fn(),
     postComment: vi.fn(),
     searchTickets: vi.fn(),
+    resolveMoveTargetStatus: vi
+      .fn()
+      .mockResolvedValue(extra.reviewDestination ?? null),
   };
 }
 
 describe("reconcileRuns owner-CAS recovery", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    (await import("./ai-review-destination.js")).resetAiReviewDestinationCache();
     mockStopSandboxesByIds.mockResolvedValue(2);
     mockListWorkflowSteps.mockResolvedValue({
       data: [],
@@ -544,6 +556,49 @@ describe("reconcileRuns owner-CAS recovery", () => {
     ).toEqual({ cancelled: 0, cleaned: 0 });
     expect(mockCancelRun).not.toHaveBeenCalled();
     expect(runRegistry.release).not.toHaveBeenCalled();
+  });
+
+  it("retains a still-executing run whose review status name differs from COLUMN_AI_REVIEW", async () => {
+    // Same retention, but COLUMN_AI_REVIEW names the transition ("Review") and
+    // the status it lands in is localized ("Weryfikacja"). Comparing display
+    // names misses, so the reconciler would cancel a run that is still
+    // publishing, undoing the webhook's own review-destination exemption.
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Weryfikacja", "PROJ-1", {
+          trackerStatusId: "11418",
+          reviewDestination: { id: "11418", name: "Weryfikacja" },
+        }),
+      ),
+    ).toEqual({ cancelled: 0, cleaned: 0 });
+    expect(mockCancelRun).not.toHaveBeenCalled();
+  });
+
+  it("still cancels a still-executing run pulled to a status that is not the review destination", async () => {
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    mockCancelRun.mockResolvedValue(true);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Gotowe", "PROJ-1", {
+          trackerStatusId: "10002",
+          reviewDestination: { id: "11418", name: "Weryfikacja" },
+        }),
+      ),
+    ).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockCancelRun).toHaveBeenCalledOnce();
   });
 
   it("still releases an AI Review ticket's owner once its world run is terminal", async () => {

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -1,5 +1,6 @@
 import { getRun } from "workflow/api";
 import { env } from "../../env.js";
+import { isAiReviewDestination } from "./ai-review-destination.js";
 import { cancelRun, cancelSubjectRun } from "./cancel-run.js";
 import { logger } from "./logger.js";
 import { stopSandboxesByIds } from "../sandbox/stop-ticket-sandboxes.js";
@@ -136,6 +137,8 @@ export async function reconcileRuns(
         ticketKey,
         entry.runId,
         departure.trackerStatus,
+        departure.trackerStatusId,
+        issueTracker,
       )
     ) {
       continue;
@@ -402,8 +405,12 @@ async function stopOwnedSandboxes(
 async function verifyTicketLeftAiColumn(
   ticketKey: string,
   issueTracker?: IssueTrackerAdapter,
-): Promise<{ left: boolean; trackerStatus: string | null }> {
-  if (!issueTracker) return { left: true, trackerStatus: null };
+): Promise<{
+  left: boolean;
+  trackerStatus: string | null;
+  trackerStatusId: string | null;
+}> {
+  if (!issueTracker) return { left: true, trackerStatus: null, trackerStatusId: null };
 
   try {
     const ticket = await issueTracker.fetchTicket(ticketKey);
@@ -411,23 +418,24 @@ async function verifyTicketLeftAiColumn(
     const expectedStatus = env.COLUMN_AI.trim().toLowerCase();
     const ticketProjectKey = resolveTicketProjectKey(ticket);
     const expectedProjectKey = env.JIRA_PROJECT_KEY.trim().toUpperCase();
+    const trackerStatusId = ticket.trackerStatusId ?? null;
     if (ticketStatus === expectedStatus && ticketProjectKey === expectedProjectKey) {
       logger.info(
         { ticketKey, status: ticket.trackerStatus, projectKey: ticketProjectKey },
         "reconcile_kept_run_missing_from_poll_snapshot",
       );
-      return { left: false, trackerStatus: ticket.trackerStatus };
+      return { left: false, trackerStatus: ticket.trackerStatus, trackerStatusId };
     }
-    return { left: true, trackerStatus: ticket.trackerStatus };
+    return { left: true, trackerStatus: ticket.trackerStatus, trackerStatusId };
   } catch (err) {
     if (err instanceof IssueTrackerNotFoundError || getErrorCode(err) === "NOT_FOUND") {
-      return { left: true, trackerStatus: null };
+      return { left: true, trackerStatus: null, trackerStatusId: null };
     }
     logger.warn(
       { ticketKey, error: (err as Error).message },
       "reconcile_orphan_verification_failed",
     );
-    return { left: false, trackerStatus: null };
+    return { left: false, trackerStatus: null, trackerStatusId: null };
   }
 }
 
@@ -445,10 +453,17 @@ async function shouldRetainFinalizingRunInAiReview(
   ticketKey: string,
   runId: string,
   trackerStatus: string | null,
+  trackerStatusId: string | null,
+  issueTracker?: IssueTrackerAdapter,
 ): Promise<boolean> {
+  if (!issueTracker) return false;
   if (
-    trackerStatus === null ||
-    trackerStatus.trim().toLowerCase() !== env.COLUMN_AI_REVIEW.trim().toLowerCase()
+    !(await isAiReviewDestination({
+      issueTracker,
+      ticketKey,
+      statusName: trackerStatus,
+      statusId: trackerStatusId,
+    }))
   ) {
     return false;
   }

--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -490,6 +490,39 @@ describe("recordRunStatusReason", () => {
       "First bookkeeping note",
     );
   });
+
+  it("leaves a successful run's empty reason empty", async () => {
+    // A run that opened its PR and then had its released claim retired by the
+    // reconciler is a green run with no reason of its own. Filling that null
+    // with the retirement note makes the trace screen state a cancellation for
+    // a run that succeeded.
+    await recordRunUsage(db, usage({ status: "success" }));
+    await recordRunStatusReason(
+      db,
+      "wrun_1",
+      "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
+    );
+    const r = await row("wrun_1");
+    expect(r.status).toBe("success");
+    expect(r.statusReason).toBeNull();
+  });
+
+  it("still fills a null reason on failed, blocked and awaiting rows", async () => {
+    for (const status of ["failed", "blocked", "awaiting"] as const) {
+      const runId = `wrun_reason_${status}`;
+      await db.insert(workflowRuns).values({
+        runId,
+        subjectKey: "ticket:jira:PROJ-1",
+        workflowId: "wf_agent",
+        workflowName: "Agent",
+        status,
+      });
+      await recordRunStatusReason(db, runId, "Cancelled via Slack /ai-workflow cancel");
+      expect((await row(runId)).statusReason).toBe(
+        "Cancelled via Slack /ai-workflow cancel",
+      );
+    }
+  });
 });
 
 describe("markRunFailedOnSelfMove", () => {

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -329,6 +329,15 @@ export async function recordBlockStatuses(
  * its failure lands. A "failure" reason is the concrete cause and always wins;
  * a "cancellation" reason is bookkeeping and only fills a still-null field, or
  * the trace screen would never say why the run actually failed.
+ *
+ * A run already recorded as "success" is excluded from the cancellation branch
+ * entirely. Retiring the claim of a run that already opened its PR is routine
+ * (the reconciler does it for every completed run whose claim outlived the poll
+ * snapshot, and a run's own AI Review move fires the same "left the AI column"
+ * webhook), and a successful run legitimately has no reason of its own, so the
+ * null it carries is not a gap to fill: writing there states a cancellation for
+ * a green run. Only "success" is protected. "awaiting" is a parked run, not a
+ * finished one, and cancelling it while it waits is a real cause worth keeping.
  */
 export type RunStatusReasonKind = "failure" | "cancellation";
 
@@ -347,7 +356,10 @@ export async function recordRunStatusReason(
         statusReason:
           options.kind === "failure"
             ? sql`excluded.status_reason`
-            : sql`coalesce(${workflowRuns.statusReason}, excluded.status_reason)`,
+            : sql`case
+                when ${workflowRuns.status} = 'success' then ${workflowRuns.statusReason}
+                else coalesce(${workflowRuns.statusReason}, excluded.status_reason)
+              end`,
         updatedAt: sql`now()`,
       },
     });

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -37,6 +37,9 @@ vi.mock("../../db/queries/runs-read.js", () => ({
   isRunRecordedSucceeded: state.isRunRecordedSucceeded,
 }));
 
+const { resetAiReviewDestinationCache } = await import(
+  "../../lib/ai-review-destination.js"
+);
 const handler = (await import("./jira.post.js")).default;
 
 function app() {
@@ -48,8 +51,10 @@ function app() {
 function request(input: {
   actor?: string | null;
   status?: string;
+  statusId?: string;
   changelog?: boolean;
 } = {}) {
+  const statusId = input.statusId ?? (input.status === "AI" ? "10" : "20");
   const raw = JSON.stringify({
     webhookEvent: "jira:issue_updated",
     ...(input.actor === null ? {} : { user: { accountId: input.actor ?? "human-account" } }),
@@ -57,13 +62,13 @@ function request(input: {
       key: "PROJ-42",
       fields: {
         project: { key: "PROJ" },
-        status: { id: input.status === "AI" ? "10" : "20", name: input.status ?? "Backlog" },
+        status: { id: statusId, name: input.status ?? "Backlog" },
       },
     },
     changelog: {
       items: input.changelog === false
         ? [{ field: "summary", toString: "Updated" }]
-        : [{ field: "status", to: input.status === "AI" ? "10" : "20", toString: input.status ?? "Backlog" }],
+        : [{ field: "status", to: statusId, toString: input.status ?? "Backlog" }],
     },
   });
   return new Request("http://localhost/", {
@@ -101,6 +106,7 @@ function adapters(options: {
         projectKey: "PROJ",
         trackerStatus: "Backlog",
       }),
+      resolveMoveTargetStatus: vi.fn().mockResolvedValue(null),
     },
     runRegistry: { get: vi.fn().mockResolvedValue(active) },
     messaging: { notifyForTicket: vi.fn().mockResolvedValue(undefined) },
@@ -110,6 +116,7 @@ function adapters(options: {
 describe("POST /webhooks/jira", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAiReviewDestinationCache();
     state.env.JIRA_WEBHOOK_SECRET = "secret";
     state.cancel.mockResolvedValue(true);
     state.dispatch.mockResolvedValue({ started: false, reason: "not_applicable" });
@@ -296,6 +303,65 @@ describe("POST /webhooks/jira", () => {
     // must never surface the retryable 503 of a failed lookup either.
     expect(state.isRunRecordedFailed).not.toHaveBeenCalled();
     expect(state.isRunRecordedSucceeded).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel a still-finalizing run when COLUMN_AI_REVIEW names the transition and the status name differs", async () => {
+    // COLUMN_AI_REVIEW is matched by the provider against transition names as
+    // well as status names, so "Review" here names the TRANSITION while the
+    // status it lands in carries a different (localized) display name. A
+    // display-name comparison misses on every such Jira and reads the run's own
+    // success destination as "ticket left the AI column".
+    const connected = adapters();
+    connected.issueTracker.fetchTicket.mockResolvedValue({
+      identifier: "PROJ-42",
+      projectKey: "PROJ",
+      trackerStatus: "Weryfikacja",
+      trackerStatusId: "11418",
+    });
+    connected.issueTracker.resolveMoveTargetStatus.mockResolvedValue({
+      id: "11418",
+      name: "Weryfikacja",
+    });
+    state.createAdapters.mockReturnValue(connected);
+
+    const response = await app()(
+      request({ actor: "automation-account", status: "Weryfikacja", statusId: "11418" }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "ticket_in_ai_review_column",
+      ticketKey: "PROJ-42",
+    });
+    expect(state.cancel).not.toHaveBeenCalled();
+    expect(state.isRunRecordedSucceeded).not.toHaveBeenCalled();
+  });
+
+  it("still cancels a genuine pull-out when the resolved review destination differs", async () => {
+    // Same resolved review destination, different landing status: a ticket
+    // dragged to Done while a run is in flight is a real abort and must cancel.
+    const connected = adapters();
+    connected.issueTracker.fetchTicket.mockResolvedValue({
+      identifier: "PROJ-42",
+      projectKey: "PROJ",
+      trackerStatus: "Gotowe",
+      trackerStatusId: "10002",
+    });
+    connected.issueTracker.resolveMoveTargetStatus.mockResolvedValue({
+      id: "11418",
+      name: "Weryfikacja",
+    });
+    state.createAdapters.mockReturnValue(connected);
+
+    const response = await app()(
+      request({ actor: "human-account", status: "Gotowe", statusId: "10002" }),
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "cancelled",
+      reason: "left_ai_column",
+    });
+    expect(state.cancel).toHaveBeenCalledOnce();
   });
 
   it("surfaces a retryable error when the failed-status lookup fails (does not cancel)", async () => {

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -7,6 +7,7 @@ import { classifyProtectedClarificationSubjects } from "../../clarifications/sto
 import { getDb } from "../../db/client.js";
 import { isRunRecordedFailed, isRunRecordedSucceeded } from "../../db/queries/runs-read.js";
 import { createAdapters } from "../../lib/adapters.js";
+import { isAiReviewDestination } from "../../lib/ai-review-destination.js";
 import { cancelRun } from "../../lib/cancel-run.js";
 import { dispatchTicket } from "../../lib/dispatch.js";
 import { logger } from "../../lib/logger.js";
@@ -205,11 +206,19 @@ export default defineEventHandler(async (event) => {
     // that same move as soon as the PR link appears, landing the ticket in AI
     // Review while the run is still finalizing and BEFORE the self-move froze
     // the "success" status, so the recorded-outcome guard below cannot help.
-    // Entering the review column is a completion gesture, never an abort:
-    // skip cancellation and let the run finish. Its own later move lands as a
-    // no-op (moveTicketForRun's already-at-target check). A human abort still
-    // cancels, because it moves the ticket to a non-review column.
-    if (isAiReviewColumnStatus(liveTicketState.status)) {
+    // Entering the review column is a completion gesture, never an abort,
+    // whichever actor performed it: skip cancellation and let the run finish.
+    // Its own later move lands as a no-op (moveTicketForRun's already-at-target
+    // check). A human abort still cancels, because it moves the ticket to a
+    // non-review column.
+    if (
+      await isAiReviewDestination({
+        issueTracker: adapters.issueTracker,
+        ticketKey,
+        statusName: liveTicketState.status,
+        statusId: liveTicketState.statusId,
+      })
+    ) {
       logger.info(
         {
           ticketKey,
@@ -534,13 +543,6 @@ function isAiColumnStatus(status: string): boolean {
   return status.trim().toLowerCase() === env.COLUMN_AI.trim().toLowerCase();
 }
 
-function isAiReviewColumnStatus(status: string | null): boolean {
-  return (
-    status !== null &&
-    status.trim().toLowerCase() === env.COLUMN_AI_REVIEW.trim().toLowerCase()
-  );
-}
-
 async function cancelTrackedRun(
   ticketKey: string,
   runRegistry: ReturnType<typeof createAdapters>["runRegistry"],
@@ -585,7 +587,12 @@ async function cancelTrackedRun(
 async function getLiveTicketState(
   ticketKey: string,
   issueTracker: ReturnType<typeof createAdapters>["issueTracker"],
-): Promise<{ inAiColumn: boolean; status: string | null; projectKey: string | null }> {
+): Promise<{
+  inAiColumn: boolean;
+  status: string | null;
+  statusId: string | null;
+  projectKey: string | null;
+}> {
   try {
     const liveTicket = await issueTracker.fetchTicket(ticketKey);
     const status = liveTicket.trackerStatus;
@@ -596,17 +603,18 @@ async function getLiveTicketState(
     return {
       inAiColumn: isAiColumnStatus(status) && inExpectedProject,
       status,
+      statusId: liveTicket.trackerStatusId ?? null,
       projectKey,
     };
   } catch (err) {
     if (err instanceof IssueTrackerNotFoundError || getErrorCode(err) === "NOT_FOUND") {
-      return { inAiColumn: false, status: null, projectKey: null };
+      return { inAiColumn: false, status: null, statusId: null, projectKey: null };
     }
     logger.warn(
       { ticketKey, error: (err as Error).message },
       "webhook_live_ticket_state_check_failed",
     );
-    return { inAiColumn: true, status: null, projectKey: null };
+    return { inAiColumn: true, status: null, statusId: null, projectKey: null };
   }
 }
 


### PR DESCRIPTION
## Why

Two production runs today did their job and were recorded wrong.

`wrun_01KYJE2ZM4H2HA33KDJ77CY9CK` (AWP-23) opened a GitLab MR and finished with `status = 'success'`, yet its `status_reason` read `Orphaned run cancelled by reconciler: ticket no longer in the AI column`. The trace screen showed a green run whose stated reason was a cancellation.

`wrun_01KYJE33JBBNK659SPQHSS9WWC` (AWP-24) published a GitHub PR **and** a GitLab MR from one multi-repo run, and was recorded `blocked` with `Ticket left the AI column (Ai → REVIEW) via Jira webhook`. A completed run counted as an error in the KPI.

## What was actually wrong

**The reason side.** A `cancellation` reason filled any NULL reason regardless of the row's status, and a successful run legitimately has none, so bookkeeping text landed on a green row. Fixed inside the existing `kind` precedence rather than at call sites: a `failure` reason still overwrites unconditionally, a `cancellation` reason still fills a NULL reason on `failed`, `blocked` and `awaiting`, and now leaves a `success` row alone. `awaiting` is deliberately not treated as success: a parked run has not finished, and cancelling it while it waits is a real cause worth recording.

**The status side, which was not a downgrade at all.** No writer can turn a recorded `success` into `blocked`; the frozen-status guard already prevents that. AWP-24's row was still `running` because it was cancelled mid-publication, and the cancel happened because the run's own success destination was not recognised.

The recognition bug: `COLUMN_AI_REVIEW` is matched by the Jira provider against transition names as well as status names, but every guard that had to *recognise* that destination compared display names only. In this project `REVIEW` is the transition name while the status it lands in is `Weryfikacja` (id `11418`), so a move into review read as "ticket was pulled out of the AI column". A Jira automation rule in the project performs that move, so the actor-based echo suppression could not help either: from the webhook's point of view a stranger pulled the ticket while the run was still opening pull requests.

The same name-only comparison existed at two decision sites, and fixing only one would have been cosmetic because the reconciler cancels the same orphan a tick later:

- `routes/webhooks/jira.post.ts` — the webhook cancel.
- `lib/reconcile.ts` — the finalizing-run retention check.

Both now go through one helper, `lib/ai-review-destination.ts`. It compares names first, exactly as before and at zero cost, and only on a miss resolves the destination's status id through a new optional `resolveMoveTargetStatus` on the issue-tracker port. The Jira implementation reuses the same `findTransition` and target-normalisation the existing `moveTicket` uses, so the configured value keeps working whether it names a transition id, a status id, or a transition name.

Scope is deliberately narrow: only the review destination is exempt. A ticket genuinely pulled to To Do, Done, or anywhere else during a run still cancels it, and an in-flight run marked `blocked` there is still correct.

## Cost and failure modes

The id resolution costs one `GET /issue/{key}/transitions` and only when a status change took the ticket out of the AI column, the name comparison missed, and the process has not resolved it yet. That path already fetches the ticket, so it is a second call on an existing round trip, memoized per process. Resolution failure and non-resolution both fall back to the name comparison, so the change can only spare runs the old code cancelled, never cancel one it spared.

Two things left deliberately alone, both flagged rather than fixed: `ticket-transition.ts`'s already-at-target check has the same name-only comparison but no `statusId` to compare, and the `cancelling` branch in the webhook needs no exemption because by the time it runs the workflow is already cancelled and the branch exists only to drive the unconfirmed tail to completion. Exempting it there would strand the claim in `cancelling` and block re-dispatch.

## Verification

- `apps/worker`: 249 files, **3106 tests, 0 failures**, both workflow bundle guards included.
- Both typechecks clean.
- RED proofs: the localized-review-status case fails on current code in both the webhook and the reconciler test, and the successful-run reason case fails with the old fill rule. Two anti-widening tests were green before and are documented as such: they exist to fail a naive "never cancel on a status change" fix, not this one.
