### PR TITLE
feat(worker): handle already-resolved tickets as no-op success (AIW-232)

### DIFF
--- a/apps/worker/src/sandbox/agents/claude.test.ts
+++ b/apps/worker/src/sandbox/agents/claude.test.ts
@@ -344,6 +344,8 @@ describe("schema constants", () => {
       "repositories",
       "writeRepositories",
       "repositoryEvidence",
+      "noChangeNeeded",
+      "resolutionEvidence",
       "error",
     ]);
     expect(s.properties.status.enum).toEqual([
@@ -351,6 +353,14 @@ describe("schema constants", () => {
       "repositories_needed",
       "clarification_needed",
       "failed",
+    ]);
+  });
+  it("RESEARCH_SCHEMA declares the no-op resolution fields as nullable", () => {
+    const s = JSON.parse(RESEARCH_SCHEMA);
+    expect(s.properties.noChangeNeeded.type).toEqual(["boolean", "null"]);
+    expect(s.properties.resolutionEvidence.anyOf).toEqual([
+      { type: "array", maxItems: 50, items: { type: "string" } },
+      { type: "null" },
     ]);
   });
   it("GENERIC_SCHEMA is valid JSON with the expected fields", () => {

--- a/apps/worker/src/sandbox/agents/types.test.ts
+++ b/apps/worker/src/sandbox/agents/types.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { foldResearchOutput, researchOutputSchema, type ResearchOutput } from "./types.js";
+
+describe("foldResearchOutput", () => {
+  it("round-trips noChangeNeeded and resolutionEvidence on the completed branch", () => {
+    const output: ResearchOutput = {
+      status: "completed",
+      plan: "Already fixed in a prior commit.",
+      noChangeNeeded: true,
+      resolutionEvidence: [
+        "Commit a1b2c3d fixes the reported crash.",
+        'Ticket comment: "Fixed" by jdoe.',
+      ],
+    };
+
+    expect(foldResearchOutput(output)).toEqual({
+      status: "completed",
+      body: "Already fixed in a prior commit.",
+      noChangeNeeded: true,
+      resolutionEvidence: [
+        "Commit a1b2c3d fixes the reported crash.",
+        'Ticket comment: "Fixed" by jdoe.',
+      ],
+    });
+  });
+
+  it("omits noChangeNeeded and resolutionEvidence when absent", () => {
+    const output: ResearchOutput = {
+      status: "completed",
+      plan: "Implement the feature.",
+      writeRepositories: [
+        { provider: "github", repoPath: "org/repo", rationale: "Owns the code." },
+      ],
+    };
+
+    const result = foldResearchOutput(output);
+    expect(result).toEqual({
+      status: "completed",
+      body: "Implement the feature.",
+      writeRepositories: [
+        { provider: "github", repoPath: "org/repo", rationale: "Owns the code." },
+      ],
+    });
+    expect(result).not.toHaveProperty("noChangeNeeded");
+    expect(result).not.toHaveProperty("resolutionEvidence");
+  });
+});
+
+describe("researchOutputSchema", () => {
+  it("accepts a payload with both new fields set", () => {
+    const result = researchOutputSchema.safeParse({
+      status: "completed",
+      plan: "Already resolved.",
+      noChangeNeeded: true,
+      resolutionEvidence: ["Commit a1b2c3d fixes the issue."],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a legacy payload without the new keys at all", () => {
+    const result = researchOutputSchema.safeParse({
+      status: "completed",
+      plan: "Implement the feature.",
+      writeRepositories: [
+        { provider: "github", repoPath: "org/repo", rationale: "Owns the code." },
+      ],
+      repositoryEvidence: ["src/index.ts contains the affected logic."],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts noChangeNeeded=true with missing resolutionEvidence (no cross-field rejection)", () => {
+    const result = researchOutputSchema.safeParse({
+      status: "completed",
+      plan: "Already resolved.",
+      noChangeNeeded: true,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/worker/src/sandbox/agents/types.ts
+++ b/apps/worker/src/sandbox/agents/types.ts
@@ -163,6 +163,10 @@ export interface ResearchResult {
   repositories?: ResearchRepository[];
   writeRepositories?: ResearchRepository[];
   repositoryEvidence?: string[];
+  /** Evidence that the ticket is already resolved (commit SHAs, PR references, quoted
+   * ticket comments), distinct from repositoryEvidence which justifies write-repo selection. */
+  noChangeNeeded?: boolean;
+  resolutionEvidence?: string[];
 }
 
 const researchRepositorySchema = z.object({
@@ -183,6 +187,8 @@ export const researchOutputSchema = z.object({
   repositories: z.array(researchRepositorySchema).max(3).nullish(),
   writeRepositories: z.array(researchRepositorySchema).max(8).nullish(),
   repositoryEvidence: z.array(z.string()).max(50).nullish(),
+  noChangeNeeded: z.boolean().nullish(),
+  resolutionEvidence: z.array(z.string()).max(50).nullish(),
   error: z.string().nullish(),
 }).strict();
 export type ResearchOutput = z.infer<typeof researchOutputSchema>;
@@ -258,6 +264,15 @@ export const RESEARCH_SCHEMA = JSON.stringify({
         { type: "null" },
       ],
     },
+    noChangeNeeded: { type: ["boolean", "null"] },
+    resolutionEvidence: {
+      anyOf: [
+        { type: "array", maxItems: 50, items: { type: "string" } },
+        { type: "null" },
+      ],
+      description:
+        "Evidence that the ticket is already resolved (commit SHAs, PR references, quoted ticket comments), distinct from repositoryEvidence. Optional.",
+    },
     error: { type: ["string", "null"] },
   },
   required: [
@@ -268,6 +283,8 @@ export const RESEARCH_SCHEMA = JSON.stringify({
     "repositories",
     "writeRepositories",
     "repositoryEvidence",
+    "noChangeNeeded",
+    "resolutionEvidence",
     "error",
   ],
   additionalProperties: false,
@@ -284,6 +301,10 @@ export function foldResearchOutput(o: ResearchOutput): ResearchResult {
         : {}),
       ...((o.repositoryEvidence ?? []).length > 0
         ? { repositoryEvidence: o.repositoryEvidence ?? [] }
+        : {}),
+      ...(o.noChangeNeeded ? { noChangeNeeded: o.noChangeNeeded } : {}),
+      ...((o.resolutionEvidence ?? []).length > 0
+        ? { resolutionEvidence: o.resolutionEvidence ?? [] }
         : {}),
     };
   }

--- a/apps/worker/src/sandbox/context.test.ts
+++ b/apps/worker/src/sandbox/context.test.ts
@@ -49,6 +49,27 @@ describe("assembleResearchPlanContext", () => {
     expect(result).toContain("Research is read-only");
   });
 
+  it("adds a Resolution Check section instructing the agent to look for prior fixes", () => {
+    const result = assembleResearchPlanContext({
+      ticket: {
+        identifier: "AIW-232",
+        title: "Already resolved ticket",
+        description: "Ticket says Fixed in a comment.",
+        acceptanceCriteria: "",
+        comments: [],
+      },
+      prompt: "",
+      branchName: "blazebot/aiw-232",
+    });
+
+    expect(result).toContain("## Resolution Check");
+    expect(result.indexOf("## Repository Access Protocol")).toBeLessThan(
+      result.indexOf("## Resolution Check"),
+    );
+    expect(result).toContain('noChangeNeeded: true');
+    expect(result).toContain("resolutionEvidence");
+  });
+
   it("assembles context for new ticket (no PR feedback)", () => {
     const result = assembleResearchPlanContext({
       ticket: {

--- a/apps/worker/src/sandbox/context.ts
+++ b/apps/worker/src/sandbox/context.ts
@@ -134,6 +134,22 @@ This protocol extends and overrides any older Output Format instructions above.
   repository.
 - Set fields that do not apply to \`null\`, as required by the structured schema.
 - Research is read-only: do not modify files, create commits, or change branches.
+
+## Resolution Check
+
+- Before planning any implementation, check whether the ticket is already resolved:
+  read the ticket comments above (for example, a "Fixed" note), inspect the git
+  history of the attached repositories for commits or merges referencing the
+  ticket key or describing the same fix (\`git log\`, \`git show\`), and consider
+  any pull request context provided.
+- If the evidence shows the ticket is already resolved or requires no repository
+  changes, return \`status: "completed"\` with \`noChangeNeeded: true\`, put the
+  concrete evidence (commit SHAs, PR references, quoted ticket comment excerpts)
+  into \`resolutionEvidence\`, leave \`writeRepositories\` empty, and explain the
+  conclusion in the plan body.
+- Only claim this when the evidence is concrete. When unsure whether the ticket
+  is resolved, do not set \`noChangeNeeded\`; follow the Repository Access
+  Protocol instead.
 `;
   return md;
 }

--- a/apps/worker/src/workflow-definition/block-registry.test.ts
+++ b/apps/worker/src/workflow-definition/block-registry.test.ts
@@ -298,6 +298,21 @@ describe("workflow block registry", () => {
     ).toEqual([]);
   });
 
+  it("accepts the no-op planning_agent output the short-circuit returns under requireNormalOutput", () => {
+    expect(
+      validateBlockOutputForDefinition(
+        "planning_agent",
+        {},
+        {
+          status: "no_change_needed",
+          plan: "The reported crash is already fixed on main.",
+          evidence: ["Commit a1b2c3d guards the null branch."],
+        },
+        { requireNormalOutput: true },
+      ),
+    ).toEqual([]);
+  });
+
   it("defaults newly authored Generic Agent blocks to workspace-free mode", () => {
     expect(buildWorkflowBlockRegistry(context).generic_agent.defaults).toMatchObject({
       workspaceMode: "none",

--- a/apps/worker/src/workflow-definition/block-registry.test.ts
+++ b/apps/worker/src/workflow-definition/block-registry.test.ts
@@ -277,6 +277,27 @@ describe("workflow block registry", () => {
     );
   });
 
+  it("accepts the no-op planning_agent shape alongside the existing ready shape", () => {
+    const registry = buildWorkflowBlockRegistry(context);
+    expect(registry.planning_agent.output.statusVariants).toEqual([
+      "ready",
+      "needs_human_input",
+      "no_change_needed",
+    ]);
+    expect(
+      validateBlockOutputForDefinition("planning_agent", {}, {
+        status: "no_change_needed",
+        evidence: ["Commit a1b2c3d already fixes this."],
+      }),
+    ).toEqual([]);
+    expect(
+      validateBlockOutputForDefinition("planning_agent", {}, {
+        status: "ready",
+        plan: "Implement the feature.",
+      }),
+    ).toEqual([]);
+  });
+
   it("defaults newly authored Generic Agent blocks to workspace-free mode", () => {
     expect(buildWorkflowBlockRegistry(context).generic_agent.defaults).toMatchObject({
       workspaceMode: "none",

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -544,11 +544,12 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
         plan: stringType(),
         questions: arrayType(stringType()),
         suggestedAnswers: arrayType(stringType()),
+        evidence: arrayType(stringType()),
       },
       [],
     ),
     normalOutputRequired: ["plan"],
-    statusVariants: ["ready", "needs_human_input"],
+    statusVariants: ["ready", "needs_human_input", "no_change_needed"],
   },
   implementation_agent: {
     presentation: presentation(

--- a/apps/worker/src/workflow-definition/interpreter.test.ts
+++ b/apps/worker/src/workflow-definition/interpreter.test.ts
@@ -1322,6 +1322,80 @@ describe("executeGraph human input and ended", () => {
   });
 });
 
+describe("executeGraph terminal_success", () => {
+  const noChangePlan = {
+    status: "ready",
+    plan: "The ticket is already resolved, so no change is needed.",
+  };
+  const linear = (): RuntimeGraph =>
+    graphFrom(
+      [
+        node("trig", "trigger_ticket_ai"),
+        node("plan", "planning_agent"),
+        node("impl", "implementation_agent"),
+      ],
+      [
+        { from: "trig", to: "plan" },
+        { from: "plan", to: "impl" },
+      ],
+    );
+
+  it("reports the natural completion outcome and skips everything downstream", async () => {
+    const rec = makeRecorder();
+    const { executor, calls } = makeExecutor({
+      plan: { kind: "terminal_success", output: noChangePlan },
+    });
+    const result = await executeGraph({
+      graph: linear(),
+      entryTriggerId: "trig",
+      triggerOutput: { status: "ok" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+    });
+    const exhausted = await executeGraph({
+      graph: graphFrom(
+        [node("trig", "trigger_ticket_ai"), node("plan", "planning_agent")],
+        [{ from: "trig", to: "plan" }],
+      ),
+      entryTriggerId: "trig",
+      triggerOutput: { status: "ok" },
+      executeBlock: makeExecutor().executor,
+      hooks: makeRecorder().hooks,
+    });
+
+    expect(result.outcome).toBe(exhausted.outcome);
+    expect(result.outcome).toBe("completed");
+    expect(calls).toEqual(["plan"]);
+    expect(result.steps.plan?.output).toEqual(noChangePlan);
+    expect(result.steps.impl).toBeUndefined();
+    expect(finishStatuses(rec, "plan")).toEqual(["ok"]);
+    expect(rec.finishes[0].state.output).toEqual(noChangePlan);
+    expect(rec.clarifications).toEqual([]);
+    expect(rec.failures).toEqual([]);
+    expect(rec.terminations).toEqual([]);
+  });
+
+  it("validates the terminating output against the declared contract", async () => {
+    const rec = makeRecorder();
+    const { executor } = makeExecutor({
+      plan: { kind: "terminal_success", output: { status: "ready" } },
+    });
+    const result = await executeGraphWithContractValidation({
+      graph: linear(),
+      entryTriggerId: "trig",
+      triggerOutput: { status: "fired", ticketKey: "AIW-232" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+    });
+
+    expect(result.outcome).toBe("stopped");
+    expect(result.steps.plan).toBeUndefined();
+    expect(rec.failures).toEqual([
+      expect.objectContaining({ phase: "contract", nodeId: "plan" }),
+    ]);
+  });
+});
+
 describe("executeGraph terminate", () => {
   const cases: Array<[string, string]> = [
     ["waiting_for_human", "warn"],

--- a/apps/worker/src/workflow-definition/interpreter.ts
+++ b/apps/worker/src/workflow-definition/interpreter.ts
@@ -166,7 +166,11 @@ export type BlockExecutionResult =
       suggestedAnswers?: string[];
     }
   | { kind: "execution_error"; error: BlockExecutionError; output?: never }
-  | { kind: "ended"; output: BlockOutput };
+  | { kind: "ended"; output: BlockOutput }
+  /** The block succeeded and the whole walk is already satisfied: everything
+   * downstream of it is skipped and the run ends successfully. Distinct from
+   * "ended", which parks the run while it awaits a human. */
+  | { kind: "terminal_success"; output: BlockOutput };
 
 /** Runs a single action-category block and reports how the walk should proceed. */
 export type BlockExecutor = (
@@ -715,7 +719,9 @@ export async function executeGraph(opts: {
       const outputIssues = outputValidator(
         node,
         result.output,
-        result.kind === "next" || result.kind === "ended",
+        result.kind === "next" ||
+          result.kind === "ended" ||
+          result.kind === "terminal_success",
       );
       if (outputIssues.length > 0) {
         const message = contractViolation(node, outputIssues);
@@ -799,6 +805,15 @@ export async function executeGraph(opts: {
         continue;
       }
       return finish("stopped");
+    }
+
+    if (result.kind === "terminal_success") {
+      // The block succeeded and reported that the run is already satisfied, so
+      // nothing downstream of it should run. Recorded as a normal success and
+      // finished with the outcome a naturally exhausted walk returns.
+      steps[id] = { output: result.output };
+      await hooks.onBlockFinish(id, { status: "ok", attempt, output: result.output });
+      return finish("completed");
     }
 
     // result.kind === "ended": a block (e.g. send_plan_approval) parked the run

--- a/apps/worker/src/workflow-definition/scenarios/harness.ts
+++ b/apps/worker/src/workflow-definition/scenarios/harness.ts
@@ -799,7 +799,12 @@ class Scenario {
       node.type,
       node.configuration as unknown as Record<string, WorkflowParamValue>,
       result.output,
-      { requireNormalOutput: result.kind === "next" || result.kind === "ended" },
+      {
+        requireNormalOutput:
+          result.kind === "next" ||
+          result.kind === "ended" ||
+          result.kind === "terminal_success",
+      },
     );
     if (issues.length === 0) return;
     throw new ScenarioViolation(

--- a/apps/worker/src/workflow-definition/scenarios/no-change-ticket.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/no-change-ticket.scenario.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import type { AgentWorkflowInput } from "../../workflows/agent-input.js";
+import { executorRunsOf, expectNeverInvoked } from "./assertions.js";
+import { createScenario, type Scenario, type ScenarioOutcome } from "./harness.js";
+
+/**
+ * An already resolved ticket ends the run as a no-op: the planning agent
+ * short-circuits with `terminal_success` (status "no_change_needed") instead
+ * of handing the walk a plan, and the standard skip cascade takes every
+ * downstream node with it. These scenarios drive the production v2
+ * scheduler over the three shipped templates that carry a planning step, so
+ * the cascade, the Branch/Loop control nodes and the second-trigger regions
+ * are the real ones.
+ *
+ * The harness performs no side effects, so the Jira evidence comment, the
+ * ticket move and the Slack note that `agent.ts` sends for a real no-op are
+ * not asserted here; they are covered by unit tests and a live smoke test.
+ */
+
+const TICKET_ENTRY: AgentWorkflowInput = {
+  kind: "ticket",
+  subjectKey: "AIW-232",
+  ticketKey: "AIW-232",
+  ownerToken: "owner-1",
+};
+
+const TICKET_CONTEXT = {
+  identifier: "AIW-232",
+  title: "Already resolved ticket",
+  description: "Cover the already-resolved no-op with scenarios.",
+  acceptanceCriteria: "Scenarios drive the production scheduler.",
+  labels: ["ai"],
+  comments: [],
+};
+
+const NO_CHANGE_OUTPUT = {
+  status: "no_change_needed",
+  plan: "already fixed",
+  evidence: ["commit abc123"],
+};
+
+const PREPARED_WORKSPACE_OUTPUT = {
+  kind: "next" as const,
+  output: {
+    status: "ok",
+    sandboxId: "sbx-scenario",
+    repositories: ["github:acme/app"],
+    workspace: { id: "sbx-scenario", repositories: ["github:acme/app"] },
+  },
+};
+
+/**
+ * Asserts a node never reached a block executor and, wherever the scheduler
+ * left a record for it, that record reports a skip rather than a failure.
+ * The stronger claim than `expectNeverInvoked` alone: a downstream node that
+ * silently failed instead of being skipped would still never "run" in the
+ * executor sense, so the skip cascade needs its own check.
+ */
+function expectSkippedNotFailed(
+  outcome: ScenarioOutcome,
+  nodeIds: readonly string[],
+): void {
+  expectNeverInvoked(outcome, nodeIds);
+  for (const nodeId of nodeIds) {
+    for (const invocation of outcome.invocationsOf(nodeId)) {
+      expect(invocation.runtimeState).not.toBe("failed");
+    }
+  }
+}
+
+describe("already resolved ticket: ticket-workflow", () => {
+  function scenario(): Scenario {
+    return createScenario({
+      template: { id: "ticket-workflow", options: { includeReview: false } },
+      entry: TICKET_ENTRY,
+      entryTriggerId: "trigger",
+      ticket: TICKET_CONTEXT,
+    });
+  }
+
+  const DOWNSTREAM_OF_PLANNING = [
+    "implementation",
+    "checks",
+    "finalize",
+    "open-pr",
+    "slack",
+    "status",
+  ];
+
+  it("ends the walk as a completed no-op and never invokes anything downstream of planning", async () => {
+    const s = scenario();
+    s.script({ nodeId: "prepare" }, PREPARED_WORKSPACE_OUTPUT);
+    s.script(
+      { nodeId: "planning" },
+      { kind: "terminal_success", output: NO_CHANGE_OUTPUT },
+    );
+
+    const outcome = await s.execute();
+
+    expect(outcome.result.outcome).toBe("completed");
+    expect(outcome.result.executionError).toBeUndefined();
+    const planningRuns = executorRunsOf(outcome, "planning");
+    expect(planningRuns).toHaveLength(1);
+    expect(planningRuns[0].result).toEqual({
+      kind: "terminal_success",
+      output: NO_CHANGE_OUTPUT,
+    });
+    expectSkippedNotFailed(outcome, DOWNSTREAM_OF_PLANNING);
+  });
+
+  it("invokes implementation on an ordinary ready plan (normal-path regression)", async () => {
+    const s = scenario();
+    s.script({ nodeId: "prepare" }, PREPARED_WORKSPACE_OUTPUT);
+    s.script(
+      { nodeId: "planning" },
+      { kind: "next", output: { status: "ready", plan: "Implement the ticket." } },
+    );
+    s.script({ nodeId: "implementation" }, {
+      kind: "next",
+      output: {
+        status: "implemented",
+        workspaceId: "sbx-scenario",
+        branches: [],
+        commits: [],
+        summary: "Implemented.",
+      },
+    });
+    s.script({ nodeId: "checks" }, {
+      kind: "next",
+      output: {
+        status: "ok",
+        ok: true,
+        outcome: "passed",
+        fixCycles: 0,
+        summary: "Checks passed.",
+      },
+    });
+    s.script({ nodeId: "finalize" }, {
+      kind: "next",
+      output: {
+        status: "finalized",
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/app",
+            branchName: "ai-workflow/AIW-232",
+            defaultBranch: "main",
+            expectedHead: "before",
+            pushedHead: "after",
+          },
+        ],
+      },
+    });
+    s.script({ nodeId: "open-pr" }, {
+      kind: "next",
+      output: {
+        status: "ok",
+        prs: [
+          {
+            provider: "github",
+            repoPath: "acme/app",
+            id: 1,
+            url: "https://github.test/acme/app/pull/1",
+            branch: "ai-workflow/AIW-232",
+            isNew: true,
+          },
+        ],
+        prUrl: "https://github.test/acme/app/pull/1",
+        prNumber: 1,
+      },
+    });
+    s.script({ nodeId: "slack" }, { kind: "next", output: { status: "ok" } });
+    s.script({ nodeId: "status" }, {
+      kind: "next",
+      output: { status: "ok", target: "ai_review" },
+    });
+
+    const outcome = await s.execute();
+
+    expect(outcome.result.outcome).toBe("completed");
+    expect(outcome.result.executionError).toBeUndefined();
+    // Guards against an over-eager short-circuit at the scheduler level: an
+    // ordinary "ready" plan must still reach implementation.
+    expect(executorRunsOf(outcome, "implementation")).toHaveLength(1);
+  });
+});
+
+describe("already resolved ticket: human-approved-plan", () => {
+  function scenario(): Scenario {
+    return createScenario({
+      template: { id: "human-approved-plan", options: { includeReview: false } },
+      entry: TICKET_ENTRY,
+      entryTriggerId: "trigger-ticket",
+      ticket: TICKET_CONTEXT,
+    });
+  }
+
+  // "prepare-implementation", "implementation", "checks", "finalize",
+  // "open-pr" and "status" all sit behind the second trigger
+  // ("trigger-approved"), so they are unreachable from this entry regardless
+  // of planning's outcome. They are asserted anyway so a future rewiring
+  // that connects them directly to planning cannot silently skip a human
+  // approval.
+  const DOWNSTREAM_OF_PLANNING = [
+    "send-approval",
+    "prepare-implementation",
+    "implementation",
+    "checks",
+    "finalize",
+    "open-pr",
+    "status",
+  ];
+
+  it("ends the walk as a completed no-op and never requests a human approval", async () => {
+    const s = scenario();
+    s.script({ nodeId: "prepare-plan" }, PREPARED_WORKSPACE_OUTPUT);
+    s.script(
+      { nodeId: "planning" },
+      { kind: "terminal_success", output: NO_CHANGE_OUTPUT },
+    );
+
+    const outcome = await s.execute();
+
+    expect(outcome.result.outcome).toBe("completed");
+    expect(outcome.result.executionError).toBeUndefined();
+    const planningRuns = executorRunsOf(outcome, "planning");
+    expect(planningRuns).toHaveLength(1);
+    expect(planningRuns[0].result).toEqual({
+      kind: "terminal_success",
+      output: NO_CHANGE_OUTPUT,
+    });
+    // The acceptance criterion this template exists to prove: an
+    // already-resolved ticket never reaches a human for plan approval.
+    expectSkippedNotFailed(outcome, DOWNSTREAM_OF_PLANNING);
+  });
+});
+
+describe("already resolved ticket: reviewed-ticket-workflow", () => {
+  function scenario(): Scenario {
+    return createScenario({
+      template: {
+        id: "reviewed-ticket-workflow",
+        options: { includeReview: true, provider: "claude" as const },
+      },
+      entry: TICKET_ENTRY,
+      entryTriggerId: "trigger",
+      ticket: TICKET_CONTEXT,
+    });
+  }
+
+  const DOWNSTREAM_OF_PLANNING = [
+    "implementation",
+    "security-review",
+    "quality-review",
+    "requirements-review",
+    "reviews-approved",
+    "checks",
+    "finalize",
+    "open-pr",
+    "status",
+    "retry",
+    "fix",
+    "exhausted-message",
+    "exhausted-failure",
+  ];
+
+  it("ends the walk as a completed no-op and never invokes implementation, review or fix", async () => {
+    const s = scenario();
+    s.script({ nodeId: "prepare" }, PREPARED_WORKSPACE_OUTPUT);
+    s.script(
+      { nodeId: "planning" },
+      { kind: "terminal_success", output: NO_CHANGE_OUTPUT },
+    );
+
+    const outcome = await s.execute();
+
+    expect(outcome.result.outcome).toBe("completed");
+    expect(outcome.result.executionError).toBeUndefined();
+    const planningRuns = executorRunsOf(outcome, "planning");
+    expect(planningRuns).toHaveLength(1);
+    expect(planningRuns[0].result).toEqual({
+      kind: "terminal_success",
+      output: NO_CHANGE_OUTPUT,
+    });
+    expectSkippedNotFailed(outcome, DOWNSTREAM_OF_PLANNING);
+  });
+});

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -1568,7 +1568,9 @@ class V2SchedulerRuntime {
       result.output,
       {
         requireNormalOutput:
-          result.kind === "next" || result.kind === "ended",
+          result.kind === "next" ||
+          result.kind === "ended" ||
+          result.kind === "terminal_success",
       },
     );
     if (outputIssues.length > 0) {
@@ -1653,6 +1655,18 @@ class V2SchedulerRuntime {
         "waiting_for_clarification",
       );
       this.admissionStopped = true;
+      return;
+    }
+
+    if (result.kind === "terminal_success") {
+      // The block succeeded and reported that the run is already satisfied, so
+      // nothing downstream of it should run. Every outgoing edge resolves
+      // inactive, which skips the downstream cone through the same cascade a
+      // non-selected branch arm uses. Admission keeps going, so parallel
+      // siblings finish and the walk drains into the "completed" outcome
+      // instead of parking like "ended".
+      this.completeNode(scopeId, nodeId, attempt, result.output);
+      this.propagatePort(scopeId, nodeId, undefined);
       return;
     }
 

--- a/apps/worker/src/workflows/agent-no-change.test.ts
+++ b/apps/worker/src/workflows/agent-no-change.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { ResearchResult } from "../sandbox/agents/types.js";
+import { buildResolutionEvidenceComment } from "./agent.js";
+
+const research = (overrides: Partial<ResearchResult> = {}): ResearchResult => ({
+  status: "completed",
+  body: "The reported crash is already fixed on main.",
+  noChangeNeeded: true,
+  resolutionEvidence: [
+    "Commit a1b2c3d guards the null branch.",
+    "PR #412 shipped the same fix.",
+  ],
+  writeRepositories: [],
+  ...overrides,
+});
+
+describe("buildResolutionEvidenceComment", () => {
+  it("states the no-op, quotes the research body, and bullets every evidence entry", () => {
+    expect(buildResolutionEvidenceComment(research())).toBe(
+      [
+        "This ticket appears to be already resolved, so no code changes were made by this run.",
+        "",
+        "The reported crash is already fixed on main.",
+        "",
+        "Evidence:",
+        "- Commit a1b2c3d guards the null branch.",
+        "- PR #412 shipped the same fix.",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps the copy free of en and em dashes", () => {
+    const comment = buildResolutionEvidenceComment(
+      research({
+        body: "Nothing to do, the fix landed earlier.",
+        resolutionEvidence: ["Ticket comment: Fixed in 9f8e7d6."],
+      }),
+    );
+    // U+2013 en dash and U+2014 em dash, matched by escape so this file does
+    // not spell them out either.
+    expect(comment).not.toMatch(/[\u2013\u2014]/);
+  });
+
+  it("drops the evidence section when there is none to list", () => {
+    const withEmpty = buildResolutionEvidenceComment(
+      research({ resolutionEvidence: [] }),
+    );
+    const withMissing = buildResolutionEvidenceComment(
+      research({ resolutionEvidence: undefined }),
+    );
+    expect(withEmpty).toBe(
+      [
+        "This ticket appears to be already resolved, so no code changes were made by this run.",
+        "",
+        "The reported crash is already fixed on main.",
+      ].join("\n"),
+    );
+    expect(withMissing).toBe(withEmpty);
+  });
+});

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -1726,18 +1726,21 @@ export async function postPrLinksComment(
 }
 postPrLinksComment.maxRetries = 0;
 
+/** Posts the comment and hands back the tracker's deep link to it when the
+ *  provider exposes one, so callers can point a notification at the comment.
+ *  Callers that only need the comment posted may ignore the return value. */
 export async function postTicketComment(
   ticketId: string,
   comment: string,
   owner: ActiveRunOwner,
-): Promise<void> {
+): Promise<string | null> {
   "use step";
   const { getDb } = await import("../db/client.js");
   const { assertActiveRunOwner } = await import("../lib/active-run-owner.js");
   const { createStepAdapters } = await import("../lib/step-adapters.js");
   const { issueTracker } = createStepAdapters();
   await assertActiveRunOwner(getDb(), owner);
-  await issueTracker.postComment(ticketId, comment);
+  return issueTracker.postComment(ticketId, comment);
 }
 
 export async function notifyTicket(
@@ -1899,6 +1902,26 @@ export function terminalStatusDisposition(
     runOutcome: "success",
     shouldRunFailureSideEffects: false,
   };
+}
+
+/**
+ * The ticket-side account of a run that ends as a no-op: research found the
+ * ticket already resolved, so this run wrote nothing. Pure so the copy stays
+ * unit-testable. The evidence section is omitted when there is nothing to list;
+ * the caller only builds this comment once it has concrete evidence.
+ */
+export function buildResolutionEvidenceComment(research: ResearchResult): string {
+  const evidence = research.resolutionEvidence ?? [];
+  const sections = [
+    "This ticket appears to be already resolved, so no code changes were made by this run.",
+    research.body,
+  ];
+  if (evidence.length > 0) {
+    sections.push(
+      ["Evidence:", ...evidence.map((item) => `- ${item}`)].join("\n"),
+    );
+  }
+  return sections.join("\n\n");
 }
 
 export function v2TerminalBlockResult(input: {
@@ -4313,6 +4336,70 @@ async function agentWorkflowBody(
                 category: "unknown",
                 phase: "research",
               });
+            }
+
+            // An already resolved ticket (fix landed in an earlier commit, PR,
+            // or ticket comment) ends the run here as a successful no-op: there
+            // is nothing for any downstream block to write. All three signals
+            // must agree, so a half-filled signal keeps the normal plan path and
+            // its researchDeclaredNoWritesGuard verdict untouched.
+            const noChangeSignal =
+              research.noChangeNeeded === true &&
+              (research.resolutionEvidence ?? []).length > 0 &&
+              (research.writeRepositories ?? []).length === 0;
+            if (noChangeSignal) {
+              // Ticket-bound side effects only, exactly like the terminate
+              // dispatch: an uncorrelated entry has no ticket to comment on,
+              // move, or notify about.
+              if (entry.ticketKey) {
+                const evidenceCommentUrl = await postTicketComment(
+                  ticket.identifier,
+                  buildResolutionEvidenceComment(research),
+                  transitionOwner,
+                );
+                // terminal_success skips the downstream cone, so the graph's own
+                // update_ticket_status node never runs. Dispatch has no
+                // post-success dedup: a ticket left in the AI column would be
+                // redispatched, so replay that node's configured move here.
+                // Graphs without such a node do not move on normal success
+                // either, so they do not move here.
+                const statusNode = ctx.definitionNodes.find(
+                  (candidate) => candidate.type === "update_ticket_status",
+                );
+                if (statusNode) {
+                  const targetName = resolveTicketStatusInput(statusNode.params, {});
+                  const target = resolveTicketMoveTarget(targetName, {
+                    backlog: backlogMoveTarget(),
+                    aiReview: aiReviewMoveTarget(),
+                  });
+                  // Same self-move race as the real block: commit the run's
+                  // success before the move fires the "ticket left the AI
+                  // column" webhook.
+                  if (targetName === "ai_review") {
+                    await markRunSucceededOnSelfMoveStep(workflowRunId);
+                  }
+                  await moveTicketStep(entry.ticketKey, target, transitionOwner);
+                }
+                const note = "Ticket already resolved, no code changes needed.";
+                await notifyTicket(
+                  ticket.identifier,
+                  {
+                    kind: "note",
+                    text: evidenceCommentUrl
+                      ? `${note} Evidence: ${evidenceCommentUrl}`
+                      : note,
+                  },
+                  transitionOwner,
+                );
+              }
+              return {
+                kind: "terminal_success",
+                output: {
+                  status: "no_change_needed",
+                  plan: research.body,
+                  evidence: research.resolutionEvidence ?? [],
+                },
+              };
             }
 
             ctx.researchWriteRepositories = research.writeRepositories ?? [];

--- a/apps/worker/src/workflows/v2-terminal-success.test.ts
+++ b/apps/worker/src/workflows/v2-terminal-success.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import type {
+  BlockOutput,
+  JsonValue,
+  WorkflowBlockType,
+  WorkflowDefinitionV2,
+  WorkflowDefinitionV2Node,
+} from "@shared/contracts";
+import { executeV2Graph } from "../workflow-definition/v2-scheduler.js";
+
+function node(
+  id: string,
+  type: WorkflowBlockType,
+  configuration: Record<string, JsonValue> = {},
+): WorkflowDefinitionV2Node {
+  return {
+    id,
+    type,
+    x: 0,
+    y: 0,
+    configuration,
+    inputs: {},
+    additionalInputs: [],
+  };
+}
+
+const NO_CHANGE_PLAN: BlockOutput = {
+  status: "ready",
+  plan: "The ticket is already resolved, so no change is needed.",
+};
+
+describe("v2 terminal_success", () => {
+  it("ends the walk as a completed no-op and skips everything downstream", async () => {
+    const calls: string[] = [];
+    const skipped: string[] = [];
+    const finishes: Array<{
+      nodeId: string;
+      status: string;
+      runtimeState: string;
+      selectedTransition: unknown;
+    }> = [];
+    const definition: WorkflowDefinitionV2 = {
+      schemaVersion: 2,
+      nodes: [
+        node("trigger", "trigger_ticket_ai"),
+        node("planning", "planning_agent"),
+        node("implementation", "implementation_agent"),
+      ],
+      edges: [
+        { id: "trigger-planning", from: "trigger", to: "planning" },
+        { id: "planning-implementation", from: "planning", to: "implementation" },
+      ],
+    };
+
+    const result = await executeV2Graph({
+      definition,
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "fired" },
+      maxConcurrency: 1,
+      hooks: {
+        onNodeSkipped(event) {
+          skipped.push(event.nodeId);
+        },
+        onNodeFinish(event) {
+          finishes.push({
+            nodeId: event.nodeId,
+            status: event.state.status,
+            runtimeState: event.runtimeState,
+            selectedTransition: event.selectedTransition,
+          });
+        },
+      },
+      executeBlock: async (current) => {
+        calls.push(current.id);
+        if (current.id === "planning") {
+          return { kind: "terminal_success", output: NO_CHANGE_PLAN };
+        }
+        return { kind: "next", output: { status: "completed" } };
+      },
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(calls).toEqual(["planning"]);
+    expect(result.steps.planning?.output).toEqual(NO_CHANGE_PLAN);
+    expect(result.steps.implementation).toBeUndefined();
+    expect(result.state.scopes.root.nodeStates.implementation?.status).toBe(
+      "skipped",
+    );
+    expect(result.state.scopes.root.edgeTokens["planning-implementation"]).toBe(
+      "inactive",
+    );
+    expect(skipped).toEqual(["implementation"]);
+    expect(finishes).toEqual([
+      {
+        nodeId: "planning",
+        status: "ok",
+        runtimeState: "completed",
+        selectedTransition: null,
+      },
+    ]);
+    expect(result.state.ended).toBe(false);
+  });
+
+  it("keeps a parallel sibling branch running to completion", async () => {
+    const calls: string[] = [];
+    const definition: WorkflowDefinitionV2 = {
+      schemaVersion: 2,
+      nodes: [
+        node("trigger", "trigger_ticket_ai"),
+        node("planning", "planning_agent"),
+        node("implementation", "implementation_agent"),
+        node("sibling", "generic_agent"),
+        node("after-sibling", "generic_agent"),
+      ],
+      edges: [
+        { id: "trigger-planning", from: "trigger", to: "planning" },
+        { id: "planning-implementation", from: "planning", to: "implementation" },
+        { id: "trigger-sibling", from: "trigger", to: "sibling" },
+        { id: "sibling-after", from: "sibling", to: "after-sibling" },
+      ],
+    };
+
+    const result = await executeV2Graph({
+      definition,
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "fired" },
+      maxConcurrency: 1,
+      executeBlock: async (current) => {
+        calls.push(current.id);
+        if (current.id === "planning") {
+          return { kind: "terminal_success", output: NO_CHANGE_PLAN };
+        }
+        return {
+          kind: "next",
+          output: { status: "completed", body: `${current.id} completed` },
+        };
+      },
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(calls).toEqual(["planning", "sibling", "after-sibling"]);
+    expect(result.steps.planning?.output).toEqual(NO_CHANGE_PLAN);
+    expect(result.steps.sibling?.output.status).toBe("completed");
+    expect(result.steps["after-sibling"]?.output.status).toBe("completed");
+    expect(result.state.scopes.root.nodeStates.implementation?.status).toBe(
+      "skipped",
+    );
+  });
+
+  it("validates the terminating output against the declared contract", async () => {
+    const result = await executeV2Graph({
+      runId: "run-terminal-success-contract",
+      definition: {
+        nodes: [
+          node("trigger", "trigger_ticket_ai"),
+          node("planning", "planning_agent"),
+          node("implementation", "implementation_agent"),
+        ],
+        edges: [
+          { id: "trigger-planning", from: "trigger", to: "planning" },
+          {
+            id: "planning-implementation",
+            from: "planning",
+            to: "implementation",
+          },
+        ],
+      },
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "fired" },
+      executeBlock: async () => ({
+        kind: "terminal_success",
+        output: { status: "ready" },
+      }),
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.executionError).toMatchObject({
+      nodeId: "planning",
+      category: "schema",
+      phase: "contract",
+    });
+  });
+});

--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -905,8 +905,8 @@
             ...typedPaths("object[]", "comments", "priorAnswers"),
           ],
           requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("string", "plan")],
-          optionalOutputs: typedPaths("string[]", "questions", "suggestedAnswers"),
-          statuses: ["ready", "needs_human_input"],
+          optionalOutputs: typedPaths("string[]", "questions", "suggestedAnswers", "evidence"),
+          statuses: ["ready", "needs_human_input", "no_change_needed"],
         }),
         implementation_agent: runtimeContract(["provider", "model", "prompt"], {
           optionalInputs: [...typedPaths("object", "ticket"), ...typedPaths("string", "plan")],


### PR DESCRIPTION
## Summary

Fixes AIW-232. A ticket that is already resolved (fix landed in a prior commit or PR, or the ticket carries a "Fixed" comment) now ends the run as a successful no-op instead of failing with "research declared no repository changes; nothing to implement, replan required".

## How it works

- The research agent can now explicitly declare an already-resolved ticket: new optional `noChangeNeeded` and `resolutionEvidence` fields on the research output contract (zod + structured-output JSON schema), plus a new "Resolution Check" section in the fixed research protocol footer instructing it to check ticket comments, git history for the ticket key, and PR context before planning, and to only claim resolution with concrete evidence.
- A new `BlockExecutionResult` kind `terminal_success` in both engines (V1 interpreter and V2 scheduler): the node completes with its real output, every outgoing edge resolves inactive so the downstream cone skips through the existing cascade, and the walk drains to the "completed" outcome (run success). Distinct from `ended`, which parks the run awaiting a human. Output contract validation still applies.
- The `planning_agent` case short-circuits when the signal is valid (`noChangeNeeded === true`, non-empty evidence, empty `writeRepositories`): posts a Jira comment with the evidence, replays the ticket move configured on the graph's `update_ticket_status` node (dispatch has no post-success dedup, so leaving the ticket in the AI column would loop redispatches), sends a Slack note with the comment deep link, and returns `terminal_success`. No write-scope promotion, no branch, no PR, no plan-approval request.
- The ambiguous case (research completed with an empty write set but no valid resolution signal) keeps failing loudly via `researchDeclaredNoWritesGuard`, unchanged.

## Notes for reviewers

- All templates get the behavior engine-side, with no definition migration; historical definition snapshots stay valid (no port/edge changes).
- The evidence comment goes through the engine-level `postTicketComment` step, which does not apply `scrubForPublication`, consistent with the existing `terminate` and PR-links comment precedent.
- The ticket move uses the status node's authored `params.target`; a bound target input would originate inside the skipped cone and is unreconstructible by design. All shipped templates use the literal `ai_review`.
- Structured-output schema gains two required-but-nullable keys; same class of change as previous field additions. A quick smoke against both CLI providers after deploy is recommended.

## Tests

- Contract: fold round-trip, backward compatibility, no cross-field rejection (a half-filled signal falls through to the normal path instead of failing research).
- Engines: terminal_success unit tests in both engines, including downstream skip, parallel sibling completion, and output-contract enforcement.
- Scenarios over the real shipped templates (production v2 scheduler): ticket-workflow, human-approved-plan (asserts `send_plan_approval` is never invoked for a resolved ticket), reviewed-ticket-workflow; plus a normal-path regression proving implementation still runs when no signal is set.
- Guard regression: `researchDeclaredNoWritesGuard` suite untouched and green.
