### PR TITLE
Fix Claude Haiku capability discovery

### DIFF
--- a/apps/worker/src/harness-profiles/capability-catalog.test.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.test.ts
@@ -467,10 +467,15 @@ describe("Harness capability catalog", () => {
   it("uses only capabilities advertised by the pinned Claude CLI", () => {
     expect(
       normalizeClaudeModel({
-        value: "claude-current",
-        displayName: "Claude Current",
+        value: "haiku",
+        displayName: "Haiku",
+        description: "Haiku 4.5 · Fastest for quick answers",
       }),
-    ).toBeNull();
+    ).toMatchObject({
+      id: "haiku",
+      reasoningEfforts: [{ id: "none" }],
+      defaultReasoningEffort: "none",
+    });
 
     expect(
       normalizeClaudeModel({
@@ -486,6 +491,14 @@ describe("Harness capability catalog", () => {
       contextWindowTokens: null,
       compactionModes: ["model_default", "disabled"],
     });
+
+    expect(
+      normalizeClaudeModel({
+        value: "claude-invalid-effort",
+        displayName: "Claude Invalid Effort",
+        supportsEffort: true,
+      }),
+    ).toBeNull();
 
     expect(
       normalizeClaudeModel({

--- a/apps/worker/src/harness-profiles/capability-catalog.ts
+++ b/apps/worker/src/harness-profiles/capability-catalog.ts
@@ -640,7 +640,7 @@ export function normalizeClaudeModel(
     ["low", "medium", "high", "xhigh", "max"].includes(candidate),
   );
   const supportsEffort = record.supportsEffort;
-  if (supportedEfforts.length === 0 && supportsEffort !== false) return null;
+  if (supportedEfforts.length === 0 && supportsEffort === true) return null;
   if (supportedEfforts.length === 0) supportedEfforts.push("none");
   const efforts = supportedEfforts.map(optionFromId);
   return {
@@ -649,7 +649,8 @@ export function normalizeClaudeModel(
     description: stringValue(record.description),
     contextWindowTokens: null,
     reasoningEfforts: efforts,
-    defaultReasoningEffort: supportsEffort === false ? "none" : null,
+    defaultReasoningEffort:
+      supportedEfforts[0] === "none" ? "none" : null,
     serviceTiers: [
       {
         id: "standard",


### PR DESCRIPTION
## What changed

- Keep Claude CLI model rows that omit effort metadata instead of dropping them.
- Represent those models with the existing `none` reasoning-effort capability.
- Preserve rejection for inconsistent rows that explicitly claim effort support without advertising any levels.
- Add regression coverage matching the real Haiku payload returned by Claude Code 2.1.216.

## Why

Claude Code advertises Haiku without `supportsEffort` or `supportedEffortLevels`. The capability normalizer previously treated that valid omission as an invalid model and removed Haiku from the dashboard picker.

## Verification

- `apps/worker/node_modules/.bin/vitest run src/harness-profiles/capability-catalog.test.ts` — 12/12 passed
- `apps/worker/node_modules/.bin/tsc --noEmit` — passed
- `git diff --check` — passed
- Full worker suite — 3,715 passed; six unrelated existing built-in prompt synchronization tests failed. The branch does not modify those files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude model capability detection and normalization.
  * Models that support no reasoning effort now correctly default to “none.”
  * Invalid effort configurations are excluded from the model catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->