### PR TITLE
fix(worker): close abandoned PR checks and keep CLI output on non-zero exit

### DIFF
--- a/apps/worker/src/sandbox/agents/protocol.test.ts
+++ b/apps/worker/src/sandbox/agents/protocol.test.ts
@@ -8,6 +8,7 @@ vi.mock("../../lib/logger.js", () => ({
 import {
   AGENT_CLI_SPECS,
   AgentRuntimeError,
+  commandProtocolFailure,
   installAndVerifyCli,
   protocolFailure,
   redactDiagnosticText,
@@ -147,6 +148,50 @@ describe("protocol diagnostics", () => {
           "ghu_abcdefghijklmnopqrstuvwxyz glpat-abcdefghijklmnop token=secretvalue",
       ),
     ).not.toMatch(/sk-ant-|gh[pousr]_|glpat-|secretvalue/);
+  });
+
+  it("keeps the stdout tail when a CLI exits non-zero, and only then", async () => {
+    const outage =
+      '{"type":"error","message":"stream disconnected before completion: ' +
+      'You have no credits remaining."}';
+
+    const exited = await commandProtocolFailure({
+      spec: AGENT_CLI_SPECS.codex,
+      phase: "repository-discovery",
+      result: command(1, outage) as never,
+      failureKind: "cli_exit",
+      message: "The current agent phase could not be completed.",
+      detail: "The agent phase wrapper exited non-zero.",
+    });
+    expect(exited.diagnostic.stdoutTail).toContain("no credits remaining");
+
+    // Setup failures are ours, not the provider's, and their stdout carries no
+    // cause worth keeping.
+    const setup = await commandProtocolFailure({
+      spec: AGENT_CLI_SPECS.codex,
+      phase: "repository-discovery",
+      result: command(1, outage) as never,
+      failureKind: "setup_failed",
+      message: "The current agent phase could not be completed.",
+      detail: "The agent phase wrapper could not be made executable.",
+    });
+    expect(setup.diagnostic.stdoutTail).toBeUndefined();
+  });
+
+  it("redacts and caps the stdout tail it keeps for a CLI exit", async () => {
+    process.env.AIW_PROTOCOL_TAIL_TOKEN = "secret-value-456";
+    const failure = await commandProtocolFailure({
+      spec: AGENT_CLI_SPECS.codex,
+      phase: "impl",
+      result: command(1, `${"x".repeat(4096)} token=secret-value-456`) as never,
+      failureKind: "cli_exit",
+      message: "The current agent phase could not be completed.",
+      detail: "The agent phase wrapper exited non-zero.",
+    });
+    const tail = failure.diagnostic.stdoutTail ?? "";
+    expect(tail).not.toContain("secret-value-456");
+    expect(Buffer.byteLength(tail)).toBeLessThanOrEqual(2 * 1024);
+    delete process.env.AIW_PROTOCOL_TAIL_TOKEN;
   });
 
   it("caps schema issues at twenty and never stores the schema value", () => {

--- a/apps/worker/src/sandbox/agents/protocol.ts
+++ b/apps/worker/src/sandbox/agents/protocol.ts
@@ -279,6 +279,14 @@ export async function commandProtocolFailure(input: {
     category: "provider",
     message: input.message,
     detail: input.detail,
+    // A CLI that exits non-zero puts the reason on its own stdout, and the
+    // adapters that parse a protocol stream already keep that tail. Without it
+    // here, the phases that fail before any adapter parsing (the wrapper script
+    // exiting) record byte counts and nothing else, so an outage that is
+    // obvious from one line of provider output ("no credits remaining") is
+    // indistinguishable from a bug in our prompt. The tail is redacted and
+    // capped exactly like every other one.
+    includeStdoutTail: input.failureKind === "cli_exit",
   });
   if (failure.ok) throw new Error("unreachable");
   return failure;

--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -183,6 +183,78 @@ describe("PR review diff placement", () => {
 });
 
 describe("PR check reconciliation", () => {
+  function pendingCheck(overrides: { id: string; runId: string; updatedAt: Date }) {
+    return {
+      nodeId: "create-check",
+      attempt: 1,
+      activationScope: "root",
+      subjectKey: "pr:github:acme/app#9",
+      provider: "github",
+      repository: "acme/app",
+      prNumber: 9,
+      headSha: "head",
+      name: "AI Workflow / Review",
+      providerReference: { provider: "github" as const, id: 9 },
+      state: "pending",
+      ...overrides,
+    };
+  }
+
+  const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+
+  it("closes a check the run abandoned, so the pull request stops waiting forever", async () => {
+    mockUpdateGateStatus.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockImplementation(gateStatusVcs);
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-dead", status: "failed" });
+    await db.insert(workflowRunExternalChecks).values([
+      pendingCheck({ id: "check-abandoned", runId: "run-dead", updatedAt: longAgo }),
+    ]);
+
+    await expect(reconcilePendingPrChecks(db)).resolves.toEqual({
+      attempted: 1,
+      closed: 1,
+      pending: 0,
+    });
+    // Cancelled, never "failure": the run died without judging the code.
+    expect(mockUpdateGateStatus).toHaveBeenCalledWith(
+      { provider: "github", id: 9 },
+      expect.objectContaining({ conclusion: "cancelled" }),
+    );
+    const [row] = await db
+      .select()
+      .from(workflowRunExternalChecks)
+      .where(eq(workflowRunExternalChecks.id, "check-abandoned"));
+    expect(row.state).toBe("completed");
+    expect(row.conclusion).toBe("cancelled");
+  });
+
+  it("never touches a check whose run can still deliver a verdict", async () => {
+    mockUpdateGateStatus.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockImplementation(gateStatusVcs);
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values([
+      { runId: "run-live", status: "running" },
+      { runId: "run-just-ended", status: "failed" },
+    ]);
+    await db.insert(workflowRunExternalChecks).values([
+      // Running for hours: still the run's to close.
+      pendingCheck({ id: "check-live", runId: "run-live", updatedAt: longAgo }),
+      // Ended a moment ago: its own closing write may still be in flight, and
+      // stamping "cancelled" here would erase a real verdict.
+      pendingCheck({ id: "check-fresh", runId: "run-just-ended", updatedAt: new Date() }),
+    ]);
+
+    await expect(reconcilePendingPrChecks(db)).resolves.toEqual({
+      attempted: 0,
+      closed: 0,
+      pending: 0,
+    });
+    expect(mockUpdateGateStatus).not.toHaveBeenCalled();
+    const rows = await db.select().from(workflowRunExternalChecks);
+    expect(rows.every((row) => row.state === "pending")).toBe(true);
+  });
+
   it("closes each check with its own stored conclusion", async () => {
     mockUpdateGateStatus.mockReset().mockResolvedValue(undefined);
     mockCreateRepositoryVCS.mockReset().mockImplementation(gateStatusVcs);

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -9,6 +9,7 @@ import {
   workflowPrReviewPublicationComments,
   workflowPrReviewPublications,
   workflowRunExternalChecks,
+  workflowRuns,
 } from "../db/schema.js";
 import {
   hasGateStatusCapability,
@@ -340,6 +341,48 @@ export async function closeRunPrChecks(args: {
   return { closed, pending };
 }
 
+/** Statuses a run never leaves, so a check it still owes will never be paid. */
+const ENDED_RUN_STATUSES = ["success", "failed", "blocked", "cancelled"];
+
+/** Long enough for a terminating run to finish closing its own checks. */
+const ABANDONED_CHECK_GRACE_MS = 60 * 1000;
+
+/**
+ * A run that dies between creating its check and deciding a verdict leaves the
+ * check open forever: the scheduler records no block outcome, so no closing
+ * step ever runs, and the pull request shows a check stuck in progress that
+ * blocks merge with no way to retry.
+ *
+ * The grace window matters. A run marks itself terminal and closes its checks
+ * as two separate writes, so a row read microseconds apart from the first would
+ * look abandoned while the second is still in flight, and we would overwrite a
+ * real verdict with "cancelled".
+ */
+async function abandonedPendingCheckIds(
+  db: Db,
+  rows: Array<{ id: string; runId: string; state: string; updatedAt: Date | null }>,
+): Promise<Set<string>> {
+  const candidates = rows.filter(
+    (row) =>
+      row.state === "pending" &&
+      Date.now() - (row.updatedAt?.getTime() ?? 0) >= ABANDONED_CHECK_GRACE_MS,
+  );
+  if (candidates.length === 0) return new Set();
+  const runIds = [...new Set(candidates.map((row) => row.runId))];
+  const runs = await db
+    .select({ runId: workflowRuns.runId, status: workflowRuns.status })
+    .from(workflowRuns)
+    .where(inArray(workflowRuns.runId, runIds));
+  const ended = new Set(
+    runs
+      .filter((run) => run.status && ENDED_RUN_STATUSES.includes(run.status))
+      .map((run) => run.runId),
+  );
+  return new Set(
+    candidates.filter((row) => ended.has(row.runId)).map((row) => row.id),
+  );
+}
+
 export async function reconcilePendingPrChecks(
   db: Db,
   limit = 25,
@@ -348,10 +391,11 @@ export async function reconcilePendingPrChecks(
     .select()
     .from(workflowRunExternalChecks)
     .where(
-      inArray(workflowRunExternalChecks.state, ["creating", "closing"]),
+      inArray(workflowRunExternalChecks.state, ["creating", "pending", "closing"]),
     )
     .orderBy(asc(workflowRunExternalChecks.updatedAt))
     .limit(limit);
+  const abandoned = await abandonedPendingCheckIds(db, rows);
   const retries: Array<{
     checkId: string;
     runId: string;
@@ -359,6 +403,27 @@ export async function reconcilePendingPrChecks(
     details: string;
   }> = [];
   for (const row of rows) {
+    if (row.state === "pending") {
+      // "pending" means the provider check exists and the run still owes it a
+      // verdict. Only a run that will never speak again may be closed here, so
+      // anything still in flight is left alone.
+      if (!abandoned.has(row.id)) continue;
+      await db
+        .update(workflowRunExternalChecks)
+        .set({
+          state: "closing",
+          closureIntent: row.closureIntent ?? "cancelled",
+          updatedAt: new Date(),
+        })
+        .where(eq(workflowRunExternalChecks.id, row.id));
+      retries.push({
+        checkId: row.id,
+        runId: row.runId,
+        intent: (row.closureIntent as CheckTerminalIntent | null) ?? "cancelled",
+        details: "The run ended without completing this check.",
+      });
+      continue;
+    }
     if (row.state === "creating" && !row.providerReference) {
       try {
         const { createRepositoryVCS } = await import("../lib/vcs-runtime.js");


### PR DESCRIPTION
Two production defects found while dogfooding the post-PR review flow on `Blazity/ai-workflow-prod`.

## A run that dies mid-review left its PR check stuck in progress forever (AIW-231)

Reproduced twice on PR #33. The run created its check, started the three review blocks, then died without the scheduler recording any block outcome. `workflow_run_external_checks` kept the row in `pending`, and the pull request showed `AI Workflow / Review` as `in_progress` with no way to retry.

`reconcilePendingPrChecks` only looked at `creating` and `closing`. Those cover "the check never reached the provider" and "the verdict never reached the provider". Nothing covered `pending`, which means the check exists and the run still owes it a verdict, so a run that never speaks again strands it.

The reconciler now also considers `pending`, but only when the owning run has reached a terminal status and the row has been untouched for a grace period. Both guards are load-bearing: without the first we would cancel checks of runs still working, and without the second we would race a terminating run's own closing write and overwrite a real verdict with `cancelled`. The closure intent is `cancelled`, never `failure`, because the run died without judging the code.

## A CLI that exits non-zero threw away the one line that explained why (AIW-229)

Ticket runs failed in `repository-discovery` with `failureKind: cli_exit`, 3156 bytes of stdout, and `log_envelope` NULL. The identical failure in a review block recorded its full output, because the codex adapter passes `includeStdoutTail` on its own paths while `commandProtocolFailure` did not.

The cause was one line of provider output: `You have no credits remaining`. Diagnosing it took an hour because the phases that fail before adapter parsing kept byte counts and nothing else.

`commandProtocolFailure` now keeps the stdout tail when the failure kind is `cli_exit`. Setup failures are unchanged, since their stdout is ours and carries no cause. The tail goes through the same `redactDiagnosticText` and the same 2 KiB cap as every other one, and a test pins both the redaction and the cap.

## Verification

- `src/sandbox/agents/protocol.test.ts` 9 passed
- `src/workflows/pr-external-resources.test.ts` 18 passed
- `tsc --noEmit` clean

After deploy, the two checks currently stuck on PR #33 should be closed by the next `/cron/poll`, which is the production proof for the first fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command failure diagnostics by including a redacted, size-limited tail of CLI output when available.
  * Prevented setup-related failures from exposing command output in diagnostics.
  * Automatically closes stale pending pull request checks for runs that have ended, while preserving checks for active or recently completed runs.
  * Maintains existing closure decisions when reconciling abandoned checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->