### PR TITLE
Fix replay capture for workflow values

### DIFF
--- a/apps/worker/src/run-observability/sanitizer.test.ts
+++ b/apps/worker/src/run-observability/sanitizer.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 import {
   appendReplayLogEnvelope,
@@ -277,6 +278,62 @@ describe("sanitizeReplayValue", () => {
         },
       ],
     });
+  });
+
+  it("keeps JSON-shaped values created in another JavaScript realm", () => {
+    const value = runInNewContext(
+      `({
+        status: "ok",
+        check: {
+          id: "check_123",
+          headSha: "abc123",
+          name: "AI Workflow / Review"
+        }
+      })`,
+    );
+
+    const envelope = sanitizeReplayValue(value);
+
+    expect(envelope.metadata.unavailable).toBe(false);
+    expect(envelope.value).toEqual({
+      status: "ok",
+      check: {
+        id: "check_123",
+        headSha: "abc123",
+        name: "AI Workflow / Review",
+      },
+    });
+  });
+
+  it("still rejects class instances created in another JavaScript realm", () => {
+    const value = runInNewContext(
+      `new (class WorkflowValue {
+        constructor() {
+          this.status = "ok";
+        }
+      })()`,
+    );
+
+    expect(sanitizeReplayValue(value).metadata.unavailableReason).toBe(
+      "serialization",
+    );
+  });
+
+  it("rejects accessor properties without invoking them", () => {
+    let accessed = false;
+    const value = {};
+    Object.defineProperty(value, "secret", {
+      enumerable: true,
+      get() {
+        accessed = true;
+        return "must-not-be-read";
+      },
+    });
+
+    expect(sanitizeReplayValue(value).metadata.unavailableReason).toBe(
+      "serialization",
+    );
+    expect(accessed).toBe(false);
   });
 
   it("caps fields at 64 KiB without splitting Unicode code points", () => {

--- a/apps/worker/src/run-observability/sanitizer.test.ts
+++ b/apps/worker/src/run-observability/sanitizer.test.ts
@@ -319,6 +319,28 @@ describe("sanitizeReplayValue", () => {
     );
   });
 
+  it("rejects a spoofed Object constructor without reading its name", () => {
+    let nameAccessed = false;
+    const constructor = function WorkflowValue() {};
+    Object.defineProperty(constructor, "name", {
+      configurable: true,
+      get() {
+        nameAccessed = true;
+        return "Object";
+      },
+    });
+    const prototype = Object.create(null);
+    Object.defineProperty(prototype, "constructor", {
+      value: constructor,
+    });
+    const value = Object.assign(Object.create(prototype), { status: "ok" });
+
+    expect(sanitizeReplayValue(value).metadata.unavailableReason).toBe(
+      "serialization",
+    );
+    expect(nameAccessed).toBe(false);
+  });
+
   it("rejects accessor properties without invoking them", () => {
     let accessed = false;
     const value = {};

--- a/apps/worker/src/run-observability/sanitizer.ts
+++ b/apps/worker/src/run-observability/sanitizer.ts
@@ -64,6 +64,7 @@ export interface ReplayAttemptEnvelopeSet {
 }
 
 const utf8Encoder = new TextEncoder();
+const intrinsicObjectSource = Function.prototype.toString.call(Object);
 
 // The workflow bundle has no Node globals (Buffer is undefined there), and this
 // module runs inside workflow bodies via replay sanitization. Measure UTF-8
@@ -203,10 +204,24 @@ function isPlainRecord(value: object): boolean {
     prototype,
     "constructor",
   )?.value;
+  const constructorName =
+    typeof constructor === "function"
+      ? Object.getOwnPropertyDescriptor(constructor, "name")
+      : undefined;
+  const constructorPrototype =
+    typeof constructor === "function"
+      ? Object.getOwnPropertyDescriptor(constructor, "prototype")
+      : undefined;
   return (
     Object.getPrototypeOf(prototype) === null &&
     typeof constructor === "function" &&
-    constructor.name === "Object"
+    constructorName !== undefined &&
+    "value" in constructorName &&
+    constructorName.value === "Object" &&
+    constructorPrototype !== undefined &&
+    "value" in constructorPrototype &&
+    constructorPrototype.value === prototype &&
+    Function.prototype.toString.call(constructor) === intrinsicObjectSource
   );
 }
 

--- a/apps/worker/src/run-observability/sanitizer.ts
+++ b/apps/worker/src/run-observability/sanitizer.ts
@@ -181,18 +181,49 @@ function isAuthenticationFilePath(value: unknown): boolean {
   );
 }
 
-function isAuthenticationFileObject(value: object): boolean {
-  try {
-    const candidate = value as Record<string, unknown>;
-    return Object.entries(candidate).some(
-      ([key, path]) =>
-        ["path", "file", "filename", "filepath"].includes(
-          normalizedKey(key),
-        ) && isAuthenticationFilePath(path),
-    );
-  } catch {
-    throw new SanitizationError("serialization");
+function isAuthenticationFileObject(
+  entries: readonly (readonly [string, unknown])[],
+): boolean {
+  return entries.some(
+    ([key, path]) =>
+      ["path", "file", "filename", "filepath"].includes(normalizedKey(key)) &&
+      isAuthenticationFilePath(path),
+  );
+}
+
+function isPlainRecord(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype === null || prototype === Object.prototype) return true;
+
+  // Workflow values can cross a JavaScript-realm boundary. A foreign realm's
+  // Object.prototype is not reference-equal to ours, but it still has no parent
+  // and owns the native Object constructor. Keep rejecting class instances and
+  // other built-ins whose prototype chains do not have this shape.
+  const constructor = Object.getOwnPropertyDescriptor(
+    prototype,
+    "constructor",
+  )?.value;
+  return (
+    Object.getPrototypeOf(prototype) === null &&
+    typeof constructor === "function" &&
+    constructor.name === "Object"
+  );
+}
+
+function enumerableOwnDataEntries(
+  value: object,
+): Array<readonly [string, unknown]> {
+  const entries: Array<readonly [string, unknown]> = [];
+  for (const [key, descriptor] of Object.entries(
+    Object.getOwnPropertyDescriptors(value),
+  )) {
+    if (!descriptor.enumerable) continue;
+    if (!("value" in descriptor)) {
+      throw new SanitizationError("serialization");
+    }
+    entries.push([key, descriptor.value]);
   }
+  return entries;
 }
 
 function replaceMatches(
@@ -695,25 +726,22 @@ function sanitizeValue(
       }
       return output;
     }
-    const prototype = Object.getPrototypeOf(value);
-    if (prototype !== Object.prototype && prototype !== null) {
+    if (!isPlainRecord(value)) {
       throw new SanitizationError("serialization");
     }
-    if (isAuthenticationFileObject(value)) {
+    const entries = enumerableOwnDataEntries(value);
+    if (isAuthenticationFileObject(entries)) {
       addRedaction(context.redactions, "hard_exclusion");
       return redacted("hard_exclusion");
     }
 
     const output: Record<string, JsonValue> = {};
-    const record = value as Record<string, unknown>;
-    for (const key in record) {
-      if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+    for (const [key, item] of entries) {
       accountInputText(key, context);
       const sanitizedKey = sanitizeText(key, context, true);
       if (Object.prototype.hasOwnProperty.call(output, sanitizedKey)) {
         throw new SanitizationError("serialization");
       }
-      const item = record[key];
       // Workflow payloads are JSON-shaped, but optional TypeScript fields can
       // still be present with an `undefined` value. JSON serialization omits
       // those fields, so do the same instead of discarding the whole replay


### PR DESCRIPTION
## What changed

- Accept JSON-shaped workflow values that originate in another JavaScript realm when capturing replay input and output.
- Continue to fail closed for class instances, built-in objects, and accessor properties.
- Read only enumerable data properties so sanitization cannot invoke a getter.

## Root cause

Hosted workflow values can cross an isolated JavaScript realm. Their `Object.prototype` is not reference-equal to the worker realm's `Object.prototype`, so the replay sanitizer rejected otherwise ordinary JSON objects and persisted the generic unavailable marker.

## User impact

New workflow runs retain sanitized block inputs and outputs for visual replay instead of showing that every value could not be sanitized. Historical unavailable captures cannot be reconstructed.

## Verification

- `sanitizer.test.ts`, `runtime-hooks.test.ts`, and `store.test.ts`: 55 tests passed
- Full worker test suite: 259 files / 3,314 tests passed
- Worker TypeScript check passed
- Regression coverage for cross-realm plain objects, foreign class rejection, and accessor rejection without invocation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay sanitization for objects created in different JavaScript contexts, preserving safe JSON-compatible “plain record” data.
  * More reliably rejects unsafe, non-serializable values (including spoofed structures) and blocks unsafe accessor properties without invoking getters.
  * Enhanced detection and handling of authentication-file-like fields during replay processing.
* **Tests**
  * Added coverage for cross-realm acceptance/rejection and deterministic failure reasons for unsafe serialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->