### PR TITLE
fix(worker): keep the CLI output on every non-zero agent exit path

### DIFF
--- a/apps/worker/src/sandbox/agents/protocol-fixtures.test.ts
+++ b/apps/worker/src/sandbox/agents/protocol-fixtures.test.ts
@@ -82,7 +82,18 @@ describe.each([
       category: "provider",
       diagnostic: { failureKind: "cli_exit", exitCode: 1 },
     });
-    if (!result.ok) expect(result.diagnostic.stdoutTail).toBeUndefined();
+    // The CLI's last words are the whole diagnosis for a non-zero exit, so the
+    // tail is kept under the same cap the malformed-output case below asserts.
+    if (!result.ok) {
+      // Nothing on stdout leaves nothing to keep; anything else has to survive,
+      // because it is the only record of why the process gave up.
+      expect(Boolean(result.diagnostic.stdoutTail)).toBe(
+        Boolean(loaded.artifacts.stdout),
+      );
+      expect(
+        Buffer.byteLength(result.diagnostic.stdoutTail ?? ""),
+      ).toBeLessThanOrEqual(2048);
+    }
   });
 
   it("rejects a missing terminal event", () => {

--- a/apps/worker/src/sandbox/agents/protocol.test.ts
+++ b/apps/worker/src/sandbox/agents/protocol.test.ts
@@ -8,6 +8,7 @@ vi.mock("../../lib/logger.js", () => ({
 import {
   AGENT_CLI_SPECS,
   AgentRuntimeError,
+  artifactFailure,
   commandProtocolFailure,
   installAndVerifyCli,
   protocolFailure,
@@ -176,6 +177,40 @@ describe("protocol diagnostics", () => {
       detail: "The agent phase wrapper could not be made executable.",
     });
     expect(setup.diagnostic.stdoutTail).toBeUndefined();
+  });
+
+  it("keeps the stdout tail for a collected phase that exited non-zero", () => {
+    // The phase-collection path raises `cli_exit` without going through
+    // commandProtocolFailure, and it was the one leaving operators blind.
+    const failure = artifactFailure(AGENT_CLI_SPECS.codex, "repository-discovery", {
+      stdout: '{"type":"error","message":"You have no credits remaining."}',
+      stderr: "",
+      structuredOutput: null,
+      exitCode: 1,
+    });
+    expect(failure?.ok).toBe(false);
+    if (failure && !failure.ok) {
+      expect(failure.diagnostic.failureKind).toBe("cli_exit");
+      expect(failure.diagnostic.stdoutTail).toContain("no credits remaining");
+    }
+  });
+
+  it("keeps no stdout tail for a failure that is not a CLI exit", () => {
+    const failure = protocolFailure({
+      spec: AGENT_CLI_SPECS.codex,
+      phase: "impl",
+      artifacts: {
+        stdout: "model prose that is none of our business",
+        stderr: "",
+        structuredOutput: null,
+        exitCode: 0,
+      },
+      failureKind: "schema_mismatch",
+      category: "schema",
+      message: "The current agent phase returned an invalid structured response.",
+    });
+    expect(failure.ok).toBe(false);
+    if (!failure.ok) expect(failure.diagnostic.stdoutTail).toBeUndefined();
   });
 
   it("redacts and caps the stdout tail it keeps for a CLI exit", async () => {

--- a/apps/worker/src/sandbox/agents/protocol.ts
+++ b/apps/worker/src/sandbox/agents/protocol.ts
@@ -279,14 +279,6 @@ export async function commandProtocolFailure(input: {
     category: "provider",
     message: input.message,
     detail: input.detail,
-    // A CLI that exits non-zero puts the reason on its own stdout, and the
-    // adapters that parse a protocol stream already keep that tail. Without it
-    // here, the phases that fail before any adapter parsing (the wrapper script
-    // exiting) record byte counts and nothing else, so an outage that is
-    // obvious from one line of provider output ("no credits remaining") is
-    // indistinguishable from a bug in our prompt. The tail is redacted and
-    // capped exactly like every other one.
-    includeStdoutTail: input.failureKind === "cli_exit",
   });
   if (failure.ok) throw new Error("unreachable");
   return failure;
@@ -336,7 +328,15 @@ export function protocolFailure(input: {
       })),
     };
   }
-  if (input.includeStdoutTail && artifacts.stdout) {
+  // A CLI that exits non-zero puts the reason on its own stdout, so keep that
+  // tail unless a caller deliberately says otherwise. Making it the default
+  // here rather than at each call site is the point: `cli_exit` is raised from
+  // more than one place, and the paths that forgot to ask were exactly the ones
+  // that recorded byte counts and nothing else, leaving an outage that one line
+  // of provider output would have explained indistinguishable from our own bug.
+  const includeStdoutTail =
+    input.includeStdoutTail ?? input.failureKind === "cli_exit";
+  if (includeStdoutTail && artifacts.stdout) {
     const tail = safeDiagnosticTail(artifacts.stdout);
     if (tail !== undefined) diagnostic.stdoutTail = tail;
   }


### PR DESCRIPTION
Follow-up to #203, which fixed this in only one of the two places that raise `cli_exit`.

## What was still broken

`commandProtocolFailure` was not the path that ticket runs take. A phase collected through `collectPhase` raises its failure in `artifactFailure`, which calls `protocolFailure` directly, so the stdout tail was still dropped there.

Verified against production after deploying #203: a ticket run failed in `repository-discovery` with `failureKind: cli_exit`, `stdoutBytes: 3156`, and `log_envelope` still NULL. Same blindness as before.

## The fix

The policy now lives in `protocolFailure` itself: when the failure kind is `cli_exit`, the stdout tail is kept unless a caller explicitly opts out. `cli_exit` is raised from more than one place, and per-call-site opt-in is exactly what let one path silently lose the cause while another kept it.

The explicit flag added to `commandProtocolFailure` in #203 is removed, since the default now covers it.

## Why this is safe

`schema_mismatch` and friends still keep nothing: there the stdout is model prose, not a diagnosis, and a test pins that. The tail a `cli_exit` keeps goes through the same `redactDiagnosticText` and the same 2 KiB cap as every other tail, both pinned by tests.

## What it would have saved

The outage behind AIW-229 was one line of provider output: `You have no credits remaining`. It was recorded for review blocks and lost for ticket blocks, and finding it took an hour of guessing from byte counts.

## Verification

- `src/sandbox/agents/protocol.test.ts` 11 passed, including the `artifactFailure` path and a negative case for non-CLI failures
- `codex.test.ts` 37, `claude.test.ts` 57 passed
- `src/run-observability` plus `pr-external-resources.test.ts` 92 passed
- `pnpm -r typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)