### PR TITLE
feat(dashboard): move source scope into modal

### DIFF
--- a/apps/dashboard/components/cockpit/flow-editor/flow-editor-validation.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/flow-editor-validation.test.tsx
@@ -11,7 +11,6 @@ import type { FlowNodeDef } from "@/lib/flows";
 import type { WorkflowValidationState } from "@/lib/workflow-editor/validation-controller";
 import { FlowEditor } from "./flow-editor";
 import { RepositoryCatalogProvider } from "./repository-catalog-context";
-import { MAX_PINNED_REPOSITORIES } from "@/lib/workflow-editor/repository-scope";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
@@ -621,19 +620,18 @@ test("the repository scope bar sits directly under the execution limits bar", ()
     true,
   );
 
-  assert.match(html, /Execution limits[\s\S]*Repositories/);
-  assert.match(html, /Pinned for every ticket/);
-  assert.match(html, /Blazity\/ai-workflow/);
-  assert.match(html, new RegExp(`1 / ${MAX_PINNED_REPOSITORIES}`));
-  assert.match(html, /\+ Add repository/);
+  assert.match(html, /Execution limits[\s\S]*Source scope/);
+  assert.match(html, /Providers &amp; repositories/);
+  assert.match(html, />1 repository</);
+  assert.match(html, /aria-haspopup="dialog"[^>]*>Configure/);
 });
 
 test("an unpinned workflow renders the bar without implying a binding", () => {
   const html = renderEditorWithRepositoryPin({}, true);
 
-  assert.match(html, /No repository pinned/);
-  assert.match(html, new RegExp(`0 / ${MAX_PINNED_REPOSITORIES}`));
-  assert.doesNotMatch(html, /inherits/);
+  assert.match(html, /Automatic provider/);
+  assert.match(html, /Automatic per ticket/);
+  assert.doesNotMatch(html, /Needs attention/);
 });
 
 test("a read-only editor disables the repository scope controls", () => {
@@ -642,8 +640,6 @@ test("a read-only editor disables the repository scope controls", () => {
     false,
   );
 
-  assert.match(html, /disabled=""[^>]*aria-label="Remove Blazity\/ai-workflow"/);
-  assert.match(html, /disabled=""[^>]*>\+ Add repository/);
-  assert.match(html, /aria-pressed="false" disabled=""[^>]*>GitHub/);
-  assert.match(html, /aria-pressed="false" disabled=""[^>]*>GitLab/);
+  assert.match(html, /aria-haspopup="dialog" disabled=""[^>]*>Configure/);
+  assert.doesNotMatch(html, /role="dialog"/);
 });

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
@@ -12,25 +12,23 @@ import type {
   RepositoryOption,
   WorkflowRepositoryScope,
 } from "@shared/contracts";
-import {
-  RepositoryScopeBar,
-  RepositoryScopePicker,
-} from "./repository-scope-bar";
+import { Listbox } from "@/components/cockpit/listbox";
+import { MAX_PINNED_REPOSITORIES } from "@/lib/workflow-editor/repository-scope";
 import {
   RepositoryCatalogProvider,
   type RepositoryCatalogStatus,
 } from "./repository-catalog-context";
-import { Listbox } from "@/components/cockpit/listbox";
-import {
-  MAX_PINNED_REPOSITORIES,
-  type PinnedRepository,
-} from "@/lib/workflow-editor/repository-scope";
+import { RepositoryScopeBar } from "./repository-scope-bar";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
 
-function gh(repoPath: string, defaultBranch = "main", archived = false): RepositoryOption {
+function gh(
+  repoPath: string,
+  defaultBranch = "main",
+  archived = false,
+): RepositoryOption {
   const [owner, ...rest] = repoPath.split("/");
   return {
     provider: "github",
@@ -73,16 +71,11 @@ function nodeText(node: ReactTestInstance): string {
 
 function byAriaLabel(root: ReactTestInstance, label: string): ReactTestInstance {
   const matches = root.findAll(
-    (node) => typeof node.type === "string" && node.props["aria-label"] === label,
+    (node) =>
+      typeof node.type === "string" && node.props["aria-label"] === label,
   );
   assert.equal(matches.length, 1, `expected exactly one element labelled ${label}`);
   return matches[0];
-}
-
-function hasAriaLabel(root: ReactTestInstance, label: string): boolean {
-  return root.findAll(
-    (node) => typeof node.type === "string" && node.props["aria-label"] === label,
-  ).length > 0;
 }
 
 function buttonWithText(root: ReactTestInstance, text: string): ReactTestInstance {
@@ -93,143 +86,14 @@ function buttonWithText(root: ReactTestInstance, text: string): ReactTestInstanc
   return matches[0];
 }
 
-interface PickerConfig {
+interface BarConfig {
   scope?: WorkflowRepositoryScope;
   canEdit?: boolean;
   status?: RepositoryCatalogStatus;
   repositories?: RepositoryOption[];
 }
 
-async function mountPicker(config: PickerConfig = {}) {
-  const {
-    scope = {},
-    canEdit = true,
-    status = "ready" as RepositoryCatalogStatus,
-    repositories = CATALOG,
-  } = config;
-  const added: PinnedRepository[][] = [];
-  const closes: number[] = [];
-  const element = (open: boolean) => (
-    <RepositoryCatalogProvider initial={{ status, repositories }}>
-      <RepositoryScopePicker
-        id="test-picker"
-        open={open}
-        scope={scope}
-        canEdit={canEdit}
-        onAdd={(repos) => added.push(repos)}
-        onClose={() => closes.push(1)}
-      />
-    </RepositoryCatalogProvider>
-  );
-  let renderer!: ReactTestRenderer;
-  await act(async () => {
-    renderer = create(element(true));
-  });
-  const root = () => renderer.root;
-  return {
-    renderer,
-    added,
-    closes,
-    setOpen: async (open: boolean) => {
-      await act(async () => renderer.update(element(open)));
-    },
-    setFilter: async (value: string) => {
-      const input = byAriaLabel(root(), "Filter repositories");
-      await act(async () => input.props.onChange({ target: { value } }));
-    },
-    toggle: async (repoPath: string, checked: boolean) => {
-      const box = byAriaLabel(root(), `Pin ${repoPath}`);
-      await act(async () => box.props.onChange({ target: { checked } }));
-    },
-    checkboxDisabled: (repoPath: string) =>
-      byAriaLabel(root(), `Pin ${repoPath}`).props.disabled === true,
-    typeManualPath: async (value: string) => {
-      const input = byAriaLabel(root(), "Repository path");
-      await act(async () => input.props.onChange({ target: { value } }));
-    },
-    chooseManualProvider: async (provider: string) => {
-      const listbox = root().findByType(Listbox);
-      await act(async () => listbox.props.onChange(provider));
-    },
-    clickManualAdd: async () => {
-      await act(async () => buttonWithText(root(), "Add").props.onClick());
-    },
-    commit: async () => {
-      await act(async () => buttonWithText(root(), "Add").props.onClick());
-    },
-    close: async () => {
-      await act(async () =>
-        byAriaLabel(root(), "Close the repository picker").props.onClick(),
-      );
-    },
-    addLabel: () => nodeText(buttonWithText(root(), "Add")),
-    addDisabled: () => buttonWithText(root(), "Add").props.disabled === true,
-    manualOffered: () => hasAriaLabel(root(), "Repository path"),
-    text: () => nodeText(root().findByType(RepositoryScopePicker)),
-  };
-}
-
-/**
- * Picker over a live-fetching provider, so `Refresh catalog` really replaces the
- * catalog the way it does in the editor.
- */
-async function mountLivePicker(
-  catalogs: RepositoryOption[][],
-  scope: WorkflowRepositoryScope = {},
-) {
-  const queue = [...catalogs];
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (() => {
-    const next = queue.shift();
-    assert.notEqual(next, undefined, "an unexpected extra catalog request was made");
-    return Promise.resolve(Response.json({ repositories: next }));
-  }) as typeof globalThis.fetch;
-
-  const added: PinnedRepository[][] = [];
-  const closes: number[] = [];
-  let renderer!: ReactTestRenderer;
-  await act(async () => {
-    renderer = create(
-      <RepositoryCatalogProvider>
-        <RepositoryScopePicker
-          id="test-picker"
-          open
-          scope={scope}
-          canEdit
-          onAdd={(repos) => added.push(repos)}
-          onClose={() => closes.push(1)}
-        />
-      </RepositoryCatalogProvider>,
-    );
-  });
-  await act(async () => undefined);
-  const root = () => renderer.root;
-  return {
-    added,
-    closes,
-    toggle: async (repoPath: string, checked: boolean) => {
-      const box = byAriaLabel(root(), `Pin ${repoPath}`);
-      await act(async () => box.props.onChange({ target: { checked } }));
-    },
-    refresh: async () => {
-      await act(async () =>
-        buttonWithText(root(), "Refresh catalog").props.onClick(),
-      );
-      await act(async () => undefined);
-    },
-    commit: async () => {
-      await act(async () => buttonWithText(root(), "Add").props.onClick());
-    },
-    addLabel: () => nodeText(buttonWithText(root(), "Add")),
-    addDisabled: () => buttonWithText(root(), "Add").props.disabled === true,
-    unmount: async () => {
-      await act(async () => renderer.unmount());
-      globalThis.fetch = originalFetch;
-    },
-  };
-}
-
-async function mountBar(config: PickerConfig = {}) {
+async function mountBar(config: BarConfig = {}) {
   const {
     scope = {},
     canEdit = true,
@@ -255,390 +119,361 @@ async function mountBar(config: PickerConfig = {}) {
     renderer = create(element());
   });
   const root = () => renderer.root;
-  /** Feed the new scope back in, the way the editor re-renders on a change. */
-  const rerender = async () => {
-    await act(async () => renderer.update(element()));
-  };
   return {
     renderer,
     changes,
     scope: () => current,
-    rerender,
-    removeChip: async (repoPath: string) => {
+    rerender: async () => {
+      await act(async () => renderer.update(element()));
+    },
+    open: async () => {
+      await act(async () =>
+        buttonWithText(root(), "Configure").props.onClick(),
+      );
+    },
+    toggleProvider: async (provider: string) => {
+      await act(async () =>
+        buttonWithText(root(), provider).props.onClick(),
+      );
+    },
+    setFilter: async (value: string) => {
+      await act(async () =>
+        byAriaLabel(root(), "Filter repositories").props.onChange({
+          target: { value },
+        }),
+      );
+    },
+    toggleRepository: async (repoPath: string, checked: boolean) => {
+      await act(async () =>
+        byAriaLabel(root(), `Pin ${repoPath}`).props.onChange({
+          target: { checked },
+        }),
+      );
+    },
+    removeRepository: async (repoPath: string) => {
       await act(async () =>
         byAriaLabel(root(), `Remove ${repoPath}`).props.onClick(),
       );
-      await rerender();
     },
-    toggleProvider: async (label: string) => {
-      await act(async () => buttonWithText(root(), label).props.onClick());
-      await rerender();
+    cancel: async () => {
+      await act(async () => buttonWithText(root(), "Cancel").props.onClick());
     },
-    openPicker: async () => {
+    apply: async () => {
       await act(async () =>
-        buttonWithText(root(), "+ Add repository").props.onClick(),
+        buttonWithText(root(), "Apply scope").props.onClick(),
       );
+      await act(async () => renderer.update(element()));
     },
-    text: () => nodeText(root().findAll((node) => node.type === "div")[0]),
+    text: () => nodeText(root()),
   };
 }
 
-test("a selection made under one filter survives a later filter", async () => {
-  const picker = await mountPicker();
+test("the compact bar opens a dialog without changing the scope", async () => {
+  const bar = await mountBar();
+  const configure = buttonWithText(bar.renderer.root, "Configure");
 
-  await picker.setFilter("prod");
-  await picker.toggle("Blazity/ai-workflow-prod", true);
-  await picker.setFilter("billing");
-  await picker.toggle("acme-group/platform/billing-core", true);
-
-  assert.equal(picker.addLabel(), "Add 2 repositories");
-  await picker.commit();
-
-  assert.deepEqual(picker.added, [
-    [
-      { provider: "github", repoPath: "Blazity/ai-workflow-prod" },
-      { provider: "gitlab", repoPath: "acme-group/platform/billing-core" },
-    ],
-  ]);
-  assert.equal(picker.closes.length, 1);
-  await act(async () => picker.renderer.unmount());
-});
-
-test("an enabled add button never silently does nothing", async () => {
-  const picker = await mountPicker();
-
-  await picker.setFilter("prod");
-  await picker.toggle("Blazity/ai-workflow-prod", true);
-  await picker.setFilter("nothing-matches-this");
-
-  assert.equal(picker.addLabel(), "Add 1 repository");
-  assert.equal(picker.addDisabled(), false);
-  await picker.commit();
-
-  assert.deepEqual(picker.added, [
-    [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
-  ]);
-  await act(async () => picker.renderer.unmount());
-});
-
-test("unchecking a row before committing drops it from the addition", async () => {
-  const picker = await mountPicker();
-
-  await picker.toggle("Blazity/ai-workflow-prod", true);
-  await picker.toggle("Blazity/ai-workflow-demo", true);
-  await picker.toggle("Blazity/ai-workflow-prod", false);
-  await picker.commit();
-
-  assert.deepEqual(picker.added, [
-    [{ provider: "github", repoPath: "Blazity/ai-workflow-demo" }],
-  ]);
-  await act(async () => picker.renderer.unmount());
-});
-
-test("dismissing the picker discards an uncommitted selection", async () => {
-  const picker = await mountPicker();
-
-  await picker.setFilter("prod");
-  await picker.toggle("Blazity/ai-workflow-prod", true);
-  assert.equal(picker.addLabel(), "Add 1 repository");
-
-  await picker.close();
-  await picker.setOpen(false);
-  await picker.setOpen(true);
-
-  assert.equal(picker.addLabel(), "Add repositories");
-  assert.equal(picker.addDisabled(), true);
+  assert.equal(configure.props["aria-haspopup"], "dialog");
   assert.equal(
-    byAriaLabel(picker.renderer.root, "Filter repositories").props.value,
-    "",
+    bar.renderer.root.findAll((node) => node.props.role === "dialog").length,
+    0,
   );
-  assert.deepEqual(picker.added, []);
-  await act(async () => picker.renderer.unmount());
+  await bar.open();
+  assert.equal(
+    bar.renderer.root.findAll((node) => node.props.role === "dialog").length,
+    1,
+  );
+  assert.deepEqual(bar.changes, []);
+  await act(async () => bar.renderer.unmount());
 });
 
-test("the picker refuses to select past the remaining slots", async () => {
-  const pinned = Array.from(
+test("provider edits stay in the modal draft until Apply scope", async () => {
+  const bar = await mountBar();
+
+  await bar.open();
+  await bar.toggleProvider("GitHub");
+  await bar.cancel();
+  assert.deepEqual(bar.changes, []);
+
+  await bar.open();
+  await bar.toggleProvider("GitHub");
+  await bar.apply();
+  assert.deepEqual(bar.changes, [{ providers: ["github"] }]);
+  await act(async () => bar.renderer.unmount());
+});
+
+test("repository choices across filters apply as one scope change", async () => {
+  const bar = await mountBar();
+
+  await bar.open();
+  await bar.setFilter("prod");
+  await bar.toggleRepository("Blazity/ai-workflow-prod", true);
+  await bar.setFilter("billing");
+  await bar.toggleRepository("acme-group/platform/billing-core", true);
+  assert.deepEqual(bar.changes, []);
+  await bar.apply();
+
+  assert.deepEqual(bar.changes, [
+    {
+      repositories: [
+        { provider: "github", repoPath: "Blazity/ai-workflow-prod" },
+        {
+          provider: "gitlab",
+          repoPath: "acme-group/platform/billing-core",
+        },
+      ],
+    },
+  ]);
+  await act(async () => bar.renderer.unmount());
+});
+
+test("catalog checkboxes and selected chips both remove from the draft", async () => {
+  const bar = await mountBar({
+    scope: {
+      repositories: [
+        { provider: "github", repoPath: "Blazity/ai-workflow-prod" },
+        {
+          provider: "gitlab",
+          repoPath: "acme-group/platform/billing-core",
+        },
+      ],
+    },
+  });
+
+  await bar.open();
+  await bar.toggleRepository("Blazity/ai-workflow-prod", false);
+  await bar.removeRepository("acme-group/platform/billing-core");
+  assert.deepEqual(bar.changes, []);
+  await bar.apply();
+  assert.deepEqual(bar.changes, [{}]);
+  await act(async () => bar.renderer.unmount());
+});
+
+test("the modal prevents selecting more than the repository limit", async () => {
+  const repositories = Array.from(
     { length: MAX_PINNED_REPOSITORIES - 1 },
     (_value, index) => ({
       provider: "github" as const,
       repoPath: `Blazity/filler-${index}`,
     }),
   );
-  const picker = await mountPicker({ scope: { repositories: pinned } });
+  const bar = await mountBar({ scope: { repositories } });
 
-  await picker.toggle("Blazity/ai-workflow-prod", true);
-
-  assert.equal(picker.checkboxDisabled("Blazity/ai-workflow-demo"), true);
-  await picker.commit();
-
-  assert.deepEqual(picker.added, [
-    [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
-  ]);
-  await act(async () => picker.renderer.unmount());
-});
-
-test("manual entry pins the exact trimmed path for the chosen provider", async () => {
-  const picker = await mountPicker({ status: "error", repositories: [] });
-
-  await picker.chooseManualProvider("gitlab");
-  await picker.typeManualPath("  acme-group/platform/billing-core  ");
-  await picker.clickManualAdd();
-
-  assert.deepEqual(picker.added, [
-    [{ provider: "gitlab", repoPath: "acme-group/platform/billing-core" }],
-  ]);
-  assert.equal(picker.closes.length, 1);
-  await act(async () => picker.renderer.unmount());
-});
-
-test("manual entry disables its button instead of silently refusing", async () => {
-  const picker = await mountPicker({
-    status: "error",
-    repositories: [],
-    scope: { repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }] },
-  });
-
-  await picker.typeManualPath("   ");
-  assert.equal(picker.addDisabled(), true);
-  await picker.clickManualAdd();
-  assert.deepEqual(picker.added, []);
-
-  // Same provider and path in a different case is the same repository.
-  await picker.typeManualPath("blazity/AI-WORKFLOW-PROD");
+  await bar.open();
+  await bar.toggleRepository("Blazity/ai-workflow-prod", true);
   assert.equal(
-    picker.addDisabled(),
+    byAriaLabel(
+      bar.renderer.root,
+      "Pin Blazity/ai-workflow-demo",
+    ).props.disabled,
     true,
-    "an already-pinned path must not sit under an enabled button",
   );
-  assert.match(picker.text(), /is already pinned for GitHub/);
-  await picker.clickManualAdd();
-  assert.deepEqual(picker.added, []);
-
-  // The same path under the other provider is a different repository.
-  await picker.chooseManualProvider("gitlab");
-  assert.equal(picker.addDisabled(), false);
-  await picker.clickManualAdd();
-  assert.deepEqual(picker.added, [
-    [{ provider: "gitlab", repoPath: "blazity/AI-WORKFLOW-PROD" }],
-  ]);
-
-  await act(async () => picker.renderer.unmount());
+  assert.match(bar.text(), new RegExp(`0 of ${MAX_PINNED_REPOSITORIES} slots left`));
+  await act(async () => bar.renderer.unmount());
 });
 
-test("manual entry states the workspace limit instead of a dead button", async () => {
-  const picker = await mountPicker({
-    status: "error",
-    repositories: [],
-    scope: {
-      repositories: Array.from({ length: MAX_PINNED_REPOSITORIES }, (_value, index) => ({
-        provider: "github" as const,
-        repoPath: `Blazity/filler-${index}`,
-      })),
+test("manual fallback updates only the draft with a trimmed exact path", async () => {
+  const bar = await mountBar({ status: "error", repositories: [] });
+
+  await bar.open();
+  const listbox = bar.renderer.root.findByType(Listbox);
+  await act(async () => listbox.props.onChange("gitlab"));
+  await act(async () =>
+    byAriaLabel(bar.renderer.root, "Repository path").props.onChange({
+      target: { value: "  acme-group/platform/billing-core  " },
+    }),
+  );
+  await act(async () =>
+    buttonWithText(bar.renderer.root, "Add to selection").props.onClick(),
+  );
+  assert.deepEqual(bar.changes, []);
+  await bar.apply();
+
+  assert.deepEqual(bar.changes, [
+    {
+      repositories: [
+        {
+          provider: "gitlab",
+          repoPath: "acme-group/platform/billing-core",
+        },
+      ],
     },
-  });
-
-  await picker.typeManualPath("Blazity/ai-workflow-prod");
-
-  assert.equal(picker.addDisabled(), true);
-  assert.match(picker.text(), new RegExp(`already holds ${MAX_PINNED_REPOSITORIES} repositories`));
-  await picker.clickManualAdd();
-  assert.deepEqual(picker.added, []);
-  await act(async () => picker.renderer.unmount());
+  ]);
+  await act(async () => bar.renderer.unmount());
 });
 
-test("an empty but healthy catalog still offers manual entry", async () => {
-  const picker = await mountPicker({ status: "ready", repositories: [] });
-
-  assert.equal(picker.manualOffered(), true);
-  await picker.typeManualPath("Blazity/ai-workflow-prod");
-  await picker.clickManualAdd();
-
-  assert.deepEqual(picker.added, [
-    [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
-  ]);
-  await act(async () => picker.renderer.unmount());
-});
-
-test("a refresh that retires a checked row leaves no phantom in the count", async () => {
-  const picker = await mountLivePicker([
-    [gh("Blazity/ai-workflow-prod"), gh("Blazity/ai-workflow-demo")],
-    [gh("Blazity/next-enterprise")],
-  ]);
-
-  await picker.toggle("Blazity/ai-workflow-prod", true);
-  assert.equal(picker.addLabel(), "Add 1 repository");
-
-  await picker.refresh();
-
-  assert.equal(
-    picker.addLabel(),
-    "Add repositories",
-    "a row the refreshed catalog no longer offers must not still be counted",
-  );
-  assert.equal(picker.addDisabled(), true);
-  await picker.unmount();
-});
-
-test("a refresh keeps the checked rows that survive it", async () => {
-  const picker = await mountLivePicker([
-    [gh("Blazity/ai-workflow-prod"), gh("Blazity/ai-workflow-demo")],
-    [gh("Blazity/ai-workflow-demo"), gh("Blazity/next-enterprise")],
-  ]);
-
-  await picker.toggle("Blazity/ai-workflow-prod", true);
-  await picker.toggle("Blazity/ai-workflow-demo", true);
-  assert.equal(picker.addLabel(), "Add 2 repositories");
-
-  await picker.refresh();
-
-  assert.equal(picker.addLabel(), "Add 1 repository");
-  await picker.commit();
-
-  assert.deepEqual(picker.added, [
-    [{ provider: "github", repoPath: "Blazity/ai-workflow-demo" }],
-  ]);
-  assert.equal(picker.closes.length, 1);
-  await picker.unmount();
-});
-
-test("removing a chip hands back a scope without that repository", async () => {
+test("provider mismatches are detailed in the modal and clear in its draft", async () => {
   const bar = await mountBar({
     scope: {
       repositories: [
         { provider: "github", repoPath: "Blazity/ai-workflow-prod" },
-        { provider: "gitlab", repoPath: "acme-group/platform/billing-core" },
       ],
+      providers: ["gitlab"],
     },
   });
 
-  await bar.removeChip("Blazity/ai-workflow-prod");
+  assert.match(bar.text(), /Needs attention/);
+  assert.doesNotMatch(bar.text(), /Provider mismatch/);
+  await bar.open();
+  assert.match(bar.text(), /Provider mismatch/);
+  assert.match(bar.text(), /Blazity\/ai-workflow-prod \(GitHub\)/);
+  await bar.toggleProvider("GitHub");
+  assert.doesNotMatch(bar.text(), /Provider mismatch/);
+  await bar.apply();
 
   assert.deepEqual(bar.scope(), {
     repositories: [
-      { provider: "gitlab", repoPath: "acme-group/platform/billing-core" },
+      { provider: "github", repoPath: "Blazity/ai-workflow-prod" },
     ],
-  });
-
-  await bar.removeChip("acme-group/platform/billing-core");
-  assert.deepEqual(bar.scope(), {});
-  await act(async () => bar.renderer.unmount());
-});
-
-test("toggling a provider pill pins it and toggling again clears the key", async () => {
-  const bar = await mountBar();
-
-  await bar.toggleProvider("GitHub");
-  assert.deepEqual(bar.scope(), { providers: ["github"] });
-
-  await bar.toggleProvider("GitLab");
-  assert.deepEqual(bar.scope(), { providers: ["github", "gitlab"] });
-
-  await bar.toggleProvider("GitHub");
-  assert.deepEqual(bar.scope(), { providers: ["gitlab"] });
-
-  await bar.toggleProvider("GitLab");
-  assert.deepEqual(bar.scope(), {});
-  await act(async () => bar.renderer.unmount());
-});
-
-test("a provider pin that excludes a pinned repository is named, not asserted", async () => {
-  const bar = await mountBar({
-    scope: {
-      repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
-      providers: ["gitlab"],
-    },
-  });
-
-  const shown = bar.text();
-  assert.match(shown, /Provider mismatch/);
-  assert.match(shown, /Blazity\/ai-workflow-prod \(GitHub\)/);
-  assert.match(shown, /Deployment rejects this until the two agree/);
-  assert.match(shown, /inherits 1 repo, provider mismatch/);
-  assert.doesNotMatch(shown, /inherits 1 repo, GitLab/);
-  await act(async () => bar.renderer.unmount());
-});
-
-test("adding the excluded provider clears the mismatch", async () => {
-  const bar = await mountBar({
-    scope: {
-      repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
-      providers: ["gitlab"],
-    },
-  });
-
-  await bar.toggleProvider("GitHub");
-
-  assert.deepEqual(bar.scope(), {
-    repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
     providers: ["github", "gitlab"],
   });
-  assert.doesNotMatch(bar.text(), /Provider mismatch/);
-  assert.match(bar.text(), /inherits 1 repo, GitHub \+ GitLab/);
   await act(async () => bar.renderer.unmount());
 });
 
-test("the picker adds through the bar and lands in the scope", async () => {
-  const bar = await mountBar();
+test("read-only mode cannot open the modal", async () => {
+  const bar = await mountBar({ canEdit: false });
+  const configure = buttonWithText(bar.renderer.root, "Configure");
 
-  await bar.openPicker();
-  const box = byAriaLabel(bar.renderer.root, "Pin Blazity/ai-workflow-prod");
-  await act(async () => box.props.onChange({ target: { checked: true } }));
-  await act(async () =>
-    buttonWithText(bar.renderer.root, "Add 1 repository").props.onClick(),
-  );
-
-  assert.deepEqual(bar.scope(), {
-    repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
-  });
-  await act(async () => bar.renderer.unmount());
-});
-
-test("the toggle announces the picker it controls", async () => {
-  const bar = await mountBar();
-  const toggle = () => buttonWithText(bar.renderer.root, "+ Add repository");
-  const controls = toggle().props["aria-controls"];
-
-  assert.equal(typeof controls, "string");
-  assert.notEqual(controls, "");
-  assert.equal(toggle().props["aria-expanded"], false);
-  assert.equal(
-    bar.renderer.root.findAll(
-      (node) => typeof node.type === "string" && node.props.id === controls,
-    ).length,
-    0,
-    "nothing is expanded yet",
-  );
-
-  await bar.openPicker();
-
-  assert.equal(
-    buttonWithText(bar.renderer.root, "Done").props["aria-expanded"],
-    true,
-  );
-  const section = bar.renderer.root.findAll(
-    (node) => typeof node.type === "string" && node.props.id === controls,
-  );
-  assert.equal(section.length, 1, "aria-controls resolves to the opened section");
-  assert.equal(section[0].props["aria-label"], "Add pinned repositories");
-  await act(async () => bar.renderer.unmount());
-});
-
-test("a read-only bar wires no handler at all", async () => {
-  const bar = await mountBar({
-    scope: {
-      repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }],
-      providers: ["github"],
-    },
-    canEdit: false,
-  });
-
-  const remove = byAriaLabel(bar.renderer.root, "Remove Blazity/ai-workflow-prod");
-  const provider = buttonWithText(bar.renderer.root, "GitHub");
-  const add = buttonWithText(bar.renderer.root, "+ Add repository");
-
-  assert.equal(remove.props.disabled, true);
-  assert.equal(provider.props.disabled, true);
-  assert.equal(add.props.disabled, true);
+  assert.equal(configure.props.disabled, true);
+  assert.equal(configure.props.onClick === undefined, false);
   assert.deepEqual(bar.changes, []);
   await act(async () => bar.renderer.unmount());
+});
+
+test("Escape and backdrop dismissal discard the modal draft", async () => {
+  const bar = await mountBar();
+
+  await bar.open();
+  await bar.toggleProvider("GitHub");
+  const backdrop = bar.renderer.root.find(
+    (node) =>
+      node.type === "div" &&
+      typeof node.props.className === "string" &&
+      node.props.className.includes("fixed inset-0"),
+  );
+  await act(async () =>
+    backdrop.props.onKeyDown({ key: "Escape", preventDefault: () => undefined }),
+  );
+  assert.deepEqual(bar.changes, []);
+  assert.equal(
+    bar.renderer.root.findAll((node) => node.props.role === "dialog").length,
+    0,
+  );
+
+  await bar.open();
+  await bar.toggleProvider("GitHub");
+  const reopenedBackdrop = bar.renderer.root.find(
+    (node) =>
+      node.type === "div" &&
+      typeof node.props.className === "string" &&
+      node.props.className.includes("fixed inset-0"),
+  );
+  await act(async () =>
+    reopenedBackdrop.props.onMouseDown({
+      target: reopenedBackdrop,
+      currentTarget: reopenedBackdrop,
+    }),
+  );
+  assert.deepEqual(bar.changes, []);
+  assert.equal(
+    bar.renderer.root.findAll((node) => node.props.role === "dialog").length,
+    0,
+  );
+  await act(async () => bar.renderer.unmount());
+});
+
+test("Tab wraps from the last modal control to the first", async () => {
+  const bar = await mountBar();
+  await bar.open();
+  const backdrop = bar.renderer.root.find(
+    (node) =>
+      node.type === "div" &&
+      typeof node.props.className === "string" &&
+      node.props.className.includes("fixed inset-0"),
+  );
+  let firstFocuses = 0;
+  let prevented = 0;
+  const first = { focus: () => firstFocuses++ };
+  const last = { focus: () => undefined };
+
+  await act(async () =>
+    backdrop.props.onKeyDown({
+      key: "Tab",
+      shiftKey: false,
+      target: last,
+      currentTarget: {
+        querySelectorAll: () => [first, last],
+      },
+      preventDefault: () => prevented++,
+    }),
+  );
+
+  assert.equal(prevented, 1);
+  assert.equal(firstFocuses, 1);
+  await act(async () => bar.renderer.unmount());
+});
+
+test("catalog refresh drops a newly selected repository that disappears", async () => {
+  const originalFetch = globalThis.fetch;
+  const queue = [
+    [gh("Blazity/ai-workflow-prod"), gh("Blazity/ai-workflow-demo")],
+    [gh("Blazity/ai-workflow-demo")],
+  ];
+  globalThis.fetch = (() => {
+    const repositories = queue.shift();
+    assert.notEqual(repositories, undefined);
+    return Promise.resolve(Response.json({ repositories }));
+  }) as typeof globalThis.fetch;
+
+  let current: WorkflowRepositoryScope = {};
+  const changes: WorkflowRepositoryScope[] = [];
+  const element = () => (
+    <RepositoryCatalogProvider>
+      <RepositoryScopeBar
+        scope={current}
+        canEdit
+        onChange={(next) => {
+          current = next;
+          changes.push(next);
+        }}
+      />
+    </RepositoryCatalogProvider>
+  );
+  let renderer!: ReactTestRenderer;
+  try {
+    await act(async () => {
+      renderer = create(element());
+    });
+    await act(async () => undefined);
+    await act(async () =>
+      buttonWithText(renderer.root, "Configure").props.onClick(),
+    );
+    await act(async () =>
+      byAriaLabel(
+        renderer.root,
+        "Pin Blazity/ai-workflow-prod",
+      ).props.onChange({ target: { checked: true } }),
+    );
+    await act(async () =>
+      buttonWithText(renderer.root, "Refresh catalog").props.onClick(),
+    );
+    await act(async () => undefined);
+
+    assert.equal(
+      renderer.root.findAll(
+        (node) =>
+          typeof node.type === "string" &&
+          node.props["aria-label"] === "Remove Blazity/ai-workflow-prod",
+      ).length,
+      0,
+    );
+    await act(async () =>
+      buttonWithText(renderer.root, "Apply scope").props.onClick(),
+    );
+    assert.deepEqual(changes, [{}]);
+  } finally {
+    if (renderer!) {
+      await act(async () => renderer.unmount());
+    }
+    globalThis.fetch = originalFetch;
+  }
 });

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx
@@ -7,27 +7,15 @@ import type {
   RepositoryOption,
   WorkflowRepositoryScope,
 } from "@shared/contracts";
-import {
-  RepositoryScopeBar,
-  RepositoryScopePicker,
-} from "./repository-scope-bar";
+import { MAX_PINNED_REPOSITORIES } from "@/lib/workflow-editor/repository-scope";
 import {
   RepositoryCatalogProvider,
   type RepositoryCatalogStatus,
 } from "./repository-catalog-context";
-import { MAX_PINNED_REPOSITORIES } from "@/lib/workflow-editor/repository-scope";
+import { RepositoryScopeBar } from "./repository-scope-bar";
+import { RepositoryScopeModal } from "./repository-scope-modal";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
-
-/** Visible text only, so assertions never depend on class strings or tag order. */
-function text(html: string): string {
-  return html
-    .replace(/<[^>]*>/g, " ")
-    .replace(/&#x27;/g, "'")
-    .replace(/&amp;/g, "&")
-    .replace(/\s+/g, " ")
-    .trim();
-}
 
 function option(overrides: Partial<RepositoryOption> = {}): RepositoryOption {
   return {
@@ -76,7 +64,7 @@ function renderBar(
   );
 }
 
-function renderPicker(
+function renderModal(
   scope: WorkflowRepositoryScope,
   canEdit = true,
   status: RepositoryCatalogStatus = "ready",
@@ -84,55 +72,31 @@ function renderPicker(
 ): string {
   return renderToStaticMarkup(
     <RepositoryCatalogProvider initial={{ status, repositories }}>
-      <RepositoryScopePicker
-        id="test-picker"
+      <RepositoryScopeModal
         open
         scope={scope}
         canEdit={canEdit}
-        onAdd={() => undefined}
-        onClose={() => undefined}
+        onApply={() => undefined}
+        onCancel={() => undefined}
       />
     </RepositoryCatalogProvider>,
   );
 }
 
-test("an unpinned workflow states that every ticket still resolves its own repository", () => {
+test("an unpinned workflow renders one compact automatic source-scope summary", () => {
   const html = renderBar({});
 
-  assert.match(html, /Repositories/);
-  assert.match(html, /Pinned for every ticket/);
-  assert.match(html, /No repository pinned: every ticket resolves its own/);
-  assert.match(html, new RegExp(`0 / ${MAX_PINNED_REPOSITORIES}`));
-  assert.match(html, /No provider pinned: the run picks the provider itself/);
+  assert.match(html, /Source scope/);
+  assert.match(html, /Providers &amp; repositories/);
+  assert.match(html, /Automatic provider/);
+  assert.match(html, /Automatic per ticket/);
+  assert.match(html, /aria-haspopup="dialog"/);
+  assert.match(html, />Configure</);
+  assert.doesNotMatch(html, /Add repositories/);
+  assert.doesNotMatch(html, /role="dialog"/);
 });
 
-test("a pinned repository shows its provider, default branch, and inherited providers", () => {
-  const html = renderBar({
-    repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow" }],
-  });
-
-  // The chip reads path, then provider, then default branch. The provider is
-  // lowercase in the DOM and uppercased by CSS.
-  assert.match(text(html), /Blazity\/ai-workflow github main/);
-  assert.match(text(html), new RegExp(`1 / ${MAX_PINNED_REPOSITORIES}`));
-  assert.match(html, /aria-label="Remove Blazity\/ai-workflow"/);
-  assert.match(html, /Inherited from the pinned repositories: GitHub\./);
-  assert.match(html, /inherits 1 repo, GitHub/);
-  assert.match(html, /never asks which repository to use/);
-  assert.doesNotMatch(html, /unverified/);
-});
-
-test("a provider-only pin does not claim the run resolves repositories freely", () => {
-  const html = renderBar({ providers: ["github", "gitlab"] });
-
-  assert.match(
-    html,
-    /No repository pinned: every ticket resolves its own within the pinned providers\./,
-  );
-  assert.doesNotMatch(html, /as it does today/);
-});
-
-test("both providers pinned reads as the multi-repo binding", () => {
+test("the compact summary uses equal-height badges for explicit scope", () => {
   const html = renderBar({
     repositories: [
       { provider: "github", repoPath: "Blazity/ai-workflow" },
@@ -141,51 +105,25 @@ test("both providers pinned reads as the multi-repo binding", () => {
     providers: ["github", "gitlab"],
   });
 
-  assert.match(html, /inherits 2 repos, GitHub \+ GitLab/);
-  assert.match(html, /aria-pressed="true"[^>]*>GitHub</);
-  assert.match(html, /aria-pressed="true"[^>]*>GitLab</);
-  assert.match(html, /Both makes a run multi-repo/);
+  assert.match(html, />GitHub</);
+  assert.match(html, />GitLab</);
+  assert.match(html, />2 repositories</);
+  assert.equal((html.match(/inline-flex h-6/g) ?? []).length, 3);
+  assert.match(html, /tabular-nums/);
 });
 
-test("a pinned repository the catalog does not return stays selected with a warning", () => {
+test("the compact summary names attention without expanding detailed warnings", () => {
   const html = renderBar({
     repositories: [{ provider: "github", repoPath: "Blazity/private-thing" }],
   });
 
-  assert.match(html, /Blazity\/private-thing/);
-  assert.match(html, /unverified/);
-  assert.match(html, /The catalog does not list Blazity\/private-thing/);
-  assert.match(html, /kept exactly as saved/);
-  assert.match(html, /outside the server allowlist/);
-  assert.match(html, /cached for 60 seconds/);
-  assert.match(html, /aria-label="Remove Blazity\/private-thing"/);
-});
-
-test("a still-loading catalog never accuses a saved pin of being missing", () => {
-  const html = renderBar(
-    { repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow-prod" }] },
-    true,
-    "loading",
-    [],
-  );
-
-  assert.match(html, /Blazity\/ai-workflow-prod/);
-  assert.match(html, /Checking the pinned repositories against the catalog…/);
-  assert.doesNotMatch(html, /unverified/);
+  assert.match(html, /role="status"/);
+  assert.match(html, /Needs attention/);
+  assert.doesNotMatch(html, /Blazity\/private-thing/);
   assert.doesNotMatch(html, /The catalog does not list/);
 });
 
-test("an archived pin is kept but its reason is stated", () => {
-  const html = renderBar({
-    repositories: [{ provider: "github", repoPath: "Blazity/legacy" }],
-  });
-
-  assert.match(html, /Archived in the provider: Blazity\/legacy/);
-  assert.match(html, /cannot open changes there/);
-  assert.doesNotMatch(html, /unverified/);
-});
-
-test("read-only mode disables every control in the bar", () => {
+test("read-only mode disables the only collapsed control", () => {
   const html = renderBar(
     {
       repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow" }],
@@ -195,124 +133,97 @@ test("read-only mode disables every control in the bar", () => {
   );
 
   const buttons = html.match(/<button[^>]*>/g) ?? [];
-  assert.equal(buttons.length > 0, true);
-  for (const button of buttons) {
-    assert.match(button, /disabled=""/);
-  }
-  assert.match(html, /Blazity\/ai-workflow/);
+  assert.equal(buttons.length, 1);
+  assert.match(buttons[0], /disabled=""/);
+  assert.match(html, />1 repository</);
 });
 
-test("a catalog outage still explains that pins survive and can be entered by path", () => {
-  const html = renderBar({}, true, "error", []);
+test("the modal is named and groups provider and repository controls", () => {
+  const html = renderModal({});
 
-  assert.match(html, /The repository catalog is unavailable/);
-  assert.match(html, /Saved pins are preserved/);
-  assert.match(html, /entered by exact path/);
+  assert.match(html, /role="dialog"/);
+  assert.match(html, /aria-modal="true"/);
+  assert.match(html, /aria-labelledby=/);
+  assert.match(html, /Configure source scope/);
+  assert.match(html, />Providers</);
+  assert.match(html, />Repositories</);
+  assert.match(html, />Cancel</);
+  assert.match(html, />Apply scope</);
+  assert.match(html, /aria-label="Close source scope"/);
 });
 
-test("the picker offers only catalog repositories, with disabled reasons", () => {
-  const html = renderPicker({
+test("the modal shows selected repositories and catalog rows without nesting another picker", () => {
+  const html = renderModal({
     repositories: [{ provider: "gitlab", repoPath: "group/app" }],
   });
 
-  assert.match(html, /aria-label="Add pinned repositories"/);
+  assert.match(html, /aria-label="Selected repositories"/);
+  assert.match(html, /aria-label="Remove group\/app"/);
   assert.match(html, /aria-label="Filter repositories"/);
   assert.match(html, /aria-label="Pin Blazity\/ai-workflow"/);
-  assert.match(html, /Already pinned/);
+  assert.match(html, /aria-label="Pin group\/app"/);
+  assert.match(html, /checked=""/);
   assert.match(html, /Archived in the provider/);
-  assert.match(html, /trunk/);
-  assert.match(html, /master/);
   assert.match(
     html,
-    new RegExp(`${MAX_PINNED_REPOSITORIES - 1} of ${MAX_PINNED_REPOSITORIES} slots left`),
+    new RegExp(
+      `${MAX_PINNED_REPOSITORIES - 1} of ${MAX_PINNED_REPOSITORIES} slots left`,
+    ),
   );
-  assert.match(html, /cached for 60 seconds/);
-  assert.match(html, /Refresh catalog/);
+  assert.doesNotMatch(html, /aria-label="Add pinned repositories"/);
 });
 
-test("a pinned repository absent from the catalog is never offered by the picker", () => {
-  const html = renderPicker({
+test("detailed mismatch and catalog warnings live inside the modal", () => {
+  const mismatch = renderModal({
+    repositories: [{ provider: "github", repoPath: "Blazity/ai-workflow" }],
+    providers: ["gitlab"],
+  });
+  assert.match(mismatch, /Provider mismatch/);
+  assert.match(mismatch, /Blazity\/ai-workflow \(GitHub\)/);
+  assert.match(mismatch, /Deployment rejects this until the two agree/);
+
+  const missing = renderModal({
     repositories: [{ provider: "github", repoPath: "Blazity/private-thing" }],
   });
-
-  assert.doesNotMatch(html, /Blazity\/private-thing/);
+  assert.match(missing, /The catalog does not list/);
+  assert.match(missing, /Blazity\/private-thing/);
+  assert.match(missing, /kept exactly as saved/);
+  assert.match(missing, /cached for 60 seconds/);
 });
 
-test("the picker reports no slots left once the workspace limit is reached", () => {
-  const html = renderPicker({
-    repositories: Array.from({ length: MAX_PINNED_REPOSITORIES }, (_value, index) => ({
-      provider: "github" as const,
-      repoPath: `owner/repo-${index}`,
-    })),
-  });
+test("loading, empty, and failed catalogs remain distinct modal states", () => {
+  const loading = renderModal({}, true, "loading", []);
+  assert.match(loading, /Loading repositories…/);
+  assert.doesNotMatch(loading, /aria-label="Filter repositories"/);
+  assert.doesNotMatch(loading, /aria-label="Repository path"/);
 
-  assert.match(html, new RegExp(`0 of ${MAX_PINNED_REPOSITORIES} slots left`));
-  assert.match(html, new RegExp(`Limit of ${MAX_PINNED_REPOSITORIES} reached`));
-});
+  const empty = renderModal({}, true, "ready", []);
+  assert.match(empty, /The catalog returned no repositories/);
+  assert.match(empty, /aria-label="Repository path"/);
+  assert.doesNotMatch(empty, /matches this filter/);
 
-test("an empty catalog is not reported as a filter miss and is not a dead end", () => {
-  const html = renderPicker({}, true, "ready", []);
-
-  assert.match(html, /The catalog returned no repositories/);
-  assert.doesNotMatch(html, /matches this filter/);
-  // Nothing to filter or select, so only the exact-path fallback is offered.
-  assert.match(html, /aria-label="Repository path"/);
-  assert.doesNotMatch(html, /aria-label="Filter repositories"/);
-  assert.doesNotMatch(html, /Add repositories<\/button>/);
-});
-
-test("a catalog outage degrades the picker to exact owner/repo entry", () => {
-  const html = renderPicker({}, true, "error", []);
-
-  assert.match(html, /role="alert"/);
-  assert.match(html, /cannot be browsed/);
-  assert.match(html, /aria-label="Repository path"/);
-  assert.match(html, /placeholder="owner\/repo"/);
+  const failed = renderModal({}, true, "error", []);
+  assert.match(failed, /role="alert"/);
+  assert.match(failed, /Saved pins are preserved/);
+  assert.match(failed, /aria-label="Repository path"/);
   assert.match(
-    html,
+    failed,
     /aria-label="Provider for the manually entered repository"/,
   );
-  assert.doesNotMatch(html, /aria-label="Filter repositories"/);
 });
 
-test("a loading catalog says so instead of looking like an empty workspace", () => {
-  const html = renderPicker({}, true, "loading", []);
-
-  assert.match(html, /Loading repositories…/);
-  assert.doesNotMatch(html, /aria-label="Filter repositories"/);
-  assert.doesNotMatch(html, /owner\/repo/);
-});
-
-test("a closed picker renders nothing", () => {
+test("a closed modal renders nothing", () => {
   const html = renderToStaticMarkup(
     <RepositoryCatalogProvider initial={{ status: "ready", repositories: catalog }}>
-      <RepositoryScopePicker
-        id="test-picker"
+      <RepositoryScopeModal
         open={false}
         scope={{}}
         canEdit
-        onAdd={() => undefined}
-        onClose={() => undefined}
+        onApply={() => undefined}
+        onCancel={() => undefined}
       />
     </RepositoryCatalogProvider>,
   );
 
   assert.equal(html, "");
-});
-
-/** Attribute order is React's to choose, so assert on the whole tag. */
-function controlTag(html: string, attribute: string): string {
-  const match = html.match(new RegExp(`<(?:input|button)[^>]*${attribute}[^>]*>`));
-  assert.notEqual(match, null, `no control carries ${attribute}`);
-  return match![0];
-}
-
-test("read-only mode disables the picker inputs", () => {
-  const html = renderPicker({}, false);
-
-  assert.match(controlTag(html, 'aria-label="Filter repositories"'), /disabled=""/);
-  assert.match(
-    controlTag(html, 'aria-label="Pin Blazity/ai-workflow"'),
-    /disabled=""/,
-  );
 });

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx
@@ -1,382 +1,19 @@
 "use client";
 
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
-import type {
-  RepositoryOption,
-  VcsProviderKind,
-  WorkflowRepositoryScope,
-} from "@shared/contracts";
-import { Listbox } from "@/components/cockpit/listbox";
+import type { WorkflowRepositoryScope } from "@shared/contracts";
 import {
-  addPinnedRepositories,
   contradictingPinnedRepositories,
-  describeRepositoryScope,
-  effectiveScopeProviders,
-  isRepositoryPinned,
-  isRepositoryScopeEmpty,
-  MAX_PINNED_REPOSITORIES,
-  PINNABLE_PROVIDERS,
   pinnedRepositories,
   providerLabel,
-  removePinnedRepository,
   repositoryKey,
-  togglePinnedProvider,
-  type PinnedRepository,
 } from "@/lib/workflow-editor/repository-scope";
 import { useRepositoryCatalog } from "./repository-catalog-context";
+import { RepositoryScopeModal } from "./repository-scope-modal";
 
-const CATALOG_CACHE_NOTE =
-  "The repository catalog is cached for 60 seconds, so access granted a moment ago can still be missing here.";
-
-/** Bordered so it reads both on the grey bar chips and on the white picker rows. */
-const providerPillClass =
-  "rounded-[3px] border border-neutral-200 bg-panel px-[5px] py-[1px] font-mono text-[10px] uppercase text-neutral-500";
-
-function ProviderPill({ provider }: { provider: VcsProviderKind }) {
-  return <span className={providerPillClass}>{provider}</span>;
-}
-
-function RepositoryChip({
-  repository,
-  defaultBranch,
-  unknown,
-  canEdit,
-  onRemove,
-}: {
-  repository: PinnedRepository;
-  defaultBranch: string | null;
-  unknown: boolean;
-  canEdit: boolean;
-  onRemove: () => void;
-}) {
-  return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-pill border px-2 py-0.5 font-mono text-[10px] ${
-        unknown
-          ? "border-amber-300 bg-amber-50 text-amber-800"
-          : "border-neutral-200 bg-app-bg text-neutral-800"
-      }`}
-    >
-      {repository.repoPath}
-      <ProviderPill provider={repository.provider} />
-      {defaultBranch !== null && defaultBranch !== "" && (
-        <span className="font-mono text-[9px] text-neutral-500">{defaultBranch}</span>
-      )}
-      {unknown && (
-        <span className="font-mono text-[9px] uppercase text-amber-700">unverified</span>
-      )}
-      <button
-        type="button"
-        disabled={!canEdit}
-        aria-label={`Remove ${repository.repoPath}`}
-        onClick={onRemove}
-        className="appearance-none border-none bg-transparent cursor-pointer text-neutral-500 hover:text-coal disabled:cursor-default disabled:opacity-40"
-      >
-        ×
-      </button>
-    </span>
-  );
-}
-
-interface CatalogEntry {
-  option: RepositoryOption;
-  disabledReason: string | null;
-}
-
-export function RepositoryScopePicker({
-  id,
-  open,
-  scope,
-  canEdit,
-  onAdd,
-  onClose,
-}: {
-  /** Target of the toggle's aria-controls. */
-  id: string;
-  open: boolean;
-  scope: WorkflowRepositoryScope;
-  canEdit: boolean;
-  onAdd: (repositories: PinnedRepository[]) => void;
-  onClose: () => void;
-}) {
-  const catalog = useRepositoryCatalog();
-  const [filter, setFilter] = useState("");
-  const [selected, setSelected] = useState<string[]>([]);
-  const [manualProvider, setManualProvider] = useState<VcsProviderKind>("github");
-  const [manualPath, setManualPath] = useState("");
-
-  const remaining = MAX_PINNED_REPOSITORIES - pinnedRepositories(scope).length;
-  const catalogByKey = useMemo(
-    () =>
-      new Map(
-        catalog.repositories.map((option) => [repositoryKey(option), option]),
-      ),
-    [catalog.repositories],
-  );
-  const entries = useMemo<CatalogEntry[]>(() => {
-    const query = filter.trim().toLowerCase();
-    return catalog.repositories
-      .filter((option) => option.repoPath.toLowerCase().includes(query))
-      .map((option) => {
-        const key = repositoryKey(option);
-        const pinned = isRepositoryPinned(scope, option);
-        const atLimit = !selected.includes(key) && selected.length >= remaining;
-        return {
-          option,
-          disabledReason: pinned
-            ? "Already pinned"
-            : option.archived
-              ? "Archived in the provider"
-              : atLimit
-                ? `Limit of ${MAX_PINNED_REPOSITORIES} reached`
-                : null,
-        };
-      });
-  }, [catalog.repositories, filter, remaining, scope, selected]);
-
-  /** A 200 with an empty list is reachable, and it must not strand the operator. */
-  const catalogEmpty =
-    catalog.status === "ready" && catalog.repositories.length === 0;
-
-  // The manual button has the same duty as the commit button: never sit enabled
-  // over a path that cannot be added.
-  const manualRepoPath = manualPath.trim();
-  const manualAlreadyPinned =
-    manualRepoPath !== "" &&
-    isRepositoryPinned(scope, {
-      provider: manualProvider,
-      repoPath: manualRepoPath,
-    });
-  const manualAddable =
-    canEdit && manualRepoPath !== "" && remaining > 0 && !manualAlreadyPinned;
-
-  // Dismissing abandons the selection. The closed picker stays mounted, so
-  // without this a reopen would show a stale count and add repositories the
-  // operator picked in a session they already walked away from.
-  useEffect(() => {
-    if (open) return;
-    setSelected([]);
-    setFilter("");
-  }, [open]);
-
-  // A refresh can retire a row that is still checked. Drop keys the current
-  // catalog no longer offers, so the count and the button never promise a
-  // repository that can no longer be resolved and added.
-  useEffect(() => {
-    setSelected((current) => {
-      const kept = current.filter((key) => catalogByKey.has(key));
-      return kept.length === current.length ? current : kept;
-    });
-  }, [catalogByKey]);
-
-  if (!open) return null;
-
-  function commitSelected() {
-    // Resolve against the whole catalog, never the filtered rows: `selected`
-    // accumulates across filter changes, so filtering by `entries` would drop
-    // everything picked under an earlier filter.
-    const additions = selected
-      .map((key) => catalogByKey.get(key))
-      .filter((option): option is RepositoryOption => option !== undefined)
-      .map((option) => ({
-        provider: option.provider,
-        repoPath: option.repoPath,
-      }));
-    if (additions.length === 0) return;
-    onAdd(additions);
-    setSelected([]);
-    setFilter("");
-    onClose();
-  }
-
-  function commitManual() {
-    if (!manualAddable) return;
-    onAdd([{ provider: manualProvider, repoPath: manualRepoPath }]);
-    setManualPath("");
-    onClose();
-  }
-
-  return (
-    <section
-      id={id}
-      aria-label="Add pinned repositories"
-      className="rounded-[3px] border border-neutral-200 bg-panel px-3 py-2.5"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.06em] text-neutral-700">
-          Add repositories
-        </span>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={catalog.refresh}
-            className="appearance-none border-none bg-transparent p-0 font-body text-[10px] font-semibold text-mariner cursor-pointer"
-          >
-            Refresh catalog
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close the repository picker"
-            className="appearance-none border-none bg-transparent p-0 font-body text-[10px] text-neutral-500 cursor-pointer"
-          >
-            Close
-          </button>
-        </div>
-      </div>
-
-      {catalog.status === "loading" && (
-        <div className="pt-2 font-body text-[10px] text-neutral-500">
-          Loading repositories…
-        </div>
-      )}
-
-      {catalog.status === "ready" && !catalogEmpty && (
-        <>
-          <input
-            value={filter}
-            disabled={!canEdit}
-            onChange={(event) => setFilter(event.target.value)}
-            placeholder="Filter repositories…"
-            aria-label="Filter repositories"
-            className="mt-2 h-[28px] w-full rounded-[3px] border border-neutral-200 bg-white px-2 font-mono text-[11px] text-coal outline-none focus:border-mariner disabled:opacity-60"
-          />
-          <div className="mt-2 max-h-[220px] overflow-y-auto rounded-[3px] border border-neutral-200">
-            {entries.length === 0 ? (
-              <div className="px-2 py-6 text-center font-body text-[10px] text-neutral-500">
-                No repository in the catalog matches this filter.
-              </div>
-            ) : (
-              entries.map(({ option, disabledReason }) => {
-                const key = repositoryKey(option);
-                const checked = selected.includes(key);
-                return (
-                  <label
-                    key={key}
-                    className={`flex items-center gap-2 border-b border-neutral-100 px-2 py-1.5 last:border-b-0 ${
-                      disabledReason === null
-                        ? "cursor-pointer bg-panel"
-                        : "cursor-default bg-app-bg"
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      disabled={!canEdit || disabledReason !== null}
-                      aria-label={`Pin ${option.repoPath}`}
-                      onChange={(event) =>
-                        setSelected((current) =>
-                          event.target.checked
-                            ? [...current, key]
-                            : current.filter((entry) => entry !== key),
-                        )
-                      }
-                      className="size-3 accent-mariner"
-                    />
-                    <span
-                      className={`min-w-0 flex-1 truncate font-mono text-[11px] ${
-                        disabledReason === null ? "text-coal" : "text-neutral-500"
-                      }`}
-                    >
-                      {option.repoPath}
-                    </span>
-                    <ProviderPill provider={option.provider} />
-                    <span className="font-mono text-[9px] text-neutral-500">
-                      {option.defaultBranch === "" ? "no default branch" : option.defaultBranch}
-                    </span>
-                    {disabledReason !== null && (
-                      <span className="font-body text-[10px] text-neutral-500">
-                        {disabledReason}
-                      </span>
-                    )}
-                  </label>
-                );
-              })
-            )}
-          </div>
-          <div className="mt-2 flex items-center justify-between gap-3">
-            <span className="font-body text-[10px] text-neutral-500">
-              {remaining} of {MAX_PINNED_REPOSITORIES} slots left. {CATALOG_CACHE_NOTE}
-            </span>
-            <button
-              type="button"
-              onClick={commitSelected}
-              disabled={!canEdit || selected.length === 0}
-              className="appearance-none rounded-[3px] border border-mariner bg-mariner px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-white cursor-pointer disabled:cursor-default disabled:opacity-40"
-            >
-              {selected.length === 0
-                ? "Add repositories"
-                : `Add ${selected.length} ${
-                    selected.length === 1 ? "repository" : "repositories"
-                  }`}
-            </button>
-          </div>
-        </>
-      )}
-
-      {(catalog.status === "error" || catalogEmpty) && (
-        <div className="pt-2">
-          {catalog.status === "error" ? (
-            <div role="alert" className="font-body text-[10px] text-red-600">
-              The repository catalog is unavailable, so it cannot be browsed. Enter an
-              exact owner/repo the workspace already has access to.
-            </div>
-          ) : (
-            <div className="font-body text-[10px] text-neutral-600">
-              The catalog returned no repositories, so there is nothing to browse. If
-              the workspace can reach one it does not list, enter its exact
-              owner/repo.
-            </div>
-          )}
-          <div className="mt-2 flex items-center gap-2">
-            <div className="w-[110px]">
-              <Listbox
-                options={PINNABLE_PROVIDERS.map((provider) => ({
-                  value: provider,
-                  label: providerLabel(provider),
-                  hint: provider === "github" ? "github.com" : "gitlab",
-                }))}
-                value={manualProvider}
-                disabled={!canEdit}
-                ariaLabel="Provider for the manually entered repository"
-                onChange={(value) => setManualProvider(value as VcsProviderKind)}
-              />
-            </div>
-            <input
-              value={manualPath}
-              disabled={!canEdit}
-              onChange={(event) => setManualPath(event.target.value)}
-              placeholder="owner/repo"
-              aria-label="Repository path"
-              className="h-[28px] flex-1 rounded-[3px] border border-neutral-200 bg-white px-2 font-mono text-[11px] text-coal outline-none focus:border-mariner disabled:opacity-60"
-            />
-            <button
-              type="button"
-              onClick={commitManual}
-              disabled={!manualAddable}
-              className="appearance-none rounded-[3px] border border-neutral-300 bg-panel px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-coal cursor-pointer disabled:cursor-default disabled:opacity-40"
-            >
-              Add
-            </button>
-          </div>
-          {manualAlreadyPinned && (
-            <div className="pt-1.5 font-body text-[10px] text-amber-800">
-              {manualRepoPath} is already pinned for{" "}
-              {providerLabel(manualProvider)}.
-            </div>
-          )}
-          {manualRepoPath !== "" && remaining <= 0 && (
-            <div className="pt-1.5 font-body text-[10px] text-amber-800">
-              The pin already holds {MAX_PINNED_REPOSITORIES} repositories, the
-              workspace limit.
-            </div>
-          )}
-        </div>
-      )}
-    </section>
-  );
-}
+const scopeBadgeClass =
+  "inline-flex h-6 shrink-0 items-center rounded-[3px] border px-2 font-mono text-[10px]";
 
 export function RepositoryScopeBar({
   scope,
@@ -388,9 +25,9 @@ export function RepositoryScopeBar({
   onChange: (scope: WorkflowRepositoryScope) => void;
 }) {
   const catalog = useRepositoryCatalog();
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const pickerId = useId();
-
+  const [modalOpen, setModalOpen] = useState(false);
+  const configureRef = useRef<HTMLButtonElement>(null);
+  const wasOpen = useRef(false);
   const pinned = pinnedRepositories(scope);
   const catalogByKey = useMemo(
     () =>
@@ -399,171 +36,98 @@ export function RepositoryScopeBar({
       ),
     [catalog.repositories],
   );
-  /** Only a settled catalog can prove a pin is missing, so a pending one never warns. */
-  const catalogSettled = catalog.status === "ready";
-  const unknownPins = catalogSettled
-    ? pinned.filter((repository) => !catalogByKey.has(repositoryKey(repository)))
-    : [];
+  const unknownPins =
+    catalog.status === "ready"
+      ? pinned.filter(
+          (repository) => !catalogByKey.has(repositoryKey(repository)),
+        )
+      : [];
   const archivedPins = pinned.filter(
-    (repository) => catalogByKey.get(repositoryKey(repository))?.archived === true,
+    (repository) =>
+      catalogByKey.get(repositoryKey(repository))?.archived === true,
   );
-  const atLimit = pinned.length >= MAX_PINNED_REPOSITORIES;
-  const providers = effectiveScopeProviders(scope);
-  const contradictingPins = contradictingPinnedRepositories(scope);
+  const explicitProviders = scope.providers ?? [];
+  const needsAttention =
+    contradictingPinnedRepositories(scope).length > 0 ||
+    unknownPins.length > 0 ||
+    archivedPins.length > 0 ||
+    catalog.status === "error";
+
+  useEffect(() => {
+    if (wasOpen.current && !modalOpen) configureRef.current?.focus();
+    wasOpen.current = modalOpen;
+  }, [modalOpen]);
 
   return (
-    <div className="flex flex-col gap-2 px-6 py-2 border-b border-neutral-200 bg-app-bg">
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-        <div className="min-w-[110px]">
-          <div className="font-mono text-[9px] font-semibold tracking-[0.06em] uppercase text-neutral-700">
-            Repositories
+    <>
+      <div className="flex min-h-[52px] items-center gap-3 border-b border-neutral-200 bg-app-bg px-6 py-2">
+        <div className="min-w-[110px] shrink-0">
+          <div className="font-mono text-[9px] font-semibold uppercase tracking-[0.06em] text-neutral-700">
+            Source scope
           </div>
           <div className="font-body text-[10px] text-neutral-500">
-            Pinned for every ticket
+            Providers &amp; repositories
           </div>
         </div>
-        {pinned.length === 0 ? (
-          <span className="font-body text-[10px] text-neutral-500">
-            {(scope.providers?.length ?? 0) === 0
-              ? "No repository pinned: every ticket resolves its own, as it does today."
-              : "No repository pinned: every ticket resolves its own within the pinned providers."}
+
+        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+          {explicitProviders.length === 0 ? (
+            <span
+              className={`${scopeBadgeClass} border-neutral-200 bg-panel text-neutral-600`}
+            >
+              Automatic provider
+            </span>
+          ) : (
+            explicitProviders.map((provider) => (
+              <span
+                key={provider}
+                className={`${scopeBadgeClass} border-mariner/30 bg-mariner-100 text-mariner`}
+              >
+                {providerLabel(provider)}
+              </span>
+            ))
+          )}
+          <span
+            className={`${scopeBadgeClass} border-neutral-200 bg-panel text-neutral-700 tabular-nums`}
+          >
+            {pinned.length === 0
+              ? "Automatic per ticket"
+              : `${pinned.length} ${
+                  pinned.length === 1 ? "repository" : "repositories"
+                }`}
           </span>
-        ) : (
-          pinned.map((repository) => {
-            const option = catalogByKey.get(repositoryKey(repository));
-            return (
-              <RepositoryChip
-                key={repositoryKey(repository)}
-                repository={repository}
-                defaultBranch={option?.defaultBranch ?? null}
-                unknown={catalogSettled && option === undefined}
-                canEdit={canEdit}
-                onRemove={() => onChange(removePinnedRepository(scope, repository))}
-              />
-            );
-          })
-        )}
-        <span
-          title={`${MAX_PINNED_REPOSITORIES} pinned repositories is the workspace limit.`}
-          className="font-mono text-[10px] text-neutral-600"
-        >
-          {pinned.length} / {MAX_PINNED_REPOSITORIES}
-        </span>
+          {needsAttention && (
+            <span
+              role="status"
+              className={`${scopeBadgeClass} border-amber-300 bg-amber-50 text-amber-800`}
+            >
+              Needs attention
+            </span>
+          )}
+        </div>
+
         <button
+          ref={configureRef}
           type="button"
-          aria-expanded={pickerOpen}
-          aria-controls={pickerId}
-          onClick={() => setPickerOpen((open) => !open)}
-          disabled={!canEdit || atLimit}
-          className="appearance-none rounded-[3px] border border-neutral-300 bg-panel px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.04em] text-coal cursor-pointer hover:bg-app-bg disabled:cursor-default disabled:opacity-40"
+          aria-haspopup="dialog"
+          onClick={() => setModalOpen(true)}
+          disabled={!canEdit}
+          className="inline-flex h-10 shrink-0 items-center justify-center rounded-[4px] border border-neutral-300 bg-panel px-3 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-coal transition-transform hover:bg-white active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-mariner motion-reduce:transform-none disabled:cursor-default disabled:opacity-40"
         >
-          {pickerOpen ? "Done" : "+ Add repository"}
+          Configure
         </button>
       </div>
 
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-        <div className="min-w-[110px]">
-          <div className="font-mono text-[9px] font-semibold tracking-[0.06em] uppercase text-neutral-700">
-            Providers
-          </div>
-          <div className="font-body text-[10px] text-neutral-500">
-            Both makes a run multi-repo
-          </div>
-        </div>
-        {PINNABLE_PROVIDERS.map((provider) => {
-          const active = (scope.providers ?? []).includes(provider);
-          return (
-            <button
-              key={provider}
-              type="button"
-              aria-pressed={active}
-              disabled={!canEdit}
-              onClick={() => onChange(togglePinnedProvider(scope, provider))}
-              className={`appearance-none rounded-pill border px-2.5 py-0.5 font-mono text-[10px] cursor-pointer disabled:cursor-default disabled:opacity-40 ${
-                active
-                  ? "border-mariner bg-mariner-100 text-mariner"
-                  : "border-neutral-200 bg-panel text-neutral-600"
-              }`}
-            >
-              {providerLabel(provider)}
-            </button>
-          );
-        })}
-        {(scope.providers?.length ?? 0) === 0 && (
-          <span className="font-body text-[10px] text-neutral-500">
-            {pinned.length === 0
-              ? "No provider pinned: the run picks the provider itself."
-              : `Inherited from the pinned repositories: ${providers
-                  .map(providerLabel)
-                  .join(" + ")}.`}
-          </span>
-        )}
-        {contradictingPins.length > 0 && (
-          <span
-            role="status"
-            className="rounded-[3px] border border-amber-300 bg-amber-50 px-2 py-0.5 font-body text-[10px] text-amber-800"
-          >
-            Provider mismatch:{" "}
-            {contradictingPins
-              .map((r) => `${r.repoPath} (${providerLabel(r.provider)})`)
-              .join(", ")}{" "}
-            {contradictingPins.length === 1 ? "is" : "are"} pinned but excluded by
-            the selected providers. Deployment rejects this until the two agree.
-          </span>
-        )}
-      </div>
-
-      {unknownPins.length > 0 && (
-        <div
-          role="status"
-          className="rounded-[3px] border border-amber-300 bg-amber-50 px-2.5 py-1.5 font-body text-[10px] text-amber-800"
-        >
-          The catalog does not list {unknownPins.map((r) => r.repoPath).join(", ")}.
-          The pin is kept exactly as saved. Access may have been revoked, the
-          repository may sit outside the server allowlist, or the catalog may be
-          stale. {CATALOG_CACHE_NOTE}
-        </div>
-      )}
-
-      {archivedPins.length > 0 && (
-        <div
-          role="status"
-          className="rounded-[3px] border border-amber-300 bg-amber-50 px-2.5 py-1.5 font-body text-[10px] text-amber-800"
-        >
-          Archived in the provider: {archivedPins.map((r) => r.repoPath).join(", ")}.
-          The pin is kept, but the workflow cannot open changes there.
-        </div>
-      )}
-
-      {catalog.status === "loading" && pinned.length > 0 && (
-        <div className="font-body text-[10px] text-neutral-500">
-          Checking the pinned repositories against the catalog…
-        </div>
-      )}
-
-      {catalog.status === "error" && !pickerOpen && (
-        <div role="status" className="font-body text-[10px] text-red-600">
-          The repository catalog is unavailable. Saved pins are preserved, and new
-          ones can be entered by exact path.
-        </div>
-      )}
-
-      {!isRepositoryScopeEmpty(scope) && (
-        <div className="font-body text-[10px] text-neutral-500">
-          Every ticket entering this workflow inherits{" "}
-          {describeRepositoryScope(scope)}. The run never asks which repository to
-          use, and the pull request trigger filter follows this pin.
-        </div>
-      )}
-
-      <RepositoryScopePicker
-        id={pickerId}
-        open={pickerOpen}
+      <RepositoryScopeModal
+        open={modalOpen}
         scope={scope}
         canEdit={canEdit}
-        onAdd={(repositories) => onChange(addPinnedRepositories(scope, repositories))}
-        onClose={() => setPickerOpen(false)}
+        onApply={(next) => {
+          onChange(next);
+          setModalOpen(false);
+        }}
+        onCancel={() => setModalOpen(false)}
       />
-    </div>
+    </>
   );
 }

--- a/apps/dashboard/components/cockpit/flow-editor/repository-scope-modal.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/repository-scope-modal.tsx
@@ -1,0 +1,504 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState } from "react";
+
+import type {
+  RepositoryOption,
+  VcsProviderKind,
+  WorkflowRepositoryScope,
+} from "@shared/contracts";
+import { Listbox } from "@/components/cockpit/listbox";
+import {
+  addPinnedRepositories,
+  contradictingPinnedRepositories,
+  isRepositoryPinned,
+  MAX_PINNED_REPOSITORIES,
+  normalizeRepositoryScope,
+  PINNABLE_PROVIDERS,
+  pinnedRepositories,
+  providerLabel,
+  removePinnedRepository,
+  repositoryKey,
+  togglePinnedProvider,
+} from "@/lib/workflow-editor/repository-scope";
+import { useRepositoryCatalog } from "./repository-catalog-context";
+
+const CATALOG_CACHE_NOTE =
+  "The repository catalog is cached for 60 seconds, so access granted a moment ago can still be missing here.";
+
+interface CatalogEntry {
+  option: RepositoryOption;
+  disabledReason: string | null;
+}
+
+export interface RepositoryScopeModalProps {
+  open: boolean;
+  scope: WorkflowRepositoryScope;
+  canEdit: boolean;
+  onApply: (scope: WorkflowRepositoryScope) => void;
+  onCancel: () => void;
+}
+
+export function RepositoryScopeModal({
+  open,
+  scope,
+  canEdit,
+  onApply,
+  onCancel,
+}: RepositoryScopeModalProps) {
+  const catalog = useRepositoryCatalog();
+  const titleId = useId();
+  const providersId = useId();
+  const repositoriesId = useId();
+  const [draft, setDraft] = useState<WorkflowRepositoryScope>(() =>
+    structuredClone(scope),
+  );
+  const [filter, setFilter] = useState("");
+  const [manualProvider, setManualProvider] =
+    useState<VcsProviderKind>("github");
+  const [manualPath, setManualPath] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setDraft(structuredClone(scope));
+    setFilter("");
+    setManualPath("");
+  }, [open, scope]);
+
+  const catalogByKey = useMemo(
+    () =>
+      new Map(
+        catalog.repositories.map((option) => [repositoryKey(option), option]),
+      ),
+    [catalog.repositories],
+  );
+
+  useEffect(() => {
+    if (!open || catalog.status !== "ready") return;
+    setDraft((current) => {
+      const currentRepositories = pinnedRepositories(current);
+      const kept = currentRepositories.filter(
+        (repository) =>
+          isRepositoryPinned(scope, repository) ||
+          catalogByKey.has(repositoryKey(repository)),
+      );
+      if (kept.length === currentRepositories.length) return current;
+      return normalizeRepositoryScope({ ...current, repositories: kept });
+    });
+  }, [catalog.status, catalogByKey, open, scope]);
+
+  if (!open) return null;
+  const pinned = pinnedRepositories(draft);
+  const remaining = MAX_PINNED_REPOSITORIES - pinned.length;
+  const catalogSettled = catalog.status === "ready";
+  const unknownPins = catalogSettled
+    ? pinned.filter((repository) => !catalogByKey.has(repositoryKey(repository)))
+    : [];
+  const archivedPins = pinned.filter(
+    (repository) =>
+      catalogByKey.get(repositoryKey(repository))?.archived === true,
+  );
+  const contradictingPins = contradictingPinnedRepositories(draft);
+  const query = filter.trim().toLowerCase();
+  const entries: CatalogEntry[] = catalog.repositories
+    .filter((option) => option.repoPath.toLowerCase().includes(query))
+    .map((option) => {
+      const selected = isRepositoryPinned(draft, option);
+      return {
+        option,
+        disabledReason:
+          option.archived && !selected
+            ? "Archived in the provider"
+            : remaining <= 0 && !selected
+              ? `Limit of ${MAX_PINNED_REPOSITORIES} reached`
+              : null,
+      };
+    });
+  const catalogEmpty =
+    catalog.status === "ready" && catalog.repositories.length === 0;
+  const manualRepoPath = manualPath.trim();
+  const manualAlreadyPinned =
+    manualRepoPath !== "" &&
+    isRepositoryPinned(draft, {
+      provider: manualProvider,
+      repoPath: manualRepoPath,
+    });
+  const manualAddable =
+    canEdit && manualRepoPath !== "" && remaining > 0 && !manualAlreadyPinned;
+
+  function toggleRepository(option: RepositoryOption, checked: boolean) {
+    setDraft((current) =>
+      checked
+        ? addPinnedRepositories(current, [
+            { provider: option.provider, repoPath: option.repoPath },
+          ])
+        : removePinnedRepository(current, option),
+    );
+  }
+
+  function addManualRepository() {
+    if (!manualAddable) return;
+    setDraft((current) =>
+      addPinnedRepositories(current, [
+        { provider: manualProvider, repoPath: manualRepoPath },
+      ]),
+    );
+    setManualPath("");
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-coal/30 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onCancel();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          onCancel();
+          return;
+        }
+        if (event.key !== "Tab") return;
+        const focusable = Array.from(
+          event.currentTarget.querySelectorAll<HTMLElement>(
+            'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          ),
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (!event.shiftKey && event.target === last) {
+          event.preventDefault();
+          first.focus();
+        } else if (event.shiftKey && event.target === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      }}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="flex max-h-[calc(100dvh-32px)] w-full max-w-[680px] flex-col overflow-hidden rounded-[6px] bg-panel shadow-2xl"
+      >
+        <header className="flex items-start justify-between gap-4 border-b border-neutral-200 px-5 py-4">
+          <div>
+            <h2
+              id={titleId}
+              className="font-mono text-[13px] font-semibold uppercase tracking-[0.04em] text-coal"
+            >
+              Configure source scope
+            </h2>
+            <p className="mt-1 font-body text-[11px] text-neutral-500">
+              Choose which providers and repositories every ticket can use.
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close source scope"
+            onClick={onCancel}
+            className="inline-flex size-10 items-center justify-center rounded-[4px] border border-transparent bg-transparent font-mono text-[18px] text-neutral-500 hover:bg-app-bg hover:text-coal focus-visible:outline-2 focus-visible:outline-mariner"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          <section aria-labelledby={providersId}>
+            <h3
+              id={providersId}
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.06em] text-neutral-700"
+            >
+              Providers
+            </h3>
+            <p className="mt-1 font-body text-[11px] text-neutral-500">
+              Select neither to let each run resolve its provider automatically.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {PINNABLE_PROVIDERS.map((provider) => {
+                const active = (draft.providers ?? []).includes(provider);
+                return (
+                  <button
+                    key={provider}
+                    type="button"
+                    autoFocus={provider === PINNABLE_PROVIDERS[0]}
+                    aria-pressed={active}
+                    disabled={!canEdit}
+                    onClick={() =>
+                      setDraft((current) =>
+                        togglePinnedProvider(current, provider),
+                      )
+                    }
+                    className={`inline-flex h-10 min-w-[112px] items-center justify-center rounded-[4px] border px-3 font-mono text-[11px] font-semibold transition-transform active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-mariner motion-reduce:transform-none disabled:cursor-default disabled:opacity-40 ${
+                      active
+                        ? "border-mariner bg-mariner-100 text-mariner"
+                        : "border-neutral-300 bg-panel text-neutral-600 hover:bg-app-bg"
+                    }`}
+                  >
+                    {providerLabel(provider)}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+          <section aria-labelledby={repositoriesId} className="mt-5">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h3
+                  id={repositoriesId}
+                  className="font-mono text-[10px] font-semibold uppercase tracking-[0.06em] text-neutral-700"
+                >
+                  Repositories
+                </h3>
+                <p className="mt-1 font-body text-[11px] text-neutral-500">
+                  Pin up to {MAX_PINNED_REPOSITORIES} repositories for every
+                  ticket, or leave this empty for automatic selection.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={catalog.refresh}
+                className="inline-flex h-10 shrink-0 items-center justify-center rounded-[4px] px-2 font-body text-[11px] font-semibold text-mariner focus-visible:outline-2 focus-visible:outline-mariner"
+              >
+                Refresh catalog
+              </button>
+            </div>
+
+            {pinned.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2" aria-label="Selected repositories">
+                {pinned.map((repository) => (
+                  <span
+                    key={repositoryKey(repository)}
+                    className="inline-flex h-8 items-center rounded-[4px] border border-neutral-200 bg-app-bg pl-2 font-mono text-[10px] text-neutral-800"
+                  >
+                    <span>{repository.repoPath}</span>
+                    <span className="ml-2 border-l border-neutral-200 px-2 text-[9px] uppercase text-neutral-500">
+                      {providerLabel(repository.provider)}
+                    </span>
+                    <button
+                      type="button"
+                      disabled={!canEdit}
+                      aria-label={`Remove ${repository.repoPath}`}
+                      onClick={() =>
+                        setDraft((current) =>
+                          removePinnedRepository(current, repository),
+                        )
+                      }
+                      className="inline-flex size-10 items-center justify-center rounded-r-[4px] text-[16px] text-neutral-500 hover:bg-white hover:text-coal focus-visible:outline-2 focus-visible:outline-mariner disabled:cursor-default disabled:opacity-40"
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {contradictingPins.length > 0 && (
+              <div
+                role="status"
+                className="mt-3 rounded-[4px] border border-amber-300 bg-amber-50 px-3 py-2 font-body text-[11px] text-amber-800"
+              >
+                Provider mismatch:{" "}
+                {contradictingPins
+                  .map(
+                    (repository) =>
+                      `${repository.repoPath} (${providerLabel(repository.provider)})`,
+                  )
+                  .join(", ")}{" "}
+                {contradictingPins.length === 1 ? "is" : "are"} excluded by the
+                selected providers. Deployment rejects this until the two agree.
+              </div>
+            )}
+
+            {unknownPins.length > 0 && (
+              <div
+                role="status"
+                className="mt-3 rounded-[4px] border border-amber-300 bg-amber-50 px-3 py-2 font-body text-[11px] text-amber-800"
+              >
+                The catalog does not list{" "}
+                {unknownPins.map((repository) => repository.repoPath).join(", ")}.
+                The pin is kept exactly as saved. Access may have been revoked,
+                the repository may sit outside the server allowlist, or the
+                catalog may be stale. {CATALOG_CACHE_NOTE}
+              </div>
+            )}
+
+            {archivedPins.length > 0 && (
+              <div
+                role="status"
+                className="mt-3 rounded-[4px] border border-amber-300 bg-amber-50 px-3 py-2 font-body text-[11px] text-amber-800"
+              >
+                Archived in the provider:{" "}
+                {archivedPins.map((repository) => repository.repoPath).join(", ")}.
+                The pin is kept, but the workflow cannot open changes there.
+              </div>
+            )}
+
+            {catalog.status === "loading" && (
+              <div className="mt-3 rounded-[4px] bg-app-bg px-3 py-6 text-center font-body text-[11px] text-neutral-500">
+                Loading repositories…
+              </div>
+            )}
+
+            {catalog.status === "ready" && !catalogEmpty && (
+              <>
+                <input
+                  value={filter}
+                  disabled={!canEdit}
+                  onChange={(event) => setFilter(event.target.value)}
+                  placeholder="Filter repositories…"
+                  aria-label="Filter repositories"
+                  className="mt-3 h-10 w-full rounded-[4px] border border-neutral-200 bg-white px-3 font-mono text-[11px] text-coal outline-none focus:border-mariner focus-visible:outline-2 focus-visible:outline-mariner disabled:opacity-60"
+                />
+                <div className="mt-2 max-h-[260px] overflow-y-auto rounded-[4px] border border-neutral-200">
+                  {entries.length === 0 ? (
+                    <div className="px-3 py-8 text-center font-body text-[11px] text-neutral-500">
+                      No repository in the catalog matches this filter.
+                    </div>
+                  ) : (
+                    entries.map(({ option, disabledReason }) => {
+                      const checked = isRepositoryPinned(draft, option);
+                      return (
+                        <label
+                          key={repositoryKey(option)}
+                          className={`flex min-h-11 items-center gap-3 border-b border-neutral-100 px-3 last:border-b-0 ${
+                            disabledReason === null
+                              ? "cursor-pointer bg-panel hover:bg-app-bg"
+                              : "cursor-default bg-app-bg"
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            disabled={!canEdit || disabledReason !== null}
+                            aria-label={`Pin ${option.repoPath}`}
+                            onChange={(event) =>
+                              toggleRepository(option, event.target.checked)
+                            }
+                            className="size-4 accent-mariner"
+                          />
+                          <span
+                            className={`min-w-0 flex-1 truncate font-mono text-[11px] ${
+                              disabledReason === null
+                                ? "text-coal"
+                                : "text-neutral-500"
+                            }`}
+                          >
+                            {option.repoPath}
+                          </span>
+                          <span className="hidden h-6 items-center rounded-[3px] border border-neutral-200 bg-panel px-2 font-mono text-[9px] uppercase text-neutral-500 sm:inline-flex">
+                            {providerLabel(option.provider)}
+                          </span>
+                          <span className="hidden font-mono text-[9px] text-neutral-500 md:inline">
+                            {option.defaultBranch === ""
+                              ? "no default branch"
+                              : option.defaultBranch}
+                          </span>
+                          {disabledReason !== null && (
+                            <span className="font-body text-[10px] text-neutral-500">
+                              {disabledReason}
+                            </span>
+                          )}
+                        </label>
+                      );
+                    })
+                  )}
+                </div>
+                <div className="mt-2 flex items-start justify-between gap-3 font-body text-[10px] text-neutral-500">
+                  <span className="tabular-nums">
+                    {remaining} of {MAX_PINNED_REPOSITORIES} slots left.
+                  </span>
+                  <span className="max-w-[420px] text-right">
+                    {CATALOG_CACHE_NOTE}
+                  </span>
+                </div>
+              </>
+            )}
+
+            {(catalog.status === "error" || catalogEmpty) && (
+              <div className="mt-3 rounded-[4px] border border-neutral-200 bg-app-bg p-3">
+                {catalog.status === "error" ? (
+                  <div role="alert" className="font-body text-[11px] text-red-600">
+                    The repository catalog is unavailable, so it cannot be
+                    browsed. Saved pins are preserved. Enter an exact owner/repo
+                    the workspace already has access to.
+                  </div>
+                ) : (
+                  <div className="font-body text-[11px] text-neutral-600">
+                    The catalog returned no repositories. Enter an exact
+                    owner/repo if the workspace can reach one it does not list.
+                  </div>
+                )}
+                <div className="mt-3 flex items-center gap-2">
+                  <div className="w-[120px] shrink-0">
+                    <Listbox
+                      options={PINNABLE_PROVIDERS.map((provider) => ({
+                        value: provider,
+                        label: providerLabel(provider),
+                        hint:
+                          provider === "github" ? "github.com" : "gitlab.com",
+                      }))}
+                      value={manualProvider}
+                      disabled={!canEdit}
+                      ariaLabel="Provider for the manually entered repository"
+                      onChange={(value) =>
+                        setManualProvider(value as VcsProviderKind)
+                      }
+                    />
+                  </div>
+                  <input
+                    value={manualPath}
+                    disabled={!canEdit}
+                    onChange={(event) => setManualPath(event.target.value)}
+                    placeholder="owner/repo"
+                    aria-label="Repository path"
+                    className="h-10 min-w-0 flex-1 rounded-[4px] border border-neutral-200 bg-white px-3 font-mono text-[11px] text-coal outline-none focus:border-mariner focus-visible:outline-2 focus-visible:outline-mariner disabled:opacity-60"
+                  />
+                  <button
+                    type="button"
+                    onClick={addManualRepository}
+                    disabled={!manualAddable}
+                    className="inline-flex h-10 shrink-0 items-center justify-center rounded-[4px] border border-neutral-300 bg-panel px-3 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-coal focus-visible:outline-2 focus-visible:outline-mariner disabled:cursor-default disabled:opacity-40"
+                  >
+                    Add to selection
+                  </button>
+                </div>
+                {manualAlreadyPinned && (
+                  <div className="pt-2 font-body text-[10px] text-amber-800">
+                    {manualRepoPath} is already pinned for{" "}
+                    {providerLabel(manualProvider)}.
+                  </div>
+                )}
+                {manualRepoPath !== "" && remaining <= 0 && (
+                  <div className="pt-2 font-body text-[10px] text-amber-800">
+                    The pin already holds {MAX_PINNED_REPOSITORIES} repositories,
+                    the workspace limit.
+                  </div>
+                )}
+              </div>
+            )}
+          </section>
+        </div>
+
+        <footer className="flex items-center justify-end gap-2 border-t border-neutral-200 bg-app-bg px-5 py-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex h-10 items-center justify-center rounded-[4px] border border-neutral-300 bg-panel px-4 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-coal transition-transform active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-mariner motion-reduce:transform-none"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canEdit}
+            onClick={() => onApply(draft)}
+            className="inline-flex h-10 items-center justify-center rounded-[4px] border border-mariner bg-mariner px-4 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-white transition-transform active:scale-[0.96] focus-visible:outline-2 focus-visible:outline-mariner motion-reduce:transform-none disabled:cursor-default disabled:opacity-40"
+          >
+            Apply scope
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/docs/superpowers/plans/2026-07-28-repository-scope-modal.md
+++ b/docs/superpowers/plans/2026-07-28-repository-scope-modal.md
@@ -1,0 +1,474 @@
+# Repository Scope Modal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the expanding provider/repository controls with one compact source-scope summary row and a draft-based modal that never shifts the workflow editor.
+
+**Architecture:** `RepositoryScopeBar` becomes a compact read-only summary plus the modal trigger. A new `RepositoryScopeModal` owns a local `WorkflowRepositoryScope` draft, catalog selection UI, warnings, and apply/cancel behavior; existing helpers in `repository-scope.ts` remain the only mutation and description logic.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS, `react-test-renderer`, Node test runner
+
+## Global Constraints
+
+- Do not change repository scope contracts, validation, catalog loading, or workflow serialization.
+- The collapsed control is one row and opening the modal must not change document layout.
+- Provider and repository summary badges use one shared height, radius, padding, and vertical alignment.
+- Modal changes stay local until `Apply scope`; every cancel path discards them.
+- Preserve the eight-repository limit, catalog refresh behavior, exact-path fallback, and all existing warnings.
+- Do not add a modal, focus-management, or animation dependency.
+- Interactive targets are at least 40 by 40 pixels and all controls retain visible keyboard focus.
+
+---
+
+### Task 1: Compact source-scope summary and modal draft boundary
+
+**Files:**
+- Create: `apps/dashboard/components/cockpit/flow-editor/repository-scope-modal.tsx`
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx`
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx`
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx`
+
+**Interfaces:**
+- Consumes: `WorkflowRepositoryScope`, `VcsProviderKind`, and the existing helpers exported by `apps/dashboard/lib/workflow-editor/repository-scope.ts`.
+- Produces:
+
+```ts
+export interface RepositoryScopeModalProps {
+  open: boolean;
+  scope: WorkflowRepositoryScope;
+  canEdit: boolean;
+  onApply: (scope: WorkflowRepositoryScope) => void;
+  onCancel: () => void;
+}
+
+export function RepositoryScopeModal(
+  props: RepositoryScopeModalProps,
+): React.ReactNode;
+```
+
+- [ ] **Step 1: Replace static bar expectations with compact-summary and dialog expectations**
+
+Update `repository-scope-bar.test.tsx` so the empty scope asserts:
+
+```ts
+const html = renderBar({});
+assert.match(html, /Source scope/);
+assert.match(html, /Automatic provider/);
+assert.match(html, /Automatic per ticket/);
+assert.match(html, /Configure/);
+assert.doesNotMatch(html, /Add repositories/);
+```
+
+Add a direct modal render helper and assertions for `role="dialog"`,
+`aria-modal="true"`, `Configure source scope`, `Providers`, `Repositories`,
+`Cancel`, and `Apply scope`. Keep the existing catalog-state, warning, and
+read-only assertions, moving modal-only assertions to the modal helper.
+
+- [ ] **Step 2: Add failing behavior tests for the draft boundary**
+
+Replace bar helpers that directly toggle providers or remove chips with modal
+actions. Add tests that mount a controlled bar and prove:
+
+```ts
+await bar.openModal();
+await bar.toggleProvider("GitHub");
+await bar.cancel();
+assert.deepEqual(bar.changes, []);
+
+await bar.openModal();
+await bar.toggleProvider("GitHub");
+await bar.apply();
+assert.deepEqual(bar.changes, [{ providers: ["github"] }]);
+```
+
+Also assert that the configure button has `aria-haspopup="dialog"`, the modal
+exists only while open, and a disabled read-only configure button cannot open
+it.
+
+- [ ] **Step 3: Run the focused tests and verify the new expectations fail**
+
+Run:
+
+```bash
+pnpm --dir apps/dashboard exec tsx --test \
+  components/cockpit/flow-editor/repository-scope-bar.test.tsx \
+  components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+```
+
+Expected: failures because the bar still renders two rows and no
+`RepositoryScopeModal` exists.
+
+- [ ] **Step 4: Implement the modal shell with an isolated draft**
+
+Create `repository-scope-modal.tsx` with:
+
+```tsx
+export function RepositoryScopeModal({
+  open,
+  scope,
+  canEdit,
+  onApply,
+  onCancel,
+}: RepositoryScopeModalProps) {
+  const titleId = useId();
+  const [draft, setDraft] = useState<WorkflowRepositoryScope>(() =>
+    structuredClone(scope),
+  );
+
+  useEffect(() => {
+    if (open) setDraft(structuredClone(scope));
+  }, [open, scope]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-coal/30 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onCancel();
+      }}
+    >
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="flex max-h-[min(760px,calc(100dvh-32px))] w-full max-w-[680px] flex-col overflow-hidden rounded-[6px] bg-panel shadow-2xl"
+      >
+        <h2 id={titleId}>Configure source scope</h2>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <section aria-labelledby={`${titleId}-providers`} />
+          <section aria-labelledby={`${titleId}-repositories`} />
+        </div>
+        <footer>
+          <button type="button" onClick={onCancel}>Cancel</button>
+          <button
+            type="button"
+            disabled={!canEdit}
+            onClick={() => onApply(draft)}
+          >
+            Apply scope
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}
+```
+
+Wire `Escape` to `onCancel` on the dialog layer. Keep `draft` and `setDraft`
+inside this component so no mutation reaches the editor before Apply.
+
+- [ ] **Step 5: Replace the two bar rows with one compact summary row**
+
+In `repository-scope-bar.tsx`, remove the inline picker and direct editing
+controls. Render one row with:
+
+```tsx
+<div className="flex min-h-[52px] items-center gap-3 border-b border-neutral-200 bg-app-bg px-6 py-2">
+  <div className="min-w-[110px]">
+    <div className="font-mono text-[9px] font-semibold uppercase tracking-[0.06em] text-neutral-700">
+      Source scope
+    </div>
+    <div className="font-body text-[10px] text-neutral-500">
+      Providers & repositories
+    </div>
+  </div>
+  <div className="flex min-w-0 flex-1 items-center gap-2">
+    {/* equal-height provider badges and repository summary */}
+  </div>
+  <button
+    type="button"
+    aria-haspopup="dialog"
+    disabled={!canEdit}
+    onClick={() => setModalOpen(true)}
+  >
+    Configure
+  </button>
+</div>
+```
+
+Use a shared `scopeBadgeClass` containing `inline-flex h-6 items-center
+rounded-[3px] border px-2`. Use `tabular-nums` on the repository count. Show
+`Needs attention` with `role="status"` when the existing mismatch, archived, or
+unknown calculations find a problem. Render `RepositoryScopeModal` as a sibling
+of the row so the fixed overlay never changes row height.
+
+- [ ] **Step 6: Run focused tests**
+
+Run the focused command from Step 3.
+
+Expected: all static summary, dialog shell, cancel, apply, and read-only tests
+pass. Run only the draft-boundary behavior tests by their exact test-name
+patterns at this checkpoint; the catalog behavior file is completed in Task 2.
+
+- [ ] **Step 7: Commit the compact bar and modal boundary**
+
+```bash
+git add \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-modal.tsx \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+git commit -m "feat(dashboard): move source scope into modal"
+```
+
+---
+
+### Task 2: Repository catalog editing and warnings inside the modal
+
+**Files:**
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-modal.tsx`
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx`
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx`
+
+**Interfaces:**
+- Consumes: `RepositoryScopeModalProps` from Task 1, `useRepositoryCatalog()`,
+  `addPinnedRepositories()`, `removePinnedRepository()`,
+  `togglePinnedProvider()`, `contradictingPinnedRepositories()`,
+  `MAX_PINNED_REPOSITORIES`, and `PINNABLE_PROVIDERS`.
+- Produces: a complete draft editor that calls `onApply(draft)` once and never
+  calls it from intermediate controls.
+
+- [ ] **Step 1: Write failing catalog draft tests**
+
+Update the behavior harness to interact with modal controls and add assertions
+for this sequence:
+
+```ts
+await modal.toggleRepository("Blazity/ai-workflow-prod", true);
+await modal.setFilter("billing");
+await modal.toggleRepository("acme-group/platform/billing-core", true);
+await modal.apply();
+
+assert.deepEqual(changes, [{
+  repositories: [
+    { provider: "github", repoPath: "Blazity/ai-workflow-prod" },
+    { provider: "gitlab", repoPath: "acme-group/platform/billing-core" },
+  ],
+}]);
+```
+
+Retain focused tests for filter persistence, the eight-repository limit,
+refresh removing retired selections, archived rows, already-selected rows,
+empty catalogs, catalog errors, and exact manual entry. Rewrite them to assert
+draft checkbox/chip state before Apply and one parent change after Apply.
+
+- [ ] **Step 2: Run the behavior tests and verify catalog cases fail**
+
+Run:
+
+```bash
+pnpm --dir apps/dashboard exec tsx --test \
+  components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+```
+
+Expected: failures because the modal shell does not yet render provider,
+catalog, selected-repository, or manual-entry controls.
+
+- [ ] **Step 3: Implement provider controls and selected repository chips**
+
+Inside the modal, render two equal-height provider toggles:
+
+```tsx
+{PINNABLE_PROVIDERS.map((provider) => {
+  const active = (draft.providers ?? []).includes(provider);
+  return (
+    <button
+      key={provider}
+      type="button"
+      aria-pressed={active}
+      onClick={() => setDraft((current) =>
+        togglePinnedProvider(current, provider)
+      )}
+      className="inline-flex h-10 min-w-[112px] items-center justify-center rounded-[4px] border px-3"
+    >
+      {providerLabel(provider)}
+    </button>
+  );
+})}
+```
+
+Render selected repositories as consistent chips with a 40-pixel remove
+button. Removal calls:
+
+```ts
+setDraft((current) => removePinnedRepository(current, repository));
+```
+
+- [ ] **Step 4: Implement direct catalog selection in the draft**
+
+Reuse the current filter, `catalogByKey`, empty/loading/error distinctions, and
+refresh action. Repository checkboxes reflect `isRepositoryPinned(draft,
+option)`. Checking adds one entry with `addPinnedRepositories`; unchecking
+removes it with `removePinnedRepository`.
+
+Disable an unchecked row when it is archived or the draft already contains
+`MAX_PINNED_REPOSITORIES`. Do not keep a second pending-selection array: the
+modal draft already provides cancel/apply semantics and remains stable across
+filter changes.
+
+- [ ] **Step 5: Preserve manual fallback and contextual warnings**
+
+For an empty or failed catalog, keep the existing provider listbox and exact
+`owner/repo` input. `Add to selection` updates only `draft`. Preserve messages
+for duplicates and the repository limit.
+
+Render the current detailed messages inside the modal for:
+
+```ts
+contradictingPinnedRepositories(draft)
+unknown pinned repositories after a settled catalog
+archived pinned repositories
+catalog loading and failure states
+```
+
+Keep the compact bar warning generic; detailed repository names and remediation
+stay inside the modal.
+
+- [ ] **Step 6: Run both focused test files**
+
+Run:
+
+```bash
+pnpm --dir apps/dashboard exec tsx --test \
+  components/cockpit/flow-editor/repository-scope-bar.test.tsx \
+  components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+```
+
+Expected: all repository scope tests pass.
+
+- [ ] **Step 7: Commit catalog editing**
+
+```bash
+git add \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-modal.tsx \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.test.tsx \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+git commit -m "feat(dashboard): edit repository scope as modal draft"
+```
+
+---
+
+### Task 3: Keyboard containment, responsive polish, and full verification
+
+**Files:**
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-modal.tsx`
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx`
+- Modify: `apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx`
+
+**Interfaces:**
+- Consumes: the complete `RepositoryScopeModal` from Task 2.
+- Produces: focus containment, focus restoration, backdrop/Escape cancellation,
+  internal viewport scrolling, and final visual consistency.
+
+- [ ] **Step 1: Write failing dismissal and focus tests**
+
+Add behavior tests that:
+
+```ts
+await modal.pressEscape();
+assert.deepEqual(changes, []);
+assert.equal(modal.isOpen(), false);
+
+await modal.open();
+await modal.clickBackdrop();
+assert.deepEqual(changes, []);
+assert.equal(modal.isOpen(), false);
+```
+
+Assert the dialog keydown handler wraps Tab from the last focusable control to
+the first and Shift+Tab from the first to the last using a mocked
+`currentTarget.querySelectorAll()` result. Verify focus restoration to
+`Configure` during the browser smoke test in Step 5 because the current
+`react-test-renderer` harness has no browser `document.activeElement`.
+
+- [ ] **Step 2: Run the behavior test and verify dismissal/focus cases fail**
+
+Run:
+
+```bash
+pnpm --dir apps/dashboard exec tsx --test \
+  components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+```
+
+Expected: new focus containment or dismissal assertions fail.
+
+- [ ] **Step 3: Implement focus entry, containment, and restoration**
+
+Use refs for the trigger and dialog. When the modal opens, focus the first
+enabled provider toggle. On dialog `keydown`:
+
+```ts
+if (event.key === "Escape") onCancel();
+if (event.key === "Tab") {
+  const focusable = dialog.querySelectorAll<HTMLElement>(
+    'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+  );
+  // Wrap forward from the last item and backward from the first item.
+}
+```
+
+When the modal closes, focus the trigger ref. Use exact transition properties
+only; do not add `transition-all`. Respect `motion-reduce` if an opacity
+transition is used.
+
+- [ ] **Step 4: Finish responsive and interaction polish**
+
+Use an internal `overflow-y-auto` body and sticky footer. Keep modal outer
+spacing at `p-4`, width at `max-w-[680px]`, and height at
+`max-h-[calc(100dvh-32px)]`. Give icon-only close/remove controls a 40 by 40
+pixel hit area, add `focus-visible` rings, and use `active:scale-[0.96]` only on
+standalone buttons where it does not move adjacent content.
+
+- [ ] **Step 5: Run focused tests and inspect the workflow editor in a browser**
+
+Run:
+
+```bash
+pnpm --dir apps/dashboard exec tsx --test \
+  components/cockpit/flow-editor/repository-scope-bar.test.tsx \
+  components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+```
+
+Start the dashboard with its normal local environment and verify:
+
+- opening and closing the modal does not move the canvas;
+- the one-row summary remains aligned at desktop and narrow widths;
+- Escape, backdrop, Cancel, close, and Apply behave as specified;
+- keyboard focus stays in the dialog and returns to Configure;
+- long repository lists scroll inside the modal;
+- badges have equal height and do not visually jump between states.
+
+- [ ] **Step 6: Run dashboard type checking and the full dashboard suite**
+
+Run:
+
+```bash
+pnpm --dir apps/dashboard typecheck
+pnpm --dir apps/dashboard test
+```
+
+Expected: both commands exit with status 0.
+
+- [ ] **Step 7: Review the diff for scope and formatting**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff --stat HEAD~2
+```
+
+Confirm every changed source or test line belongs to the repository-scope modal
+and no generated `.superpowers/` files are tracked.
+
+- [ ] **Step 8: Commit final accessibility and polish**
+
+```bash
+git add \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-modal.tsx \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.tsx \
+  apps/dashboard/components/cockpit/flow-editor/repository-scope-bar.behavior.test.tsx
+git commit -m "fix(dashboard): polish source scope modal interactions"
+```

--- a/docs/superpowers/specs/2026-07-28-repository-scope-modal-design.md
+++ b/docs/superpowers/specs/2026-07-28-repository-scope-modal-design.md
@@ -1,0 +1,99 @@
+# Repository Scope Modal Design
+
+## Goal
+
+Make provider and repository scope configuration readable without expanding the
+workflow editor or shifting the canvas when the repository picker opens.
+
+The change is limited to the dashboard UI. Repository scope contracts,
+validation rules, catalog loading, and workflow serialization remain unchanged.
+
+## Collapsed State
+
+Replace the current two-row repository/provider bar with one compact `Source
+scope` row.
+
+The row contains:
+
+- an `Automatic` provider summary when no provider is pinned, otherwise one
+  equal-height badge for each pinned provider;
+- `Automatic per ticket` when no repository is pinned, otherwise a repository
+  count such as `2 repositories`;
+- a compact warning status when the saved scope contains a provider mismatch,
+  an archived repository, or a repository missing from the settled catalog;
+- one `Configure` button.
+
+All summary badges use the same height, border radius, padding, and vertical
+alignment. Dynamic counts use tabular numerals. The collapsed row never expands
+to render the picker.
+
+## Modal
+
+`Configure` opens a centered modal over a fixed backdrop. The modal overlays the
+editor and does not participate in document layout, so opening, filtering, and
+closing it cannot move the workflow canvas.
+
+The modal contains:
+
+1. A header with `Configure source scope`, supporting copy, and a close button.
+2. A `Providers` section with equal-size GitHub and GitLab toggle controls.
+   Selecting neither means automatic provider resolution.
+3. A `Repositories` section with selected repository chips, the existing
+   catalog refresh action, search input, repository rows, remaining-slot count,
+   and existing catalog fallback for exact manual entry.
+4. Contextual warnings for provider mismatches, archived repositories, missing
+   catalog entries, and catalog failures.
+5. A sticky footer with `Cancel` and `Apply scope`.
+
+The modal keeps a local draft of the entire `WorkflowRepositoryScope`. Provider
+toggles, repository additions, and repository removals update only that draft.
+`Apply scope` calls the existing `onChange` once with the complete draft and
+closes the modal. `Cancel`, the close button, backdrop dismissal, and `Escape`
+discard the draft.
+
+Opening the modal always initializes a fresh draft from the current `scope`
+prop. Read-only mode disables `Configure`, matching the current bar behavior.
+
+## Interaction and Accessibility
+
+- The modal uses accessible dialog semantics with an accessible title.
+- Focus moves into the modal when it opens and returns to `Configure` when it
+  closes.
+- Focus stays within the modal while it is open.
+- `Escape` and backdrop click cancel the draft.
+- Buttons and row controls have at least a 40 by 40 pixel hit area.
+- Visible keyboard focus is preserved for every interactive control.
+- The modal body scrolls internally on short viewports; the workflow editor
+  behind it remains fixed.
+- On narrow screens the modal uses the available viewport width with safe outer
+  spacing.
+
+## Component Boundaries
+
+Keep the change surgical:
+
+- `RepositoryScopeBar` owns the compact summary and modal open state.
+- `RepositoryScopeModal` owns the local draft and apply/cancel behavior.
+- The existing picker catalog and manual-entry behavior are reused inside the
+  modal rather than duplicated.
+- Small presentational helpers may be introduced for consistent provider and
+  repository badges.
+- Domain helpers in `repository-scope.ts` remain the source of truth for scope
+  mutations and validation descriptions.
+
+## Verification
+
+Update component and behavior tests to verify:
+
+- the collapsed bar renders one compact source-scope row;
+- the picker is absent from document flow until the modal is open;
+- opening the modal does not mutate the supplied scope;
+- cancel, close, backdrop click, and `Escape` discard draft changes;
+- applying calls `onChange` once with provider and repository draft changes;
+- provider toggles, repository filtering, multi-selection, removal, refresh,
+  manual fallback, limits, and warnings retain their current behavior;
+- read-only mode cannot open the modal;
+- dialog naming and control labels remain accessible.
+
+Run the focused repository-scope tests, dashboard type checking, and the
+dashboard test suite before completion.


### PR DESCRIPTION
## Summary
- replace the expanding provider/repository rows with one compact Source scope summary
- move provider and repository editing into a fixed, draft-based modal that does not shift the workflow canvas
- align badges and preserve catalog refresh, manual fallback, warnings, limits, and keyboard accessibility

## Verification
- `pnpm --dir apps/dashboard test` (587 tests)
- `pnpm --dir apps/dashboard typecheck`
- `pnpm --dir apps/dashboard build`

## Notes
- live browser smoke testing was unavailable in the current session; component, behavior, editor integration, type, and production-build checks all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a compact “Source scope” summary bar to the workflow editor.
  - Added a modal for configuring providers and repositories without shifting the editor layout.
  - Added draft editing with Apply, Cancel, Escape, and backdrop dismissal support.
  - Added repository filtering, manual entry fallback, pin-limit handling, warnings, and focus management.
  - Read-only editors now prevent scope configuration.

- **Documentation**
  - Added design and implementation documentation for the repository scope modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->