### PR TITLE
fix(worker): a second review pass on the release-blocker fixes

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -13,6 +13,7 @@
     "validate:pre-sandbox": "tsx scripts/validate-pre-sandbox-config.ts",
     "capture:agent-protocol-fixtures": "tsx scripts/capture-agent-protocol-fixtures.ts",
     "cleanup:startup-orphans": "tsx scripts/cleanup-startup-orphans.ts",
+    "check:prompt-drift": "tsx src/prompt-library/builtin-prompt-drift-gate.ts",
     "build:arthur-tracer": "node scripts/build-arthur-tracer.mjs",
     "test:e2e": "pnpm test:e2e:agent && pnpm test:e2e:orchestration && pnpm test:e2e:capacity",
     "test:e2e:agent": "pnpm build:shared && vitest run --config e2e/vitest.e2e.config.ts --project agent",

--- a/apps/worker/src/prompt-library/builtin-prompt-drift-gate.test.ts
+++ b/apps/worker/src/prompt-library/builtin-prompt-drift-gate.test.ts
@@ -1,0 +1,223 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { describe, expect, it } from "vitest";
+import type { Db } from "../db/client.js";
+import * as schema from "../db/schema.js";
+import { defaultWorkflowDefinitionV2 } from "../workflow-definition/default.js";
+import {
+  assertNoBuiltInPromptDrift,
+  BuiltInPromptDriftError,
+  evaluateBuiltInPromptDriftGate,
+} from "./builtin-prompt-drift-gate.js";
+import { findBuiltInPromptDrift } from "./builtin-prompt-drift.js";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+const migrationFiles = readdirSync(migrationsDir)
+  .filter((file) => file.endsWith(".sql"))
+  .sort();
+
+interface TestDatabase {
+  client: PGlite;
+  db: Db;
+}
+
+async function migrateThrough(lastPrefix: string): Promise<TestDatabase> {
+  const client = new PGlite();
+  for (const file of migrationFiles) {
+    if (file.slice(0, 4) > lastPrefix) break;
+    await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+  }
+  return { client, db: drizzle({ client, schema }) as unknown as Db };
+}
+
+/** Migration 0013's versionless enabled ticket definition, which the check walks
+ *  as the fresh-install code default. Retired when a fixture needs it out. */
+async function retireFreshInstallDefinition(client: PGlite): Promise<void> {
+  await client.query(
+    `UPDATE workflow_definitions SET enabled = false, archived_at = now() WHERE id = 1`,
+  );
+}
+
+async function deployDefinition(
+  client: PGlite,
+  name: string,
+  definition: unknown,
+): Promise<number> {
+  const created = await client.query<{ id: number }>(
+    `INSERT INTO workflow_definitions (name, enabled, trigger_types, created_by_id, created_by_label)
+     VALUES ($1, false, '{}', 'u_admin', 'Admin') RETURNING id`,
+    [name],
+  );
+  const id = created.rows[0]!.id;
+  await client.query(
+    `INSERT INTO workflow_definition_versions (definition_id, version, definition, created_by_id, created_by_label)
+     VALUES ($1, 1, $2, 'u_admin', 'Admin')`,
+    [id, JSON.stringify(definition)],
+  );
+  await client.query(
+    `UPDATE workflow_definitions SET deployed_version = 1 WHERE id = $1`,
+    [id],
+  );
+  return id;
+}
+
+async function appendPlatformVersion(
+  client: PGlite,
+  slug: string,
+  version: number,
+  body: string,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO prompt_library_versions
+       (prompt_id, version, body, created_by_id, created_by_label, restored_from_version)
+     SELECT id, $2, $3, 'system', 'System migration', NULL
+     FROM prompt_library WHERE slug = $1`,
+    [slug, version, body],
+  );
+}
+
+function definitionPinning(pins: Record<string, string>): unknown {
+  let json = JSON.stringify(
+    defaultWorkflowDefinitionV2({
+      includeReview: true,
+      includeLeakReview: false,
+      provider: "claude",
+    }),
+  );
+  for (const [from, to] of Object.entries(pins)) json = json.replaceAll(from, to);
+  return JSON.parse(json);
+}
+
+const STALE = "stale platform body that is not the shipped constant";
+
+const codesOf = (result: { failures: { code: string }[] }): string[] =>
+  result.failures.map((failure) => failure.code).sort();
+
+describe("built-in prompt drift gate", () => {
+  it("passes on the shipped shape and says what it actually inspected", async () => {
+    const { client, db } = await migrateThrough("9999");
+    await deployDefinition(
+      client,
+      "Deployed ticket workflow",
+      defaultWorkflowDefinitionV2({
+        includeReview: true,
+        includeLeakReview: false,
+        provider: "claude",
+      }),
+    );
+
+    const result = await assertNoBuiltInPromptDrift(db);
+
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.report.pins.length).toBe(6);
+    expect(result.message).toContain("passed");
+    expect(result.message).toContain("6 reference(s)");
+  });
+
+  it("fails on drift: a platform version a run resolves no longer matches the constant", async () => {
+    const { client, db } = await migrateThrough("0036");
+    await retireFreshInstallDefinition(client);
+    await appendPlatformVersion(client, "implement", 2, STALE);
+    await deployDefinition(
+      client,
+      "Deployed ticket workflow",
+      definitionPinning({ "{{prompt:implement@1}}": "{{prompt:implement@2}}" }),
+    );
+
+    const result = evaluateBuiltInPromptDriftGate(
+      await findBuiltInPromptDrift(db),
+    );
+
+    expect(codesOf(result)).toEqual(["drift"]);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("implement@2");
+    await expect(assertNoBuiltInPromptDrift(db)).rejects.toBeInstanceOf(
+      BuiltInPromptDriftError,
+    );
+  });
+
+  it("fails on unfixable drift even though the drift list is empty", async () => {
+    // This is the case a gate written as `if (report.drift.length)` would wave
+    // through: the body is wrong AND no resync migration will ever repair it,
+    // because 0037's guard requires an unarchived, platform-owned parent row.
+    const { client, db } = await migrateThrough("0036");
+    await retireFreshInstallDefinition(client);
+    await appendPlatformVersion(client, "implement", 2, STALE);
+    await client.query(
+      `UPDATE prompt_library SET archived_at = now() WHERE slug = 'implement'`,
+    );
+    await deployDefinition(
+      client,
+      "Deployed ticket workflow",
+      definitionPinning({ "{{prompt:implement@1}}": "{{prompt:implement@2}}" }),
+    );
+
+    const report = await findBuiltInPromptDrift(db);
+    const result = evaluateBuiltInPromptDriftGate(report);
+
+    expect(report.drift).toEqual([]);
+    expect(report.unfixableDrift).toHaveLength(1);
+    expect(codesOf(result)).toEqual(["unfixable_drift"]);
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("no resync migration can");
+  });
+
+  it("fails on an incomplete walk even when everything it did read was clean", async () => {
+    const { client, db } = await migrateThrough("9999");
+    await deployDefinition(client, "Broken shape", {
+      schemaVersion: 2,
+      nodes: "nope",
+    });
+
+    const report = await findBuiltInPromptDrift(db);
+    const result = evaluateBuiltInPromptDriftGate(report);
+
+    // The fresh-install default still resolves cleanly, so drift is empty and
+    // the walk is non-empty; only the unread snapshot makes this a failure.
+    expect(report.drift).toEqual([]);
+    expect(report.pins.length).toBeGreaterThan(0);
+    expect(codesOf(result)).toEqual(["incomplete_walk"]);
+    expect(result.message).toContain("NOT WALKED");
+  });
+
+  it("fails when nothing was inspected at all", async () => {
+    // No deployed definition, no queue, and the fresh-install row retired: the
+    // report is empty, which is the failure that looks exactly like success.
+    const { client, db } = await migrateThrough("9999");
+    await retireFreshInstallDefinition(client);
+
+    const report = await findBuiltInPromptDrift(db);
+    const result = evaluateBuiltInPromptDriftGate(report);
+
+    expect(report.pins).toEqual([]);
+    expect(report.drift).toEqual([]);
+    expect(report.skipped).toEqual([]);
+    expect(report.definitionsWalked).toBe(0);
+    expect(codesOf(result)).toEqual(["nothing_inspected"]);
+    expect(result.message).toContain("An empty report is not a clean one");
+  });
+
+  it("reports every failing condition at once rather than the first", async () => {
+    const { client, db } = await migrateThrough("0036");
+    await retireFreshInstallDefinition(client);
+    await appendPlatformVersion(client, "implement", 2, STALE);
+    await deployDefinition(
+      client,
+      "Deployed ticket workflow",
+      definitionPinning({ "{{prompt:implement@1}}": "{{prompt:implement@2}}" }),
+    );
+    await deployDefinition(client, "Broken shape", {
+      schemaVersion: 2,
+      nodes: "nope",
+    });
+
+    const result = evaluateBuiltInPromptDriftGate(
+      await findBuiltInPromptDrift(db),
+    );
+
+    expect(codesOf(result)).toEqual(["drift", "incomplete_walk"]);
+  });
+});

--- a/apps/worker/src/prompt-library/builtin-prompt-drift-gate.ts
+++ b/apps/worker/src/prompt-library/builtin-prompt-drift-gate.ts
@@ -1,0 +1,152 @@
+import { fileURLToPath } from "node:url";
+import type { Db } from "../db/client.js";
+import {
+  describeBuiltInPromptDrift,
+  findBuiltInPromptDrift,
+  type BuiltInPromptDriftReport,
+  type FindBuiltInPromptDriftOptions,
+} from "./builtin-prompt-drift.js";
+
+/**
+ * The caller for the built-in prompt drift report.
+ *
+ * findBuiltInPromptDrift only describes; this decides. It exists because a
+ * report nobody reads is the same as no report: the defect it was written for
+ * (0034 and 0036 silently correcting a row no run resolved) survived precisely
+ * because nothing ever compared what a run resolves against what the code
+ * ships.
+ *
+ * Two callers use this gate, and they catch different things:
+ *
+ *   1. The test suite (builtin-prompt-drift-gate.test.ts), which runs it against
+ *      a database built from the committed migrations. In CI there is no
+ *      production data, so it CANNOT see a row inserted out of band, which is
+ *      exactly how production got `implement@2`. What it does catch, and what
+ *      nothing caught before, is a code constant edited without a matching
+ *      resync migration: the seeded and fresh-install shapes then stop matching
+ *      DEFAULT_AGENT_PROMPTS and the suite goes red on the offending commit.
+ *
+ *   2. `runBuiltInPromptDriftGate` as a command against a real DATABASE_URL,
+ *      which is the half that sees production rows. Run it after deploying a
+ *      release that changes any built-in prompt:
+ *
+ *        pnpm exec tsx src/prompt-library/builtin-prompt-drift-gate.ts
+ *
+ * The gate fails on four conditions, not one. Gating on `drift` alone would
+ * pass a prompt no migration can repair (`unfixableDrift`), a walk that could
+ * not read part of the graph (`skipped`), and a walk that inspected nothing at
+ * all (`pins` empty). The last is the important one: an empty result is the
+ * failure mode a check like this dies of, and it looks identical to success.
+ */
+
+export type BuiltInPromptDriftGateFailureCode =
+  | "drift"
+  | "unfixable_drift"
+  | "incomplete_walk"
+  | "nothing_inspected";
+
+export interface BuiltInPromptDriftGateFailure {
+  code: BuiltInPromptDriftGateFailureCode;
+  detail: string;
+}
+
+export interface BuiltInPromptDriftGateResult {
+  ok: boolean;
+  failures: BuiltInPromptDriftGateFailure[];
+  report: BuiltInPromptDriftReport;
+  /** Operator-facing summary: the failures, then the report's own detail. */
+  message: string;
+}
+
+export function evaluateBuiltInPromptDriftGate(
+  report: BuiltInPromptDriftReport,
+): BuiltInPromptDriftGateResult {
+  const failures: BuiltInPromptDriftGateFailure[] = [];
+
+  if (report.drift.length > 0) {
+    failures.push({
+      code: "drift",
+      detail:
+        `${report.drift.length} platform prompt version(s) a run can still resolve ` +
+        `no longer match DEFAULT_AGENT_PROMPTS. A resync migration will correct these.`,
+    });
+  }
+  if (report.unfixableDrift.length > 0) {
+    failures.push({
+      code: "unfixable_drift",
+      detail:
+        `${report.unfixableDrift.length} platform prompt version(s) drifted under a prompt row ` +
+        `no resync migration will touch (archived, or not platform-owned). Code alone cannot fix these.`,
+    });
+  }
+  if (report.skipped.length > 0) {
+    failures.push({
+      code: "incomplete_walk",
+      detail:
+        `${report.skipped.length} definition snapshot(s) or block(s) could not be read, so the ` +
+        `report is incomplete and a clean drift list proves nothing.`,
+    });
+  }
+  if (report.pins.length === 0) {
+    failures.push({
+      code: "nothing_inspected",
+      detail:
+        `No built-in prompt reference was reached at all (definitionsWalked=${report.definitionsWalked}). ` +
+        `An empty report is not a clean one: the walk found nothing to check.`,
+    });
+  }
+
+  const detail = describeBuiltInPromptDrift(report);
+  return {
+    ok: failures.length === 0,
+    failures,
+    report,
+    message:
+      failures.length === 0
+        ? `Built-in prompt drift gate passed: ${report.pins.length} reference(s) across ` +
+          `${report.definitionsWalked} definition snapshot(s) match the shipped constants.`
+        : [
+            "Built-in prompt drift gate FAILED.",
+            ...failures.map((failure) => `  [${failure.code}] ${failure.detail}`),
+            ...(detail === "" ? [] : ["", detail]),
+          ].join("\n"),
+  };
+}
+
+export class BuiltInPromptDriftError extends Error {
+  constructor(readonly result: BuiltInPromptDriftGateResult) {
+    super(result.message);
+    this.name = "BuiltInPromptDriftError";
+  }
+}
+
+/** Throws BuiltInPromptDriftError unless every gate condition passes. */
+export async function assertNoBuiltInPromptDrift(
+  db: Db,
+  options: FindBuiltInPromptDriftOptions = {},
+): Promise<BuiltInPromptDriftGateResult> {
+  const result = evaluateBuiltInPromptDriftGate(
+    await findBuiltInPromptDrift(db, options),
+  );
+  if (!result.ok) throw new BuiltInPromptDriftError(result);
+  return result;
+}
+
+/** Command entry point. Resolves the database lazily so importing this module
+ *  never requires DATABASE_URL to be set. */
+export async function runBuiltInPromptDriftGate(): Promise<number> {
+  const { getDb } = await import("../db/client.js");
+  const result = evaluateBuiltInPromptDriftGate(
+    await findBuiltInPromptDrift(getDb()),
+  );
+  console.log(result.message);
+  return result.ok ? 0 : 1;
+}
+
+// Only when executed directly, never on import.
+if (
+  process.argv[1] !== undefined &&
+  process.argv[1] === fileURLToPath(import.meta.url)
+) {
+  process.exitCode = await runBuiltInPromptDriftGate();
+}

--- a/apps/worker/src/prompt-library/builtin-prompt-drift.test.ts
+++ b/apps/worker/src/prompt-library/builtin-prompt-drift.test.ts
@@ -3,7 +3,11 @@ import { fileURLToPath } from "node:url";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle } from "drizzle-orm/pglite";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_AGENT_PROMPTS, type WorkflowDefinitionV2 } from "@shared/contracts";
+import {
+  DEFAULT_AGENT_PROMPTS,
+  WORKFLOW_PROMPT_PARAM_KEYS,
+  type WorkflowDefinitionV2,
+} from "@shared/contracts";
 import type { Db } from "../db/client.js";
 import * as schema from "../db/schema.js";
 import { defaultWorkflowDefinitionV2 } from "../workflow-definition/default.js";
@@ -526,5 +530,151 @@ describe("findBuiltInPromptDrift", () => {
       "unknown_node_type:mystery",
     ]);
     expect(describeBuiltInPromptDrift(report)).toContain("NOT WALKED");
+  });
+
+  it("does not count a snapshot with no blocks as a walked definition", async () => {
+    const { client, db } = await migrateThrough("9999");
+    await retireFreshInstallDefinition(client);
+    await deployDefinition(client, "Empty graph", {
+      schemaVersion: 2,
+      nodes: [],
+    });
+
+    const report = await findBuiltInPromptDrift(db);
+
+    // An array is not an inspection: nothing was read, so nothing may be
+    // counted, and the empty node list is named instead of passing quietly.
+    expect(report.definitionsWalked).toBe(0);
+    expect(report.pins).toEqual([]);
+    expect(report.skipped.map((skip) => skip.reason)).toEqual([
+      "definition_has_no_nodes",
+    ]);
+  });
+
+  it("names a prompt-bearing block type that has no prompt-key entry", async () => {
+    // Reproduces the next version of the very bug this report exists to catch:
+    // WORKFLOW_PROMPT_PARAM_KEYS is a Partial record, so an agent block added
+    // without a key entry would contribute no fields, no pins and no findings,
+    // while the walk still looked successful. Simulated by removing an existing
+    // entry, because no such block type exists yet.
+    const { client, db } = await migrateThrough("9999");
+    await retireFreshInstallDefinition(client);
+    await deployDefinition(
+      client,
+      "Deployed ticket workflow",
+      defaultWorkflowDefinitionV2({
+        includeReview: true,
+        includeLeakReview: false,
+        provider: "claude",
+      }),
+    );
+    const mutable = WORKFLOW_PROMPT_PARAM_KEYS as Record<
+      string,
+      readonly string[] | undefined
+    >;
+    const original = mutable.review_agent;
+
+    try {
+      delete mutable.review_agent;
+      const report = await findBuiltInPromptDrift(db);
+
+      expect(
+        report.skipped.map((skip) => `${skip.reason}:${skip.nodeId ?? "-"}`),
+      ).toEqual(["prompt_keys_unknown:review"]);
+      // The review pin is genuinely gone from the walk, which is exactly why the
+      // silence has to be recorded rather than inferred from a clean drift list.
+      expect(report.pins.map((pin) => pin.slug).sort()).toEqual([
+        "implement",
+        "research-plan",
+      ]);
+      expect(report.drift).toEqual([]);
+    } finally {
+      mutable.review_agent = original;
+    }
+
+    // Restored, so the same walk sees all three again.
+    const restored = await findBuiltInPromptDrift(db);
+    expect(restored.skipped).toEqual([]);
+    expect(restored.pins.map((pin) => pin.slug).sort()).toEqual([
+      "implement",
+      "research-plan",
+      "review",
+    ]);
+  });
+
+  it("costs the same whether the queue holds five rows or two hundred", async () => {
+    // A wedged dispatcher is exactly when someone runs this check, so the cost
+    // must not scale with the queue depth. The queues are deduplicated in SQL
+    // and the remaining lookups are batched, so the number of round trips is a
+    // function of distinct snapshots, not of pending events.
+    const measure = async (
+      deliveries: number,
+    ): Promise<{ calls: number; report: Awaited<ReturnType<typeof findBuiltInPromptDrift>> }> => {
+      const { client, db } = await migrateThrough("9999");
+      await retireFreshInstallDefinition(client);
+      const definitionId = await deployDefinition(
+        client,
+        "Deployed ticket workflow",
+        defaultWorkflowDefinitionV2({
+          includeReview: true,
+          includeLeakReview: false,
+          provider: "claude",
+        }),
+      );
+      await client.query(
+        `UPDATE workflow_definitions SET archived_at = now() WHERE id = $1`,
+        [definitionId],
+      );
+      for (let index = 0; index < deliveries; index += 1) {
+        await client.query(
+          `INSERT INTO trigger_deliveries
+             (provider, delivery_id, producer, trigger_type, subject_key, head_sha,
+              definition_id, definition_version, payload, pending)
+           VALUES ('github', $1, 'test', 'trigger_pr_created', $2, 'sha', $3, 1, '{}'::jsonb, true)`,
+          [`d_${index}`, `subject_${index}`, definitionId],
+        );
+      }
+
+      let calls = 0;
+      const query = client.query.bind(client);
+      const exec = client.exec.bind(client);
+      Object.assign(client, {
+        query: (...args: Parameters<typeof query>) => {
+          calls += 1;
+          return query(...args);
+        },
+        exec: (...args: Parameters<typeof exec>) => {
+          calls += 1;
+          return exec(...args);
+        },
+      });
+      try {
+        // Await first, then read the counter. Building the object literal with
+        // `{ calls, report: await ... }` would evaluate `calls` before the await
+        // and record 0 every time, which is a vacuous pass.
+        const report = await findBuiltInPromptDrift(db);
+        return { calls, report };
+      } finally {
+        Object.assign(client, { query, exec });
+      }
+    };
+
+    const small = await measure(5);
+    const large = await measure(200);
+
+    // The counter must observe something, or "equal" would mean "measured
+    // nothing" rather than "cost nothing".
+    expect(small.calls).toBeGreaterThan(0);
+    expect(large.calls).toBe(small.calls);
+    // And the flood still resolves to exactly one snapshot, walked once.
+    for (const { report } of [small, large]) {
+      expect(report.definitionsWalked).toBe(1);
+      expect(report.skipped).toEqual([]);
+      expect(report.pins.map(pinKey).sort()).toEqual([
+        "trigger_delivery:implement@1",
+        "trigger_delivery:research-plan@1",
+        "trigger_delivery:review@1",
+      ]);
+    }
   });
 });

--- a/apps/worker/src/prompt-library/builtin-prompt-drift.test.ts
+++ b/apps/worker/src/prompt-library/builtin-prompt-drift.test.ts
@@ -11,6 +11,7 @@ import {
 import type { Db } from "../db/client.js";
 import * as schema from "../db/schema.js";
 import { defaultWorkflowDefinitionV2 } from "../workflow-definition/default.js";
+import { evaluateBuiltInPromptDriftGate } from "./builtin-prompt-drift-gate.js";
 import {
   describeBuiltInPromptDrift,
   findBuiltInPromptDrift,
@@ -530,6 +531,67 @@ describe("findBuiltInPromptDrift", () => {
       "unknown_node_type:mystery",
     ]);
     expect(describeBuiltInPromptDrift(report)).toContain("NOT WALKED");
+  });
+
+  it("does not report a gap for a queue row that resolves to the walked code default", async () => {
+    // A fresh install: migration 0013's enabled, versionless ticket definition
+    // is walked as the code default, and an approval filed against it pins no
+    // version because there is none to pin. That row resolves to the snapshot
+    // that was just walked, so it is a duplicate, not something unread.
+    // Reporting it would fail the gate on `skipped.length` for a healthy
+    // install, and a gate that cries wolf on day one is a gate someone mutes.
+    const { client, db } = await migrateThrough("9999");
+    await client.query(
+      `INSERT INTO approval_requests (id, ticket_key, definition_id, definition_version, run_id, plan, status)
+       VALUES ('ap_default', 'AWP-1', 1, NULL, 'wrun_1', '{"markdown":"plan"}'::jsonb, 'pending')`,
+    );
+
+    const report = await findBuiltInPromptDrift(db);
+
+    expect(report.skipped).toEqual([]);
+    expect(report.definitionsWalked).toBe(1);
+    expect(report.pins.map(pinKey).sort()).toEqual([
+      "fresh_install_default:implement@1",
+      "fresh_install_default:research-plan@1",
+      "fresh_install_default:review@1",
+    ]);
+    // The whole point: the gate stays green on a healthy fresh install.
+    const gate = evaluateBuiltInPromptDriftGate(report);
+    expect(gate.failures).toEqual([]);
+    expect(gate.ok).toBe(true);
+  });
+
+  it("still reports a gap for a queue row nothing walked", async () => {
+    // Same unresolvable shape, but nothing covers this definition: it is not
+    // enabled, so the fresh-install walk skips it, and it has no deployed
+    // version for the null pin to fall back to. Dispatch would fail this
+    // approval with definition_gone, and the report has to say so.
+    const { client, db } = await migrateThrough("9999");
+    const created = await client.query<{ id: number }>(
+      `INSERT INTO workflow_definitions (name, enabled, trigger_types, created_by_id, created_by_label)
+       VALUES ('Never deployed', false, '{trigger_ticket_ai}', 'u_admin', 'Admin') RETURNING id`,
+    );
+    const orphan = created.rows[0]!.id;
+    await client.query(
+      `INSERT INTO approval_requests (id, ticket_key, definition_id, definition_version, run_id, plan, status)
+       VALUES ('ap_orphan', 'AWP-2', $1, NULL, 'wrun_2', '{"markdown":"plan"}'::jsonb, 'pending')`,
+      [orphan],
+    );
+
+    const report = await findBuiltInPromptDrift(db);
+
+    expect(report.skipped).toHaveLength(1);
+    expect(report.skipped[0]).toMatchObject({
+      reason: "definition_version_missing",
+      definitionId: orphan,
+      definitionVersion: null,
+      source: "approval",
+      detail:
+        "reachable snapshot pins no version and the definition has none deployed",
+    });
+    expect(evaluateBuiltInPromptDriftGate(report).failures.map((f) => f.code)).toEqual([
+      "incomplete_walk",
+    ]);
   });
 
   it("does not count a snapshot with no blocks as a walked definition", async () => {

--- a/apps/worker/src/prompt-library/builtin-prompt-drift.ts
+++ b/apps/worker/src/prompt-library/builtin-prompt-drift.ts
@@ -7,7 +7,7 @@ import {
   type PromptReferenceSelector,
   type WorkflowBlockType,
 } from "@shared/contracts";
-import { and, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
 import type { Db } from "../db/client.js";
 import {
   approvalRequests,
@@ -140,8 +140,10 @@ export interface SkippedWalkTarget {
   reason:
     | "definition_version_missing"
     | "definition_shape"
+    | "definition_has_no_nodes"
     | "node_shape"
     | "unknown_node_type"
+    | "prompt_keys_unknown"
     | "node_container_missing";
   definitionId: number;
   definitionVersion: number | null;
@@ -166,8 +168,12 @@ export interface BuiltInPromptDriftReport {
   customerAuthored: BuiltInPromptPin[];
   /** References a reachable snapshot pins that resolve to nothing. */
   unresolved: UnresolvedPromptReference[];
-  /** Definition snapshots whose node list was actually read. Zero means the
-   *  report is meaningless, not clean. */
+  /**
+   * Definition snapshots that had at least one node and were read. Diagnostic
+   * only: it counts snapshots opened, not references checked, so it is the
+   * weaker signal. `pins.length` is what tells you the walk actually reached
+   * built-in prompt text, and that is what the gate trusts.
+   */
   definitionsWalked: number;
   /** Everything the walk could not read. Non-empty means the report is
    *  incomplete and must not be treated as a pass. */
@@ -212,6 +218,19 @@ export function describeBuiltInPromptDrift(
     ),
   ];
   return lines.join("\n");
+}
+
+/**
+ * Whether a block type is one that carries authored prompt text by convention.
+ *
+ * BLOCK_TYPE_SPECS records only category (trigger/action/control), so there is
+ * no structural "is an agent" flag to read. Naming is the available signal, and
+ * every prompt-bearing block today is either `*_agent` or `call_llm`. The point
+ * is not to classify blocks, it is to notice a block that looks like it should
+ * have a prompt-key entry and does not.
+ */
+function carriesPromptByConvention(blockType: string): boolean {
+  return blockType.endsWith("_agent") || blockType === "call_llm";
 }
 
 function isPlatformAuthored(row: {
@@ -318,6 +337,12 @@ async function collectWalkTargets(
     });
   }
 
+  // Deduplicated in SQL, not afterwards. A queue holds one row per event, not
+  // per definition: a wedged dispatcher with thousands of pending deliveries all
+  // pointing at one definition is exactly when someone runs this check, and
+  // selectDistinct makes that return a single row instead of thousands. The work
+  // below is then bounded by the number of distinct pinned snapshots, which is
+  // bounded by the number of definition versions that exist.
   const reachable: {
     definitionId: number;
     definitionVersion: number | null;
@@ -325,7 +350,7 @@ async function collectWalkTargets(
   }[] = [
     ...(
       await db
-        .select({
+        .selectDistinct({
           definitionId: approvalRequests.definitionId,
           definitionVersion: approvalRequests.definitionVersion,
         })
@@ -334,7 +359,7 @@ async function collectWalkTargets(
     ).map((row) => ({ ...row, source: "approval" as const })),
     ...(
       await db
-        .select({
+        .selectDistinct({
           definitionId: triggerDeliveries.definitionId,
           definitionVersion: triggerDeliveries.definitionVersion,
         })
@@ -343,7 +368,7 @@ async function collectWalkTargets(
     ).map((row) => ({ ...row, source: "trigger_delivery" as const })),
     ...(
       await db
-        .select({
+        .selectDistinct({
           definitionId: manualDispatchRequests.definitionId,
           definitionVersion: manualDispatchRequests.definitionVersion,
         })
@@ -354,7 +379,17 @@ async function collectWalkTargets(
     ).map((row) => ({ ...row, source: "manual_dispatch" as const })),
   ];
 
+  // The three queues can each name the same snapshot, so collapse across them
+  // before any further query runs. First source wins, matching the ordering
+  // rationale above.
+  const pending = new Map<string, (typeof reachable)[number]>();
   for (const entry of reachable) {
+    const key = `${entry.definitionId}@${entry.definitionVersion ?? "deployed"}`;
+    if (!pending.has(key)) pending.set(key, entry);
+  }
+
+  if (pending.size > 0) {
+    // One query for every definition the queues name, instead of one per row.
     const definitionRows = await db
       .select({
         id: workflowDefinitions.id,
@@ -362,54 +397,99 @@ async function collectWalkTargets(
         deployedVersion: workflowDefinitions.deployedVersion,
       })
       .from(workflowDefinitions)
-      .where(eq(workflowDefinitions.id, entry.definitionId))
-      .limit(1);
-    const definitionRow = definitionRows[0];
-    // A legacy approval with no pinned version falls back to the deployed
-    // version, exactly as approvals/dispatch.ts does.
-    const version = entry.definitionVersion ?? definitionRow?.deployedVersion ?? null;
-    if (!definitionRow || version === null) {
-      skipped.push({
-        reason: "definition_version_missing",
-        definitionId: entry.definitionId,
-        definitionVersion: entry.definitionVersion,
-        source: entry.source,
-        nodeId: null,
-        detail: definitionRow
-          ? "reachable snapshot pins no version and the definition has none deployed"
-          : "reachable snapshot points at a definition that no longer exists",
-      });
-      continue;
-    }
-    if (seen.has(`${entry.definitionId}@${version}`)) continue;
-    const versionRows = await db
-      .select({ definition: workflowDefinitionVersions.definition })
-      .from(workflowDefinitionVersions)
       .where(
-        and(
-          eq(workflowDefinitionVersions.definitionId, entry.definitionId),
-          eq(workflowDefinitionVersions.version, version),
+        inArray(
+          workflowDefinitions.id,
+          [...new Set([...pending.values()].map((entry) => entry.definitionId))],
         ),
-      )
-      .limit(1);
-    if (versionRows.length === 0) {
-      skipped.push({
-        reason: "definition_version_missing",
+      );
+    const definitionById = new Map(definitionRows.map((row) => [row.id, row]));
+
+    // Resolve each entry to a concrete version and drop everything already
+    // collected, before touching workflow_definition_versions at all.
+    const wanted: {
+      definitionId: number;
+      definitionName: string;
+      version: number;
+      source: BuiltInPromptPinSource;
+    }[] = [];
+    const wantedKeys = new Set<string>();
+    for (const entry of pending.values()) {
+      const definitionRow = definitionById.get(entry.definitionId);
+      // A legacy approval with no pinned version falls back to the deployed
+      // version, exactly as approvals/dispatch.ts does.
+      const version =
+        entry.definitionVersion ?? definitionRow?.deployedVersion ?? null;
+      if (!definitionRow || version === null) {
+        skipped.push({
+          reason: "definition_version_missing",
+          definitionId: entry.definitionId,
+          definitionVersion: entry.definitionVersion,
+          source: entry.source,
+          nodeId: null,
+          detail: definitionRow
+            ? "reachable snapshot pins no version and the definition has none deployed"
+            : "reachable snapshot points at a definition that no longer exists",
+        });
+        continue;
+      }
+      const key = `${entry.definitionId}@${version}`;
+      if (seen.has(key) || wantedKeys.has(key)) continue;
+      wantedKeys.add(key);
+      wanted.push({
         definitionId: entry.definitionId,
-        definitionVersion: version,
+        definitionName: definitionRow.name,
+        version,
         source: entry.source,
-        nodeId: null,
-        detail: "reachable snapshot pins a version row that does not exist",
       });
-      continue;
     }
-    add({
-      definitionId: entry.definitionId,
-      definitionName: definitionRow.name,
-      definitionVersion: version,
-      source: entry.source,
-      definition: versionRows[0]!.definition,
-    });
+
+    if (wanted.length > 0) {
+      // One query for every distinct snapshot still needed.
+      const versionRows = await db
+        .select({
+          definitionId: workflowDefinitionVersions.definitionId,
+          version: workflowDefinitionVersions.version,
+          definition: workflowDefinitionVersions.definition,
+        })
+        .from(workflowDefinitionVersions)
+        .where(
+          or(
+            ...wanted.map((entry) =>
+              and(
+                eq(workflowDefinitionVersions.definitionId, entry.definitionId),
+                eq(workflowDefinitionVersions.version, entry.version),
+              ),
+            ),
+          ),
+        );
+      const definitionByKey = new Map(
+        versionRows.map((row) => [`${row.definitionId}@${row.version}`, row]),
+      );
+      for (const entry of wanted) {
+        const versionRow = definitionByKey.get(
+          `${entry.definitionId}@${entry.version}`,
+        );
+        if (!versionRow) {
+          skipped.push({
+            reason: "definition_version_missing",
+            definitionId: entry.definitionId,
+            definitionVersion: entry.version,
+            source: entry.source,
+            nodeId: null,
+            detail: "reachable snapshot pins a version row that does not exist",
+          });
+          continue;
+        }
+        add({
+          definitionId: entry.definitionId,
+          definitionName: entry.definitionName,
+          definitionVersion: entry.version,
+          source: entry.source,
+          definition: versionRow.definition,
+        });
+      }
+    }
   }
 
   return targets;
@@ -573,6 +653,20 @@ export async function findBuiltInPromptDrift(
       });
       continue;
     }
+    if (definition.nodes.length === 0) {
+      // An array is not an inspection. A snapshot with no blocks contributed
+      // nothing, so counting it as walked would let an empty result look like a
+      // clean one.
+      skipped.push({
+        reason: "definition_has_no_nodes",
+        definitionId: target.definitionId,
+        definitionVersion: target.definitionVersion,
+        source: target.source,
+        nodeId: null,
+        detail: "stored definition has an empty nodes array",
+      });
+      continue;
+    }
     definitionsWalked += 1;
     // Anything not explicitly schema 2 is read as v1, which is how the runtime
     // treats a legacy row predating the field.
@@ -623,9 +717,25 @@ export async function findBuiltInPromptDrift(
         source: target.source,
         nodeId,
       };
-      const keys = WORKFLOW_PROMPT_PARAM_KEYS[blockType] ?? [];
+      const keys = WORKFLOW_PROMPT_PARAM_KEYS[blockType];
+      if (keys === undefined && carriesPromptByConvention(blockType)) {
+        // The blind spot this whole report exists to prevent, one level down.
+        // WORKFLOW_PROMPT_PARAM_KEYS is a Partial record, so a new agent block
+        // added without a key entry would silently contribute no fields and no
+        // finding, and the walk would still look successful. Naming it is the
+        // only way the next person hears about it.
+        skipped.push({
+          reason: "prompt_keys_unknown",
+          definitionId: target.definitionId,
+          definitionVersion: target.definitionVersion,
+          source: target.source,
+          nodeId,
+          detail: `block type "${blockType}" looks prompt-bearing but has no WORKFLOW_PROMPT_PARAM_KEYS entry, so its prompt fields cannot be located`,
+        });
+        continue;
+      }
       const fields =
-        keys.length === 0
+        keys === undefined || keys.length === 0
           ? []
           : promptFields(schemaVersion, node, target, nodeId, keys, skipped);
       for (const { field, text } of fields) {

--- a/apps/worker/src/prompt-library/builtin-prompt-drift.ts
+++ b/apps/worker/src/prompt-library/builtin-prompt-drift.ts
@@ -420,6 +420,19 @@ async function collectWalkTargets(
       // version, exactly as approvals/dispatch.ts does.
       const version =
         entry.definitionVersion ?? definitionRow?.deployedVersion ?? null;
+      // Resolving to no concrete version does not automatically mean a gap. A
+      // queue row that pins nothing against a definition with nothing deployed
+      // targets the very code-default snapshot the fresh-install walk already
+      // covers, so reporting it as unread would fail the gate on a healthy
+      // fresh install. Dedupe against what was walked before deciding it is a
+      // gap; a definition nobody walked still records one below.
+      if (
+        definitionRow &&
+        version === null &&
+        seen.has(`${entry.definitionId}@default`)
+      ) {
+        continue;
+      }
       if (!definitionRow || version === null) {
         skipped.push({
           reason: "definition_version_missing",

--- a/apps/worker/src/workflow-definition/failure-message.test.ts
+++ b/apps/worker/src/workflow-definition/failure-message.test.ts
@@ -260,6 +260,8 @@ describe("sanitizeFailureMessage", () => {
     // The first of these is a real GitHub and GitLab HTTP error. A rule that
     // accepts any eight-or-more-letter run ate the diagnosis on exactly the git
     // auth failure this file exists to preserve, and rewrote the prose casing.
+    // The 16-character floor is what keeps these green; measured against real
+    // corpora the longest lowercase word following "basic" is 14 characters.
     for (const prose of [
       "remote: Basic authentication is not supported for Git operations.",
       "basic authentication failed for repository origin",
@@ -268,6 +270,18 @@ describe("sanitizeFailureMessage", () => {
       "Bearer Credentials were not supplied.",
     ]) {
       expect(sanitizeFailureMessage(prose), prose).toBe(prose);
+    }
+  });
+
+  it("keeps the longest real prose word under the redaction floor", () => {
+    // Pins the 2-character margin the floor relies on. If a longer word is ever
+    // found following a scheme word in real error text, this is the assumption
+    // that broke.
+    for (const word of ["authentication", "implementation", "optimizations"]) {
+      expect(word.length, word).toBeLessThan(16);
+      expect(sanitizeFailureMessage(`Basic ${word} is not supported`)).toBe(
+        `Basic ${word} is not supported`,
+      );
     }
   });
 
@@ -291,6 +305,25 @@ describe("sanitizeFailureMessage", () => {
     expect(sanitizeFailureMessage(`authorization: bearer ${jwt}`)).toBe(
       "authorization: Bearer [redacted]",
     );
+  });
+
+  it("redacts an all-lowercase opaque token after either scheme word", () => {
+    // A valid bearer token carries no guarantee of an uppercase letter or a
+    // digit, and for base64 the guarantee is only probabilistic: a 16-character
+    // run is all-lowercase roughly one time in 1.8 million. A composition check
+    // therefore traded a certain under-redaction for a prose risk the
+    // 16-character floor already covers, on the path that reaches Slack, the
+    // GitLab commit status and the dashboard.
+    expect(sanitizeFailureMessage("Authorization: Bearer abcdefghijklmnop")).toBe(
+      "Authorization: Bearer [redacted]",
+    );
+    expect(sanitizeFailureMessage("Authorization: Basic abcdefghijklmnop")).toBe(
+      "Authorization: Basic [redacted]",
+    );
+    // And in the composed shape a real failure message takes.
+    expect(
+      sanitizeDetail("push rejected: Authorization: bearer qwertyuiopasdfghjkl"),
+    ).toBe("push rejected: Authorization: Bearer [redacted]");
   });
 
   it("still redacts an encoded value after the scheme word, either casing", () => {

--- a/apps/worker/src/workflow-definition/failure-message.test.ts
+++ b/apps/worker/src/workflow-definition/failure-message.test.ts
@@ -256,6 +256,21 @@ describe("sanitizeFailureMessage", () => {
     ).toBe("[redacted]");
   });
 
+  it("leaves prose after the scheme word alone", () => {
+    // The first of these is a real GitHub and GitLab HTTP error. A rule that
+    // accepts any eight-or-more-letter run ate the diagnosis on exactly the git
+    // auth failure this file exists to preserve, and rewrote the prose casing.
+    for (const prose of [
+      "remote: Basic authentication is not supported for Git operations.",
+      "basic authentication failed for repository origin",
+      "No bearer credentials were supplied by the caller.",
+      "remote: Basic Authentication is not supported.",
+      "Bearer Credentials were not supplied.",
+    ]) {
+      expect(sanitizeFailureMessage(prose), prose).toBe(prose);
+    }
+  });
+
   it("redacts Basic credentials and whole JWTs, not just their signature", () => {
     const basic = sanitizeFailureMessage(
       "clone failed: Authorization: Basic eHVzZXI6c2VjcmV0dmFsdWU=",
@@ -268,6 +283,60 @@ describe("sanitizeFailureMessage", () => {
     const out = sanitizeFailureMessage(`token ${jwt} rejected`);
     expect(out).not.toContain("eyJzdWIiOiJhZG1pbiJ9");
     expect(out).toBe("token [redacted] rejected");
+
+    // Signature-less JWT, and a Bearer-carried one.
+    expect(
+      sanitizeFailureMessage("cookie eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9 set"),
+    ).toBe("cookie [redacted] set");
+    expect(sanitizeFailureMessage(`authorization: bearer ${jwt}`)).toBe(
+      "authorization: Bearer [redacted]",
+    );
+  });
+
+  it("still redacts an encoded value after the scheme word, either casing", () => {
+    for (const [input, expected] of [
+      [
+        "clone failed: Authorization: Basic dXNlcjpwYXNzd29yZDEyMw==",
+        "clone failed: Authorization: Basic [redacted]",
+      ],
+      // Lowercase scheme, as HTTP/2 and curl -v print it.
+      ["authorization: basic eHVzZXI6c2VjcmV0dmFsdWU=", "authorization: Basic [redacted]"],
+      // Opaque all-lowercase token: kept covered by the separator evidence, so
+      // the prose fix did not weaken this direction.
+      ["Authorization: Bearer abcdef.ghijkl-mnop_qrstuv", "Authorization: Bearer [redacted]"],
+      ["Bearer sk-ant-api03-abcDEF1234567890_-token", "Bearer [redacted]"],
+    ] as const) {
+      expect(sanitizeFailureMessage(input), input).toBe(expected);
+    }
+  });
+
+  it("rejects a diagnostic ID longer than any real one", () => {
+    // Repeating the segment group left the total length unbounded, so a bulk
+    // payload chunked into cap-sized segments satisfied the shape. Segments are
+    // deliberately non-hex so the earlier hex rule is not what redacts them.
+    const segment = "Zx".repeat(16);
+    const chunked = `AIW-DIAG-${segment}-${segment}-${segment}-${segment}-1`;
+    expect(segment.length).toBe(32);
+    expect(chunked.length).toBeGreaterThan(120);
+    expect(sanitizeFailureMessage(`echoed ${chunked}`)).toBe("echoed [redacted]");
+  });
+
+  it("KNOWN LIMITATION: shape matching is defeatable by chunking a known secret", () => {
+    // Recorded as an executable fact, not hidden in a comment. This is shape
+    // matching, not authentication: a secret split across cap-sized segments
+    // still satisfies the shape and survives verbatim. Exploiting it needs text
+    // injection into a failure detail AND prior knowledge of the secret. The
+    // real fix is to splice in the ID we know out of band instead of inspecting
+    // shape, which means threading the run's own ID down to this boundary.
+    // If a future change makes this expectation fail, the weakness is closed:
+    // delete this test rather than restoring the behaviour.
+    // The payload is deliberately not shaped like any real credential: an
+    // earlier version used a Stripe-looking prefix and GitHub push protection
+    // rejected the push. What the case needs is only that the run is opaque,
+    // carries no recognised prefix, and is split into cap-sized segments.
+    const chunked = "AIW-DIAG-notarealsecret_AAAAAAAAAAAAAAAAA-bbbbbbbbbbbbbbbbbbbbbbbbb-0";
+    expect(chunked.length).toBeLessThanOrEqual(120);
+    expect(sanitizeFailureMessage(chunked)).toBe(chunked);
   });
 
   it("still bounds, redacts and single-lines an over-long message", () => {

--- a/apps/worker/src/workflow-definition/failure-message.ts
+++ b/apps/worker/src/workflow-definition/failure-message.ts
@@ -156,27 +156,31 @@ function redactSecrets(text: string): string {
       // Bearer and Basic credentials. Basic needs its own rule: a base64
       // "user:pass" pair is usually well under the token-run length below.
       //
-      // The value must look ENCODED, not word-shaped. "Basic authentication is
-      // not supported" is a real GitHub and GitLab HTTP error, and an
-      // 8-or-more-lowercase-letters rule ate the diagnosis on exactly the git
-      // auth failures this file exists to preserve. Two guards, both needed:
-      // at least 16 characters (rejects "authentication", "credentials", and
-      // their capitalised forms) and at least one non-lowercase character
-      // (rejects long all-lowercase prose). The scheme word is matched with a
-      // character class rather than the /i flag, because /i would also make the
-      // [A-Z] evidence class match lowercase and defeat the whole check.
-      .replace(
-        /\b[Bb]earer\s+(?=[A-Za-z0-9._-]*[A-Z0-9._-])[A-Za-z0-9._-]{16,}/g,
-        `Bearer ${REDACTED}`,
-      )
-      // Basic values are base64, so the evidence class here is the stricter
-      // [A-Z0-9+/=]: a 16-character base64 run with no uppercase, digit or
-      // padding does not occur in practice, while "." "_" "-" do occur in the
-      // opaque tokens the Bearer rule has to keep covering.
-      .replace(
-        /\b[Bb]asic\s+(?=[A-Za-z0-9+/=_-]*[A-Z0-9+/=])[A-Za-z0-9+/=_-]{16,}/g,
-        `Basic ${REDACTED}`,
-      )
+      // Length alone separates a credential from prose here. "Basic
+      // authentication is not supported" is a real GitHub and GitLab HTTP
+      // error, and an 8-or-more-characters rule ate the diagnosis on exactly
+      // the git auth failures this file exists to preserve.
+      //
+      // 16 is measured, not guessed. Across 157 MB of real library code, error
+      // strings and docs, the longest all-lowercase run following "bearer" is 7
+      // characters and the longest following "basic" is 14 ("authentication",
+      // "implementation"), so the floor clears the worst observed prose by 2
+      // characters and no real value was missed.
+      //
+      // There is deliberately NO "must contain an uppercase letter or digit"
+      // guard. A valid opaque bearer token can be all lowercase, and for a
+      // base64 Basic value the composition assumption is only probabilistic
+      // (a 16-character run is all-lowercase about one time in 1.8 million),
+      // so such a guard trades a certain under-redaction for a prose risk the
+      // length floor already covers. Both schemes therefore get the same rule
+      // shape; only the value alphabets differ, base64url separators for Bearer
+      // and base64 padding for Basic.
+      //
+      // The scheme word is matched with a character class rather than the /i
+      // flag on purpose: /i would also fold any [A-Z] guard to lowercase, which
+      // is how a composition check silently becomes a no-op.
+      .replace(/\b[Bb]earer\s+[A-Za-z0-9._-]{16,}/g, `Bearer ${REDACTED}`)
+      .replace(/\b[Bb]asic\s+[A-Za-z0-9+/=_-]{16,}/g, `Basic ${REDACTED}`)
       // JWTs, whole. The token-run rule below only reaches the signature, so a
       // short claim set would otherwise travel in clear as header.payload.
       .replace(

--- a/apps/worker/src/workflow-definition/failure-message.ts
+++ b/apps/worker/src/workflow-definition/failure-message.ts
@@ -31,6 +31,22 @@ const ELISION = " [...] ";
  * because that is where diagnostics put the verdict. */
 const TAIL_SHARE = 0.6;
 
+/** Longest string we will accept as a diagnostic ID. The execution branch below
+ * repeats its segment group, so without an overall cap a chunked payload of any
+ * length satisfies the shape. Real IDs are ~59 characters. */
+const DIAGNOSTIC_ID_MAX_LENGTH = 120;
+
+/** Longest run of token characters allowed in one segment of an execution
+ * diagnostic ID.
+ *
+ * This has ONE character of margin on real data: the production run-id segment
+ * `wrun_01KYSFRC85YWWMD6WH2FQG0C30` is 31. Any change to the run-id scheme that
+ * pushes it past 32 silently drops the correlation handle product-wide, because
+ * the redaction below would eat the ID and every surface would show
+ * `[redacted]` where the ID belongs. If run ids get longer, raise this with
+ * them. */
+const DIAGNOSTIC_ID_SEGMENT_MAX = 32;
+
 /** A whole, well-formed diagnostic ID. Deliberately anchored and shaped rather
  * than a prefix test: a bare `startsWith` check exempts anything merely
  * BEGINNING with the prefix, so a credential glued behind it rides straight out
@@ -42,11 +58,28 @@ const TAIL_SHARE = 0.6;
  *    joined by "-". Segments are length-bounded, which is what stops a long
  *    opaque token from passing as a run or node id.
  *  - `recordIngestionFailure`: prefix + "ingest-" + a v4 UUID. Matched as a
- *    strict lowercase-hex UUID, so it cannot carry a base64 secret either. */
+ *    strict lowercase-hex UUID, so it cannot carry a base64 secret either.
+ *
+ * KNOWN AND ACCEPTED WEAKNESS, recorded deliberately rather than left implicit.
+ * This is shape matching, not authentication, so it is defeatable by chunking a
+ * known secret across segments that each satisfy the cap
+ * (`AIW-DIAG-<32 chars>-<25 chars>-0`). Exploiting it needs BOTH text injection
+ * into a failure detail AND prior knowledge of the secret, at which point the
+ * attacker already has the secret; the length cap above at least stops a bulk
+ * payload. The real fix is to stop inspecting shape and splice in the ID we
+ * already know out of band, which means threading the run's own diagnostic ID
+ * from the run record down to this boundary. That is a signature change across
+ * files this change does not own, so it is deferred, not dismissed.
+ *
+ * Related, same cause: a node id containing any character outside
+ * [A-Za-z0-9_-] mangles the ID rather than preserving it ("review.gate" yields
+ * "[redacted].gate-1"). Node ids are validated only as a non-empty trimmed
+ * string, so that needs a hand-authored definition; all eight built-in ids are
+ * safe. */
 const DIAGNOSTIC_ID_PATTERN = new RegExp(
   `^${EXECUTION_DIAGNOSTIC_PREFIX}(?:` +
     "ingest-[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}" +
-    "|(?:[A-Za-z0-9_]{1,32}-){2,}\\d{1,4}" +
+    `|(?:[A-Za-z0-9_]{1,${DIAGNOSTIC_ID_SEGMENT_MAX}}-){2,}\\d{1,4}` +
     ")$",
 );
 
@@ -87,7 +120,9 @@ const PROVIDER_CAUSES: Array<{ pattern: RegExp; message: string }> = [
  * `startsWith(EXECUTION_DIAGNOSTIC_PREFIX)` admits anything merely beginning
  * with the prefix, so a credential glued behind it rides straight out. */
 export function isDiagnosticId(value: string): boolean {
-  return DIAGNOSTIC_ID_PATTERN.test(value);
+  return (
+    value.length <= DIAGNOSTIC_ID_MAX_LENGTH && DIAGNOSTIC_ID_PATTERN.test(value)
+  );
 }
 
 /** Match `detail` against the curated provider causes, returning the safe
@@ -120,8 +155,28 @@ function redactSecrets(text: string): string {
       )
       // Bearer and Basic credentials. Basic needs its own rule: a base64
       // "user:pass" pair is usually well under the token-run length below.
-      .replace(/\bBearer\s+[A-Za-z0-9._-]{8,}/gi, `Bearer ${REDACTED}`)
-      .replace(/\bBasic\s+[A-Za-z0-9+/=_-]{8,}/gi, `Basic ${REDACTED}`)
+      //
+      // The value must look ENCODED, not word-shaped. "Basic authentication is
+      // not supported" is a real GitHub and GitLab HTTP error, and an
+      // 8-or-more-lowercase-letters rule ate the diagnosis on exactly the git
+      // auth failures this file exists to preserve. Two guards, both needed:
+      // at least 16 characters (rejects "authentication", "credentials", and
+      // their capitalised forms) and at least one non-lowercase character
+      // (rejects long all-lowercase prose). The scheme word is matched with a
+      // character class rather than the /i flag, because /i would also make the
+      // [A-Z] evidence class match lowercase and defeat the whole check.
+      .replace(
+        /\b[Bb]earer\s+(?=[A-Za-z0-9._-]*[A-Z0-9._-])[A-Za-z0-9._-]{16,}/g,
+        `Bearer ${REDACTED}`,
+      )
+      // Basic values are base64, so the evidence class here is the stricter
+      // [A-Z0-9+/=]: a 16-character base64 run with no uppercase, digit or
+      // padding does not occur in practice, while "." "_" "-" do occur in the
+      // opaque tokens the Bearer rule has to keep covering.
+      .replace(
+        /\b[Bb]asic\s+(?=[A-Za-z0-9+/=_-]*[A-Z0-9+/=])[A-Za-z0-9+/=_-]{16,}/g,
+        `Basic ${REDACTED}`,
+      )
       // JWTs, whole. The token-run rule below only reaches the signature, so a
       // short claim set would otherwise travel in clear as header.payload.
       .replace(
@@ -147,8 +202,10 @@ function redactSecrets(text: string): string {
       // Every credential shape we recognise is handled above this rule, so the
       // exemption can at most spare an unrecognised token that is also shaped
       // exactly like a diagnostic ID.
+      // Goes through isDiagnosticId, not the bare pattern, so the length cap
+      // applies here too: one predicate, one answer, everywhere.
       .replace(/[A-Za-z0-9_-]{40,}/g, (match) =>
-        DIAGNOSTIC_ID_PATTERN.test(match) ? match : REDACTED,
+        isDiagnosticId(match) ? match : REDACTED,
       )
   );
 }

--- a/apps/worker/src/workflows/repo-memory-steps.test.ts
+++ b/apps/worker/src/workflows/repo-memory-steps.test.ts
@@ -3892,6 +3892,91 @@ describe("captureDefaultBranchFilesStep", () => {
     expect(removal?.[2]).not.toBe("/vercel/sandbox");
   });
 
+  it("does not report a deadline when only the cleanup ran out of budget", async () => {
+    // The flag means "the repositories behind a hung one lost their listings".
+    // Routing the cleanup through the reporting wrapper made a skipped rm after
+    // the LAST repository had already been listed flip it, so a run that lost
+    // nothing reported as one that ran out of time. An operator who chases that
+    // twice stops reading the field.
+    mocks.fetchExit = 0;
+    fakeSandbox();
+    // Warm the dynamic imports on real time before the clock is frozen.
+    mocks.lsTree.set("FETCH_HEAD", { exitCode: 0, paths: DEFAULT_BRANCH_FILES });
+    await captureDefaultBranchFilesStep({
+      ...CAPTURE_INPUT,
+      repositories: [ownedBranchRepository()],
+    });
+    mocks.logInfo.mockClear();
+    mocks.gitCommands = [];
+    vi.useFakeTimers();
+    mocks.getSandbox.mockResolvedValue({
+      runCommand: async (command: string, args: string[]) => {
+        mocks.gitCommands.push([command, ...args]);
+        if (command === "rm" || args.includes("init")) {
+          return { exitCode: 0, stdout: async () => "" };
+        }
+        if (args.includes("fetch")) return { exitCode: 0, stdout: async () => "" };
+        if (args[args.length - 1] === "FETCH_HEAD") {
+          // The whole budget is spent the instant the listing lands, so the only
+          // thing left needing it is the cleanup. setSystemTime moves the clock
+          // without running the pending race timer, which is what makes this the
+          // cleanup's own budget check rather than a lost race.
+          vi.setSystemTime(Date.now() + 61_000);
+          return {
+            exitCode: 0,
+            stdout: async () => DEFAULT_BRANCH_FILES.map((p) => `${p}\0`).join(""),
+          };
+        }
+        return { exitCode: 128, stdout: async () => "" };
+      },
+    });
+
+    const captured = await captureDefaultBranchFilesStep({
+      ...CAPTURE_INPUT,
+      repositories: [ownedBranchRepository()],
+    });
+
+    // Nothing was lost, so nothing may say otherwise.
+    expect(captured).toEqual({ [REPO_KEY]: DEFAULT_BRANCH_FILES });
+    expect(mocks.logInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ listed: 1, unavailable: 0, deadlineExceeded: false }),
+      "repo_memory_default_branch_files_captured",
+    );
+    // The cleanup really was the call that hit the exhausted budget.
+    expect(mocks.gitCommands.some((argv) => argv[0] === "rm")).toBe(false);
+  });
+
+  it("removes the throwaway repository even when the listing throws", async () => {
+    // The cleanup lives in a finally precisely so it survives `continue` and a
+    // thrown command alike. Without this, the one path that leaks is the one
+    // nobody exercises.
+    mocks.fetchExit = 0;
+    mocks.getSandbox.mockResolvedValue({
+      runCommand: async (command: string, args: string[]) => {
+        mocks.gitCommands.push([command, ...args]);
+        if (command === "rm" || args.includes("init")) {
+          return { exitCode: 0, stdout: async () => "" };
+        }
+        if (args.includes("fetch")) return { exitCode: 0, stdout: async () => "" };
+        if (args[args.length - 1] === "FETCH_HEAD") {
+          throw new Error("sandbox died mid-listing");
+        }
+        return { exitCode: 128, stdout: async () => "" };
+      },
+    });
+
+    expect(
+      await captureDefaultBranchFilesStep({
+        ...CAPTURE_INPUT,
+        repositories: [ownedBranchRepository()],
+      }),
+    ).toEqual({});
+    const removal = mocks.gitCommands.find((argv) => argv[0] === "rm");
+    expect(removal?.slice(0, 2)).toEqual(["rm", "-rf"]);
+    expect(removal?.[2]).toContain("/tmp/");
+    expect(removal?.[2]).not.toBe("/vercel/sandbox");
+  });
+
   it("shallow-fetches the default branch when the remote-tracking ref is absent", async () => {
     // The discovery attach clones --no-tags --single-branch --branch <owned>, so a
     // re-picked-up ticket and a pr_trigger run carry no origin/<default> ref at

--- a/apps/worker/src/workflows/repo-memory-steps.test.ts
+++ b/apps/worker/src/workflows/repo-memory-steps.test.ts
@@ -500,6 +500,9 @@ function fakeSandbox(): void {
       // Dispatched on the subcommand, not on the last argument: the fetch
       // fallback ends in the branch name and the listing ends in a ref, and a
       // case has to be able to answer them differently.
+      if (command === "rm" || args.includes("init")) {
+        return { exitCode: 0, stdout: async () => "" };
+      }
       if (args.includes("fetch")) return { exitCode: mocks.fetchExit, stdout: async () => "" };
       const answer = mocks.lsTree.get(args[args.length - 1] ?? "");
       if (!answer) return { exitCode: 128, stdout: async () => "" };
@@ -3729,6 +3732,32 @@ describe("distillRepoMemoryStep default-branch path filter false positives", () 
     // looked up as a root file. Pinned separately so neither guard can be removed
     // on the grounds that the other covers it.
     ["a call on a SHOUTING receiver", "Reads go through CONFIG.json() at startup"],
+    // Chained access. Testing the whole stem only ever caught one level, because
+    // every one of these carries a dot and so failed the identifier test and was
+    // looked up as a root file. Same destructive direction as the single-level
+    // case: one such token discards the entry and evicts its true stored twin.
+    ["chained access through a request", "Route handlers await ctx.req.json for the body"],
+    ["chained access through a response", "The helper reads res.body.json before validating"],
+    ["chained access with a namespace", "The parser walks config.database.properties in order"],
+    ["chained access on an option bag", "Writers take options.db.lock before committing"],
+    ["chained access through this", "Reducers must not mutate this.state.lock directly"],
+    ["chained access into a schema", "Field order comes from schema.items.properties"],
+    // SHOUTING receivers, which the stem-shape carve-out cannot tell from
+    // LICENSE.txt. Handled by keeping json, lock and properties out of the
+    // root-level extension set entirely.
+    ["a SHOUTING receiver property", "Connection pooling is configured on DB.lock"],
+    ["a SHOUTING receiver serialiser", "Every handler returns ENV.json for diagnostics"],
+    ["a SHOUTING acronym receiver", "The client parses API.json once per boot"],
+    ["a SHOUTING receiver with a properties tail", "Parsing starts from URL.properties"],
+    // The stem guard's only unique coverage once json, lock and properties are
+    // out of the root extension set: a dotted bare name whose tail is an
+    // identifier and whose extension stays in that set. This one is genuinely
+    // ambiguous, "job.config.yml" reads as a pipeline file as easily as as access
+    // on a `job.config` object, and the rule resolves ambiguity toward keeping.
+    // The cost is stated plainly: a dotted config file that really is absent is
+    // not caught. The alternative is dropping a true entry, and one dropped token
+    // takes the whole entry and evicts its stored twin.
+    ["a dotted name whose tail is an identifier", "The stage is defined in job.config.yml"],
     ["snake_case property access", "The adapter reads request_body.json for the payload"],
     [
       "a separator-packed list whose every file exists",
@@ -3792,6 +3821,77 @@ describe("captureDefaultBranchFilesStep", () => {
     expect(mocks.gitCommands.some((argv) => argv.includes("fetch"))).toBe(false);
   });
 
+  it("leaves the agent's checkout complete rather than shallow", async () => {
+    // The invariant, not the command string. A --depth=1 fetch writes
+    // .git/shallow, which grafts a parentless boundary at the default-branch tip
+    // and is an ancestor of the agent's own branch: measured on a complete clone
+    // of five commits plus one agent commit, fetching in the checkout turned
+    // `git rev-list --count HEAD` from 6 into 2 and made `git blame` attribute
+    // every pre-existing line to the boundary. Silently, with no error. This step
+    // runs before the first agent block, so reading history, which is how a
+    // coding agent understands a repository, would be degraded for the whole run.
+    //
+    // Modelled here as the state a real git would reach: any --depth fetch marks
+    // whatever repository it ran in as shallow, and this asserts the agent's
+    // checkout is not among them.
+    const shallow = new Set<string>();
+    mocks.getSandbox.mockResolvedValue({
+      runCommand: async (command: string, args: string[]) => {
+        mocks.gitCommands.push([command, ...args]);
+        const cwd = args[args.indexOf("-C") + 1] ?? "";
+        if (args.includes("fetch")) {
+          if (args.some((arg) => arg.startsWith("--depth"))) shallow.add(cwd);
+          return { exitCode: 0, stdout: async () => "" };
+        }
+        if (args.includes("ls-tree")) {
+          const ref = args[args.length - 1];
+          if (ref === "FETCH_HEAD") {
+            return {
+              exitCode: 0,
+              stdout: async () => DEFAULT_BRANCH_FILES.map((p) => `${p}\0`).join(""),
+            };
+          }
+          return { exitCode: 128, stdout: async () => "" };
+        }
+        return { exitCode: 0, stdout: async () => "" };
+      },
+    });
+
+    expect(
+      await captureDefaultBranchFilesStep({
+        ...CAPTURE_INPUT,
+        repositories: [ownedBranchRepository()],
+      }),
+    ).toEqual({ [REPO_KEY]: DEFAULT_BRANCH_FILES });
+
+    // The listing still arrives, and the checkout is untouched by it.
+    expect(shallow.has("/vercel/sandbox")).toBe(false);
+    expect([...shallow]).toEqual([expect.stringContaining("/tmp/") as unknown as string]);
+    // Nothing at all ran inside the checkout except the read-only listing that
+    // failed to resolve the ref.
+    const inCheckout = mocks.gitCommands.filter(
+      (argv) => argv[argv.indexOf("-C") + 1] === "/vercel/sandbox",
+    );
+    expect(inCheckout.every((argv) => argv.includes("ls-tree"))).toBe(true);
+  });
+
+  it("removes the throwaway repository it fetched into", async () => {
+    mocks.lsTree.set("FETCH_HEAD", { exitCode: 0, paths: DEFAULT_BRANCH_FILES });
+    mocks.fetchExit = 0;
+    fakeSandbox();
+
+    await captureDefaultBranchFilesStep({
+      ...CAPTURE_INPUT,
+      repositories: [ownedBranchRepository()],
+    });
+
+    const removal = mocks.gitCommands.find((argv) => argv[0] === "rm");
+    expect(removal?.slice(0, 2)).toEqual(["rm", "-rf"]);
+    expect(removal?.[2]).toContain("/tmp/");
+    // Never the checkout, whatever else changes here.
+    expect(removal?.[2]).not.toBe("/vercel/sandbox");
+  });
+
   it("shallow-fetches the default branch when the remote-tracking ref is absent", async () => {
     // The discovery attach clones --no-tags --single-branch --branch <owned>, so a
     // re-picked-up ticket and a pr_trigger run carry no origin/<default> ref at
@@ -3808,16 +3908,57 @@ describe("captureDefaultBranchFilesStep", () => {
       }),
     ).toEqual({ [REPO_KEY]: DEFAULT_BRANCH_FILES });
     const fetched = mocks.gitCommands.find((argv) => argv.includes("fetch"));
-    // Shallow and tagless, so the cost is one commit's trees however long the
-    // history is. Auth goes per invocation, because the clone leaves no
-    // credential behind and a bare fetch fails on any private repository.
+    // Shallow and tagless, so the cost is one commit however long the history
+    // is, and blob-filtered because only the trees are ever read. Auth goes per
+    // invocation, because the clone leaves no credential behind and a bare fetch
+    // fails on any private repository.
     expect(fetched).toContain("--depth=1");
     expect(fetched).toContain("--no-tags");
+    expect(fetched).toContain("--filter=blob:none");
     expect(fetched?.[fetched.length - 1]).toBe("main");
     expect(fetched?.some((arg) => arg.includes("AUTHORIZATION"))).toBe(true);
-    // FETCH_HEAD, so no branch is created, moved or checked out and the agent's
-    // own branch is untouched.
-    expect(mocks.gitCommands[mocks.gitCommands.length - 1]).toContain("FETCH_HEAD");
+    // Into a throwaway bare repository, never the checkout: see the shallow
+    // invariant case above.
+    expect(fetched?.[fetched.indexOf("-C") + 1]).toContain("/tmp/");
+    const listing = mocks.gitCommands.filter((argv) => argv.includes("FETCH_HEAD"));
+    expect(listing).toHaveLength(1);
+    expect(listing[0]?.[listing[0].indexOf("-C") + 1]).toContain("/tmp/");
+  });
+
+  it("falls back to an unfiltered fetch on a server that rejects the blob filter", async () => {
+    // --filter=blob:none fails the whole fetch on a server without partial-clone
+    // support, so the plain fetch is a fallback rather than an optimisation.
+    let attempt = 0;
+    mocks.getSandbox.mockResolvedValue({
+      runCommand: async (command: string, args: string[]) => {
+        mocks.gitCommands.push([command, ...args]);
+        if (command === "rm" || args.includes("init")) {
+          return { exitCode: 0, stdout: async () => "" };
+        }
+        if (args.includes("fetch")) {
+          attempt += 1;
+          return {
+            exitCode: args.includes("--filter=blob:none") ? 128 : 0,
+            stdout: async () => "",
+          };
+        }
+        const ref = args[args.length - 1];
+        return ref === "FETCH_HEAD"
+          ? {
+              exitCode: 0,
+              stdout: async () => DEFAULT_BRANCH_FILES.map((p) => `${p}\0`).join(""),
+            }
+          : { exitCode: 128, stdout: async () => "" };
+      },
+    });
+
+    expect(
+      await captureDefaultBranchFilesStep({
+        ...CAPTURE_INPUT,
+        repositories: [ownedBranchRepository()],
+      }),
+    ).toEqual({ [REPO_KEY]: DEFAULT_BRANCH_FILES });
+    expect(attempt).toBe(2);
   });
 
   it("warns with a count when neither the ref nor the fetch resolves", async () => {
@@ -3845,6 +3986,66 @@ describe("captureDefaultBranchFilesStep", () => {
         deadlineExceeded: false,
       },
       "repo_memory_default_branch_files_captured",
+    );
+  });
+
+  it.each([
+    [
+      "resolving the provider configuration",
+      () => {
+        mocks.buildSandboxProviderConfigs.mockReturnValue(new Promise(() => {}));
+      },
+    ],
+    [
+      "minting the installation token",
+      () => {
+        mocks.buildSandboxProviderConfigs.mockResolvedValue([
+          {
+            kind: "github",
+            host: "https://github.com",
+            getToken: () => new Promise(() => {}),
+            commitAuthor: "bot",
+            commitEmail: "bot@example.com",
+          },
+        ]);
+      },
+    ],
+  ])("gives up when %s never returns", async (_case, arrange) => {
+    // Neither of these is a sandbox command, and neither has a timeout of its
+    // own: the provider configuration resolves the commit identity over two API
+    // calls and the token is a third. Left outside the race they would stall
+    // workspace preparation exactly as a hung command would, which is the whole
+    // reason the deadline exists.
+    mocks.lsTree.set("FETCH_HEAD", { exitCode: 0, paths: DEFAULT_BRANCH_FILES });
+    mocks.fetchExit = 0;
+    fakeSandbox();
+    // Warm the dynamic imports on real time before the clock is frozen.
+    await captureDefaultBranchFilesStep({
+      ...CAPTURE_INPUT,
+      repositories: [ownedBranchRepository()],
+    });
+    mocks.logWarn.mockClear();
+    arrange();
+    vi.useFakeTimers();
+
+    const pending = captureDefaultBranchFilesStep({
+      ...CAPTURE_INPUT,
+      repositories: [ownedBranchRepository()],
+    });
+    let settled = false;
+    void pending.then(
+      () => { settled = true; },
+      () => { settled = true; },
+    );
+    for (let attempt = 0; attempt < 20 && !settled; attempt += 1) {
+      await vi.advanceTimersByTimeAsync(60_000);
+    }
+
+    expect(settled).toBe(true);
+    expect(await pending).toEqual({});
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: REPO_KEY, deadlineMs: 60_000 }),
+      "repo_memory_default_branch_files_deadline_exceeded",
     );
   });
 

--- a/apps/worker/src/workflows/repo-memory-steps.ts
+++ b/apps/worker/src/workflows/repo-memory-steps.ts
@@ -244,9 +244,13 @@ const MAX_DEFAULT_BRANCH_FILE_BYTES = 512 * 1024;
  * already refuses to accept, so the budget is deliberately loose and the
  * accounting is what makes a timeout visible.
  *
- * Promise.race, so a timed-out command keeps running inside the sandbox. That is
- * fine: the sandbox is torn down at the end of the run either way, and nothing
- * here writes.
+ * Promise.race, so a timed-out command keeps running inside the sandbox and
+ * cannot be cancelled. That is why every write this step performs is confined to
+ * a throwaway bare repository under /tmp: an abandoned fetch still holds its own
+ * lock files, and if it were running inside the agent's checkout it would hold
+ * .git/shallow.lock while the agent ran its own git commands. Nothing it can
+ * still be doing after the race is lost touches a path anything else reads, and
+ * the sandbox is torn down at the end of the run either way.
  */
 const CAPTURE_DEADLINE_MS = 60_000;
 /** What a timed-out sandbox command resolves to. A unique symbol, so it can
@@ -287,32 +291,35 @@ const GENERATED_PATH_ROOTS = new Set([
  * CONTRIBUTING.md, SUPPORT.md and pnpm-lock.yaml, none of which exist on the
  * default branch they were filed under.
  *
- * "json", "properties" and "lock" are in here and are also the tail of ordinary
- * property access: Response.json(), res.json(), schema.properties, db.lock. On
- * their own they made this set delete five true entries, including
- * "lib/http.ts returns { status, body }, not response.json()", which is close to
- * verbatim the correction this filter exists to let through. They stay only
- * because CODE_IDENTIFIER_STEM below refuses to look up a bare token whose stem
- * could be an identifier, so they are now reachable only for a SHOUTING or
- * hyphenated stem. Neither guard is redundant: drop this set and every dotted
- * word in prose becomes a lookup, drop that one and property access does.
+ * "json", "lock" and "properties" are deliberately NOT here, though they are
+ * perfectly good root-file extensions, because each is also the tail of ordinary
+ * property access: Response.json(), res.json(), schema.properties, db.lock. The
+ * identifier-stem guard below catches those, but it cannot catch a SHOUTING
+ * receiver, and "ENV.json", "DB.lock", "API.json" and "URL.properties" are
+ * indistinguishable from "LICENSE.txt" by stem shape alone.
+ *
+ * Removing them costs no measured detection at all: of the 23 phantom entries in
+ * production, the root-level ones were CONTRIBUTING.md, SUPPORT.md and
+ * pnpm-lock.yaml, which are ".md" and ".yaml". What it buys is that an entire
+ * class of true entries stops being destroyed, and the destruction is what is
+ * asymmetric here, not the detection. A bare root file with one of these three
+ * extensions is simply never judged; with a directory in front of it, the token
+ * is a path claim rather than a receiver, so NESTED_PATH_EXTENSIONS keeps all
+ * three.
  */
 const ROOT_PATH_EXTENSIONS = new Set([
   "md",
   "mdx",
-  "json",
   "jsonc",
   "yml",
   "yaml",
   "toml",
-  "lock",
   "txt",
   "csv",
   "cfg",
   "ini",
   "conf",
   "xml",
-  "properties",
   "sql",
   "sh",
   "mk",
@@ -336,6 +343,11 @@ const ROOT_PATH_EXTENSIONS = new Set([
  */
 const NESTED_PATH_EXTENSIONS = new Set([
   ...ROOT_PATH_EXTENSIONS,
+  // The three the root set leaves out: with a directory in front of them the
+  // token is a path claim, not access on a receiver.
+  "json",
+  "lock",
+  "properties",
   "ts",
   "tsx",
   "mts",
@@ -580,15 +592,38 @@ function pathToken(raw: string): string | null {
   // dot at all. Both are names this filter will not judge.
   if (dot <= 0) return null;
   const stem = last.slice(0, dot);
-  const extension = last.slice(dot + 1).toLowerCase();
-  // A bare token whose stem could be an identifier is property access, not a
-  // file. Without this, "json", "properties" and "lock" in ROOT_PATH_EXTENSIONS
-  // turn Response.json(), res.json(), schema.properties and db.lock into missing
-  // files, and one missing token discards the whole entry: see the note on the
+  // The LAST dot-separated component of the stem, which is what makes the guard
+  // reach chained property access. Testing the whole stem only ever caught
+  // single-level access: "ctx.req.json", "res.body.json", "options.db.lock" and
+  // "config.database.properties" all carry a dot, so they failed the identifier
+  // test and were looked up as files, which is the destructive direction. A
+  // stem-tail test reads each of those as the identifier it is.
+  const stemTail = stem.slice(stem.lastIndexOf(".") + 1);
+  // A bare token whose stem tail could be an identifier is property access, not
+  // a file, and one such token discards the whole entry: see the note on the
   // loop in absentDefaultBranchPathChecker.
-  if (!nested && CODE_IDENTIFIER_STEM.test(stem) && stem !== stem.toUpperCase()) {
+  //
+  // This overlaps with keeping "json", "lock" and "properties" out of
+  // ROOT_PATH_EXTENSIONS, deliberately. Either guard alone protects chained
+  // access like "ctx.req.json", so neither can be shown to matter by removing it
+  // on its own; remove both and all six chained shapes are looked up again. They
+  // do not cover the same ground: the extension set is what catches a SHOUTING
+  // receiver such as "ENV.json", which no stem-shape test can tell from
+  // "LICENSE.txt", and this test is what catches a chained tail whose extension
+  // stays in the root set, such as "job.config.yml".
+  //
+  // A stem that STARTS with a dot is carved out, so a dotfile keeps resolving:
+  // ".markdownlint.yml" has the stem ".markdownlint" whose tail is an ordinary
+  // identifier, and it is a real root file rather than access on a receiver.
+  if (
+    !nested &&
+    !stem.startsWith(".") &&
+    CODE_IDENTIFIER_STEM.test(stemTail) &&
+    stemTail !== stemTail.toUpperCase()
+  ) {
     return null;
   }
+  const extension = last.slice(dot + 1).toLowerCase();
   return (nested ? NESTED_PATH_EXTENSIONS : ROOT_PATH_EXTENSIONS).has(extension)
     ? token
     : null;
@@ -1321,17 +1356,23 @@ export async function captureDefaultBranchFilesStep(
       ]);
     for (const repository of input.repositories) {
       const key = `${repository.provider}:${repository.repoPath}`;
+      /** The throwaway repository this repository's fallback fetched into, if it
+       * needed one, so the cleanup below knows what to remove. */
+      let scratchPath: string | null = null;
+      const reportDeadline = (ref: string): void => {
+        unavailable += 1;
+        log.warn(
+          { repo: key, ref, deadlineMs: CAPTURE_DEADLINE_MS },
+          "repo_memory_default_branch_files_deadline_exceeded",
+        );
+      };
       // Per repository, not per step: a checkout whose listing fails must cost
       // only its own filter and not every repository listed after it.
       try {
         const ref = defaultBranchRef(repository);
         let listed = await withinDeadline(() => listTree(repository.localPath, ref));
         if (listed === CAPTURE_DEADLINE) {
-          unavailable += 1;
-          log.warn(
-            { repo: key, ref, deadlineMs: CAPTURE_DEADLINE_MS },
-            "repo_memory_default_branch_files_deadline_exceeded",
-          );
+          reportDeadline(ref);
           continue;
         }
         if (listed.exitCode !== 0 && ref !== "HEAD") {
@@ -1340,32 +1381,69 @@ export async function captureDefaultBranchFilesStep(
           // and a pr_trigger run carry no remote-tracking ref for the default
           // branch at all, and that is exactly the shape that accumulated the
           // phantom entries. Fetch the one commit needed to read its tree.
-          // Shallow and tagless, so the cost is one commit's trees regardless of
-          // how much history the repository has.
-          providers ??= await (async () => {
-            const { buildSandboxProviderConfigs } = await import("../lib/vcs-runtime.js");
-            return buildSandboxProviderConfigs(
-              input.repositories.map((entry) => entry.provider),
+          //
+          // Into a throwaway BARE repository, never into the checkout. A
+          // --depth=1 fetch writes .git/shallow, and that file is not a local
+          // detail of the fetch: it grafts a parentless boundary at the
+          // default-branch tip, which is an ancestor of the agent's own branch.
+          // Measured on a complete clone of five commits plus one agent commit,
+          // fetching in place turned `git rev-list --count HEAD` from 6 into 2
+          // and made `git blame` attribute every pre-existing line to the
+          // boundary, silently and with no error. This step is awaited before the
+          // first agent block, so that damage would stand for the whole run, and
+          // reading history is exactly how a coding agent understands a
+          // repository. A memory-quality fix must not degrade the agent.
+          const { buildSandboxProviderConfigs } = await import("../lib/vcs-runtime.js");
+          if (providers === null) {
+            // Inside the deadline like every other round trip here: for GitHub
+            // this resolves the commit identity over two API calls, and a hung
+            // API call stalls workspace preparation exactly as a hung command
+            // would.
+            const resolved = await withinDeadline(() =>
+              buildSandboxProviderConfigs(input.repositories.map((entry) => entry.provider)),
             );
-          })();
+            if (resolved === CAPTURE_DEADLINE) {
+              reportDeadline(ref);
+              continue;
+            }
+            providers = resolved;
+          }
           const provider = providers.find(
             (candidate) => candidate.kind === repository.provider,
           );
           if (provider) {
             const { buildVcsUrls, gitAuthArgs } = await import("../lib/vcs-urls.js");
+            const { buildProviderRepoSlug } = await import("../sandbox/repo-workspace.js");
             const urls = buildVcsUrls({
               kind: provider.kind,
               host: provider.host,
               repoPath: repository.repoPath,
             });
-            // Resolved outside the raced closure, so the deadline covers the
-            // fetch itself rather than a token round trip it cannot cancel.
-            const token = await provider.getToken();
-            // The network command, and the one the deadline is really sized for.
-            const fetched = await withinDeadline(() =>
-              sandbox.runCommand("git", [
+            // Minting an installation token is a third API call, and it has no
+            // timeout of its own either.
+            const token = await withinDeadline(() => provider.getToken());
+            if (token === CAPTURE_DEADLINE) {
+              reportDeadline(ref);
+              continue;
+            }
+            // Outside every checkout and unique per repository, so two
+            // repositories in one manifest cannot collide and nothing here can
+            // reach a working tree.
+            scratchPath = `/tmp/aiw-default-branch-${buildProviderRepoSlug(
+              repository.provider,
+              repository.repoPath,
+            )}.git`;
+            const prepared = await withinDeadline(() =>
+              sandbox.runCommand("git", ["init", "--bare", "--quiet", scratchPath as string]),
+            );
+            if (prepared === CAPTURE_DEADLINE) {
+              reportDeadline(ref);
+              continue;
+            }
+            if (prepared.exitCode === 0) {
+              const fetchArgs = (filtered: boolean) => [
                 "-C",
-                repository.localPath,
+                scratchPath as string,
                 // Per-invocation auth, the same way the manager and the discovery
                 // attach do it: the clone leaves no credential behind, so a bare
                 // fetch would fail on any private repository. This is what puts a
@@ -1375,33 +1453,44 @@ export async function captureDefaultBranchFilesStep(
                 "fetch",
                 "--no-tags",
                 "--depth=1",
+                // Only the trees are read, so the blobs are never needed. On a
+                // large repository this is the difference between transferring
+                // one commit's whole worktree and transferring its directory
+                // listing. Safe to attempt only because the promisor
+                // configuration it leaves behind lives in a directory that is
+                // deleted moments later; in the checkout it would be another
+                // durable change to the agent's repository. A server that does
+                // not support the filter fails the whole fetch, so the plain
+                // fetch below is the fallback rather than an optimisation.
+                ...(filtered ? ["--filter=blob:none"] : []),
                 urls.cloneUrl,
                 repository.defaultBranch,
-              ]),
-            );
-            if (fetched === CAPTURE_DEADLINE) {
-              unavailable += 1;
-              log.warn(
-                { repo: key, ref, deadlineMs: CAPTURE_DEADLINE_MS },
-                "repo_memory_default_branch_files_deadline_exceeded",
+              ];
+              let fetched = await withinDeadline(() =>
+                sandbox.runCommand("git", fetchArgs(true)),
               );
-              continue;
-            }
-            // FETCH_HEAD, not a branch: nothing is created, moved or checked out,
-            // so the agent's own branch and working tree are untouched.
-            if (fetched.exitCode === 0) {
-              const refetched = await withinDeadline(() =>
-                listTree(repository.localPath, "FETCH_HEAD"),
-              );
-              if (refetched === CAPTURE_DEADLINE) {
-                unavailable += 1;
-                log.warn(
-                  { repo: key, ref, deadlineMs: CAPTURE_DEADLINE_MS },
-                  "repo_memory_default_branch_files_deadline_exceeded",
+              if (fetched !== CAPTURE_DEADLINE && fetched.exitCode !== 0) {
+                fetched = await withinDeadline(() =>
+                  sandbox.runCommand("git", fetchArgs(false)),
                 );
+              }
+              if (fetched === CAPTURE_DEADLINE) {
+                reportDeadline(ref);
                 continue;
               }
-              listed = refetched;
+              // FETCH_HEAD in the throwaway repository. Nothing is created,
+              // moved or checked out anywhere the agent can see, and the
+              // checkout keeps its complete history.
+              if (fetched.exitCode === 0) {
+                const refetched = await withinDeadline(() =>
+                  listTree(scratchPath as string, "FETCH_HEAD"),
+                );
+                if (refetched === CAPTURE_DEADLINE) {
+                  reportDeadline(ref);
+                  continue;
+                }
+                listed = refetched;
+              }
             }
           }
         }
@@ -1453,6 +1542,22 @@ export async function captureDefaultBranchFilesStep(
           { repo: key, err: redactProviderError(err) },
           "repo_memory_default_branch_files_failed",
         );
+      } finally {
+        // Reached by every exit from the block above, `continue` included. The
+        // removal is best effort twice over: it goes through the deadline, so a
+        // step that has already run out of time skips it rather than hanging on
+        // it, and its own failure is swallowed. A leaked directory under /tmp
+        // costs nothing, because the sandbox holding it is torn down at the end
+        // of the run and nothing else ever reads that path.
+        if (scratchPath !== null) {
+          try {
+            await withinDeadline(() =>
+              sandbox.runCommand("rm", ["-rf", scratchPath as string]),
+            );
+          } catch {
+            // Nothing here may cost a repository its listing.
+          }
+        }
       }
     }
     // One line an operator can alert on. `listed: 0` with a non-zero repository

--- a/apps/worker/src/workflows/repo-memory-steps.ts
+++ b/apps/worker/src/workflows/repo-memory-steps.ts
@@ -1309,29 +1309,43 @@ export async function captureDefaultBranchFilesStep(
      */
     const deadlineAt = Date.now() + CAPTURE_DEADLINE_MS;
     let deadlineExceeded = false;
-    const withinDeadline = async <T>(
+    /**
+     * The bound, with no accounting attached. Separate from the reporting
+     * wrapper below because not every call bounded by this budget represents a
+     * listing that could be lost: the scratch-repository cleanup is bounded too,
+     * and a cleanup skipped because the budget had already run out costs nothing
+     * an operator needs to hear about.
+     */
+    const raceDeadline = async <T>(
       work: () => Promise<T>,
     ): Promise<T | typeof CAPTURE_DEADLINE> => {
       const remaining = deadlineAt - Date.now();
-      if (remaining <= 0) {
-        deadlineExceeded = true;
-        return CAPTURE_DEADLINE;
-      }
+      if (remaining <= 0) return CAPTURE_DEADLINE;
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {
-        const outcome = await Promise.race([
+        return await Promise.race([
           work(),
           new Promise<typeof CAPTURE_DEADLINE>((resolve) => {
             timer = setTimeout(() => resolve(CAPTURE_DEADLINE), remaining);
           }),
         ]);
-        if (outcome === CAPTURE_DEADLINE) deadlineExceeded = true;
-        return outcome;
       } finally {
         // The loser of the race is always cleared, so a healthy step leaves no
         // pending timer behind it.
         clearTimeout(timer);
       }
+    };
+    /**
+     * The same bound for the work whose loss an operator has to see. `unavailable`
+     * counts the repository and this flag says the step ran out of time, so both
+     * belong only to calls that were trying to produce a listing.
+     */
+    const withinDeadline = async <T>(
+      work: () => Promise<T>,
+    ): Promise<T | typeof CAPTURE_DEADLINE> => {
+      const outcome = await raceDeadline(work);
+      if (outcome === CAPTURE_DEADLINE) deadlineExceeded = true;
+      return outcome;
     };
     /** Resolved at most once, and only if some repository needs the fetch
      * fallback. A fresh short-lived token per step invocation, resolved here
@@ -1543,15 +1557,22 @@ export async function captureDefaultBranchFilesStep(
           "repo_memory_default_branch_files_failed",
         );
       } finally {
-        // Reached by every exit from the block above, `continue` included. The
-        // removal is best effort twice over: it goes through the deadline, so a
-        // step that has already run out of time skips it rather than hanging on
-        // it, and its own failure is swallowed. A leaked directory under /tmp
-        // costs nothing, because the sandbox holding it is torn down at the end
-        // of the run and nothing else ever reads that path.
+        // Reached by every exit from the block above, `continue` and a thrown
+        // listing included. The removal is best effort twice over: it is bounded
+        // by the same budget, so a step that has already run out of time skips it
+        // rather than hanging on it, and its own failure is swallowed. A leaked
+        // directory under /tmp costs nothing, because the sandbox holding it is
+        // torn down at the end of the run and nothing else ever reads that path.
+        //
+        // Bounded through raceDeadline, NOT through withinDeadline: a cleanup
+        // skipped after the last repository was listed successfully would
+        // otherwise flip `deadlineExceeded` and report a run in which nothing was
+        // lost as one that ran out of time. That flag is the operator's signal
+        // that the repositories behind a hung one lost their listings, and a
+        // signal that cries wolf is one people stop reading.
         if (scratchPath !== null) {
           try {
-            await withinDeadline(() =>
+            await raceDeadline(() =>
               sandbox.runCommand("rm", ["-rf", scratchPath as string]),
             );
           } catch {


### PR DESCRIPTION
A second review gate on the fixes from #192, scoped to the fixes themselves rather than to what the first gate had already cleared. It found one blocker and six should-fixes, all of them in code that had been added to reduce risk.

## The blocker: the memory fix was degrading the agent's repository

The default-branch listing has a fallback that runs `git fetch --no-tags --depth=1` when the remote-tracking ref is missing. It ran **inside the agent's working checkout**, directly beneath a comment asserting that nothing is created, moved or checked out. `.git/shallow` is created, and it grafts a parentless boundary at the default-branch tip, which is an ancestor of the agent's own branch. Measured on a real repository with five commits on the default branch plus one agent commit:

| | before | after |
|---|---|---|
| `is-shallow-repository` | false | true |
| `git rev-list --count HEAD` | 6 | 2 |
| `git blame` | the real commit | the boundary |

No error, no warning. The step is awaited during workspace preparation, so this landed before the first agent block and persisted for the whole run: `git log` showing two commits instead of six, and `git blame` attributing every pre-existing line to the default-branch tip. Reading history is how a coding agent understands a repository, so a change meant to improve what memory stores was quietly degrading what the agent could work out for itself.

The fetch now runs in a throwaway bare repository outside every checkout, removed in a `finally` and covered by the step deadline. The test asserts the invariant rather than the command string: the checkout is not shallow afterwards, the only shallow-marked path is the scratch one, and the only thing that ran inside the checkout was the read-only listing.

Because only trees are ever read, the fetch also uses `--filter=blob:none` now, with a plain `--depth=1` retry for servers without partial-clone support. That is safe only because of the scratch repository: the promisor configuration it leaves behind lives in a directory deleted moments later, where in the checkout it would have been another durable change.

## The path filter was still discarding true knowledge

The identifier-stem guard tested the whole stem, so it covered `res.json` but not chained access. `ctx.req.json`, `res.body.json`, `options.db.lock` and `schema.items.properties` were all read as missing files, and one such token discards the entire entry and leaves its true stored twin first in line for eviction. The guard now tests the last dot-separated component.

The root cause was one level down. `json`, `lock` and `properties` were in the bare-token extension set, which is what made property access look like a filename at all. Of the twenty-three phantom entries measured on production, the root-level ones were `.md` and `.yaml`: those three extensions caught nothing, while being the tail of every property-access shape. They are gone from the bare set and kept in the nested one, where a directory makes the token a genuine path claim.

That removal subsumed two guards added in the previous round, which is reported rather than quietly absorbed: both mutants survived once the extension set was corrected. Rather than relaxing the expectations, two new mutants prove the guards are complementary rather than duplicative, a keep-case covers the stem guard's genuinely unique shape, and the one remaining uncovered mutant is declared a survivor with its reason, since it is the guard that holds if anyone loosens the extension set again.

## The step deadline did not cover the network

Three round trips sat outside the race: two API calls resolving the bot identity, and one minting an installation token. None had a timeout of its own, and the stated reason for excluding them did not hold, since the deadline cannot cancel the fetch either. Both are inside it now, with tests that hang each one.

## The credential rules were eating the diagnosis

The `Basic` and `Bearer` redaction rules accepted any eight-character run from a class that includes lowercase letters, so `remote: Basic authentication is not supported for Git operations.` became `remote: Basic [redacted] is not supported...`. That is a real GitHub and GitLab error string, and destroying it defeats the change that exists to preserve failure causes. The rules now require the value to look encoded rather than word-shaped, with the scheme matched case-insensitively by hand rather than by a flag, because a case-insensitive flag would have silently neutralised the evidence class.

The diagnostic-id exemption is length-bounded now, closing the unbounded-payload half of a known weakness. The other half, defeating shape matching by chunking a secret the attacker already holds, is left open deliberately and recorded as an executable test that asserts the gap, with a comment telling whoever closes it to delete the test rather than restore the behaviour.

## The drift check had no caller

The check introduced in #192 as the part that mattered most was referenced only by its own test and two comments. It now has a gate that fails on four independent conditions, including an incomplete walk and an empty pin list, so a clean drift list cannot be mistaken for a clean install. Two callers: the normal test suite, and a script for a real database.

What each buys is worth stating precisely. The suite cannot see a row inserted outside the application, which is how production acquired the prompt version this line of work was chasing. It does catch a code constant edited without a matching resync migration, which is the failure that went unnoticed for nine days.

Two ways the walk counter could lie are also closed: an empty node list counted as an inspected definition, and a prompt-bearing block type with no parameter-key entry contributing nothing silently. Both record a skip now, and the trust signal is the pin count rather than the definition count.

Query cost no longer scales with queue depth either: the three queue reads are deduplicated before any lookup and the follow-ups are batched, which measured 17 database calls instead of 212 for two hundred pending deliveries.

## Verification

Every fix carries mutants re-run against final code with an identity control. Three survivors are declared rather than papered over, each with its reason. Two executors found and reported defects in their own instruments: a mutation batch that timed out and left a mutant on disk, caught by hashing before doing anything else, and a test helper whose measurement was read before the await it depended on, so it compared zero to zero and passed.

## Not fixed

The publish failure that started this line of work, which is diagnosable now rather than repaired. The run-journal entry that still reached memory under the new policy: the recommendation from the executor who owns that filter is that it needs a code-side counterpart of its own rather than a widening of the path filter, since aiming a destructive instrument at the wrong target trades a safe false negative for a false positive that discards a whole entry and evicts its stored twin. The PGlite fixture is also slow enough now that hook timeouts are marginal under load, which is worth attention before it starts producing results nobody can trust.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added prompt drift validation that detects unresolved, incomplete, or uninspectable built-in prompt references and reports actionable failures.
  * Added a command to run prompt drift validation directly.
* **Bug Fixes**
  * Improved repository-memory handling for complex paths, fallback retrieval, cleanup, and operation timeouts.
  * Improved failure-message redaction while preserving ordinary diagnostic text.
* **Performance**
  * Reduced duplicate repository and prompt lookups during drift inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->