### PR TITLE
Restore Harness Profile model capability discovery

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -172,7 +172,9 @@ Pick one — controlled by `AGENT_KIND`.
 
 **Claude (default):**
 
-- Create an API key at https://console.anthropic.com → `ANTHROPIC_API_KEY`.
+- Configure either a standard Console API key or a Claude Code OAuth token as
+  `ANTHROPIC_API_KEY`. The same credential is used for execution and pinned-CLI
+  Harness Profile discovery.
 - Optionally pin a model: `CLAUDE_MODEL=claude-opus-4-6` (default).
 
 **Codex:**
@@ -180,6 +182,10 @@ Pick one — controlled by `AGENT_KIND`.
 - `AGENT_KIND=codex`
 - `CODEX_API_KEY=sk-...` (or `CODEX_CHATGPT_OAUTH_TOKEN`)
 - Optionally `CODEX_MODEL=gpt-5-codex`.
+
+To edit Harness Profiles for both providers, configure `ANTHROPIC_API_KEY` and
+one Codex credential even when `AGENT_KIND` selects only one execution default.
+The scheduled worker refresh populates both exact-version catalogs.
 
 ---
 
@@ -266,8 +272,8 @@ vercel env add JIRA_API_TOKEN production
 | `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_INSTALLATION_ID`, `GITHUB_OWNER`, `GITHUB_REPO` | If GitHub is configured (GitHub App auth)              |
 | `GITHUB_WEBHOOK_SECRET`                                                                            | If GitHub is configured — signs `pull_request` webhook deliveries for the post-PR gate. Required in **every** environment (Production, Preview, Development) because the webhook fires on preview deployments too. Generate: `openssl rand -hex 32`. |
 | `GITLAB_TOKEN`, `GITLAB_PROJECT_ID`, `GITLAB_BASE_BRANCH`, `GITLAB_WEBHOOK_SECRET`                  | If GitLab is configured — GitLab.com token with `api` + `write_repository`, namespace/project path, target branch, and merge request webhook secret. Generate: `openssl rand -hex 32`. |
-| `ANTHROPIC_API_KEY`                                                                                | If `AGENT_KIND=claude` (default)                       |
-| `CODEX_API_KEY` (or `CODEX_CHATGPT_OAUTH_TOKEN`)                                                   | If `AGENT_KIND=codex`                                  |
+| `ANTHROPIC_API_KEY`                                                                                | Claude execution and Harness Profile capability discovery; accepts a standard API key or Claude Code OAuth token |
+| `CODEX_API_KEY` (or `CODEX_CHATGPT_OAUTH_TOKEN`)                                                   | Codex execution or Harness Profile capability discovery |
 | `DATABASE_URL`                                                                                     | Auto-injected by Neon integration                      |
 | `BETTER_AUTH_SECRET` | Signing/encryption key for Better Auth (dashboard human login). At least 32 chars. Generate: `openssl rand -base64 32`. |
 | `BETTER_AUTH_URL` | The worker's own base URL (no trailing slash) — Better Auth's `baseURL`. |

--- a/apps/dashboard/app/api/harness-capabilities/handler.test.ts
+++ b/apps/dashboard/app/api/harness-capabilities/handler.test.ts
@@ -4,12 +4,14 @@ import { handleHarnessCapabilitiesGet } from "./handler";
 
 test("capability proxy forwards only normalized supported query values", async () => {
   const paths: string[] = [];
+  const timeouts: number[] = [];
   const response = await handleHarnessCapabilitiesGet(
     new Request(
       "https://dashboard.test/api/harness-capabilities?provider=codex&cliVersion=0.144.6&refresh=1&unsafe=value",
     ),
-    async (path, init) => {
+    async (path, init, timeoutMs) => {
       paths.push(`${init?.method}:${path}`);
+      if (timeoutMs !== undefined) timeouts.push(timeoutMs);
       return Response.json({ stale: false }, { status: 200 });
     },
   );
@@ -17,8 +19,9 @@ test("capability proxy forwards only normalized supported query values", async (
   assert.equal(response.status, 200);
   assert.equal(response.headers.get("cache-control"), "no-store");
   assert.deepEqual(paths, [
-    "GET:/api/v1/harness-capabilities?provider=codex&cliVersion=0.144.6&refresh=true",
+    "GET:/api/v1/harness-capabilities?provider=codex&cliVersion=0.144.6",
   ]);
+  assert.deepEqual(timeouts, [5_000]);
 });
 
 test("capability proxy rejects invalid requests and preserves worker failures", async () => {
@@ -53,4 +56,8 @@ test("capability proxy rejects invalid requests and preserves worker failures", 
     },
   );
   assert.equal(timeout.status, 504);
+  assert.deepEqual(await timeout.json(), {
+    error:
+      "Capability cache lookup timed out. Scheduled model discovery continues independently.",
+  });
 });

--- a/apps/dashboard/app/api/harness-capabilities/handler.ts
+++ b/apps/dashboard/app/api/harness-capabilities/handler.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
 
-type WorkerProxy = (path: string, init?: RequestInit) => Promise<Response>;
+const CAPABILITY_CACHE_TIMEOUT_MS = 5_000;
+
+type WorkerProxy = (
+  path: string,
+  init?: RequestInit,
+  timeoutMs?: number,
+) => Promise<Response>;
 
 export async function handleHarnessCapabilitiesGet(
   request: Request,
@@ -9,7 +15,6 @@ export async function handleHarnessCapabilitiesGet(
   const source = new URL(request.url);
   const provider = source.searchParams.get("provider");
   const cliVersion = source.searchParams.get("cliVersion");
-  const refresh = source.searchParams.get("refresh");
   if (
     (provider !== "claude" && provider !== "codex") ||
     !cliVersion ||
@@ -21,13 +26,11 @@ export async function handleHarnessCapabilitiesGet(
     );
   }
   const query = new URLSearchParams({ provider, cliVersion });
-  if (refresh === "1" || refresh === "true") {
-    query.set("refresh", "true");
-  }
   try {
     const response = await workerProxy(
       `/api/v1/harness-capabilities?${query.toString()}`,
       { method: "GET" },
+      CAPABILITY_CACHE_TIMEOUT_MS,
     );
     return NextResponse.json(await response.json().catch(() => ({})), {
       status: response.status,
@@ -37,7 +40,10 @@ export async function handleHarnessCapabilitiesGet(
     const candidate = error as { name?: unknown; code?: unknown };
     if (candidate.name === "TimeoutError" || candidate.code === 23) {
       return NextResponse.json(
-        { error: "Worker request timed out" },
+        {
+          error:
+            "Capability cache lookup timed out. Scheduled model discovery continues independently.",
+        },
         { status: 504, headers: { "cache-control": "no-store" } },
       );
     }

--- a/apps/dashboard/components/cockpit/harness-profiles/profile-editor.test.tsx
+++ b/apps/dashboard/components/cockpit/harness-profiles/profile-editor.test.tsx
@@ -100,6 +100,11 @@ test("editable profiles expose the complete manifest and GitHub skill authoring"
   assert.match(html, /Safe home files/);
   assert.match(html, /Add from GitHub/);
   assert.match(html, /Provider default/);
+  assert.match(html, /gpt-5\.4 · unavailable/);
+  assert.match(
+    html,
+    /Historical selection; choose a current model before publishing/,
+  );
   assert.match(html, /None available/);
   assert.match(html, /filesystem/);
   assert.match(html, /openai/);

--- a/apps/dashboard/components/cockpit/harness-profiles/profile-editor.tsx
+++ b/apps/dashboard/components/cockpit/harness-profiles/profile-editor.tsx
@@ -10,12 +10,12 @@ import {
   isProfileSlug,
   newProfileDraft,
   upgradeProfileDraft,
+  withHarnessModel,
   withHarnessProvider,
 } from "@/lib/harness-profiles/editor";
 import { readErrorMessage } from "@/lib/api/error-message";
 import type {
   HarnessCapabilitiesResponse,
-  HarnessModelCapability,
   HarnessProvider,
   HarnessProfileDetailResponse,
   HarnessProfileDraftManifest,
@@ -375,31 +375,14 @@ export function ProfileEditor({
     );
   }
 
-  function selectModel(model: HarnessModelCapability) {
+  function selectModel(
+    model: HarnessCapabilitiesResponse["models"][number],
+  ) {
     if (!capabilities || capabilities.stale) return;
-    const effort =
-      model.defaultReasoningEffort ?? model.reasoningEfforts[0]?.id;
-    const serviceTier =
-      model.defaultServiceTier ?? model.serviceTiers[0]?.id;
-    if (!effort || !serviceTier) return;
-    setDraft((current) => ({
-      ...current,
-      schemaVersion: 2,
-      model: {
-        id: model.id,
-        reasoning: {
-          selection: "model_default",
-          effectiveEffort: effort,
-        },
-        serviceTier,
-        ...(model.defaultVerbosity
-          ? { verbosity: model.defaultVerbosity }
-          : {}),
-        capability: structuredClone(model),
-        catalogHash: capabilities.catalogHash,
-      },
-      compaction: { mode: "model_default" },
-    }));
+    setDraft(
+      (current) =>
+        withHarnessModel(current, capabilities, model.id) ?? current,
+    );
   }
 
   async function switchProvider(provider: HarnessProvider) {
@@ -1124,26 +1107,17 @@ export function ProfileEditor({
                   className={inputClass}
                 />
                 <Listbox
-                  options={[
-                    ...(!catalogModels.some(
-                      (model) => model.id === draft.model.id,
-                    )
-                      ? [
-                          {
-                            value: draft.model.id,
-                            label: `${draft.model.id} · unavailable`,
-                            hint:
-                              "Historical selection; choose a current model before publishing.",
-                          },
-                        ]
-                      : []),
-                    ...filteredModels.map((model) => ({
-                      value: model.id,
-                      label: model.name,
-                      hint: model.id,
-                    })),
-                  ]}
+                  options={filteredModels.map((model) => ({
+                    value: model.id,
+                    label: model.name,
+                    hint: model.id,
+                  }))}
                   value={draft.model.id}
+                  fallbackLabel={
+                    catalogModels.find(
+                      (model) => model.id === draft.model.id,
+                    )?.name ?? `${draft.model.id} · unavailable`
+                  }
                   disabled={
                     !editable ||
                     capabilityLoading ||
@@ -1158,6 +1132,14 @@ export function ProfileEditor({
                     if (model) selectModel(model);
                   }}
                 />
+                {!catalogModels.some(
+                  (model) => model.id === draft.model.id,
+                ) && (
+                  <span className="font-body text-[10px] leading-[1.35] text-amber-700">
+                    Historical selection; choose a current model before
+                    publishing.
+                  </span>
+                )}
               </div>
             </Field>
             {draft.schemaVersion === 1 && (
@@ -1194,6 +1176,11 @@ export function ProfileEditor({
               <div className="sm:col-span-2 rounded-[3px] border border-amber-200 bg-amber-50 px-3 py-2 font-body text-[11px] text-amber-800">
                 Showing the last safe capability catalog. Refresh must
                 succeed before this profile can be published.
+                {capabilities.refreshFailure && (
+                  <span className="mt-1 block">
+                    {capabilities.refreshFailure.message}
+                  </span>
+                )}
               </div>
             )}
             {draft.schemaVersion === 2 && (
@@ -1201,10 +1188,14 @@ export function ProfileEditor({
                 <Field label="Reasoning effort">
                   <Listbox
                     options={[
-                      {
-                        value: "model_default",
-                        label: `Model default · ${draft.model.capability.defaultReasoningEffort ?? draft.model.reasoning.effectiveEffort}`,
-                      },
+                      ...(draft.model.capability.defaultReasoningEffort
+                        ? [
+                            {
+                              value: "model_default",
+                              label: `Model default · ${draft.model.capability.defaultReasoningEffort}`,
+                            },
+                          ]
+                        : []),
                       ...draft.model.capability.reasoningEfforts.map(
                         (effort) => ({
                           value: effort.id,

--- a/apps/dashboard/components/cockpit/listbox.tsx
+++ b/apps/dashboard/components/cockpit/listbox.tsx
@@ -26,9 +26,18 @@ export interface ListboxProps {
   disabled?: boolean;
   ariaLabel: string;
   className?: string;
+  fallbackLabel?: string;
 }
 
-export function Listbox({ options, value, onChange, disabled, ariaLabel, className }: ListboxProps) {
+export function Listbox({
+  options,
+  value,
+  onChange,
+  disabled,
+  ariaLabel,
+  className,
+  fallbackLabel,
+}: ListboxProps) {
   const [state, dispatch] = useReducer(listboxReducer, { open: false, activeIdx: 0 });
   const { open, activeIdx } = state;
   const rootRef = useRef<HTMLDivElement>(null);
@@ -39,7 +48,9 @@ export function Listbox({ options, value, onChange, disabled, ariaLabel, classNa
 
   const selectedIdx = options.findIndex((o) => o.value === value);
   const current = selectedIdx >= 0 ? options[selectedIdx] : undefined;
-  const displayLabel = current ? current.label : value !== "" ? value : options[0]?.label ?? "";
+  const displayLabel = current
+    ? current.label
+    : fallbackLabel ?? (value !== "" ? value : options[0]?.label ?? "");
 
   useLayoutEffect(() => {
     if (!open) {

--- a/apps/dashboard/lib/harness-profiles/editor.test.ts
+++ b/apps/dashboard/lib/harness-profiles/editor.test.ts
@@ -8,6 +8,7 @@ import {
   newProfileDraft,
   upgradeProfileDraft,
   upsertProfile,
+  withHarnessModel,
   withHarnessProvider,
 } from "./editor";
 import {
@@ -150,6 +151,60 @@ test("switching a v2 profile requires fresh target capabilities and remains v2",
   assert.equal(switched.schemaVersion, 2);
   assert.equal(switched.harness.provider, "claude");
   assert.equal(switched.model.id, claudeDraft.model.id);
+});
+
+test("selecting an advertised model pins its exact capability snapshot and controls", () => {
+  const draft = newProfileDraft("claude");
+  const model: HarnessCapabilitiesResponse["models"][number] = {
+    id: "claude-supported",
+    name: "Claude Supported",
+    description: null,
+    contextWindowTokens: 200_000,
+    reasoningEfforts: [
+      { id: "medium", name: "Medium", description: null },
+      { id: "high", name: "High", description: null },
+    ],
+    defaultReasoningEffort: null,
+    serviceTiers: [
+      { id: "standard", name: "Standard", description: null },
+    ],
+    defaultServiceTier: "standard",
+    verbosityOptions: [],
+    defaultVerbosity: null,
+    compactionModes: [
+      "model_default",
+      "custom_threshold",
+      "disabled",
+    ],
+  };
+  const capabilities: HarnessCapabilitiesResponse = {
+    ...draft.harness,
+    provider: "claude",
+    models: [model],
+    catalogHash: "catalog-current",
+    fetchedAt: "2026-07-29T00:00:00.000Z",
+    stale: false,
+    refreshFailure: null,
+  };
+
+  const selected = withHarnessModel(
+    draft,
+    capabilities,
+    "claude-supported",
+  );
+
+  assert.ok(selected);
+  assert.deepEqual(selected.model, {
+    id: "claude-supported",
+    reasoning: {
+      selection: "medium",
+      effectiveEffort: "medium",
+    },
+    serviceTier: "standard",
+    capability: model,
+    catalogHash: "catalog-current",
+  });
+  assert.deepEqual(selected.compaction, { mode: "model_default" });
 });
 
 test("profile slugs match the worker-owned public constraint", () => {

--- a/apps/dashboard/lib/harness-profiles/editor.ts
+++ b/apps/dashboard/lib/harness-profiles/editor.ts
@@ -83,6 +83,50 @@ export function upgradeProfileDraft(
   return buildHarnessProfileDraftV2(draft, capabilities);
 }
 
+export function withHarnessModel(
+  draft: HarnessProfileDraftManifest,
+  capabilities: HarnessCapabilitiesResponse,
+  modelId: string,
+): HarnessProfileDraftManifestV2 | null {
+  const model = capabilities.models.find(
+    (candidate) => candidate.id === modelId,
+  );
+  if (
+    capabilities.stale ||
+    capabilities.provider !== draft.harness.provider ||
+    capabilities.cliVersion !== draft.harness.cliVersion ||
+    !model
+  ) {
+    return null;
+  }
+  const effort =
+    model.defaultReasoningEffort ?? model.reasoningEfforts[0]?.id;
+  const serviceTier =
+    model.defaultServiceTier ?? model.serviceTiers[0]?.id;
+  if (!effort || !serviceTier) return null;
+
+  return {
+    ...draft,
+    schemaVersion: 2,
+    model: {
+      id: model.id,
+      reasoning: {
+        selection: model.defaultReasoningEffort
+          ? "model_default"
+          : effort,
+        effectiveEffort: effort,
+      },
+      serviceTier,
+      ...(model.defaultVerbosity
+        ? { verbosity: model.defaultVerbosity }
+        : {}),
+      capability: structuredClone(model),
+      catalogHash: capabilities.catalogHash,
+    },
+    compaction: { mode: "model_default" },
+  };
+}
+
 export function isProfileSlug(value: string): boolean {
   return (
     value.length <= 64 &&

--- a/apps/shared/contracts/harness-profiles.ts
+++ b/apps/shared/contracts/harness-profiles.ts
@@ -213,7 +213,9 @@ export function buildHarnessProfileDraftV2(
     model: {
       id: model.id,
       reasoning: {
-        selection: "model_default",
+        selection: model.defaultReasoningEffort
+          ? "model_default"
+          : effectiveEffort,
         effectiveEffort,
       },
       serviceTier,

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -67,7 +67,7 @@ CHAT_SDK_BOT_NAME=blazebot
 # Agent — choose runtime (claude | codex). Defaults to claude.
 AGENT_KIND=claude
 
-# Claude (active when AGENT_KIND=claude — one of API_KEY or OAUTH_TOKEN required)
+# Claude (standard API keys and Claude Code OAuth tokens are both accepted)
 ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
 CLAUDE_MODEL=claude-opus-4-6
 
@@ -90,7 +90,8 @@ CLAUDE_MODEL=claude-opus-4-6
 # branch-per-environment enabled — DATABASE_URL is auto-injected by Vercel.
 DATABASE_URL=
 
-# Cron auth — required in production so /cron/poll rejects unauthenticated callers.
+# Cron auth — required in production so polling and capability prewarm reject
+# unauthenticated callers.
 # Generate with `openssl rand -hex 32`.
 CRON_SECRET=
 

--- a/apps/worker/env.test.ts
+++ b/apps/worker/env.test.ts
@@ -49,6 +49,7 @@ describe("env", () => {
     Object.assign(process.env, VALID_ENV);
     const { env } = await import("./env.js");
     expect(env.JIRA_BASE_URL).toBe("https://test.atlassian.net");
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-test");
     expect(env.MAX_CONCURRENT_AGENTS).toBe(3);
     expect(env.JOB_TIMEOUT_MS).toBe(1800000);
   });

--- a/apps/worker/src/harness-profiles/capability-catalog.test.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.test.ts
@@ -11,10 +11,14 @@ import type { Db } from "../db/client.js";
 import { organization } from "../db/schema.js";
 import { createTestDb } from "../db/test-db.js";
 import {
+  claudeDiscoveryCredentialEnv,
+  CODEX_CAPABILITY_DISCOVERY_TIMEOUT_MS,
+  getCachedHarnessCapabilities,
   getHarnessCapabilities,
   HarnessCapabilityCatalogError,
   hashHarnessCapabilityCatalog,
   normalizeClaudeModel,
+  prewarmHarnessCapabilityCatalogs,
   requireFreshHarnessCapabilities,
   upgradeHarnessDraftToHistoricalV2,
   upgradeHarnessDraftToV2,
@@ -61,6 +65,46 @@ beforeEach(async () => {
 });
 
 describe("Harness capability catalog", () => {
+  it("keeps request-time reads cache-only and reports cold prerequisites actionably", async () => {
+    await expect(
+      getCachedHarnessCapabilities(db, {
+        organizationId: "org-a",
+        provider: "claude",
+        cliVersion: "2.1.216",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 503,
+      message: expect.stringContaining("ANTHROPIC_API_KEY"),
+    });
+
+    await getHarnessCapabilities(db, {
+      organizationId: "org-a",
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: {
+        now: () => new Date("2026-07-27T10:00:00.000Z"),
+        discoverCodex: async () => CATALOG,
+      },
+    });
+    await expect(
+      getCachedHarnessCapabilities(db, {
+        organizationId: "org-a",
+        provider: "codex",
+        cliVersion: "0.144.6",
+        now: () => new Date("2026-07-27T10:14:59.999Z"),
+      }),
+    ).resolves.toMatchObject({ stale: false });
+    await expect(
+      getCachedHarnessCapabilities(db, {
+        organizationId: "org-a",
+        provider: "codex",
+        cliVersion: "0.144.6",
+        now: () => new Date("2026-07-27T10:15:00.000Z"),
+      }),
+    ).resolves.toMatchObject({ stale: true });
+  });
+
   it("caches a live catalog for fifteen minutes and keeps organizations isolated", async () => {
     const discover = vi.fn(async () => CATALOG);
     const first = await getHarnessCapabilities(db, {
@@ -131,18 +175,125 @@ describe("Harness capability catalog", () => {
       "Capability discovery failed.",
     );
     await expect(
+      getCachedHarnessCapabilities(db, {
+        organizationId: "org-a",
+        provider: "codex",
+        cliVersion: "0.144.6",
+        now: () => new Date("2026-07-27T10:15:01.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      stale: true,
+      refreshFailure: { message: "Capability discovery failed." },
+    });
+    await expect(
       requireFreshHarnessCapabilities(db, {
         organizationId: "org-a",
         provider: "codex",
         cliVersion: "0.144.6",
-        dependencies: {
-          now: () => new Date("2026-07-27T10:16:00.000Z"),
-          discoverCodex: async () => {
-            throw new Error("offline");
-          },
-        },
+        now: () => new Date("2026-07-27T10:16:00.000Z"),
       }),
     ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("bounds scheduled Codex discovery independently from dashboard requests", async () => {
+    vi.useFakeTimers();
+    let startedDiscovery!: () => void;
+    const started = new Promise<void>((resolve) => {
+      startedDiscovery = resolve;
+    });
+    const pending = getHarnessCapabilities(db, {
+      organizationId: "org-a",
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: {
+        discoverCodex: async (_cliVersion, signal) => {
+          startedDiscovery();
+          return await new Promise<HarnessCapabilityCatalog>(
+            (_resolve, reject) => {
+              signal.addEventListener(
+                "abort",
+                () =>
+                  reject(
+                    new DOMException("Discovery timed out", "AbortError"),
+                  ),
+                { once: true },
+              );
+            },
+          );
+        },
+      },
+    });
+    await started;
+    const rejection = expect(pending).rejects.toMatchObject({
+      statusCode: 503,
+    });
+    await vi.advanceTimersByTimeAsync(
+      CODEX_CAPABILITY_DISCOVERY_TIMEOUT_MS,
+    );
+    await rejection;
+    vi.useRealTimers();
+  });
+
+  it("prewarms every organization and isolates provider failures", async () => {
+    const result = await prewarmHarnessCapabilityCatalogs(db, {
+      dependencies: {
+        discoverCodex: async () => CATALOG,
+        discoverClaude: async () => {
+          throw new Error("missing models credential");
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      organizations: 2,
+      attempted: 4,
+      ready: 2,
+      stale: 0,
+      failed: 2,
+    });
+    expect(
+      await getCachedHarnessCapabilities(db, {
+        organizationId: "org-a",
+        provider: "codex",
+        cliVersion: "0.144.6",
+      }),
+    ).toMatchObject({ stale: false });
+  });
+
+  it("refreshes warm catalogs before they expire", async () => {
+    await getHarnessCapabilities(db, {
+      organizationId: "org-a",
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: {
+        now: () => new Date("2026-07-27T10:00:00.000Z"),
+        discoverCodex: async () => CATALOG,
+      },
+    });
+    const discoverCodex = vi.fn(async () => CATALOG);
+    const discoverClaude = async () => {
+      throw new Error("missing models credential");
+    };
+
+    await prewarmHarnessCapabilityCatalogs(db, {
+      dependencies: {
+        now: () => new Date("2026-07-27T10:09:59.999Z"),
+        discoverCodex,
+        discoverClaude,
+      },
+    });
+    expect(discoverCodex).toHaveBeenCalledTimes(1);
+
+    await prewarmHarnessCapabilityCatalogs(db, {
+      dependencies: {
+        now: () => new Date("2026-07-27T10:10:00.000Z"),
+        discoverCodex,
+        discoverClaude,
+      },
+    });
+    expect(discoverCodex).toHaveBeenCalledTimes(2);
   });
 
   it("coalesces forced refreshes and throttles repeated discovery", async () => {
@@ -295,59 +446,47 @@ describe("Harness capability catalog", () => {
     expect(historical.model.catalogHash).not.toBe(response.catalogHash);
   });
 
-  it("fills Claude CLI-only effort and compaction controls without inventing model metadata", () => {
+  it("uses only capabilities advertised by the pinned Claude CLI", () => {
     expect(
       normalizeClaudeModel({
-        id: "claude-current",
-        display_name: "Claude Current",
+        value: "claude-current",
+        displayName: "Claude Current",
+      }),
+    ).toBeNull();
+
+    expect(
+      normalizeClaudeModel({
+        value: "claude-advertised",
+        displayName: "Claude Advertised",
+        description: "Pinned CLI model",
+        supportsEffort: true,
+        supportedEffortLevels: ["medium", "high"],
       }),
     ).toMatchObject({
-      id: "claude-current",
+      reasoningEfforts: [{ id: "medium" }, { id: "high" }],
+      defaultReasoningEffort: null,
       contextWindowTokens: null,
-      reasoningEfforts: [
-        { id: "low" },
-        { id: "medium" },
-        { id: "high" },
-      ],
-      defaultReasoningEffort: "high",
       compactionModes: ["model_default", "disabled"],
     });
 
     expect(
       normalizeClaudeModel({
-        id: "claude-advertised",
-        capabilities: {
-          effort: {
-            supported_efforts: ["medium"],
-            default_effort: "medium",
-          },
-          max_input_tokens: 200_000,
-        },
+        value: "claude-no-effort",
+        displayName: "Claude No Effort",
+        supportsEffort: false,
       }),
     ).toMatchObject({
-      reasoningEfforts: [{ id: "medium" }],
-      defaultReasoningEffort: "medium",
-      contextWindowTokens: 200_000,
-      compactionModes: [
-        "model_default",
-        "custom_threshold",
-        "disabled",
-      ],
+      reasoningEfforts: [{ id: "none" }],
+      defaultReasoningEffort: "none",
     });
+  });
 
-    expect(
-      normalizeClaudeModel({
-        id: "claude-invalid-default",
-        capabilities: {
-          effort: {
-            supported_efforts: ["medium"],
-            default_effort: "high",
-          },
-        },
-      }),
-    ).toMatchObject({
-      reasoningEfforts: [{ id: "medium" }],
-      defaultReasoningEffort: "medium",
+  it("routes the existing Claude credential by its actual type", () => {
+    expect(claudeDiscoveryCredentialEnv("sk-ant-api-test")).toEqual({
+      ANTHROPIC_API_KEY: "sk-ant-api-test",
+    });
+    expect(claudeDiscoveryCredentialEnv("sk-ant-oat-test")).toEqual({
+      CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat-test",
     });
   });
 });

--- a/apps/worker/src/harness-profiles/capability-catalog.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -16,7 +16,10 @@ import type {
 } from "@shared/contracts";
 import { buildHarnessProfileDraftV2 } from "@shared/contracts";
 import type { Db } from "../db/client.js";
-import { harnessCapabilityCatalogs } from "../db/schema.js";
+import {
+  harnessCapabilityCatalogs,
+  organization,
+} from "../db/schema.js";
 import { logger } from "../lib/logger.js";
 import {
   HARNESS_PROVIDER_CONTRACTS,
@@ -24,7 +27,9 @@ import {
 } from "./manifest.js";
 
 export const HARNESS_CAPABILITY_CACHE_TTL_MS = 15 * 60 * 1_000;
-export const HARNESS_CAPABILITY_DISCOVERY_TIMEOUT_MS = 10_000;
+export const HARNESS_CAPABILITY_PREWARM_LEAD_MS = 5 * 60 * 1_000;
+export const CLAUDE_CAPABILITY_DISCOVERY_TIMEOUT_MS = 180_000;
+export const CODEX_CAPABILITY_DISCOVERY_TIMEOUT_MS = 180_000;
 export const HARNESS_CAPABILITY_REFRESH_THROTTLE_MS = 30_000;
 
 const inFlightRefreshes = new Map<
@@ -40,6 +45,8 @@ export class HarnessCapabilityCatalogError extends Error {
     super(message);
   }
 }
+
+class HarnessCapabilityDiscoveryPrerequisiteError extends Error {}
 
 export interface HarnessCapabilityDiscoveryDependencies {
   now?: () => Date;
@@ -96,17 +103,7 @@ async function getHarnessCapabilitiesInternal(
     dependencies?: HarnessCapabilityDiscoveryDependencies;
   },
 ): Promise<HarnessCapabilitiesResponse> {
-  const providerContract = HARNESS_PROVIDER_CONTRACTS[input.provider];
-  if (
-    !(providerContract.cliVersions as readonly string[]).includes(
-      input.cliVersion,
-    )
-  ) {
-    throw new HarnessCapabilityCatalogError(
-      400,
-      "CLI version is not in the code-owned Harness Profile catalog.",
-    );
-  }
+  assertSupportedCliVersion(input.provider, input.cliVersion);
 
   const now = input.dependencies?.now?.() ?? new Date();
   const cached = await readCachedCatalog(db, input);
@@ -116,13 +113,15 @@ async function getHarnessCapabilitiesInternal(
     now.getTime() - cached.fetchedAt.getTime() <
       HARNESS_CAPABILITY_REFRESH_THROTTLE_MS
   ) {
-    return responseFromCache(cached, false);
+    return responseFromCache(
+      cached,
+      !isCachedCatalogFresh(cached, now),
+    );
   }
   if (
     !input.refresh &&
     cached &&
-    now.getTime() - cached.fetchedAt.getTime() <
-      HARNESS_CAPABILITY_CACHE_TTL_MS
+    isCachedCatalogFresh(cached, now)
   ) {
     return responseFromCache(cached, false);
   }
@@ -130,7 +129,9 @@ async function getHarnessCapabilitiesInternal(
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(),
-    HARNESS_CAPABILITY_DISCOVERY_TIMEOUT_MS,
+    input.provider === "codex"
+      ? CODEX_CAPABILITY_DISCOVERY_TIMEOUT_MS
+      : CLAUDE_CAPABILITY_DISCOVERY_TIMEOUT_MS,
   );
   const discoveryStartedAt = Date.now();
   let catalog: HarnessCapabilityCatalog;
@@ -219,18 +220,48 @@ async function getHarnessCapabilitiesInternal(
   return responseFromCache(row!, false);
 }
 
+/**
+ * Request-time reads never launch provider discovery. Discovery may install a
+ * pinned CLI and is therefore owned by the scheduled prewarm path below.
+ */
+export async function getCachedHarnessCapabilities(
+  db: Db,
+  input: {
+    organizationId: string;
+    provider: HarnessProvider;
+    cliVersion: string;
+    now?: () => Date;
+  },
+): Promise<HarnessCapabilitiesResponse> {
+  assertSupportedCliVersion(input.provider, input.cliVersion);
+  const now = input.now?.() ?? new Date();
+  const cached = await readCachedCatalog(db, input);
+  if (!cached) {
+    throw new HarnessCapabilityCatalogError(
+      503,
+      missingCatalogMessage(input.provider, input.cliVersion),
+    );
+  }
+  return responseFromCache(
+    cached,
+    !isCachedCatalogFresh(cached, now),
+  );
+}
+
 export async function requireFreshHarnessCapabilities(
   db: Db,
   input: {
     organizationId: string;
     provider: HarnessProvider;
     cliVersion: string;
-    dependencies?: HarnessCapabilityDiscoveryDependencies;
+    now?: () => Date;
   },
 ): Promise<HarnessCapabilitiesResponse> {
-  const response = await getHarnessCapabilities(db, {
-    ...input,
-    refresh: true,
+  const response = await getCachedHarnessCapabilities(db, {
+    organizationId: input.organizationId,
+    provider: input.provider,
+    cliVersion: input.cliVersion,
+    now: input.now,
   });
   if (response.stale) {
     throw new HarnessCapabilityCatalogError(
@@ -239,6 +270,78 @@ export async function requireFreshHarnessCapabilities(
     );
   }
   return response;
+}
+
+export async function prewarmHarnessCapabilityCatalogs(
+  db: Db,
+  input: {
+    dependencies?: HarnessCapabilityDiscoveryDependencies;
+  } = {},
+): Promise<{
+  organizations: number;
+  attempted: number;
+  ready: number;
+  stale: number;
+  failed: number;
+}> {
+  const organizations = await db
+    .select({ id: organization.id })
+    .from(organization);
+  const result = {
+    organizations: organizations.length,
+    attempted: 0,
+    ready: 0,
+    stale: 0,
+    failed: 0,
+  };
+
+  for (const { id: organizationId } of organizations) {
+    for (const provider of ["claude", "codex"] as const) {
+      for (const cliVersion of HARNESS_PROVIDER_CONTRACTS[provider]
+        .cliVersions) {
+        result.attempted++;
+        try {
+          const now = input.dependencies?.now?.() ?? new Date();
+          const cached = await readCachedCatalog(db, {
+            organizationId,
+            provider,
+            cliVersion,
+          });
+          const capabilities = await getHarnessCapabilities(db, {
+            organizationId,
+            provider,
+            cliVersion,
+            refresh:
+              !cached ||
+              !isCachedCatalogFresh(cached, now) ||
+              now.getTime() - cached.fetchedAt.getTime() >=
+                HARNESS_CAPABILITY_CACHE_TTL_MS -
+                  HARNESS_CAPABILITY_PREWARM_LEAD_MS,
+            dependencies: input.dependencies,
+          });
+          if (capabilities.stale) result.stale++;
+          else result.ready++;
+        } catch (error) {
+          result.failed++;
+          logger.warn(
+            {
+              event: "harness_capability_prewarm",
+              organization_id: organizationId,
+              provider,
+              cli_version: cliVersion,
+              failure:
+                error instanceof HarnessCapabilityCatalogError
+                  ? error.message
+                  : safeDiscoveryFailure(error),
+            },
+            "Harness capability prewarm failed",
+          );
+        }
+      }
+    }
+  }
+
+  return result;
 }
 
 export function hashHarnessCapabilityCatalog(
@@ -364,6 +467,47 @@ async function readCachedCatalog(
   return row ?? null;
 }
 
+function assertSupportedCliVersion(
+  provider: HarnessProvider,
+  cliVersion: string,
+): void {
+  const providerContract = HARNESS_PROVIDER_CONTRACTS[provider];
+  if (
+    !(providerContract.cliVersions as readonly string[]).includes(
+      cliVersion,
+    )
+  ) {
+    throw new HarnessCapabilityCatalogError(
+      400,
+      "CLI version is not in the code-owned Harness Profile catalog.",
+    );
+  }
+}
+
+function isCachedCatalogFresh(
+  row: CachedCatalog,
+  now: Date,
+): boolean {
+  const unresolvedFailure =
+    row.lastRefreshFailedAt !== null &&
+    row.lastRefreshFailedAt.getTime() >= row.fetchedAt.getTime();
+  return (
+    !unresolvedFailure &&
+    now.getTime() - row.fetchedAt.getTime() <
+      HARNESS_CAPABILITY_CACHE_TTL_MS
+  );
+}
+
+function missingCatalogMessage(
+  provider: HarnessProvider,
+  cliVersion: string,
+): string {
+  if (provider === "claude") {
+    return "Claude model discovery is not ready. Configure ANTHROPIC_API_KEY on the worker and wait for the scheduled capability refresh.";
+  }
+  return `Codex model discovery for @openai/codex@${cliVersion} is not ready. Configure CODEX_API_KEY or CODEX_CHATGPT_OAUTH_TOKEN on the worker and check the scheduled capability refresh.`;
+}
+
 function responseFromCache(
   row: CachedCatalog,
   stale: boolean,
@@ -454,47 +598,23 @@ function uniqueOptions(
   });
 }
 
-async function discoverClaudeCapabilities(
+export async function discoverClaudeCapabilities(
   cliVersion: string,
   signal: AbortSignal,
+  credential?: string,
 ): Promise<HarnessCapabilityCatalog> {
-  const { env } = await import("../../env.js");
-  if (
-    !env.ANTHROPIC_API_KEY ||
-    env.ANTHROPIC_API_KEY.startsWith("sk-ant-oat")
-  ) {
-    throw new Error("Anthropic Models API credentials are unavailable.");
+  const resolvedCredential =
+    credential ?? (await import("../../env.js")).env.ANTHROPIC_API_KEY;
+  if (!resolvedCredential) {
+    throw new HarnessCapabilityDiscoveryPrerequisiteError(
+      "Configure ANTHROPIC_API_KEY for Claude model discovery.",
+    );
   }
-  const models: HarnessModelCapability[] = [];
-  let afterId: string | undefined;
-  do {
-    const url = new URL("https://api.anthropic.com/v1/models");
-    url.searchParams.set("limit", "1000");
-    if (afterId) url.searchParams.set("after_id", afterId);
-    const response = await fetch(url, {
-      headers: {
-        "x-api-key": env.ANTHROPIC_API_KEY,
-        "anthropic-version": "2023-06-01",
-      },
-      signal,
-    });
-    if (!response.ok) {
-      throw new Error("Anthropic model discovery failed.");
-    }
-    const body = (await response.json()) as {
-      data?: unknown[];
-      has_more?: boolean;
-      last_id?: string;
-    };
-    for (const raw of body.data ?? []) {
-      const normalized = normalizeClaudeModel(raw);
-      if (normalized) models.push(normalized);
-    }
-    afterId =
-      body.has_more === true && typeof body.last_id === "string"
-        ? body.last_id
-        : undefined;
-  } while (afterId);
+  const rawModels = await readClaudeCodeModels(
+    cliVersion,
+    resolvedCredential,
+    signal,
+  );
 
   return {
     provider: "claude",
@@ -502,63 +622,176 @@ async function discoverClaudeCapabilities(
     cliVersion,
     protocolVersion:
       HARNESS_PROVIDER_CONTRACTS.claude.protocolVersions[0],
-    models,
+    models: rawModels
+      .map(normalizeClaudeModel)
+      .filter((model): model is HarnessModelCapability => model !== null),
   };
 }
 
 export function normalizeClaudeModel(
   raw: unknown,
-  cliVersion = HARNESS_PROVIDER_CONTRACTS.claude.cliVersions[0],
 ): HarnessModelCapability | null {
   const record = objectRecord(raw);
-  const id = stringValue(record.id);
+  const id = stringValue(record.value);
   if (!id) return null;
-  const displayName = stringValue(record.display_name) ?? id;
-  const capabilities = objectRecord(record.capabilities);
-  const effort = objectRecord(capabilities.effort);
-  const advertisedEfforts =
-    stringArray(effort.supported_efforts) ??
-    stringArray(capabilities.supported_efforts) ??
-    [];
-  const supportedEfforts =
-    advertisedEfforts.length > 0
-      ? advertisedEfforts
-      : claudeCliReasoningEfforts(cliVersion);
+  const displayName = stringValue(record.displayName) ?? id;
+  const advertisedEfforts = stringArray(record.supportedEffortLevels) ?? [];
+  const supportedEfforts = advertisedEfforts.filter((candidate) =>
+    ["low", "medium", "high", "xhigh", "max"].includes(candidate),
+  );
+  const supportsEffort = record.supportsEffort;
+  if (supportedEfforts.length === 0 && supportsEffort !== false) return null;
+  if (supportedEfforts.length === 0) supportedEfforts.push("none");
   const efforts = supportedEfforts.map(optionFromId);
-  const advertisedDefault = stringValue(effort.default_effort);
-  const defaultEffort =
-    advertisedDefault && supportedEfforts.includes(advertisedDefault)
-      ? advertisedDefault
-      : supportedEfforts.includes("high")
-        ? "high"
-        : (supportedEfforts[0] ?? "none");
-  const contextWindow =
-    positiveInteger(record.max_input_tokens) ??
-    positiveInteger(capabilities.max_input_tokens);
   return {
     id,
     name: displayName,
     description: stringValue(record.description),
-    contextWindowTokens: contextWindow,
+    contextWindowTokens: null,
     reasoningEfforts: efforts,
-    defaultReasoningEffort: defaultEffort,
-    serviceTiers: [optionFromId("standard")],
+    defaultReasoningEffort: supportsEffort === false ? "none" : null,
+    serviceTiers: [
+      {
+        id: "standard",
+        name: "Standard",
+        description: "Pinned Claude CLI default service tier.",
+      },
+    ],
     defaultServiceTier: "standard",
     verbosityOptions: [],
     defaultVerbosity: null,
-    compactionModes: [
-      "model_default",
-      ...(contextWindow === null ? [] : ["custom_threshold" as const]),
-      "disabled",
-    ],
+    compactionModes: ["model_default", "disabled"],
   };
 }
 
-function claudeCliReasoningEfforts(cliVersion: string): string[] {
-  return (HARNESS_PROVIDER_CONTRACTS.claude.cliVersions as readonly string[])
-    .includes(cliVersion)
-    ? ["low", "medium", "high"]
-    : ["none"];
+export function claudeDiscoveryCredentialEnv(
+  credential: string,
+): Record<string, string> {
+  return credential.startsWith("sk-ant-oat")
+    ? { CLAUDE_CODE_OAUTH_TOKEN: credential }
+    : { ANTHROPIC_API_KEY: credential };
+}
+
+async function readClaudeCodeModels(
+  cliVersion: string,
+  credential: string,
+  signal: AbortSignal,
+): Promise<unknown[]> {
+  const isolatedHome = await mkdtemp(
+    join(tmpdir(), "aiw-claude-models-"),
+  );
+  await writeFile(
+    join(isolatedHome, ".claude.json"),
+    JSON.stringify({ hasCompletedOnboarding: true }),
+    { mode: 0o600 },
+  );
+  const child = spawn(
+    "npx",
+    [
+      "--yes",
+      `@anthropic-ai/claude-code@${cliVersion}`,
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--input-format",
+      "stream-json",
+      "--no-session-persistence",
+    ],
+    {
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: isolatedHome,
+        CLAUDE_CODE_ENTRYPOINT: "sdk-ts",
+        DISABLE_AUTOUPDATER: "1",
+        ...claudeDiscoveryCredentialEnv(credential),
+        npm_config_cache: join(
+          tmpdir(),
+          "aiw-claude-capability-npm-cache",
+        ),
+        npm_config_prefer_offline: "true",
+      },
+      stdio: ["pipe", "pipe", "ignore"],
+    },
+  );
+  const lines = createInterface({ input: child.stdout });
+  const requestId = "capability-initialize";
+  let settled = false;
+  let failInitialization: (error: Error) => void = () => {};
+  const initialization = new Promise<unknown[]>((resolve, reject) => {
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+    failInitialization = fail;
+    lines.on("line", (line) => {
+      try {
+        const message = objectRecord(JSON.parse(line));
+        const response = objectRecord(message.response);
+        if (
+          message.type !== "control_response" ||
+          response.request_id !== requestId
+        ) {
+          return;
+        }
+        if (response.subtype !== "success") {
+          fail(new Error("Claude Code model discovery was rejected."));
+          return;
+        }
+        const payload = objectRecord(response.response);
+        if (!Array.isArray(payload.models)) {
+          fail(
+            new Error(
+              "Claude Code returned an invalid model catalog.",
+            ),
+          );
+          return;
+        }
+        settled = true;
+        resolve(payload.models);
+      } catch {
+        // Non-JSON diagnostics and unrelated SDK messages are ignored.
+      }
+    });
+    child.once("error", fail);
+    child.once("exit", () => {
+      fail(new Error("Claude Code exited before model discovery."));
+    });
+    child.stdin.once("error", () => {
+      fail(new Error("Claude Code model discovery input closed."));
+    });
+    child.stdin.write(
+      `${JSON.stringify({
+        request_id: requestId,
+        type: "control_request",
+        request: { subtype: "initialize" },
+      })}\n`,
+      (error) => {
+        if (error) {
+          fail(new Error("Claude Code model discovery input failed."));
+        }
+      },
+    );
+  });
+  const abort = () => {
+    child.kill("SIGKILL");
+    failInitialization(
+      new DOMException(
+        "Claude Code capability discovery timed out.",
+        "AbortError",
+      ),
+    );
+  };
+  signal.addEventListener("abort", abort, { once: true });
+
+  try {
+    return await initialization;
+  } finally {
+    signal.removeEventListener("abort", abort);
+    child.kill("SIGTERM");
+    lines.close();
+    await rm(isolatedHome, { recursive: true, force: true });
+  }
 }
 
 async function discoverCodexCapabilities(
@@ -583,6 +816,11 @@ async function readCodexAppServerModels(
   signal: AbortSignal,
 ): Promise<unknown[]> {
   const { env } = await import("../../env.js");
+  if (!env.CODEX_API_KEY && !env.CODEX_CHATGPT_OAUTH_TOKEN) {
+    throw new HarnessCapabilityDiscoveryPrerequisiteError(
+      "Configure CODEX_API_KEY or CODEX_CHATGPT_OAUTH_TOKEN for Codex model discovery.",
+    );
+  }
   const isolatedHome = await mkdtemp(join(tmpdir(), "aiw-codex-models-"));
   const child = spawn(
     "npx",
@@ -604,6 +842,11 @@ async function readCodexAppServerModels(
         ...(env.CODEX_CHATGPT_OAUTH_TOKEN
           ? { CODEX_ACCESS_TOKEN: env.CODEX_CHATGPT_OAUTH_TOKEN }
           : {}),
+        npm_config_cache: join(
+          tmpdir(),
+          "aiw-codex-capability-npm-cache",
+        ),
+        npm_config_prefer_offline: "true",
       },
       stdio: ["pipe", "pipe", "ignore"],
     },
@@ -638,7 +881,9 @@ async function readCodexAppServerModels(
   });
   const abort = () => {
     child.kill("SIGKILL");
-    failPending(new Error("Codex capability discovery timed out."));
+    failPending(
+      new DOMException("Codex capability discovery timed out.", "AbortError"),
+    );
   };
   signal.addEventListener("abort", abort, { once: true });
 
@@ -860,6 +1105,9 @@ function titleCase(value: string): string {
 }
 
 function safeDiscoveryFailure(error: unknown): string {
+  if (error instanceof HarnessCapabilityDiscoveryPrerequisiteError) {
+    return error.message;
+  }
   if (
     error instanceof DOMException &&
     (error.name === "AbortError" || error.name === "TimeoutError")

--- a/apps/worker/src/harness-profiles/store.test.ts
+++ b/apps/worker/src/harness-profiles/store.test.ts
@@ -25,6 +25,7 @@ import { createTestDb } from "../db/test-db.js";
 import { DashboardAuthError } from "../lib/auth/users-read.js";
 import { hashHarnessSkillArtifact } from "./skill-artifact.js";
 import {
+  getHarnessCapabilities,
   hashHarnessCapabilityCatalog,
   upgradeHarnessDraftToV2,
 } from "./capability-catalog.js";
@@ -356,6 +357,13 @@ describe("organization profiles", () => {
     const capabilityDependencies = {
       discoverCodex: async () => liveCapabilities,
     };
+    await getHarnessCapabilities(db, {
+      organizationId: ADMIN.organizationId,
+      provider: "codex",
+      cliVersion: "0.144.6",
+      refresh: false,
+      dependencies: capabilityDependencies,
+    });
     const created = await createHarnessProfile(db, {
       slug: "lifecycle",
       draft: draft(),
@@ -390,7 +398,6 @@ describe("organization profiles", () => {
       profileId: created.id,
       expectedRevision: changedDraft.draftRevision,
       actor: ADMIN,
-      capabilityDependencies,
     });
     expect(second.version.version).toBe(2);
 
@@ -406,7 +413,6 @@ describe("organization profiles", () => {
         profileId: created.id,
         expectedRevision: restored.draftRevision,
         actor: ADMIN,
-        capabilityDependencies,
       }),
     ).rejects.toMatchObject({
       statusCode: 409,
@@ -430,7 +436,6 @@ describe("organization profiles", () => {
       profileId: created.id,
       expectedRevision: reviewedRestore.draftRevision,
       actor: ADMIN,
-      capabilityDependencies,
     });
     expect(third.version.version).toBe(3);
     expect(third.version.restoredFromVersion).toBe(1);

--- a/apps/worker/src/harness-profiles/store.ts
+++ b/apps/worker/src/harness-profiles/store.ts
@@ -58,7 +58,6 @@ import {
   HarnessCapabilityCatalogError,
   requireFreshHarnessCapabilities,
   upgradeHarnessDraftToHistoricalV2,
-  type HarnessCapabilityDiscoveryDependencies,
 } from "./capability-catalog.js";
 import {
   HarnessSkillArtifactIntegrityError,
@@ -702,7 +701,6 @@ export async function publishHarnessProfile(
     profileId: string;
     expectedRevision: number;
     actor: HarnessProfileActor;
-    capabilityDependencies?: HarnessCapabilityDiscoveryDependencies;
   },
 ): Promise<{
   profile: HarnessProfileDto;
@@ -720,7 +718,6 @@ export async function publishHarnessProfile(
         organizationId: input.actor.organizationId,
         provider: draft.harness.provider,
         cliVersion: draft.harness.cliVersion,
-        dependencies: input.capabilityDependencies,
       });
     } catch (error) {
       if (error instanceof HarnessCapabilityCatalogError) {

--- a/apps/worker/src/routes/api/v1/harness-capabilities.get.ts
+++ b/apps/worker/src/routes/api/v1/harness-capabilities.get.ts
@@ -10,7 +10,7 @@ import type {
 } from "@shared/contracts";
 import { getDb } from "../../../db/client.js";
 import {
-  getHarnessCapabilities,
+  getCachedHarnessCapabilities,
   HarnessCapabilityCatalogError,
 } from "../../../harness-profiles/capability-catalog.js";
 import {
@@ -26,13 +26,10 @@ export default defineEventHandler(
       const query = getQuery(event);
       const provider = parseProvider(query.provider);
       const cliVersion = parseCliVersion(query.cliVersion);
-      const refresh =
-        query.refresh === "1" || query.refresh === "true";
-      return await getHarnessCapabilities(getDb(), {
+      return await getCachedHarnessCapabilities(getDb(), {
         organizationId: actor.organizationId,
         provider,
         cliVersion,
-        refresh,
       });
     } catch (error) {
       if (error instanceof HarnessCapabilityCatalogError) {

--- a/apps/worker/src/routes/cron/harness-capabilities.get.test.ts
+++ b/apps/worker/src/routes/cron/harness-capabilities.get.test.ts
@@ -1,0 +1,65 @@
+import { createApp, toWebHandler } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  prewarm: vi.fn(),
+}));
+
+vi.mock("../../../env.js", () => ({
+  env: { CRON_SECRET: "cron-secret" },
+}));
+vi.mock("../../db/client.js", () => ({
+  getDb: () => ({ db: true }),
+}));
+vi.mock("../../harness-profiles/capability-catalog.js", () => ({
+  prewarmHarnessCapabilityCatalogs: (...args: unknown[]) =>
+    mocks.prewarm(...args),
+}));
+vi.mock("../../lib/logger.js", () => ({
+  logger: { info: vi.fn() },
+}));
+
+const handler = (await import("./harness-capabilities.get.js")).default;
+
+function request(authorization?: string) {
+  const app = createApp();
+  app.use("/", handler);
+  return toWebHandler(app)(
+    new Request("http://worker.test/", {
+      headers: authorization ? { authorization } : undefined,
+    }),
+  );
+}
+
+describe("capability prewarm cron", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prewarm.mockResolvedValue({
+      organizations: 1,
+      attempted: 2,
+      ready: 2,
+      stale: 0,
+      failed: 0,
+    });
+  });
+
+  it("requires cron auth and returns bounded refresh metrics", async () => {
+    expect((await request()).status).toBe(401);
+
+    const response = await request("Bearer cron-secret");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe(
+      "private, no-store",
+    );
+    await expect(response.json()).resolves.toEqual({
+      status: "ok",
+      organizations: 1,
+      attempted: 2,
+      ready: 2,
+      stale: 0,
+      failed: 0,
+    });
+    expect(mocks.prewarm).toHaveBeenCalledWith({ db: true });
+  });
+});

--- a/apps/worker/src/routes/cron/harness-capabilities.get.ts
+++ b/apps/worker/src/routes/cron/harness-capabilities.get.ts
@@ -1,0 +1,31 @@
+import {
+  createError,
+  defineEventHandler,
+  getHeader,
+  setResponseHeader,
+} from "h3";
+import { env } from "../../../env.js";
+import { getDb } from "../../db/client.js";
+import { prewarmHarnessCapabilityCatalogs } from "../../harness-profiles/capability-catalog.js";
+import { logger } from "../../lib/logger.js";
+
+export default defineEventHandler(async (event) => {
+  verifyCronAuth(getHeader(event, "authorization"));
+  setResponseHeader(event, "Cache-Control", "private, no-store");
+
+  const result = await prewarmHarnessCapabilityCatalogs(getDb());
+  logger.info(
+    {
+      event: "harness_capability_prewarm",
+      ...result,
+    },
+    "Harness capability prewarm completed",
+  );
+  return { status: "ok", ...result };
+});
+
+function verifyCronAuth(authHeader: string | undefined): void {
+  if (!env.CRON_SECRET) return;
+  if (authHeader === `Bearer ${env.CRON_SECRET}`) return;
+  throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+}

--- a/apps/worker/vercel.json
+++ b/apps/worker/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/cron/poll",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/cron/harness-capabilities",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- move Codex and Claude model discovery off the dashboard request path into a scheduled, persistent capability cache
- discover Claude models through the exact pinned Claude CLI using the existing `ANTHROPIC_API_KEY` credential, with API-key and Claude Code OAuth routing
- serve cached/stale catalogs without triggering a slow package bootstrap during profile editing
- keep model selection usable when a provider does not advertise a default model or effort

## Root cause

Codex discovery launched a cold `npx` CLI process inside a request with a 10-second timeout, while the pinned package can take longer to install and initialize. Claude discovery called the Anthropic Models API even though the configured production credential is accepted by Claude Code but rejected by that endpoint.

## Production credential validation

Using the configured Vercel production credential, the exact pinned Claude CLI returned three models with effort capabilities. The direct Anthropic Models API returned 401, confirming that CLI discovery is the compatible no-new-secret path. Temporary credential files were removed after the check.

## Validation

- worker: 260 test files / 3,313 tests passed
- dashboard: 593 tests passed
- worker and dashboard TypeScript checks passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic background refresh of Claude and Codex model capabilities.
  * Added support for Claude Console API keys and Claude Code OAuth tokens.
  * Profile editing now reflects available models, preserves historical selections, and applies model-specific reasoning settings.
  * Added scheduled capability prewarming every five minutes.

* **Bug Fixes**
  * Capability requests now use cached results for faster, more reliable responses.
  * Improved timeout and refresh-failure messages while background discovery continues independently.
  * Improved handling of unavailable models and incomplete capability data.

* **Documentation**
  * Updated setup and environment variable guidance for Claude and Codex credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->