### PR TITLE
feat(runs): link every pull request and merge request a run opened

### DIFF
--- a/apps/dashboard/app/api/runs/search/dedupe.test.ts
+++ b/apps/dashboard/app/api/runs/search/dedupe.test.ts
@@ -22,6 +22,7 @@ function run(over: Partial<Run> & Pick<Run, "id">): Run {
     prNumber: null,
     ticketUrl: "",
     prUrl: null,
+    prs: null,
     ...over,
   };
 }

--- a/apps/dashboard/components/cockpit/mobile/screens/runs-mobile.tsx
+++ b/apps/dashboard/components/cockpit/mobile/screens/runs-mobile.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useState } from "react";
-import { CkStatusPill, CkChip, TicketLink, PRLink } from "@/components/ui";
+import { CkStatusPill, CkChip, TicketLink, PRLinks } from "@/components/ui";
 import { useCockpit } from "@/components/cockpit/context";
 import { WindowSelector } from "@/components/cockpit/controls";
 import { windowPhrase, type TimeWindow } from "@/lib/window";
@@ -74,7 +74,7 @@ export function RunsMobileScreen({
             <div className="font-semibold text-neutral-900 text-[14px] mt-1.5 overflow-hidden text-ellipsis whitespace-nowrap">{r.ticketTitle}</div>
             <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
               <TicketLink ticket={r.ticket} url={r.ticketUrl} />
-              {r.prNumber && r.prUrl && <PRLink num={r.prNumber} url={r.prUrl} />}
+              <PRLinks run={r} />
               <CkChip>{r.workflowName}</CkChip>
             </div>
             <div className="grid grid-cols-2 gap-2 mt-3 pt-2.5 border-t border-neutral-200 font-mono">

--- a/apps/dashboard/components/cockpit/mobile/screens/ticket-mobile.tsx
+++ b/apps/dashboard/components/cockpit/mobile/screens/ticket-mobile.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { CkChip, CkStatusPill, PRLink } from "@/components/ui";
+import { CkChip, CkStatusPill, PRLinks } from "@/components/ui";
 import { useCockpit } from "@/components/cockpit/context";
 import type { TicketRunsResponse } from "@shared/contracts";
 
@@ -69,7 +69,7 @@ export function TicketMobileScreen({
             </div>
             <div className="flex items-center gap-1.5 mt-2 flex-wrap">
               <CkChip>{r.workflowName}</CkChip>
-              {r.prNumber && r.prUrl && <PRLink num={r.prNumber} url={r.prUrl} />}
+              <PRLinks run={r} />
             </div>
             <div className="grid grid-cols-2 gap-2 mt-3 pt-2.5 border-t border-neutral-200 font-mono">
               <div>

--- a/apps/dashboard/components/cockpit/screens/overview.tsx
+++ b/apps/dashboard/components/cockpit/screens/overview.tsx
@@ -8,7 +8,7 @@ import {
   CkStatusPill,
   CkDot,
   TicketLink,
-  PRLink,
+  PRLinks,
   CkPagination,
 } from "@/components/ui";
 import { Spark, Donut } from "@/components/charts";
@@ -509,13 +509,11 @@ export function OverviewScreen({
                         <span className="font-semibold text-neutral-900 max-w-[480px] overflow-hidden text-ellipsis whitespace-nowrap block">
                           {r.ticketTitle}
                         </span>
-                        <div className="flex items-center gap-1.5">
+                        <div className="flex items-center gap-1.5 flex-wrap">
                           {r.ticket && r.ticketUrl && (
                             <TicketLink ticket={r.ticket} url={r.ticketUrl} />
                           )}
-                          {r.prNumber && r.prUrl && (
-                            <PRLink num={r.prNumber} url={r.prUrl} />
-                          )}
+                          <PRLinks run={r} />
                           <span className="font-mono text-[10px] text-neutral-500">
                             {r.actor}
                           </span>
@@ -612,16 +610,14 @@ export function OverviewScreen({
                         <span className="font-mono text-[10px] text-neutral-500">· {w.gateway}</span>
                       </div>
                       {latest ? (
-                        <div className="flex items-center gap-2 text-xs text-neutral-700">
+                        <div className="flex items-center gap-2 text-xs text-neutral-700 flex-wrap">
                           {latest.ticket && latest.ticketUrl && (
                             <TicketLink ticket={latest.ticket} url={latest.ticketUrl} />
                           )}
                           <span className="text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-[560px]">
                             {latest.ticketTitle}
                           </span>
-                          {latest.prNumber && latest.prUrl && (
-                            <PRLink num={latest.prNumber} url={latest.prUrl} />
-                          )}
+                          <PRLinks run={latest} />
                         </div>
                       ) : (
                         <div className="text-[11px] text-neutral-500">No recent tickets</div>

--- a/apps/dashboard/components/cockpit/screens/runs.tsx
+++ b/apps/dashboard/components/cockpit/screens/runs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { CkCard, CkChip, CkStatusPill, CkTabs, CkPagination, TicketLink, PRLink } from "@/components/ui";
+import { CkCard, CkChip, CkStatusPill, CkTabs, CkPagination, TicketLink, PRLinks } from "@/components/ui";
 import { useCockpit } from "@/components/cockpit/context";
 import { WindowSelector } from "@/components/cockpit/controls";
 import { SpotlightTrigger } from "@/components/cockpit/spotlight-search";
@@ -92,9 +92,9 @@ export function RunsScreen({
                 <td className="px-3 py-2.5">
                   <div className="flex flex-col gap-1">
                     <span className="block font-semibold text-neutral-900 max-w-[320px] overflow-hidden text-ellipsis whitespace-nowrap">{r.ticketTitle}</span>
-                    <div className="flex items-center gap-1.5">
+                    <div className="flex items-center gap-1.5 flex-wrap">
                       <TicketLink ticket={r.ticket} url={r.ticketUrl} />
-                      {r.prNumber && r.prUrl && <PRLink num={r.prNumber} url={r.prUrl} />}
+                      <PRLinks run={r} />
                       <span className="font-mono text-[10px] text-neutral-500">{r.id}</span>
                     </div>
                   </div>

--- a/apps/dashboard/components/cockpit/screens/trace-replay.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace-replay.test.tsx
@@ -24,6 +24,7 @@ const detail: RunDetailResponse = {
     ticketUrl: "https://jira.example/browse/AIW-134",
     prNumber: null,
     prUrl: null,
+    prs: null,
     model: "gpt-5.6",
     createdAt: "2026-07-23T10:00:00.000Z",
     startedAt: "2026-07-23T10:00:00.000Z",

--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -13,7 +13,9 @@ import {
 import { answerPanelMode } from "@/lib/answer-panel-mode";
 import { readErrorMessage } from "@/lib/api/error-message";
 import { runHref } from "@/lib/run-href";
+import { runPullRequests } from "@/lib/run-prs";
 import { SPAN_KIND_COLOR } from "@/lib/theme";
+import { pullRequestRef, pullRequestRepoLabel } from "@shared/contracts";
 import type { Span, SpanKind, SpanStatus } from "@/lib/types";
 import type {
   ClarificationAnswerResponse,
@@ -310,6 +312,7 @@ export function TraceDetail({
   const replayFailed = currentReplay.attempts.filter(
     (attempt) => attempt.state === "failed",
   ).length;
+  const runPrs = runPullRequests(run);
 
   return (
     <div className="flex min-w-0 max-w-full flex-col gap-4">
@@ -335,8 +338,8 @@ export function TraceDetail({
             {run.ticketTitle || run.id}
           </h2>
         </div>
-        {(run.ticketUrl || run.prUrl) && (
-          <div className="flex items-center gap-2 self-start lg:self-auto">
+        {(run.ticketUrl || runPrs.length > 0) && (
+          <div className="flex items-center gap-2 self-start lg:self-auto flex-wrap">
             {run.ticketUrl && (
               <a
                 href={run.ticketUrl}
@@ -347,16 +350,21 @@ export function TraceDetail({
                 Open ticket ↗
               </a>
             )}
-            {run.prUrl && (
+            {/* One button per repository the run published to, so a multi-repo
+                run does not hide every PR/MR but the first. */}
+            {runPrs.map((pr) => (
               <a
-                href={run.prUrl}
+                key={`${pr.provider}:${pr.repoPath}:${pr.id}`}
+                href={pr.url}
                 target="_blank"
                 rel="noreferrer"
+                title={pr.repoPath || undefined}
                 className="appearance-none border border-neutral-200 bg-coal px-3.5 py-2 rounded-[3px] font-mono text-[11px] text-white uppercase tracking-[0.04em] cursor-pointer no-underline hover:bg-neutral-800"
               >
-                {run.prNumber ? `PR #${run.prNumber}` : "Open PR"} ↗
+                {runPrs.length > 1 ? `${pullRequestRepoLabel(pr.repoPath)} ` : ""}
+                {pr.provider === "gitlab" ? "MR" : "PR"} {pullRequestRef(pr)} ↗
               </a>
-            )}
+            ))}
           </div>
         )}
       </div>

--- a/apps/dashboard/components/ui.tsx
+++ b/apps/dashboard/components/ui.tsx
@@ -2,6 +2,9 @@
 
 import React from "react";
 import { Spark } from "@/components/charts";
+import { pullRequestRef, pullRequestRepoLabel } from "@shared/contracts";
+import type { RunPullRequest } from "@shared/contracts";
+import { runPullRequests } from "@/lib/run-prs";
 import type { RunStatus } from "@/lib/types";
 
 /* ── BlazityLogo — inline SVG flame + wordmark ───────────────────────────── */
@@ -319,19 +322,57 @@ export function TicketLink({ ticket, url, size = "sm" }: { ticket: string; url: 
   );
 }
 
-export function PRLink({ num, url, size = "sm" }: { num: number; url: string; size?: "sm" | "lg" }) {
+export function PRLink({
+  pr,
+  showRepo = false,
+  size = "sm",
+}: {
+  pr: RunPullRequest;
+  showRepo?: boolean;
+  size?: "sm" | "lg";
+}) {
   return (
     <a
-      href={url}
+      href={pr.url}
       target="_blank"
       rel="noopener"
       onClick={(e) => e.stopPropagation()}
+      title={pr.repoPath || undefined}
       className={`inline-flex items-center gap-1 border border-neutral-200 rounded-xs bg-coal text-white no-underline font-mono font-medium tracking-[0.02em] whitespace-nowrap transition-all duration-[120ms] hover:bg-neutral-800 ${
         size === "sm" ? "py-0.5 px-1.5 text-[10px]" : "py-[3px] px-2 text-[11px]"
       }`}
     >
-      <span className="opacity-60">PR</span>#{num}
+      {showRepo && <span className="opacity-60">{pullRequestRepoLabel(pr.repoPath)}</span>}
+      <span className="opacity-60">{pr.provider === "gitlab" ? "MR" : "PR"}</span>
+      {pullRequestRef(pr)}
       <span className="text-[9px] opacity-70">↗</span>
     </a>
+  );
+}
+
+/**
+ * All of a run's PR/MR chips. A multi-repo run opens one per changed repository,
+ * so each chip is qualified by repo name; a single-PR run keeps the bare ref it
+ * has always shown. Renders nothing when the run opened none.
+ */
+export function PRLinks({
+  run,
+  size = "sm",
+}: {
+  run: { prs: RunPullRequest[] | null; prUrl: string | null; prNumber: number | null };
+  size?: "sm" | "lg";
+}) {
+  const prs = runPullRequests(run);
+  return (
+    <>
+      {prs.map((pr) => (
+        <PRLink
+          key={`${pr.provider}:${pr.repoPath}:${pr.id}`}
+          pr={pr}
+          showRepo={prs.length > 1}
+          size={size}
+        />
+      ))}
+    </>
   );
 }

--- a/apps/dashboard/lib/data/mock.ts
+++ b/apps/dashboard/lib/data/mock.ts
@@ -12,6 +12,7 @@ import type {
   Prompt,
   PromptVersion,
   Run,
+  RunPullRequest,
   RunStatus,
   Span,
   Workflow,
@@ -224,18 +225,47 @@ const TICKET_PRS: Record<string, number> = {
   "LIN-4477": 2131,
 };
 
+// Repositories beyond the storefront that a run also published to. Covers the
+// multi-repo case the PR chips exist for: a GitLab MR next to the GitHub PR.
+const TICKET_EXTRA_PRS: Record<string, RunPullRequest[]> = {
+  "LIN-4521": [
+    {
+      provider: "gitlab",
+      repoPath: "acme/platform/api",
+      id: 318,
+      url: "https://gitlab.com/acme/platform/api/-/merge_requests/318",
+    },
+  ],
+};
+
 // Attach titles + PR refs to runs (live + historical).
-function decorate(run: Omit<Run, "ticketTitle" | "prNumber" | "ticketUrl" | "prUrl">): Run {
+function decorate(
+  run: Omit<Run, "ticketTitle" | "prNumber" | "ticketUrl" | "prUrl" | "prs">,
+): Run {
+  const prNumber = TICKET_PRS[run.ticket] || null;
+  const prUrl = prNumber
+    ? "https://github.com/acme/storefront/pull/" + prNumber
+    : null;
   return {
     ...run,
     ticketTitle: TICKET_TITLES[run.ticket] || run.ticket,
-    prNumber: TICKET_PRS[run.ticket] || null,
+    prNumber,
     ticketUrl: run.ticket.startsWith("JIRA")
       ? "https://acme.atlassian.net/browse/" + run.ticket
       : "https://linear.app/acme/issue/" + run.ticket,
-    prUrl: TICKET_PRS[run.ticket]
-      ? "https://github.com/acme/storefront/pull/" + TICKET_PRS[run.ticket]
-      : null,
+    prUrl,
+    prs:
+      prNumber && prUrl
+        ? [
+            {
+              provider: "github",
+              repoPath: "acme/storefront",
+              id: prNumber,
+              url: prUrl,
+            },
+            ...(TICKET_EXTRA_PRS[run.ticket] ?? []),
+          ]
+        : null,
   };
 }
 

--- a/apps/dashboard/lib/merge-live-runs.test.ts
+++ b/apps/dashboard/lib/merge-live-runs.test.ts
@@ -21,6 +21,7 @@ function run(over: Partial<Run> & Pick<Run, "id" | "status">): Run {
     prNumber: null,
     ticketUrl: "",
     prUrl: null,
+    prs: null,
     ...over,
   };
 }

--- a/apps/dashboard/lib/run-prs.test.ts
+++ b/apps/dashboard/lib/run-prs.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runPullRequests } from "./run-prs";
+
+test("a multi-repo run returns every PR/MR in stored order", () => {
+  assert.deepEqual(
+    runPullRequests({
+      prs: [
+        {
+          provider: "github",
+          repoPath: "acme/backend",
+          id: 12,
+          url: "https://github.com/acme/backend/pull/12",
+        },
+        {
+          provider: "gitlab",
+          repoPath: "acme/ops/infra",
+          id: 3,
+          url: "https://gitlab.com/acme/ops/infra/-/merge_requests/3",
+        },
+      ],
+      prUrl: "https://github.com/acme/backend/pull/12",
+      prNumber: 12,
+    }),
+    [
+      {
+        provider: "github",
+        repoPath: "acme/backend",
+        id: 12,
+        url: "https://github.com/acme/backend/pull/12",
+      },
+      {
+        provider: "gitlab",
+        repoPath: "acme/ops/infra",
+        id: 3,
+        url: "https://gitlab.com/acme/ops/infra/-/merge_requests/3",
+      },
+    ],
+  );
+});
+
+test("a legacy run without the list keeps its GitHub PR link", () => {
+  assert.deepEqual(
+    runPullRequests({
+      prs: null,
+      prUrl: "https://github.com/acme/storefront/pull/91",
+      prNumber: 91,
+    }),
+    [
+      {
+        provider: "github",
+        repoPath: "",
+        id: 91,
+        url: "https://github.com/acme/storefront/pull/91",
+      },
+    ],
+  );
+});
+
+test("a legacy GitLab URL is recognised as a merge request", () => {
+  assert.deepEqual(
+    runPullRequests({
+      prs: null,
+      prUrl: "https://gitlab.com/acme/api/-/merge_requests/18",
+      prNumber: 18,
+    }),
+    [
+      {
+        provider: "gitlab",
+        repoPath: "",
+        id: 18,
+        url: "https://gitlab.com/acme/api/-/merge_requests/18",
+      },
+    ],
+  );
+});
+
+test("a run that opened nothing renders no links", () => {
+  assert.deepEqual(runPullRequests({ prs: null, prUrl: null, prNumber: null }), []);
+  assert.deepEqual(runPullRequests({ prs: [], prUrl: null, prNumber: null }), []);
+});
+
+test("a run with only half a legacy ref is not rendered as a broken link", () => {
+  assert.deepEqual(
+    runPullRequests({ prs: null, prUrl: "https://github.com/a/b/pull/4", prNumber: null }),
+    [],
+  );
+});

--- a/apps/dashboard/lib/run-prs.ts
+++ b/apps/dashboard/lib/run-prs.ts
@@ -1,0 +1,39 @@
+import type { RunPullRequest, VcsProviderKind } from "@shared/contracts";
+
+/** The PR-carrying fields of a Run/RunDetail, so both shapes can be passed in. */
+interface RunPrRefs {
+  prs: RunPullRequest[] | null;
+  prUrl: string | null;
+  prNumber: number | null;
+}
+
+/**
+ * GitLab MR web URLs always contain the `/-/merge_requests/` segment; every
+ * other shape we store is a GitHub pull URL. Only used for legacy rows — runs
+ * recorded since the `prs` list exists carry their provider explicitly.
+ */
+function providerFromUrl(url: string): VcsProviderKind {
+  return url.includes("/-/merge_requests/") ? "gitlab" : "github";
+}
+
+/**
+ * Every PR/MR to render for a run.
+ *
+ * Runs recorded before `prs` existed — and gate runs, which never populate it —
+ * only have the single `prUrl`/`prNumber`, so those are lifted into a one-entry
+ * list rather than dropped. `repoPath` is empty for them: the repository was
+ * never stored, and callers only use it to disambiguate multi-PR runs, which a
+ * single legacy PR is not.
+ */
+export function runPullRequests(run: RunPrRefs): RunPullRequest[] {
+  if (run.prs && run.prs.length > 0) return run.prs;
+  if (!run.prUrl || run.prNumber == null) return [];
+  return [
+    {
+      provider: providerFromUrl(run.prUrl),
+      repoPath: "",
+      id: run.prNumber,
+      url: run.prUrl,
+    },
+  ];
+}

--- a/apps/dashboard/lib/ticket.test.ts
+++ b/apps/dashboard/lib/ticket.test.ts
@@ -23,6 +23,7 @@ function run(id: string): Run {
     prNumber: null,
     ticketUrl: "",
     prUrl: null,
+    prs: null,
   };
 }
 

--- a/apps/dashboard/lib/types.ts
+++ b/apps/dashboard/lib/types.ts
@@ -5,6 +5,7 @@ export type {
   SpanKind,
   Workflow,
   Run,
+  RunPullRequest,
   HourPoint,
 } from "@shared/contracts";
 

--- a/apps/shared/contracts/api.ts
+++ b/apps/shared/contracts/api.ts
@@ -151,7 +151,7 @@ export interface WorkflowRow extends Pick<Workflow, "id" | "name" | "blurb" | "g
   costToday: number | null;
   latestRun: Pick<
     Run,
-    "ticket" | "ticketUrl" | "ticketTitle" | "prNumber" | "prUrl"
+    "ticket" | "ticketUrl" | "ticketTitle" | "prNumber" | "prUrl" | "prs"
   > | null;
   trend24h: number[] | null;
 }

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -25,6 +25,29 @@ export type WorkflowMeta = Pick<
   "id" | "name" | "blurb" | "gateway" | "primary"
 >;
 
+/**
+ * One pull request / merge request a run opened. A run touching several
+ * repositories opens one per changed repository, across both providers, so the
+ * PR refs on a run are a list, and `prNumber`/`prUrl` only carry the first.
+ */
+export interface RunPullRequest {
+  provider: VcsProviderKind;
+  repoPath: string;
+  id: number;
+  url: string;
+}
+
+/** Provider-native reference: GitHub numbers PRs `#12`, GitLab MRs `!12`. */
+export function pullRequestRef(pr: Pick<RunPullRequest, "provider" | "id">): string {
+  return `${pr.provider === "gitlab" ? "!" : "#"}${pr.id}`;
+}
+
+/** Last path segment of `owner/repo` (or a nested GitLab group path), used to
+ * tell two PRs of one run apart without spending a whole row on the full path. */
+export function pullRequestRepoLabel(repoPath: string): string {
+  return repoPath.split("/").filter(Boolean).at(-1) ?? repoPath;
+}
+
 export interface Run {
   id: string;
   workflow: string;
@@ -48,6 +71,9 @@ export interface Run {
   prNumber: number | null;
   ticketUrl: string;
   prUrl: string | null;
+  /** Every PR/MR the run opened. `null` on runs recorded before the list was
+   * tracked and on gate runs, which only ever have the single `prUrl`. */
+  prs: RunPullRequest[] | null;
   // Live — status === "running"
   currentSpan?: string;
   currentSpanKind?: SpanKind;
@@ -123,6 +149,8 @@ export interface RunDetail {
   ticketUrl: string;
   prNumber: number | null;
   prUrl: string | null;
+  /** See {@link Run.prs}. */
+  prs: RunPullRequest[] | null;
   model: string;
   createdAt: string;
   startedAt: string | null;

--- a/apps/worker/drizzle/0035_run_pull_requests.sql
+++ b/apps/worker/drizzle/0035_run_pull_requests.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflow_runs" ADD COLUMN "prs" jsonb;

--- a/apps/worker/drizzle/meta/0035_snapshot.json
+++ b/apps/worker/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,5013 @@
+{
+  "id": "434053fe-b3c4-40d0-ae51-d47118e7ce40",
+  "prevId": "6d7db0d9-16e4-4518-8bdb-661aa5fc2e1b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_capability_catalogs": {
+      "name": "harness_capability_catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_hash": {
+          "name": "catalog_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "harness_capability_catalogs_scope_unique": {
+          "name": "harness_capability_catalogs_scope_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_capability_catalogs_organization_id_organization_id_fk": {
+          "name": "harness_capability_catalogs_organization_id_organization_id_fk",
+          "tableFrom": "harness_capability_catalogs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_capability_catalogs_provider_check": {
+          "name": "harness_capability_catalogs_provider_check",
+          "value": "\"harness_capability_catalogs\".\"provider\" in ('claude', 'codex')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publication_comments": {
+      "name": "workflow_pr_review_publication_comments",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk",
+          "tableFrom": "workflow_pr_review_publication_comments",
+          "tableTo": "workflow_pr_review_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_pr_review_publication_comments_publication_id_content_hash_pk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_content_hash_pk",
+          "columns": [
+            "publication_id",
+            "content_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publication_comments_state_check": {
+          "name": "workflow_pr_review_publication_comments_state_check",
+          "value": "\"workflow_pr_review_publication_comments\".\"state\" in ('pending', 'published')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publications": {
+      "name": "workflow_pr_review_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_comment_count": {
+          "name": "inline_comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summary_fallback_count": {
+          "name": "summary_fallback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_pr_review_publications_content_unique": {
+          "name": "workflow_pr_review_publications_content_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pr_review_publications_run_idx": {
+          "name": "workflow_pr_review_publications_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_pr_review_publications",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publications_state_check": {
+          "name": "workflow_pr_review_publications_state_check",
+          "value": "\"workflow_pr_review_publications\".\"state\" in ('pending', 'published')"
+        },
+        "workflow_pr_review_publications_decision_check": {
+          "name": "workflow_pr_review_publications_decision_check",
+          "value": "\"workflow_pr_review_publications\".\"decision\" in ('approve', 'request_changes')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_external_checks": {
+      "name": "workflow_run_external_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "closure_intent": {
+          "name": "closure_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_external_checks_attempt_unique": {
+          "name": "workflow_run_external_checks_attempt_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_reconcile_idx": {
+          "name": "workflow_run_external_checks_reconcile_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_run_idx": {
+          "name": "workflow_run_external_checks_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_external_checks_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_external_checks_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_external_checks",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_external_checks_state_check": {
+          "name": "workflow_run_external_checks_state_check",
+          "value": "\"workflow_run_external_checks\".\"state\" in ('creating', 'pending', 'closing', 'completed')"
+        },
+        "workflow_run_external_checks_conclusion_check": {
+          "name": "workflow_run_external_checks_conclusion_check",
+          "value": "\"workflow_run_external_checks\".\"conclusion\" is null or \"workflow_run_external_checks\".\"conclusion\" in ('success', 'failure', 'neutral', 'cancelled', 'timed_out', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_started_at": {
+          "name": "entry_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_deadline_at": {
+          "name": "startup_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_startup_watchdog_idx": {
+          "name": "workflow_runs_startup_watchdog_idx",
+          "columns": [
+            {
+              "expression": "startup_deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_runs\".\"entry_started_at\" is null and coalesce(\"workflow_runs\".\"status\", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memory_documents": {
+      "name": "agent_memory_documents",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memory_documents_ticket_key_idx": {
+          "name": "agent_memory_documents_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_documents_updated_at_idx": {
+          "name": "agent_memory_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_memory_documents_subject_key_doc_path_pk": {
+          "name": "agent_memory_documents_subject_key_doc_path_pk",
+          "columns": [
+            "subject_key",
+            "doc_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1785307257897,
       "tag": "0034_builtin_prompt_resync",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1785393913911,
+      "tag": "0035_run_pull_requests",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/adapters/messaging/chatsdk.test.ts
+++ b/apps/worker/src/adapters/messaging/chatsdk.test.ts
@@ -113,7 +113,14 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
 
     await adapter.notifyForTicket("AWT-42", {
       kind: "pr_ready",
-      pr: { url: "https://github.com/o/r/pull/7", number: 7 },
+      prs: [
+        {
+          provider: "github",
+          repoPath: "o/r",
+          id: 7,
+          url: "https://github.com/o/r/pull/7",
+        },
+      ],
       usageReport: "Total: $0.10",
     });
 
@@ -123,7 +130,7 @@ describe("ChatSDKAdapter.notifyForTicket", () => {
       `:white_check_mark: ${JIRA_LINK} STATUS: PR ready (<https://github.com/o/r/pull/7|#7>)`,
     );
     expect(mockThreadPost).toHaveBeenCalledWith(
-      `:white_check_mark: Task ${JIRA_LINK} PR ready for review — <https://github.com/o/r/pull/7|#7>\nTotal: $0.10`,
+      `:white_check_mark: Task ${JIRA_LINK} PR ready for review: <https://github.com/o/r/pull/7|#7>\nTotal: $0.10`,
     );
   });
 

--- a/apps/worker/src/adapters/messaging/format.test.ts
+++ b/apps/worker/src/adapters/messaging/format.test.ts
@@ -1,11 +1,26 @@
 import { describe, it, expect } from "vitest";
 import { formatTicketEvent, formatTicketStatus, neutralizeSlackBroadcasts } from "./format.js";
+import type { RunPullRequest } from "@shared/contracts";
 
 const ZWSP = "\u200b";
 
 const JIRA = "https://example.atlassian.net";
 const KEY = "AWT-42";
 const LINK = `<${JIRA}/browse/${KEY}|${KEY}>`;
+
+const ghPr = (id: number, repoPath = "o/r"): RunPullRequest => ({
+  provider: "github",
+  repoPath,
+  id,
+  url: `https://github.com/${repoPath}/pull/${id}`,
+});
+
+const glPr = (id: number, repoPath = "g/r"): RunPullRequest => ({
+  provider: "gitlab",
+  repoPath,
+  id,
+  url: `https://gitlab.com/${repoPath}/-/merge_requests/${id}`,
+});
 
 describe("formatTicketStatus", () => {
   it("started → in progress", () => {
@@ -30,16 +45,60 @@ describe("formatTicketStatus", () => {
   it("pr_ready → includes PR link inline", () => {
     expect(
       formatTicketStatus(
+        { kind: "pr_ready", prs: [ghPr(9)], usageReport: "u" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:white_check_mark: ${LINK} STATUS: PR ready (<https://github.com/o/r/pull/9|#9>)`,
+    );
+  });
+
+  it("pr_ready → a lone GitLab MR uses the provider-native ! reference", () => {
+    expect(
+      formatTicketStatus(
+        { kind: "pr_ready", prs: [glPr(9)], usageReport: "u" },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:white_check_mark: ${LINK} STATUS: PR ready (<https://gitlab.com/g/r/-/merge_requests/9|!9>)`,
+    );
+  });
+
+  it("pr_ready → multi-repo lists every link, each qualified by repo name", () => {
+    expect(
+      formatTicketStatus(
         {
           kind: "pr_ready",
-          pr: { url: "https://github.com/o/r/pull/9", number: 9 },
+          prs: [ghPr(12, "acme/backend"), glPr(3, "acme/ops/infra")],
           usageReport: "u",
         },
         KEY,
         JIRA,
       ),
     ).toBe(
-      `:white_check_mark: ${LINK} STATUS: PR ready (<https://github.com/o/r/pull/9|#9>)`,
+      `:white_check_mark: ${LINK} STATUS: PR ready (` +
+        `<https://github.com/acme/backend/pull/12|backend #12>, ` +
+        `<https://gitlab.com/acme/ops/infra/-/merge_requests/3|infra !3>)`,
+    );
+  });
+
+  it("pr_ready → two repos on one provider stay distinguishable", () => {
+    expect(
+      formatTicketStatus(
+        {
+          kind: "pr_ready",
+          prs: [ghPr(12, "acme/backend"), ghPr(12, "acme/frontend")],
+          usageReport: "u",
+        },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:white_check_mark: ${LINK} STATUS: PR ready (` +
+        `<https://github.com/acme/backend/pull/12|backend #12>, ` +
+        `<https://github.com/acme/frontend/pull/12|frontend #12>)`,
     );
   });
 
@@ -226,18 +285,34 @@ describe("formatTicketEvent", () => {
     ).toBe(`:question: Task ${LINK} needs clarification`);
   });
 
-  it("pr_ready — includes PR link inline and usage report", () => {
+  it("pr_ready: includes PR link inline and usage report", () => {
+    const text = formatTicketEvent(
+      { kind: "pr_ready", prs: [ghPr(123)], usageReport: "Total: $0.42" },
+      KEY,
+      JIRA,
+    );
+    expect(text).toBe(
+      `:white_check_mark: Task ${LINK} PR ready for review: <https://github.com/o/r/pull/123|#123>\nTotal: $0.42`,
+    );
+  });
+
+  it("pr_ready: multi-repo lists each PR/MR under provider and repo path", () => {
     const text = formatTicketEvent(
       {
         kind: "pr_ready",
-        pr: { url: "https://github.com/o/r/pull/123", number: 123 },
+        prs: [ghPr(12, "acme/backend"), glPr(3, "acme/ops/infra")],
         usageReport: "Total: $0.42",
       },
       KEY,
       JIRA,
     );
     expect(text).toBe(
-      `:white_check_mark: Task ${LINK} PR ready for review — <https://github.com/o/r/pull/123|#123>\nTotal: $0.42`,
+      [
+        `:white_check_mark: Task ${LINK} PR/MR ready for review (2):`,
+        "• github:acme/backend: <https://github.com/acme/backend/pull/12|#12>",
+        "• gitlab:acme/ops/infra: <https://gitlab.com/acme/ops/infra/-/merge_requests/3|!3>",
+        "Total: $0.42",
+      ].join("\n"),
     );
   });
 
@@ -245,7 +320,7 @@ describe("formatTicketEvent", () => {
     const text = formatTicketEvent(
       {
         kind: "pr_ready",
-        pr: { url: "https://github.com/o/r/pull/5", number: 5 },
+        prs: [ghPr(5)],
         usageReport: "Total: $0.10",
         extraText: "Deployed to staging",
       },
@@ -253,7 +328,7 @@ describe("formatTicketEvent", () => {
       JIRA,
     );
     expect(text).toBe(
-      `:white_check_mark: Task ${LINK} PR ready for review — <https://github.com/o/r/pull/5|#5>\nTotal: $0.10\nDeployed to staging`,
+      `:white_check_mark: Task ${LINK} PR ready for review: <https://github.com/o/r/pull/5|#5>\nTotal: $0.10\nDeployed to staging`,
     );
   });
 
@@ -331,7 +406,7 @@ describe("formatTicketEvent", () => {
     const text = formatTicketEvent(
       {
         kind: "pr_ready",
-        pr: { url: "https://github.com/o/r/pull/7", number: 7 },
+        prs: [ghPr(7)],
         usageReport: "Total: $0.10",
         extraText: "Ship it <!channel>",
       },

--- a/apps/worker/src/adapters/messaging/format.test.ts
+++ b/apps/worker/src/adapters/messaging/format.test.ts
@@ -102,6 +102,12 @@ describe("formatTicketStatus", () => {
     );
   });
 
+  it("pr_ready → an empty list degrades to the bare status, never 'PR ready ()'", () => {
+    expect(
+      formatTicketStatus({ kind: "pr_ready", prs: [], usageReport: "u" }, KEY, JIRA),
+    ).toBe(`:white_check_mark: ${LINK} STATUS: PR ready`);
+  });
+
   it("failed with phase → status names the phase", () => {
     expect(
       formatTicketStatus(
@@ -313,6 +319,17 @@ describe("formatTicketEvent", () => {
         "• gitlab:acme/ops/infra: <https://gitlab.com/acme/ops/infra/-/merge_requests/3|!3>",
         "Total: $0.42",
       ].join("\n"),
+    );
+  });
+
+  it("pr_ready: an empty list drops the link instead of announcing '(0):'", () => {
+    const text = formatTicketEvent(
+      { kind: "pr_ready", prs: [], usageReport: "Total: $0.42" },
+      KEY,
+      JIRA,
+    );
+    expect(text).toBe(
+      `:white_check_mark: Task ${LINK} PR ready for review\nTotal: $0.42`,
     );
   });
 

--- a/apps/worker/src/adapters/messaging/format.ts
+++ b/apps/worker/src/adapters/messaging/format.ts
@@ -1,3 +1,5 @@
+import { pullRequestRef, pullRequestRepoLabel } from "@shared/contracts";
+import type { RunPullRequest } from "@shared/contracts";
 import type { TicketEvent } from "./types.js";
 
 /**
@@ -41,8 +43,14 @@ export function formatTicketStatus(
       return `${head} in progress`;
     case "needs_clarification":
       return `${head} needs clarification`;
-    case "pr_ready":
-      return `${head} PR ready (<${event.pr.url}|#${event.pr.number}>)`;
+    case "pr_ready": {
+      // Every link inline: this line is what the channel shows without opening
+      // the thread, so a multi-repo run must be clickable straight from it.
+      const withRepo = event.prs.length > 1;
+      return `${head} PR ready (${event.prs
+        .map((pr) => prSlackLink(pr, withRepo))
+        .join(", ")})`;
+    }
     case "failed":
       return event.phase ? `${head} failed (${event.phase})` : `${head} failed`;
     case "plan_approval_requested":
@@ -105,11 +113,19 @@ export function formatTicketEvent(
     }
 
     case "pr_ready": {
-      const prLink = `<${event.pr.url}|#${event.pr.number}>`;
-      const withUsage = appendUsage(
-        `${head} PR ready for review — ${prLink}`,
-        event.usageReport,
-      );
+      // One repository keeps the single-line copy; several get a bulleted list
+      // qualified by provider and repo path, since two repos can carry the same
+      // PR number and a bare "#12" would be ambiguous.
+      const body =
+        event.prs.length === 1
+          ? `${head} PR ready for review: ${prSlackLink(event.prs[0]!, false)}`
+          : [
+              `${head} PR/MR ready for review (${event.prs.length}):`,
+              ...event.prs.map(
+                (pr) => `• ${pr.provider}:${pr.repoPath}: ${prSlackLink(pr, false)}`,
+              ),
+            ].join("\n");
+      const withUsage = appendUsage(body, event.usageReport);
       // extraText is user/ticket-derived (a send_slack_message block's message
       // after {{variable}} substitution), so defang Slack broadcast tokens in it
       // before it joins our system-built copy. Applied ONLY here, not to the
@@ -156,6 +172,16 @@ export function formatTicketEvent(
  */
 export function neutralizeSlackBroadcasts(text: string): string {
   return text.replace(/<!(channel|here|everyone|subteam\^[^>]*)>/g, "<\u200b!$1>");
+}
+
+/**
+ * Slack `<url|label>` for one PR/MR. The label is the provider-native reference
+ * (`#12` on GitHub, `!12` on GitLab), prefixed with the repository name when the
+ * run opened more than one so the links are told apart without a hover.
+ */
+function prSlackLink(pr: RunPullRequest, withRepo: boolean): string {
+  const ref = pullRequestRef(pr);
+  return `<${pr.url}|${withRepo ? `${pullRequestRepoLabel(pr.repoPath)} ${ref}` : ref}>`;
 }
 
 function jiraLink(ticketKey: string, jiraBaseUrl: string): string {

--- a/apps/worker/src/adapters/messaging/format.ts
+++ b/apps/worker/src/adapters/messaging/format.ts
@@ -47,9 +47,11 @@ export function formatTicketStatus(
       // Every link inline: this line is what the channel shows without opening
       // the thread, so a multi-repo run must be clickable straight from it.
       const withRepo = event.prs.length > 1;
-      return `${head} PR ready (${event.prs
-        .map((pr) => prSlackLink(pr, withRepo))
-        .join(", ")})`;
+      const links = event.prs.map((pr) => prSlackLink(pr, withRepo)).join(", ");
+      // An empty list would render a dangling "PR ready ()". Senders guarantee
+      // at least one, but this formatter is exported and the type allows [],
+      // so degrade to the bare status instead of emitting broken copy.
+      return links ? `${head} PR ready (${links})` : `${head} PR ready`;
     }
     case "failed":
       return event.phase ? `${head} failed (${event.phase})` : `${head} failed`;
@@ -115,16 +117,21 @@ export function formatTicketEvent(
     case "pr_ready": {
       // One repository keeps the single-line copy; several get a bulleted list
       // qualified by provider and repo path, since two repos can carry the same
-      // PR number and a bare "#12" would be ambiguous.
+      // PR number and a bare "#12" would be ambiguous. An empty list drops the
+      // link rather than announcing "(0):" with nothing under it — see the
+      // matching guard in formatTicketStatus.
+      const [first] = event.prs;
       const body =
-        event.prs.length === 1
-          ? `${head} PR ready for review: ${prSlackLink(event.prs[0]!, false)}`
-          : [
-              `${head} PR/MR ready for review (${event.prs.length}):`,
-              ...event.prs.map(
-                (pr) => `• ${pr.provider}:${pr.repoPath}: ${prSlackLink(pr, false)}`,
-              ),
-            ].join("\n");
+        first === undefined
+          ? `${head} PR ready for review`
+          : event.prs.length === 1
+            ? `${head} PR ready for review: ${prSlackLink(first, false)}`
+            : [
+                `${head} PR/MR ready for review (${event.prs.length}):`,
+                ...event.prs.map(
+                  (pr) => `• ${pr.provider}:${pr.repoPath}: ${prSlackLink(pr, false)}`,
+                ),
+              ].join("\n");
       const withUsage = appendUsage(body, event.usageReport);
       // extraText is user/ticket-derived (a send_slack_message block's message
       // after {{variable}} substitution), so defang Slack broadcast tokens in it

--- a/apps/worker/src/adapters/messaging/types.ts
+++ b/apps/worker/src/adapters/messaging/types.ts
@@ -26,7 +26,9 @@ export type TicketEvent =
       /**
        * One entry per repository the run published to, so a run spanning a
        * GitHub repo and a GitLab repo (or two repos on one provider) links every
-       * PR/MR instead of only the first. Never empty when this event is sent.
+       * PR/MR instead of only the first. Senders only emit this event once a
+       * publication produced at least one; the formatters still degrade to
+       * link-less copy rather than trusting that.
        */
       kind: "pr_ready";
       prs: RunPullRequest[];

--- a/apps/worker/src/adapters/messaging/types.ts
+++ b/apps/worker/src/adapters/messaging/types.ts
@@ -1,3 +1,5 @@
+import type { RunPullRequest } from "@shared/contracts";
+
 export type TicketEvent =
   | { kind: "started" }
   | {
@@ -21,8 +23,13 @@ export type TicketEvent =
       usageReport?: string;
     }
   | {
+      /**
+       * One entry per repository the run published to, so a run spanning a
+       * GitHub repo and a GitLab repo (or two repos on one provider) links every
+       * PR/MR instead of only the first. Never empty when this event is sent.
+       */
       kind: "pr_ready";
-      pr: { url: string; number: number };
+      prs: RunPullRequest[];
       usageReport: string;
       extraText?: string;
     }

--- a/apps/worker/src/db/queries/run-detail-read.test.ts
+++ b/apps/worker/src/db/queries/run-detail-read.test.ts
@@ -280,8 +280,46 @@ describe("fetchRunRefs", () => {
       ticketTitle: "Add greeting endpoint",
       prUrl: "https://github.com/acme/demo/pull/42",
       prNumber: 42,
+      prs: null,
       statusReason: null,
     });
+  });
+
+  it("returns every PR/MR of a multi-repo run", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "r1",
+      ticketKey: "AWT-981",
+      prUrl: "https://github.com/acme/backend/pull/12",
+      prNumber: 12,
+      prs: [
+        {
+          provider: "github",
+          repoPath: "acme/backend",
+          id: 12,
+          url: "https://github.com/acme/backend/pull/12",
+        },
+        {
+          provider: "gitlab",
+          repoPath: "acme/infra",
+          id: 3,
+          url: "https://gitlab.com/acme/infra/-/merge_requests/3",
+        },
+      ],
+    });
+    expect((await fetchRunRefs(db, "r1", JIRA))?.prs).toEqual([
+      {
+        provider: "github",
+        repoPath: "acme/backend",
+        id: 12,
+        url: "https://github.com/acme/backend/pull/12",
+      },
+      {
+        provider: "gitlab",
+        repoPath: "acme/infra",
+        id: 3,
+        url: "https://gitlab.com/acme/infra/-/merge_requests/3",
+      },
+    ]);
   });
 
   it("returns the persisted status reason", async () => {

--- a/apps/worker/src/db/queries/run-detail-read.ts
+++ b/apps/worker/src/db/queries/run-detail-read.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import type { RunDetail, RunStep } from "@shared/contracts";
+import type { RunDetail, RunPullRequest, RunStep } from "@shared/contracts";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
 import { coerceStatus } from "./runs-read.js";
@@ -116,6 +116,7 @@ export async function fetchRunDetailFromDb(
       row.ticketUrl ?? (row.ticketKey ? `${tenantOrigin}/browse/${row.ticketKey}` : ""),
     prNumber: row.prNumber,
     prUrl: row.prUrl,
+    prs: row.prs,
     model: row.model ?? modelFallback,
     createdAt: (row.createdAt ?? row.firstSeenAt).toISOString(),
     startedAt: row.startedAt?.toISOString() ?? null,
@@ -159,6 +160,7 @@ export async function fetchRunRefs(
   ticketTitle: string | null;
   prNumber: number | null;
   prUrl: string | null;
+  prs: RunPullRequest[] | null;
   statusReason: string | null;
 } | null> {
   const [row] = await db
@@ -168,6 +170,7 @@ export async function fetchRunRefs(
       ticketTitle: workflowRuns.ticketTitle,
       prNumber: workflowRuns.prNumber,
       prUrl: workflowRuns.prUrl,
+      prs: workflowRuns.prs,
       statusReason: workflowRuns.statusReason,
     })
     .from(workflowRuns)
@@ -183,6 +186,7 @@ export async function fetchRunRefs(
     ticketTitle: row.ticketTitle,
     prNumber: row.prNumber,
     prUrl: row.prUrl,
+    prs: row.prs,
     statusReason: row.statusReason,
   };
 }

--- a/apps/worker/src/db/queries/runs-read.test.ts
+++ b/apps/worker/src/db/queries/runs-read.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { createTestDb } from "../test-db.js";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
-import type { WorkflowMeta } from "@shared/contracts";
+import type { RunPullRequest, WorkflowMeta } from "@shared/contracts";
 import {
   parseWindow,
   parseSearch,
@@ -48,6 +48,7 @@ interface SeedRun {
   tokensOutput?: number | null;
   prNumber?: number | null;
   prUrl?: string | null;
+  prs?: RunPullRequest[] | null;
 }
 
 async function seed(over: SeedRun = {}): Promise<void> {
@@ -70,6 +71,7 @@ async function seed(over: SeedRun = {}): Promise<void> {
     tokensOutput: over.tokensOutput === undefined ? 500 : over.tokensOutput,
     prNumber: over.prNumber ?? null,
     prUrl: over.prUrl ?? null,
+    prs: over.prs ?? null,
   });
 }
 
@@ -113,6 +115,28 @@ describe("listRuns", () => {
     expect(r.cost).toBeCloseTo(2.25);
     expect(r.tokens).toBe(2000);
     expect(r.status).toBe("success");
+  });
+
+  it("carries every PR/MR of a multi-repo run, and null for runs without the list", async () => {
+    const prs: RunPullRequest[] = [
+      {
+        provider: "github",
+        repoPath: "acme/backend",
+        id: 12,
+        url: "https://github.com/acme/backend/pull/12",
+      },
+      {
+        provider: "gitlab",
+        repoPath: "acme/infra",
+        id: 3,
+        url: "https://gitlab.com/acme/infra/-/merge_requests/3",
+      },
+    ];
+    await seed({ runId: "r1", prNumber: 12, prUrl: prs[0].url, prs });
+    await seed({ runId: "r2", prNumber: 91, prUrl: "https://github.com/acme/app/pull/91" });
+    const { rows } = await listRuns({ db, window: "all", q: null, ...base });
+    expect(rows.find((x) => x.id === "r1")!.prs).toEqual(prs);
+    expect(rows.find((x) => x.id === "r2")!.prs).toBeNull();
   });
 
   it("treats a null status (usage recorded before snapshot) as running", async () => {

--- a/apps/worker/src/db/queries/runs-read.ts
+++ b/apps/worker/src/db/queries/runs-read.ts
@@ -3,6 +3,7 @@ import type {
   CostResponse,
   KpisResponse,
   Run,
+  RunPullRequest,
   RunStatus,
   WorkflowMeta,
   WorkflowRow,
@@ -207,6 +208,7 @@ const runColumns = {
   tokensOutput: workflowRuns.tokensOutput,
   prNumber: workflowRuns.prNumber,
   prUrl: workflowRuns.prUrl,
+  prs: workflowRuns.prs,
 } as const;
 
 type RunRow = {
@@ -227,6 +229,7 @@ type RunRow = {
   tokensOutput: number | null;
   prNumber: number | null;
   prUrl: string | null;
+  prs: RunPullRequest[] | null;
 };
 
 function mapRun(r: RunRow, now: Date, tenantOrigin: string, modelFallback: string): Run {
@@ -255,6 +258,7 @@ function mapRun(r: RunRow, now: Date, tenantOrigin: string, modelFallback: strin
     prNumber: r.prNumber,
     ticketUrl: r.ticketUrl ?? (r.ticketKey ? `${tenantOrigin}/browse/${r.ticketKey}` : ""),
     prUrl: r.prUrl,
+    prs: r.prs,
   };
 }
 
@@ -444,6 +448,7 @@ export async function workflowAgg(
       ticketUrl: workflowRuns.ticketUrl,
       prNumber: workflowRuns.prNumber,
       prUrl: workflowRuns.prUrl,
+      prs: workflowRuns.prs,
     })
     .from(workflowRuns)
     .orderBy(workflowRuns.workflowId, sql`${effTime()} desc`);
@@ -478,6 +483,7 @@ export async function workflowAgg(
             ticketTitle: lr.ticketTitle ?? lr.ticketKey ?? "",
             prNumber: lr.prNumber,
             prUrl: lr.prUrl,
+            prs: lr.prs,
           }
         : null,
       trend24h: wf.length ? countBuckets(times, spec) : null,

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -29,6 +29,7 @@ import type {
   ReplayCaptureStatus,
   ReplaySanitizedEnvelope,
   ResolvedPromptReference,
+  RunPullRequest,
   WorkflowDefinitionLayoutInput,
   WorkflowReplayGraphSnapshot,
   WorkflowReplayLayoutSnapshot,
@@ -310,6 +311,10 @@ export const workflowRuns = pgTable("workflow_runs", {
   prUrl: text("pr_url"),
   prNumber: integer("pr_number"),
   prRepo: text("pr_repo"),
+  /** Every PR/MR an agent run opened, one per changed repository, so a
+   * multi-repo run is not reduced to the single prUrl/prNumber above (which
+   * stay: gate runs write them, and runs predating this column only have them). */
+  prs: jsonb("prs").$type<RunPullRequest[]>(),
 
   // Cost & usage — workflow-owned (accumulated PhaseUsage). costKnown is false
   // when any phase cost couldn't be priced (e.g. Codex with no price lookup).

--- a/apps/worker/src/lib/overview/collect-awaiting-store.ts
+++ b/apps/worker/src/lib/overview/collect-awaiting-store.ts
@@ -43,6 +43,7 @@ export async function collectAwaitingRuns(
       firstSeenAt: workflowRuns.firstSeenAt,
       prNumber: workflowRuns.prNumber,
       prUrl: workflowRuns.prUrl,
+      prs: workflowRuns.prs,
       questions: clarificationRequests.questions,
       suggestedAnswers: clarificationRequests.suggestedAnswers,
       askedAt: clarificationRequests.askedAt,
@@ -84,6 +85,7 @@ export async function collectAwaitingRuns(
       ticketUrl:
         r.ticketUrl ?? (r.ticketKey ? `${tenantOrigin}/browse/${r.ticketKey}` : ""),
       prUrl: r.prUrl,
+      prs: r.prs,
     };
 
     if (r.askedAt) {

--- a/apps/worker/src/lib/overview/collect-live-runs.ts
+++ b/apps/worker/src/lib/overview/collect-live-runs.ts
@@ -66,6 +66,7 @@ export async function collectLiveRuns(
         prNumber: null,
         ticketUrl: ticketKey ? `${tenantOrigin}/browse/${ticketKey}` : "",
         prUrl: null,
+        prs: null,
       };
     }),
   );

--- a/apps/worker/src/lib/overview/collect-run-detail.ts
+++ b/apps/worker/src/lib/overview/collect-run-detail.ts
@@ -193,6 +193,7 @@ export async function collectRunDetail(
     ticketUrl: "",
     prNumber: null,
     prUrl: null,
+    prs: null,
     model,
     createdAt: run.createdAt.toISOString(),
     startedAt: run.startedAt?.toISOString() ?? null,

--- a/apps/worker/src/lib/overview/resolve-run-detail.test.ts
+++ b/apps/worker/src/lib/overview/resolve-run-detail.test.ts
@@ -12,6 +12,7 @@ const RUN = (id: string): RunDetail => ({
   ticketUrl: "",
   prNumber: null,
   prUrl: null,
+  prs: null,
   model: "m",
   createdAt: "2026-06-16T10:00:00Z",
   startedAt: "2026-06-16T10:00:00Z",

--- a/apps/worker/src/lib/overview/sanitize-run-detail.test.ts
+++ b/apps/worker/src/lib/overview/sanitize-run-detail.test.ts
@@ -13,6 +13,7 @@ const run: RunDetail = {
   ticketUrl: "",
   prNumber: null,
   prUrl: null,
+  prs: null,
   model: "model",
   createdAt: "2026-07-23T10:00:00.000Z",
   startedAt: "2026-07-23T10:00:00.000Z",

--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -70,6 +70,9 @@ const usage = (over: Partial<RunUsage> = {}): RunUsage => ({
   budgetFailure: null,
   prUrl: "https://github.com/o/r/pull/7",
   prNumber: 7,
+  prs: [
+    { provider: "github", repoPath: "o/r", id: 7, url: "https://github.com/o/r/pull/7" },
+  ],
   steps: null,
   ...over,
 });

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -5,6 +5,7 @@ import type {
   BlockRunState,
   HarnessRunManifestRecord,
   ResolvedPromptReference,
+  RunPullRequest,
   RunStep,
   WorkflowRunBudgetFailure,
 } from "@shared/contracts";
@@ -85,6 +86,9 @@ export interface RunUsage {
   budgetFailure: WorkflowRunBudgetFailure | null;
   prUrl: string | null;
   prNumber: number | null;
+  /** Every PR/MR the run opened. prUrl/prNumber above stay the first of these,
+   * so a single-repo run and every existing consumer are unaffected. */
+  prs: RunPullRequest[] | null;
   /** Exact non-secret profile/runtime capabilities resolved for this run. */
   harnessManifests?: HarnessRunManifestRecord[];
 }
@@ -196,6 +200,7 @@ export async function recordRunUsage(db: Db, usage: RunUsage): Promise<void> {
       budgetFailure: usage.budgetFailure,
       prUrl: usage.prUrl,
       prNumber: usage.prNumber,
+      prs: usage.prs,
       harnessManifests: usage.harnessManifests,
     })
     .onConflictDoUpdate({
@@ -229,6 +234,7 @@ export async function recordRunUsage(db: Db, usage: RunUsage): Promise<void> {
         budgetFailure: sql`excluded.budget_failure`,
         prUrl: keepIfNull(workflowRuns.prUrl, workflowRuns.prUrl),
         prNumber: keepIfNull(workflowRuns.prNumber, workflowRuns.prNumber),
+        prs: keepIfNull(workflowRuns.prs, workflowRuns.prs),
         harnessManifests: keepIfNull(
           workflowRuns.harnessManifests,
           workflowRuns.harnessManifests,

--- a/apps/worker/src/routes/api/v1/runs/[runId].get.ts
+++ b/apps/worker/src/routes/api/v1/runs/[runId].get.ts
@@ -74,6 +74,7 @@ export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
         ]);
         run.prNumber = refs?.prNumber ?? null;
         run.prUrl = refs?.prUrl ?? null;
+        run.prs = refs?.prs ?? null;
         if (refs?.ticketKey) {
           run.ticket = refs.ticketKey;
           run.ticketUrl = refs.ticketUrl ?? "";

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -184,6 +184,7 @@ import type {
   ReplayObservationKind,
   ReplaySanitizedEnvelope,
   ResolvedPromptReference,
+  RunPullRequest,
   TransformConfiguration,
   VcsProviderKind,
   WorkflowBlockType,
@@ -786,6 +787,22 @@ function publicationPrForTelemetry(
   if (publication?.status !== "published") return null;
   const primary = publication.prs[0];
   return primary ? { url: primary.url, number: primary.id } : null;
+}
+
+/** Every PR/MR the publication opened, for the run's durable PR list. Kept
+ * alongside publicationPrForTelemetry rather than replacing it: the single
+ * prUrl/prNumber columns are still written (gate runs share them) and stay the
+ * first entry, while this preserves the repositories the first entry drops. */
+function publicationPrsForTelemetry(
+  publication: WorkspacePublicationResult | null | undefined,
+): RunPullRequest[] | null {
+  if (publication?.status !== "published" || publication.prs.length === 0) return null;
+  return publication.prs.map((pr) => ({
+    provider: pr.provider,
+    repoPath: pr.repoPath,
+    id: pr.id,
+    url: pr.url,
+  }));
 }
 
 /** Append one durable answer round without duplicating a retry of the same answer. */
@@ -2306,6 +2323,7 @@ export async function recordRunTelemetryStep(payload: {
   totals: UsageTotals;
   budgetFailure: RunBudgetFailure | null;
   pr: { url: string; number: number } | null;
+  prs: RunPullRequest[] | null;
   executionError: { message: string; code: string } | null;
   harnessManifests?: HarnessRunManifestRecord[];
 }) {
@@ -2357,6 +2375,7 @@ export async function recordRunTelemetryStep(payload: {
     budgetFailure: payload.budgetFailure,
     prUrl: payload.pr?.url ?? null,
     prNumber: payload.pr?.number ?? null,
+    prs: payload.prs,
     harnessManifests: payload.harnessManifests,
   });
 }
@@ -3046,6 +3065,7 @@ async function agentWorkflowBody(
   };
   // Captured on the success path; written as run telemetry in the finally.
   let prForTelemetry: { url: string; number: number } | null = null;
+  let prsForTelemetry: RunPullRequest[] | null = null;
   // Authoritative terminal status for telemetry, written in the finally on
   // every exit path. Defaults to "failed". The genuine PR-opened success flips
   // it to "success"; the clarification exits record "awaiting" (the run is
@@ -3949,6 +3969,7 @@ async function agentWorkflowBody(
             await materializeHumanDecisions();
           }
           prForTelemetry ??= publicationPrForTelemetry(ctx.publication);
+          prsForTelemetry ??= publicationPrsForTelemetry(ctx.publication);
           return result;
         }
 
@@ -4813,6 +4834,7 @@ async function agentWorkflowBody(
 
             const primaryPr = publication.prs[0]!;
             prForTelemetry = { url: primaryPr.url, number: primaryPr.id };
+            prsForTelemetry = publicationPrsForTelemetry(publication);
             return { kind: "next", output: buildOpenPrSuccessOutput(publication.prs) };
           }
 
@@ -4832,12 +4854,12 @@ async function agentWorkflowBody(
             // Default "pr_ready": ride along with the PR-ready card, only once a PR
             // has been published.
             const publication = ctx.publication;
-            if (publication?.status === "published") {
-              const primaryPr = publication.prs[0]!;
+            const publishedPrs = publicationPrsForTelemetry(publication);
+            if (publication?.status === "published" && publishedPrs) {
               const usageReport = formatUsageReport(phaseUsages, priceLookup, activeModel, phaseModels);
               await notifyTicket(ticket.identifier, {
                 kind: "pr_ready",
-                pr: { url: primaryPr.url, number: primaryPr.id },
+                prs: publishedPrs,
                 usageReport,
                 ...(message ? { extraText: message } : {}),
               }, transitionOwner);
@@ -5624,6 +5646,7 @@ async function agentWorkflowBody(
       ),
       budgetFailure: terminalBudgetFailure,
       pr: prForTelemetry,
+      prs: prsForTelemetry,
       executionError: terminalExecutionError
         ? {
             message: formatExecutionErrorForUser(terminalExecutionError),

--- a/apps/worker/src/workflows/slack-message-variables.test.ts
+++ b/apps/worker/src/workflows/slack-message-variables.test.ts
@@ -98,7 +98,14 @@ describe("send_slack_message: what actually goes to Slack", () => {
     const slackText = formatTicketEvent(
       {
         kind: "pr_ready",
-        pr: { url: "https://github.com/acme/api/pull/128", number: 128 },
+        prs: [
+          {
+            provider: "github",
+            repoPath: "acme/api",
+            id: 128,
+            url: "https://github.com/acme/api/pull/128",
+          },
+        ],
         usageReport: "",
         extraText: sent,
       },


### PR DESCRIPTION
## Problem

A run can change several repositories at once: different providers (GitHub + GitLab), or several repos on one provider (a separate backend and frontend). Publication already handles this — `openPullRequestsForPublication` iterates every changed repository and returns a list of PRs — but three places took `prs[0]` and dropped the rest:

- Slack `pr_ready` used only the first PR.
- The run record stored a single `pr_url` / `pr_number`, so the dashboard showed one link.
- Only the Jira comment listed them all.

The result: a ticket that touched a GitHub repo and a GitLab repo really did open the merge request, but no link to it existed outside the Jira comment. The same blind spot applied to two repos on one provider.

## Change

Every PR/MR a run opens is now persisted and surfaced.

| Surface | Before | After |
|---|---|---|
| Slack STATUS line | `PR ready (#12)` | `PR ready (backend #12, frontend #8, infra !3)` |
| Slack thread | one line | bulleted list, `• github:acme/backend: #12` |
| Runs / Overview | one chip | one chip per repo, repo-qualified when there are several |
| Trace header | one button | one button per repo |

References follow provider convention: `#12` on GitHub, `!12` on GitLab.

## Implementation notes

- **New `prs` jsonb column on `workflow_runs`** (migration `0035_run_pull_requests`), added alongside the existing `pr_url` / `pr_number` / `pr_repo`. Those stay: the poll cron writes them for gate runs, and every historical run only has them. `prs[0]` is still written to them, so nothing that reads them changes. No data migration, no backfill.
- **`RunPullRequest` + `pullRequestRef` / `pullRequestRepoLabel`** live in `@shared/contracts` so the worker's Slack formatting and the dashboard's chips label GitHub and GitLab identically.
- **`TicketEvent`'s `pr_ready` now carries `prs`** instead of a single `pr`. There was exactly one construction site, so the field was replaced outright rather than shimmed.
- **Legacy runs keep their link.** `apps/dashboard/lib/run-prs.ts` lifts a pre-migration `prUrl` / `prNumber` into a one-entry list, inferring the provider from the URL shape. It is the only place that knows about the fallback.
- Single-PR Slack copy changed from `PR ready for review — <link>` to `PR ready for review: <link>`.

## Out of scope

- `{{pr_url}}` stays scalar — a prompt variable is inherently singular and changing it would break stored workflow definitions.
- `buildOpenPrSuccessOutput` already emitted the full `prs` array for bindings; its `prUrl` / `prNumber` remain the primary for compatibility with #118.

## Verification

- Worker: 3727/3727 tests, typecheck clean.
- Dashboard: 614/614 tests, typecheck and `next build` clean.
- Migration verified through `createTestDb`, which applies the committed migration SQL; the new read-path tests insert into and read back the `prs` column.
- New coverage: multi-repo and cross-provider Slack formatting, GitLab `!` references, two repos on one provider, the read path carrying the list, and the dashboard legacy fallback.

Note on the full worker suite: at default parallelism it fails 30-40 DB-backed tests, but `origin/main` fails a comparable set at the same setting, in a different group of files each run. That is test-Postgres contention, not this change. At `--maxWorkers=3` the whole suite is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard run views now display multiple pull requests or merge requests, including repository context and provider-specific labels.
  * PR/MR links are supported across multiple repositories and preserved for existing runs.
  * Slack notifications now include all associated PR/MR links with clearer formatting.

* **Bug Fixes**
  * Improved handling of legacy and incomplete PR references to prevent broken links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->