### PR TITLE
Fix disposable reviews and replay details

### DIFF
--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -141,7 +141,7 @@ export function TraceScreen({
   const onBack = () => router.push("/runs");
   const onTicket = (key: string) => router.push(`/ticket/${encodeURIComponent(key)}`);
   return (
-    <div className="flex flex-col gap-4 px-4 pt-4 pb-6 lg:px-6 lg:pt-5 lg:pb-8">
+    <div className="flex w-full min-w-0 max-w-full flex-col gap-4 overflow-x-hidden px-4 pt-4 pb-6 lg:px-6 lg:pt-5 lg:pb-8">
       <Breadcrumb
         runId={runId}
         ticket={data.run?.ticket ?? ""}
@@ -312,7 +312,7 @@ export function TraceDetail({
   ).length;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex min-w-0 max-w-full flex-col gap-4">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
         <div className="flex flex-col gap-1 min-w-0">
           <div className="flex items-center gap-2.5 flex-wrap lg:flex-nowrap">

--- a/apps/dashboard/components/cockpit/screens/workflow-replay.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-replay.test.tsx
@@ -138,10 +138,23 @@ test("visual replay contains wide graph and inspector content within the page", 
     html.match(/<div[^>]*data-replay-canvas="true"[^>]*>/)?.[0] ?? "";
   const tabs =
     html.match(/<div[^>]*data-replay-tabs="true"[^>]*>/)?.[0] ?? "";
+  const inspector =
+    html.match(/<section[^>]*class="[^"]*replay-inspector[^"]*"[^>]*>/)?.[0] ??
+    "";
 
-  assert.match(root, /class="[^"]*max-w-full[^"]*overflow-hidden/);
-  assert.match(canvas, /class="[^"]*max-w-full[^"]*overflow-auto/);
-  assert.match(tabs, /class="[^"]*overflow-x-auto/);
+  assert.match(
+    root,
+    /class="[^"]*w-full[^"]*min-w-0[^"]*max-w-full[^"]*overflow-hidden/,
+  );
+  assert.match(
+    canvas,
+    /class="[^"]*w-full[^"]*min-w-0[^"]*max-w-full[^"]*overflow-auto/,
+  );
+  assert.match(
+    inspector,
+    /class="[^"]*min-w-0[^"]*overflow-hidden/,
+  );
+  assert.match(tabs, /class="[^"]*max-w-full[^"]*overflow-x-auto/);
 });
 
 test("visual replay preserves persisted stable-edge geometry", () => {

--- a/apps/dashboard/components/cockpit/screens/workflow-replay.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-replay.test.tsx
@@ -129,6 +129,21 @@ test("visual replay renders graph state, selected path, and read-only inspector"
   assert.doesNotMatch(html, /Rerun|Run step|Replay side effects/);
 });
 
+test("visual replay contains wide graph and inspector content within the page", () => {
+  const html = renderToStaticMarkup(
+    <WorkflowReplay runId="wrun_1" initialResponse={response} />,
+  );
+  const root = html.match(/<div[^>]*data-replay-root="true"[^>]*>/)?.[0] ?? "";
+  const canvas =
+    html.match(/<div[^>]*data-replay-canvas="true"[^>]*>/)?.[0] ?? "";
+  const tabs =
+    html.match(/<div[^>]*data-replay-tabs="true"[^>]*>/)?.[0] ?? "";
+
+  assert.match(root, /class="[^"]*max-w-full[^"]*overflow-hidden/);
+  assert.match(canvas, /class="[^"]*max-w-full[^"]*overflow-auto/);
+  assert.match(tabs, /class="[^"]*overflow-x-auto/);
+});
+
 test("visual replay preserves persisted stable-edge geometry", () => {
   const withAuthoredBend: WorkflowRunReplayResponse = {
     ...response,

--- a/apps/dashboard/components/cockpit/screens/workflow-replay.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-replay.tsx
@@ -437,7 +437,7 @@ function ReplayCanvas({
 
   return (
     <div
-      className="relative overflow-auto rounded-[3px] border border-neutral-200 bg-[#F8F9FB]"
+      className="relative w-full min-w-0 max-w-full overflow-auto rounded-[3px] border border-neutral-200 bg-[#F8F9FB]"
       aria-label="Workflow run replay"
       data-replay-canvas="true"
     >
@@ -732,6 +732,7 @@ function AttemptInspector({
 
   return (
     <CkCard
+      className="min-w-0 overflow-hidden"
       eyebrow="Sanitized observation"
       title={selectedAttempt ? displayAttempt(selectedAttempt) : "No attempt"}
       action={
@@ -769,17 +770,22 @@ function AttemptInspector({
       }
     >
       <div className="flex flex-col gap-3">
-        <CkTabs
-          tabs={[
-            { id: "input", label: "Input" },
-            { id: "output", label: "Output" },
-            { id: "logs", label: "Logs" },
-            { id: "metadata", label: "Metadata" },
-            { id: "attempts", label: `Attempts (${attempts.length})` },
-          ]}
-          active={tab}
-          onChange={(next) => setTab(next as ReplayTab)}
-        />
+        <div
+          className="max-w-full overflow-x-auto"
+          data-replay-tabs="true"
+        >
+          <CkTabs
+            tabs={[
+              { id: "input", label: "Input" },
+              { id: "output", label: "Output" },
+              { id: "logs", label: "Logs" },
+              { id: "metadata", label: "Metadata" },
+              { id: "attempts", label: `Attempts (${attempts.length})` },
+            ]}
+            active={tab}
+            onChange={(next) => setTab(next as ReplayTab)}
+          />
+        </div>
         {tab === "attempts" ? (
           <div className="flex max-h-[360px] flex-col gap-1 overflow-auto">
             {attempts.map((attempt) => (
@@ -1071,12 +1077,16 @@ export function WorkflowReplay({
   }
 
   return (
-    <div className="grid min-w-0 gap-3 2xl:grid-cols-[minmax(0,1.7fr)_minmax(360px,1fr)]">
+    <div
+      className="grid w-full min-w-0 max-w-full gap-3 overflow-hidden 2xl:grid-cols-[minmax(0,1.7fr)_minmax(360px,1fr)]"
+      data-replay-root="true"
+    >
       <CkCard
+        className="min-w-0 overflow-hidden"
         eyebrow="Visual replay · read-only"
         title="Executed workflow"
         action={
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <CkChip tone="success">{graphAttempts.length} attempts</CkChip>
             {graphLoadRequest.cursor !== null ? (
               <CkChip tone="neutral">loading recent history</CkChip>

--- a/apps/dashboard/components/cockpit/screens/workflow-replay.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-replay.tsx
@@ -732,7 +732,7 @@ function AttemptInspector({
 
   return (
     <CkCard
-      className="min-w-0 overflow-hidden"
+      className="replay-inspector min-w-0 overflow-hidden"
       eyebrow="Sanitized observation"
       title={selectedAttempt ? displayAttempt(selectedAttempt) : "No attempt"}
       action={

--- a/apps/worker/src/run-observability/sanitizer.test.ts
+++ b/apps/worker/src/run-observability/sanitizer.test.ts
@@ -253,6 +253,32 @@ describe("sanitizeReplayValue", () => {
     ).toBe("serialization");
   });
 
+  it("keeps replay payloads with undefined optional object fields", () => {
+    const envelope = sanitizeReplayValue({
+      decision: "request_changes",
+      feedback: undefined,
+      findings: [
+        {
+          file: "src/index.ts",
+          description: "Handle this case.",
+          startLine: undefined,
+          endLine: undefined,
+        },
+      ],
+    });
+
+    expect(envelope.metadata.unavailable).toBe(false);
+    expect(envelope.value).toEqual({
+      decision: "request_changes",
+      findings: [
+        {
+          file: "src/index.ts",
+          description: "Handle this case.",
+        },
+      ],
+    });
+  });
+
   it("caps fields at 64 KiB without splitting Unicode code points", () => {
     const envelope = sanitizeReplayValue("🦊".repeat(40_000));
     expect(Buffer.byteLength(serialized(envelope), "utf8")).toBeLessThanOrEqual(

--- a/apps/worker/src/run-observability/sanitizer.ts
+++ b/apps/worker/src/run-observability/sanitizer.ts
@@ -714,6 +714,11 @@ function sanitizeValue(
         throw new SanitizationError("serialization");
       }
       const item = record[key];
+      // Workflow payloads are JSON-shaped, but optional TypeScript fields can
+      // still be present with an `undefined` value. JSON serialization omits
+      // those fields, so do the same instead of discarding the whole replay
+      // envelope.
+      if (item === undefined) continue;
       if (isHardExcludedKey(key)) {
         output[sanitizedKey] = redacted("hard_exclusion");
         addRedaction(context.redactions, "hard_exclusion");

--- a/apps/worker/src/sandbox/disposable-review-workspace.test.ts
+++ b/apps/worker/src/sandbox/disposable-review-workspace.test.ts
@@ -246,7 +246,7 @@ describe("disposable review workspace", () => {
     );
   });
 
-  it("writes /blazebot/memory/ into the review excludes file", async () => {
+  it("ignores restored memory and harness scratch links in the review checkout", async () => {
     await provisionDisposableReviewWorkspaceStep({
       sourceSandboxId: "source-1",
       workspaceManifest: manifest,
@@ -261,7 +261,37 @@ describe("disposable review workspace", () => {
       .flatMap(([files]) => files as Array<{ path: string; content: Buffer }>)
       .find((file) => file.path === "/tmp/aiw-review-primary-git-excludes");
     expect(excludeWrite?.content.toString("utf8")).toBe(
-      "/aiw-repos.json\n/repos/\n/blazebot/memory/\n/.codex/\n/.claude/\n",
+      "/aiw-repos.json\n/repos/\n/blazebot/memory/\n/.codex\n/.claude\n",
+    );
+  });
+
+  it("rejects setup artifacts before starting a reviewer", async () => {
+    let scratchLinksCreated = false;
+    mocks.reviewCommand.mockImplementation(
+      async (name: string, args: string[]) => {
+        if (name === "ln") scratchLinksCreated = true;
+        if (args.includes("rev-parse")) return command(headForArgs(args));
+        if (scratchLinksCreated && args.includes("status")) {
+          return command("?? .codex");
+        }
+        return command();
+      },
+    );
+
+    await expect(
+      provisionDisposableReviewWorkspaceStep({
+        sourceSandboxId: "source-1",
+        workspaceManifest: manifest,
+        subjectKey: "ticket:jira:AIW-120",
+        ownerToken: "owner-1",
+        agentKind: "codex",
+        model: "gpt-5",
+        arthurTaskId: null,
+      }),
+    ).rejects.toThrow(/not clean after setup/i);
+
+    expect(mocks.stopSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ sandboxId: "review-1" }),
     );
   });
 

--- a/apps/worker/src/sandbox/disposable-review-workspace.ts
+++ b/apps/worker/src/sandbox/disposable-review-workspace.ts
@@ -15,7 +15,7 @@ import { fingerprintWorkspaceState } from "../workflows/workspace-gate-fingerpri
 
 const PRIMARY_REPOSITORY_EXCLUDES_PATH = "/tmp/aiw-review-primary-git-excludes";
 const PRIMARY_REPOSITORY_EXCLUDES =
-  "/aiw-repos.json\n/repos/\n/blazebot/memory/\n/.codex/\n/.claude/\n";
+  "/aiw-repos.json\n/repos/\n/blazebot/memory/\n/.codex\n/.claude\n";
 
 export interface DisposableReviewRepository {
   repoPath: string;
@@ -394,6 +394,24 @@ export async function provisionDisposableReviewWorkspaceStep(
         ]),
         `review ${scratch.name} scratch link could not be created`,
       );
+    }
+    for (const repo of exported) {
+      const status = await requireCommand(
+        await sandbox.runCommand("git", [
+          "--no-optional-locks",
+          "-C",
+          repo.localPath,
+          "status",
+          "--porcelain=v1",
+          "--untracked-files=all",
+        ]),
+        `review checkout cleanliness could not be inspected for ${repo.repoPath}`,
+      );
+      if ((await status.stdout()).trim()) {
+        throw new Error(
+          `review checkout is not clean after setup for ${repo.repoPath}`,
+        );
+      }
     }
     for (const repo of [...exported].reverse()) {
       await requireCommand(


### PR DESCRIPTION
## Summary
- prevent harness scratch symlinks from making disposable review checkouts look modified
- verify review checkout cleanliness immediately after setup
- preserve replay inputs and outputs that contain undefined optional object fields
- contain the replay canvas, inspector, and tabs so the trace page no longer scrolls horizontally

## Root causes
The review checkout ignored .codex/ and .claude/ as directories, but setup creates symlinks with those names. Git therefore reported them as untracked and the post-review integrity check failed.

Replay sanitization treated an undefined optional property as an unsafe value and discarded the entire envelope. Object properties with undefined values are now omitted, matching JSON serialization, while unsupported structures still fail closed.

## Verification
- worker focused regressions: 43 tests passed
- dashboard replay regressions: 24 tests passed
- full worker package test suite passed
- full dashboard package test suite passed
- worker typecheck passed
- dashboard typecheck passed
- git diff --check passed

No database migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved workflow replay layouts with tighter width constraints, more reliable scrolling/overflow handling, horizontally scrollable tabs, and updated action control wrapping.
  * Enhanced trace screen horizontal sizing and overflow behavior for better viewing.
  * Replay sanitization now omits explicitly `undefined` optional fields instead of marking the payload unavailable.
  * Disposable review workspaces now enforce repository cleanliness checks before making repositories read-only.
* **Tests**
  * Added new tests covering wide replay layout/inspector overflow behavior, `undefined` optional field sanitization, and disposable workspace integrity/failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->