### PR TITLE
Create Codex discovery home before launch

### DIFF
--- a/apps/worker/src/harness-profiles/capability-catalog.test.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   HarnessCapabilityCatalog,
@@ -18,6 +21,7 @@ import {
   HarnessCapabilityCatalogError,
   hashHarnessCapabilityCatalog,
   normalizeClaudeModel,
+  prepareCodexDiscoveryHome,
   prewarmHarnessCapabilityCatalogs,
   requireFreshHarnessCapabilities,
   upgradeHarnessDraftToHistoricalV2,
@@ -65,6 +69,20 @@ beforeEach(async () => {
 });
 
 describe("Harness capability catalog", () => {
+  it("creates CODEX_HOME before starting pinned CLI discovery", async () => {
+    const isolatedHome = await mkdtemp(
+      join(tmpdir(), "aiw-codex-home-test-"),
+    );
+    try {
+      const codexHome = await prepareCodexDiscoveryHome(isolatedHome);
+
+      expect(codexHome).toBe(join(isolatedHome, ".codex"));
+      expect((await stat(codexHome)).isDirectory()).toBe(true);
+    } finally {
+      await rm(isolatedHome, { recursive: true, force: true });
+    }
+  });
+
   it("keeps request-time reads cache-only and reports cold prerequisites actionably", async () => {
     await expect(
       getCachedHarnessCapabilities(db, {

--- a/apps/worker/src/harness-profiles/capability-catalog.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -822,6 +822,7 @@ async function readCodexAppServerModels(
     );
   }
   const isolatedHome = await mkdtemp(join(tmpdir(), "aiw-codex-models-"));
+  const codexHome = await prepareCodexDiscoveryHome(isolatedHome);
   const child = spawn(
     "npx",
     [
@@ -835,7 +836,7 @@ async function readCodexAppServerModels(
       env: {
         PATH: process.env.PATH ?? "",
         HOME: isolatedHome,
-        CODEX_HOME: join(isolatedHome, ".codex"),
+        CODEX_HOME: codexHome,
         ...(env.CODEX_API_KEY
           ? { OPENAI_API_KEY: env.CODEX_API_KEY }
           : {}),
@@ -974,6 +975,14 @@ async function readCodexAppServerModels(
     lines.close();
     await rm(isolatedHome, { recursive: true, force: true });
   }
+}
+
+export async function prepareCodexDiscoveryHome(
+  isolatedHome: string,
+): Promise<string> {
+  const codexHome = join(isolatedHome, ".codex");
+  await mkdir(codexHome, { recursive: true });
+  return codexHome;
 }
 
 function normalizeCodexModel(raw: unknown): HarnessModelCapability | null {


### PR DESCRIPTION
## Summary

- create the isolated `CODEX_HOME` directory before launching the exact pinned Codex app-server
- add a regression test for the required directory invariant

## Production finding

The first scheduled AIW-192 prewarm returned HTTP 200 and discovered three Claude models, but Codex exited after about five seconds. A bounded reproduction with `@openai/codex@0.144.6` showed that the CLI rejects a `CODEX_HOME` path that does not already exist. Creating the directory makes the same model-list protocol return seven models immediately.

## Validation

- exact pinned Codex protocol probe: 7 models, no protocol error
- focused worker tests: 13 passed
- worker TypeScript check passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex capability discovery by reliably preparing its required configuration directory.
  * Increased discovery stability when running in isolated environments.

* **Tests**
  * Added coverage verifying that the required Codex directory is created correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->