### PR TITLE
AIW-186: Add editable review/fix/retry workflow template

### DIFF
--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields-v2.test.tsx
@@ -143,6 +143,82 @@ test("an incompatible saved binding remains visible with its exact reason", () =
   );
 });
 
+test("array inputs render ordered workflow-value lists without raw references", () => {
+  const reviewResultSchema = {
+    type: "object" as const,
+    properties: {
+      decision: { type: "string" as const },
+      findings: {
+        type: "array" as const,
+        items: { type: "unknown" as const },
+      },
+    },
+    required: ["decision", "findings"],
+    additionalProperties: true,
+  };
+  const html = renderToStaticMarkup(
+    <V2BindingFields
+      node={{
+        ...node,
+        type: "fix_agent",
+        inputs: {
+          reviewResults: {
+            kind: "reference_list",
+            references: [
+              "steps.security.output",
+              "steps.quality.output",
+            ],
+          },
+        },
+        additionalInputs: [],
+      }}
+      contract={{
+        ...contract,
+        type: "fix_agent",
+        inputs: {
+          reviewResults: {
+            required: false,
+            schema: {
+              type: "array",
+              items: reviewResultSchema,
+            },
+          },
+        },
+      }}
+      availableValues={[
+        {
+          reference: "steps.security.output",
+          label: "Security review · Entire output",
+          description: "Security result.",
+          schema: reviewResultSchema,
+          source: { kind: "step", nodeId: "security" },
+          presence: "required",
+          availability: { state: "available", guarantee: "Guaranteed." },
+          compatibleInputNames: ["reviewResults"],
+        },
+        {
+          reference: "steps.quality.output",
+          label: "Code quality review · Entire output",
+          description: "Quality result.",
+          schema: reviewResultSchema,
+          source: { kind: "step", nodeId: "quality" },
+          presence: "required",
+          availability: { state: "available", guarantee: "Guaranteed." },
+          compatibleInputNames: ["reviewResults"],
+        },
+      ]}
+      canEdit
+      onChange={() => undefined}
+    />,
+  );
+
+  assert.match(html, /Workflow values/);
+  assert.match(html, /Security review/);
+  assert.match(html, /Code quality review/);
+  assert.match(html, /Add workflow value/);
+  assert.doesNotMatch(html, /steps\.security\.output/);
+});
+
 test("v2 additional-input authoring accepts safe dotted names", () => {
   const existingNames = new Set(["checks.unit"]);
 

--- a/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/binding-fields.tsx
@@ -206,6 +206,19 @@ function initialLiteralForSchema(
   }
 }
 
+function isArrayInputSchema(
+  schema: WorkflowValueSchema | JsonSchema202012,
+): boolean {
+  if (schema.type === "nullable") {
+    return isArrayInputSchema(
+      (schema as Extract<WorkflowValueSchema, { type: "nullable" }>).value,
+    );
+  }
+  return Array.isArray(schema.type)
+    ? schema.type.includes("array")
+    : schema.type === "array";
+}
+
 function JsonValueField({
   value,
   disabled,
@@ -326,6 +339,9 @@ function V2BindingEditor({
     ? compatibility(currentReference)
     : null;
   const literalDefault = initialLiteralForSchema(inputSchema);
+  const acceptsReferenceList = isArrayInputSchema(inputSchema);
+  const listReferences =
+    binding?.kind === "reference_list" ? binding.references : [];
 
   return (
     <div className="space-y-1.5">
@@ -337,6 +353,9 @@ function V2BindingEditor({
           if (event.target.value === "") onChange(undefined);
           else if (event.target.value === "reference") {
             setPickerOpen(true);
+          } else if (event.target.value === "reference_list") {
+            onChange({ kind: "reference_list", references: [] });
+            setPickerOpen(true);
           } else {
             onChange({ kind: "literal", value: literalDefault });
           }
@@ -347,6 +366,9 @@ function V2BindingEditor({
         <option value="reference">
           Workflow value
         </option>
+        {acceptsReferenceList && (
+          <option value="reference_list">Workflow values</option>
+        )}
         <option value="literal">Literal value</option>
       </select>
       {binding?.kind === "reference" && (
@@ -363,18 +385,72 @@ function V2BindingEditor({
           onClear={() => onChange(undefined)}
         />
       )}
+      {binding?.kind === "reference_list" && (
+        <div className="space-y-1.5">
+          {binding.references.map((reference, index) => {
+            const entry = availableValues.find(
+              (value) => value.reference === reference,
+            );
+            const result = entry ? compatibility(entry) : null;
+            return (
+              <WorkflowValueChip
+                key={`${reference}-${index}`}
+                value={entry ?? null}
+                reference={reference}
+                invalidReason={
+                  result?.compatible === false
+                    ? result.reason?.message
+                    : null
+                }
+                disabled={!canEdit}
+                onOpen={() => setPickerOpen(true)}
+                onClear={() =>
+                  onChange({
+                    kind: "reference_list",
+                    references: binding.references.filter(
+                      (_, candidate) => candidate !== index,
+                    ),
+                  })
+                }
+              />
+            );
+          })}
+          <button
+            type="button"
+            disabled={!canEdit}
+            onClick={() => setPickerOpen(true)}
+            className="flex min-h-9 w-full items-center gap-2 rounded-[3px] border border-dashed border-neutral-300 bg-panel px-3 text-left font-body text-[12px] text-mariner disabled:opacity-50"
+          >
+            <span aria-hidden>＋</span>
+            Add workflow value
+          </button>
+        </div>
+      )}
       <WorkflowDataPicker
         open={pickerOpen}
         entries={availableValues}
         selectedReference={
           binding?.kind === "reference" ? binding.reference : undefined
         }
+        selectedReferences={listReferences}
+        selectionMode={
+          binding?.kind === "reference_list" ? "multiple" : "single"
+        }
         compatibility={compatibility}
         refreshing={valuesRefreshing}
         onClose={() => setPickerOpen(false)}
         onSelect={(entry) => {
-          onChange({ kind: "reference", reference: entry.reference });
-          setPickerOpen(false);
+          if (binding?.kind === "reference_list") {
+            const references = binding.references.includes(entry.reference)
+              ? binding.references.filter(
+                  (reference) => reference !== entry.reference,
+                )
+              : [...binding.references, entry.reference];
+            onChange({ kind: "reference_list", references });
+          } else {
+            onChange({ kind: "reference", reference: entry.reference });
+            setPickerOpen(false);
+          }
         }}
       />
       {binding?.kind === "literal" && (

--- a/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/workflow-data-picker.tsx
@@ -171,6 +171,8 @@ export function WorkflowDataPicker({
   open,
   entries,
   selectedReference,
+  selectedReferences,
+  selectionMode = "single",
   compatibility,
   refreshing,
   onClose,
@@ -179,6 +181,8 @@ export function WorkflowDataPicker({
   open: boolean;
   entries: readonly WorkflowDataCatalogEntry[];
   selectedReference?: WorkflowDataReferenceV2;
+  selectedReferences?: readonly WorkflowDataReferenceV2[];
+  selectionMode?: "single" | "multiple";
   compatibility: WorkflowDataCompatibility;
   refreshing?: boolean;
   onClose: () => void;
@@ -189,6 +193,14 @@ export function WorkflowDataPicker({
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const dialogRef = useRef<HTMLElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const selected = useMemo(
+    () =>
+      new Set(
+        selectedReferences ??
+          (selectedReference === undefined ? [] : [selectedReference]),
+      ),
+    [selectedReference, selectedReferences],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -219,14 +231,15 @@ export function WorkflowDataPicker({
   }, [onClose, open]);
 
   useEffect(() => {
-    if (!open || !selectedReference) return;
-    const selected = entries.find(
-      (entry) => entry.reference === selectedReference,
+    const firstSelected = selected.values().next().value;
+    if (!open || !firstSelected) return;
+    const selectedEntry = entries.find(
+      (entry) => entry.reference === firstSelected,
     );
-    if (!selected) return;
-    setTab(selected.source.kind === "run" ? "run" : "steps");
-    setExpanded((current) => new Set(current).add(sourceKey(selected)));
-  }, [entries, open, selectedReference]);
+    if (!selectedEntry) return;
+    setTab(selectedEntry.source.kind === "run" ? "run" : "steps");
+    setExpanded((current) => new Set(current).add(sourceKey(selectedEntry)));
+  }, [entries, open, selected]);
 
   const normalizedQuery = query.trim().toLowerCase();
   const visibleEntries = useMemo(() => {
@@ -273,7 +286,7 @@ export function WorkflowDataPicker({
               Workflow data
             </span>
             <h2 className="m-0 mt-1 font-display text-xl font-medium text-coal">
-              Choose a value
+              {selectionMode === "multiple" ? "Choose values" : "Choose a value"}
             </h2>
           </div>
           <button
@@ -368,7 +381,7 @@ export function WorkflowDataPicker({
                         disabled={refreshing}
                         aria-disabled={reason !== null ? "true" : undefined}
                         aria-current={
-                          selectedReference === entry.reference
+                          selected.has(entry.reference)
                             ? "true"
                             : undefined
                         }
@@ -378,7 +391,7 @@ export function WorkflowDataPicker({
                         className={`flex w-full items-start gap-3 rounded-[3px] border-none px-3 py-2 text-left disabled:opacity-50 ${
                           reason !== null
                             ? "bg-off-white text-neutral-500"
-                            : selectedReference === entry.reference
+                            : selected.has(entry.reference)
                             ? "bg-mariner-100"
                             : "bg-transparent hover:bg-off-white"
                         }`}
@@ -392,7 +405,9 @@ export function WorkflowDataPicker({
                           </small>
                         </span>
                         <span className="rounded-full bg-off-white px-2 py-0.5 font-mono text-[8px] uppercase text-neutral-500">
-                          {schemaType(entry.schema)}
+                          {selected.has(entry.reference) && selectionMode === "multiple"
+                            ? "Selected"
+                            : schemaType(entry.schema)}
                         </span>
                       </button>
                     )})}

--- a/apps/shared/contracts/index.ts
+++ b/apps/shared/contracts/index.ts
@@ -10,3 +10,4 @@ export * from "./run-replay.js";
 export * from "./default-prompts.js";
 export * from "./default-agent-prompt-references.js";
 export * from "./workflow-value-compatibility.js";
+export * from "./review-result.js";

--- a/apps/shared/contracts/review-result.ts
+++ b/apps/shared/contracts/review-result.ts
@@ -1,0 +1,56 @@
+import type { JsonSchema202012 } from "./domain.js";
+
+export interface ReviewResultFinding {
+  file: string;
+  description: string;
+  severity: "critical" | "suggestion";
+  startLine?: number;
+  endLine?: number;
+}
+
+export interface ReviewResult {
+  decision: "approve" | "request_changes";
+  findings: ReviewResultFinding[];
+  feedback?: string;
+}
+
+/**
+ * The code-owned structural contract shared by Review Agent outputs and every
+ * consumer of review results. Additional fields are accepted so compatible
+ * custom-agent envelopes can be projected onto this canonical shape.
+ *
+ * The cross-field line invariant (`endLine >= startLine`) is enforced by the
+ * shared runtime normalizer because JSON Schema cannot compare sibling numeric
+ * values without a non-standard extension.
+ */
+export const REVIEW_RESULT_JSON_SCHEMA: JsonSchema202012 = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+  properties: {
+    decision: {
+      type: "string",
+      enum: ["approve", "request_changes"],
+    },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          file: { type: "string" },
+          description: { type: "string" },
+          severity: {
+            type: "string",
+            enum: ["critical", "suggestion"],
+          },
+          startLine: { type: "number" },
+          endLine: { type: "number" },
+        },
+        required: ["file", "description", "severity"],
+        additionalProperties: true,
+      },
+    },
+    feedback: { type: "string" },
+  },
+  required: ["decision", "findings"],
+  additionalProperties: true,
+};

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -362,6 +362,7 @@ describe("GET /api/v1/workflow-definitions", () => {
       "Ticket workflow",
       "Human-approved plan",
       "Review & fix after PR",
+      "Reviewed ticket workflow",
       "Fully modular",
     ]);
     expect(

--- a/apps/worker/src/sandbox/context.test.ts
+++ b/apps/worker/src/sandbox/context.test.ts
@@ -736,6 +736,45 @@ describe("formatCheckResults", () => {
 });
 
 describe("assembleFixContext", () => {
+  it("delimits ordered internal review results without mixing them into PR feedback", () => {
+    const result = assembleFixContext({
+      ticket: {
+        identifier: "AIW-186",
+        title: "Reviewed workflow",
+        description: "",
+        acceptanceCriteria: "",
+        comments: [],
+      },
+      prComments: [],
+      failedChecks: [],
+      reviewResults: [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Fix this.",
+              severity: "critical",
+            },
+          ],
+        },
+        {
+          decision: "approve",
+          findings: [],
+        },
+      ],
+      repositories: [],
+    });
+
+    expect(result).toContain("## Internal Review Results");
+    expect(result).toContain("<review-results>");
+    expect(result).toContain('"decision": "request_changes"');
+    expect(result.indexOf('"decision": "request_changes"')).toBeLessThan(
+      result.indexOf('"decision": "approve"'),
+    );
+    expect(result).not.toContain("## PR Review Feedback");
+  });
+
   const ticket = {
     identifier: "TEST-9",
     title: "Fix the thing",

--- a/apps/worker/src/sandbox/context.ts
+++ b/apps/worker/src/sandbox/context.ts
@@ -1,4 +1,5 @@
 import type { PRComment, CheckRunResult } from "../adapters/vcs/types.js";
+import type { ReviewResult } from "@shared/contracts";
 import type { SelectedRepository } from "../adapters/vcs/repository-directory.js";
 import type { DownloadedAttachment } from "./attachments.js";
 import { formatAttachmentsIndex } from "./attachments.js";
@@ -226,6 +227,7 @@ export interface FixContextInput {
   ticket: TicketData;
   prComments: PRComment[];
   failedChecks: CheckRunResult[];
+  reviewResults?: ReviewResult[];
   conflictNotes?: string;
   instructions?: string;
   repositories: SelectedRepository[];
@@ -239,11 +241,23 @@ export interface FixContextInput {
  * omitted when their inputs are empty so the prompt stays focused on the fix.
  */
 export function assembleFixContext(input: FixContextInput): string {
-  const { ticket, prComments, failedChecks, conflictNotes, instructions, repositories } = input;
+  const {
+    ticket,
+    prComments,
+    failedChecks,
+    reviewResults,
+    conflictNotes,
+    instructions,
+    repositories,
+  } = input;
   const prFeedbackSection =
     prComments.length > 0 ? `\n## PR Review Feedback\n\n${formatPRComments(prComments)}\n` : "";
   const failedChecksSection =
     failedChecks.length > 0 ? `\n## CI/CD Check Results\n\n${formatCheckResults(failedChecks)}\n` : "";
+  const internalReviewsSection =
+    reviewResults && reviewResults.length > 0
+      ? `\n## Internal Review Results\n\n<review-results>\n${JSON.stringify(reviewResults, null, 2)}\n</review-results>\n`
+      : "";
   const conflictSection = conflictNotes ? `\n## Merge Conflicts\n\n${conflictNotes}\n` : "";
   const selectedRepositoriesSection = renderSelectedRepositories(repositories, input.workspaceManifest);
   const instructionsSection = instructions ? `\n## Fix Instructions\n\n${instructions}\n` : "";
@@ -262,7 +276,7 @@ ${ticket.title}
 ## Acceptance Criteria
 
 ${ticket.acceptanceCriteria || "None specified."}
-${clarificationsSection}${prFeedbackSection}${failedChecksSection}${conflictSection}${selectedRepositoriesSection}${instructionsSection}`;
+${clarificationsSection}${prFeedbackSection}${failedChecksSection}${internalReviewsSection}${conflictSection}${selectedRepositoriesSection}${instructionsSection}`;
 }
 
 function formatComments(

--- a/apps/worker/src/workflow-definition/available-values.test.ts
+++ b/apps/worker/src/workflow-definition/available-values.test.ts
@@ -819,6 +819,48 @@ describe("v2 binding validation", () => {
     expect(firstPlan?.compatibleInputNames).not.toContain("reviews");
     expect(firstPlan?.compatibleListInputNames).toContain("reviews");
 
+    const nullableConsumer = node("nullable-consumer", "generic_agent");
+    nullableConsumer.additionalInputs = [
+      {
+        name: "reviews",
+        schema: {
+          type: ["array", "null"],
+          items: { type: "string" },
+        },
+        binding: {
+          kind: "reference_list",
+          references: ["steps.first.output.plan"],
+        },
+      },
+    ];
+    const nullableDefinition = definition(
+      [
+        node("trigger", "trigger_ticket_ai"),
+        node("first", "planning_agent"),
+        nullableConsumer,
+      ],
+      [
+        { id: "to-first", from: "trigger", to: "first" },
+        {
+          id: "to-nullable-consumer",
+          from: "first",
+          to: "nullable-consumer",
+        },
+      ],
+    );
+    expect(
+      analyzeWorkflowV2Bindings(nullableDefinition, registryContext).issues,
+    ).toEqual([]);
+    const nullableCatalog = analyzeWorkflowV2Catalog(
+      nullableDefinition,
+      registryContext,
+    );
+    expect(
+      nullableCatalog.catalogByNode["nullable-consumer"]?.find(
+        (entry) => entry.reference === "steps.first.output.plan",
+      )?.compatibleListInputNames,
+    ).toContain("reviews");
+
     const invalid = node("invalid", "post_ticket_comment", {
       body: {
         kind: "reference_list",

--- a/apps/worker/src/workflow-definition/available-values.ts
+++ b/apps/worker/src/workflow-definition/available-values.ts
@@ -108,7 +108,6 @@ function contractForNode(
       }
       const inspected = inspectJsonSchema202012(
         carry.schema as JsonSchema202012,
-        { requireClosedObjects: true },
       );
       if (inspected.ok) properties[carry.name] = inspected.valueSchema;
     }
@@ -656,6 +655,7 @@ interface AuthoringLoopRegion {
   initialEntryNodeIds: string[];
   retryEntryNodeIds: string[];
   phaseAdjacency: ReadonlyMap<string, readonly string[]>;
+  phaseGuaranteedAdjacency: ReadonlyMap<string, readonly string[]>;
   initialGraphAdjacency: ReadonlyMap<string, readonly string[]>;
   triggerNodeIds: string[];
 }
@@ -697,6 +697,9 @@ function authoringLoopRegions(
     const phaseAdjacency = new Map(
       component.map((nodeId) => [nodeId, [] as string[]]),
     );
+    const phaseGuaranteedAdjacency = new Map(
+      component.map((nodeId) => [nodeId, [] as string[]]),
+    );
     const initialGraphAdjacency = new Map(
       definition.nodes.map((node) => [node.id, [] as string[]]),
     );
@@ -712,6 +715,13 @@ function authoringLoopRegions(
         continue;
       }
       phaseAdjacency.get(edge.from)?.push(edge.to);
+      const source = nodeById.get(edge.from);
+      if (
+        source &&
+        BLOCK_TYPE_SPECS[source.type].ports.length === 1
+      ) {
+        phaseGuaranteedAdjacency.get(edge.from)?.push(edge.to);
+      }
     }
     const region = {
       loopNodeId,
@@ -719,6 +729,7 @@ function authoringLoopRegions(
       initialEntryNodeIds,
       retryEntryNodeIds,
       phaseAdjacency,
+      phaseGuaranteedAdjacency,
       initialGraphAdjacency,
       triggerNodeIds: definition.nodes
         .filter((node) => isTriggerBlockType(node.type))
@@ -757,6 +768,16 @@ function phaseGuaranteesSource(
   if (!reachable.has(consumerId)) return null;
   if (sourceId === region.loopNodeId) return starts === region.retryEntryNodeIds;
   if (!reachable.has(sourceId)) return false;
+  const guaranteed = reachableFromStarts(
+    starts,
+    region.phaseGuaranteedAdjacency,
+  );
+  if (
+    guaranteed.has(sourceId) &&
+    reachableFromStarts([sourceId], region.phaseAdjacency).has(consumerId)
+  ) {
+    return true;
+  }
   return !reachableFromStarts(
     starts,
     region.phaseAdjacency,
@@ -1105,7 +1126,6 @@ function inputTargets(
       seenCarry.add(rawCarry.name);
       const parsed = inspectJsonSchema202012(
         rawCarry.schema as JsonSchema202012,
-        { requireClosedObjects: true },
       );
       if (!parsed.ok) {
         for (const issue of parsed.issues) {
@@ -1392,19 +1412,23 @@ export function analyzeWorkflowV2Bindings(
         consumer.id,
         loopRegionsByNodeId,
       );
+      const directSolePredecessor =
+        (incoming.get(consumer.id)?.length ?? 0) > 0 &&
+        incoming.get(consumer.id)?.every((edge) => edge.from === source.id);
       if (
         source.id === consumer.id ||
         isTriggerBlockType(source.type) ||
         !reachability.get(source.id)?.has(consumer.id) ||
         !(
           scopedGuarantee ??
+          (directSolePredecessor ||
           (
             !cyclicNodeIds.has(source.id) &&
             formulaImplies(
               consumerFormula,
               formulas.get(source.id) ?? emptyFormula(),
             )
-          )
+          ))
         )
       ) {
         continue;

--- a/apps/worker/src/workflow-definition/available-values.ts
+++ b/apps/worker/src/workflow-definition/available-values.ts
@@ -1042,16 +1042,25 @@ function targetCompatibility(
     .map((target) => target.name);
 }
 
+function arrayItemSchema(
+  schema: WorkflowValueSchema,
+): WorkflowValueSchema | null {
+  const unwrapped = nullableSchema(schema).schema;
+  return unwrapped.type === "array" ? unwrapped.items : null;
+}
+
 function targetListCompatibility(
   source: WorkflowValueSchema,
   targets: readonly InputTarget[],
 ): string[] {
   return targets
-    .filter(
-      (target) =>
-        target.schema.type === "array" &&
-        isWorkflowSchemaAssignable(source, target.schema.items),
-    )
+    .filter((target) => {
+      const itemSchema = arrayItemSchema(target.schema);
+      return (
+        itemSchema !== null &&
+        isWorkflowSchemaAssignable(source, itemSchema)
+      );
+    })
     .map((target) => target.name);
 }
 
@@ -1262,7 +1271,8 @@ function validateBindings(
         continue;
       }
       if (target.binding.kind === "reference_list") {
-        if (target.schema.type !== "array") {
+        const itemSchema = arrayItemSchema(target.schema);
+        if (!itemSchema) {
           issues.push({
             code: "binding.reference_list_destination",
             severity: "error",
@@ -1289,7 +1299,7 @@ function validateBindings(
             !parsedSource?.ok ||
             !isWorkflowSchemaAssignable(
               parsedSource.valueSchema,
-              target.schema.items,
+              itemSchema,
             )
           ) {
             issues.push({

--- a/apps/worker/src/workflow-definition/block-registry.test.ts
+++ b/apps/worker/src/workflow-definition/block-registry.test.ts
@@ -132,6 +132,17 @@ describe("workflow block registry", () => {
     });
     expect(registry.fix_agent.inputs).toEqual({
       reviewFeedback: reviewFeedbackInput,
+      reviewResults: {
+        required: false,
+        schema: expect.objectContaining({
+          type: "array",
+          items: expect.objectContaining({
+            type: "object",
+            required: ["decision", "findings"],
+            additionalProperties: true,
+          }),
+        }),
+      },
     });
     expect(registry.fetch_pr_context.inputs).toEqual({});
     expect(Object.keys(registry.generic_agent.inputs)).toEqual(["prompt"]);

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -2,6 +2,7 @@ import {
   BLOCK_TYPE_SPECS,
   DEFAULT_OPEN_PR_BODY,
   DEFAULT_OPEN_PR_TITLE,
+  REVIEW_RESULT_JSON_SCHEMA,
   type BlockOutput,
   type VcsProviderKind,
   type WorkflowBlockAvailability,
@@ -16,6 +17,7 @@ import {
 } from "@shared/contracts";
 import { resolveLlmProvider, type LlmProvider } from "../lib/llm-provider.js";
 import {
+  inspectJsonSchema202012,
   parseJsonSchema202012,
   type JsonSchemaInspectionOptions,
   type JsonSchemaIssue,
@@ -131,11 +133,13 @@ const reviewFeedbackType = objectType({
   author: stringType(),
   body: stringType(),
 });
-const reviewFindingType = objectType({
-  file: stringType(),
-  description: stringType(),
-  severity: enumStringType(["critical", "suggestion"]),
-});
+const parsedReviewResultType = inspectJsonSchema202012(
+  REVIEW_RESULT_JSON_SCHEMA,
+);
+if (!parsedReviewResultType.ok || parsedReviewResultType.valueSchema.type !== "object") {
+  throw new Error("The code-owned Review Result schema is invalid.");
+}
+const reviewResultType = parsedReviewResultType.valueSchema;
 const workflowPrRefType = objectType({
   provider: stringType(),
   repoPath: stringType(),
@@ -480,11 +484,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     inputs: {
       reviewFeedback: input(reviewFeedbackType),
     },
-    output: statusOutput({
-      findings: arrayType(reviewFindingType),
-      decision: enumStringType(["approve", "request_changes"]),
-      feedback: stringType(),
-    }),
+    output: statusOutput(reviewResultType.properties),
     normalOutputRequired: ["findings", "decision"],
     statusVariants: ["reviewed"],
   },
@@ -498,6 +498,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     defaults: { maxMinutes: 25 },
     inputs: {
       reviewFeedback: input(reviewFeedbackType),
+      reviewResults: input(arrayType(reviewResultType)),
     },
     output: statusOutput({
       workspaceId: stringType(),

--- a/apps/worker/src/workflow-definition/default-v2.test.ts
+++ b/apps/worker/src/workflow-definition/default-v2.test.ts
@@ -221,7 +221,7 @@ describe("v2 built-in authoring definitions", () => {
         provider,
       });
 
-      expect(templates).toHaveLength(4);
+      expect(templates).toHaveLength(5);
       for (const template of templates) {
         expect(template.definition.schemaVersion).toBe(2);
         if (template.definition.schemaVersion !== 2) continue;
@@ -239,6 +239,74 @@ describe("v2 built-in authoring definitions", () => {
       }
     },
   );
+
+  it("builds the editable reviewed ticket retry graph", () => {
+    const template = workflowDefinitionTemplate("reviewed-ticket-workflow", {
+      includeReview: true,
+      provider: "claude",
+    });
+    expect(template?.name).toBe("Reviewed ticket workflow");
+    if (!template || template.definition.schemaVersion !== 2) {
+      throw new Error("Reviewed ticket template must use schema version 2");
+    }
+    const definition = template.definition;
+    const reviews = definition.nodes.filter(
+      (node) => node.type === "review_agent",
+    );
+    expect(reviews.map((node) => node.name)).toEqual([
+      "Security review",
+      "Code quality review",
+      "Requirements review",
+    ]);
+    const branch = definition.nodes.find(
+      (node) => node.id === "reviews-approved",
+    );
+    expect(branch?.configuration).toMatchObject({
+      combinator: "all",
+      conditions: [
+        { value: "approve" },
+        { value: "approve" },
+        { value: "approve" },
+      ],
+    });
+    const loop = definition.nodes.find((node) => node.id === "retry");
+    expect(loop?.configuration).toMatchObject({
+      maxAttempts: 3,
+      onExhaust: "fail",
+      carry: expect.arrayContaining([
+        expect.objectContaining({ name: "securityReview" }),
+        expect.objectContaining({ name: "qualityReview" }),
+        expect.objectContaining({ name: "requirementsReview" }),
+      ]),
+    });
+    const fix = definition.nodes.find((node) => node.id === "fix");
+    expect(fix?.inputs.reviewResults).toEqual({
+      kind: "reference_list",
+      references: [
+        "steps.retry.output.values.securityReview",
+        "steps.retry.output.values.qualityReview",
+        "steps.retry.output.values.requirementsReview",
+      ],
+    });
+    expect(
+      definition.edges.filter(
+        (edge) =>
+          edge.from === "implementation" &&
+          reviews.some((review) => review.id === edge.to),
+      ),
+    ).toHaveLength(3);
+    expect(
+      definition.edges.filter(
+        (edge) =>
+          edge.from === "fix" &&
+          reviews.some((review) => review.id === edge.to),
+      ),
+    ).toHaveLength(3);
+    expect(
+      definition.nodes.find((node) => node.id === "exhausted-failure")
+        ?.configuration,
+    ).toEqual({ terminalStatus: "failed" });
+  });
 
   it("returns independent template snapshots", () => {
     const first = workflowDefinitionTemplate("ticket-workflow", {

--- a/apps/worker/src/workflow-definition/reviewed-ticket-template.test.ts
+++ b/apps/worker/src/workflow-definition/reviewed-ticket-template.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import type {
+  BlockOutput,
+  WorkflowDefinitionV2Node,
+} from "@shared/contracts";
+import { workflowDefinitionTemplate } from "./templates.js";
+import { executeV2Graph } from "./v2-scheduler.js";
+
+function reviewedTemplate() {
+  const template = workflowDefinitionTemplate("reviewed-ticket-workflow", {
+    includeReview: true,
+    provider: "claude",
+  });
+  if (!template || template.definition.schemaVersion !== 2) {
+    throw new Error("Reviewed ticket template is unavailable.");
+  }
+  return template.definition;
+}
+
+function ordinaryOutput(node: WorkflowDefinitionV2Node): BlockOutput {
+  switch (node.type) {
+    case "prepare_workspace":
+      return {
+        status: "ok",
+        sandboxId: "sbx-template",
+        repositories: ["github:acme/app"],
+        workspace: {
+          id: "sbx-template",
+          repositories: ["github:acme/app"],
+        },
+      };
+    case "planning_agent":
+      return { status: "ready", plan: "Implement the ticket." };
+    case "implementation_agent":
+      return {
+        status: "implemented",
+        workspaceId: "sbx-template",
+        branches: [],
+        commits: [],
+        summary: "Implemented.",
+      };
+    case "fix_agent":
+      return {
+        status: "fixed",
+        workspaceId: "sbx-template",
+        commits: [],
+        resolvedConflicts: [],
+        unresolvedConflicts: [],
+        summary: "Fixed.",
+      };
+    case "run_pre_pr_checks":
+      return {
+        status: "ok",
+        ok: true,
+        outcome: "passed",
+        fixCycles: 0,
+        summary: "Checks passed.",
+      };
+    case "finalize_workspace":
+      return {
+        status: "finalized",
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/app",
+            branchName: "ai-workflow/AIW-186",
+            defaultBranch: "main",
+            expectedHead: "before",
+            pushedHead: "after",
+          },
+        ],
+      };
+    case "open_pr":
+      return {
+        status: "ok",
+        prs: [
+          {
+            provider: "github",
+            repoPath: "acme/app",
+            id: 1,
+            url: "https://github.com/acme/app/pull/1",
+            branch: "ai-workflow/AIW-186",
+            isNew: true,
+          },
+        ],
+        prUrl: "https://github.com/acme/app/pull/1",
+        prNumber: 1,
+      };
+    case "update_ticket_status":
+      return { status: "ok", target: "ai_review" };
+    case "send_slack_message":
+      return { status: "ok" };
+    default:
+      return { status: "ok" };
+  }
+}
+
+describe("Reviewed ticket workflow template execution", () => {
+  it("passes the exact prior results to Fix and exits after the fourth review pass", async () => {
+    const reviewAttempts = new Map<string, number[]>();
+    const fixInputs: unknown[] = [];
+    const result = await executeV2Graph({
+      definition: reviewedTemplate(),
+      entryTriggerId: "trigger",
+      triggerOutput: {
+        status: "ok",
+        ticket: {},
+        comments: [],
+        priorAnswers: [],
+      },
+      executeBlock: async (node, _steps, inputs, context) => {
+        if (node.type === "review_agent") {
+          const attempts = reviewAttempts.get(node.id) ?? [];
+          attempts.push(context.attempt);
+          reviewAttempts.set(node.id, attempts);
+          return {
+            kind: "next",
+            output: {
+              status: "reviewed",
+              decision:
+                context.attempt === 4 ? "approve" : "request_changes",
+              findings:
+                context.attempt === 4
+                  ? []
+                  : [
+                      {
+                        file: `${node.id}.ts`,
+                        description: `Finding from pass ${context.attempt}.`,
+                        severity: "critical",
+                      },
+                    ],
+            },
+          };
+        }
+        if (node.id === "fix") {
+          fixInputs.push(structuredClone(inputs.reviewResults));
+        }
+        return { kind: "next", output: ordinaryOutput(node) };
+      },
+    });
+
+    expect(result.executionError).toBeUndefined();
+    expect(result.outcome).toBe("completed");
+    expect([...reviewAttempts.values()]).toEqual([
+      [1, 2, 3, 4],
+      [1, 2, 3, 4],
+      [1, 2, 3, 4],
+    ]);
+    expect(fixInputs).toHaveLength(3);
+    for (const [index, input] of fixInputs.entries()) {
+      expect(input).toEqual([
+        expect.objectContaining({
+          decision: "request_changes",
+          findings: [
+            expect.objectContaining({
+              description: `Finding from pass ${index + 1}.`,
+            }),
+          ],
+        }),
+        expect.objectContaining({ decision: "request_changes" }),
+        expect.objectContaining({ decision: "request_changes" }),
+      ]);
+    }
+  });
+
+  it("reports exhaustion and terminates the workflow as failed", async () => {
+    const invoked: string[] = [];
+    const result = await executeV2Graph({
+      definition: reviewedTemplate(),
+      entryTriggerId: "trigger",
+      triggerOutput: {
+        status: "ok",
+        ticket: {},
+        comments: [],
+        priorAnswers: [],
+      },
+      executeBlock: async (node) => {
+        invoked.push(node.id);
+        if (node.type === "terminate") {
+          return {
+            kind: "execution_error",
+            error: {
+              category: "engine",
+              phase: "terminate",
+              message: "Terminated by workflow.",
+            },
+          };
+        }
+        if (node.type === "review_agent") {
+          return {
+            kind: "next",
+            output: {
+              status: "reviewed",
+              decision: "request_changes",
+              findings: [
+                {
+                  file: `${node.id}.ts`,
+                  description: "Still unresolved.",
+                  severity: "critical",
+                },
+              ],
+            },
+          };
+        }
+        return { kind: "next", output: ordinaryOutput(node) };
+      },
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.executionError).toMatchObject({
+      nodeId: "exhausted-failure",
+      category: "engine",
+      phase: "terminate",
+    });
+    expect(invoked).toContain("exhausted-message");
+    expect(invoked).not.toContain("checks");
+    expect(result.state.scopes.root.nodeStates["exhausted-failure"]).toEqual({
+      status: "failed",
+      attempt: 1,
+    });
+  });
+});

--- a/apps/worker/src/workflow-definition/schema-v2.test.ts
+++ b/apps/worker/src/workflow-definition/schema-v2.test.ts
@@ -224,6 +224,8 @@ describe("Workflow Definition v2 schema", () => {
     };
     expect(workflowDefinitionV2Schema.safeParse(invalidReference).success).toBe(false);
     expect(isWorkflowDataReferenceV2("steps.entry.output.ticket")).toBe(true);
+    expect(isWorkflowDataReferenceV2("steps.entry.output")).toBe(true);
+    expect(isWorkflowDataReferenceV2("steps.review.output")).toBe(true);
     expect(isWorkflowDataReferenceV2("steps.plan.output.summary")).toBe(true);
     expect(isWorkflowDataReferenceV2("run.id")).toBe(true);
     expect(isWorkflowDataReferenceV2("trigger.ticket")).toBe(false);

--- a/apps/worker/src/workflow-definition/schema.test.ts
+++ b/apps/worker/src/workflow-definition/schema.test.ts
@@ -888,12 +888,13 @@ describe("workflowDefinitionSchema block-executor node types", () => {
 });
 
 describe("validateWorkflowGraph fixtures", () => {
-  it("ships four deployable starter templates with the production ticket workflow first", () => {
+  it("ships five deployable starter templates with the production ticket workflow first", () => {
     const templates = workflowDefinitionTemplates({ includeReview: true });
     expect(templates.map((template) => template.name)).toEqual([
       "Ticket workflow",
       "Human-approved plan",
       "Review & fix after PR",
+      "Reviewed ticket workflow",
       "Fully modular",
     ]);
     expect(templates[0].definition.nodes.some((node) => node.type === "review_agent")).toBe(true);

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -417,7 +417,7 @@ export function isWorkflowDataReferenceV2(
   }
   if (
     segments[0] !== "steps" ||
-    segments.length < 4 ||
+    segments.length < 3 ||
     segments[2] !== "output"
   ) {
     return false;

--- a/apps/worker/src/workflow-definition/store.test.ts
+++ b/apps/worker/src/workflow-definition/store.test.ts
@@ -185,7 +185,7 @@ describe("migration seed", () => {
 });
 
 describe("starter template seed", () => {
-  it("adds the three disabled starter workflows exactly once", async () => {
+  it("adds the four disabled starter workflows exactly once", async () => {
     await seedWorkflowDefinitionTemplates(db, { includeReview: true });
     await seedWorkflowDefinitionTemplates(db, { includeReview: true });
 
@@ -194,14 +194,32 @@ describe("starter template seed", () => {
       "Ticket workflow",
       "Human-approved plan",
       "Review & fix after PR",
+      "Reviewed ticket workflow",
       "Fully modular",
     ]);
-    expect(defs.map((definition) => definition.enabled)).toEqual([true, false, false, false]);
-    expect(defs.slice(1).map((definition) => definition.draftRevision)).toEqual([1, 1, 1]);
-    expect(defs.slice(1).map((definition) => definition.deployedVersion)).toEqual([1, 1, 1]);
+    expect(defs.map((definition) => definition.enabled)).toEqual([
+      true,
+      false,
+      false,
+      false,
+      false,
+    ]);
+    expect(defs.slice(1).map((definition) => definition.draftRevision)).toEqual([
+      1,
+      1,
+      1,
+      1,
+    ]);
+    expect(defs.slice(1).map((definition) => definition.deployedVersion)).toEqual([
+      1,
+      1,
+      1,
+      1,
+    ]);
     expect(defs.slice(1).map((definition) => definition.triggerTypes)).toEqual([
       ["trigger_ticket_ai", "trigger_plan_approved"],
       ["trigger_pr_checks_failed", "trigger_pr_review"],
+      ["trigger_ticket_ai"],
       ["trigger_ticket_ai"],
     ]);
   });

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -1,8 +1,9 @@
-import type {
-  HarnessProvider,
-  HarnessProfileReference,
-  WorkflowDefinitionTemplate,
-  WorkflowDefinitionV2,
+import {
+  REVIEW_RESULT_JSON_SCHEMA,
+  type HarnessProvider,
+  type HarnessProfileReference,
+  type WorkflowDefinitionTemplate,
+  type WorkflowDefinitionV2,
 } from "@shared/contracts";
 import {
   buildBuiltinV2Definition,
@@ -385,6 +386,285 @@ function fullyModularDefinition(
   ]);
 }
 
+const REVIEW_TASKS = {
+  security:
+    "Review the implementation for security vulnerabilities, unsafe trust boundaries, credential exposure, and abuse cases. Do not modify files. Report concrete findings only.",
+  quality:
+    "Review the implementation for correctness, maintainability, test coverage, regressions, and adherence to repository conventions. Do not modify files. Report concrete findings only.",
+  requirements:
+    "Review the implementation against the ticket, approved plan, and acceptance criteria. Do not modify files. Report concrete gaps only.",
+} as const;
+
+function reviewedTicketDefinition(
+  provider: HarnessProvider,
+  profileReference?: HarnessProfileReference,
+): WorkflowDefinitionV2 {
+  const profile = () =>
+    builtinHarnessProfileConfiguration(provider, profileReference);
+  const specs: V2BlockSpec[] = [
+    {
+      id: "trigger",
+      type: "trigger_ticket_ai",
+      name: "Ticket assigned to AI",
+      column: 0,
+    },
+    {
+      id: "prepare",
+      type: "prepare_workspace",
+      name: "Prepare workspace",
+      column: 1,
+    },
+    {
+      id: "planning",
+      type: "planning_agent",
+      name: "Planning agent",
+      column: 2,
+      configuration: {
+        ...profile(),
+        prompt: "{{prompt:research-plan@1}}",
+      },
+      inputs: {
+        ticket: {
+          kind: "reference",
+          reference: "steps.entry.output.ticket",
+        },
+        comments: {
+          kind: "reference",
+          reference: "steps.entry.output.comments",
+        },
+        priorAnswers: {
+          kind: "reference",
+          reference: "steps.entry.output.priorAnswers",
+        },
+      },
+    },
+    {
+      id: "implementation",
+      type: "implementation_agent",
+      name: "Implementation agent",
+      column: 3,
+      configuration: {
+        ...profile(),
+        prompt: "{{prompt:implement@1}}",
+      },
+      inputs: {
+        ticket: {
+          kind: "reference",
+          reference: "steps.entry.output.ticket",
+        },
+        plan: {
+          kind: "reference",
+          reference: "steps.planning.output.plan",
+        },
+      },
+    },
+    ...([
+      ["security-review", "Security review", REVIEW_TASKS.security, -1],
+      ["quality-review", "Code quality review", REVIEW_TASKS.quality, 0],
+      [
+        "requirements-review",
+        "Requirements review",
+        REVIEW_TASKS.requirements,
+        1,
+      ],
+    ] as const).map(
+      ([id, name, prompt, row]) =>
+        ({
+          id,
+          type: "review_agent",
+          name,
+          column: 5,
+          row,
+          configuration: {
+            ...profile(),
+            prompt,
+          },
+        }) satisfies V2BlockSpec,
+    ),
+    {
+      id: "reviews-approved",
+      type: "branch",
+      name: "All reviews approved?",
+      column: 6,
+      configuration: {
+        combinator: "all",
+        conditions: [
+          {
+            reference: "steps.security-review.output.decision",
+            operator: "equals",
+            value: "approve",
+          },
+          {
+            reference: "steps.quality-review.output.decision",
+            operator: "equals",
+            value: "approve",
+          },
+          {
+            reference: "steps.requirements-review.output.decision",
+            operator: "equals",
+            value: "approve",
+          },
+        ],
+      },
+    },
+    {
+      id: "checks",
+      type: "run_pre_pr_checks",
+      name: "Run pre-PR checks",
+      column: 7,
+      row: -1,
+    },
+    {
+      id: "finalize",
+      type: "finalize_workspace",
+      name: "Finalize workspace",
+      column: 8,
+      row: -1,
+    },
+    {
+      id: "open-pr",
+      type: "open_pr",
+      name: "Open pull request",
+      column: 9,
+      row: -1,
+      inputs: {
+        repositories: {
+          kind: "reference",
+          reference: "steps.finalize.output.repositories",
+        },
+      },
+    },
+    {
+      id: "status",
+      type: "update_ticket_status",
+      name: "Update ticket status",
+      column: 10,
+      row: -1,
+      configuration: { target: "ai_review" },
+    },
+    {
+      id: "retry",
+      type: "loop",
+      name: "Retry review fixes",
+      column: 7,
+      row: 1,
+      configuration: {
+        maxAttempts: 3,
+        onExhaust: "fail",
+        carry: [
+          {
+            name: "securityReview",
+            schema: REVIEW_RESULT_JSON_SCHEMA,
+            binding: {
+              kind: "reference",
+              reference: "steps.security-review.output",
+            },
+          },
+          {
+            name: "qualityReview",
+            schema: REVIEW_RESULT_JSON_SCHEMA,
+            binding: {
+              kind: "reference",
+              reference: "steps.quality-review.output",
+            },
+          },
+          {
+            name: "requirementsReview",
+            schema: REVIEW_RESULT_JSON_SCHEMA,
+            binding: {
+              kind: "reference",
+              reference: "steps.requirements-review.output",
+            },
+          },
+        ],
+      },
+    },
+    {
+      id: "fix",
+      type: "fix_agent",
+      name: "Fix review findings",
+      column: 4,
+      row: 2,
+      configuration: {
+        ...profile(),
+        instructions:
+          "Resolve the supplied internal review findings, verify the changes, and commit the fix.",
+        maxMinutes: 25,
+      },
+      inputs: {
+        reviewResults: {
+          kind: "reference_list",
+          references: [
+            "steps.retry.output.values.securityReview",
+            "steps.retry.output.values.qualityReview",
+            "steps.retry.output.values.requirementsReview",
+          ],
+        },
+      },
+    },
+    {
+      id: "exhausted-message",
+      type: "send_slack_message",
+      name: "Report unresolved review findings",
+      column: 8,
+      row: 2,
+      configuration: {
+        message:
+          "The workflow could not resolve all review findings after three fix attempts.",
+        sendOn: "always",
+      },
+    },
+    {
+      id: "exhausted-failure",
+      type: "terminate",
+      name: "Fail unresolved review",
+      column: 9,
+      row: 2,
+      configuration: {
+        terminalStatus: "failed",
+      },
+    },
+  ];
+  return buildBuiltinV2Definition("reviewed-ticket-workflow", specs, [
+    { from: "trigger", to: "prepare" },
+    { from: "prepare", to: "planning" },
+    { from: "planning", to: "implementation" },
+    { from: "implementation", to: "security-review" },
+    { from: "implementation", to: "quality-review" },
+    { from: "implementation", to: "requirements-review" },
+    { from: "security-review", to: "reviews-approved" },
+    { from: "quality-review", to: "reviews-approved" },
+    { from: "requirements-review", to: "reviews-approved" },
+    {
+      from: "reviews-approved",
+      fromPort: "true",
+      to: "checks",
+    },
+    { from: "checks", to: "finalize" },
+    { from: "finalize", to: "open-pr" },
+    { from: "open-pr", to: "status" },
+    {
+      from: "reviews-approved",
+      fromPort: "false",
+      to: "retry",
+    },
+    {
+      from: "retry",
+      fromPort: "continue",
+      to: "fix",
+    },
+    { from: "fix", to: "security-review" },
+    { from: "fix", to: "quality-review" },
+    { from: "fix", to: "requirements-review" },
+    {
+      from: "retry",
+      fromPort: "exhausted",
+      to: "exhausted-message",
+    },
+    { from: "exhausted-message", to: "exhausted-failure" },
+  ]);
+}
+
 export function workflowDefinitionTemplates({
   includeReview,
   includeLeakReview = false,
@@ -417,6 +697,13 @@ export function workflowDefinitionTemplates({
       description:
         "Responds to failed checks or requested changes on workflow-owned pull requests.",
       definition: reviewFixAfterPrDefinition(provider, profileReference),
+    },
+    {
+      id: "reviewed-ticket-workflow",
+      name: "Reviewed ticket workflow",
+      description:
+        "Implements a ticket, runs three parallel reviews, and retries visible fixes up to three times.",
+      definition: reviewedTicketDefinition(provider, profileReference),
     },
     {
       id: "fully-modular",

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -411,6 +411,78 @@ describe("fix_agent execute", () => {
     expect(mocks.assembleFixContext).not.toHaveBeenCalled();
   });
 
+  it("validates and forwards ordered internal Review Results separately", async () => {
+    await execute(makeNode("fix_agent"), {}, makeCtx(), {
+      reviewResults: [
+        {
+          status: "reviewed",
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/security.ts",
+              description: "Validate the token.",
+              severity: "critical",
+            },
+          ],
+        },
+        {
+          status: "reviewed",
+          decision: "approve",
+          findings: [],
+          feedback: "Looks good.",
+        },
+      ],
+    });
+
+    expect(mocks.assembleFixContext.mock.calls[0][0]).toMatchObject({
+      reviewResults: [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/security.ts",
+              description: "Validate the token.",
+              severity: "critical",
+            },
+          ],
+        },
+        {
+          decision: "approve",
+          findings: [],
+          feedback: "Looks good.",
+        },
+      ],
+    });
+  });
+
+  it("rejects malformed internal Review Results before invoking the agent", async () => {
+    const result = await execute(makeNode("fix_agent"), {}, makeCtx(), {
+      reviewResults: [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Invalid range.",
+              severity: "critical",
+              endLine: 3,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toEqual({
+      kind: "execution_error",
+      error: expect.objectContaining({
+        category: "binding",
+        message:
+          "reviewResults[0].findings[0].endLine requires startLine.",
+      }),
+    });
+    expect(mocks.assembleFixContext).not.toHaveBeenCalled();
+  });
+
   it("threads clarification history from ctx into the fix context", async () => {
     mocks.parseAgentOutput.mockReturnValue({ result: "implemented" });
     const clarifications = [

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -45,6 +45,10 @@ import {
   resolveReviewFeedbackInput,
   type ReviewFeedback,
 } from "../review-feedback.js";
+import {
+  normalizeReviewResultsInput,
+  type ReviewResultsResolution,
+} from "../review-results.js";
 
 export const paramsSchema = z
   .object({
@@ -213,6 +217,7 @@ async function buildFixInput(
   block: WorkflowDefinitionNode,
   ctx: EngineCtx,
   reviewFeedback: ReviewFeedback | undefined,
+  reviewResults: Extract<ReviewResultsResolution, { ok: true }>["value"],
   includeInstructions = true,
 ): Promise<string> {
   const { assembleFixContext } = await import("../../sandbox/context.js");
@@ -251,6 +256,7 @@ async function buildFixInput(
     ticket: { ...ctx.ticket, ...(ctx.clarifications ? { clarifications: ctx.clarifications } : {}) },
     prComments,
     failedChecks,
+    ...(reviewResults ? { reviewResults } : {}),
     ...(conflictRepos.length > 0
       ? {
           conflictNotes: `These repositories have merge conflicts: ${conflictRepos.join(", ")}. Resolve the conflict markers, stage the files, and continue the merge in each repository.`,
@@ -315,11 +321,21 @@ export const execute: BlockExecuteFn = async (
         message: reviewFeedback.message,
       });
     }
+    const reviewResults = normalizeReviewResultsInput(
+      resolvedInputs.reviewResults,
+    );
+    if (!reviewResults.ok) {
+      return executionError("invalid reviewResults binding", {
+        category: "binding",
+        message: reviewResults.message,
+      });
+    }
     const before = await inspectFixWorkspace(sandboxId);
     const fallbackInput = await buildFixInput(
       block,
       ctx,
       reviewFeedback.value,
+      reviewResults.value,
       execution?.compileEffectivePrompt === undefined,
     );
     const resolvedInput = await resolveAgentInput({

--- a/apps/worker/src/workflows/review-results.test.ts
+++ b/apps/worker/src/workflows/review-results.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { normalizeReviewResultsInput } from "./review-results.js";
+
+describe("normalizeReviewResultsInput", () => {
+  it("projects compatible envelopes onto the canonical ordered result", () => {
+    expect(
+      normalizeReviewResultsInput([
+        {
+          status: "reviewed",
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Handle the rejected input.",
+              severity: "critical",
+              startLine: 10,
+              endLine: 12,
+              providerMetadata: "discarded",
+            },
+          ],
+          feedback: "One issue.",
+          customField: true,
+        },
+        {
+          decision: "approve",
+          findings: [],
+        },
+      ]),
+    ).toEqual({
+      ok: true,
+      value: [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Handle the rejected input.",
+              severity: "critical",
+              startLine: 10,
+              endLine: 12,
+            },
+          ],
+          feedback: "One issue.",
+        },
+        {
+          decision: "approve",
+          findings: [],
+        },
+      ],
+    });
+  });
+
+  it("rejects empty lists and invalid line ranges", () => {
+    expect(normalizeReviewResultsInput([])).toEqual({
+      ok: false,
+      message: "reviewResults must contain at least one Review Result.",
+    });
+    expect(
+      normalizeReviewResultsInput([
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Bad range.",
+              severity: "critical",
+              startLine: 12,
+              endLine: 10,
+            },
+          ],
+        },
+      ]),
+    ).toEqual({
+      ok: false,
+      message:
+        "reviewResults[0].findings[0].endLine must be greater than or equal to startLine.",
+    });
+  });
+});

--- a/apps/worker/src/workflows/review-results.ts
+++ b/apps/worker/src/workflows/review-results.ts
@@ -1,0 +1,98 @@
+import {
+  REVIEW_RESULT_JSON_SCHEMA,
+  type ReviewResult,
+  type ReviewResultFinding,
+} from "@shared/contracts";
+import { validateJsonSchemaValue } from "../workflow-definition/json-schema.js";
+
+export type ReviewResultsResolution =
+  | { ok: true; value: ReviewResult[] | undefined }
+  | { ok: false; message: string };
+
+function normalizedFinding(
+  value: Record<string, unknown>,
+  resultIndex: number,
+  findingIndex: number,
+): ReviewResultFinding | string {
+  const startLine = value.startLine;
+  const endLine = value.endLine;
+  const location = `reviewResults[${resultIndex}].findings[${findingIndex}]`;
+  if (
+    startLine !== undefined &&
+    (!Number.isInteger(startLine) || (startLine as number) < 1)
+  ) {
+    return `${location}.startLine must be a positive integer.`;
+  }
+  if (
+    endLine !== undefined &&
+    (!Number.isInteger(endLine) || (endLine as number) < 1)
+  ) {
+    return `${location}.endLine must be a positive integer.`;
+  }
+  if (endLine !== undefined && startLine === undefined) {
+    return `${location}.endLine requires startLine.`;
+  }
+  if (
+    typeof endLine === "number" &&
+    typeof startLine === "number" &&
+    endLine < startLine
+  ) {
+    return `${location}.endLine must be greater than or equal to startLine.`;
+  }
+  return {
+    file: value.file as string,
+    description: value.description as string,
+    severity: value.severity as ReviewResultFinding["severity"],
+    ...(typeof startLine === "number" ? { startLine } : {}),
+    ...(typeof endLine === "number" ? { endLine } : {}),
+  };
+}
+
+export function normalizeReviewResultsInput(
+  value: unknown,
+): ReviewResultsResolution {
+  if (value === undefined) return { ok: true, value: undefined };
+  if (!Array.isArray(value) || value.length === 0) {
+    return {
+      ok: false,
+      message: "reviewResults must contain at least one Review Result.",
+    };
+  }
+
+  const normalized: ReviewResult[] = [];
+  for (const [resultIndex, candidate] of value.entries()) {
+    const issues = validateJsonSchemaValue(
+      REVIEW_RESULT_JSON_SCHEMA,
+      candidate,
+    );
+    if (issues.length > 0) {
+      return {
+        ok: false,
+        message: `reviewResults[${resultIndex}] is invalid: ${issues[0]!.message}`,
+      };
+    }
+    const result = candidate as Record<string, unknown>;
+    const findings: ReviewResultFinding[] = [];
+    for (const [findingIndex, candidateFinding] of (
+      result.findings as unknown[]
+    ).entries()) {
+      const finding = normalizedFinding(
+        candidateFinding as Record<string, unknown>,
+        resultIndex,
+        findingIndex,
+      );
+      if (typeof finding === "string") {
+        return { ok: false, message: finding };
+      }
+      findings.push(finding);
+    }
+    normalized.push({
+      decision: result.decision as ReviewResult["decision"],
+      findings,
+      ...(typeof result.feedback === "string"
+        ? { feedback: result.feedback }
+        : {}),
+    });
+  }
+  return { ok: true, value: normalized };
+}

--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -916,7 +916,10 @@
           statuses: ["reviewed"],
         }),
         fix_agent: runtimeContract(["provider", "model", "instructions", "maxMinutes"], {
-          optionalInputs: typedPaths("object", "reviewFeedback"),
+          optionalInputs: [
+            ...typedPaths("object", "reviewFeedback"),
+            ...typedPaths("object[]", "reviewResults"),
+          ],
           requiredOutputs: [
             ...STATUS_OUTPUT,
             ...typedPaths("string", "workspaceId", "summary"),


### PR DESCRIPTION
## Summary
- add the shared canonical Review Result contract and ordered multi-value Fix Agent input
- add the editable Reviewed ticket workflow with three parallel reviews, visible decision branch, three fix retries, and explicit exhaustion failure
- make loop authoring analysis and whole-output references support the template without changing v1 execution
- expose ordered workflow-value selection for array inputs in the dashboard

## Stack
- Base: #172
- Jira: AIW-186
- No database migration

## Verification
- `pnpm typecheck`
- `pnpm test` — 3,142 worker tests and 529 dashboard tests passed
- `pnpm --filter worker test:workflow-sdk` — 11 passed
- focused Reviewed ticket scheduler execution tests cover approval after three retries and exhaustion failure
- orchestration E2E attempted; unavailable locally because preview/Jira/GitHub/database E2E credentials are not configured

## Compatibility
Workflow Definition v1 and the existing provider review protocol are unchanged. The new canonical Review Result and template apply to v2 authoring/runtime only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Reviewed Ticket workflow with parallel reviews, automated fixes, retry handling, and failure notifications.
  * Fix steps can now use structured results from previous reviews, including decisions, findings, and feedback.
  * Added shared review-result validation and support for workflow references to complete step outputs.
  * Improved workflow editing for ordered review-result lists with clear labels and reorder controls.

* **Bug Fixes**
  * Improved handling of nullable and array-based workflow inputs.
  * Prevented raw internal reference identifiers from appearing in workflow value selections.

* **Documentation**
  * Updated the workflow workspace contract to reflect review-result inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->