### PR TITLE
Fix answered clarification terminal cleanup

### DIFF
--- a/apps/worker/src/clarifications/hook-store.test.ts
+++ b/apps/worker/src/clarifications/hook-store.test.ts
@@ -11,6 +11,7 @@ import {
   publishHookClarification,
   recordHookClarificationSnapshot,
 } from "./hook-store.js";
+import { classifyProtectedClarificationSubjects } from "./store.js";
 
 const input = {
   ticketKey: "AWT-1",
@@ -169,5 +170,52 @@ describe("getResumableClarificationForTicket", () => {
 
     const found = await getResumableClarificationForTicket(db, "AWT-1");
     expect(found?.id).toBe(newer.id);
+  });
+});
+
+describe("classifyProtectedClarificationSubjects", () => {
+  it("retains a pending clarification while the same Workflow run is bound", async () => {
+    const db = await createTestDb();
+    await publishPending(db);
+    await bindRun(db);
+
+    await expect(classifyProtectedClarificationSubjects(db)).resolves.toEqual({
+      all: [input.subjectKey],
+      retained: [input.subjectKey],
+      terminal: [],
+    });
+  });
+
+  it("routes an answered clarification through terminal-only reconciliation", async () => {
+    const db = await createTestDb();
+    const clarification = await publishPending(db);
+    await answerHookClarification(db, clarification.id, "Use main", {
+      id: "user_1",
+      label: "Ada",
+    });
+    await bindRun(db);
+
+    await expect(classifyProtectedClarificationSubjects(db)).resolves.toEqual({
+      all: [input.subjectKey],
+      retained: [],
+      terminal: [input.subjectKey],
+    });
+  });
+
+  it("lets a newer pending round retain the run over an older answered round", async () => {
+    const db = await createTestDb();
+    const older = await publishPending(db, new Date("2026-07-20T10:00:00.000Z"));
+    await answerHookClarification(db, older.id, "First answer", {
+      id: "user_1",
+      label: "Ada",
+    });
+    await publishPending(db, new Date("2026-07-20T12:00:00.000Z"));
+    await bindRun(db);
+
+    await expect(classifyProtectedClarificationSubjects(db)).resolves.toEqual({
+      all: [input.subjectKey],
+      retained: [input.subjectKey],
+      terminal: [],
+    });
   });
 });

--- a/apps/worker/src/clarifications/store.ts
+++ b/apps/worker/src/clarifications/store.ts
@@ -136,12 +136,20 @@ export interface ProtectedClarificationSubjects {
   terminal: string[];
 }
 
-/** Protect the same asking run while its ticket is parked outside the AI column. */
+/**
+ * A pending hook must bypass generic orphan handling while its ticket is parked
+ * outside the AI column. Once answered, the same Workflow may keep running, so
+ * route it through terminal-only reconciliation: that path retains non-terminal
+ * runs and releases only after the whole Workflow and its steps have drained.
+ */
 export async function classifyProtectedClarificationSubjects(
   db: Db,
 ): Promise<ProtectedClarificationSubjects> {
   const rows = await db
-    .select({ subjectKey: clarificationRequests.subjectKey })
+    .select({
+      subjectKey: clarificationRequests.subjectKey,
+      status: clarificationRequests.status,
+    })
     .from(clarificationRequests)
     .where(
       and(
@@ -155,9 +163,21 @@ export async function classifyProtectedClarificationSubjects(
         )`,
       ),
     );
-  const retained = [...new Set(rows.flatMap((row) => row.subjectKey ? [row.subjectKey] : []))]
-    .sort();
-  return { all: retained, retained, terminal: [] };
+  const retainedSet = new Set<string>();
+  const terminalSet = new Set<string>();
+  for (const row of rows) {
+    if (!row.subjectKey) continue;
+    if (row.status === "pending") retainedSet.add(row.subjectKey);
+    else terminalSet.add(row.subjectKey);
+  }
+  // A newer pending round keeps the same run suspended even when older rounds
+  // are answered.
+  for (const subjectKey of retainedSet) terminalSet.delete(subjectKey);
+
+  const retained = [...retainedSet].sort();
+  const terminal = [...terminalSet].sort();
+  const all = [...new Set([...retained, ...terminal])].sort();
+  return { all, retained, terminal };
 }
 
 export async function supersedePendingForTicket(

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -293,7 +293,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
     expect(mockCancelRun).not.toHaveBeenCalled();
   });
 
-  it("lets retained clarification protection win over an older terminal successor", async () => {
+  it("lets a pending clarification win over an older answered round", async () => {
     const parked = entry();
     const runRegistry = registry([parked]);
     mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
@@ -316,9 +316,9 @@ describe("reconcileRuns owner-CAS recovery", () => {
     expect(runRegistry.release).not.toHaveBeenCalled();
   });
 
-  it("terminal-cleans a consumed clarification successor instead of retaining it forever", async () => {
-    const successor = entry();
-    const runRegistry = registry([successor]);
+  it("terminal-cleans an answered same-run clarification instead of retaining it forever", async () => {
+    const answered = entry();
+    const runRegistry = registry([answered]);
     const tracker = issueTracker("Done");
     const db = { db: true } as never;
     const onReleased = vi.fn();
@@ -334,21 +334,21 @@ describe("reconcileRuns owner-CAS recovery", () => {
         onReleased,
         new Set(),
         db,
-        new Set([successor.subjectKey]),
+        new Set([answered.subjectKey]),
       ),
     ).resolves.toEqual({ cancelled: 0, cleaned: 1 });
     expect(mockCancelRun).not.toHaveBeenCalled();
     expect(runRegistry.release).toHaveBeenCalledWith(
-      successor.subjectKey,
-      successor.ownerToken,
-      successor.runId,
+      answered.subjectKey,
+      answered.ownerToken,
+      answered.runId,
     );
-    expect(onReleased).toHaveBeenCalledWith(successor.subjectKey);
+    expect(onReleased).toHaveBeenCalledWith(answered.subjectKey);
   });
 
-  it("keeps a running consumed clarification successor without orphan-cancelling it outside AI", async () => {
-    const successor = entry();
-    const runRegistry = registry([successor]);
+  it("keeps a running answered clarification without orphan-cancelling it outside AI", async () => {
+    const answered = entry();
+    const runRegistry = registry([answered]);
     const tracker = issueTracker("Done");
     mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
     const { reconcileRuns } = await import("./reconcile.js");
@@ -362,7 +362,34 @@ describe("reconcileRuns owner-CAS recovery", () => {
         undefined,
         new Set(),
         undefined,
-        new Set([successor.subjectKey]),
+        new Set([answered.subjectKey]),
+      ),
+    ).resolves.toEqual({ cancelled: 0, cleaned: 0 });
+    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(runRegistry.release).not.toHaveBeenCalled();
+  });
+
+  it("keeps a terminal answered clarification until its Workflow steps drain", async () => {
+    const answered = entry();
+    const runRegistry = registry([answered]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+    mockListWorkflowSteps.mockResolvedValue({
+      data: [{ status: "running" }],
+      cursor: null,
+      hasMore: false,
+    });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Done"),
+        undefined,
+        undefined,
+        new Set(),
+        undefined,
+        new Set([answered.subjectKey]),
       ),
     ).resolves.toEqual({ cancelled: 0, cleaned: 0 });
     expect(mockCancelRun).not.toHaveBeenCalled();

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -88,15 +88,13 @@ export async function reconcileRuns(
       entry = recovered;
     }
 
-    // A pending durable clarification intentionally keeps its predecessor
-    // parked after the Workflow run exits and the ticket has left AI. The
-    // answer path needs that exact claim for its owner-CAS successor handoff.
+    // A pending clarification suspends the same Workflow while its ticket is
+    // parked outside AI. Do not mistake that deliberate wait for an orphan.
     if (parkedSubjects?.has(entry.subjectKey)) continue;
 
-    // A consumed clarification successor is allowed to run while the ticket is
-    // outside AI, but it is not a retained parked predecessor. Reconcile only
-    // its terminal cleanup so a failed best-effort release cannot leak the
-    // exact bound owner forever.
+    // Once answered, that Workflow may keep running while the ticket remains
+    // outside AI. Reconcile only terminal cleanup: cleanFinishedRun retains the
+    // exact owner until the whole Workflow and every durable step have drained.
     if (terminalReconciliationSubjects?.has(entry.subjectKey)) {
       if (entry.runId) {
         cleaned += await cleanFinishedRun(


### PR DESCRIPTION
## Summary

- keep pending same-run clarifications protected from generic orphan handling
- route answered clarification rows through terminal-only reconciliation
- retain the exact active owner until the overall Workflow is terminal and every durable step has drained

## Root cause

The same-run clarification hook migration classified every bound pending or answered clarification as retained. Answered rows therefore never reached terminal reconciliation, so a successfully completed Workflow could remain in `active_runs` and block plan approval with `run_in_flight`.

This fix keeps the protection boundary at the active-run producer: pending clarification wins over older answered history, while answered-only subjects become eligible for the existing terminal cleanup path. It does not release the lock when the planning agent returns; a Workflow that has later blocks or running durable steps remains locked until the entire run is terminal.

## Verification

- `corepack pnpm --filter worker exec vitest run` — 268 files, 3,826 tests passed
- focused clarification and reconciliation tests — 38 passed
- approval polling and Jira webhook tests — 30 passed
- `corepack pnpm --filter worker exec tsc --noEmit`
- `git diff --check`

Jira: https://blazity.atlassian.net/browse/AIW-203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarification reconciliation to correctly distinguish pending, answered, and terminal states.
  * Preserved newer pending clarification rounds over older answered rounds.
  * Ensured completed clarifications are cleaned up only after associated workflow steps finish draining.
  * Prevented active clarification workflows from being incorrectly cancelled or released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->