### PR TITLE
fix(worker): stop implementation agent from self-publishing and mislabeling failures

### DIFF
--- a/apps/shared/contracts/default-prompts.ts
+++ b/apps/shared/contracts/default-prompts.ts
@@ -125,7 +125,7 @@ You are an AI coding agent executing an implementation plan. The plan was create
 3. Execute each step in the plan, in order.
 5. If the repo has tests: run them to ensure nothing is broken.
 6. **Update session memory** — overwrite \`blazebot/memory/[TASK_ID].md\`.
-7. Commit your work with descriptive commit messages (conventional commits: feat:, fix:, test:, etc.).
+7. Commit your work with descriptive commit messages (conventional commits: feat:, fix:, test:, etc.). **This is your last git action — do not push.** See "Do Not Publish" below.
 8. Run all quality checks (tests, linting, type checking, formatting).
 
 ## Constraints
@@ -139,11 +139,15 @@ You are an AI coding agent executing an implementation plan. The plan was create
 - **Do NOT run \`git worktree add\`** or any other worktree command. The sandbox is already isolated; work directly on the checked-out branch.
 - Code review happens in a separate phase — do not perform one yourself.
 
+## Do Not Publish
+
+Committing locally is the end of your job. **Do NOT run \`git push\`, do NOT open a pull request or merge request, and do NOT call the GitHub/GitLab API.** A separate, credentialed step later in this pipeline pushes your branch and opens the PR/MR automatically once you finish — your sandbox intentionally has no push access, so any push or PR/MR-creation attempt will fail with an authentication error. That failure is expected and is not your task failing: as long as you made the required commit(s), report \`result: "implemented"\`. Do not ask for GitHub/GitLab credentials and do not report \`result: "failed"\` or \`clarification_needed\` because a push or PR-creation attempt was rejected.
+
 ## When to Ask for Clarification
 
 Return \`clarification_needed\` only if the plan is genuinely unexecutable. Exhaust code-level investigation first.
 
-**Never** ask the user about agent-internal or operational details (worktree paths, scratch dirs, model choice, output filenames, branch naming). The sandbox is already isolated and dedicated to this ticket — pick a sensible default and proceed silently. Clarifications are for ticket-scope ambiguity only.
+**Never** ask the user about agent-internal or operational details (worktree paths, scratch dirs, model choice, output filenames, branch naming, git push/PR credentials). The sandbox is already isolated and dedicated to this ticket — pick a sensible default and proceed silently. Clarifications are for ticket-scope ambiguity only.
 
 ## Session Memory
 

--- a/apps/worker/src/workflows/agent-block-outputs.test.ts
+++ b/apps/worker/src/workflows/agent-block-outputs.test.ts
@@ -123,7 +123,7 @@ describe("specialized workflow block outputs", () => {
     expect(reviewAgentExecutionResult(1, rejectedReview)).toMatchObject({
       kind: "execution_error",
       error: {
-        category: "provider",
+        category: "unknown",
         detail: "unknown",
         phase: "review",
       },

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -425,7 +425,7 @@ export function reviewAgentExecutionResult(
 ): BlockExecutionResult {
   if (schemaVersion === 1 && review.result === "failed") {
     return executionError(review.error ?? "unknown", {
-      category: "provider",
+      category: "unknown",
       phase: "review",
     });
   }
@@ -4110,7 +4110,7 @@ async function agentWorkflowBody(
             if (research.status === "failed") {
               const reason = research.body.slice(0, 200);
               return executionError(reason, {
-                category: "provider",
+                category: "unknown",
                 phase: "research",
               });
             }
@@ -4287,7 +4287,7 @@ async function agentWorkflowBody(
             if (implOutput.result === "failed") {
               const reason = implOutput.error ?? "unknown";
               return executionError(reason, {
-                category: implDone ? "provider" : "timeout",
+                category: implDone ? "unknown" : "timeout",
                 phase: "impl",
               });
             }


### PR DESCRIPTION
## Summary
- Fixes a real production bug found via E2E testing on AWP-28..31: the implementation agent believed pushing the branch and opening the PR/MR was its own job, but the sandbox intentionally has no git push credentials (a separate `finalize_workspace`/`open_pr` step does that afterward with real credentials). The agent either self-reported the whole task as failed or asked a bogus clarification question begging for GitHub credentials. Fixed via an explicit "Do Not Publish" instruction in the implement prompt (`apps/shared/contracts/default-prompts.ts`, which also seeds production's prompt library — this was already hotfixed live in prod's DB and is now reflected in code).
- Fixes a related mislabeling bug: `agent.ts` hardcoded `category: "provider"` whenever the agent's own JSON payload said `result: "failed"`, regardless of the actual cause — so any self-reported agent failure rendered as "The AI provider rejected the credentials (authentication failed)" even when the real cause had nothing to do with the LLM provider (e.g. the push/PR issue above). Changed to `category: "unknown"` in the three affected spots (research/planning, implementation, review), which surfaces the real sanitized error snippet instead.

## Test plan
- [x] `pnpm typecheck` clean.
- [x] Targeted vitest suites (`agent-block-outputs.test.ts`, `run-telemetry-integration.test.ts`) green, including the updated assertion for the new `category: "unknown"` behavior.
- [x] Verified live on production: retriggered AWP-28, AWP-29, AWP-30, AWP-31 end-to-end after deploying this prompt fix — all four completed successfully and opened real PRs (Blazity/ai-workflow-prod#15, #17, Blazity/ai-workflow-demo#312, #313), exercising cross-repo, repository-pinning, and cross-provider (GitHub+GitLab) scenarios that previously failed on this exact bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)