### PR TITLE
fix: resolve production stress-test findings across worker and dashboard

### DIFF
--- a/apps/dashboard/app/overview-data.tsx
+++ b/apps/dashboard/app/overview-data.tsx
@@ -21,6 +21,22 @@ import {
   workflowsFallback,
 } from "@/lib/api/fallbacks";
 import { deriveKpisFromRuns } from "@/lib/api/derive-kpis";
+import { mergeLiveRuns } from "@/lib/merge-live-runs";
+
+/**
+ * Reconciles the live registry rows against the durable store, the same way
+ * runs-data.tsx feeds the Runs page (see mergeLiveRuns). Without this, a
+ * lingering registry entry for a run that already finished in the store would
+ * still render as "running"/"awaiting" in the Overview's live panels (Now
+ * running, Input needed), even though the Recent runs table on the same page
+ * (fed from the store directly) already shows its real terminal status.
+ */
+export function reconcileOverviewLiveRuns(
+  recentRuns: RunsResponse,
+  liveRuns: LiveRunsResponse,
+): LiveRunsResponse {
+  return mergeLiveRuns(recentRuns, liveRuns);
+}
 
 export async function OverviewData({ window }: { window: TimeWindow }) {
   const now = new Date().toISOString();
@@ -63,7 +79,7 @@ export async function OverviewData({ window }: { window: TimeWindow }) {
   const data: OverviewScreenData = {
     kpis: mergedKpis,
     evalHealth,
-    liveRuns,
+    liveRuns: reconcileOverviewLiveRuns(recentRuns, liveRuns),
     recentRuns,
     workflows,
   };

--- a/apps/dashboard/components/cockpit/mobile/screens/overview-mobile.tsx
+++ b/apps/dashboard/components/cockpit/mobile/screens/overview-mobile.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 
 import { CkKPI, CkChip, CkStatusPill, TicketLink, CkPagination } from "@/components/ui";
 import { useCockpit } from "@/components/cockpit/context";
@@ -87,37 +88,56 @@ export function OverviewMobileScreen({
         <div>
           <div className="font-mono text-[10px] tracking-[0.06em] uppercase text-[#A2351C] mb-2">Input needed · {awaiting.length}</div>
           <div className="flex flex-col gap-2">
-            {awaiting.map((r) => (
-              // Anchors are not allowed inside buttons, so the card is a div
-              // with a stretched overlay button as the TicketLink's sibling;
-              // the relative wrapper keeps the link on top and clickable.
-              <div
-                key={r.id}
-                className="relative bg-[#FFFCFA] border border-[#FFE4D6] rounded-sm px-3 py-2.5 active:bg-[#FFF4EC]"
-              >
-                <button
-                  type="button"
-                  onClick={() => openRun(r)}
-                  aria-label={`Open run: ${r.workflowName}`}
-                  className="appearance-none absolute inset-0 cursor-pointer rounded-sm"
-                />
-                <div className="flex items-center gap-2 flex-wrap">
-                  <CkStatusPill status="awaiting" />
-                  <span className="font-semibold text-[13px] text-neutral-900">{r.workflowName}</span>
-                  {r.ticket && r.ticketUrl && (
-                    <span className="relative">
-                      <TicketLink ticket={r.ticket} url={r.ticketUrl} />
-                    </span>
+            {awaiting.map((r) => {
+              // A plan parked for human approval has no clarification: send
+              // the card to Approvals instead of the run trace's answer form.
+              const isApproval = r.awaitingKind === "approval";
+              return (
+                // Anchors are not allowed inside buttons, so the card is a div
+                // with a stretched overlay control as the TicketLink's sibling;
+                // the relative wrapper keeps the link on top and clickable.
+                <div
+                  key={r.id}
+                  className="relative bg-[#FFFCFA] border border-[#FFE4D6] rounded-sm px-3 py-2.5 active:bg-[#FFF4EC]"
+                >
+                  {isApproval ? (
+                    <Link
+                      href="/approvals"
+                      aria-label={`Review plan: ${r.workflowName}`}
+                      className="appearance-none absolute inset-0 cursor-pointer rounded-sm"
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => openRun(r)}
+                      aria-label={`Open run: ${r.workflowName}`}
+                      className="appearance-none absolute inset-0 cursor-pointer rounded-sm"
+                    />
                   )}
-                  {typeof r.askedAtMin === "number" && (
-                    <span className="ml-auto font-mono text-[10px] text-neutral-500">{r.askedAtMin}m ago</span>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <CkStatusPill status="awaiting" />
+                    <span className="font-semibold text-[13px] text-neutral-900">{r.workflowName}</span>
+                    {r.ticket && r.ticketUrl && (
+                      <span className="relative">
+                        <TicketLink ticket={r.ticket} url={r.ticketUrl} />
+                      </span>
+                    )}
+                    {typeof r.askedAtMin === "number" && (
+                      <span className="ml-auto font-mono text-[10px] text-neutral-500">{r.askedAtMin}m ago</span>
+                    )}
+                  </div>
+                  {isApproval ? (
+                    <p className="font-body text-[13px] leading-[1.5] text-neutral-700 m-0 mt-2">
+                      Plan submitted for approval before this run continues.
+                    </p>
+                  ) : (
+                    r.question && (
+                      <p className="font-body text-[13px] leading-[1.5] text-neutral-800 m-0 mt-2 border-l-2 border-burnt-orange pl-2.5">{r.question}</p>
+                    )
                   )}
                 </div>
-                {r.question && (
-                  <p className="font-body text-[13px] leading-[1.5] text-neutral-800 m-0 mt-2 border-l-2 border-burnt-orange pl-2.5">{r.question}</p>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       )}

--- a/apps/dashboard/components/cockpit/screens/approvals.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/approvals.test.tsx
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import { LocalDateTime, formatDateTime } from "./approvals";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const REQUESTED_AT = "2026-07-30T14:44:00.000Z";
+
+test("the timestamp is formatted in one pinned locale, not the renderer's", () => {
+  assert.equal(formatDateTime(REQUESTED_AT, "UTC"), "Jul 30, 02:44 PM");
+});
+
+test("an unparseable timestamp is passed through untouched", () => {
+  assert.equal(formatDateTime("whenever"), "whenever");
+});
+
+test("the server render carries no time of day", () => {
+  // The server formats in its own zone (UTC on Vercel) and the browser in the
+  // viewer's, so any timestamp in the server HTML guarantees a hydration
+  // mismatch, which discards the hydrated tree: duplicated rows, dead handlers.
+  const html = renderToStaticMarkup(<LocalDateTime value={REQUESTED_AT} />);
+  assert.equal(html, "...");
+  assert.doesNotMatch(html, /\d/);
+});
+
+test("the local time fills in after mount", (t) => {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(<LocalDateTime value={REQUESTED_AT} />);
+  });
+  t.after(() => {
+    act(() => renderer.unmount());
+  });
+
+  // Compared against the helper, not a literal: the mounted value is the
+  // runner's own zone, and pinning it here would only assert the test's zone.
+  assert.equal(renderer.toJSON(), formatDateTime(REQUESTED_AT));
+});

--- a/apps/dashboard/components/cockpit/screens/approvals.tsx
+++ b/apps/dashboard/components/cockpit/screens/approvals.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { CkCard, CkChip, type ChipTone } from "@/components/ui";
@@ -137,7 +137,7 @@ export function ApprovalsScreen({
                     </span>
                     <CkChip tone={STATUS_TONE[approval.status]}>{STATUS_LABEL[approval.status]}</CkChip>
                     <span className="ml-auto font-mono text-[11px] text-neutral-500">
-                      {formatDateTime(approval.requestedAt)}
+                      <LocalDateTime value={approval.requestedAt} />
                     </span>
                     <span className="font-mono text-[11px] text-neutral-700">{approval.requestedBy}</span>
                     <span
@@ -169,7 +169,7 @@ export function ApprovalsScreen({
                       {approval.decidedAt ? (
                         <div className="font-mono text-[11px] text-neutral-500">
                           Decided by {approval.decidedByLabel ?? approval.decidedById ?? "unknown"} ·{" "}
-                          {formatDateTime(approval.decidedAt)}
+                          <LocalDateTime value={approval.decidedAt} />
                         </div>
                       ) : null}
 
@@ -290,13 +290,36 @@ function DarkButton({ children, ...props }: React.ButtonHTMLAttributes<HTMLButto
   );
 }
 
-function formatDateTime(value: string): string {
+// Locale is pinned so the string never depends on which machine formatted it.
+// `timeZone` is a test seam: production always wants the viewer's own zone.
+export function formatDateTime(value: string, timeZone?: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString(undefined, {
+  return date.toLocaleString("en-US", {
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+    ...(timeZone ? { timeZone } : {}),
   });
+}
+
+/** Stands in for the timestamp until the browser can format it. */
+const PENDING_DATE_TIME = "...";
+
+/**
+ * A local wall-clock time cannot be server-rendered: the server formats in its
+ * own zone (UTC on Vercel) and the browser in the viewer's, so the two renders
+ * disagree. A text mismatch here is not cosmetic: React throws away the
+ * hydrated tree, which is what rendered every approval row twice and left the
+ * surviving rows with no working click handler. Rendering the placeholder on
+ * the server and on the first client render keeps hydration byte-identical;
+ * the real time lands in the effect right after.
+ */
+export function LocalDateTime({ value }: { value: string }) {
+  const [text, setText] = useState<string | null>(null);
+  useEffect(() => {
+    setText(formatDateTime(value));
+  }, [value]);
+  return <>{text ?? PENDING_DATE_TIME}</>;
 }

--- a/apps/dashboard/components/cockpit/screens/overview.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/overview.test.tsx
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import React from "react";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
+
+import type { Run } from "@/lib/types";
+import { AwaitingInputPanel } from "./overview";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+// next/link schedules its prefetch through an idle callback that reads `self`,
+// which node does not define. Without it every render of a row link throws.
+(globalThis as { self?: unknown }).self = globalThis;
+
+const BASE_RUN: Run = {
+  id: "run_1",
+  workflow: "wf_agent",
+  workflowName: "Agent",
+  status: "awaiting",
+  ticket: "AWT-1",
+  actor: "ai-bot",
+  model: "claude-opus-4-8",
+  startedAtMin: 30,
+  duration: null,
+  tokens: null,
+  cost: null,
+  spans: null,
+  evalScore: null,
+  guardrailHits: null,
+  ticketTitle: "Ship it",
+  prNumber: null,
+  ticketUrl: "https://blazity.atlassian.net/browse/AWT-1",
+  prUrl: null,
+  prs: null,
+};
+
+function nodeText(node: ReactTestInstance): string {
+  return node.children
+    .flatMap((child) => (typeof child === "string" ? [child] : [nodeText(child)]))
+    .join("");
+}
+
+/** Minimal app router: AwaitingInputPanel never navigates through it directly
+ *  (the approval CTA is a next/link `<Link>`), but next/link needs the context
+ *  to exist at all. */
+function stubRouter() {
+  return {
+    refresh: () => {},
+    push: () => {},
+    replace: () => {},
+    back: () => {},
+    forward: () => {},
+    prefetch: () => {},
+  };
+}
+
+function renderPanel(t: TestContext, rows: Run[]): { root: ReactTestInstance; opened: Run[] } {
+  const opened: Run[] = [];
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <AppRouterContext.Provider value={stubRouter() as never}>
+        <AwaitingInputPanel rows={rows} onOpenRun={(r) => opened.push(r)} />
+      </AppRouterContext.Provider>,
+    );
+  });
+  t.after(() => {
+    act(() => renderer.unmount());
+  });
+  return { root: renderer.root, opened };
+}
+
+test("a clarification row keeps its Answer CTA to the run trace, unchanged", (t) => {
+  const row: Run = {
+    ...BASE_RUN,
+    question: "1. Which environment?",
+    suggestedAnswers: ["staging"],
+    askedAtMin: 5,
+  };
+  const { root, opened } = renderPanel(t, [row]);
+
+  const links = root.findAll((n) => n.type === "a").map((n) => String(n.props.href ?? ""));
+  assert.deepEqual(links.filter((href) => href === "/approvals"), []);
+
+  const answerButtons = root
+    .findAll((n) => n.type === "button")
+    .filter((n) => nodeText(n).includes("Answer"));
+  assert.equal(answerButtons.length, 1);
+
+  act(() => {
+    answerButtons[0].props.onClick();
+  });
+  assert.deepEqual(opened, [row]);
+  assert.match(nodeText(root), /Which environment\?/);
+});
+
+test("an approval-parked row gets a Review plan link to /approvals, not the Answer dead end", (t) => {
+  const row: Run = {
+    ...BASE_RUN,
+    awaitingKind: "approval",
+    approvalId: "ap_1",
+  };
+  const { root } = renderPanel(t, [row]);
+
+  const text = nodeText(root);
+  assert.match(text, /Review plan/);
+  assert.doesNotMatch(text, /Answer →/);
+
+  const approvalLinks = root
+    .findAll((n) => n.type === "a")
+    .filter((n) => n.props.href === "/approvals");
+  assert.equal(approvalLinks.length, 1);
+
+  // The null question must never render as if it were a clarification.
+  assert.doesNotMatch(text, /undefined/);
+});

--- a/apps/dashboard/components/cockpit/screens/overview.tsx
+++ b/apps/dashboard/components/cockpit/screens/overview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import Link from "next/link";
 import {
   CkCard,
   CkKPI,
@@ -211,8 +212,10 @@ function NowRunningPanel({
   );
 }
 
-/* Awaiting input panel — workflows paused on a clarification question. */
-function AwaitingInputPanel({
+/* Awaiting input panel — workflows paused on a clarification question, or a
+ * plan parked for human approval. Exported for a direct render test: it takes
+ * plain props, so it needs no cockpit context of its own. */
+export function AwaitingInputPanel({
   rows,
   onOpenRun,
 }: {
@@ -240,55 +243,76 @@ function AwaitingInputPanel({
         <div className="px-5 py-8 text-center text-neutral-500 text-sm">No clarifications pending</div>
       ) : (
         <div className="flex flex-col">
-          {awaiting.map((r, i) => (
-            <div
-              key={r.id}
-              className={`px-5 py-[14px] ${i < awaiting.length - 1 ? "border-b border-[#FFE4D6]" : ""}`}
-            >
-              <div className="flex items-center gap-2 mb-2 flex-wrap">
-                <CkStatusPill status="awaiting" />
-                <span
-                  onClick={() => onOpenRun(r)}
-                  className="font-body text-sm font-semibold text-neutral-900 cursor-pointer"
-                >
-                  {r.workflowName}
-                </span>
-                {r.ticket && r.ticketUrl ? (
-                  <TicketLink ticket={r.ticket} url={r.ticketUrl} />
-                ) : null}
-                {r.questionFor && <CkChip tone="warn">@{r.questionFor}</CkChip>}
-                {typeof r.askedAtMin === "number" && (
-                  <span className="ml-auto font-mono text-[11px] text-neutral-500 whitespace-nowrap">
-                    {r.askedAtMin}m ago
-                  </span>
-                )}
-              </div>
-              {r.question && (
-                <p className="font-body font-normal text-[13px] leading-[1.55] text-neutral-800 m-0 mb-2.5 border-l-2 border-burnt-orange pl-3">
-                  {r.question}
-                </p>
-              )}
-              <div className="flex flex-wrap gap-1.5 items-center">
-                {/* Read-only preview of the suggestions: picking one happens in
-                    the trace screen's answer form, so these are not buttons. */}
-                {r.suggestedAnswers?.map((a, j) => (
+          {awaiting.map((r, i) => {
+            // A plan parked for human approval has no clarification: it
+            // belongs on the Approvals page, not the run trace's answer form.
+            const isApproval = r.awaitingKind === "approval";
+            return (
+              <div
+                key={r.id}
+                className={`px-5 py-[14px] ${i < awaiting.length - 1 ? "border-b border-[#FFE4D6]" : ""}`}
+              >
+                <div className="flex items-center gap-2 mb-2 flex-wrap">
+                  <CkStatusPill status="awaiting" />
                   <span
-                    key={j}
-                    className="border border-neutral-200 bg-panel px-2.5 py-[5px] rounded-[3px] font-body text-xs text-neutral-700"
+                    onClick={() => onOpenRun(r)}
+                    className="font-body text-sm font-semibold text-neutral-900 cursor-pointer"
                   >
-                    {a}
+                    {r.workflowName}
                   </span>
-                ))}
-                <button
-                  type="button"
-                  onClick={() => onOpenRun(r)}
-                  className="appearance-none border border-neutral-900 bg-neutral-900 px-3 py-[6px] rounded-[3px] cursor-pointer font-mono text-[10px] font-medium uppercase tracking-[0.04em] text-white transition-all duration-100 hover:bg-neutral-800"
-                >
-                  Answer →
-                </button>
+                  {r.ticket && r.ticketUrl ? (
+                    <TicketLink ticket={r.ticket} url={r.ticketUrl} />
+                  ) : null}
+                  {r.questionFor && <CkChip tone="warn">@{r.questionFor}</CkChip>}
+                  {typeof r.askedAtMin === "number" && (
+                    <span className="ml-auto font-mono text-[11px] text-neutral-500 whitespace-nowrap">
+                      {r.askedAtMin}m ago
+                    </span>
+                  )}
+                </div>
+                {isApproval ? (
+                  <p className="font-body font-normal text-[13px] leading-[1.55] text-neutral-700 m-0 mb-2.5">
+                    Plan submitted for approval before this run continues.
+                  </p>
+                ) : (
+                  r.question && (
+                    <p className="font-body font-normal text-[13px] leading-[1.55] text-neutral-800 m-0 mb-2.5 border-l-2 border-burnt-orange pl-3">
+                      {r.question}
+                    </p>
+                  )
+                )}
+                <div className="flex flex-wrap gap-1.5 items-center">
+                  {/* Read-only preview of the suggestions: picking one happens in
+                      the trace screen's answer form, so these are not buttons. */}
+                  {r.suggestedAnswers?.map((a, j) => (
+                    <span
+                      key={j}
+                      className="border border-neutral-200 bg-panel px-2.5 py-[5px] rounded-[3px] font-body text-xs text-neutral-700"
+                    >
+                      {a}
+                    </span>
+                  ))}
+                  {isApproval ? (
+                    <Link
+                      href="/approvals"
+                      onClick={(e) => e.stopPropagation()}
+                      className="appearance-none border border-neutral-900 bg-neutral-900 px-3 py-[6px] rounded-[3px] cursor-pointer font-mono text-[10px] font-medium uppercase tracking-[0.04em] text-white no-underline transition-all duration-100 hover:bg-neutral-800"
+                    >
+                      Review plan →
+                    </Link>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => onOpenRun(r)}
+                      className="appearance-none border border-neutral-900 bg-neutral-900 px-3 py-[6px] rounded-[3px] cursor-pointer font-mono text-[10px] font-medium uppercase tracking-[0.04em] text-white transition-all duration-100 hover:bg-neutral-800"
+                    >
+                      Answer →
+                    </button>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </CkCard>

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -125,6 +125,12 @@ export interface Run {
   questionFor?: string;
   blockingReason?: string;
   suggestedAnswers?: string[];
+  /** Which surface owns the next action for an "awaiting" row. Absent means
+   *  "clarification" (the historical default, answered on the run trace); a
+   *  plan parked for human review is "approval", decided on the Approvals page. */
+  awaitingKind?: "clarification" | "approval";
+  /** Set when `awaitingKind === "approval"`: the pending approval_requests row. */
+  approvalId?: string;
 }
 
 /** Structured error as returned by the Workflow runtime for failed runs/steps. */

--- a/apps/worker/src/approvals/dispatch.test.ts
+++ b/apps/worker/src/approvals/dispatch.test.ts
@@ -76,6 +76,20 @@ function makeRegistry(options: {
     rows.splice(index, 1);
     return true;
   });
+  // Mirrors PostgresRunRegistry.release: exact owner/run compare-and-delete on a
+  // non-reserved claim, the call terminal reconciliation makes to free a subject.
+  const release = vi.fn(async (subjectKey: string, ownerToken: string, runId: string) => {
+    const index = rows.findIndex(
+      (row) =>
+        row.subjectKey === subjectKey &&
+        row.ownerToken === ownerToken &&
+        row.runId === runId &&
+        row.state !== "reserved",
+    );
+    if (index < 0) return false;
+    rows.splice(index, 1);
+    return true;
+  });
   return {
     reserve,
     commitStartedRun: vi.fn(async () => true),
@@ -88,7 +102,7 @@ function makeRegistry(options: {
     beginCancellation: vi.fn(),
     releaseCancellation: vi.fn(),
     releaseReservation,
-    release: vi.fn(),
+    release,
     listAll: vi.fn(async () => [...rows]),
     registerSandbox: vi.fn(),
     listSandboxes: vi.fn(),
@@ -250,6 +264,40 @@ describe("dispatchPlanApproved owner reservation", () => {
     const registry = makeRegistry({ reserveResult: false });
     expect(await dispatch(registry)).toEqual({ status: "run_in_flight" });
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("waits for the parked owner's terminal release before it can start the approved plan", async () => {
+    // The run that filed the plan keeps its bound claim after parking the ticket,
+    // and active_runs is keyed by subject, so approving before reconciliation has
+    // released that claim cannot reserve: the route maps this to HTTP 409
+    // run_in_flight and the operator (or the poll's approval recovery) retries.
+    const parked: ActiveRunEntry = {
+      subjectKey: "ticket:jira:AWT-1",
+      ticketKey: "AWT-1",
+      ownerToken: "owner:parked",
+      runId: "run-produced",
+      state: "bound",
+      kind: "ticket",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const registry = makeRegistry({ initial: [parked] });
+
+    expect(await dispatch(registry)).toEqual({ status: "run_in_flight" });
+    expect(mockStart).not.toHaveBeenCalled();
+
+    // One reconcile pass over the approval-parked subject: terminal cleanup
+    // releases the exact owner quietly (no cancellation cascade, so the approval
+    // row is untouched), and the same approval then dispatches.
+    await expect(
+      registry.release(parked.subjectKey, parked.ownerToken, parked.runId!),
+    ).resolves.toBe(true);
+
+    expect(await dispatch(registry)).toEqual({
+      status: "started",
+      runId: "run-dispatched",
+    });
+    expect(mockStart).toHaveBeenCalledOnce();
   });
 
   it("returns run_in_flight when capacity is already full", async () => {

--- a/apps/worker/src/approvals/store.test.ts
+++ b/apps/worker/src/approvals/store.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { sql } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import type { Db } from "../db/client.js";
-import { approvalRequests } from "../db/schema.js";
+import { activeRuns, approvalRequests } from "../db/schema.js";
 import { createTestDb } from "../db/test-db.js";
 import {
   ApprovalStoreError,
@@ -10,6 +10,7 @@ import {
   decideApproval,
   getApproval,
   hasDispatchBlockingApprovalForTicket,
+  listApprovalParkedSubjects,
   listApprovals,
   listDispatchBlockingApprovals,
   rejectUndispatchableApproval,
@@ -416,6 +417,83 @@ describe("retireApprovalCancellation", () => {
       status: "approved",
       dispatchedRunId: "run-successor",
     });
+  });
+});
+
+describe("listApprovalParkedSubjects", () => {
+  async function bind(
+    db: Db,
+    ticketKey: string,
+    runId: string | null,
+  ): Promise<void> {
+    await db.insert(activeRuns).values({
+      subjectKey: `ticket:jira:${ticketKey}`,
+      ticketKey,
+      ownerToken: `owner:${ticketKey}`,
+      runId,
+      state: runId === null ? "reserved" : "bound",
+    });
+  }
+
+  it("returns only subjects whose blocking approval was filed by the run still holding the claim", async () => {
+    const db = await createTestDb();
+    // Parked on a pending decision, and parked on an approved plan whose
+    // continuation has not started yet: both must survive reconciliation.
+    await createApprovalRequest(db, { ...seed("AWT-PENDING"), runId: "run-pending" });
+    await bind(db, "AWT-PENDING", "run-pending");
+    const approved = await createApprovalRequest(db, {
+      ...seed("AWT-APPROVED"),
+      runId: "run-approved",
+    });
+    await decideApproval(db, {
+      id: approved.id,
+      decision: "approved",
+      actor: { id: "u1", label: "Alice" },
+    });
+    await bind(db, "AWT-APPROVED", "run-approved");
+
+    await expect(listApprovalParkedSubjects(db)).resolves.toEqual([
+      "ticket:jira:AWT-APPROVED",
+      "ticket:jira:AWT-PENDING",
+    ]);
+  });
+
+  it("excludes decided, dispatched, differently owned, and unbound subjects", async () => {
+    const db = await createTestDb();
+    // Decided against: nothing left to protect.
+    const rejected = await createApprovalRequest(db, {
+      ...seed("AWT-REJECTED"),
+      runId: "run-rejected",
+    });
+    await decideApproval(db, {
+      id: rejected.id,
+      decision: "rejected",
+      actor: { id: "u1", label: "Alice" },
+    });
+    await bind(db, "AWT-REJECTED", "run-rejected");
+    // The approved continuation already runs: its claim is an ordinary live run
+    // and must stay cancellable when the ticket leaves the AI column.
+    const dispatched = await createApprovalRequest(db, {
+      ...seed("AWT-DISPATCHED"),
+      runId: "run-planning",
+    });
+    await decideApproval(db, {
+      id: dispatched.id,
+      decision: "approved",
+      actor: { id: "u1", label: "Alice" },
+    });
+    await setDispatchedRunId(db, dispatched.id, "run-continuation");
+    await bind(db, "AWT-DISPATCHED", "run-continuation");
+    // A blocking approval whose filing run no longer owns the subject: some
+    // other run holds the claim and is not parked on this plan.
+    await createApprovalRequest(db, { ...seed("AWT-OTHER"), runId: "run-planning-other" });
+    await bind(db, "AWT-OTHER", "run-unrelated");
+    // A fresh reservation is not a parked owner; stale-reservation recovery
+    // must keep reaching it.
+    await createApprovalRequest(db, { ...seed("AWT-RESERVED"), runId: "run-reserved" });
+    await bind(db, "AWT-RESERVED", null);
+
+    await expect(listApprovalParkedSubjects(db)).resolves.toEqual([]);
   });
 });
 

--- a/apps/worker/src/approvals/store.ts
+++ b/apps/worker/src/approvals/store.ts
@@ -6,7 +6,7 @@ import type {
   ApprovedRepositoryScope,
 } from "@shared/contracts";
 import type { Db } from "../db/client.js";
-import { approvalRequests } from "../db/schema.js";
+import { activeRuns, approvalRequests } from "../db/schema.js";
 
 export interface ApprovalRow {
   id: string;
@@ -185,6 +185,40 @@ export async function listDispatchBlockingApprovals(db: Db): Promise<ApprovalRow
     )
     .orderBy(desc(approvalRequests.requestedAt));
   return rows.map(mapRow);
+}
+
+/**
+ * Subjects parked on a plan approval: the run that filed a still dispatch-
+ * blocking approval also still holds the subject's bound claim. send_plan_approval
+ * ends its run with the ticket moved out of the AI column, so reconciliation sees
+ * a terminal bound owner it would otherwise cancel as an orphan, and that
+ * cancellation cascade retires the approval (superseded, no decision, no
+ * successor) leaving nobody able to approve the plan. These subjects belong in
+ * the reconciler's terminal-cleanup channel instead: the claim is released
+ * quietly, which is exactly what the approval's own dispatch needs to reserve.
+ *
+ * Matching the approval's filing run (not merely the ticket) keeps a fresh
+ * reservation and an already dispatched continuation run out of the set, so
+ * every other run stays cancellable exactly as before.
+ */
+export async function listApprovalParkedSubjects(db: Db): Promise<string[]> {
+  const rows = await db
+    .select({ subjectKey: activeRuns.subjectKey })
+    .from(activeRuns)
+    .innerJoin(approvalRequests, eq(approvalRequests.runId, activeRuns.runId))
+    .where(
+      and(
+        eq(activeRuns.state, "bound"),
+        or(
+          eq(approvalRequests.status, "pending"),
+          and(
+            eq(approvalRequests.status, "approved"),
+            isNull(approvalRequests.dispatchedRunId),
+          ),
+        ),
+      ),
+    );
+  return [...new Set(rows.map((row) => row.subjectKey))].sort();
 }
 
 export async function hasDispatchBlockingApprovalForTicket(

--- a/apps/worker/src/lib/cancel-run.test.ts
+++ b/apps/worker/src/lib/cancel-run.test.ts
@@ -31,7 +31,7 @@ vi.mock("./telemetry/run-telemetry.js", () => ({
   recordRunStatusReason: state.recordStatusReason,
 }));
 
-import { cancelRun } from "./cancel-run.js";
+import { cancelRun, cancelRunDetailed } from "./cancel-run.js";
 
 function active(overrides: Partial<ActiveRunEntry> = {}): ActiveRunEntry {
   return {
@@ -126,6 +126,24 @@ describe("cancelRun", () => {
       runRegistry,
     )).resolves.toBe(false);
     expect(runRegistry.releaseCancellation).not.toHaveBeenCalled();
+  });
+
+  it("reports the already-terminal outcome and still releases the claim when the run had already failed", async () => {
+    state.getRun.mockReturnValue({
+      cancel: vi.fn().mockRejectedValue(new Error("run already terminal")),
+      status: Promise.resolve("failed"),
+    });
+    const runRegistry = registry();
+    await expect(cancelRunDetailed(
+      "PROJ-1",
+      { ownerToken: "owner-a", runId: "run-1" },
+      runRegistry,
+    )).resolves.toEqual({ cancelled: true, released: true, alreadyTerminal: true });
+    expect(runRegistry.releaseCancellation).toHaveBeenCalledWith(
+      "ticket:jira:PROJ-1",
+      "owner-a",
+      "run-1",
+    );
   });
 
   it("performs a compatibility ticket move under the cancelling owner", async () => {

--- a/apps/worker/src/lib/cancel-run.ts
+++ b/apps/worker/src/lib/cancel-run.ts
@@ -23,6 +23,22 @@ export interface ObservedRunClaim {
 export type CancelRunTarget = string | ObservedRunClaim;
 
 /**
+ * Result of a cancellation attempt. `alreadyTerminal` distinguishes a run
+ * that was genuinely still in flight and got cancelled by this call from one
+ * that had already reached a terminal Workflow status before this call
+ * observed it: Workflow's `cancel()` throws in that case, and the outcome is
+ * confirmed only by re-reading `status`. Callers that notify operators (e.g.
+ * Slack "canceled" messages) must treat the two differently, since the
+ * already-terminal case is a release of bookkeeping for a run that failed or
+ * completed on its own, not a fresh cancellation.
+ */
+export interface CancelRunResult {
+  cancelled: boolean;
+  released: boolean;
+  alreadyTerminal?: boolean;
+}
+
+/**
  * Cancel a workflow run and unregister it from the registry.
  * Idempotent: safe to call multiple times for the same ticket.
  * Returns true only after durable clarification retirement (when applicable),
@@ -42,6 +58,34 @@ export async function cancelRun(
   onReleased?: (subjectKey: string) => Promise<void> | void,
   reason?: string,
 ): Promise<boolean> {
+  return (
+    await cancelRunDetailed(
+      ticketKey,
+      target,
+      runRegistry,
+      issueTracker,
+      targetColumn,
+      onReleased,
+      reason,
+    )
+  ).cancelled;
+}
+
+/**
+ * Same as {@link cancelRun}, but also reports whether the run was already
+ * terminal when this call observed it, so a caller (the reconciler) can skip
+ * re-notifying operators about a run that already failed or completed on its
+ * own.
+ */
+export async function cancelRunDetailed(
+  ticketKey: string,
+  target: CancelRunTarget,
+  runRegistry: RunRegistryAdapter,
+  issueTracker?: IssueTrackerAdapter,
+  targetColumn?: IssueTrackerMoveTarget,
+  onReleased?: (subjectKey: string) => Promise<void> | void,
+  reason?: string,
+): Promise<CancelRunResult> {
   const subjectKey = ticketSubjectKey("jira", ticketKey);
   const confirmTicketMove = issueTracker && targetColumn
     ? async (owner: { subjectKey: string; ownerToken: string; runId: string | null }) => {
@@ -59,16 +103,14 @@ export async function cancelRun(
       });
     }
     : undefined;
-  return (
-    await cancelOwnedSubject(
-      subjectKey,
-      target,
-      runRegistry,
-      onReleased,
-      confirmTicketMove,
-      reason,
-    )
-  ).cancelled;
+  return cancelOwnedSubject(
+    subjectKey,
+    target,
+    runRegistry,
+    onReleased,
+    confirmTicketMove,
+    reason,
+  );
 }
 
 /** Operational cancellation for provider-neutral subjects, including
@@ -80,7 +122,21 @@ export async function cancelSubjectRun(
   onReleased?: (subjectKey: string) => Promise<void> | void,
   reason?: string,
 ): Promise<boolean> {
-  return (await cancelOwnedSubject(subjectKey, target, runRegistry, onReleased, undefined, reason)).cancelled;
+  return (
+    await cancelSubjectRunDetailed(subjectKey, target, runRegistry, onReleased, reason)
+  ).cancelled;
+}
+
+/** Same as {@link cancelSubjectRun}, but also reports `alreadyTerminal` (see
+ * {@link cancelRunDetailed}). */
+export async function cancelSubjectRunDetailed(
+  subjectKey: string,
+  target: CancelRunTarget,
+  runRegistry: RunRegistryAdapter,
+  onReleased?: (subjectKey: string) => Promise<void> | void,
+  reason?: string,
+): Promise<CancelRunResult> {
+  return cancelOwnedSubject(subjectKey, target, runRegistry, onReleased, undefined, reason);
 }
 
 async function cancelOwnedSubject(
@@ -94,7 +150,7 @@ async function cancelOwnedSubject(
     runId: string | null;
   }) => Promise<void>,
   reason?: string,
-): Promise<{ cancelled: boolean; released: boolean }> {
+): Promise<CancelRunResult> {
   let observed: ObservedRunClaim;
   if (typeof target === "string") {
     const entry = await runRegistry.get(subjectKey).catch(() => undefined);
@@ -173,6 +229,7 @@ async function cancelOwnedSubject(
   }
   if (!closed) return { cancelled: false, released: false };
 
+  let alreadyTerminal = false;
   if (closed.runId) {
     const workflowRun = getRun(closed.runId);
     try {
@@ -200,6 +257,7 @@ async function cancelOwnedSubject(
         );
         return { cancelled: false, released: false };
       }
+      alreadyTerminal = true;
       logger.info(
         { subjectKey, runId: closed.runId, status },
         "cancel_run_already_terminal",
@@ -253,7 +311,7 @@ async function cancelOwnedSubject(
     if (refreshed !== null) return { cancelled: false, released: false };
   }
   await notifyReleased(subjectKey, onReleased);
-  return { cancelled: true, released: true };
+  return { cancelled: true, released: true, alreadyTerminal };
 }
 
 /**

--- a/apps/worker/src/lib/dispatch.test.ts
+++ b/apps/worker/src/lib/dispatch.test.ts
@@ -1,10 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ActiveRunEntry,
   RunRegistryAdapter,
   RunReservation,
   ThreadStore,
 } from "../adapters/run-registry/types.js";
+import type { Db } from "../db/client.js";
+import { workflowRuns } from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
 import type { Adapters } from "./adapters.js";
 
 vi.mock("../../env.js", () => ({
@@ -14,7 +17,10 @@ const mockStart = vi.fn();
 vi.mock("workflow/api", () => ({ start: (...args: any[]) => mockStart(...args) }));
 vi.mock("../workflows/agent.js", () => ({ agentWorkflow: "agentWorkflow_sentinel" }));
 
-vi.mock("../db/client.js", () => ({ getDb: vi.fn(() => ({})) }));
+// A real in-memory Postgres: the no-definition skip now writes a durable run
+// row, and its anti-spam guard is a query the fake object could not answer.
+const dbRef = vi.hoisted(() => ({ current: null as unknown as Db }));
+vi.mock("../db/client.js", () => ({ getDb: () => dbRef.current }));
 const mockGetEnabled = vi.fn();
 const mockHasBlockingApproval = vi.fn();
 vi.mock("../workflow-definition/store.js", () => ({
@@ -26,6 +32,7 @@ vi.mock("../approvals/store.js", () => ({
 }));
 
 const { dispatchTicket, STALE_CLAIM_MS } = await import("./dispatch.js");
+const { NO_DEFINITION_BLOCKED_REASON } = await import("./run-start-lifecycle.js");
 
 function entry(overrides: Partial<ActiveRunEntry> = {}): ActiveRunEntry {
   return {
@@ -130,7 +137,12 @@ function adapters(runRegistry = registry(), ticketValue = ticket()): Adapters {
 }
 
 describe("dispatchTicket owner reservation", () => {
-  beforeEach(() => {
+  beforeAll(async () => {
+    dbRef.current = await createTestDb();
+  });
+
+  beforeEach(async () => {
+    await dbRef.current.delete(workflowRuns);
     mockStart.mockReset();
     mockGetEnabled.mockReset();
     mockHasBlockingApproval.mockReset().mockResolvedValue(false);
@@ -210,6 +222,46 @@ describe("dispatchTicket owner reservation", () => {
     });
     expect(runRegistry.releaseReservation).toHaveBeenCalledOnce();
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("records the skipped ticket as a blocked run so the skip is visible", async () => {
+    mockGetEnabled.mockResolvedValue(null);
+    const runRegistry = registry();
+
+    await dispatchTicket("PROJ-42", adapters(runRegistry), 3);
+
+    const rows = await dbRef.current.select().from(workflowRuns);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      status: "blocked",
+      statusReason: NO_DEFINITION_BLOCKED_REASON,
+      subjectKey: "ticket:jira:PROJ-42",
+      ticketKey: "PROJ-42",
+      ticketTitle: "Implement it",
+    });
+    expect(runRegistry.markFailed).not.toHaveBeenCalled();
+  });
+
+  it("records the blocked run once while the ticket keeps being polled", async () => {
+    mockGetEnabled.mockResolvedValue(null);
+
+    await dispatchTicket("PROJ-42", adapters(), 3);
+    expect(await dispatchTicket("PROJ-42", adapters(), 3)).toEqual({
+      started: false,
+      reason: "no_definition",
+    });
+
+    expect(await dbRef.current.select().from(workflowRuns)).toHaveLength(1);
+  });
+
+  it("dispatches the blocked ticket normally once a definition owns the trigger", async () => {
+    mockGetEnabled.mockResolvedValueOnce(null);
+
+    await dispatchTicket("PROJ-42", adapters(), 3);
+    expect(await dispatchTicket("PROJ-42", adapters(), 3)).toEqual({
+      started: true,
+      runId: "run-started",
+    });
   });
 
   it("releases the reservation when the live ticket left the AI column", async () => {

--- a/apps/worker/src/lib/dispatch.ts
+++ b/apps/worker/src/lib/dispatch.ts
@@ -102,6 +102,17 @@ export async function dispatchTicket(
         );
         if (!enabled) {
           logger.info({ ticketKey }, "dispatch_skipped_no_definition");
+          // The reservation is released right after this guard bails, so the
+          // recorded row is a plain tombstone: it holds nothing, fails nothing,
+          // and the next poll dispatches normally once a definition resolves.
+          const { recordNoDefinitionBlockedRun } = await import(
+            "./run-start-lifecycle.js"
+          );
+          await recordNoDefinitionBlockedRun({
+            subjectKey,
+            ticketKey,
+            ticketTitle: ticket.title,
+          });
           return { started: false, reason: "no_definition" };
         }
         definitionId = enabled.definition.id;

--- a/apps/worker/src/lib/overview/collect-awaiting-store.test.ts
+++ b/apps/worker/src/lib/overview/collect-awaiting-store.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { describe, it, expect, beforeEach } from "vitest";
 import { createTestDb } from "../../db/test-db.js";
 import type { Db } from "../../db/client.js";
-import { clarificationRequests, workflowRuns } from "../../db/schema.js";
+import { approvalRequests, clarificationRequests, workflowRuns } from "../../db/schema.js";
 import { collectAwaitingRuns } from "./collect-awaiting-store.js";
 
 const NOW = new Date("2026-06-16T12:00:00.000Z");
@@ -32,6 +32,21 @@ async function seedRun(over: {
     ticketTitle: over.ticketTitle === undefined ? "A ticket" : over.ticketTitle,
     model: "claude-opus-4-8",
     startedAt: over.startedAt === undefined ? new Date(NOW.getTime() - HOUR) : over.startedAt,
+  });
+}
+
+async function seedApproval(over: {
+  runId: string;
+  ticketKey?: string;
+  status?: string;
+}): Promise<void> {
+  await db.insert(approvalRequests).values({
+    id: randomUUID(),
+    ticketKey: over.ticketKey ?? "AWT-1",
+    definitionId: 1,
+    runId: over.runId,
+    plan: { markdown: "# Plan" },
+    status: over.status ?? "pending",
   });
 }
 
@@ -97,6 +112,46 @@ describe("collectAwaitingRuns (store)", () => {
     expect(rows[0].question).toBeUndefined();
     expect(rows[0].suggestedAnswers).toBeUndefined();
     expect(rows[0].askedAtMin).toBeUndefined();
+  });
+
+  it("marks a run parked on a pending approval (no clarification) as awaitingKind approval", async () => {
+    await seedRun({ runId: "run_approval", ticketKey: "AWT-4" });
+    await seedApproval({ runId: "run_approval", ticketKey: "AWT-4" });
+
+    const rows = await collectAwaitingRuns({ ...base, db });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("run_approval");
+    expect(rows[0].awaitingKind).toBe("approval");
+    expect(rows[0].approvalId).toBeDefined();
+    // No clarification joined -> no question payload, guarding against the
+    // dead-end "Answer" CTA rendering a null question as if it were one.
+    expect(rows[0].question).toBeUndefined();
+    expect(rows[0].suggestedAnswers).toBeUndefined();
+    expect(rows[0].askedAtMin).toBeUndefined();
+  });
+
+  it("keeps a clarification row's shape unchanged even when a pending approval also exists", async () => {
+    await seedRun({ runId: "run_await", ticketKey: "AWT-1", ticketTitle: "Ship it" });
+    await seedClarification({
+      runId: "run_await",
+      questions: ["Which environment?", "Ship behind a flag?"],
+      suggestedAnswers: ["staging", "yes"],
+    });
+    await seedApproval({ runId: "run_await", ticketKey: "AWT-1" });
+
+    const rows = await collectAwaitingRuns({ ...base, db });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "run_await",
+      question: "1. Which environment?\n2. Ship behind a flag?",
+      suggestedAnswers: ["staging", "yes"],
+      askedAtMin: 30,
+    });
+    // A clarification always wins the label: unset, exactly as before this join.
+    expect(rows[0].awaitingKind).toBeUndefined();
+    expect(rows[0].approvalId).toBeUndefined();
   });
 
   it("ignores non-awaiting runs", async () => {

--- a/apps/worker/src/lib/overview/collect-awaiting-store.ts
+++ b/apps/worker/src/lib/overview/collect-awaiting-store.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, sql } from "drizzle-orm";
 import type { Run } from "@shared/contracts";
 import type { Db } from "../../db/client.js";
-import { clarificationRequests, workflowRuns } from "../../db/schema.js";
+import { approvalRequests, clarificationRequests, workflowRuns } from "../../db/schema.js";
 
 export interface CollectAwaitingRunsOptions {
   db: Db;
@@ -23,6 +23,13 @@ export interface CollectAwaitingRunsOptions {
  * The join is a LEFT join on purpose: an awaiting run whose pending clarification
  * is missing still lists (just without the question payload). No time window: a run
  * parked days ago must still show.
+ *
+ * A second LEFT join against `approval_requests` (matched on the filing run id,
+ * status "pending") distinguishes the other reason a run can sit in "awaiting":
+ * a plan parked for human approval. That row carries no clarification, so without
+ * this join it would render like a clarification with a null question. `awaitingKind`
+ * tells the dashboard which surface actually owns the next action: a clarification
+ * is answered on the run trace, an approval is decided on the Approvals page.
  */
 export async function collectAwaitingRuns(
   opts: CollectAwaitingRunsOptions,
@@ -47,6 +54,7 @@ export async function collectAwaitingRuns(
       questions: clarificationRequests.questions,
       suggestedAnswers: clarificationRequests.suggestedAnswers,
       askedAt: clarificationRequests.askedAt,
+      approvalId: approvalRequests.id,
     })
     .from(workflowRuns)
     .leftJoin(
@@ -54,6 +62,13 @@ export async function collectAwaitingRuns(
       and(
         eq(clarificationRequests.runId, workflowRuns.runId),
         eq(clarificationRequests.status, "pending"),
+      ),
+    )
+    .leftJoin(
+      approvalRequests,
+      and(
+        eq(approvalRequests.runId, workflowRuns.runId),
+        eq(approvalRequests.status, "pending"),
       ),
     )
     .where(eq(workflowRuns.status, "awaiting"))
@@ -94,11 +109,22 @@ export async function collectAwaitingRuns(
         Math.round((now.getTime() - r.askedAt.getTime()) / 60000),
       );
     }
-    if (r.questions && r.questions.length > 0) {
-      run.question = r.questions.map((q, i) => `${i + 1}. ${q}`).join("\n");
+    const hasQuestion = r.questions !== null && r.questions.length > 0;
+    if (hasQuestion) {
+      run.question = r.questions!.map((q, i) => `${i + 1}. ${q}`).join("\n");
     }
     if (r.suggestedAnswers && r.suggestedAnswers.length > 0) {
       run.suggestedAnswers = r.suggestedAnswers;
+    }
+
+    // A pending approval with no clarification is a plan parked for human
+    // review, not a question: the dashboard must send it to /approvals instead
+    // of the run trace's dead-end answer form. Leave `awaitingKind` unset for
+    // every other row (clarification or neither) so their shape stays exactly
+    // what it was before this join existed.
+    if (!hasQuestion && r.approvalId) {
+      run.awaitingKind = "approval";
+      run.approvalId = r.approvalId;
     }
 
     return run;

--- a/apps/worker/src/lib/overview/collect-block-statuses.test.ts
+++ b/apps/worker/src/lib/overview/collect-block-statuses.test.ts
@@ -130,6 +130,28 @@ describe("collectBlockStatuses", () => {
     },
   );
 
+  it.each(["success", "failed"] as const)(
+    "falls through to the completed fallback when a registry-bound run's own row is already %s",
+    async (status) => {
+      const db = await createTestDb();
+      // The registry still lists this run as bound (it hasn't unregistered
+      // yet), but the row itself already recorded a terminal outcome.
+      await insert(db, {
+        runId: "ghost",
+        status,
+        updatedAt: new Date("2026-07-10T12:00:00Z"),
+        completedAt: new Date("2026-07-10T12:00:00Z"),
+        blockStatuses: { b1: { status: "fail", error: "boom" } },
+      });
+      const registry = makeRegistry([{ ticketKey: "AWT-1", runId: "ghost" }]);
+
+      const snap = await collectBlockStatuses({ registry, db });
+      expect(snap?.runId).toBe("ghost");
+      expect(snap?.source).toBe("last");
+      expect(snap?.status).toBe(status);
+    },
+  );
+
   it("falls back to the latest success/failed row with block statuses", async () => {
     const db = await createTestDb();
     await insert(db, {

--- a/apps/worker/src/lib/overview/collect-block-statuses.ts
+++ b/apps/worker/src/lib/overview/collect-block-statuses.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, notInArray, or, sql } from "drizzle-orm";
 import type { RunBlockStatusSnapshot } from "@shared/contracts";
 import type { Db } from "../../db/client.js";
 import { workflowRuns } from "../../db/schema.js";
@@ -11,6 +11,15 @@ export interface CollectBlockStatusesOptions {
   /** When set, restrict both the live and last queries to this definition. */
   definitionId?: number;
 }
+
+/**
+ * Statuses `workflow_runs.status` reports once a run has finished; mirrors
+ * apps/dashboard/lib/merge-live-runs.ts's TERMINAL_STATUSES. The run registry
+ * unregisters a run asynchronously, so a still-bound/parking/parked entry can
+ * outlive the run it points to: its own row may already carry one of these.
+ * A null status (not yet snapshotted) counts as in-flight, not terminal.
+ */
+const TERMINAL_RUN_STATUSES: string[] = ["success", "failed", "blocked"];
 
 /**
  * Builds the single block-status snapshot the editor canvas renders live dots
@@ -45,6 +54,12 @@ export async function collectBlockStatuses(
         and(
           inArray(workflowRuns.runId, liveRunIds),
           isNotNull(workflowRuns.blockStatuses),
+          // Registry membership alone isn't enough: only count the row as live
+          // if it hasn't already recorded a terminal outcome (see comment above).
+          or(
+            isNull(workflowRuns.status),
+            notInArray(workflowRuns.status, TERMINAL_RUN_STATUSES),
+          ),
           ...(definitionFilter ? [definitionFilter] : []),
         ),
       )

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -365,7 +365,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
         new Set([answered.subjectKey]),
       ),
     ).resolves.toEqual({ cancelled: 0, cleaned: 0 });
-    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
     expect(runRegistry.release).not.toHaveBeenCalled();
   });
 

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -396,6 +396,77 @@ describe("reconcileRuns owner-CAS recovery", () => {
     expect(runRegistry.release).not.toHaveBeenCalled();
   });
 
+  it("releases an approval-parked owner quietly instead of cancelling it as an orphan", async () => {
+    // send_plan_approval ends its run with the ticket parked outside AI, so the
+    // bound claim is terminal bookkeeping. Cancelling it retires the pending
+    // approval (no decision, no successor) and strands the ticket; the poll
+    // routes these subjects to terminal cleanup, which frees the claim the
+    // approval dispatch needs without touching the approval row.
+    const parked = entry();
+    const runRegistry = registry([parked]);
+    const onReleased = vi.fn();
+    mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Backlog"),
+        undefined,
+        onReleased,
+        new Set(),
+        undefined,
+        new Set([parked.subjectKey]),
+      ),
+    ).resolves.toEqual({ cancelled: 0, cleaned: 1 });
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
+    expect(runRegistry.release).toHaveBeenCalledWith(
+      parked.subjectKey,
+      parked.ownerToken,
+      parked.runId,
+    );
+    expect(onReleased).toHaveBeenCalledWith(parked.subjectKey);
+  });
+
+  it("runs the cancellation cascade on the same owner when it is not reported as approval-parked", async () => {
+    // Negative companion: without the terminal-channel classification the exact
+    // same entry takes the orphan path, and that cascade is what superseded the
+    // pending approvals in production.
+    const parked = entry();
+    const runRegistry = registry([parked]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+    mockCancelRunDetailed.mockResolvedValue({
+      cancelled: true,
+      released: true,
+      alreadyTerminal: true,
+    });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Backlog"),
+        undefined,
+        undefined,
+        new Set(),
+        undefined,
+        new Set(),
+      ),
+    ).resolves.toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockCancelRunDetailed).toHaveBeenCalledWith(
+      "PROJ-1",
+      "run-1",
+      runRegistry,
+      expect.anything(),
+      undefined,
+      undefined,
+      "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
+    );
+    expect(runRegistry.release).not.toHaveBeenCalled();
+  });
+
   it("recovers an interrupted parking drain before protecting the clarification", async () => {
     const parking = entry({ state: "parking" });
     const runRegistry = registry([parking]);

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -17,8 +17,8 @@ vi.mock("../../env.js", () => ({
 }));
 
 const mockGetRun = vi.fn();
-const mockCancelRun = vi.fn();
-const mockCancelSubjectRun = vi.fn();
+const mockCancelRunDetailed = vi.fn();
+const mockCancelSubjectRunDetailed = vi.fn();
 const mockStopSandboxesByIds = vi.fn();
 const mockListWorkflowSteps = vi.fn();
 vi.mock("workflow/api", () => ({ getRun: (...args: any[]) => mockGetRun(...args) }));
@@ -28,8 +28,8 @@ vi.mock("workflow/runtime", () => ({
   }),
 }));
 vi.mock("./cancel-run.js", () => ({
-  cancelRun: (...args: any[]) => mockCancelRun(...args),
-  cancelSubjectRun: (...args: any[]) => mockCancelSubjectRun(...args),
+  cancelRunDetailed: (...args: any[]) => mockCancelRunDetailed(...args),
+  cancelSubjectRunDetailed: (...args: any[]) => mockCancelSubjectRunDetailed(...args),
 }));
 vi.mock("./run-start-lifecycle.js", () => ({
   reconcileStartupWatchdog: vi.fn().mockResolvedValue({
@@ -290,7 +290,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
       cancelled: 0,
       cleaned: 0,
     });
-    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
   });
 
   it("lets a pending clarification win over an older answered round", async () => {
@@ -312,7 +312,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
       ),
     ).toEqual({ cancelled: 0, cleaned: 0 });
     expect(mockGetRun).not.toHaveBeenCalled();
-    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
     expect(runRegistry.release).not.toHaveBeenCalled();
   });
 
@@ -337,7 +337,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
         new Set([answered.subjectKey]),
       ),
     ).resolves.toEqual({ cancelled: 0, cleaned: 1 });
-    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
     expect(runRegistry.release).toHaveBeenCalledWith(
       answered.subjectKey,
       answered.ownerToken,
@@ -392,7 +392,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
         new Set([answered.subjectKey]),
       ),
     ).resolves.toEqual({ cancelled: 0, cleaned: 0 });
-    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
     expect(runRegistry.release).not.toHaveBeenCalled();
   });
 
@@ -426,20 +426,20 @@ describe("reconcileRuns owner-CAS recovery", () => {
       parking.ownerToken,
       parking.runId,
     );
-    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
   });
 
   it("does not strand an expired parked clarification owner outside generic cleanup", async () => {
     const parked = entry({ state: "parked" });
     const runRegistry = registry([parked]);
     const tracker = issueTracker("Done");
-    mockCancelRun.mockResolvedValue(true);
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
     const { reconcileRuns } = await import("./reconcile.js");
 
     expect(
       await reconcileRuns(new Set(), runRegistry, tracker),
     ).toEqual({ cancelled: 1, cleaned: 0 });
-    expect(mockCancelRun).toHaveBeenCalledWith(
+    expect(mockCancelRunDetailed).toHaveBeenCalledWith(
       "PROJ-1",
       "run-1",
       runRegistry,
@@ -454,7 +454,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
     const closing = entry({ state: "cancelling" });
     const runRegistry = registry([closing]);
     const tracker = issueTracker("AI");
-    mockCancelRun.mockResolvedValue(true);
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
     const onReleased = vi.fn();
     const { reconcileRuns } = await import("./reconcile.js");
 
@@ -468,7 +468,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
         new Set([closing.subjectKey]),
       ),
     ).toEqual({ cancelled: 1, cleaned: 0 });
-    expect(mockCancelRun).toHaveBeenCalledWith(
+    expect(mockCancelRunDetailed).toHaveBeenCalledWith(
       "PROJ-1",
       { ownerToken: "owner-a", runId: "run-1" },
       runRegistry,
@@ -483,14 +483,14 @@ describe("reconcileRuns owner-CAS recovery", () => {
     const closing = entry({ state: "cancelling" });
     const runRegistry = registry([closing]);
     const tracker = issueTracker("Done");
-    mockCancelRun.mockResolvedValue(true);
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
     const onReleased = vi.fn();
     const { reconcileRuns } = await import("./reconcile.js");
 
     expect(
       await reconcileRuns(new Set(), runRegistry, tracker, undefined, onReleased),
     ).toEqual({ cancelled: 1, cleaned: 0 });
-    expect(mockCancelRun).toHaveBeenCalledWith(
+    expect(mockCancelRunDetailed).toHaveBeenCalledWith(
       "PROJ-1",
       { ownerToken: "owner-a", runId: "run-1" },
       runRegistry,
@@ -509,7 +509,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
       state: "cancelling",
     });
     const runRegistry = registry([closing]);
-    mockCancelSubjectRun.mockResolvedValue(true);
+    mockCancelSubjectRunDetailed.mockResolvedValue({ cancelled: true, released: true });
     const onReleased = vi.fn();
     const { reconcileRuns } = await import("./reconcile.js");
 
@@ -522,7 +522,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
         onReleased,
       ),
     ).toEqual({ cancelled: 1, cleaned: 0 });
-    expect(mockCancelSubjectRun).toHaveBeenCalledWith(
+    expect(mockCancelSubjectRunDetailed).toHaveBeenCalledWith(
       closing.subjectKey,
       { ownerToken: "owner-a", runId: "run-1" },
       runRegistry,
@@ -536,17 +536,17 @@ describe("reconcileRuns owner-CAS recovery", () => {
     const runRegistry = registry([bound]);
     const tracker = issueTracker("Done");
     const onReleased = vi.fn();
-    mockCancelRun.mockImplementation(async (...args: unknown[]) => {
+    mockCancelRunDetailed.mockImplementation(async (...args: unknown[]) => {
       const releaseCallback = args[5] as (subjectKey: string) => Promise<void>;
       await releaseCallback(bound.subjectKey);
-      return true;
+      return { cancelled: true, released: true };
     });
     const { reconcileRuns } = await import("./reconcile.js");
 
     expect(
       await reconcileRuns(new Set(), runRegistry, tracker, undefined, onReleased),
     ).toEqual({ cancelled: 1, cleaned: 0 });
-    expect(mockCancelRun).toHaveBeenCalledWith(
+    expect(mockCancelRunDetailed).toHaveBeenCalledWith(
       "PROJ-1",
       "run-1",
       runRegistry,
@@ -561,13 +561,13 @@ describe("reconcileRuns owner-CAS recovery", () => {
   it("applies normal AI-column cancellation semantics to manual ticket runs", async () => {
     const bound = entry({ kind: "manual_ticket" });
     const runRegistry = registry([bound]);
-    mockCancelRun.mockResolvedValue(true);
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
     const { reconcileRuns } = await import("./reconcile.js");
 
     await expect(
       reconcileRuns(new Set(), runRegistry, issueTracker("Done")),
     ).resolves.toEqual({ cancelled: 1, cleaned: 0 });
-    expect(mockCancelRun).toHaveBeenCalledWith(
+    expect(mockCancelRunDetailed).toHaveBeenCalledWith(
       "PROJ-1",
       "run-1",
       runRegistry,
@@ -590,7 +590,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
     expect(
       await reconcileRuns(new Set(), runRegistry, issueTracker("Review")),
     ).toEqual({ cancelled: 0, cleaned: 0 });
-    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
     expect(runRegistry.release).not.toHaveBeenCalled();
   });
 
@@ -614,14 +614,14 @@ describe("reconcileRuns owner-CAS recovery", () => {
         }),
       ),
     ).toEqual({ cancelled: 0, cleaned: 0 });
-    expect(mockCancelRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
   });
 
   it("still cancels a still-executing run pulled to a status that is not the review destination", async () => {
     const bound = entry();
     const runRegistry = registry([bound]);
     mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
-    mockCancelRun.mockResolvedValue(true);
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
     const { reconcileRuns } = await import("./reconcile.js");
 
     expect(
@@ -634,7 +634,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
         }),
       ),
     ).toEqual({ cancelled: 1, cleaned: 0 });
-    expect(mockCancelRun).toHaveBeenCalledOnce();
+    expect(mockCancelRunDetailed).toHaveBeenCalledOnce();
   });
 
   it("still releases an AI Review ticket's owner once its world run is terminal", async () => {
@@ -644,13 +644,74 @@ describe("reconcileRuns owner-CAS recovery", () => {
     const bound = entry();
     const runRegistry = registry([bound]);
     mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
-    mockCancelRun.mockResolvedValue(true);
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
     const { reconcileRuns } = await import("./reconcile.js");
 
     expect(
       await reconcileRuns(new Set(), runRegistry, issueTracker("Review")),
     ).toEqual({ cancelled: 1, cleaned: 0 });
-    expect(mockCancelRun).toHaveBeenCalledOnce();
+    expect(mockCancelRunDetailed).toHaveBeenCalledOnce();
+  });
+
+  it("releases an already-terminal orphaned run without emitting a canceled notification", async () => {
+    // The run genuinely failed (or completed) on its own before the
+    // reconciler observed it. cancelRunDetailed's already-terminal outcome
+    // must still release the claim, but must not relabel that failure as a
+    // fresh "canceled" event for operators.
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockCancelRunDetailed.mockResolvedValue({
+      cancelled: true,
+      released: true,
+      alreadyTerminal: true,
+    });
+    const onCancelled = vi.fn();
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(new Set(), runRegistry, issueTracker("Done"), onCancelled),
+    ).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(onCancelled).not.toHaveBeenCalled();
+  });
+
+  it("still emits a canceled notification for a genuinely running orphaned run", async () => {
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
+    const onCancelled = vi.fn();
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(new Set(), runRegistry, issueTracker("Done"), onCancelled),
+    ).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(onCancelled).toHaveBeenCalledWith("PROJ-1", "orphaned_run");
+  });
+
+  it("releases an already-terminal closing ticket claim without emitting a canceled notification", async () => {
+    // Same already-terminal race as the orphan path, but observed while the
+    // claim is in the durable "cancelling" retry state.
+    const closing = entry({ state: "cancelling" });
+    const runRegistry = registry([closing]);
+    const tracker = issueTracker("AI");
+    mockCancelRunDetailed.mockResolvedValue({
+      cancelled: true,
+      released: true,
+      alreadyTerminal: true,
+    });
+    const onCancelled = vi.fn();
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(
+        new Set(["PROJ-1"]),
+        runRegistry,
+        tracker,
+        onCancelled,
+        undefined,
+        new Set([closing.subjectKey]),
+      ),
+    ).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(onCancelled).not.toHaveBeenCalled();
   });
 
   it("never releases an owner solely because the Workflow status API is unreachable", async () => {
@@ -674,7 +735,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
   it("does not report or drain an orphan when Workflow cancellation was not confirmed", async () => {
     const bound = entry();
     const runRegistry = registry([bound]);
-    mockCancelRun.mockResolvedValue(false);
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: false, released: false });
     const onCancelled = vi.fn();
     const onReleased = vi.fn();
     const { reconcileRuns } = await import("./reconcile.js");

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -1,7 +1,11 @@
 import { getRun } from "workflow/api";
 import { env } from "../../env.js";
 import { isAiReviewDestination } from "./ai-review-destination.js";
-import { cancelRun, cancelSubjectRun } from "./cancel-run.js";
+import {
+  cancelRunDetailed,
+  cancelSubjectRunDetailed,
+  type CancelRunResult,
+} from "./cancel-run.js";
 import { logger } from "./logger.js";
 import { stopSandboxesByIds } from "../sandbox/stop-ticket-sandboxes.js";
 import {
@@ -65,18 +69,25 @@ export async function reconcileRuns(
     // a clarification tombstone may have made a previously parked subject
     // closing, and it must not be skipped by the old protection snapshot.
     if (entry.state === "cancelling") {
-      const confirmed = await retryCancellingClaim(
+      const result = await retryCancellingClaim(
         entry,
         runRegistry,
         issueTracker,
         onSubjectReleased,
       );
-      if (confirmed) {
-        await notifyTicketCancelled(
-          entry.ticketKey ?? "",
-          entry.runId ? "orphaned_run" : "inflight_claim",
-          entry.ticketKey ? onTicketCancelled : undefined,
-        );
+      if (result.cancelled) {
+        if (result.alreadyTerminal) {
+          logger.info(
+            { ticketKey: entry.ticketKey ?? "", runId: entry.runId },
+            "reconcile_released_already_terminal_run",
+          );
+        } else {
+          await notifyTicketCancelled(
+            entry.ticketKey ?? "",
+            entry.runId ? "orphaned_run" : "inflight_claim",
+            entry.ticketKey ? onTicketCancelled : undefined,
+          );
+        }
         cancelled++;
       }
       continue;
@@ -160,7 +171,7 @@ export async function reconcileRuns(
       continue;
     }
 
-    const cancellationConfirmed = await cancelRun(
+    const cancellationResult = await cancelRunDetailed(
       ticketKey,
       entry.runId,
       runRegistry,
@@ -169,12 +180,19 @@ export async function reconcileRuns(
       onSubjectReleased,
       "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
     );
-    if (!cancellationConfirmed) {
+    if (!cancellationResult.cancelled) {
       logger.warn({ ticketKey, runId: entry.runId }, "reconcile_orphan_cancel_unconfirmed");
       continue;
     }
-    logger.info({ ticketKey, runId: entry.runId }, "reconcile_cancelled_orphaned_run");
-    await notifyTicketCancelled(ticketKey, "orphaned_run", onTicketCancelled);
+    if (cancellationResult.alreadyTerminal) {
+      logger.info(
+        { ticketKey, runId: entry.runId },
+        "reconcile_released_already_terminal_run",
+      );
+    } else {
+      logger.info({ ticketKey, runId: entry.runId }, "reconcile_cancelled_orphaned_run");
+      await notifyTicketCancelled(ticketKey, "orphaned_run", onTicketCancelled);
+    }
     cancelled++;
   }
 
@@ -252,13 +270,13 @@ async function retryCancellingClaim(
   runRegistry: RunRegistryAdapter,
   issueTracker?: IssueTrackerAdapter,
   onSubjectReleased?: SubjectReleasedCallback,
-): Promise<boolean> {
+): Promise<CancelRunResult> {
   const target = { ownerToken: entry.ownerToken, runId: entry.runId };
   const reason = entry.runId
     ? "Orphaned run cancelled by reconciler: ticket no longer in the AI column"
     : "In-flight claim cancelled by reconciler: ticket left the AI column before a run was bound";
   if (!entry.ticketKey) {
-    return cancelSubjectRun(
+    return cancelSubjectRunDetailed(
       entry.subjectKey,
       target,
       runRegistry,
@@ -273,12 +291,12 @@ async function retryCancellingClaim(
       { ticketKey: entry.ticketKey, runId: entry.runId },
       "reconcile_closing_ticket_state_unconfirmed",
     );
-    return false;
+    return { cancelled: false, released: false };
   }
   const backlogTarget = env.JIRA_BACKLOG_TRANSITION_ID
     ? { name: env.COLUMN_BACKLOG, transitionId: env.JIRA_BACKLOG_TRANSITION_ID }
     : env.COLUMN_BACKLOG;
-  return cancelRun(
+  return cancelRunDetailed(
     entry.ticketKey,
     target,
     runRegistry,

--- a/apps/worker/src/lib/run-start-lifecycle.ts
+++ b/apps/worker/src/lib/run-start-lifecycle.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { getRun } from "workflow/api";
 import type {
   RunRegistryAdapter,
@@ -109,6 +109,66 @@ export async function recordAndCancelOrphanStartedRun(
     },
     "dispatch_orphan_candidate",
   );
+}
+
+export const NO_DEFINITION_BLOCKED_REASON =
+  "No enabled workflow definition currently handles the trigger_ticket_ai trigger, so this ticket was never picked up. Enable a workflow definition whose trigger is the AI column.";
+
+/**
+ * A ticket the dispatcher skips for want of a definition never reaches a hosted
+ * run, so without this row the dashboard, Slack and Jira show nothing at all and
+ * the ticket sits in the AI column forever. Record one terminal "blocked" row
+ * carrying the cause instead. Best-effort by contract: the caller's dispatch
+ * result must not change because bookkeeping failed.
+ *
+ * The poll retries the same ticket every minute, so a run row is written only
+ * when the subject's most recent one is not already this same block. Anything
+ * newer (a real run, or a different block) makes the ticket visible again.
+ */
+export async function recordNoDefinitionBlockedRun(input: {
+  subjectKey: string;
+  ticketKey: string;
+  ticketTitle: string | null;
+}): Promise<void> {
+  try {
+    const db = getDb();
+    const [latest] = await db
+      .select({
+        status: workflowRuns.status,
+        statusReason: workflowRuns.statusReason,
+      })
+      .from(workflowRuns)
+      .where(eq(workflowRuns.subjectKey, input.subjectKey))
+      .orderBy(desc(workflowRuns.firstSeenAt))
+      .limit(1);
+    if (
+      latest?.status === "blocked" &&
+      latest.statusReason === NO_DEFINITION_BLOCKED_REASON
+    ) {
+      return;
+    }
+    await db.insert(workflowRuns).values({
+      runId: `no_definition_${randomUUID()}`,
+      status: "blocked",
+      statusReason: NO_DEFINITION_BLOCKED_REASON,
+      subjectKey: input.subjectKey,
+      ticketKey: input.ticketKey,
+      ticketTitle: input.ticketTitle,
+      createdAt: sql`now()`,
+      startedAt: sql`now()`,
+      completedAt: sql`now()`,
+      durationSec: 0,
+    });
+  } catch (error) {
+    logger.warn(
+      {
+        subjectKey: input.subjectKey,
+        ticketKey: input.ticketKey,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "dispatch_no_definition_record_failed",
+    );
+  }
 }
 
 export interface StartupWatchdogResult {

--- a/apps/worker/src/prompt-library/store.test.ts
+++ b/apps/worker/src/prompt-library/store.test.ts
@@ -767,6 +767,41 @@ describe("findPromptUsage", () => {
     expect(byNode.get("legacy")).toMatchObject({ version: 2, state: "current" });
     expect(rows).toHaveLength(3);
   });
+
+  it("finds usage on a node whose params and promptRefs are populated multi-key records", async () => {
+    const { prompt } = await createPrompt(db, { name: "Records", body: "BODY", actor: ADMIN });
+
+    const definition: WorkflowDefinition = {
+      schemaVersion: 1,
+      nodes: [
+        {
+          id: "multi",
+          type: "planning_agent",
+          x: 0,
+          y: 0,
+          inputs: {},
+          params: { prompt: "BODY", model: "gpt-4", temperature: 0.2 },
+          promptRefs: {
+            prompt: { promptId: prompt.id, version: 1 },
+          },
+        },
+      ],
+      edges: [],
+    };
+    await db.insert(workflowDefinitionVersions).values({
+      definitionId: 1,
+      version: 1,
+      definition,
+      createdById: "u_admin",
+      createdByLabel: "Admin",
+      restoredFromVersion: null,
+    });
+
+    const rows = await findPromptUsage(db, prompt.id);
+    expect(rows).toEqual([
+      expect.objectContaining({ nodeId: "multi", paramKey: "prompt", version: 1, state: "current" }),
+    ]);
+  });
 });
 
 describe("findPromptUsageInPrompts", () => {

--- a/apps/worker/src/prompt-library/store.ts
+++ b/apps/worker/src/prompt-library/store.ts
@@ -45,9 +45,9 @@ const usageScanNodeSchema = z.object({
   id: z.string(),
   type: z.string(),
   name: z.string().optional(),
-  params: z.record(z.unknown()).catch({}),
+  params: z.record(z.string(), z.unknown()).catch({}),
   promptRefs: z
-    .record(z.object({ promptId: z.number(), version: z.number() }))
+    .record(z.string(), z.object({ promptId: z.number(), version: z.number() }))
     .optional()
     .catch(undefined),
 });

--- a/apps/worker/src/routes/api/v1/approvals.test.ts
+++ b/apps/worker/src/routes/api/v1/approvals.test.ts
@@ -1,7 +1,8 @@
 import { createApp, createRouter, toWebHandler } from "h3";
+import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Db } from "../../../db/client.js";
-import { member, organization, user } from "../../../db/schema.js";
+import { member, organization, user, workflowRuns } from "../../../db/schema.js";
 import { createTestDb } from "../../../db/test-db.js";
 import {
   createApprovalRequest,
@@ -87,6 +88,18 @@ async function seedPending(ticketKey = "AWT-1") {
   });
 }
 
+/** The run that filed the plan, parked on the approval gate. */
+async function seedParkedRun(runId = "run-produced") {
+  await db.insert(workflowRuns).values({ runId, status: "awaiting" });
+}
+
+const runStatus = (runId: string) =>
+  db
+    .select({ status: workflowRuns.status })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, runId))
+    .then((rows) => rows[0]?.status ?? null);
+
 beforeEach(async () => {
   vi.clearAllMocks();
   state.sessionUserId = "user_admin";
@@ -153,6 +166,37 @@ describe("POST /api/v1/approvals/:id/approve", () => {
     const stored = await getApproval(db, row.id);
     expect(stored?.status).toBe("approved");
     expect(stored?.dispatchedRunId).toBeNull();
+  });
+
+  it("settles the awaiting run that filed the plan", async () => {
+    const row = await seedPending("AWT-1");
+    await seedParkedRun();
+    mocks.dispatchPlanApproved.mockImplementation(async (input) => {
+      await input.onClaimed();
+      return { status: "started", runId: "run-x" };
+    });
+
+    const res = await approve(row.id);
+
+    expect(res.status).toBe(200);
+    // The parked run never resumes (a fresh run implements the plan), so the
+    // decision is the only thing that can take it off "awaiting".
+    expect(await runStatus("run-produced")).toBe("success");
+    // The dispatched run owns its own status; the decision must not write it.
+    expect(await runStatus("run-x")).toBeNull();
+  });
+
+  it("approves even when the parked run row is gone", async () => {
+    const row = await seedPending("AWT-1");
+    mocks.dispatchPlanApproved.mockImplementation(async (input) => {
+      await input.onClaimed();
+      return { status: "started", runId: "run-x" };
+    });
+
+    const res = await approve(row.id);
+
+    expect(res.status).toBe(200);
+    expect((await getApproval(db, row.id))?.status).toBe("approved");
   });
 
   it("rejects members with 403", async () => {
@@ -306,6 +350,24 @@ describe("POST /api/v1/approvals/:id/reject", () => {
     expect(body.approval.status).toBe("rejected");
     expect(body.runId).toBeNull();
     expect(mocks.postComment).toHaveBeenCalledWith("AWT-1", "Plan rejected by Admin.");
+    expect((await getApproval(db, row.id))?.status).toBe("rejected");
+  });
+
+  it("settles the awaiting run that filed the plan", async () => {
+    const row = await seedPending("AWT-1");
+    await seedParkedRun();
+
+    const res = await reject(row.id);
+
+    expect(res.status).toBe(200);
+    // A rejected plan ends the wait exactly as an approved one does.
+    expect(await runStatus("run-produced")).toBe("success");
+  });
+
+  it("rejects the plan even when the parked run row is gone", async () => {
+    const row = await seedPending("AWT-1");
+    const res = await reject(row.id);
+    expect(res.status).toBe(200);
     expect((await getApproval(db, row.id))?.status).toBe("rejected");
   });
 

--- a/apps/worker/src/routes/api/v1/approvals/[id]/approve.post.ts
+++ b/apps/worker/src/routes/api/v1/approvals/[id]/approve.post.ts
@@ -7,6 +7,7 @@ import { canApproveWorkflowPlans } from "../../../../../lib/auth/roles.js";
 import { createStepAdapters } from "../../../../../lib/step-adapters.js";
 import { IssueTrackerNotFoundError } from "../../../../../adapters/issue-tracker/types.js";
 import { dashboardUserLabel } from "../../../../../pre-pr-checks/store.js";
+import { resolveAwaitingRun } from "../../../../../lib/telemetry/run-telemetry.js";
 import { dispatchPlanApproved } from "../../../../../approvals/dispatch.js";
 import {
   decideApproval,
@@ -94,6 +95,13 @@ export default defineEventHandler(async (event): Promise<ApprovalDecisionRespons
     if (result.status === "run_in_flight") {
       throw createError({ statusCode: 409, statusMessage: "run_in_flight" });
     }
+
+    // The run that filed the plan parked itself as "awaiting" and has already
+    // returned, so the decision is the only thing that can end its wait: a new
+    // run implements the plan, it never resumes. Same helper and same
+    // best-effort handling as the clarification path (clarifications/
+    // answer-core.ts), and the helper is a no-op unless the row is awaiting.
+    await resolveAwaitingRun(db, row.runId).catch(() => {});
 
     await adapters.issueTracker
       .postComment(row.ticketKey, `Plan approved by ${approver.label}, implementation started.`)

--- a/apps/worker/src/routes/api/v1/approvals/[id]/reject.post.ts
+++ b/apps/worker/src/routes/api/v1/approvals/[id]/reject.post.ts
@@ -5,6 +5,7 @@ import { requireDashboardActor } from "../../../../../lib/auth/request-context.j
 import { canApproveWorkflowPlans } from "../../../../../lib/auth/roles.js";
 import { createStepAdapters } from "../../../../../lib/step-adapters.js";
 import { dashboardUserLabel } from "../../../../../pre-pr-checks/store.js";
+import { resolveAwaitingRun } from "../../../../../lib/telemetry/run-telemetry.js";
 import {
   decideApproval,
   getApproval,
@@ -34,6 +35,12 @@ export default defineEventHandler(async (event): Promise<ApprovalDecisionRespons
       decision: "rejected",
       actor: { id: actor.userId, label },
     });
+
+    // A rejected plan ends the wait just as an approved one does: the run that
+    // filed it parked itself as "awaiting" and has already returned, so nothing
+    // else will ever settle it. Same helper and same best-effort handling as
+    // the clarification path (clarifications/answer-core.ts).
+    await resolveAwaitingRun(db, row.runId).catch(() => {});
 
     const { issueTracker } = createStepAdapters();
     await issueTracker.postComment(row.ticketKey, `Plan rejected by ${label}.`).catch(() => {});

--- a/apps/worker/src/routes/cron/poll.get.test.ts
+++ b/apps/worker/src/routes/cron/poll.get.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   startCleanups: vi.fn(),
   expireClarifications: vi.fn(),
   listDispatchBlockingApprovals: vi.fn(),
+  listApprovalParkedSubjects: vi.fn(),
   getApproval: vi.fn(),
   rejectUndispatchableApproval: vi.fn(),
   dispatchPlanApproved: vi.fn(),
@@ -56,6 +57,8 @@ vi.mock("../../lib/dispatch.js", () => ({
 vi.mock("../../approvals/store.js", () => ({
   listDispatchBlockingApprovals: (...args: any[]) =>
     mocks.listDispatchBlockingApprovals(...args),
+  listApprovalParkedSubjects: (...args: any[]) =>
+    mocks.listApprovalParkedSubjects(...args),
   getApproval: (...args: any[]) => mocks.getApproval(...args),
   rejectUndispatchableApproval: (...args: any[]) =>
     mocks.rejectUndispatchableApproval(...args),
@@ -170,6 +173,7 @@ describe("cron clarification recovery ordering", () => {
     mocks.startCleanups.mockResolvedValue(0);
     mocks.expireClarifications.mockResolvedValue({ expired: 0, retryable: 0, cleanupFailed: 0 });
     mocks.listDispatchBlockingApprovals.mockResolvedValue([]);
+    mocks.listApprovalParkedSubjects.mockResolvedValue([]);
     mocks.getApproval.mockResolvedValue(null);
     mocks.rejectUndispatchableApproval.mockResolvedValue(undefined);
     mocks.dispatchPlanApproved.mockResolvedValue({ status: "run_in_flight" });
@@ -273,6 +277,10 @@ describe("cron clarification recovery ordering", () => {
       state.order.push("protect-approvals");
       return [pending, approved];
     });
+    // AIW-1's planning run still holds the bound claim it parked on: reconciliation
+    // must clean it up terminally, never through the orphan cancellation cascade
+    // that would supersede the pending approval.
+    mocks.listApprovalParkedSubjects.mockResolvedValue(["ticket:jira:AIW-1"]);
     mocks.getApproval.mockResolvedValue(approved);
     mocks.dispatchPlanApproved.mockImplementation(async (input) => {
       state.order.push(`recover-approval:${input.approval.ticketKey}`);
@@ -301,6 +309,16 @@ describe("cron clarification recovery ordering", () => {
     );
     expect(state.order).not.toContain("dispatch:AIW-1");
     expect(state.order).not.toContain("dispatch:AIW-2");
+    expect(mocks.reconcileRuns).toHaveBeenCalledWith(
+      expect.any(Set),
+      expect.anything(),
+      expect.anything(),
+      expect.any(Function),
+      expect.any(Function),
+      new Set(),
+      { db: true },
+      new Set(["ticket:jira:AIW-1"]),
+    );
     expect(mocks.dispatchPlanApproved).toHaveBeenCalledWith(
       expect.objectContaining({
         approval: approved,

--- a/apps/worker/src/routes/cron/poll.get.ts
+++ b/apps/worker/src/routes/cron/poll.get.ts
@@ -21,6 +21,7 @@ import { expireHookClarifications } from "../../clarifications/expiry.js";
 import { dispatchPlanApproved } from "../../approvals/dispatch.js";
 import {
   getApproval,
+  listApprovalParkedSubjects,
   listDispatchBlockingApprovals,
   type ApprovalRow,
 } from "../../approvals/store.js";
@@ -41,7 +42,10 @@ export default defineEventHandler(async (event) => {
   const clarificationProtection =
     await classifyProtectedClarificationSubjects(db);
   const protectedClarificationSubjects = new Set(clarificationProtection.all);
-  const terminalClarificationSubjects = new Set(
+  // Subjects reconciled by terminal cleanup only: their run is finished and its
+  // bound claim must be released quietly, never through the orphan cancellation
+  // cascade. Clarification successors and approval parks share that shape.
+  const terminalReconciliationSubjects = new Set(
     clarificationProtection.terminal,
   );
   const retainedClarificationSubjects = new Set(
@@ -56,6 +60,15 @@ export default defineEventHandler(async (event) => {
   const protectedDiscoverySubjects = new Set(protectedClarificationSubjects);
   for (const approval of blockingApprovals) {
     protectedDiscoverySubjects.add(ticketSubjectKey("jira", approval.ticketKey));
+  }
+
+  // The run that filed a plan ended when it parked the ticket outside the AI
+  // column, so its bound claim is terminal bookkeeping, not an orphan. Cancelling
+  // it retires the pending approval and strands the ticket with nobody able to
+  // approve; terminal cleanup releases the same claim quietly, which is what the
+  // approval dispatch needs to reserve.
+  for (const subjectKey of await listApprovalParkedSubjects(db)) {
+    terminalReconciliationSubjects.add(subjectKey);
   }
 
   // Durable clarification recovery owns its subject before generic AI-column
@@ -109,7 +122,7 @@ export default defineEventHandler(async (event) => {
     },
     protectedRunSubjects,
     db,
-    terminalClarificationSubjects,
+    terminalReconciliationSubjects,
   );
 
   const polledTriggerRecovery = await recoverPendingTriggers(

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -18,6 +18,7 @@ const state = vi.hoisted(() => ({
   isRunRecordedFailed: vi.fn(),
   isRunRecordedSucceeded: vi.fn(),
   classifyProtected: vi.fn(),
+  listApprovalParked: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({ env: state.env }));
@@ -31,6 +32,10 @@ vi.mock("../../clarifications/resume-from-comments.js", () => ({
 vi.mock("../../clarifications/store.js", () => ({
   classifyProtectedClarificationSubjects: (...args: unknown[]) =>
     state.classifyProtected(...args),
+}));
+vi.mock("../../approvals/store.js", () => ({
+  listApprovalParkedSubjects: (...args: unknown[]) =>
+    state.listApprovalParked(...args),
 }));
 vi.mock("../../db/queries/runs-read.js", () => ({
   isRunRecordedFailed: state.isRunRecordedFailed,
@@ -123,6 +128,7 @@ describe("POST /webhooks/jira", () => {
     state.isRunRecordedFailed.mockResolvedValue(false);
     state.isRunRecordedSucceeded.mockResolvedValue(false);
     state.classifyProtected.mockResolvedValue({ all: [], retained: [], terminal: [] });
+    state.listApprovalParked.mockResolvedValue([]);
   });
 
   it("rejects unauthenticated configuration", async () => {
@@ -222,6 +228,62 @@ describe("POST /webhooks/jira", () => {
       status: "cancelled",
       reason: "left_ai_column",
     });
+    expect(state.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an approval-parked run's plan alive when its own backlog move fires the webhook", async () => {
+    // parkForApprovalStep moves the ticket to the backlog itself after filing the
+    // plan, and the run then ends as "awaiting", which the recorded-outcome
+    // guards do not treat as terminal. With a dead actor-check that self-move
+    // reads as a human move, and cancelling it would supersede the pending
+    // approval so nobody could ever approve the plan.
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+    state.listApprovalParked.mockResolvedValue(["ticket:jira:PROJ-42"]);
+
+    const response = await app()(request({ actor: "human-account" }));
+
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "run_parked_for_approval",
+      ticketKey: "PROJ-42",
+    });
+    expect(state.cancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels an approval-parked subject when the ticket moves to a non-backlog column (human abort)", async () => {
+    const connected = adapters();
+    connected.issueTracker.fetchTicket.mockResolvedValue({
+      identifier: "PROJ-42",
+      projectKey: "PROJ",
+      trackerStatus: "Done",
+    });
+    state.createAdapters.mockReturnValue(connected);
+    state.listApprovalParked.mockResolvedValue(["ticket:jira:PROJ-42"]);
+
+    const response = await app()(request({ actor: "human-account", status: "Done" }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "cancelled",
+      reason: "left_ai_column",
+    });
+    expect(state.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("still cancels an in-flight run on a backlog move when no approval park is reported", async () => {
+    // The helper only reports the exact run that filed a still blocking approval,
+    // so an ordinary in-flight run (and an already dispatched approved
+    // continuation) keeps cancelling on a human backlog move.
+    const connected = adapters();
+    state.createAdapters.mockReturnValue(connected);
+
+    const response = await app()(request({ actor: "human-account" }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "cancelled",
+      reason: "left_ai_column",
+    });
+    expect(state.listApprovalParked).toHaveBeenCalledOnce();
     expect(state.cancel).toHaveBeenCalledOnce();
   });
 

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -3,6 +3,7 @@ import { defineEventHandler, readRawBody, getHeader, createError } from "h3";
 import { env } from "../../../env.js";
 import { IssueTrackerNotFoundError } from "../../adapters/issue-tracker/types.js";
 import { resumeClarificationFromComments } from "../../clarifications/resume-from-comments.js";
+import { listApprovalParkedSubjects } from "../../approvals/store.js";
 import { classifyProtectedClarificationSubjects } from "../../clarifications/store.js";
 import { getDb } from "../../db/client.js";
 import { isRunRecordedFailed, isRunRecordedSucceeded } from "../../db/queries/runs-read.js";
@@ -319,6 +320,32 @@ export default defineEventHandler(async (event) => {
         return {
           status: "ignored",
           reason: "run_parked_for_clarification",
+          ticketKey,
+        };
+      }
+
+      // Parking for a plan approval is the same window: send_plan_approval moves
+      // the ticket to the backlog itself (parkForApprovalStep) and its run then
+      // ends as "awaiting", which the recorded-outcome guard above does not treat
+      // as terminal. Cancelling that self-move would retire the pending approval
+      // (retireApprovalCancellation) and leave nobody able to approve the plan.
+      // Only the exact run that filed a still dispatch-blocking approval is
+      // protected, so an in-flight ticket run or an already dispatched approved
+      // continuation still cancels, and any move to a non-backlog column
+      // (a human abort) never reaches this branch at all.
+      const approvalParkedSubjects = await listApprovalParkedSubjects(getDb());
+      if (approvalParkedSubjects.includes(subjectKey)) {
+        logger.info(
+          {
+            ticketKey,
+            runId: activeRun?.runId ?? null,
+            liveStatus: liveTicketState.status,
+          },
+          "webhook_skip_cancel_run_parked_for_approval",
+        );
+        return {
+          status: "ignored",
+          reason: "run_parked_for_approval",
           ticketKey,
         };
       }

--- a/apps/worker/src/run-observability/sanitizer.test.ts
+++ b/apps/worker/src/run-observability/sanitizer.test.ts
@@ -132,6 +132,24 @@ describe("sanitizeReplayValue", () => {
     },
   );
 
+  it("does not mistake a UUID's decimal-only segments for a phone number", () => {
+    const uuid = "0b363504-6791-4963-9492-0cdea08acfe2";
+    const envelope = sanitizeReplayValue({ approvalRequestId: uuid });
+    expect(envelope.value).toEqual({ approvalRequestId: uuid });
+    expect(envelope.metadata.redactions.phone).toBeUndefined();
+  });
+
+  it("keeps a UUID intact when embedded in a JSON-ish sentence", () => {
+    const uuid = "0b363504-6791-4963-9492-0cdea08acfe2";
+    const envelope = sanitizeReplayValue(
+      `run failed; "approvalRequestId": "${uuid}" needs review`,
+    );
+    expect(envelope.value).toBe(
+      `run failed; "approvalRequestId": "${uuid}" needs review`,
+    );
+    expect(envelope.metadata.redactions.phone).toBeUndefined();
+  });
+
   it("does not rescan redaction markers when a short secret occurs inside one", () => {
     const envelope = sanitizeReplayValue("secret configured secret", {
       secrets: ["secret", "configured"],

--- a/apps/worker/src/run-observability/sanitizer.ts
+++ b/apps/worker/src/run-observability/sanitizer.ts
@@ -486,7 +486,11 @@ function sanitizeText(
   );
   value = replaceMatches(
     value,
-    /(?<![A-Za-z0-9])(?:\+\d{1,3}[\s.-]?)?(?:\(?\d{2,4}\)?[\s.-]?){2,4}\d{2,4}(?![A-Za-z0-9])/g,
+    // Phone separators (hyphens, spaces) overlap UUID segment separators, so a
+    // run of decimal digit groups inside a canonical UUID (8-4-4-4-12 hex) can
+    // otherwise match as a phone number; these lookarounds refuse to start or
+    // end a match at a UUID segment boundary.
+    /(?<![A-Za-z0-9])(?<![0-9a-fA-F]{8}-)(?:\+\d{1,3}[\s.-]?)?(?:\(?\d{2,4}\)?[\s.-]?){2,4}\d{2,4}(?!-[0-9a-fA-F]{12}\b)(?![A-Za-z0-9])/g,
     "phone",
     context.redactions,
     isLikelyPhone,

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
@@ -229,6 +229,57 @@ describe("trusted workspace publisher", () => {
     expect(mocks.createSandbox).not.toHaveBeenCalled();
   });
 
+  it("rides out a 404 on the ref read that verifies the push", async () => {
+    // The push wrote refs/heads/blazebot/AIW-100 milliseconds earlier, so the
+    // branch exists; a 404 here is the provider ref API lagging its own write.
+    mocks.getBranchSha
+      .mockReset()
+      .mockResolvedValueOnce("before-acme/api")
+      .mockRejectedValueOnce(Object.assign(new Error("ref read failed"), { status: 404 }))
+      .mockResolvedValueOnce("after");
+
+    const result = await publishTrustedWorkspaceFromSandbox({
+      sourceSandboxId: "source-sandbox",
+      workspaceManifest: manifest,
+      ...owner,
+    });
+
+    expect(result).toMatchObject({ pushed: true, repositories: [{ pushedHead: "after" }] });
+    expect(mocks.getBranchSha).toHaveBeenCalledTimes(3);
+  });
+
+  it("rides out a 404 on the preflight ref read of the promoted branch", async () => {
+    // GitLab reclassifies a 404 into an error that keeps only the message.
+    mocks.getBranchSha
+      .mockReset()
+      .mockRejectedValueOnce(new Error("404 Branch Not Found"))
+      .mockResolvedValueOnce("before-acme/api")
+      .mockResolvedValueOnce("after");
+
+    const result = await publishTrustedWorkspaceFromSandbox({
+      sourceSandboxId: "source-sandbox",
+      workspaceManifest: manifest,
+      ...owner,
+    });
+
+    expect(result).toMatchObject({ pushed: true, repositories: [{ pushedHead: "after" }] });
+  });
+
+  it("propagates a non-404 ref read failure on the first attempt", async () => {
+    mocks.getBranchSha
+      .mockReset()
+      .mockRejectedValue(Object.assign(new Error("provider unavailable"), { status: 500 }));
+
+    await expect(
+      publishTrustedWorkspaceFromSandbox({
+        sourceSandboxId: "source-sandbox",
+        workspaceManifest: manifest,
+        ...owner,
+      }),
+    ).rejects.toThrow("provider unavailable");
+    expect(mocks.getBranchSha).toHaveBeenCalledTimes(1);
+  });
+
   it("fails every publication before a push when a read-only repository changed", async () => {
     const scopedManifest: WorkspaceManifest = {
       version: 2,

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.ts
@@ -261,7 +261,7 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
       continue;
     }
 
-    const providerHead = await runtime.vcs.getBranchSha(repo.branchName);
+    const providerHead = await readBranchShaAfterWrite(runtime.vcs, repo.branchName);
     const changed = targetHead !== repo.preAgentSha;
     if (providerHead !== repo.expectedRemoteSha && providerHead !== targetHead) {
       fail({
@@ -487,7 +487,7 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
         repoPath: item.repo.repoPath,
         baseBranch: item.repo.defaultBranch,
       });
-      const providerHead = await runtime.vcs.getBranchSha(item.repo.branchName);
+      const providerHead = await readBranchShaAfterWrite(runtime.vcs, item.repo.branchName);
       if (providerHead !== item.result.targetHead) {
         const error =
           push.exitCode === 0
@@ -525,6 +525,46 @@ function failPrepared(
   failureKind: TrustedWorkspacePushRepositoryResult["failureKind"] = "push_failed",
 ): void {
   item.result = { ...item.result, pushed: false, failureKind, error };
+}
+
+const BRANCH_SHA_RETRY_DELAYS_MS = [1000, 2000];
+
+/**
+ * Reads a branch head this run has already written: promotion created the owned
+ * branch, and the verification reads run milliseconds after the push that moved
+ * it. The provider ref API can still answer 404 for a ref it just accepted, and
+ * no caller treats absence as an answer, so a transient 404 threw the whole step
+ * and burned a retry (a publication retry redoes the sandbox, clone and bundle
+ * import) on a branch that demonstrably exists. Retry only that, and only
+ * briefly. Every other error propagates on the first attempt, and a 404 that
+ * survives the retries is rethrown exactly as the provider raised it. Exported
+ * for the finalized-branch verification in workspace-publication.ts, which reads
+ * the same ref this module has just pushed.
+ */
+export async function readBranchShaAfterWrite(
+  vcs: { getBranchSha(branch: string): Promise<string> },
+  branchName: string,
+): Promise<string> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await vcs.getBranchSha(branchName);
+    } catch (error) {
+      if (attempt >= BRANCH_SHA_RETRY_DELAYS_MS.length || !isRefNotFound(error)) throw error;
+      await new Promise((resolve) => setTimeout(resolve, BRANCH_SHA_RETRY_DELAYS_MS[attempt]!));
+    }
+  }
+}
+
+/**
+ * GitHub raises an Octokit error carrying the status; GitLab reclassifies a 404
+ * into a FatalError that keeps only the message, so match the text as well.
+ */
+function isRefNotFound(error: unknown): boolean {
+  if (typeof error === "object" && error !== null) {
+    const candidate = error as { status?: unknown; response?: { status?: unknown } };
+    if (candidate.status === 404 || candidate.response?.status === 404) return true;
+  }
+  return /\b404\b|not found/i.test(error instanceof Error ? error.message : String(error));
 }
 
 async function verifyAncestors(

--- a/apps/worker/src/workflow-definition/interpreter.ts
+++ b/apps/worker/src/workflow-definition/interpreter.ts
@@ -803,7 +803,7 @@ export async function executeGraph(opts: {
 
     // result.kind === "ended": a block (e.g. send_plan_approval) parked the run
     // cleanly while it awaits a human. Distinct from "stopped" so agent.ts can
-    // record it as a success instead of the default failed outcome.
+    // record it as an awaiting park instead of the default failed outcome.
     const output = result.output;
     steps[id] = { output };
     await hooks.onBlockFinish(id, { status: "warn", attempt, output });

--- a/apps/worker/src/workflow-definition/store.test.ts
+++ b/apps/worker/src/workflow-definition/store.test.ts
@@ -25,6 +25,10 @@ vi.mock("../../env.js", () => ({
     GENAI_ENGINE_TRACE_ENDPOINT: "https://arthur.example/traces",
   },
 }));
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("../lib/logger.js", () => ({ logger: loggerMock }));
 import {
   workflowDefinitions,
   workflowDefinitionTriggers,
@@ -166,6 +170,7 @@ let db: Db;
 
 beforeEach(async () => {
   db = await createTestDb();
+  loggerMock.warn.mockClear();
 });
 
 describe("migration seed", () => {
@@ -936,6 +941,64 @@ describe("getEnabledWorkflowDefinitionForTrigger", () => {
   it("returns null when no enabled definition handles the trigger", async () => {
     await updateWorkflowDefinition(db, { definitionId: SEEDED_DEFAULT_ID, enabled: false, actor: ADMIN });
     expect(await getEnabledWorkflowDefinitionForTrigger(db, "trigger_ticket_ai")).toBeNull();
+  });
+
+  it("re-claims the trigger for the only enabled definition that lost its binding", async () => {
+    // AWP-49: enabling a second definition moves the single owning row to it and
+    // disabling that one deletes the row. Both writers are scoped to one
+    // definition id, so the definition that stayed enabled throughout never gets
+    // the row back and every ticket dispatch silently finds nothing.
+    // The direct updates below forge that state: assertNoTriggerOverlap 409s a
+    // second enable through the public API, so this models the orphaned end
+    // state, not a literal API sequence.
+    const stealer = await createDeployed("Legacy", def(["trigger_ticket_ai"]));
+    await db
+      .update(workflowDefinitions)
+      .set({ enabled: true })
+      .where(eq(workflowDefinitions.id, stealer.id));
+    await db
+      .update(workflowDefinitionTriggers)
+      .set({ definitionId: stealer.id })
+      .where(eq(workflowDefinitionTriggers.triggerType, "trigger_ticket_ai"));
+    await updateWorkflowDefinition(db, { definitionId: stealer.id, enabled: false, actor: ADMIN });
+    expect(await db.select().from(workflowDefinitionTriggers)).toEqual([]);
+
+    const hit = await getEnabledWorkflowDefinitionForTrigger(db, "trigger_ticket_ai");
+    expect(hit?.definition.id).toBe(SEEDED_DEFAULT_ID);
+    expect(await db.select().from(workflowDefinitionTriggers)).toEqual([
+      { triggerType: "trigger_ticket_ai", definitionId: SEEDED_DEFAULT_ID },
+    ]);
+  });
+
+  it("creates no binding when no enabled definition declares the trigger", async () => {
+    await updateWorkflowDefinition(db, { definitionId: SEEDED_DEFAULT_ID, enabled: false, actor: ADMIN });
+
+    expect(await getEnabledWorkflowDefinitionForTrigger(db, "trigger_ticket_ai")).toBeNull();
+    expect(await db.select().from(workflowDefinitionTriggers)).toEqual([]);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      { triggerType: "trigger_ticket_ai", candidates: [] },
+      "trigger_binding_unclaimed",
+    );
+  });
+
+  it("never guesses an owner when two enabled definitions declare the trigger", async () => {
+    // Direct writes forge the ambiguous state (two enabled declarers, no owner
+    // row) that assertNoTriggerOverlap forbids through the public API.
+    const rival = await createDeployed("Rival", def(["trigger_ticket_ai"]));
+    await db
+      .update(workflowDefinitions)
+      .set({ enabled: true })
+      .where(eq(workflowDefinitions.id, rival.id));
+    await db
+      .delete(workflowDefinitionTriggers)
+      .where(eq(workflowDefinitionTriggers.triggerType, "trigger_ticket_ai"));
+
+    expect(await getEnabledWorkflowDefinitionForTrigger(db, "trigger_ticket_ai")).toBeNull();
+    expect(await db.select().from(workflowDefinitionTriggers)).toEqual([]);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      { triggerType: "trigger_ticket_ai", candidates: [SEEDED_DEFAULT_ID, rival.id] },
+      "trigger_binding_unclaimed",
+    );
   });
 });
 

--- a/apps/worker/src/workflow-definition/store.ts
+++ b/apps/worker/src/workflow-definition/store.ts
@@ -19,6 +19,7 @@ import {
 } from "../db/schema.js";
 import { canEditWorkflowDefinitions, type DashboardRole } from "../lib/auth/roles.js";
 import { DashboardAuthError } from "../lib/auth/users-read.js";
+import { logger } from "../lib/logger.js";
 import {
   describeWorkflowDefinitionIssues,
   upgradeStoredWorkflowDefinition,
@@ -483,13 +484,11 @@ export async function getEnabledWorkflowDefinitionForTrigger(
   // consistent with the graph head even when the denormalized trigger_types
   // column drifts (a write that crashed between the version insert and the
   // column update).
-  const bindingRows = await db
-    .select({ definitionId: workflowDefinitionTriggers.definitionId })
-    .from(workflowDefinitionTriggers)
-    .where(eq(workflowDefinitionTriggers.triggerType, triggerType))
-    .limit(1);
-  const binding = bindingRows[0];
-  if (!binding) return null;
+  const bindingDefinitionId =
+    (await readTriggerBinding(db, triggerType)) ??
+    (await healMissingTriggerBinding(db, triggerType));
+  if (bindingDefinitionId == null) return null;
+  const binding = { definitionId: bindingDefinitionId };
 
   const defRows = await db
     .select()
@@ -544,9 +543,98 @@ export async function getEnabledWorkflowDefinitionForTrigger(
         ),
       )
       .catch(() => {});
+    logger.warn(
+      {
+        triggerType,
+        definitionId: binding.definitionId,
+        enabled: defRow?.enabled ?? false,
+        archived: defRow?.archivedAt != null,
+        declaresTrigger: actualTriggers.includes(triggerType),
+      },
+      "trigger_binding_stale_dropped",
+    );
     return null;
   }
   return { definition: mapDefinitionRow(defRow!, current?.version ?? 0), current };
+}
+
+async function readTriggerBinding(
+  db: Db,
+  triggerType: WorkflowBlockType,
+): Promise<number | null> {
+  const rows = await db
+    .select({ definitionId: workflowDefinitionTriggers.definitionId })
+    .from(workflowDefinitionTriggers)
+    .where(eq(workflowDefinitionTriggers.triggerType, triggerType))
+    .limit(1);
+  return rows[0]?.definitionId ?? null;
+}
+
+/**
+ * No binding row at all is not the same as no handler: enabling a second
+ * definition steals the row from the definition that owns it, and disabling that
+ * second one deletes the row outright, so the still-enabled original keeps
+ * declaring the trigger with nothing pointing at it and every dispatch silently
+ * finds nothing forever. Re-create the claim when exactly one enabled definition
+ * declares the trigger. Two candidates are never guessed between: only an
+ * operator can say which one should own it.
+ */
+async function healMissingTriggerBinding(
+  db: Db,
+  triggerType: WorkflowBlockType,
+): Promise<number | null> {
+  const candidates = await enabledDefinitionsDeclaringTrigger(db, triggerType);
+  if (candidates.length !== 1) {
+    logger.warn({ triggerType, candidates }, "trigger_binding_unclaimed");
+    return null;
+  }
+  const definitionId = candidates[0];
+  // DO NOTHING on conflict: a concurrent enable/deploy writes the same row, and
+  // its claim is a deliberate operator action that must outrank this repair.
+  await db
+    .insert(workflowDefinitionTriggers)
+    .values({ triggerType, definitionId })
+    .onConflictDoNothing()
+    .catch(() => {});
+  const bound = await readTriggerBinding(db, triggerType);
+  logger.warn(
+    { triggerType, definitionId, boundDefinitionId: bound },
+    bound == null ? "trigger_binding_heal_failed" : "trigger_binding_healed",
+  );
+  return bound;
+}
+
+/** Same trigger-declaration source the stale-binding check uses: the deployed
+ *  version's graph, falling back to the denormalized column for a definition
+ *  with no version (the built-in default). */
+async function enabledDefinitionsDeclaringTrigger(
+  db: Db,
+  triggerType: WorkflowBlockType,
+): Promise<number[]> {
+  const rows = await db
+    .select({
+      id: workflowDefinitions.id,
+      deployedVersion: workflowDefinitions.deployedVersion,
+      triggerTypes: workflowDefinitions.triggerTypes,
+    })
+    .from(workflowDefinitions)
+    .where(
+      and(eq(workflowDefinitions.enabled, true), isNull(workflowDefinitions.archivedAt)),
+    )
+    .orderBy(asc(workflowDefinitions.id));
+  const declaring = await Promise.all(
+    rows.map(async (row) => {
+      const deployed =
+        row.deployedVersion != null
+          ? await getWorkflowDefinitionVersion(db, row.id, row.deployedVersion)
+          : null;
+      const triggers = deployed
+        ? triggerTypesOf(deployed.definition)
+        : ((row.triggerTypes as WorkflowBlockType[]) ?? []);
+      return triggers.includes(triggerType) ? row.id : null;
+    }),
+  );
+  return declaring.filter((id): id is number => id != null);
 }
 
 // --- Writes (role-gated). neon-http (the production driver, also loaded inside

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -5371,22 +5371,27 @@ async function agentWorkflowBody(
           formatExecutionErrorForUser(terminalExecutionError),
         );
       }
-      // "ended" is a clean awaiting stop (e.g. send_plan_approval parked the
-      // run for human approval and already moved the ticket): a success, not a
-      // failure. No ticket move here; the block owns that.
+      // "completed" is the only genuine success: the walk ran out of work.
+      // "ended" is a clean park, not a finish: send_plan_approval (the only
+      // block that returns it) stopped the run while a human decides on the
+      // plan, and nothing downstream of the gate ran. That is the same state a
+      // clarification park records, so it records the same status and the
+      // approval decision endpoints flip it off "awaiting" later. Calling it a
+      // success here made a parked run read as shipped in every run listing.
+      // No ticket move on either branch; the block owns that.
       // Constraint: never promote a clarification park to success here. The
       // terminate/clarification paths set runOutcome = "awaiting" and own it
-      // (the answer endpoint flips it later), so a completed/ended walk that
-      // left "awaiting" set must keep it. The `as string` read is needed
-      // because TS can't see the hook closures writing runOutcome and narrows
-      // it to its "failed" initializer.
+      // (the answer endpoint flips it later), so a completed walk that left
+      // "awaiting" set must keep it. The `as string` read is needed because TS
+      // can't see the hook closures writing runOutcome and narrows it to its
+      // "failed" initializer.
       if (
         !terminalExecutionError &&
         (walk.outcome === "completed" || walk.outcome === "ended") &&
         (runOutcome as string) !== "awaiting"
       ) {
         currentBlockId = null;
-        runOutcome = "success";
+        runOutcome = walk.outcome === "ended" ? "awaiting" : "success";
       }
     } finally {
       // Capture the memory document before the sandbox that holds it is gone.

--- a/apps/worker/src/workflows/run-telemetry-integration.test.ts
+++ b/apps/worker/src/workflows/run-telemetry-integration.test.ts
@@ -242,7 +242,8 @@ async function runWorkflowAgainstDb(db: Db, fx: RunFixture): Promise<RunResult> 
     });
     outcome = walk.outcome;
     terminalExecutionError = walk.executionError;
-    // Mirror agent.ts: never promote a clarification park (awaiting) to success.
+    // Mirror agent.ts: only a "completed" walk is a success, an "ended" walk is
+    // an approval park, and a clarification park (awaiting) is never promoted.
     // `as string` because TS narrows runOutcome to its "failed" initializer (it
     // can't see the hook closures writing it).
     if (
@@ -250,7 +251,7 @@ async function runWorkflowAgainstDb(db: Db, fx: RunFixture): Promise<RunResult> 
       (walk.outcome === "completed" || walk.outcome === "ended") &&
       (runOutcome as string) !== "awaiting"
     ) {
-      runOutcome = "success";
+      runOutcome = walk.outcome === "ended" ? "awaiting" : "success";
     }
   } catch (err) {
     budgetFailure = runBudgetFailureFromError(err);
@@ -505,6 +506,59 @@ describe("run telemetry integration (executeGraph -> pglite)", () => {
     expect(result.outcome).toBe("stopped");
     expect(result.runOutcome).toBe("awaiting");
     expect((await runRow("wrun_wait")).status).toBe("awaiting");
+  });
+
+  it("send_plan_approval park: an ended walk records the run as awaiting, not success", async () => {
+    // The approval gate returns kind "ended": the walk stopped cleanly with a
+    // human still owing a decision and nothing shipped. Recording that as
+    // success made a parked run read as done in every run listing.
+    const nodes = [
+      node("trig", "trigger_ticket_ai"),
+      node("prep", "prepare_workspace"),
+      node("plan", "planning_agent"),
+      node("gate", "send_plan_approval"),
+    ];
+    const edges: WorkflowDefinitionEdge[] = [
+      { from: "trig", to: "prep" },
+      { from: "prep", to: "plan" },
+      { from: "plan", to: "gate" },
+    ];
+
+    const result = await runWorkflowAgainstDb(db, {
+      runId: "wrun_approval",
+      nodes,
+      edges,
+      entryTriggerType: "trigger_ticket_ai",
+      scripts: {
+        prep: { result: { kind: "next", output: { status: "ok" } }, activeModel: "claude-default" },
+        plan: {
+          result: { kind: "next", output: { status: "ready" } },
+          usage: { phase: "Research", usage: claudeUsage(0.5), model: "claude-opus" },
+        },
+        gate: {
+          result: {
+            kind: "ended",
+            output: { status: "awaiting_approval", approvalRequestId: "apr_1" },
+          },
+        },
+      },
+    });
+
+    expect(result.outcome).toBe("ended");
+    expect(result.runOutcome).toBe("awaiting");
+
+    const r = await runRow("wrun_approval");
+    expect(r.status).toBe("awaiting");
+    expect(r.blockStatuses).toEqual({
+      prep: { status: "ok", attempt: 1 },
+      plan: { status: "ok", attempt: 1 },
+      // The gate ran and parked: warn, the same shape a clarification park writes.
+      gate: { status: "warn", attempt: 1 },
+    });
+    // Parked, not failed: the cost spent before the gate still lands.
+    expect(r.costUsd).toBeCloseTo(0.5);
+    expect(r.costKnown).toBe(true);
+    expect(r.prNumber).toBeNull();
   });
 
   it("failed block with no failure edge: fail persisted, run recorded as failed, cost still captured", async () => {

--- a/apps/worker/src/workflows/workspace-publication.test.ts
+++ b/apps/worker/src/workflows/workspace-publication.test.ts
@@ -13,7 +13,11 @@ const mocks = vi.hoisted(() => ({
   getPrHead: vi.fn(),
 }));
 
-vi.mock("../sandbox/trusted-workspace-publisher.js", () => ({
+// Keep the module's real exports: the finalized-branch verification depends on
+// the read-after-write retry helper published from here, so stubbing the whole
+// module would stub away the behaviour under test.
+vi.mock("../sandbox/trusted-workspace-publisher.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../sandbox/trusted-workspace-publisher.js")>()),
   publishTrustedWorkspaceFromSandbox: mocks.publish,
 }));
 vi.mock("../sandbox/write-human-decisions-memory.js", () => ({
@@ -325,6 +329,44 @@ describe("workspace publication", () => {
     expect(mocks.recordIntent).not.toHaveBeenCalled();
     expect(mocks.createPr).not.toHaveBeenCalled();
     expect(mocks.recordPr).not.toHaveBeenCalled();
+  });
+
+  it("rides out a 404 on the ref read that verifies the finalized branch", async () => {
+    // Publication pushed this branch moments earlier, so the ref exists; a 404
+    // here is the provider ref API lagging its own write.
+    mocks.getBranchSha
+      .mockReset()
+      .mockRejectedValueOnce(Object.assign(new Error("ref read failed"), { status: 404 }))
+      .mockResolvedValue("after");
+
+    const result = await openPullRequestsForPublication({
+      ...common,
+      title: "Implement the ticket",
+      body: "## What changed\nImplemented the ticket.",
+      repositories: [finalized],
+    });
+
+    expect(result.status).toBe("published");
+    expect(mocks.getBranchSha).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails the finalized branch verification on a non-404 ref read error", async () => {
+    mocks.getBranchSha
+      .mockReset()
+      .mockRejectedValue(Object.assign(new Error("provider unavailable"), { status: 500 }));
+
+    const result = await openPullRequestsForPublication({
+      ...common,
+      title: "Implement the ticket",
+      body: "## What changed\nImplemented the ticket.",
+      repositories: [finalized],
+    });
+
+    expect(result).toMatchObject({
+      status: "failed",
+      reason: expect.stringContaining("provider unavailable"),
+    });
+    expect(mocks.getBranchSha).toHaveBeenCalledTimes(1);
   });
 
   it("rejects a stale PR head before recording final ownership", async () => {

--- a/apps/worker/src/workflows/workspace-publication.ts
+++ b/apps/worker/src/workflows/workspace-publication.ts
@@ -5,6 +5,7 @@ import type { HumanDecision } from "../lib/human-decisions-memory.js";
 import type { WorkspaceManifest } from "../sandbox/repo-workspace.js";
 import {
   publishTrustedWorkspaceFromSandbox,
+  readBranchShaAfterWrite,
   type TrustedWorkspacePushResult,
 } from "../sandbox/trusted-workspace-publisher.js";
 import {
@@ -298,11 +299,16 @@ verifyPullRequestStep.maxRetries = 3;
 async function verifyFinalizedBranchHeadStep(repository: FinalizedBranch): Promise<string> {
   "use step";
   const { createRepositoryVcsRuntime } = await import("../lib/vcs-runtime.js");
-  return createRepositoryVcsRuntime({
-    provider: repository.provider,
-    repoPath: repository.repoPath,
-    baseBranch: repository.defaultBranch,
-  }).vcs.getBranchSha(repository.branchName);
+  // Publication pushed this branch moments ago, so tolerate a provider ref API
+  // that has not caught up with its own write instead of spending a step retry.
+  return readBranchShaAfterWrite(
+    createRepositoryVcsRuntime({
+      provider: repository.provider,
+      repoPath: repository.repoPath,
+      baseBranch: repository.defaultBranch,
+    }).vcs,
+    repository.branchName,
+  );
 }
 verifyFinalizedBranchHeadStep.maxRetries = 3;
 


### PR DESCRIPTION
## Summary

Fixes every code-level finding from the 2026-07-30 production stress test (docs/qa/production-stress-test-findings.md), each verified against the live production DB or reproduced with a failing test before the fix.

### Approvals (the top blocker)
- Runs parked at the plan-approval gate persisted status `success`; they now persist `awaiting` and are settled when the approval is decided (approve and reject).
- The Approvals page was unusable: an SSR/client timestamp mismatch broke hydration (duplicate rows, dead click handlers). Timestamps now render post-mount with a pinned locale.
- Pending approvals were silently destroyed: the reconciler treated approval-parked tickets (moved out of the Ai column by design) as orphans and its cancellation cascade flipped pending rows to `superseded` with no successor (confirmed in the prod DB for AWP-41/45/47). Approval-parked subjects now go through the terminal-cleanup channel (quiet claim release, approval row untouched), with the same guard in the Jira webhook path.
- Approval parks now surface correctly in the Input-needed panels with a "Review plan" CTA to /approvals instead of a dead-end clarification prompt.

### Dispatch black hole (AWP-49)
- `trigger_ticket_ai` had no owner row in `workflow_definition_triggers` on prod (confirmed via DB), so every fresh ticket dispatch was skipped silently forever. The resolver now self-heals a missing binding when exactly one enabled definition declares the trigger, logs the previously silent stale-binding drop, and records a visible `blocked` run row instead of a silent skip.

### Reliability
- Post-push branch-ref reads (publisher preflight/verify, finalized-branch verify) ride out GitHub read-after-write 404s with a bounded 404-only retry instead of burning full step retries.
- The reconciler no longer sends a "canceled" notification for runs that already reached a terminal state on their own (real failure reasons stay visible in Slack).

### Smaller fixes
- prompt-library `/usage` 500s: zod records now use the two-argument form (the deployed bundle resolves zod 4, where the one-argument form crashes in `safeParse`).
- PII scrubber no longer redacts decimal-only UUID segments as phone numbers.
- Overview "Now running" and the editor banner no longer show long-finished runs as live (dashboard merges live rows against recorded outcomes; the editor block-status query skips registry entries whose run row is already terminal).

## Verification
- Every fix carries a test that failed before the change and passes after; affected test files and typechecks run clean per package.
- Reviewed per-commit and adversarially (cross-commit and rebase interactions) before push; branch rebased onto current main.

## Notes for after merge
- Prod currently has no enabled definition owning `trigger_ticket_ai` and "Human-approved plan" is disabled; after deploy, enabling a definition re-creates the binding automatically.
- AWP-41/45/47 approvals were destroyed pre-fix and need a fresh trigger once deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval-paused runs are clearly identified in the Overview and link directly to plan review.
  * Clarification-paused runs retain their questions and Answer actions.
  * Approval decisions now resolve the associated waiting run.
  * Missing workflow definitions are recorded for clearer run history.
* **Bug Fixes**
  * Prevented approval-paused work from being cancelled incorrectly.
  * Improved recovery of stale workflow bindings and completed runs.
  * Added resilience for temporary branch propagation delays.
  * Preserved UUIDs during sensitive-data sanitization.
* **Tests**
  * Expanded coverage for approvals, cancellation, reconciliation, dispatch, and workspace publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->