### PR TITLE
fix(dashboard): shorten repository labels on run pull request links

### DIFF
--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -15,7 +15,7 @@ import { readErrorMessage } from "@/lib/api/error-message";
 import { runHref } from "@/lib/run-href";
 import { runPullRequests } from "@/lib/run-prs";
 import { SPAN_KIND_COLOR } from "@/lib/theme";
-import { pullRequestRef, pullRequestRepoLabel } from "@shared/contracts";
+import { pullRequestRef, pullRequestRepoLabels } from "@shared/contracts";
 import type { Span, SpanKind, SpanStatus } from "@/lib/types";
 import type {
   ClarificationAnswerResponse,
@@ -313,6 +313,7 @@ export function TraceDetail({
     (attempt) => attempt.state === "failed",
   ).length;
   const runPrs = runPullRequests(run);
+  const runPrLabels = runPrs.length > 1 ? pullRequestRepoLabels(runPrs) : [];
 
   return (
     <div className="flex min-w-0 max-w-full flex-col gap-4">
@@ -352,17 +353,21 @@ export function TraceDetail({
             )}
             {/* One button per repository the run published to, so a multi-repo
                 run does not hide every PR/MR but the first. */}
-            {runPrs.map((pr) => (
+            {runPrs.map((pr, i) => (
               <a
                 key={`${pr.provider}:${pr.repoPath}:${pr.id}`}
                 href={pr.url}
                 target="_blank"
                 rel="noreferrer"
                 title={pr.repoPath || undefined}
-                className="appearance-none border border-neutral-200 bg-coal px-3.5 py-2 rounded-[3px] font-mono text-[11px] text-white uppercase tracking-[0.04em] cursor-pointer no-underline hover:bg-neutral-800"
+                className="inline-flex items-center gap-1 max-w-full appearance-none border border-neutral-200 bg-coal px-3.5 py-2 rounded-[3px] font-mono text-[11px] text-white uppercase tracking-[0.04em] cursor-pointer no-underline hover:bg-neutral-800"
               >
-                {runPrs.length > 1 ? `${pullRequestRepoLabel(pr.repoPath)} ` : ""}
-                {pr.provider === "gitlab" ? "MR" : "PR"} {pullRequestRef(pr)} ↗
+                {runPrLabels[i] && (
+                  <span className="truncate max-w-[180px]">{runPrLabels[i]}</span>
+                )}
+                <span className="whitespace-nowrap">
+                  {pr.provider === "gitlab" ? "MR" : "PR"} {pullRequestRef(pr)} ↗
+                </span>
               </a>
             ))}
           </div>

--- a/apps/dashboard/components/ui.tsx
+++ b/apps/dashboard/components/ui.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Spark } from "@/components/charts";
-import { pullRequestRef, pullRequestRepoLabel } from "@shared/contracts";
+import { pullRequestRef, pullRequestRepoLabels } from "@shared/contracts";
 import type { RunPullRequest } from "@shared/contracts";
 import { runPullRequests } from "@/lib/run-prs";
 import type { RunStatus } from "@/lib/types";
@@ -324,11 +324,13 @@ export function TicketLink({ ticket, url, size = "sm" }: { ticket: string; url: 
 
 export function PRLink({
   pr,
-  showRepo = false,
+  repoLabel,
   size = "sm",
 }: {
   pr: RunPullRequest;
-  showRepo?: boolean;
+  /** Shown before the reference to tell one run's PRs apart. Omitted for a
+   *  single-PR run, where there is nothing to disambiguate. */
+  repoLabel?: string;
   size?: "sm" | "lg";
 }) {
   return (
@@ -342,7 +344,13 @@ export function PRLink({
         size === "sm" ? "py-0.5 px-1.5 text-[10px]" : "py-[3px] px-2 text-[11px]"
       }`}
     >
-      {showRepo && <span className="opacity-60">{pullRequestRepoLabel(pr.repoPath)}</span>}
+      {repoLabel && (
+        // An unusually long name is ellipsized rather than allowed to push the
+        // sibling chips out of the row; the full path stays in the title.
+        <span className={`opacity-60 truncate ${size === "sm" ? "max-w-[104px]" : "max-w-[140px]"}`}>
+          {repoLabel}
+        </span>
+      )}
       <span className="opacity-60">{pr.provider === "gitlab" ? "MR" : "PR"}</span>
       {pullRequestRef(pr)}
       <span className="text-[9px] opacity-70">↗</span>
@@ -363,13 +371,14 @@ export function PRLinks({
   size?: "sm" | "lg";
 }) {
   const prs = runPullRequests(run);
+  const repoLabels = prs.length > 1 ? pullRequestRepoLabels(prs) : [];
   return (
     <>
-      {prs.map((pr) => (
+      {prs.map((pr, i) => (
         <PRLink
           key={`${pr.provider}:${pr.repoPath}:${pr.id}`}
           pr={pr}
-          showRepo={prs.length > 1}
+          repoLabel={repoLabels[i]}
           size={size}
         />
       ))}

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -42,10 +42,46 @@ export function pullRequestRef(pr: Pick<RunPullRequest, "provider" | "id">): str
   return `${pr.provider === "gitlab" ? "!" : "#"}${pr.id}`;
 }
 
-/** Last path segment of `owner/repo` (or a nested GitLab group path), used to
- * tell two PRs of one run apart without spending a whole row on the full path. */
-export function pullRequestRepoLabel(repoPath: string): string {
+/** Last path segment of `owner/repo` (or a nested GitLab group path). */
+function repoLeaf(repoPath: string): string {
   return repoPath.split("/").filter(Boolean).at(-1) ?? repoPath;
+}
+
+/**
+ * Display labels for the repositories of one run, positionally matching `prs`.
+ * Used to tell two PRs of one run apart without spending a whole row on the
+ * full path.
+ *
+ * A deployment usually names every repository off one prefix
+ * (`ai-workflow-demo`, `ai-workflow-prod`, `ai-workflow-integration-test`).
+ * Repeated in every chip that prefix is pure width: it is in all of them, so it
+ * distinguishes none of them. It is dropped at a `-` boundary, leaving only the
+ * part that actually differs. Repositories with nothing in common keep their
+ * full leaf name, and a prefix is never dropped when doing so would leave any
+ * label empty, so `api` next to `api-gateway` stays intact.
+ */
+export function pullRequestRepoLabels(
+  prs: ReadonlyArray<Pick<RunPullRequest, "repoPath">>,
+): string[] {
+  const labels = prs.map((pr) => repoLeaf(pr.repoPath));
+  const [first, ...rest] = labels;
+  if (first === undefined || rest.length === 0) return labels;
+
+  let shared = first;
+  for (const label of rest) {
+    let i = 0;
+    while (i < shared.length && i < label.length && shared[i] === label[i]) i += 1;
+    shared = shared.slice(0, i);
+    if (shared === "") return labels;
+  }
+
+  // Cut whole dash-separated words only, so a shared prefix that stops
+  // mid-word never produces a label like "-gateway".
+  const prefix = shared.slice(0, shared.lastIndexOf("-") + 1);
+  if (prefix === "" || labels.some((label) => label.length <= prefix.length)) {
+    return labels;
+  }
+  return labels.map((label) => label.slice(prefix.length));
 }
 
 export interface Run {

--- a/apps/worker/src/adapters/messaging/format.test.ts
+++ b/apps/worker/src/adapters/messaging/format.test.ts
@@ -102,6 +102,56 @@ describe("formatTicketStatus", () => {
     );
   });
 
+  it("pr_ready → drops the prefix every repo of the run shares", () => {
+    expect(
+      formatTicketStatus(
+        {
+          kind: "pr_ready",
+          prs: [
+            ghPr(24, "blazity/ai-workflow-prod"),
+            glPr(6, "filipmaszota3/ai-workflow-integration-test"),
+          ],
+          usageReport: "u",
+        },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:white_check_mark: ${LINK} STATUS: PR ready (` +
+        `<https://github.com/blazity/ai-workflow-prod/pull/24|prod #24>, ` +
+        `<https://gitlab.com/filipmaszota3/ai-workflow-integration-test/-/merge_requests/6|integration-test !6>)`,
+    );
+  });
+
+  it("pr_ready → keeps a shared prefix that would leave a label empty", () => {
+    expect(
+      formatTicketStatus(
+        {
+          kind: "pr_ready",
+          prs: [ghPr(1, "acme/api"), ghPr(2, "acme/api-gateway")],
+          usageReport: "u",
+        },
+        KEY,
+        JIRA,
+      ),
+    ).toBe(
+      `:white_check_mark: ${LINK} STATUS: PR ready (` +
+        `<https://github.com/acme/api/pull/1|api #1>, ` +
+        `<https://github.com/acme/api-gateway/pull/2|api-gateway #2>)`,
+    );
+  });
+
+  it("pr_ready → ellipsizes a repo label too long for the status line", () => {
+    const long = `acme/${"repository-with-a-very-long-name"}`;
+    const status = formatTicketStatus(
+      { kind: "pr_ready", prs: [ghPr(1, long), ghPr(2, "acme/short")], usageReport: "u" },
+      KEY,
+      JIRA,
+    );
+    expect(status).toContain("|repository-with-a-very… #1>");
+    expect(status).toContain("|short #2>");
+  });
+
   it("pr_ready → an empty list degrades to the bare status, never 'PR ready ()'", () => {
     expect(
       formatTicketStatus({ kind: "pr_ready", prs: [], usageReport: "u" }, KEY, JIRA),

--- a/apps/worker/src/adapters/messaging/format.ts
+++ b/apps/worker/src/adapters/messaging/format.ts
@@ -1,4 +1,4 @@
-import { pullRequestRef, pullRequestRepoLabel } from "@shared/contracts";
+import { pullRequestRef, pullRequestRepoLabels } from "@shared/contracts";
 import type { RunPullRequest } from "@shared/contracts";
 import type { TicketEvent } from "./types.js";
 
@@ -46,8 +46,11 @@ export function formatTicketStatus(
     case "pr_ready": {
       // Every link inline: this line is what the channel shows without opening
       // the thread, so a multi-repo run must be clickable straight from it.
-      const withRepo = event.prs.length > 1;
-      const links = event.prs.map((pr) => prSlackLink(pr, withRepo)).join(", ");
+      const repoLabels =
+        event.prs.length > 1 ? pullRequestRepoLabels(event.prs) : [];
+      const links = event.prs
+        .map((pr, i) => prSlackLink(pr, repoLabels[i]))
+        .join(", ");
       // An empty list would render a dangling "PR ready ()". Senders guarantee
       // at least one, but this formatter is exported and the type allows [],
       // so degrade to the bare status instead of emitting broken copy.
@@ -125,11 +128,11 @@ export function formatTicketEvent(
         first === undefined
           ? `${head} PR ready for review`
           : event.prs.length === 1
-            ? `${head} PR ready for review: ${prSlackLink(first, false)}`
+            ? `${head} PR ready for review: ${prSlackLink(first)}`
             : [
                 `${head} PR/MR ready for review (${event.prs.length}):`,
                 ...event.prs.map(
-                  (pr) => `• ${pr.provider}:${pr.repoPath}: ${prSlackLink(pr, false)}`,
+                  (pr) => `• ${pr.provider}:${pr.repoPath}: ${prSlackLink(pr)}`,
                 ),
               ].join("\n");
       const withUsage = appendUsage(body, event.usageReport);
@@ -182,13 +185,26 @@ export function neutralizeSlackBroadcasts(text: string): string {
 }
 
 /**
+ * Longest repository label the status line will carry. Slack has no ellipsis of
+ * its own, so an unusually long repository name is cut here rather than pushing
+ * the other links off the readable part of the line.
+ */
+const MAX_SLACK_REPO_LABEL = 24;
+
+function truncateRepoLabel(label: string): string {
+  if (label.length <= MAX_SLACK_REPO_LABEL) return label;
+  // Drop a trailing separator so the cut reads "very…" rather than "very-…".
+  return `${label.slice(0, MAX_SLACK_REPO_LABEL - 1).replace(/-+$/, "")}…`;
+}
+
+/**
  * Slack `<url|label>` for one PR/MR. The label is the provider-native reference
  * (`#12` on GitHub, `!12` on GitLab), prefixed with the repository name when the
  * run opened more than one so the links are told apart without a hover.
  */
-function prSlackLink(pr: RunPullRequest, withRepo: boolean): string {
+function prSlackLink(pr: RunPullRequest, repoLabel?: string): string {
   const ref = pullRequestRef(pr);
-  return `<${pr.url}|${withRepo ? `${pullRequestRepoLabel(pr.repoPath)} ${ref}` : ref}>`;
+  return `<${pr.url}|${repoLabel ? `${truncateRepoLabel(repoLabel)} ${ref}` : ref}>`;
 }
 
 function jiraLink(ticketKey: string, jiraBaseUrl: string): string {


### PR DESCRIPTION
## Problem

Follow-up to #188, from looking at the first real multi-repo runs on production.

Deployments tend to name every repository off one prefix. On production the three are `ai-workflow-prod`, `ai-workflow-demo` and `ai-workflow-integration-test`, so a run's chips read:

```
AWP-38  [ ai-workflow-demo PR #314 ]  [ ai-workflow-prod PR #24 ]
AWP-37  [ ai-workflow-prod PR #23 ]  [ ai-workflow-integration-test MR !6 ]
```

`ai-workflow-` is in every chip, so it distinguishes none of them — it is pure width. On the trace screen the second button wrapped onto its own line and pushed the header taller.

## Change

`pullRequestRepoLabels(prs)` replaces `pullRequestRepoLabel(repoPath)`. It takes the run's whole list and returns positionally matching labels with the shared prefix removed:

```
AWP-38  [ demo PR #314 ]  [ prod PR #24 ]
AWP-37  [ prod PR #23 ]  [ integration-test MR !6 ]
```

The prefix is only cut at a `-` boundary, and never when doing so would leave a label empty, so `api` next to `api-gateway` is left alone rather than becoming `` and `-gateway`. Repositories with nothing in common keep their full leaf name.

On top of that, a label that is still long is ellipsized:

- Dashboard chips and trace buttons use CSS (`truncate` + `max-width`), so the cut only happens when the label genuinely does not fit. The full path stays in `title`.
- Slack has no ellipsis of its own, so `format.ts` caps the label at 24 characters and trims a trailing separator, giving `repository-with-a-very…` rather than `repository-with-a-very-…`.

## Verification

- `src/adapters/messaging`: 53/53. New cases cover the shared-prefix cut, the `api` / `api-gateway` guard, and the Slack character cap.
- Worker typecheck clean.
- Dashboard: 614/614, typecheck and `next build` clean.

Existing multi-repo tests were unaffected: their fixtures (`acme/backend`, `acme/frontend`, `acme/ops/infra`) share no prefix, which is itself the no-op case.
