### PR TITLE
fix(worker): resolve which-repo clarification replies by short name and typo

### DIFF
--- a/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
@@ -163,6 +163,168 @@ describe("selectRepositoriesFromMetadata", () => {
     ]);
   });
 
+  it("resolves a direct clarification answer by short name instead of falling to discovery", () => {
+    // The "which repository" fallback question never lists candidates here, but
+    // a human still naturally answers with a short name, not a full owner/repo
+    // path — that reply must resolve deterministically, not fall to discovery.
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "web",
+    });
+
+    expect(selected).toEqual({
+      status: "selected",
+      repositories: [
+        expect.objectContaining({
+          repoPath: "acme/web",
+          selectedRationale: "human clarification answer",
+        }),
+      ],
+    });
+  });
+
+  it("resolves a direct clarification answer by full path, tolerating trailing punctuation", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "  acme/web. ",
+    });
+
+    expect(selected).toEqual({
+      status: "selected",
+      repositories: [
+        expect.objectContaining({
+          repoPath: "acme/web",
+          selectedRationale: "human clarification answer",
+        }),
+      ],
+    });
+  });
+
+  it("falls through to discovery on an ambiguous short-name clarification answer", () => {
+    const ambiguous: RepositoryMetadata[] = [
+      { ...repos[0], provider: "github", repoPath: "acme/web", name: "web" },
+      { ...repos[0], provider: "gitlab", repoPath: "other-org/web", name: "web" },
+    ];
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: ambiguous,
+      workflowOwnedBranches: [],
+      directAnswer: "web",
+    });
+
+    expect(selected.status).toBe("discovery_needed");
+  });
+
+  it("never fuzzy-matches a 3-character short name, even one edit away", () => {
+    // "web" (3 chars) has too large a space of one-edit neighbors ("wet",
+    // "wed", "webs"...) relative to plausible short names for a coincidental
+    // near-miss reply to be trusted. Below the 4-char floor, only an exact
+    // match resolves.
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "wet",
+    });
+
+    expect(selected.status).toBe("discovery_needed");
+  });
+
+  it("resolves a transposed-letter typo once the name is long enough to fuzzy-match safely", () => {
+    // "webyb" is "webby" with the last two letters swapped — a one-edit
+    // transposition once the name clears the 4-char fuzzy-match floor.
+    const named: RepositoryMetadata[] = [
+      { ...repos[0], repoPath: "acme/webby", name: "webby" },
+      { ...repos[1], repoPath: "acme/other", name: "other" },
+    ];
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: named,
+      workflowOwnedBranches: [],
+      directAnswer: "webyb",
+    });
+
+    expect(selected).toEqual({
+      status: "selected",
+      repositories: [
+        expect.objectContaining({
+          repoPath: "acme/webby",
+          selectedRationale: "human clarification answer",
+        }),
+      ],
+    });
+  });
+
+  it("resolves a dropped-letter typo on a longer repository name", () => {
+    const longNamed: RepositoryMetadata[] = [
+      { ...repos[0], repoPath: "blazity/arthur-engine", name: "arthur-engine" },
+      { ...repos[1], repoPath: "blazity/arthur-autogen-agentic-demo", name: "arthur-autogen-agentic-demo" },
+    ];
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: longNamed,
+      workflowOwnedBranches: [],
+      directAnswer: "arthur-engin",
+    });
+
+    expect(selected).toEqual({
+      status: "selected",
+      repositories: [
+        expect.objectContaining({
+          repoPath: "blazity/arthur-engine",
+          selectedRationale: "human clarification answer",
+        }),
+      ],
+    });
+  });
+
+  it("does not resolve a typo that's ambiguous between two similarly-named repositories", () => {
+    const ambiguous: RepositoryMetadata[] = [
+      { ...repos[0], repoPath: "acme/webapi", name: "webapi" },
+      { ...repos[1], repoPath: "acme/webapp", name: "webapp" },
+    ];
+    // "webap" is one deletion away from both "webapi" and "webapp".
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: ambiguous,
+      workflowOwnedBranches: [],
+      directAnswer: "webap",
+    });
+
+    expect(selected.status).toBe("discovery_needed");
+  });
+
+  it("skips the typo-tolerant scan for an implausibly long reply instead of running it against prose", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "I think it should probably be the ".repeat(10) + "api one",
+    });
+
+    expect(selected.status).toBe("discovery_needed");
+  });
+
+  it("combines an exact ticket mention with a direct-answer match for a different repository", () => {
+    // Both are deterministic, high-confidence signals, same as an exact
+    // ticket mention combining with a workflow-owned branch elsewhere in this
+    // suite — neither silently overrides the other.
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Change the billing callback in acme/api.",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "web",
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories.map((r) => r.repoPath).sort()).toEqual(["acme/api", "acme/web"]);
+  });
+
   it("force-includes repositories with workflow-owned branches", () => {
     const selected = selectRepositoriesFromMetadata({
       ticketText: "Address review feedback",
@@ -549,6 +711,27 @@ describe("selectRepositoriesFromMetadata", () => {
     ]);
   });
 
+  it("resolves an incomplete catalog from a direct clarification answer", () => {
+    // Naming a repository we did see doesn't claim anything about the repos we
+    // didn't — same justification as the exact-mention case above.
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "api",
+      incompleteCatalogProviders: ["gitlab"],
+    });
+
+    expect(selected.status).toBe("selected");
+    if (selected.status !== "selected") throw new Error("expected selected");
+    expect(selected.repositories).toEqual([
+      expect.objectContaining({
+        repoPath: "acme/api",
+        selectedRationale: "human clarification answer",
+      }),
+    ]);
+  });
+
   it("resolves an incomplete catalog from this ticket's workflow-owned branch", () => {
     const selected = selectRepositoriesFromMetadata({
       ticketText: "Address review feedback",
@@ -749,6 +932,36 @@ describe("repoSelectionStep", () => {
       }),
     ]);
     expect(result.promptAdditions?.[0]?.content).toContain("github:acme/web");
+  });
+
+  it("resolves the ticket's most recent 'Human clarification' comment as the direct answer, skipping discovery", async () => {
+    mocks.listRepositories.mockResolvedValueOnce(repos);
+    mocks.listWorkflowOwnedBranchesForTicket.mockResolvedValueOnce([]);
+
+    const result = await repoSelectionStep({
+      context: {
+        ticket: {
+          identifier: "AIW-45",
+          title: "Fix billing webhook retry behavior",
+          description: "",
+          acceptanceCriteria: "",
+          comments: [
+            { author: "Human clarification", body: "not-a-repo" },
+            { author: "Human clarification", body: "web" },
+          ],
+          labels: [],
+        },
+        run: { branchName: "blazebot/aiw-45" },
+      },
+      config: undefined,
+      step: { uses: "repo-selection", onFailure: "fail" },
+    });
+
+    expect(result.status).toBe("continue");
+    expect(result.selectedRepositories).toEqual([
+      expect.objectContaining({ repoPath: "acme/web", selectedRationale: "human clarification answer" }),
+    ]);
+    expect(result.repositoryDiscovery).toBeUndefined();
   });
 
   it("queries only the pinned providers and reports the narrowing", async () => {

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.ts
@@ -65,12 +65,14 @@ export const repoSelectionStep: PreSandboxStepHandler = async ({ context, step }
     )
     .map((failure) => failure.provider);
 
+  const directAnswer = latestClarificationAnswer(context.ticket.comments);
   const selected = selectRepositoriesFromMetadata({
     ticketText: ticketText(context.ticket),
     repositories,
     workflowOwnedBranches,
     ...(repositoryScope ? { repositoryScope } : {}),
     ...(incompleteCatalogProviders.length > 0 ? { incompleteCatalogProviders } : {}),
+    ...(directAnswer ? { directAnswer } : {}),
   });
   const narrowing = scopeNarrowing(repositories, repositoryScope);
   const degradation = catalogDegradation(
@@ -226,6 +228,11 @@ export function selectRepositoriesFromMetadata(input: {
    *  still have changed this choice. Absent when every provider answered, which
    *  keeps a healthy run on exactly its normal path. */
   incompleteCatalogProviders?: RepositoryMetadata["provider"][];
+  /** The human's direct reply to a prior which-repo clarification question, if
+   *  this is a retry. Matched leniently (short name, full path, or a small
+   *  typo tolerance) against every scoped repository, separately from the
+   *  strict full-path scan over free-form ticket text below. */
+  directAnswer?: string | null;
 }):
   | { status: "selected"; repositories: SelectedRepository[] }
   | {
@@ -319,6 +326,32 @@ export function selectRepositoriesFromMetadata(input: {
     }
   }
 
+  // A direct reply to a prior which-repo clarification is a much higher-
+  // confidence signal than organic ticket text, so it's matched leniently: a
+  // human naturally replies with a short name, not necessarily the full
+  // owner/repo path the exact-mention scan above requires. Only added when it
+  // resolves to exactly one repository — an ambiguous or unmatched reply is
+  // left for the fallbacks below (discovery, or asking again).
+  if (input.directAnswer) {
+    const normalizedAnswer = normalizeRepoAnswer(input.directAnswer);
+    const answerExactMatches = scopedRepositories.filter(
+      (repo) =>
+        normalizeRepoAnswer(repo.repoPath) === normalizedAnswer ||
+        normalizeRepoAnswer(repoShortName(repo)) === normalizedAnswer,
+    );
+    const answerMatches =
+      answerExactMatches.length > 0
+        ? answerExactMatches
+        : fuzzyRepoMatches(normalizedAnswer, scopedRepositories);
+    if (answerMatches.length === 1) {
+      const repo = answerMatches[0]!;
+      const key = repositoryKey(repo);
+      if (!selected.has(key)) {
+        selected.set(key, selectedRepository(repo, "human clarification answer"));
+      }
+    }
+  }
+
   if (selected.size > 0) {
     if (selected.size > 3) {
       if (incompleteCatalogProviders.length > 0) {
@@ -337,7 +370,8 @@ export function selectRepositoriesFromMetadata(input: {
   // Degradation stops here on purpose. Every path above resolves the selection
   // from a signal that does not depend on seeing the whole catalog: a
   // workflow-owned branch for this ticket, a repository path written in the ticket,
-  // or a pin the surviving listing fully satisfied. The paths below do depend on
+  // a direct clarification answer naming a repository we did see, or a pin the
+  // surviving listing fully satisfied. The paths below do depend on
   // it. "Only accessible repository" is a claim about the entire catalog that a
   // partial listing cannot support, and discovery hands the catalog to the model,
   // which would then choose from a set silently missing a whole provider. A
@@ -395,6 +429,89 @@ function mentionsRepositoryPath(ticketText: string, repoPath: string): boolean {
   const escaped = repoPath.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const boundary = "[^a-z0-9/_-]";
   return new RegExp(`(^|${boundary})${escaped}($|${boundary})`).test(ticketText);
+}
+
+/** The most recent direct answer to a which-repo clarification, or null when
+ *  this isn't a retry. `execution?.clarificationAnswer` is appended as a
+ *  synthetic trailing comment (see prepare-workspace.ts); scanning from the
+ *  end finds the current round's answer regardless of how many prior rounds
+ *  (if any) also appended one. */
+function latestClarificationAnswer(
+  comments: Array<{ author: string; body: string }> | undefined,
+): string | null {
+  if (!comments) return null;
+  for (let i = comments.length - 1; i >= 0; i--) {
+    if (comments[i]!.author === "Human clarification") return comments[i]!.body;
+  }
+  return null;
+}
+
+function repoShortName(repo: Pick<RepositoryMetadata, "name" | "repoPath">): string {
+  return repo.name || repo.repoPath.split("/").pop() || repo.repoPath;
+}
+
+function normalizeRepoAnswer(value: string): string {
+  return value.trim().toLowerCase().replace(/[.,;:!?]+$/, "");
+}
+
+/** No real repository short name or path is longer than this; a reply beyond
+ *  it is prose, not a typo'd answer, so skip the O(n*m) edit-distance scan
+ *  instead of running it against an unbounded human-supplied string. */
+const MAX_TYPO_TOLERANT_ANSWER_LENGTH = 100;
+
+/** Edit-distance budget for a typo'd clarification reply, or null when the
+ *  candidate is too short to fuzzy-match safely. At length <=4 the space of
+ *  one-edit neighbors ("web" ~ "wet", "wed", " web") is large relative to the
+ *  number of plausible short names, so a coincidental near-miss reply could
+ *  silently resolve to the wrong repository — the exact failure mode keyword
+ *  scoring caused in production (see the "asks for clarification" tests
+ *  above). Below that floor we require an exact match instead of guessing.
+ *  Longer names get one slip up to 7 characters, two beyond that, so
+ *  "arthur-engine" can absorb a dropped or transposed letter. */
+function typoTolerance(value: string): number | null {
+  if (value.length <= 4) return null;
+  return value.length <= 7 ? 1 : 2;
+}
+
+/** Repositories within typo distance of a clarification answer with no exact
+ *  match. Skipped for implausibly long replies (prose, not a typo'd name) so
+ *  a human pasting an essay doesn't run an O(n*m) edit-distance scan per
+ *  repo. */
+function fuzzyRepoMatches(
+  normalizedAnswer: string,
+  repositories: RepositoryMetadata[],
+): RepositoryMetadata[] {
+  if (normalizedAnswer.length === 0 || normalizedAnswer.length > MAX_TYPO_TOLERANT_ANSWER_LENGTH) {
+    return [];
+  }
+  return repositories.filter((repo) =>
+    [normalizeRepoAnswer(repo.repoPath), normalizeRepoAnswer(repoShortName(repo))].some((candidate) => {
+      const tolerance = typoTolerance(candidate);
+      return tolerance !== null && editDistance(normalizedAnswer, candidate) <= tolerance;
+    }),
+  );
+}
+
+/** Damerau-Levenshtein (optimal string alignment): counts an adjacent
+ *  transposition ("aip" -> "api") as a single edit, like a plain
+ *  substitution or insertion/deletion — the most common typo shapes for a
+ *  short reply. */
+function editDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dp: number[][] = Array.from({ length: rows }, () => new Array<number>(cols).fill(0));
+  for (let i = 0; i < rows; i++) dp[i]![0] = i;
+  for (let j = 0; j < cols; j++) dp[0]![j] = j;
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i]![j] = Math.min(dp[i - 1]![j]! + 1, dp[i]![j - 1]! + 1, dp[i - 1]![j - 1]! + cost);
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        dp[i]![j] = Math.min(dp[i]![j]!, dp[i - 2]![j - 2]! + 1);
+      }
+    }
+  }
+  return dp[rows - 1]![cols - 1]!;
 }
 
 function ticketText(ticket: {


### PR DESCRIPTION
## Summary
- Same bug as ai-workflow-arthur#9, ported to this repo's more evolved repository-selection logic (repository pinning, provider-outage survival, bounded model discovery).
- A human's direct reply to a which-repo clarification question was only matched by exact full `owner/repo` path (`mentionsRepositoryPath`). A natural short-name reply (or one with a typo) could never resolve — the run either fell through to model discovery or kept re-asking.
- Adds a `directAnswer` signal to `selectRepositoriesFromMetadata`: matched by exact short name or full path first, then a length-gated, edit-distance-tolerant match for typos (Damerau-Levenshtein, skipped for names <=4 chars to avoid false positives on names like "web"/"api"). Resolves at the same priority tier as an exact ticket-text mention — before the incomplete-catalog fail-closed check, "only accessible repository", and `discovery_needed` — and bypasses discovery entirely once resolved.
- Scoped intentionally to the single-repository case (the ">3 repositories match" and "which repositories are essential" clarifications ask for a *set*, a different UX shape not touched here).

## Test plan
- [x] `pnpm -r typecheck` clean
- [x] `apps/worker` full test suite: 3318/3325 passing
- [x] 7 pre-existing failures, all unrelated: 6 are the known DB-hook-timeout concurrency flake (confirmed passing in isolation), 1 (`prompt-library/store.test.ts`) is a pre-existing seed/DEFAULT_AGENT_PROMPTS drift from the latest commit on main (#183), unrelated to repository selection — not touched by this change
- [x] 11 new/updated tests in `repo-selection.test.ts`: short-name match, full-path match, ambiguous short names, typo tolerance (transposition/deletion), the <=4-char fuzzy-match floor, an implausibly-long-reply guard, combining with an exact ticket mention, and resolving despite an incomplete catalog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository selection now recognizes direct clarification replies using repository names or full paths.
  * Minor typos and surrounding punctuation are tolerated when the reply clearly identifies one repository.
  * Recent human clarification replies are used during retry flows to continue without unnecessary repository discovery.

* **Bug Fixes**
  * Ambiguous, incomplete, or implausibly long replies no longer produce unreliable repository selections.
  * Direct clarification answers remain effective when repository catalog information is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->