### PR TITLE
fix(worker): keep the agent poll loop reproducible across workflow replays

### DIFF
--- a/apps/worker/src/workflows/blocks/poll-phase.test.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.test.ts
@@ -42,7 +42,12 @@ describe("pollPhaseUntilDone", () => {
     mocks.sandboxGet.mockResolvedValue({ getCommand: mocks.getCommand });
   });
 
-  it("caps each Workflow sleep to the remaining active duration", async () => {
+  // Replaces an earlier expectation that the sleep was capped to the remaining
+  // active duration. That cap read the shared run budget, so two blocks polling
+  // concurrently produced sleep durations a replay could not reproduce, and the
+  // workflow runtime discarded the run with CORRUPTED_EVENT_LOG. Losing the cap
+  // only delays noticing an exhausted duration budget by one interval.
+  it("sleeps a fixed interval that no budget reading can influence", async () => {
     const observeBudget = vi
       .fn()
       .mockResolvedValueOnce(ok(12_345))
@@ -53,9 +58,52 @@ describe("pollPhaseUntilDone", () => {
       pollPhaseUntilDone("sbx-1", "/tmp/done", 25, "cmd-1", observeBudget),
     ).resolves.toBe(true);
 
-    expect(mocks.sleep).toHaveBeenCalledWith("12345ms");
+    expect(mocks.sleep).toHaveBeenCalledWith("30000ms");
     expect(mocks.checkPhaseDone).toHaveBeenCalledWith("sbx-1", "/tmp/done");
     expect(observeBudget.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it("asks for the same sleep whatever the budget reports, so a replay matches", async () => {
+    mocks.checkPhaseDone.mockResolvedValue(true);
+    const sleepArguments: unknown[] = [];
+
+    for (const remaining of [12_345, 777, 60_000]) {
+      mocks.sleep.mockClear();
+      await pollPhaseUntilDone(
+        "sbx-1",
+        "/tmp/done",
+        25,
+        "cmd-replay",
+        vi.fn().mockResolvedValue(ok(remaining)),
+      );
+      sleepArguments.push(mocks.sleep.mock.calls[0]?.[0]);
+    }
+
+    expect(new Set(sleepArguments)).toEqual(new Set(["30000ms"]));
+  });
+
+  it("does not race the durable sleep against the in-memory cancellation promise", async () => {
+    const controller = createV2InvocationCancellationController();
+    // Cancelled before the loop sleeps: a racing implementation would settle on
+    // the cancellation promise and never call sleep at all, which is precisely
+    // the non-reproducible ordering that corrupts the event log.
+    mocks.sleep.mockImplementationOnce(async () => {
+      controller.cancel("sibling failed mid-sleep");
+    });
+    mocks.checkPhaseDone.mockResolvedValue(false);
+
+    await expect(
+      pollPhaseUntilDone(
+        "sbx-1",
+        "/tmp/done",
+        25,
+        "cmd-no-race",
+        vi.fn().mockResolvedValue(ok(60_000)),
+        controller.view,
+      ),
+    ).rejects.toMatchObject({ name: "V2InvocationCancelledError" });
+
+    expect(mocks.sleep).toHaveBeenCalledWith("30000ms");
   });
 
   it("accepts a phase that writes its sentinel exactly at the duration limit", async () => {
@@ -118,7 +166,9 @@ describe("pollPhaseUntilDone", () => {
       failure: durationFailure,
     });
 
-    expect(mocks.sleep).toHaveBeenCalledWith("5000ms");
+    // Fixed interval, not the 5000ms the budget still had left: see the note on
+    // the first test in this file.
+    expect(mocks.sleep).toHaveBeenCalledWith("30000ms");
     expect(mocks.sandboxGet).toHaveBeenCalledWith({ sandboxId: "sbx-1" });
     expect(mocks.getCommand).toHaveBeenCalledWith("cmd-9");
     expect(mocks.kill).toHaveBeenCalledOnce();

--- a/apps/worker/src/workflows/blocks/poll-phase.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.ts
@@ -9,6 +9,20 @@ import {
  * Returns false when the phase stopped without finishing or the cap ran out.
  * Plain async orchestration (not a "use step"): it drives the checkPhaseDone
  * step, so it is safe to share between block executors.
+ *
+ * Every await in this loop must be reproducible on replay. Blocks that poll run
+ * concurrently in a fan-out, and the workflow runtime replays the whole function
+ * to rebuild its state, matching recorded step events to call sites in the order
+ * they are reached. If one loop's timing shifts, a later step event is handed to
+ * a different block's call site, the runtime reports a replay divergence and,
+ * after its recovery attempts, discards the run with CORRUPTED_EVENT_LOG. That
+ * failure arrives with no diagnostic of ours attached, because our error paths
+ * never run: the whole run is thrown away.
+ *
+ * Concretely, this means the sleep duration is computed only from constants and
+ * this loop's own counter, and nothing here races a durable await against a
+ * plain in-memory promise. Both rules cost a little responsiveness and buy the
+ * only thing that matters here, a run that survives its own replay.
  */
 export async function pollPhaseUntilDone(
   sandboxId: string,
@@ -32,8 +46,16 @@ export async function pollPhaseUntilDone(
       await killPhaseCommand(sandboxId, commandId);
       throw new RunBudgetError(before.check);
     }
-    const sleepMs = Math.min(30_000, phaseLimitMs - phaseElapsedMs, before.remainingDurationMs);
-    if (sleepMs <= 0) {
+    // The sleep length is derived only from constants and this loop's own
+    // counter, never from the run budget. Several agent blocks poll at once
+    // while sharing one budget accumulator, so a budget-derived duration is not
+    // reproducible on replay: the workflow runtime then matches recorded step
+    // events to the wrong call site and kills the run with CORRUPTED_EVENT_LOG
+    // instead of any failure we could report. Budget exhaustion is still
+    // enforced, by the guard below and by the check after the sleep; the only
+    // cost is noticing an exhausted duration budget up to one interval late.
+    const sleepMs = Math.min(30_000, phaseLimitMs - phaseElapsedMs);
+    if (sleepMs <= 0 || before.remainingDurationMs <= 0) {
       const limit = before.durationLimitMs ?? before.activeElapsedMs ?? 0;
       const consumed = before.activeElapsedMs ?? limit;
       await killPhaseCommand(sandboxId, commandId);
@@ -46,18 +68,12 @@ export async function pollPhaseUntilDone(
       });
     }
 
-    if (cancellation) {
-      const cancelled = await Promise.race([
-        sleep(`${Math.ceil(sleepMs)}ms`).then(() => false),
-        cancellation.wait().then(() => true),
-      ]);
-      if (cancelled) {
-        await killPhaseCommand(sandboxId, commandId);
-        throw new V2InvocationCancelledError(cancellation.reason);
-      }
-    } else {
-      await sleep(`${Math.ceil(sleepMs)}ms`);
-    }
+    // Never race this durable sleep against the cancellation promise. That
+    // promise lives in memory only, so a replay recreates it unresolved and the
+    // race can settle differently than it did on the original pass, which is
+    // the same event-log corruption described above. The check right after the
+    // sleep already picks a sibling's failure up, one interval later at worst.
+    await sleep(`${Math.ceil(sleepMs)}ms`);
     phaseElapsedMs += sleepMs;
 
     if (cancellation?.cancelled) {


### PR DESCRIPTION
Parallel review agents killed their own run. Definition 12 (Post-PR review) has three `review_agent` nodes; every run of it died about two minutes in with `status_reason` and `diagnostic_id` NULL and all three review blocks frozen in `running`. No error path of ours had run, so nothing explained it.

## What was actually happening

From the Vercel runtime errors:

```
errorCode: CORRUPTED_EVENT_LOG
Workflow replay diverged 4 times after 3 recovery replays
Replay divergence: step event step_created for step_01KZ96H2GV8PGJK83T2W81YZB9
  belongs to "step//./src/workflows/agent//writeAndStartPhase",
  but the current step consumer is "step//./src/sandbox/poll-agent//checkPhaseDone"
```

The runtime replays the workflow function to rebuild its state and hands recorded step events to call sites in the order they are reached. `pollPhaseUntilDone` computed its sleep as `Math.min(30_000, phaseLimitMs - phaseElapsedMs, before.remainingDurationMs)`, and that last term comes from the run budget: a single accumulator, shared by every block, advanced by a `Date.now()` step. Three blocks polling at once each got a different budget reading depending on interleaving, so each asked for a different sleep duration, so a replay could not reproduce the ordering. One shifted loop is enough for a later step event to reach the wrong block's call site, and after its recovery attempts the runtime discards the run.

That the run dies with no diagnostic is the signature: our failure handling never executes, the whole run is thrown away.

## The fix

The sleep duration now comes only from constants and the loop's own counter. Budget exhaustion is still enforced, by the pre-sleep guard (now reading `before.remainingDurationMs <= 0` directly) and by the check after the sleep. The only cost is noticing an exhausted duration budget up to one interval late.

The durable sleep is also no longer raced against `cancellation.wait()`. That promise lives in memory only, so a replay recreates it unresolved and the race can settle differently than it did originally, which is the same corruption by another route. The existing check immediately after the sleep still picks a sibling's failure up, one interval later at worst.

## A test expectation is deliberately reversed

`caps each Workflow sleep to the remaining active duration` pinned the behaviour being removed. It is replaced by `sleeps a fixed interval that no budget reading can influence`, plus a test asserting three different budget readings all produce the same sleep argument, plus one asserting the sleep is not raced. Each carries a comment saying why, so nobody restores the cap as an optimisation.

## Verification

- `src/workflows`, `src/sandbox`, `src/workflow-definition`: 125 files, 2195 tests passing
- `pnpm -r typecheck` clean

Determinism under a real replay cannot be asserted in vitest, so this needs the production check that follows: repeated runs of the three-reviewer flow on a real pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)