### PR TITLE
Handle self-authored GitHub review publication

### DIFF
--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -618,6 +618,153 @@ describe("GitHubAdapter", () => {
       );
       expect(result).toEqual({ id: "702", commentIds: [null] });
     });
+
+    it("publishes findings as a comment review when the app cannot request changes on its own pull request", async () => {
+      mockOctokit.paginate
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 803,
+            path: "src/index.ts",
+            line: 12,
+            start_line: 10,
+          },
+        ]);
+      const rejected = Object.assign(
+        new Error(
+          'Unprocessable Entity: "Review Can not request changes on your own pull request"',
+        ),
+        { status: 422 },
+      );
+      mockOctokit.pulls.createReview
+        .mockRejectedValueOnce(rejected)
+        .mockResolvedValueOnce({ data: { id: 703 } });
+
+      const result = await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "reviewed-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          {
+            path: "src/index.ts",
+            body: "Handle this failure.",
+            startLine: 10,
+            endLine: 12,
+          },
+        ],
+      });
+
+      expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(2);
+      expect(mockOctokit.pulls.createReview).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          event: "COMMENT",
+          comments: [
+            expect.objectContaining({
+              path: "src/index.ts",
+              body: "Handle this failure.",
+            }),
+          ],
+        }),
+      );
+      expect(result).toEqual({ id: "703", commentIds: ["803"] });
+    });
+
+    it("publishes approval as a comment review when the app cannot approve its own pull request", async () => {
+      mockOctokit.paginate
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      const rejected = Object.assign(
+        new Error(
+          'Unprocessable Entity: "Review Can not approve your own pull request"',
+        ),
+        { status: 422 },
+      );
+      mockOctokit.pulls.createReview
+        .mockRejectedValueOnce(rejected)
+        .mockResolvedValueOnce({ data: { id: 704 } });
+
+      const result = await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "reviewed-head",
+        decision: "approve",
+        summary: "Approved.",
+        comments: [],
+      });
+
+      expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(2);
+      expect(mockOctokit.pulls.createReview).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          event: "COMMENT",
+          comments: [],
+        }),
+      );
+      expect(result).toEqual({ id: "704", commentIds: [] });
+    });
+
+    it("falls back to a summary-only comment review when self-review inline positions are rejected", async () => {
+      mockOctokit.paginate.mockResolvedValueOnce([]);
+      const selfReviewRejected = Object.assign(
+        new Error(
+          'Unprocessable Entity: "Review Can not request changes on your own pull request"',
+        ),
+        { status: 422 },
+      );
+      const inlineRejected = Object.assign(new Error("Validation failed"), {
+        status: 422,
+      });
+      mockOctokit.pulls.createReview
+        .mockRejectedValueOnce(selfReviewRejected)
+        .mockRejectedValueOnce(inlineRejected)
+        .mockResolvedValueOnce({ data: { id: 705 } });
+
+      const result = await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "reviewed-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          {
+            path: "src/index.ts",
+            body: "Handle this failure.",
+            startLine: 10,
+            endLine: 12,
+          },
+        ],
+      });
+
+      expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(3);
+      expect(mockOctokit.pulls.createReview).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          event: "COMMENT",
+          comments: [],
+          body: expect.stringContaining(
+            "- `src/index.ts:10-12` — Handle this failure.",
+          ),
+        }),
+      );
+      expect(result).toEqual({ id: "705", commentIds: [null] });
+    });
+
+    it("does not hide unrelated GitHub validation failures", async () => {
+      mockOctokit.paginate.mockResolvedValueOnce([]);
+      const rejected = Object.assign(new Error("Validation failed"), {
+        status: 422,
+      });
+      mockOctokit.pulls.createReview.mockRejectedValueOnce(rejected);
+
+      await expect(
+        ghAdapter().publishPRReview(42, {
+          idempotencyKey: "review-hash",
+          headSha: "reviewed-head",
+          decision: "approve",
+          summary: "Approved.",
+          comments: [],
+        }),
+      ).rejects.toBe(rejected);
+
+      expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("getPRComments", () => {

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -28,6 +28,34 @@ export interface GitHubConfig {
   baseBranch: string;
 }
 
+function isSelfAuthoredReviewError(error: unknown): boolean {
+  const candidate = error as {
+    status?: unknown;
+    message?: unknown;
+    response?: {
+      data?: {
+        message?: unknown;
+        errors?: unknown;
+      };
+    };
+  };
+  if (candidate.status !== 422) return false;
+
+  const details = [
+    candidate.message,
+    candidate.response?.data?.message,
+    candidate.response?.data?.errors === undefined
+      ? undefined
+      : JSON.stringify(candidate.response.data.errors),
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+
+  return /review can not (?:request changes on|approve) your own pull request/i.test(
+    details,
+  );
+}
+
 export class GitHubAdapter
   implements
     VCSAdapter,
@@ -510,7 +538,7 @@ export class GitHubAdapter
         commentIds: this.alignReviewCommentIds(publication.comments, comments),
       };
     }
-    const request = {
+    const request: Parameters<Octokit["pulls"]["createReview"]>[0] = {
       ...this.ownerRepo,
       pull_number: prId,
       commit_id: publication.headSha,
@@ -533,24 +561,52 @@ export class GitHubAdapter
       })),
     };
     let data: { id: number };
+    let publishedRequest = request;
     try {
-      ({ data } = await this.octokit.pulls.createReview(request));
+      ({ data } = await this.octokit.pulls.createReview(publishedRequest));
     } catch (error) {
-      if (
-        (error as { status?: unknown }).status !== 422 ||
-        publication.comments.length === 0
-      ) {
-        throw error;
+      if (isSelfAuthoredReviewError(error)) {
+        publishedRequest = {
+          ...request,
+          event: "COMMENT" as const,
+        };
+        try {
+          ({ data } =
+            await this.octokit.pulls.createReview(publishedRequest));
+        } catch (commentError) {
+          if (
+            (commentError as { status?: unknown }).status !== 422 ||
+            publication.comments.length === 0
+          ) {
+            throw commentError;
+          }
+          ({ data } = await this.octokit.pulls.createReview({
+            ...publishedRequest,
+            body: this.reviewBodyWithInlineFallbacks(publication, marker),
+            comments: [],
+          }));
+          return {
+            id: String(data.id),
+            commentIds: publication.comments.map(() => null),
+          };
+        }
+      } else {
+        if (
+          (error as { status?: unknown }).status !== 422 ||
+          publication.comments.length === 0
+        ) {
+          throw error;
+        }
+        ({ data } = await this.octokit.pulls.createReview({
+          ...publishedRequest,
+          body: this.reviewBodyWithInlineFallbacks(publication, marker),
+          comments: [],
+        }));
+        return {
+          id: String(data.id),
+          commentIds: publication.comments.map(() => null),
+        };
       }
-      ({ data } = await this.octokit.pulls.createReview({
-        ...request,
-        body: this.reviewBodyWithInlineFallbacks(publication, marker),
-        comments: [],
-      }));
-      return {
-        id: String(data.id),
-        commentIds: publication.comments.map(() => null),
-      };
     }
     const comments = await this.octokit.paginate(
       this.octokit.pulls.listCommentsForReview,


### PR DESCRIPTION
## What changed

- Detect GitHub's specific `422` response when the workflow's GitHub App tries to approve or request changes on a pull request authored by the same App.
- Retry that publication as a neutral `COMMENT` review while preserving the review summary and inline findings.
- If GitHub also rejects an inline location, retain the existing summary-only fallback using the neutral review event.
- Keep the workflow's typed `approve` / `request_changes` decision unchanged so Branch and Complete PR check still carry the business verdict.
- Continue surfacing unrelated GitHub validation failures.

## Why

Production run `wrun_01KYMN8Q8EYZNP2NTTRFW789Q0` completed all three Review Agents, then failed in **Post PR review** because GitHub returned:

> Review Can not request changes on your own pull request

PR `Blazity/ai-workflow-prod#14` is authored by the same GitHub App that publishes the workflow review. GitHub forbids an author from approving or requesting changes on its own PR, but it permits a neutral comment review.

Diagnostic: `AIW-DIAG-wrun_01KYMN8Q8EYZNP2NTTRFW789Q0-post-review-1`

## User impact

Bot-authored PRs can now complete the editable post-PR review workflow. Findings remain visible on the PR, and the separate PR check continues to report whether the review passed or failed.

## Verification

- `corepack pnpm --filter worker exec vitest run src/adapters/vcs/github.test.ts src/workflows/pr-external-resources.test.ts` — 37 passed
- `corepack pnpm --filter worker exec tsc --noEmit` — passed
- `corepack pnpm --filter worker exec vitest run --silent` — full worker suite passed

Regression coverage includes self-authored request-changes, self-authored approval, inline-location fallback after neutralization, idempotent comment mapping, and unrelated `422` propagation.