### PR TITLE
fix(release): skip commits with no first-parent diff in drift detection

### DIFF
--- a/scripts/release-notes/sync.test.ts
+++ b/scripts/release-notes/sync.test.ts
@@ -258,3 +258,49 @@ test("destination drift does not accept a patch that exists only before the rele
     [destinationHotfix],
   );
 });
+
+test("destination drift tolerates source merge commits with no first-parent diff", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "artur-drift-merge-"));
+  t.after(async () => {
+    await exec("rm", ["-rf", root]);
+  });
+  const baseDir = path.join(root, "base");
+  const sourceDir = path.join(root, "source");
+  const destinationDir = path.join(root, "destination");
+  await initRepository(baseDir);
+  await mkdir(path.join(baseDir, "apps"), { recursive: true });
+  await writeFile(path.join(baseDir, "apps", "shared.txt"), "before\n");
+  await commitAll(baseDir, "base");
+  await exec("git", ["clone", "-q", baseDir, sourceDir]);
+  await exec("git", ["clone", "-q", baseDir, destinationDir]);
+  for (const dir of [sourceDir, destinationDir]) {
+    await git(dir, "config", "user.email", "release-test@example.com");
+    await git(dir, "config", "user.name", "Release Test");
+  }
+  const baseline = await git(destinationDir, "rev-parse", "HEAD");
+  const previousSourceCommit = await git(sourceDir, "rev-parse", "HEAD");
+
+  await git(sourceDir, "checkout", "-q", "-b", "feature");
+  await writeFile(path.join(sourceDir, "apps", "shared.txt"), "after\n");
+  await commitAll(sourceDir, "feature change");
+  await git(sourceDir, "checkout", "-q", "-");
+  await writeFile(path.join(sourceDir, "apps", "shared.txt"), "after\n");
+  await commitAll(sourceDir, "same change on main");
+  await git(sourceDir, "merge", "-q", "--no-ff", "-m", "merge feature", "feature");
+  const targetSourceCommit = await git(sourceDir, "rev-parse", "HEAD");
+  assert.equal(await git(sourceDir, "diff", "HEAD^1", "HEAD"), "");
+
+  await writeFile(path.join(destinationDir, "apps", "unique.txt"), "not backported\n");
+  const uniqueCommit = await commitAll(destinationDir, "unbackported Artur hotfix");
+
+  assert.deepEqual(
+    await findUnbackportedDestinationCommits({
+      sourceSnapshotDir: sourceDir,
+      destinationDir,
+      previousSourceCommit,
+      targetSourceCommit,
+      previousDestinationRef: baseline,
+    }),
+    [uniqueCommit],
+  );
+});

--- a/scripts/release-notes/sync.ts
+++ b/scripts/release-notes/sync.ts
@@ -31,7 +31,7 @@ async function trackedFiles(dir: string): Promise<string[]> {
     .sort();
 }
 
-async function stablePatchId(dir: string, commit: string): Promise<string> {
+async function stablePatchId(dir: string, commit: string): Promise<string | null> {
   const patch = await git(dir, [
     "diff",
     "--binary",
@@ -40,6 +40,8 @@ async function stablePatchId(dir: string, commit: string): Promise<string> {
     `${commit}^1`,
     commit,
   ]);
+  // Merge and empty commits have no first-parent diff, so there is no patch to compare.
+  if (!patch.trim()) return null;
   return new Promise((resolve, reject) => {
     const child = spawn("git", ["patch-id", "--stable"], { cwd: dir, stdio: "pipe" });
     let stdout = "";
@@ -107,7 +109,8 @@ export async function findUnbackportedDestinationCommits(input: {
     .filter(Boolean);
   const sourcePatches = new Set<string>();
   for (const commit of sourceCommits) {
-    sourcePatches.add(await stablePatchId(input.destinationDir, commit));
+    const patchId = await stablePatchId(input.destinationDir, commit);
+    if (patchId !== null) sourcePatches.add(patchId);
   }
   const destinationCommits = (await git(input.destinationDir, [
     "rev-list",
@@ -129,6 +132,7 @@ export async function findUnbackportedDestinationCommits(input: {
       .filter(Boolean);
     if (!changed.some((file) => !isDestinationOwned(file))) continue;
     const patch = await stablePatchId(input.destinationDir, commit);
+    if (patch === null) continue;
     if (!sourcePatches.has(patch)) applicationCommits.push(commit);
   }
   return applicationCommits.sort();


### PR DESCRIPTION
Sync run 30813237535 failed on merge commit ae8c1aef (empty first-parent diff, git patch-id yields no ID). Such commits carry no comparable patch, so drift detection now skips them on both the source and destination side. Regression test included; focused release-notes suite 43/43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)