### PR TITLE
Fix rejected v2 review verdict handling

### DIFF
--- a/apps/worker/src/workflows/agent-block-outputs.test.ts
+++ b/apps/worker/src/workflows/agent-block-outputs.test.ts
@@ -4,6 +4,7 @@ import {
   buildOpenPrSuccessOutput,
   buildReviewAgentSuccessOutput,
   resolveImplementationPlanInput,
+  shouldAbortForReviewResult,
 } from "./agent.js";
 import { validateBlockOutputForDefinition } from "../workflow-definition/block-registry.js";
 
@@ -99,6 +100,12 @@ describe("specialized workflow block outputs", () => {
         requireNormalOutput: true,
       }),
     ).toEqual([]);
+  });
+
+  it("keeps rejected v2 reviews as normal data while preserving the v1 compatibility failure", () => {
+    expect(shouldAbortForReviewResult(2, { result: "failed" })).toBe(false);
+    expect(shouldAbortForReviewResult(2, { result: "approved" })).toBe(false);
+    expect(shouldAbortForReviewResult(1, { result: "failed" })).toBe(true);
   });
 
   it("reports every created PR while preserving the primary legacy fields", () => {

--- a/apps/worker/src/workflows/agent-block-outputs.test.ts
+++ b/apps/worker/src/workflows/agent-block-outputs.test.ts
@@ -3,8 +3,8 @@ import {
   buildImplementationAgentSuccessOutput,
   buildOpenPrSuccessOutput,
   buildReviewAgentSuccessOutput,
+  reviewAgentExecutionResult,
   resolveImplementationPlanInput,
-  shouldAbortForReviewResult,
 } from "./agent.js";
 import { validateBlockOutputForDefinition } from "../workflow-definition/block-registry.js";
 
@@ -102,10 +102,32 @@ describe("specialized workflow block outputs", () => {
     ).toEqual([]);
   });
 
-  it("keeps rejected v2 reviews as normal data while preserving the v1 compatibility failure", () => {
-    expect(shouldAbortForReviewResult(2, { result: "failed" })).toBe(false);
-    expect(shouldAbortForReviewResult(2, { result: "approved" })).toBe(false);
-    expect(shouldAbortForReviewResult(1, { result: "failed" })).toBe(true);
+  it("routes rejected v2 reviews as normal data while preserving the v1 compatibility failure", () => {
+    const rejectedReview = {
+      result: "failed" as const,
+      feedback: "One blocking issue.",
+      issues: [
+        { file: "src/index.ts", description: "Handle null input.", severity: "critical" as const },
+      ],
+    };
+
+    expect(reviewAgentExecutionResult(2, rejectedReview)).toEqual({
+      kind: "next",
+      output: {
+        status: "reviewed",
+        findings: rejectedReview.issues,
+        decision: "request_changes",
+        feedback: "One blocking issue.",
+      },
+    });
+    expect(reviewAgentExecutionResult(1, rejectedReview)).toMatchObject({
+      kind: "execution_error",
+      error: {
+        category: "provider",
+        detail: "unknown",
+        phase: "review",
+      },
+    });
   });
 
   it("reports every created PR while preserving the primary legacy fields", () => {

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -419,11 +419,20 @@ export function buildReviewAgentSuccessOutput(
   };
 }
 
-export function shouldAbortForReviewResult(
+export function reviewAgentExecutionResult(
   schemaVersion: 1 | 2,
-  review: Pick<ReviewOutput, "result">,
-): boolean {
-  return schemaVersion === 1 && review.result === "failed";
+  review: ReviewOutput,
+): BlockExecutionResult {
+  if (schemaVersion === 1 && review.result === "failed") {
+    return executionError(review.error ?? "unknown", {
+      category: "provider",
+      phase: "review",
+    });
+  }
+  return {
+    kind: "next",
+    output: buildReviewAgentSuccessOutput(review),
+  };
 }
 
 type PublishedPullRequests = Extract<
@@ -4516,18 +4525,7 @@ async function agentWorkflowBody(
                 });
               }
 
-              if (shouldAbortForReviewResult(ctx.schemaVersion, reviewOutput)) {
-                const reason = reviewOutput.error ?? "unknown";
-                return executionError(reason, {
-                  category: "provider",
-                  phase: "review",
-                });
-              }
-
-              return {
-                kind: "next",
-                output: buildReviewAgentSuccessOutput(reviewOutput),
-              };
+              return reviewAgentExecutionResult(ctx.schemaVersion, reviewOutput);
             } finally {
               await teardownSandboxes([sandboxId]);
             }

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -419,6 +419,13 @@ export function buildReviewAgentSuccessOutput(
   };
 }
 
+export function shouldAbortForReviewResult(
+  schemaVersion: 1 | 2,
+  review: Pick<ReviewOutput, "result">,
+): boolean {
+  return schemaVersion === 1 && review.result === "failed";
+}
+
 type PublishedPullRequests = Extract<
   WorkspacePublicationResult,
   { status: "published" }
@@ -4509,7 +4516,7 @@ async function agentWorkflowBody(
                 });
               }
 
-              if (reviewOutput.result === "failed") {
+              if (shouldAbortForReviewResult(ctx.schemaVersion, reviewOutput)) {
                 const reason = reviewOutput.error ?? "unknown";
                 return executionError(reason, {
                   category: "provider",


### PR DESCRIPTION
## What changed

- Keep rejected Review Agent verdicts as normal typed workflow data in Workflow Definition v2.
- Preserve the existing Workflow Definition v1 compatibility behavior.
- Add regression coverage for approved and rejected v2 verdicts plus the v1 boundary.

## Root cause

The Review Agent parser correctly returned a rejected review as `result: "failed"` with structured findings. The shared agent workflow then treated that domain verdict as a provider execution failure, substituted `"unknown"` because no provider error existed, and caused the v2 scheduler to cancel the sibling review blocks.

V2 already represents the same result as `decision: "request_changes"`. The runtime must therefore continue normally so the visible Branch and downstream review actions can handle it.

## User impact

Review workflows can now report genuine findings and take their configured request-changes path instead of failing the entire workflow and cancelling parallel reviewers.

## Compatibility

- Workflow Definition v1 retains its legacy failed-review behavior.
- Genuine provider, parsing, and runtime errors still fail the block and workflow.

## Verification

- `corepack pnpm --filter worker exec vitest run src/workflows/agent-block-outputs.test.ts`
- `corepack pnpm --filter worker exec vitest run src/workflows/agent-block-outputs.test.ts src/workflows/agent-provider-fences.test.ts src/workflow-definition/reviewed-ticket-template.test.ts src/workflow-definition/v2-scheduler.test.ts`
- `corepack pnpm --filter worker exec tsc --noEmit`
- Full worker suite initiated locally; GitHub CI remains authoritative for the complete package suite.

Jira: [AIW-193](https://blazity.atlassian.net/browse/AIW-193)


[AIW-193]: https://blazity.atlassian.net/browse/AIW-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated review workflow handling so rejected review outcomes now abort only under schema version 1.
  * For schema version 2, rejected reviews are routed as normal “reviewed” next steps (including request-changes decision and preserved review feedback) rather than failing execution.

* **Tests**
  * Added test coverage to validate the differing behavior for rejected review results across schema versions 1 and 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->