### PR TITLE
fix(worker): mark clarification-parked runs awaiting and settle every park exit

### DIFF
--- a/apps/worker/src/clarifications/answer-core.ts
+++ b/apps/worker/src/clarifications/answer-core.ts
@@ -6,7 +6,7 @@ import {
   IssueTrackerNotFoundError,
   type IssueTrackerAdapter,
 } from "../adapters/issue-tracker/types.js";
-import { resolveAwaitingRun } from "../lib/telemetry/run-telemetry.js";
+import { markRunBlockedOnCancel, markRunResumed } from "../lib/telemetry/run-telemetry.js";
 import { answerHookClarification, type HookClarificationRow } from "./hook-store.js";
 import { supersedeClarification, supersedePendingForTicket } from "./store.js";
 
@@ -88,13 +88,25 @@ export async function answerClarificationAndResume(input: {
     }
   }
 
+  // The answer is delivered, so the asking run is live again. Clearing the park
+  // marker here (and not only from the resumed workflow body) means the run
+  // stops reading as awaiting input the moment the answer lands, however long
+  // the resumed body takes to reach its next write. Guarded on "awaiting" and
+  // best-effort: a status write must never fail a delivered answer.
+  await markRunResumed(db, row.runId).catch(() => {});
+
   return { kind: "answered", row: answered };
 }
 
 /**
  * Best-effort teardown when a clarification's Jira ticket has been deleted:
- * supersede sibling questions, supersede this row, and resolve the awaiting run
- * so it does not stay parked forever. Each step swallows its own error.
+ * supersede sibling questions, supersede this row, and settle the parked run so
+ * it does not stay awaiting forever. Each step swallows its own error.
+ *
+ * The run is settled as "blocked", not "success": it is still suspended on a
+ * hook whose question was just superseded, so nobody can answer it and it will
+ * never reach a PR. Recording success would freeze that dead run into a green
+ * result the cron can no longer correct.
  */
 export async function retireClarificationForGoneTicket(
   db: Db,
@@ -104,5 +116,5 @@ export async function retireClarificationForGoneTicket(
     await supersedePendingForTicket(db, row.ticketKey).catch(() => {});
   }
   await supersedeClarification(db, row.id).catch(() => {});
-  await resolveAwaitingRun(db, row.runId).catch(() => {});
+  await markRunBlockedOnCancel(db, row.runId).catch(() => {});
 }

--- a/apps/worker/src/clarifications/store.test.ts
+++ b/apps/worker/src/clarifications/store.test.ts
@@ -1,0 +1,131 @@
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import type { Db } from "../db/client.js";
+import { activeRuns, workflowRuns } from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+import { ActiveRunOwnerError } from "../lib/run-control-errors.js";
+import { getHookClarification, prepareHookClarification, publishHookClarification } from "./hook-store.js";
+import { reconcileClarificationPickupState } from "./store.js";
+
+const TICKET = "AWT-1";
+const SUBJECT = `ticket:jira:${TICKET}`;
+
+const owner = {
+  subjectKey: SUBJECT,
+  ownerToken: "owner-fresh",
+  runId: "run-fresh",
+};
+
+async function bindFreshRun(db: Db): Promise<void> {
+  await db.insert(activeRuns).values({
+    subjectKey: SUBJECT,
+    ticketKey: TICKET,
+    ownerToken: owner.ownerToken,
+    runId: owner.runId,
+    state: "bound",
+    runKind: "ticket",
+  });
+}
+
+async function parkPredecessor(db: Db, runId: string, ticketKey = TICKET) {
+  const prepared = await prepareHookClarification(db, {
+    ticketKey,
+    subjectKey: `ticket:jira:${ticketKey}`,
+    runId,
+    blockId: "question",
+    definitionId: 1,
+    definitionVersion: 4,
+    questions: ["Which repository?"],
+  });
+  await publishHookClarification(db, prepared.id);
+  await db.insert(workflowRuns).values({
+    runId,
+    subjectKey: `ticket:jira:${ticketKey}`,
+    ticketKey,
+    status: "awaiting",
+  });
+  return prepared.id;
+}
+
+const runStatus = (db: Db, runId: string) =>
+  db
+    .select()
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, runId))
+    .then((r) => r[0]?.status);
+
+describe("reconcileClarificationPickupState", () => {
+  it("supersedes the predecessor's question and takes its run off awaiting", async () => {
+    const db = await createTestDb();
+    await bindFreshRun(db);
+    const parked = await parkPredecessor(db, "run-parked");
+
+    const result = await reconcileClarificationPickupState(db, {
+      ticketKey: TICKET,
+      currentRunId: owner.runId,
+      owner,
+    });
+
+    expect(result).toEqual({ superseded: 1, resolvedAwaiting: 1 });
+    expect((await getHookClarification(db, parked))?.status).toBe("superseded");
+    expect(await runStatus(db, "run-parked")).toBe("blocked");
+  });
+
+  it("never touches the picking-up run or another ticket's parked run", async () => {
+    const db = await createTestDb();
+    await bindFreshRun(db);
+    await db.insert(workflowRuns).values({
+      runId: owner.runId,
+      subjectKey: SUBJECT,
+      ticketKey: TICKET,
+      status: "awaiting",
+    });
+    await parkPredecessor(db, "run-other-ticket", "AWT-2");
+
+    const result = await reconcileClarificationPickupState(db, {
+      ticketKey: TICKET,
+      currentRunId: owner.runId,
+      owner,
+    });
+
+    expect(result).toEqual({ superseded: 0, resolvedAwaiting: 0 });
+    expect(await runStatus(db, owner.runId)).toBe("awaiting");
+    expect(await runStatus(db, "run-other-ticket")).toBe("awaiting");
+  });
+
+  it("is safe to repeat after a step retry", async () => {
+    const db = await createTestDb();
+    await bindFreshRun(db);
+    await parkPredecessor(db, "run-parked");
+
+    const first = await reconcileClarificationPickupState(db, {
+      ticketKey: TICKET,
+      currentRunId: owner.runId,
+      owner,
+    });
+    const second = await reconcileClarificationPickupState(db, {
+      ticketKey: TICKET,
+      currentRunId: owner.runId,
+      owner,
+    });
+
+    expect(first).toEqual({ superseded: 1, resolvedAwaiting: 1 });
+    expect(second).toEqual({ superseded: 0, resolvedAwaiting: 0 });
+    expect(await runStatus(db, "run-parked")).toBe("blocked");
+  });
+
+  it("refuses to reconcile without the exact bound owner", async () => {
+    const db = await createTestDb();
+    await bindFreshRun(db);
+    await parkPredecessor(db, "run-parked");
+
+    await expect(
+      reconcileClarificationPickupState(db, {
+        ticketKey: TICKET,
+        currentRunId: owner.runId,
+        owner: { ...owner, ownerToken: "owner-foreign" },
+      }),
+    ).rejects.toBeInstanceOf(ActiveRunOwnerError);
+    expect(await runStatus(db, "run-parked")).toBe("awaiting");
+  });
+});

--- a/apps/worker/src/clarifications/store.ts
+++ b/apps/worker/src/clarifications/store.ts
@@ -4,6 +4,7 @@ import type { Db } from "../db/client.js";
 import { activeRuns, clarificationRequests } from "../db/schema.js";
 import type { ActiveRunOwner } from "../lib/active-run-owner.js";
 import { ActiveRunOwnerError } from "../lib/run-control-errors.js";
+import { resolveAwaitingRunsForTicket } from "../lib/telemetry/run-telemetry.js";
 
 export interface ClarificationRow {
   id: string;
@@ -214,7 +215,7 @@ export async function supersedeClarification(db: Db, id: string): Promise<number
 export async function reconcileClarificationPickupState(
   db: Db,
   input: { ticketKey: string; currentRunId: string; owner: ActiveRunOwner },
-): Promise<{ superseded: number; resolvedAwaiting: 0 }> {
+): Promise<{ superseded: number; resolvedAwaiting: number }> {
   const result = await db.execute(sql`
     WITH exact_owner AS MATERIALIZED (
       SELECT subject_key
@@ -243,7 +244,15 @@ export async function reconcileClarificationPickupState(
       "Cannot reconcile clarification pickup without the exact bound owner.",
     );
   }
-  return { superseded: Number(row?.superseded_count ?? 0), resolvedAwaiting: 0 };
+  // Only after the ownership gate above has confirmed this run is the exact
+  // bound owner: a fresh pickup supersedes its parked predecessors, which stay
+  // "awaiting" until something flips them.
+  const resolvedAwaiting = await resolveAwaitingRunsForTicket(
+    db,
+    input.ticketKey,
+    input.currentRunId,
+  );
+  return { superseded: Number(row?.superseded_count ?? 0), resolvedAwaiting };
 }
 
 export async function tombstoneClarificationCancellation(

--- a/apps/worker/src/lib/cancel-run.test.ts
+++ b/apps/worker/src/lib/cancel-run.test.ts
@@ -10,6 +10,7 @@ const state = vi.hoisted(() => ({
   retireApproval: vi.fn(),
   moveTicket: vi.fn(),
   recordStatusReason: vi.fn(),
+  markBlockedOnCancel: vi.fn(),
 }));
 
 vi.mock("workflow/api", () => ({ getRun: state.getRun }));
@@ -29,6 +30,7 @@ vi.mock("../approvals/store.js", () => ({
 vi.mock("./ticket-transition.js", () => ({ moveTicketForRun: state.moveTicket }));
 vi.mock("./telemetry/run-telemetry.js", () => ({
   recordRunStatusReason: state.recordStatusReason,
+  markRunBlockedOnCancel: state.markBlockedOnCancel,
 }));
 
 import { cancelRun, cancelRunDetailed } from "./cancel-run.js";
@@ -81,6 +83,7 @@ describe("cancelRun", () => {
     state.retireApproval.mockResolvedValue(0);
     state.moveTicket.mockResolvedValue(undefined);
     state.recordStatusReason.mockResolvedValue(undefined);
+    state.markBlockedOnCancel.mockResolvedValue(undefined);
   });
 
   it("closes, cancels, drains, cleans, and releases the exact owner", async () => {
@@ -210,6 +213,45 @@ describe("cancelRun", () => {
       undefined,
       undefined,
       "reason",
+    )).resolves.toBe(true);
+    expect(runRegistry.releaseCancellation).toHaveBeenCalled();
+  });
+
+  // A run cancelled while it was parked on a clarification never resumes to
+  // clear the live "awaiting" the park wrote, so cancellation settles it.
+  it("settles a parked run as blocked after a confirmed cancel", async () => {
+    const runRegistry = registry({ ...active(), state: "parked" });
+    await expect(cancelRun(
+      "PROJ-1",
+      { ownerToken: "owner-a", runId: "run-1" },
+      runRegistry,
+    )).resolves.toBe(true);
+    expect(state.markBlockedOnCancel).toHaveBeenCalledWith({ db: true }, "run-1");
+  });
+
+  // Cancelling wakes the parked body, whose own error path flips the run back to
+  // "running". The settle has to land after the step drain proves that body can
+  // no longer write, or that flip wins and the cancelled run reads as in flight.
+  it("settles the park only after the step drain barrier", async () => {
+    const runRegistry = registry({ ...active(), state: "parked" });
+    await expect(cancelRun(
+      "PROJ-1",
+      { ownerToken: "owner-a", runId: "run-1" },
+      runRegistry,
+    )).resolves.toBe(true);
+    const drained = Math.max(...state.listSteps.mock.invocationCallOrder);
+    expect(state.markBlockedOnCancel.mock.invocationCallOrder[0]).toBeGreaterThan(
+      drained,
+    );
+  });
+
+  it("still confirms cancellation when the awaiting settle fails", async () => {
+    state.markBlockedOnCancel.mockRejectedValue(new Error("db down"));
+    const runRegistry = registry({ ...active(), state: "parked" });
+    await expect(cancelRun(
+      "PROJ-1",
+      { ownerToken: "owner-a", runId: "run-1" },
+      runRegistry,
     )).resolves.toBe(true);
     expect(runRegistry.releaseCancellation).toHaveBeenCalled();
   });

--- a/apps/worker/src/lib/cancel-run.ts
+++ b/apps/worker/src/lib/cancel-run.ts
@@ -297,6 +297,10 @@ async function cancelOwnedSubject(
     return { cancelled: false, released: false };
   }
 
+  if (closed.runId) {
+    await settleCancelledPark(subjectKey, closed.runId);
+  }
+
   if (beforeRelease) {
     if (!(await confirmBeforeRelease(subjectKey, closed, beforeRelease))) {
       return { cancelled: false, released: false };
@@ -338,6 +342,35 @@ async function persistCancelReason(
     logger.warn(
       { subjectKey, runId, error: (error as Error).message },
       "cancel_run_status_reason_unconfirmed",
+    );
+  }
+}
+
+/**
+ * Best-effort settling of a run cancelled while it was parked on a
+ * clarification. That park writes a live "awaiting" the run itself clears when
+ * it resumes, which a cancelled run never does, and the cron never downgrades a
+ * frozen status: without this the row shows awaiting input forever. Guarded on
+ * "awaiting" inside, so it is a no-op for every run that was not parked, and
+ * like the cancel reason it must never affect the cancel outcome.
+ *
+ * Must stay behind the step-drain barrier. Cancelling wakes the parked body,
+ * whose own error path flips the run back to "running" on its way out; running
+ * this before the drain would let that flip land last and leave the cancelled
+ * run reading as in flight. After the barrier no step of the body can write
+ * again.
+ */
+async function settleCancelledPark(subjectKey: string, runId: string): Promise<void> {
+  try {
+    const [{ getDb }, { markRunBlockedOnCancel }] = await Promise.all([
+      import("../db/client.js"),
+      import("./telemetry/run-telemetry.js"),
+    ]);
+    await markRunBlockedOnCancel(getDb(), runId);
+  } catch (error) {
+    logger.warn(
+      { subjectKey, runId, error: (error as Error).message },
+      "cancel_run_awaiting_status_unconfirmed",
     );
   }
 }

--- a/apps/worker/src/lib/overview/resolve-run-detail.test.ts
+++ b/apps/worker/src/lib/overview/resolve-run-detail.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { RunDetail, RunStep } from "@shared/contracts";
+import type { RunDetail, RunStatus, RunStep } from "@shared/contracts";
 import { resolveRunDetail, type RunDetailParts } from "./resolve-run-detail.js";
 
 const RUN = (id: string): RunDetail => ({
@@ -36,10 +36,17 @@ const STEPS = (name: string): RunStep[] => [
     error: null,
   },
 ];
-const parts = (hasRealSteps: boolean): RunDetailParts => ({
-  run: RUN("db"),
+const parts = (
+  hasRealSteps: boolean,
+  status: RunStatus = "success",
+): RunDetailParts => ({
+  run: { ...RUN("db"), status },
   steps: STEPS("db"),
   hasRealSteps,
+});
+const runningWorld = async () => ({
+  run: { ...RUN("world"), status: "running" as const },
+  steps: STEPS("world"),
 });
 
 describe("resolveRunDetail", () => {
@@ -66,6 +73,52 @@ describe("resolveRunDetail", () => {
       },
     });
     expect(res?.steps[0].name).toBe("db");
+  });
+
+  it("reports awaiting when the durable row is parked and the world says running", async () => {
+    const res = await resolveRunDetail({
+      dbDetail: parts(false, "awaiting"),
+      loadWorld: runningWorld,
+    });
+    expect(res?.run.status).toBe("awaiting");
+    expect(res?.run.id).toBe("world");
+    expect(res?.steps[0].name).toBe("world");
+  });
+
+  it.each(["success", "failed", "blocked"] as const)(
+    "keeps the settled world status %s even when the durable row is awaiting",
+    async (status) => {
+      const res = await resolveRunDetail({
+        dbDetail: parts(false, "awaiting"),
+        loadWorld: async () => ({
+          run: { ...RUN("world"), status },
+          steps: STEPS("world"),
+        }),
+      });
+      expect(res?.run.status).toBe(status);
+      expect(res?.steps[0].name).toBe("world");
+    },
+  );
+
+  it.each(["running", "success", "failed"] as const)(
+    "keeps the world status when the durable row is %s",
+    async (status) => {
+      const res = await resolveRunDetail({
+        dbDetail: parts(false, status),
+        loadWorld: runningWorld,
+      });
+      expect(res?.run.status).toBe("running");
+      expect(res?.steps[0].name).toBe("world");
+    },
+  );
+
+  it("keeps the world status when there is no durable row", async () => {
+    const res = await resolveRunDetail({
+      dbDetail: null,
+      loadWorld: runningWorld,
+    });
+    expect(res?.run.status).toBe("running");
+    expect(res?.steps[0].name).toBe("world");
   });
 
   it("returns null when the world throws and there is no db detail", async () => {

--- a/apps/worker/src/lib/overview/resolve-run-detail.ts
+++ b/apps/worker/src/lib/overview/resolve-run-detail.ts
@@ -22,7 +22,16 @@ export async function resolveRunDetail(opts: {
     return { run: dbDetail.run, steps: dbDetail.steps };
   }
   try {
-    return await loadWorld();
+    const world = await loadWorld();
+    // A run parked on a clarification is suspended on a workflow hook, which the
+    // world still reports as "running". Only the durable row knows it is waiting
+    // for an answer, so it overrides that one world status. A world run that
+    // already settled (success/failed/blocked) always wins, so a stale
+    // "awaiting" row can never resurrect an answer form on a dead run.
+    if (dbDetail?.run.status === "awaiting" && world.run.status === "running") {
+      return { run: { ...world.run, status: "awaiting" }, steps: world.steps };
+    }
+    return world;
   } catch {
     return dbDetail ? { run: dbDetail.run, steps: dbDetail.steps } : null;
   }

--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -3,7 +3,7 @@ import { eq } from "drizzle-orm";
 import { createTestDb } from "../../db/test-db.js";
 import type { Db } from "../../db/client.js";
 import type { ResolvedPromptReference } from "@shared/contracts";
-import { workflowRuns } from "../../db/schema.js";
+import { approvalRequests, clarificationRequests, workflowRuns } from "../../db/schema.js";
 import {
   upsertRunSnapshots,
   recordRunUsage,
@@ -11,8 +11,12 @@ import {
   recordRunStatusReason,
   resolveAwaitingRun,
   resolveAwaitingRunsForTicket,
+  markRunAwaiting,
+  markRunBlockedOnCancel,
   markRunFailedOnSelfMove,
+  markRunResumed,
   markRunSucceededOnSelfMove,
+  sweepOrphanedAwaitingRuns,
   type RunSnapshot,
   type RunUsage,
   type RunBlockStatusWrite,
@@ -645,7 +649,8 @@ describe("awaiting (clarification park)", () => {
     await recordRunUsage(db, usage({ runId: "wrun_new", status: "awaiting" }));
     const flipped = await resolveAwaitingRunsForTicket(db, "PROJ-1", "wrun_new");
     expect(flipped).toBe(1);
-    expect((await row("wrun_old")).status).toBe("success");
+    // Superseded, never answered: a predecessor is settled, not successful.
+    expect((await row("wrun_old")).status).toBe("blocked");
     expect((await row("wrun_new")).status).toBe("awaiting");
   });
 
@@ -656,5 +661,195 @@ describe("awaiting (clarification park)", () => {
     expect(flipped).toBe(0);
     expect((await row("wrun_other_ticket")).status).toBe("awaiting");
     expect((await row("wrun_done")).status).toBe("success");
+  });
+});
+
+/** The park marker of a run that is suspended on its hook, not finished. */
+describe("live clarification park status", () => {
+  const frozen = ["failed", "blocked", "success"] as const;
+
+  async function seed(runId: string, status: string) {
+    await db.insert(workflowRuns).values({
+      runId,
+      subjectKey: "ticket:jira:PROJ-1",
+      workflowId: "wf_agent",
+      workflowName: "Agent",
+      ticketKey: "PROJ-1",
+      status,
+    });
+  }
+
+  it("markRunAwaiting parks an in-flight 'running' row", async () => {
+    await recordBlockStatuses(db, blockWrite()); // inserts status 'running'
+    await markRunAwaiting(db, "wrun_1");
+    expect((await row("wrun_1")).status).toBe("awaiting");
+  });
+
+  it("markRunAwaiting never overwrites a frozen outcome", async () => {
+    for (const status of frozen) {
+      await seed(`wrun_park_${status}`, status);
+      await markRunAwaiting(db, `wrun_park_${status}`);
+      expect((await row(`wrun_park_${status}`)).status).toBe(status);
+    }
+  });
+
+  it("parks a null-status (in-flight) row", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_park_null",
+      subjectKey: "ticket:jira:PROJ-1",
+      // status omitted -> stored NULL; must be treated as in-flight, not skipped
+    });
+    await markRunAwaiting(db, "wrun_park_null");
+    expect((await row("wrun_park_null")).status).toBe("awaiting");
+  });
+
+  it("markRunAwaiting is a no-op for a missing run", async () => {
+    await markRunAwaiting(db, "wrun_missing");
+    expect(await row("wrun_missing")).toBeUndefined();
+  });
+
+  it("markRunResumed flips an awaiting row back to running", async () => {
+    await seed("wrun_resume", "awaiting");
+    await markRunResumed(db, "wrun_resume");
+    expect((await row("wrun_resume")).status).toBe("running");
+  });
+
+  it("markRunResumed leaves every non-awaiting row alone", async () => {
+    for (const status of [...frozen, "running"]) {
+      await seed(`wrun_resume_${status}`, status);
+      await markRunResumed(db, `wrun_resume_${status}`);
+      expect((await row(`wrun_resume_${status}`)).status).toBe(status);
+    }
+    await markRunResumed(db, "wrun_missing");
+    expect(await row("wrun_missing")).toBeUndefined();
+  });
+
+  it("markRunBlockedOnCancel flips an awaiting row to blocked", async () => {
+    await seed("wrun_cancelled", "awaiting");
+    await markRunBlockedOnCancel(db, "wrun_cancelled");
+    expect((await row("wrun_cancelled")).status).toBe("blocked");
+  });
+
+  it("markRunBlockedOnCancel leaves every non-awaiting row alone", async () => {
+    for (const status of [...frozen, "running"]) {
+      await seed(`wrun_cancel_${status}`, status);
+      await markRunBlockedOnCancel(db, `wrun_cancel_${status}`);
+      expect((await row(`wrun_cancel_${status}`)).status).toBe(status);
+    }
+    await markRunBlockedOnCancel(db, "wrun_missing");
+    expect(await row("wrun_missing")).toBeUndefined();
+  });
+
+  // A workflow step can be re-executed after a worker restart, so every writer
+  // has to survive being called twice with the same argument.
+  it("repeating any of the three writes changes nothing", async () => {
+    await seed("wrun_twice", "running");
+    await markRunAwaiting(db, "wrun_twice");
+    await markRunAwaiting(db, "wrun_twice");
+    expect((await row("wrun_twice")).status).toBe("awaiting");
+
+    await markRunResumed(db, "wrun_twice");
+    await markRunResumed(db, "wrun_twice");
+    expect((await row("wrun_twice")).status).toBe("running");
+
+    await markRunAwaiting(db, "wrun_twice");
+    await markRunBlockedOnCancel(db, "wrun_twice");
+    await markRunBlockedOnCancel(db, "wrun_twice");
+    expect((await row("wrun_twice")).status).toBe("blocked");
+  });
+});
+
+describe("sweepOrphanedAwaitingRuns", () => {
+  async function parked(runId: string) {
+    await db.insert(workflowRuns).values({
+      runId,
+      subjectKey: "ticket:jira:PROJ-1",
+      workflowId: "wf_agent",
+      workflowName: "Agent",
+      ticketKey: "PROJ-1",
+      status: "awaiting",
+    });
+  }
+
+  async function question(runId: string, status: string) {
+    await db.insert(clarificationRequests).values({
+      id: `clar_${runId}_${status}`,
+      ticketKey: "PROJ-1",
+      subjectKey: "ticket:jira:PROJ-1",
+      runId,
+      questions: ["Which repository?"],
+      status,
+    });
+  }
+
+  async function approval(runId: string, status: string) {
+    await db.insert(approvalRequests).values({
+      id: `appr_${runId}_${status}`,
+      ticketKey: "PROJ-1",
+      definitionId: 1,
+      runId,
+      plan: { markdown: "# Plan" },
+      status,
+    });
+  }
+
+  it("leaves a healthy park alone", async () => {
+    await parked("wrun_pending");
+    await question("wrun_pending", "pending");
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(0);
+    expect((await row("wrun_pending")).status).toBe("awaiting");
+  });
+
+  it("leaves an answered question alone: the lost resume is retryable", async () => {
+    await parked("wrun_answered");
+    await question("wrun_answered", "answered");
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(0);
+    expect((await row("wrun_answered")).status).toBe("awaiting");
+  });
+
+  it("settles a run whose questions are all superseded", async () => {
+    await parked("wrun_superseded");
+    await question("wrun_superseded", "superseded");
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(1);
+    expect((await row("wrun_superseded")).status).toBe("blocked");
+  });
+
+  it("settles a run with no continuation at all", async () => {
+    await parked("wrun_orphan");
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(1);
+    expect((await row("wrun_orphan")).status).toBe("blocked");
+  });
+
+  it("leaves a run waiting on a pending approval alone", async () => {
+    await parked("wrun_approval");
+    await approval("wrun_approval", "pending");
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(0);
+    expect((await row("wrun_approval")).status).toBe("awaiting");
+  });
+
+  it("settles a run whose approval was already decided", async () => {
+    await parked("wrun_decided");
+    await approval("wrun_decided", "approved");
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(1);
+    expect((await row("wrun_decided")).status).toBe("blocked");
+  });
+
+  it("never touches a row that is not awaiting", async () => {
+    for (const status of ["running", "success", "failed", "blocked"]) {
+      await db.insert(workflowRuns).values({
+        runId: `wrun_sweep_${status}`,
+        subjectKey: "ticket:jira:PROJ-1",
+        status,
+      });
+    }
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(0);
+    expect((await row("wrun_sweep_running")).status).toBe("running");
+  });
+
+  it("is idempotent across cron ticks", async () => {
+    await parked("wrun_orphan");
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(1);
+    expect(await sweepOrphanedAwaitingRuns(db)).toBe(0);
+    expect((await row("wrun_orphan")).status).toBe("blocked");
   });
 });

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -1,6 +1,6 @@
 import { and, eq, isNull, ne, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "../../db/client.js";
-import { workflowRuns } from "../../db/schema.js";
+import { approvalRequests, clarificationRequests, workflowRuns } from "../../db/schema.js";
 import type {
   BlockRunState,
   HarnessRunManifestRecord,
@@ -448,10 +448,14 @@ export async function resolveAwaitingRun(db: Db, runId: string): Promise<boolean
 
 /**
  * Re-pickup housekeeping: flips every OTHER awaiting run for a ticket from
- * "awaiting" to "success", excluding the run doing the pickup. A fresh run
+ * "awaiting" to "blocked", excluding the run doing the pickup. A fresh run
  * supersedes its parked predecessors, so those must not stay "awaiting"
- * forever. Guarded on status='awaiting' and run_id <> exclude, so it is a
- * tolerant no-op when nothing is parked. Returns the number of rows flipped.
+ * forever. "blocked" and not "success": a superseded predecessor never got its
+ * answer and never finished its work, and the ticket key alone does not prove
+ * the row belongs to the same work thread (a pr_trigger run carries it too), so
+ * a run still suspended on its own hook would be frozen into a permanent lie.
+ * Guarded on status='awaiting' and run_id <> exclude, so it is a tolerant no-op
+ * when nothing is parked. Returns the number of rows flipped.
  */
 export async function resolveAwaitingRunsForTicket(
   db: Db,
@@ -460,12 +464,105 @@ export async function resolveAwaitingRunsForTicket(
 ): Promise<number> {
   const rows = await db
     .update(workflowRuns)
-    .set({ status: "success", updatedAt: sql`now()` })
+    .set({ status: "blocked", updatedAt: sql`now()` })
     .where(
       and(
         eq(workflowRuns.ticketKey, ticketKey),
         eq(workflowRuns.status, "awaiting"),
         ne(workflowRuns.runId, excludeRunId),
+      ),
+    )
+    .returning({ runId: workflowRuns.runId });
+  return rows.length;
+}
+
+/**
+ * Marks a run suspended on a clarification hook as "awaiting" while it is still
+ * alive. The workflow body parks inside the hook await, so the outer finally
+ * that records a run's own status never runs for a park, and the cron keeps
+ * snapshotting the parked run as "running". Unlike the terminal "awaiting" that
+ * recordRunUsage writes, this one belongs to a LIVE run, so every exit from the
+ * park has to clear it again (markRunResumed, markRunBlockedOnCancel) or the row
+ * stays awaiting forever. UPDATE-only on purpose: the row already exists from
+ * the run's own registration write, and an INSERT here would create one with no
+ * ticket identity. Guarded so an already-frozen outcome is never re-opened.
+ */
+export async function markRunAwaiting(db: Db, runId: string): Promise<void> {
+  await db
+    .update(workflowRuns)
+    .set({ status: "awaiting", updatedAt: sql`now()` })
+    .where(
+      and(
+        eq(workflowRuns.runId, runId),
+        // A NULL status is an in-flight row too: `status NOT IN (...)` is NULL
+        // (not true) for NULL, so without this a run whose row was created by a
+        // status-less writer would never be recorded as parked.
+        or(
+          isNull(workflowRuns.status),
+          notInArray(workflowRuns.status, ["failed", "blocked", "success"]),
+        ),
+      ),
+    );
+}
+
+/**
+ * Clears the live park marker once the answer lands and the parked run carries
+ * on, so the dashboard stops reporting it as awaiting input. Guarded on exactly
+ * "awaiting": a run that reached "failed", "blocked" or "success" while parked
+ * must never be resurrected into "running".
+ */
+export async function markRunResumed(db: Db, runId: string): Promise<void> {
+  await db
+    .update(workflowRuns)
+    .set({ status: "running", updatedAt: sql`now()` })
+    .where(and(eq(workflowRuns.runId, runId), eq(workflowRuns.status, "awaiting")));
+}
+
+/**
+ * Clears the live park marker when a parked run is cancelled instead of
+ * answered (the ticket is moved out of the AI column while the question is
+ * open). The run never resumes to clear it itself and the cron never downgrades
+ * a frozen status, so without this the cancelled row keeps showing awaiting
+ * input. Guarded on exactly "awaiting" so it only ever touches a parked run.
+ */
+export async function markRunBlockedOnCancel(db: Db, runId: string): Promise<void> {
+  await db
+    .update(workflowRuns)
+    .set({ status: "blocked", updatedAt: sql`now()` })
+    .where(and(eq(workflowRuns.runId, runId), eq(workflowRuns.status, "awaiting")));
+}
+
+/**
+ * Cron backstop for the live park marker. "awaiting" is frozen against the
+ * cron's own snapshot, and every writer that clears it is best-effort, so a
+ * single database blip while a park ends leaves a row stuck in "Input needed"
+ * that nothing else will ever touch. This settles those orphans on "blocked",
+ * the same outcome a cancelled park gets.
+ *
+ * A run is an orphan only when nothing can still resume it: a healthy park
+ * always has a pending clarification (the hook is published before the park is
+ * recorded), an answered one is the recoverable "answer stored, resume lost"
+ * state the dashboard retries and must stay awaiting, and a pending approval is
+ * a human continuation of the same kind. Everything else (superseded, expired,
+ * decided, or no continuation at all) has no way back.
+ */
+export async function sweepOrphanedAwaitingRuns(db: Db): Promise<number> {
+  const rows = await db
+    .update(workflowRuns)
+    .set({ status: "blocked", updatedAt: sql`now()` })
+    .where(
+      and(
+        eq(workflowRuns.status, "awaiting"),
+        sql`not exists (
+          select 1 from ${clarificationRequests}
+          where ${clarificationRequests.runId} = ${workflowRuns.runId}
+            and ${clarificationRequests.status} in ('pending', 'answered')
+        )`,
+        sql`not exists (
+          select 1 from ${approvalRequests}
+          where ${approvalRequests.runId} = ${workflowRuns.runId}
+            and ${approvalRequests.status} = 'pending'
+        )`,
       ),
     )
     .returning({ runId: workflowRuns.runId });

--- a/apps/worker/src/routes/api/v1/clarifications.test.ts
+++ b/apps/worker/src/routes/api/v1/clarifications.test.ts
@@ -1,7 +1,8 @@
 import { createApp, createRouter, toWebHandler } from "h3";
+import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Db } from "../../../db/client.js";
-import { member, organization, user } from "../../../db/schema.js";
+import { member, organization, user, workflowRuns } from "../../../db/schema.js";
 import { createTestDb } from "../../../db/test-db.js";
 import {
   getHookClarification,
@@ -20,7 +21,6 @@ const mocks = vi.hoisted(() => ({
   fetchTicket: vi.fn(),
   resumeHook: vi.fn(),
   getHookByToken: vi.fn(),
-  resolveAwaitingRun: vi.fn(),
 }));
 
 vi.mock("../../../db/client.js", () => ({ getDb: () => state.db }));
@@ -35,10 +35,6 @@ vi.mock("workflow/api", () => ({
   resumeHook: (...args: unknown[]) => mocks.resumeHook(...args),
   getHookByToken: (...args: unknown[]) => mocks.getHookByToken(...args),
 }));
-vi.mock("../../../lib/telemetry/run-telemetry.js", () => ({
-  resolveAwaitingRun: (...args: unknown[]) => mocks.resolveAwaitingRun(...args),
-}));
-
 const answerPost = (await import("./clarifications/[id]/answer.post.js")).default;
 let db: Db;
 
@@ -73,13 +69,28 @@ async function seedPending(ticketKey: string | null = "AWT-1") {
   return publishHookClarification(db, row.id);
 }
 
+function parkedRun(runId = "run-asked") {
+  return db.insert(workflowRuns).values({
+    runId,
+    subjectKey: "ticket:jira:AWT-1",
+    ticketKey: "AWT-1",
+    status: "awaiting",
+  });
+}
+
+const runStatus = (runId: string) =>
+  db
+    .select()
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, runId))
+    .then((r) => r[0]?.status);
+
 beforeEach(async () => {
   vi.clearAllMocks();
   state.session = { user: { id: "user_admin" }, session: { id: "session_test" } };
   mocks.fetchTicket.mockResolvedValue({ identifier: "AWT-1" });
   mocks.resumeHook.mockResolvedValue({ runId: "run-asked" });
   mocks.getHookByToken.mockRejectedValue(new Error("hook consumed"));
-  mocks.resolveAwaitingRun.mockResolvedValue(true);
   db = await createTestDb();
   state.db = db;
   await db.insert(organization).values({ id: "org_aiw", name: "AI Workflow", slug: "ai-workflow" });
@@ -151,8 +162,27 @@ describe("POST /api/v1/clarifications/:id/answer", () => {
     expect((await getHookClarification(db, row.id))?.answer).toBe("Use Next.js");
   });
 
+  it("clears the asking run's park marker once the answer is delivered", async () => {
+    const row = await seedPending();
+    await parkedRun();
+
+    expect((await answer(row.id)).status).toBe(200);
+    expect(await runStatus("run-asked")).toBe("running");
+  });
+
+  it("leaves the park marker in place when the resume can still be retried", async () => {
+    const row = await seedPending();
+    await parkedRun();
+    mocks.resumeHook.mockRejectedValueOnce(new Error("transport failed"));
+    mocks.getHookByToken.mockResolvedValueOnce({ runId: "run-asked" });
+
+    expect((await answer(row.id)).status).toBe(503);
+    expect(await runStatus("run-asked")).toBe("awaiting");
+  });
+
   it("retires the clarification when its Jira ticket was deleted", async () => {
     const row = await seedPending();
+    await parkedRun();
     mocks.fetchTicket.mockRejectedValueOnce(
       new IssueTrackerNotFoundError("AWT-1", "Ticket was deleted"),
     );
@@ -160,5 +190,8 @@ describe("POST /api/v1/clarifications/:id/answer", () => {
     expect((await answer(row.id)).status).toBe(410);
     expect((await getHookClarification(db, row.id))?.status).toBe("superseded");
     expect(mocks.resumeHook).not.toHaveBeenCalled();
+    // The run is still suspended on a hook nobody can answer now, so it settles
+    // as blocked. Recording success would freeze a dead run as a green result.
+    expect(await runStatus("run-asked")).toBe("blocked");
   });
 });

--- a/apps/worker/src/routes/cron/poll.get.test.ts
+++ b/apps/worker/src/routes/cron/poll.get.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   resumeClarificationFromComments: vi.fn(),
   recoverManualDispatches: vi.fn(),
   listRecoverableManualDispatches: vi.fn(),
+  sweepOrphanedAwaitingRuns: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({
@@ -123,6 +124,8 @@ vi.mock("../../lib/telemetry/collect-snapshots.js", () => ({
 }));
 vi.mock("../../lib/telemetry/run-telemetry.js", () => ({
   upsertRunSnapshots: vi.fn().mockResolvedValue(undefined),
+  sweepOrphanedAwaitingRuns: (...args: unknown[]) =>
+    mocks.sweepOrphanedAwaitingRuns(...args),
 }));
 
 const poll = (await import("./poll.get.js")).default;
@@ -189,6 +192,19 @@ describe("cron clarification recovery ordering", () => {
       return { scanned: 0, started: 0, recovering: 0, failed: 0 };
     });
     mocks.listRecoverableManualDispatches.mockResolvedValue([]);
+    mocks.sweepOrphanedAwaitingRuns.mockResolvedValue(0);
+  });
+
+  // "awaiting" is frozen against the snapshot write, and every writer that
+  // clears it is best-effort, so the poll has to settle the leftovers.
+  it("sweeps orphaned awaiting runs alongside the telemetry snapshot", async () => {
+    expect((await request()).status).toBe(200);
+    expect(mocks.sweepOrphanedAwaitingRuns).toHaveBeenCalledWith({ db: true });
+  });
+
+  it("keeps polling when the awaiting sweep fails", async () => {
+    mocks.sweepOrphanedAwaitingRuns.mockRejectedValue(new Error("db down"));
+    expect((await request()).status).toBe(200);
   });
 
   it("protects same-run clarifications before discovering generic ticket work", async () => {

--- a/apps/worker/src/routes/cron/poll.get.ts
+++ b/apps/worker/src/routes/cron/poll.get.ts
@@ -8,7 +8,10 @@ import { logger } from "../../lib/logger.js";
 import { GateStore } from "../../post-pr-gate/gate-store.js";
 import { getDb } from "../../db/client.js";
 import { collectSnapshots } from "../../lib/telemetry/collect-snapshots.js";
-import { upsertRunSnapshots } from "../../lib/telemetry/run-telemetry.js";
+import {
+  sweepOrphanedAwaitingRuns,
+  upsertRunSnapshots,
+} from "../../lib/telemetry/run-telemetry.js";
 import type { RunsLister } from "../../lib/overview/collect-runs.js";
 import { drainOldestPendingTrigger } from "../../lib/dispatch-trigger.js";
 import { listPendingTriggers } from "../../lib/trigger-delivery-store.js";
@@ -180,6 +183,10 @@ export default defineEventHandler(async (event) => {
       db,
     });
     await upsertRunSnapshots(db, snapshots);
+    // The snapshot above deliberately never downgrades "awaiting", so a park
+    // marker left behind by a best-effort writer that failed is invisible to it.
+    // This settles those orphans.
+    await sweepOrphanedAwaitingRuns(db);
   } catch (err) {
     logger.warn({ err: (err as Error).message }, "poll_snapshot_failed");
   }

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -3299,6 +3299,8 @@ async function agentWorkflowBody(
 
         const {
           markClarificationHookCleanupStep,
+          markRunAwaitingStep,
+          markRunResumedStep,
           prepareClarificationHookStep,
           publishClarificationHookStep,
           recordClarificationHookSnapshotStep,
@@ -3372,6 +3374,13 @@ async function agentWorkflowBody(
           }
 
           await publishClarificationHookStep(clarification.id);
+          // The body suspends on the hook below, so the run's own status writer
+          // never runs while it is parked and the cron keeps snapshotting it as
+          // "running". Record the park itself, before any of the ticket-side
+          // notifications a human can act on. Best-effort like the other two
+          // park writes: dashboard bookkeeping must never sink a real park (the
+          // cron sweep settles a marker that never landed).
+          await markRunAwaitingStep(workflowRunId).catch(() => undefined);
           if (entry.ticketKey) {
             await parkForClarificationStep(
               ticketId,
@@ -3406,6 +3415,13 @@ async function agentWorkflowBody(
           }
 
           const answered = await hook;
+          // First thing after the park, ahead of the expiry branch: that branch
+          // throws, and the failure path's markRunFailedOnSelfMove is a no-op on
+          // an "awaiting" row, so the run must be back to "running" before any
+          // later exit can record its real outcome. Best-effort: the answer is
+          // already consumed at this point, so a status write must never be what
+          // fails the resumed run.
+          await markRunResumedStep(workflowRunId).catch(() => undefined);
           lastBudgetClockMs = await readRunBudgetClockStep();
           if ("expired" in answered) {
             throw new Error("clarification expired before it was answered");
@@ -3498,6 +3514,10 @@ async function agentWorkflowBody(
           return answered.answer;
         } catch (error) {
           await supersedeClarificationHookStep(clarification.id).catch(() => undefined);
+          // A park that ends in a throw must not leave the row awaiting either.
+          // Guarded on "awaiting", so this is a no-op for a failure raised
+          // before the park and for a run a cancellation already flipped.
+          await markRunResumedStep(workflowRunId).catch(() => undefined);
           throw error;
         } finally {
           hook.dispose();

--- a/apps/worker/src/workflows/clarification-hook-steps.ts
+++ b/apps/worker/src/workflows/clarification-hook-steps.ts
@@ -72,6 +72,20 @@ export async function markClarificationHookCleanupStep(
   await markHookClarificationCleanup(getDb(), id, result);
 }
 
+export async function markRunAwaitingStep(runId: string): Promise<void> {
+  "use step";
+  const { getDb } = await import("../db/client.js");
+  const { markRunAwaiting } = await import("../lib/telemetry/run-telemetry.js");
+  await markRunAwaiting(getDb(), runId);
+}
+
+export async function markRunResumedStep(runId: string): Promise<void> {
+  "use step";
+  const { getDb } = await import("../db/client.js");
+  const { markRunResumed } = await import("../lib/telemetry/run-telemetry.js");
+  await markRunResumed(getDb(), runId);
+}
+
 export async function supersedeClarificationHookStep(id: string): Promise<void> {
   "use step";
   const { getDb } = await import("../db/client.js");


### PR DESCRIPTION
## Problem

A run parked on a clarification (agent asks a human and suspends on the WDK hook) kept showing **Running** in the runs table, the overview and the trace, and never appeared in the Input needed panel. Confirmed live on prod: parked run `wrun_01KZ5TF61BPMPV44S98EW7JDMR` (AWP-51) had `workflow_runs.status='running'`, and historical parks (AWP-44/46) sat as running for almost 3 days.

Root cause: the park suspends the workflow body inside `awaitClarification`, so the outer `finally` that records run status never runs at park time, and the cron keeps snapshotting the run as running. Nobody ever writes `awaiting`.

## Fix

`awaiting` used to be a terminal status; this change also gives it to a live suspended run, so every park exit now clears it:

- park: `markRunAwaiting` step right after the clarification hook is published (best effort, NULL-safe guard)
- answer: `markRunResumed` from both the answer endpoint and the resumed body, ahead of the expiry branch so a failure can still record `failed`
- throw inside the park window: best-effort resume flip in the catch
- cancel: `markRunBlockedOnCancel` after the step-drain barrier (a woken body cannot outrace it)
- gone ticket / superseded by pickup: `blocked` instead of a false green `success`
- cron safety net: `sweepOrphanedAwaitingRuns` flips an `awaiting` row with no live clarification or approval to `blocked` (answered-but-unresumed rows stay retryable)
- run detail: durable `awaiting` wins over the world's `running` only, so a dead run never shows an answer form

## Tests

151 tests across the 9 touched files (typecheck clean). Gate: Opus reviewer plus adversarial skeptic, both verdicts folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer workflow run status tracking while runs wait for clarification, resume, or become blocked.
  * Cancelled runs are now marked appropriately after cancellation completes.
  * Added automatic cleanup for abandoned clarification or approval waits.

* **Bug Fixes**
  * Prevented superseded or deleted-ticket runs from being incorrectly reported as successful.
  * Improved run details so waiting states are preserved accurately.
  * Clarification processing now handles retries and failures without losing status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->