### PR TITLE
fix: survive a single VCS provider outage

### DIFF
--- a/apps/worker/src/adapters/vcs/repository-directory.test.ts
+++ b/apps/worker/src/adapters/vcs/repository-directory.test.ts
@@ -16,6 +16,8 @@ import {
   createRepositoryDirectoryForProviders,
   filterPinnedRepositories,
   isRepositoryWithinPinnedScope,
+  listRepositoriesAcrossProviders,
+  pinnedScopeExcludesProvider,
 } from "./repository-directory.js";
 
 const mockFetch = vi.fn();
@@ -33,6 +35,45 @@ function gitLabResponse(
     text: vi.fn().mockResolvedValue(JSON.stringify(body)),
   };
 }
+
+function gitLabErrorResponse(status: number, statusText: string) {
+  return {
+    ok: false,
+    status,
+    statusText,
+    headers: new Headers(),
+    json: vi.fn().mockResolvedValue({}),
+    text: vi.fn().mockResolvedValue(""),
+  };
+}
+
+function gitLabProject(pathWithNamespace: string) {
+  return {
+    path_with_namespace: pathWithNamespace,
+    name: pathWithNamespace.split("/").at(-1),
+    namespace: { full_path: pathWithNamespace.split("/")[0] },
+    default_branch: "main",
+    description: "",
+    web_url: `https://gitlab.example.com/${pathWithNamespace}`,
+    topics: [],
+    archived: false,
+    visibility: "private",
+  };
+}
+
+const githubProvider = {
+  kind: "github" as const,
+  auth: { appId: 1, privateKeyBase64: "pem", installationId: 2 },
+  host: "https://github.com",
+  legacyBaseBranch: "main",
+};
+
+const gitlabProvider = {
+  kind: "gitlab" as const,
+  token: "glpat",
+  host: "https://gitlab.example.com",
+  legacyBaseBranch: "main",
+};
 
 describe("createRepositoryDirectory", () => {
   beforeEach(() => {
@@ -226,6 +267,122 @@ describe("createRepositoryDirectory", () => {
   });
 });
 
+describe("provider listing resilience", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("retries a GitLab 5xx once and keeps the recovered listing", async () => {
+    mockFetch
+      .mockResolvedValueOnce(gitLabErrorResponse(503, "Service Unavailable"))
+      .mockResolvedValueOnce(gitLabResponse([gitLabProject("acme/api")]));
+
+    const listing = await listRepositoriesAcrossProviders([gitlabProvider]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(listing.failures).toEqual([]);
+    expect(listing.repositories).toEqual([
+      expect.objectContaining({ provider: "gitlab", repoPath: "acme/api" }),
+    ]);
+  });
+
+  it("retries a GitLab timeout once and reports the provider when it times out again", async () => {
+    const timeout = new DOMException("The operation timed out.", "TimeoutError");
+    mockFetch.mockRejectedValue(timeout);
+
+    const listing = await listRepositoriesAcrossProviders([gitlabProvider]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(listing.repositories).toEqual([]);
+    expect(listing.failures).toEqual([
+      expect.objectContaining({
+        provider: "gitlab",
+        message: expect.stringContaining("GitLab projects list timed out"),
+      }),
+    ]);
+  });
+
+  // A rejected credential is replayed unchanged by a retry, so retrying only
+  // doubles the time to a failure the operator has to fix by hand.
+  it("never retries a GitLab 401", async () => {
+    mockFetch.mockResolvedValue(gitLabErrorResponse(401, "Unauthorized"));
+
+    const listing = await listRepositoriesAcrossProviders([gitlabProvider]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(listing.failures).toEqual([
+      expect.objectContaining({
+        provider: "gitlab",
+        message: "GitLab projects list failed: 401 Unauthorized",
+      }),
+    ]);
+  });
+
+  it("retries a GitHub 5xx and never retries a GitHub 403", async () => {
+    mockOctokit.paginate
+      .mockRejectedValueOnce(Object.assign(new Error("server error"), { status: 500 }))
+      .mockResolvedValueOnce([]);
+
+    await listRepositoriesAcrossProviders([githubProvider]);
+    expect(mockOctokit.paginate).toHaveBeenCalledTimes(2);
+
+    mockOctokit.paginate.mockRejectedValue(
+      Object.assign(new Error("Resource not accessible by integration"), { status: 403 }),
+    );
+    const forbidden = await listRepositoriesAcrossProviders([githubProvider]);
+
+    expect(mockOctokit.paginate).toHaveBeenCalledTimes(3);
+    expect(forbidden.failures).toEqual([
+      expect.objectContaining({ provider: "github" }),
+    ]);
+  });
+
+  it("returns the surviving provider's repositories alongside the failed provider", async () => {
+    mockOctokit.paginate.mockResolvedValueOnce([
+      {
+        full_name: "acme/web",
+        name: "web",
+        owner: { login: "acme" },
+        default_branch: "main",
+        description: "Storefront",
+        html_url: "https://github.com/acme/web",
+        topics: [],
+        archived: false,
+        private: true,
+      },
+    ]);
+    mockFetch.mockResolvedValue(gitLabErrorResponse(503, "Service Unavailable"));
+
+    const listing = await listRepositoriesAcrossProviders([
+      githubProvider,
+      gitlabProvider,
+    ]);
+
+    expect(listing.repositories).toEqual([
+      expect.objectContaining({ provider: "github", repoPath: "acme/web" }),
+    ]);
+    expect(listing.failures).toEqual([
+      expect.objectContaining({ provider: "gitlab" }),
+    ]);
+  });
+
+  // The fan-out directory has no partial-catalog contract, so its callers keep
+  // seeing the provider's own error.
+  it("keeps a provider failure terminal for the merged directory", async () => {
+    mockOctokit.paginate.mockResolvedValue([]);
+    mockFetch.mockResolvedValue(gitLabErrorResponse(503, "Service Unavailable"));
+
+    await expect(
+      createRepositoryDirectoryForProviders([
+        githubProvider,
+        gitlabProvider,
+      ]).listRepositories(),
+    ).rejects.toThrow("GitLab projects list failed: 503 Service Unavailable");
+  });
+});
+
 describe("definition repository pin", () => {
   const listed = [
     { provider: "github" as const, repoPath: "Acme/Web" },
@@ -269,6 +426,34 @@ describe("definition repository pin", () => {
         repositories: [{ provider: "github", repoPath: "acme/secret" }],
       }),
     ).toEqual([]);
+  });
+
+  it("answers whether a provider is outside the pin from the same filter", () => {
+    expect(pinnedScopeExcludesProvider(undefined, "gitlab")).toBe(false);
+    expect(pinnedScopeExcludesProvider({}, "gitlab")).toBe(false);
+    expect(
+      pinnedScopeExcludesProvider({ providers: ["github"] }, "gitlab"),
+    ).toBe(true);
+    expect(
+      pinnedScopeExcludesProvider({ providers: ["github", "gitlab"] }, "gitlab"),
+    ).toBe(false);
+    // A pin that names repositories without naming providers still excludes every
+    // provider none of those repositories belong to.
+    expect(
+      pinnedScopeExcludesProvider(
+        { repositories: [{ provider: "github", repoPath: "acme/web" }] },
+        "gitlab",
+      ),
+    ).toBe(true);
+    expect(
+      pinnedScopeExcludesProvider(
+        {
+          providers: ["github"],
+          repositories: [{ provider: "gitlab", repoPath: "acme/web" }],
+        },
+        "gitlab",
+      ),
+    ).toBe(true);
   });
 
   it("answers the single-subject question from the same filter", () => {

--- a/apps/worker/src/adapters/vcs/repository-directory.ts
+++ b/apps/worker/src/adapters/vcs/repository-directory.ts
@@ -5,6 +5,13 @@ import { filterAllowedRepositories } from "../../lib/repo-allowlist.js";
 
 const GITLAB_PROJECTS_TIMEOUT_MS = 15_000;
 
+// One retry with a short backoff. A provider's 5xx or timeout is usually gone by
+// the second call, while the pre-sandbox step that owns this listing runs under a
+// 60s budget: a longer ladder would spend that budget hanging instead of failing
+// with a reason an operator can act on.
+const LISTING_MAX_ATTEMPTS = 2;
+const LISTING_RETRY_DELAY_MS = 500;
+
 export type VcsProvider = "github" | "gitlab";
 
 export interface RepositoryMetadata {
@@ -34,12 +41,101 @@ export function createRepositoryDirectoryForProviders(
 ): RepositoryDirectory {
   return {
     async listRepositories() {
-      const lists = await Promise.all(
-        providers.map((provider) => createRepositoryDirectory(provider).listRepositories()),
-      );
-      return lists.flat();
+      const { repositories, failures } = await listRepositoriesAcrossProviders(providers);
+      // Callers of this directory have no partial-catalog contract, so a provider
+      // that never answered stays terminal for them exactly as before, with its
+      // own error rather than a wrapper.
+      if (failures.length > 0) throw failures[0]!.error;
+      return repositories;
     },
   };
+}
+
+export interface RepositoryListingFailure {
+  provider: VcsProvider;
+  message: string;
+  error: unknown;
+}
+
+/**
+ * Fan out over the configured providers and report what each one did, so a caller
+ * that can reason about a partial catalog gets the surviving listings plus the
+ * providers that failed instead of a single rejection standing in for all of them.
+ * Each provider's listing is retried under a bounded policy first.
+ *
+ * Latency budget for whoever tunes GITLAB_PROJECTS_TIMEOUT_MS next: the retry
+ * doubles the worst case, so a hung provider costs about 30.5s here rather than
+ * 15s, for every caller including the dashboard catalog endpoint. allSettled also
+ * means the slowest provider sets the floor: a fast 401 next to a hung provider
+ * now surfaces at the hung provider's pace instead of immediately.
+ */
+export async function listRepositoriesAcrossProviders(
+  providers: VcsProviderConfig[],
+): Promise<{
+  repositories: RepositoryMetadata[];
+  failures: RepositoryListingFailure[];
+}> {
+  const settled = await Promise.allSettled(
+    providers.map((provider) => listRepositoriesWithRetry(provider)),
+  );
+  const repositories: RepositoryMetadata[] = [];
+  const failures: RepositoryListingFailure[] = [];
+  settled.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      repositories.push(...result.value);
+      return;
+    }
+    failures.push({
+      provider: providers[index]!.kind,
+      message: listingErrorMessage(result.reason),
+      error: result.reason,
+    });
+  });
+  return { repositories, failures };
+}
+
+async function listRepositoriesWithRetry(
+  provider: VcsProviderConfig,
+): Promise<RepositoryMetadata[]> {
+  const directory = createRepositoryDirectory(provider);
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= LISTING_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await directory.listRepositories();
+    } catch (err) {
+      lastError = err;
+      if (attempt >= LISTING_MAX_ATTEMPTS || !isTransientListingError(err)) break;
+      await new Promise((resolve) => setTimeout(resolve, LISTING_RETRY_DELAY_MS));
+    }
+  }
+  throw lastError;
+}
+
+/** Retry only what the provider can recover from without us changing anything: a
+ *  timeout or a 5xx. A 401 or 403 is a credential the retry would replay
+ *  unchanged, and every other 4xx is a request this code will keep sending. */
+function isTransientListingError(err: unknown): boolean {
+  if (isAbortError(err)) return true;
+  if (typeof err !== "object" || err === null) return false;
+  if ((err as { timedOut?: unknown }).timedOut === true) return true;
+  const status = (err as { status?: unknown }).status;
+  return typeof status === "number" && status >= 500 && status < 600;
+}
+
+function listingErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+class RepositoryListingError extends Error {
+  readonly status: number | undefined;
+  readonly timedOut: boolean;
+
+  constructor(message: string, detail: { status?: number; timedOut?: boolean } = {}) {
+    super(message);
+    this.name = "RepositoryListingError";
+    this.status = detail.status;
+    this.timedOut = detail.timedOut ?? false;
+  }
 }
 
 /**
@@ -64,6 +160,30 @@ export function filterPinnedRepositories<
     filtered = filtered.filter((repository) => keys.has(pinnedRepositoryKey(repository)));
   }
   return filtered;
+}
+
+/**
+ * Whether the pin already excludes every repository a provider could offer, so
+ * that provider's catalog cannot change what this run selects. Derived from the
+ * same intersection filter, so it can never drift from it. The provider narrowing
+ * in pre-sandbox/steps/repo-selection.ts keeps a provider-pinned run from even
+ * querying an excluded provider; this answers the case that narrowing leaves
+ * behind, a pin that names repositories without naming providers, where every
+ * provider is still queried but only the named ones can survive the filter.
+ */
+export function pinnedScopeExcludesProvider(
+  scope: WorkflowRepositoryScope | undefined,
+  provider: VcsProvider,
+): boolean {
+  const providers = scope?.providers ?? [];
+  const pinned = scope?.repositories ?? [];
+  if (providers.length === 0 && pinned.length === 0) return false;
+  if (pinned.length > 0) {
+    return !filterPinnedRepositories(pinned, scope).some(
+      (repository) => repository.provider === provider,
+    );
+  }
+  return !providers.includes(provider);
 }
 
 /** Whether one repository identity survives the pin. Derived from the filter so
@@ -130,12 +250,18 @@ class GitLabRepositoryDirectory implements RepositoryDirectory {
         signal: AbortSignal.timeout(GITLAB_PROJECTS_TIMEOUT_MS),
       }).catch((err) => {
         if (isAbortError(err)) {
-          throw new Error(`GitLab projects list timed out after ${GITLAB_PROJECTS_TIMEOUT_MS}ms`);
+          throw new RepositoryListingError(
+            `GitLab projects list timed out after ${GITLAB_PROJECTS_TIMEOUT_MS}ms`,
+            { timedOut: true },
+          );
         }
         throw err;
       });
       if (!response.ok) {
-        throw new Error(`GitLab projects list failed: ${response.status} ${response.statusText}`);
+        throw new RepositoryListingError(
+          `GitLab projects list failed: ${response.status} ${response.statusText}`,
+          { status: response.status },
+        );
       }
 
       projects.push(...await response.json());

--- a/apps/worker/src/pre-sandbox/runner.test.ts
+++ b/apps/worker/src/pre-sandbox/runner.test.ts
@@ -115,6 +115,52 @@ describe("executePreSandboxPhase", () => {
     expect(result.selectedRepositories).toEqual(selectedRepositories);
   });
 
+  it("carries a catalog degradation from a continuing and from a halting step", async () => {
+    const repositoryCatalogDegradation = {
+      providers: ["gitlab" as const],
+      outcome: "continued_degraded" as const,
+    };
+    const continued = await executePreSandboxPhase(
+      input,
+      config([{ uses: "select", onFailure: "fail" }]),
+      {
+        select: vi.fn(async () => ({
+          status: "continue" as const,
+          repositoryCatalogDegradation,
+        })),
+      },
+    );
+
+    expect(continued.repositoryCatalogDegradation).toEqual(
+      repositoryCatalogDegradation,
+    );
+
+    const halted = await executePreSandboxPhase(
+      input,
+      config([{ uses: "select", onFailure: "fail" }]),
+      {
+        select: vi.fn(async () => ({
+          status: "halt" as const,
+          outcome: "failed" as const,
+          message: "gitlab catalog incomplete",
+          repositoryCatalogDegradation: {
+            providers: ["gitlab" as const],
+            outcome: "failed_closed" as const,
+          },
+        })),
+      },
+    );
+
+    expect(halted).toMatchObject({
+      status: "halt",
+      outcome: "failed",
+      repositoryCatalogDegradation: {
+        providers: ["gitlab"],
+        outcome: "failed_closed",
+      },
+    });
+  });
+
   it("preserves selected repositories when a later step is not registered", async () => {
     const selectedRepositories = [
       {

--- a/apps/worker/src/pre-sandbox/runner.ts
+++ b/apps/worker/src/pre-sandbox/runner.ts
@@ -37,6 +37,7 @@ export async function executePreSandboxPhase(
   let selectedRepositories: RunPreSandboxPhaseResult["selectedRepositories"];
   let repositoryDiscovery: RunPreSandboxPhaseResult["repositoryDiscovery"];
   let repositoryScopeNarrowing: RunPreSandboxPhaseResult["repositoryScopeNarrowing"];
+  let repositoryCatalogDegradation: RunPreSandboxPhaseResult["repositoryCatalogDegradation"];
 
   for (const step of config.preSandbox.steps) {
     const handler = registry[step.uses];
@@ -78,6 +79,9 @@ export async function executePreSandboxPhase(
       if (result.repositoryScopeNarrowing) {
         repositoryScopeNarrowing = result.repositoryScopeNarrowing;
       }
+      if (result.repositoryCatalogDegradation) {
+        repositoryCatalogDegradation = result.repositoryCatalogDegradation;
+      }
 
       if (result.status === "halt") {
         return {
@@ -89,6 +93,7 @@ export async function executePreSandboxPhase(
           selectedRepositories,
           repositoryDiscovery,
           repositoryScopeNarrowing,
+          repositoryCatalogDegradation,
         };
       }
     } catch (err) {
@@ -114,6 +119,7 @@ export async function executePreSandboxPhase(
     selectedRepositories,
     repositoryDiscovery,
     repositoryScopeNarrowing,
+    repositoryCatalogDegradation,
   };
 }
 

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
@@ -1,11 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { RepositoryMetadata } from "../../adapters/vcs/repository-directory.js";
+import type {
+  RepositoryListingFailure,
+  RepositoryMetadata,
+} from "../../adapters/vcs/repository-directory.js";
 
 const mocks = vi.hoisted(() => {
   const listRepositories = vi.fn();
   return {
     listRepositories,
-    createRepositoryDirectoryForProviders: vi.fn(() => ({ listRepositories })),
+    // Every provider answers unless a test says otherwise, so listRepositories
+    // stays the one knob for the catalog.
+    listRepositoriesAcrossProviders: vi.fn(
+      async (): Promise<{
+        repositories: RepositoryMetadata[];
+        failures: RepositoryListingFailure[];
+      }> => ({
+        repositories: await listRepositories(),
+        failures: [],
+      }),
+    ),
     getConfiguredVcsProviders: vi.fn(),
     getDb: vi.fn(),
     listWorkflowOwnedBranchesForTicket: vi.fn(),
@@ -18,10 +31,7 @@ vi.mock("../../adapters/vcs/repository-directory.js", async (importOriginal) => 
   ...(await importOriginal<
     typeof import("../../adapters/vcs/repository-directory.js")
   >()),
-  createRepositoryDirectory: vi.fn(() => ({
-    listRepositories: mocks.listRepositories,
-  })),
-  createRepositoryDirectoryForProviders: mocks.createRepositoryDirectoryForProviders,
+  listRepositoriesAcrossProviders: mocks.listRepositoriesAcrossProviders,
 }));
 
 vi.mock("../../../env.js", () => ({
@@ -521,6 +531,133 @@ describe("selectRepositoriesFromMetadata", () => {
     expect(unpinned.status).toBe("discovery_needed");
   });
 
+  it("resolves an incomplete catalog from an exact ticket mention", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Change the billing callback in acme/api.",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      incompleteCatalogProviders: ["gitlab"],
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories).toEqual([
+      expect.objectContaining({
+        repoPath: "acme/api",
+        selectedRationale: "ticket mentions repository path",
+      }),
+    ]);
+  });
+
+  it("resolves an incomplete catalog from this ticket's workflow-owned branch", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Address review feedback",
+      repositories: repos,
+      workflowOwnedBranches: [
+        {
+          provider: "github",
+          repoPath: "acme/web",
+          branch: { branchName: "blazebot/aiw-45" },
+        },
+      ],
+      incompleteCatalogProviders: ["gitlab"],
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories).toEqual([
+      expect.objectContaining({
+        repoPath: "acme/web",
+        selectedRationale: "workflow-owned branch for this ticket",
+      }),
+    ]);
+  });
+
+  it("never hands an incomplete catalog to model discovery", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      incompleteCatalogProviders: ["gitlab"],
+    });
+
+    expect(selected).toEqual({
+      status: "catalog_incomplete",
+      providers: ["gitlab"],
+    });
+  });
+
+  // "Only accessible repository" is a claim about the whole catalog, and a partial
+  // listing cannot support it.
+  it("never calls the survivor of an incomplete catalog the only accessible repository", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Update copy",
+      repositories: [repos[0]],
+      workflowOwnedBranches: [],
+      incompleteCatalogProviders: ["gitlab"],
+    });
+
+    expect(selected).toEqual({
+      status: "catalog_incomplete",
+      providers: ["gitlab"],
+    });
+  });
+
+  it("never asks a human to choose from an incomplete catalog", () => {
+    const many = Array.from({ length: 4 }, (_, index) => ({
+      ...repos[0],
+      repoPath: `acme/repo-${index}`,
+      name: `repo-${index}`,
+    }));
+
+    expect(
+      selectRepositoriesFromMetadata({
+        ticketText: many.map((repo) => repo.repoPath).join(" "),
+        repositories: many,
+        workflowOwnedBranches: [],
+        incompleteCatalogProviders: ["gitlab"],
+      }),
+    ).toEqual({ status: "catalog_incomplete", providers: ["gitlab"] });
+
+    expect(
+      selectRepositoriesFromMetadata({
+        ticketText: "Update copy",
+        repositories: repos,
+        workflowOwnedBranches: [],
+        repositoryScope: {
+          repositories: [{ provider: "gitlab", repoPath: "acme/billing" }],
+        },
+        incompleteCatalogProviders: ["gitlab"],
+      }),
+    ).toEqual({ status: "catalog_incomplete", providers: ["gitlab"] });
+  });
+
+  // Invariant: a healthy listing must leave every existing path byte for byte intact.
+  it("keeps every path identical when no provider is missing", () => {
+    const cases = [
+      { ticketText: "Fix billing webhook retry behavior", repositories: repos },
+      { ticketText: "Change the billing callback in acme/api.", repositories: repos },
+      { ticketText: "Update copy", repositories: [repos[0]] },
+    ];
+
+    for (const { ticketText, repositories } of cases) {
+      expect(
+        selectRepositoriesFromMetadata({
+          ticketText,
+          repositories,
+          workflowOwnedBranches: [],
+          incompleteCatalogProviders: [],
+        }),
+      ).toEqual(
+        selectRepositoriesFromMetadata({
+          ticketText,
+          repositories,
+          workflowOwnedBranches: [],
+        }),
+      );
+    }
+  });
+
   it("selects the single usable repository regardless of archived catalog volume", () => {
     const archived = Array.from(
       { length: MAX_ACCESSIBLE_REPOSITORIES + 1 },
@@ -634,7 +771,7 @@ describe("repoSelectionStep", () => {
       step: { uses: "repo-selection", onFailure: "fail" },
     });
 
-    expect(mocks.createRepositoryDirectoryForProviders).toHaveBeenCalledWith([
+    expect(mocks.listRepositoriesAcrossProviders).toHaveBeenCalledWith([
       expect.objectContaining({ kind: "gitlab" }),
     ]);
     expect(result.selectedRepositories).toEqual([
@@ -668,7 +805,7 @@ describe("repoSelectionStep", () => {
       step: { uses: "repo-selection", onFailure: "fail" },
     });
 
-    expect(mocks.createRepositoryDirectoryForProviders).toHaveBeenCalledWith([
+    expect(mocks.listRepositoriesAcrossProviders).toHaveBeenCalledWith([
       expect.objectContaining({ kind: "github" }),
       expect.objectContaining({ kind: "gitlab" }),
     ]);
@@ -687,7 +824,7 @@ describe("repoSelectionStep", () => {
       step: { uses: "repo-selection", onFailure: "fail" },
     });
 
-    expect(mocks.createRepositoryDirectoryForProviders).toHaveBeenCalledWith([
+    expect(mocks.listRepositoriesAcrossProviders).toHaveBeenCalledWith([
       expect.objectContaining({ kind: "github" }),
       expect.objectContaining({ kind: "gitlab" }),
     ]);
@@ -740,5 +877,193 @@ describe("repoSelectionStep", () => {
         workflowOwnedBranch: expect.objectContaining({ branchName: "blazebot/aiw-45" }),
       }),
     ]);
+  });
+});
+
+describe("repoSelectionStep with a provider that never answered", () => {
+  const timedOutGitLab: RepositoryListingFailure = {
+    provider: "gitlab",
+    message: "GitLab projects list timed out after 15000ms",
+    error: new Error("GitLab projects list timed out after 15000ms"),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDb.mockReturnValue({ db: true });
+    mocks.listWorkflowOwnedBranchesForTicket.mockResolvedValue([]);
+    mocks.getConfiguredVcsProviders.mockReturnValue([
+      {
+        kind: "github",
+        auth: { appId: 1, privateKeyBase64: "pem", installationId: 2 },
+        host: "https://github.com",
+        legacyBaseBranch: "main",
+      },
+      {
+        kind: "gitlab",
+        token: "glpat",
+        host: "https://gitlab.example.com",
+        legacyBaseBranch: "main",
+      },
+    ]);
+  });
+
+  it("continues on a deterministic ticket mention and records the degradation", async () => {
+    mocks.listRepositoriesAcrossProviders.mockResolvedValueOnce({
+      repositories: repos,
+      failures: [timedOutGitLab],
+    });
+
+    const result = await repoSelectionStep({
+      context: {
+        ticket: {
+          identifier: "AIW-45",
+          title: "Fix the billing callback in acme/api",
+        },
+        run: { branchName: "blazebot/aiw-45" },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", onFailure: "fail" },
+    });
+
+    expect(result.status).toBe("continue");
+    expect(result.selectedRepositories).toEqual([
+      expect.objectContaining({
+        provider: "github",
+        repoPath: "acme/api",
+        selectedRationale: "ticket mentions repository path",
+      }),
+    ]);
+    expect(result.repositoryCatalogDegradation).toEqual({
+      providers: ["gitlab"],
+      outcome: "continued_degraded",
+    });
+  });
+
+  it("fails closed and names the provider when no deterministic signal survives", async () => {
+    mocks.listRepositoriesAcrossProviders.mockResolvedValueOnce({
+      repositories: repos,
+      failures: [timedOutGitLab],
+    });
+
+    const result = await repoSelectionStep({
+      context: {
+        ticket: { identifier: "AIW-45", title: "Fix billing webhook retry behavior" },
+        run: { branchName: "blazebot/aiw-45" },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", name: "Select repositories", onFailure: "fail" },
+    });
+
+    expect(result).toMatchObject({
+      status: "halt",
+      outcome: "failed",
+      repositoryCatalogDegradation: {
+        providers: ["gitlab"],
+        outcome: "failed_closed",
+      },
+    });
+    if (result.status !== "halt") throw new Error("expected halt");
+    // Operators grep the run reason by step name, so a step that stops itself must
+    // still say which step it was.
+    expect(result.message).toContain("Select repositories failed:");
+    expect(result.message).toContain("gitlab");
+    expect(result.message).toContain("incomplete");
+    expect(result.message).toContain("GitLab projects list timed out after 15000ms");
+    expect(result.selectedRepositories).toBeUndefined();
+    expect(result.repositoryDiscovery).toBeUndefined();
+    expect(result.questions).toBeUndefined();
+  });
+
+  it("continues normally when the pin already excluded the failed provider", async () => {
+    mocks.listRepositoriesAcrossProviders.mockResolvedValueOnce({
+      repositories: repos,
+      failures: [timedOutGitLab],
+    });
+
+    const result = await repoSelectionStep({
+      context: {
+        ticket: { identifier: "AIW-45", title: "Update copy" },
+        run: { branchName: "blazebot/aiw-45" },
+        // No provider list, so GitLab is still queried, but nothing it could have
+        // returned survives this pin.
+        repositoryScope: {
+          repositories: [{ provider: "github", repoPath: "acme/api" }],
+        },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", onFailure: "fail" },
+    });
+
+    expect(result.status).toBe("continue");
+    expect(result.selectedRepositories).toEqual([
+      expect.objectContaining({
+        provider: "github",
+        repoPath: "acme/api",
+        selectedRationale: "pinned to this workflow",
+      }),
+    ]);
+    expect(result.repositoryCatalogDegradation).toEqual({
+      providers: ["gitlab"],
+      outcome: "continued_degraded",
+    });
+  });
+
+  // The provider is queried past the pin precisely so an in-flight pull request is
+  // not stranded, so its silence is never harmless.
+  it("fails closed when the failed provider carries this ticket's workflow-owned branch", async () => {
+    mocks.listRepositoriesAcrossProviders.mockResolvedValueOnce({
+      repositories: repos,
+      failures: [timedOutGitLab],
+    });
+    mocks.listWorkflowOwnedBranchesForTicket.mockResolvedValue([
+      {
+        ticketKey: "AIW-45",
+        provider: "gitlab",
+        repoPath: "acme/api",
+        branchName: "blazebot/aiw-45",
+        pr: null,
+      },
+    ]);
+
+    const result = await repoSelectionStep({
+      context: {
+        ticket: { identifier: "AIW-45", title: "Address review feedback" },
+        run: { branchName: "blazebot/aiw-45" },
+        repositoryScope: { providers: ["github"] },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", onFailure: "fail" },
+    });
+
+    expect(result).toMatchObject({
+      status: "halt",
+      outcome: "failed",
+      repositoryCatalogDegradation: {
+        providers: ["gitlab"],
+        outcome: "failed_closed",
+      },
+    });
+  });
+
+  it("records no degradation when every provider answers", async () => {
+    mocks.listRepositories.mockResolvedValueOnce(repos);
+
+    const result = await repoSelectionStep({
+      context: {
+        ticket: {
+          identifier: "AIW-45",
+          title: "Fix the billing callback in acme/api",
+        },
+        run: { branchName: "blazebot/aiw-45" },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", onFailure: "fail" },
+    });
+
+    expect(result.status).toBe("continue");
+    expect(result.selectedRepositories).toEqual([
+      expect.objectContaining({ provider: "github", repoPath: "acme/api" }),
+    ]);
+    expect(result).not.toHaveProperty("repositoryCatalogDegradation");
   });
 });

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.ts
@@ -1,11 +1,15 @@
 import type { WorkflowRepositoryScope } from "@shared/contracts";
 import {
   filterPinnedRepositories,
+  pinnedScopeExcludesProvider,
+  type RepositoryListingFailure,
   type RepositoryMetadata,
   type SelectedRepository,
   type WorkflowOwnedBranch,
 } from "../../adapters/vcs/repository-directory.js";
 import type {
+  PreSandboxConfigStep,
+  PreSandboxRepositoryCatalogDegradation,
   PreSandboxRepositoryScopeNarrowing,
   PreSandboxStepHandler,
 } from "../types.js";
@@ -21,8 +25,8 @@ export interface WorkflowOwnedBranchSelectionInput {
   branch: WorkflowOwnedBranch;
 }
 
-export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
-  const { createRepositoryDirectoryForProviders } = await import("../../adapters/vcs/repository-directory.js");
+export const repoSelectionStep: PreSandboxStepHandler = async ({ context, step }) => {
+  const { listRepositoriesAcrossProviders } = await import("../../adapters/vcs/repository-directory.js");
   const { getDb } = await import("../../db/client.js");
   const { listWorkflowOwnedBranchesForTicket } = await import("../../db/queries/workflow-owned-branches.js");
   const { getConfiguredVcsProviders } = await import("../../../env.js");
@@ -38,21 +42,47 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
       }))
     : [];
   const repositoryScope = context.repositoryScope;
-  const repositories = await createRepositoryDirectoryForProviders(
+  const listing = await listRepositoriesAcrossProviders(
     listedVcsProviders(
       getConfiguredVcsProviders(),
       repositoryScope,
       workflowOwnedBranches,
     ),
-  ).listRepositories();
+  );
+  const repositories = listing.repositories;
+  const incompleteCatalogProviders = listing.failures
+    .filter(
+      (failure) =>
+        !failedProviderCannotAffectSelection(
+          failure.provider,
+          repositoryScope,
+          workflowOwnedBranches,
+        ),
+    )
+    .map((failure) => failure.provider);
 
   const selected = selectRepositoriesFromMetadata({
     ticketText: ticketText(context.ticket),
     repositories,
     workflowOwnedBranches,
     ...(repositoryScope ? { repositoryScope } : {}),
+    ...(incompleteCatalogProviders.length > 0 ? { incompleteCatalogProviders } : {}),
   });
   const narrowing = scopeNarrowing(repositories, repositoryScope);
+  const degradation = catalogDegradation(
+    listing.failures,
+    selected.status === "catalog_incomplete",
+  );
+
+  if (selected.status === "catalog_incomplete") {
+    return {
+      status: "halt",
+      outcome: "failed",
+      message: incompleteCatalogMessage(step, listing.failures, selected.providers),
+      ...(narrowing ? { repositoryScopeNarrowing: narrowing } : {}),
+      ...(degradation ? { repositoryCatalogDegradation: degradation } : {}),
+    };
+  }
 
   if (selected.status === "clarification_needed") {
     return {
@@ -61,6 +91,7 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
       message: selected.questions[0],
       questions: selected.questions,
       ...(narrowing ? { repositoryScopeNarrowing: narrowing } : {}),
+      ...(degradation ? { repositoryCatalogDegradation: degradation } : {}),
     };
   }
 
@@ -72,6 +103,7 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
         mandatoryRepositories: selected.mandatoryRepositories,
       },
       ...(narrowing ? { repositoryScopeNarrowing: narrowing } : {}),
+      ...(degradation ? { repositoryCatalogDegradation: degradation } : {}),
     };
   }
 
@@ -88,8 +120,61 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context }) => {
       },
     ],
     ...(narrowing ? { repositoryScopeNarrowing: narrowing } : {}),
+    ...(degradation ? { repositoryCatalogDegradation: degradation } : {}),
   };
 };
+
+/**
+ * Whether a provider that failed to answer could not have changed this run's
+ * choice anyway. The definition pin already excludes everything it could have
+ * offered, so the surviving listing is exactly what selection would have seen had
+ * the provider answered, and the run proceeds on its normal path. A provider
+ * carrying a workflow-owned branch for this ticket never qualifies: listedVcsProviders
+ * queries it precisely so an in-flight pull request is not stranded, and treating
+ * its silence as harmless would strand that pull request without saying so.
+ */
+function failedProviderCannotAffectSelection(
+  provider: RepositoryMetadata["provider"],
+  repositoryScope: WorkflowRepositoryScope | undefined,
+  workflowOwnedBranches: WorkflowOwnedBranchSelectionInput[],
+): boolean {
+  if (workflowOwnedBranches.some((branch) => branch.provider === provider)) {
+    return false;
+  }
+  return pinnedScopeExcludesProvider(repositoryScope, provider);
+}
+
+/** Operator-facing telemetry for a provider that never answered, recorded whether
+ *  or not the run survived it. */
+function catalogDegradation(
+  failures: RepositoryListingFailure[],
+  failedClosed: boolean,
+): PreSandboxRepositoryCatalogDegradation | null {
+  if (failures.length === 0) return null;
+  return {
+    providers: failures.map((failure) => failure.provider),
+    outcome: failedClosed ? "failed_closed" : "continued_degraded",
+  };
+}
+
+/** Names the step the way the runner's own failureMessage does, so a run that
+ *  stopped itself here stays greppable by step name exactly like a run whose
+ *  listing threw. */
+function incompleteCatalogMessage(
+  step: PreSandboxConfigStep,
+  failures: RepositoryListingFailure[],
+  providers: RepositoryMetadata["provider"][],
+): string {
+  const reasons = failures
+    .filter((failure) => providers.includes(failure.provider))
+    .map((failure) => `${failure.provider}: ${failure.message}`)
+    .join("; ");
+  return (
+    `${step.name ?? step.uses} failed: repository listing for ${providers.join(", ")} is unavailable (${reasons}), so the repository catalog was incomplete. ` +
+    "No deterministic repository signal resolved the selection, and choosing from a partial catalog could pick the wrong repository. " +
+    "Retry once the provider recovers, or name the repository path in the ticket."
+  );
+}
 
 /**
  * Providers whose listings this run needs. A pin narrows the set so an excluded
@@ -133,6 +218,10 @@ export function selectRepositoriesFromMetadata(input: {
   repositories: RepositoryMetadata[];
   workflowOwnedBranches: WorkflowOwnedBranchSelectionInput[];
   repositoryScope?: WorkflowRepositoryScope;
+  /** Providers whose listing failed after retries and whose repositories could
+   *  still have changed this choice. Absent when every provider answered, which
+   *  keeps a healthy run on exactly its normal path. */
+  incompleteCatalogProviders?: RepositoryMetadata["provider"][];
 }):
   | { status: "selected"; repositories: SelectedRepository[] }
   | {
@@ -140,7 +229,12 @@ export function selectRepositoriesFromMetadata(input: {
       catalog: RepositoryCatalogEntry[];
       mandatoryRepositories: SelectedRepository[];
     }
-  | { status: "clarification_needed"; questions: string[] } {
+  | { status: "clarification_needed"; questions: string[] }
+  | {
+      status: "catalog_incomplete";
+      providers: RepositoryMetadata["provider"][];
+    } {
+  const incompleteCatalogProviders = input.incompleteCatalogProviders ?? [];
   const catalog = buildRepositoryCatalogEntries(input.repositories);
   const usableKeys = new Set(
     catalog.filter((repo) => repo.usable).map((repo) => repositoryKey(repo)),
@@ -187,6 +281,11 @@ export function selectRepositoriesFromMetadata(input: {
     // model discovery would silently replace the operator's explicit choice, and
     // an empty selection would silently resolve the ticket to nothing.
     if (unavailable.length > 0) {
+      // A pinned repository that is missing only because its provider never
+      // answered is not an access problem the operator can fix in the pin.
+      if (incompleteCatalogProviders.length > 0) {
+        return incompleteCatalog(incompleteCatalogProviders);
+      }
       return {
         status: "clarification_needed",
         questions: [
@@ -218,6 +317,9 @@ export function selectRepositoriesFromMetadata(input: {
 
   if (selected.size > 0) {
     if (selected.size > 3) {
+      if (incompleteCatalogProviders.length > 0) {
+        return incompleteCatalog(incompleteCatalogProviders);
+      }
       return {
         status: "clarification_needed",
         questions: [
@@ -226,6 +328,21 @@ export function selectRepositoriesFromMetadata(input: {
       };
     }
     return { status: "selected", repositories: [...selected.values()] };
+  }
+
+  // Degradation stops here on purpose. Every path above resolves the selection
+  // from a signal that does not depend on seeing the whole catalog: a
+  // workflow-owned branch for this ticket, a repository path written in the ticket,
+  // or a pin the surviving listing fully satisfied. The paths below do depend on
+  // it. "Only accessible repository" is a claim about the entire catalog that a
+  // partial listing cannot support, and discovery hands the catalog to the model,
+  // which would then choose from a set silently missing a whole provider. A
+  // clarification is no safer: it presents the same partial catalog to a human as
+  // if it were the full picture. Failing the run names the provider that went
+  // down; the wrong repository is found much later, by a human, after the branch
+  // and pull request already exist.
+  if (incompleteCatalogProviders.length > 0) {
+    return incompleteCatalog(incompleteCatalogProviders);
   }
 
   if (scopedRepositories.length === 1) {
@@ -246,6 +363,12 @@ export function selectRepositoriesFromMetadata(input: {
     ),
     mandatoryRepositories: [...selected.values()],
   };
+}
+
+function incompleteCatalog(
+  providers: RepositoryMetadata["provider"][],
+): { status: "catalog_incomplete"; providers: RepositoryMetadata["provider"][] } {
+  return { status: "catalog_incomplete", providers };
 }
 
 function repositoryKey(repo: Pick<RepositoryMetadata, "provider" | "repoPath">): string {

--- a/apps/worker/src/pre-sandbox/types.ts
+++ b/apps/worker/src/pre-sandbox/types.ts
@@ -1,5 +1,8 @@
 import type { WorkflowRepositoryScope } from "@shared/contracts";
-import type { SelectedRepository } from "../adapters/vcs/repository-directory.js";
+import type {
+  SelectedRepository,
+  VcsProvider,
+} from "../adapters/vcs/repository-directory.js";
 import type { RepositoryCatalogEntry } from "../repository-discovery/catalog.js";
 
 export interface PreSandboxRepositoryDiscovery {
@@ -15,6 +18,13 @@ export interface PreSandboxRepositoryScopeNarrowing {
   catalogSize: number;
   /** Repositories left after the pin narrowed that listing. */
   scopedCatalogSize: number;
+}
+
+/** A provider whose repository listing failed after the bounded retry, and how the
+ *  run responded to the missing catalog. Telemetry only, never a selection input. */
+export interface PreSandboxRepositoryCatalogDegradation {
+  providers: VcsProvider[];
+  outcome: "continued_degraded" | "failed_closed";
 }
 
 export const preSandboxPromptTargets = ["research", "implementation", "review"] as const;
@@ -38,6 +48,7 @@ export type PreSandboxStepResult =
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
       repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
+      repositoryCatalogDegradation?: PreSandboxRepositoryCatalogDegradation;
     }
   | {
       status: "halt";
@@ -48,6 +59,7 @@ export type PreSandboxStepResult =
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
       repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
+      repositoryCatalogDegradation?: PreSandboxRepositoryCatalogDegradation;
     };
 
 export const preSandboxTicketInputFields = [
@@ -117,6 +129,7 @@ export type RunPreSandboxPhaseResult =
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
       repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
+      repositoryCatalogDegradation?: PreSandboxRepositoryCatalogDegradation;
     }
   | {
       status: "halt";
@@ -127,4 +140,5 @@ export type RunPreSandboxPhaseResult =
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
       repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
+      repositoryCatalogDegradation?: PreSandboxRepositoryCatalogDegradation;
     };

--- a/apps/worker/src/run-observability/agent-observations.ts
+++ b/apps/worker/src/run-observability/agent-observations.ts
@@ -72,6 +72,16 @@ export type RepositoryWorkflowObservation =
       reason: "scope_validation_failed";
     }
   | {
+      /** A provider's repository listing failed after the bounded retry, so the
+       *  catalog selection saw was incomplete. */
+      event: "catalog_degraded";
+      providers: Array<"github" | "gitlab">;
+      /** continued_degraded means a deterministic signal resolved the selection
+       *  without the missing catalog; failed_closed means the run stopped rather
+       *  than choose from a partial one. */
+      outcome: "continued_degraded" | "failed_closed";
+    }
+  | {
       event: "publication";
       prCount: number;
     };

--- a/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
@@ -1095,6 +1095,43 @@ describe("prepare_workspace execute", () => {
     });
   });
 
+  it("records a catalog degradation that failed the run closed", async () => {
+    const emit = vi.fn();
+    mocks.runPreSandboxPhase.mockResolvedValue({
+      status: "halt",
+      outcome: "failed",
+      message: "Repository listing failed for gitlab",
+      promptAdditions: { research: [], implementation: [], review: [] },
+      repositoryCatalogDegradation: {
+        providers: ["gitlab"],
+        outcome: "failed_closed",
+      },
+    });
+
+    const result = await execute(
+      makeNode("prepare_workspace"),
+      {},
+      makeCtx({ sandboxId: null }),
+      {},
+      { observations: { emit } },
+    );
+
+    expect(emit).toHaveBeenCalledWith({
+      kind: "metadata",
+      value: {
+        repositoryWorkflow: {
+          event: "catalog_degraded",
+          providers: ["gitlab"],
+          outcome: "failed_closed",
+        },
+      },
+    });
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("Repository listing failed for gitlab");
+    }
+  });
+
   it("prepares a review-only human PR without creating a workflow branch", async () => {
     const pr = makePrPayload();
     const reviewRepo: SelectedRepository = {

--- a/apps/worker/src/workflows/blocks/prepare-workspace.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.ts
@@ -26,6 +26,7 @@ import {
 import type { BlockExecutionContext } from "../../workflow-definition/interpreter.js";
 import type { ResolvedHarnessRuntime } from "../../sandbox/harness-runtime.js";
 import type {
+  PreSandboxRepositoryCatalogDegradation,
   PreSandboxRepositoryDiscovery,
   PreSandboxRepositoryScopeNarrowing,
 } from "../../pre-sandbox/types.js";
@@ -62,6 +63,7 @@ type PreSandboxOutcome =
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
       repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
+      repositoryCatalogDegradation?: PreSandboxRepositoryCatalogDegradation;
     }
   | {
       status: "halt";
@@ -72,6 +74,7 @@ type PreSandboxOutcome =
       selectedRepositories?: SelectedRepository[];
       repositoryDiscovery?: PreSandboxRepositoryDiscovery;
       repositoryScopeNarrowing?: PreSandboxRepositoryScopeNarrowing;
+      repositoryCatalogDegradation?: PreSandboxRepositoryCatalogDegradation;
     };
 
 async function blockPrepareWorkspacePreSandboxStep(
@@ -655,6 +658,15 @@ export async function ensureWorkspace(
       });
       if (preSandbox.repositoryScopeNarrowing) {
         ctx.repositoryScopeNarrowing = preSandbox.repositoryScopeNarrowing;
+      }
+      // Emitted before the halt below returns, so a run that failed closed on an
+      // incomplete catalog still tells an operator which provider was missing.
+      if (preSandbox.repositoryCatalogDegradation) {
+        await emitRepositoryWorkflowObservation(execution?.observations, {
+          event: "catalog_degraded",
+          providers: preSandbox.repositoryCatalogDegradation.providers,
+          outcome: preSandbox.repositoryCatalogDegradation.outcome,
+        });
       }
       if (preSandbox.status === "halt") {
         if (preSandbox.outcome === "needs_clarification") {


### PR DESCRIPTION
## Why

`gitlab.com` went degraded this evening: unauthenticated probes returned HTTP 503 after 0.2s, 6.6s and 7.8s. Two consecutive production runs for a ticket whose work lives entirely in a **GitHub** repository then died in pre-sandbox:

```
pre-sandbox: Pre-sandbox step "Select repositories" failed:
GitLab projects list timed out after 15000ms
```

Repository listing fans out across every configured provider and any single rejection failed the whole selection step, so one provider's bad ten minutes took down the entire instance, including work that had nothing to do with that provider. The only mitigation available at the time was detaching the GitLab credential from production.

## What changed

**Bounded retry.** Provider listings go through `listRepositoriesWithRetry`: two attempts, 500ms apart, and only for timeouts and HTTP 5xx. A 401 or 403 is never retried, because a bad credential is not transient and retrying it only burns the step's time budget. GitLab now raises an error carrying `status`/`timedOut` so the classification is explicit rather than string-matched; the messages themselves are byte-identical to before.

**Safe degradation, deliberately narrow.** `listRepositoriesAcrossProviders` returns `{ repositories, failures }` and the selection step continues without a failed provider **only when the choice does not need that provider's catalog**:

- this ticket already has a workflow-owned branch in a surviving provider, or
- the ticket text deterministically names a repository path that exists in the surviving catalog, or
- the workflow's pin is fully satisfied by what survived.

Everything else fails closed exactly as before: model-driven discovery, the "only accessible repository" shortcut, the pinned-repository-unavailable clarification, and the more-than-three-matches clarification. A partial catalog must never reach the model or a human as if it were complete, because both would then choose from a list that is silently missing half the world. That is the one rule the whole change hangs on, and it is stated in a comment at the gate.

A pinned workflow was already immune where the pin excludes the failed provider, since that provider is never queried. One deliberate exception: a provider carrying an in-flight workflow-owned branch stays in the query set even when the pin excludes it, and if its listing fails the run fails closed rather than silently abandoning that branch's open pull request.

**Observability.** A new `catalog_degraded` observation records which providers failed and whether the run continued degraded or failed closed, emitted on both paths. The failure message now names the provider, states the catalog was incomplete, and says what to do:

```
pre-sandbox: Select repositories failed: repository listing for gitlab is unavailable
(gitlab: GitLab projects list timed out after 15000ms), so the repository catalog was
incomplete. No deterministic repository signal resolved the selection, and choosing from
a partial catalog could pick the wrong repository. Retry once the provider recovers, or
name the repository path in the ticket.
```

## Cost, stated plainly

The retry doubles the worst case for every multi-provider caller, including the dashboard catalog endpoint: about 30.5s instead of 15s against a hung provider, and `allSettled` makes the slowest provider the floor. Pre-sandbox has a 60s step budget, and the editor already degrades to manual repository entry when the catalog fetch fails. This is documented at the fan-out for whoever tunes the timeout next.

One behavior change worth calling out: the fail-closed path now stops the step with a structured result instead of throwing, so the degradation can be recorded on that path too. The consequence is that this particular failure no longer honors the deprecated `pre-sandbox.yaml` `onFailure` override, whose shipped default is `fail` anyway.

## Verification

- `apps/worker`: 250 files, **3202 tests, 0 failures**, first run.
- `pnpm --filter worker typecheck`: exit 0. Both workflow bundle guards green.
- RED proofs: with the baseline files restored, 19 tests fail, including both required cases (a deterministic ticket mention carrying the run through a provider outage, and a fail-closed run naming the provider when no deterministic signal survives) and the retry policy tests (retries a 5xx, does not retry a 401).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Repository discovery now retries temporary provider failures and combines results from providers that respond successfully.
  * Runs can continue with clear degraded-status information when repository data is incomplete but selection remains reliable.
  * Runs now fail safely instead of selecting from an incomplete repository catalog when reliable selection is not possible.

* **Observability**
  * Added workflow reporting for unavailable providers, including whether execution continued with degraded data or stopped safely.
  * Failure details now include the affected provider and underlying listing error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->