### PR TITLE
fix(worker): allow lowering block dispatch concurrency operationally

### DIFF
--- a/apps/worker/env.ts
+++ b/apps/worker/env.ts
@@ -98,6 +98,19 @@ export const env = createEnv({
     MAX_CONCURRENT_AGENTS: z.coerce.number().int().positive().default(3),
     JOB_TIMEOUT_MS: z.coerce.number().int().positive().default(1_800_000),
 
+    /**
+     * Operational ceiling on how many blocks of one run are dispatched at once.
+     * Unset means the code-owned bound, which is what scenarios assert. This
+     * only ever lowers it, and the scheduler clamps whatever arrives here.
+     *
+     * Set it to 1 while AIW-233 is open. The workflow runtime corrupts its own
+     * event log when several blocks suspend concurrently and then discards the
+     * whole run, with no failure of ours recorded, so a serialized run that
+     * finishes beats a parallel one that never does. Remove the variable, do not
+     * edit the code-owned bound, once the runtime is fixed.
+     */
+    V2_MAX_BLOCK_CONCURRENCY: z.coerce.number().int().positive().optional(),
+
     // Attachments
     ATTACHMENT_MAX_FILE_SIZE_MB: z.coerce.number().int().positive().default(25),
     ATTACHMENT_MAX_TOTAL_SIZE_MB: z.coerce.number().int().positive().default(100),

--- a/apps/worker/src/workflow-definition/scenarios/harness.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/harness.test.ts
@@ -610,10 +610,24 @@ describe("scenario harness", () => {
       "utf8",
     );
     expect(agentSource).toContain(
-      "maxConcurrency: V2_PRODUCTION_SCHEDULER_BOUNDS.maxConcurrency",
+      "V2_PRODUCTION_SCHEDULER_BOUNDS.maxConcurrency",
     );
     expect(agentSource).toContain(
       "V2_PRODUCTION_SCHEDULER_BOUNDS.maxTotalExecutions",
+    );
+    // The call site may lower concurrency operationally through
+    // V2_MAX_BLOCK_CONCURRENCY, but it must never raise it above the
+    // code-owned bound these scenarios assert, so the env value has to pass
+    // through a Math.min against that bound rather than replace it.
+    const concurrencyIndex = agentSource.indexOf("maxConcurrency: Math.min(");
+    expect(concurrencyIndex).toBeGreaterThan(-1);
+    const concurrencyCallSite = agentSource.slice(
+      concurrencyIndex,
+      concurrencyIndex + 300,
+    );
+    expect(concurrencyCallSite).toContain("env.V2_MAX_BLOCK_CONCURRENCY");
+    expect(concurrencyCallSite).toContain(
+      "V2_PRODUCTION_SCHEDULER_BOUNDS.maxConcurrency",
     );
   });
 });

--- a/apps/worker/src/workflow-definition/v2-scheduler.test.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.test.ts
@@ -431,6 +431,48 @@ describe("executeV2Graph concurrency and failure", () => {
     });
   });
 
+  // The operational ceiling behind V2_MAX_BLOCK_CONCURRENCY. Production runs
+  // with it set to 1 while AIW-233 is open, because the workflow runtime
+  // corrupts its own event log when several blocks suspend at once and then
+  // discards the run. A fan-out must still complete, one block at a time.
+  it("runs a fan-out one block at a time when admission is capped at one", async () => {
+    const gates = new Map(
+      ["one", "two", "three"].map((id) => [id, deferred<void>()]),
+    );
+    const started: string[] = [];
+    let running = 0;
+    let maximum = 0;
+    const children = [...gates.keys()];
+    const run = executeV2Graph({
+      runId: "run-serial",
+      maxConcurrency: 1,
+      definition: definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          ...children.map((id) => node(id, "generic_agent")),
+        ],
+        children.map((id) => ({ id: `trigger-${id}`, from: "trigger", to: id })),
+      ),
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "ok" },
+      executeBlock: async (current) => {
+        started.push(current.id);
+        running += 1;
+        maximum = Math.max(maximum, running);
+        // Release itself so the next block can be admitted; the point is that
+        // no second block is ever in flight beside it.
+        gates.get(current.id)!.resolve();
+        await gates.get(current.id)!.promise;
+        running -= 1;
+        return { kind: "next", output: successfulOutput(current) };
+      },
+    });
+
+    expect((await run).outcome).toBe("completed");
+    expect(maximum).toBe(1);
+    expect(started.sort()).toEqual(["one", "three", "two"]);
+  });
+
   it("admits at most four block invocations at once", async () => {
     const gates = new Map(
       ["one", "two", "three", "four", "five"].map((id) => [

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -5406,7 +5406,14 @@ async function agentWorkflowBody(
             runValues,
             executeBlock: executeV2Block,
             hooks: v2Hooks,
-            maxConcurrency: V2_PRODUCTION_SCHEDULER_BOUNDS.maxConcurrency,
+            // The env value is an operational ceiling only, never a raise: see
+            // V2_MAX_BLOCK_CONCURRENCY in env.ts for why production runs
+            // serialized while AIW-233 is open.
+            maxConcurrency: Math.min(
+              env.V2_MAX_BLOCK_CONCURRENCY ??
+                V2_PRODUCTION_SCHEDULER_BOUNDS.maxConcurrency,
+              V2_PRODUCTION_SCHEDULER_BOUNDS.maxConcurrency,
+            ),
             maxTotalExecutions:
               V2_PRODUCTION_SCHEDULER_BOUNDS.maxTotalExecutions,
             shouldRethrowExecutionError: isRunControlError,


### PR DESCRIPTION
Unblocks end-to-end verification of the three-reviewer Post-PR review flow, which currently cannot complete a single run. Full diagnosis in [AIW-233](https://blazity.atlassian.net/browse/AIW-233).

## Why

Every run of definition 12 dies after about 90 seconds with `CORRUPTED_EVENT_LOG`: the workflow runtime cannot replay a fan-out in which several blocks suspend concurrently, and discards the run. `status_reason` and `diagnostic_id` are NULL because none of our error paths execute.

Per the `workflow` docs this is an SDK or server bug, not our workflow code, and upgrading is the prescribed remedy. We upgraded 4.6.0 to 4.8.0, including the 4.7.0 concurrent-event guard, and it still fails. Five other hypotheses were eliminated with evidence, listed in the ticket.

So the pattern has to be avoided rather than fixed here: at most one block in flight means nothing can interleave.

## What this changes

A new optional `V2_MAX_BLOCK_CONCURRENCY` lowers how many blocks of one run are dispatched at once. It is a ceiling only: the call site passes it through `Math.min` against the code-owned bound, so it can never raise concurrency.

Deliberately an environment value and not an edit to `V2_PRODUCTION_SCHEDULER_BOUNDS`:

- The scenario suite asserts the code-owned bound and rejects a barrier wider than it. Lowering the constant would rewrite that suite to assert sequential execution, encoding "no parallelism" as the intended design, which it is not.
- Reverting is one variable and a redeploy once the runtime is fixed, with no code churn.

Three reviewers still run as three blocks and produce three independent reviews. On production, set to 1, they run one after another, so wall-clock review time is roughly tripled. A serialized run that finishes beats a parallel one the runtime throws away.

## Verification

- New scheduler test: a three-way fan-out capped at one admits exactly one block at a time and still completes
- The harness guard on the production call site is updated to assert the env value passes through `Math.min` against the code-owned bound, rather than matching a literal
- `src/workflows`, `src/workflow-definition`: 101 files, 1803 tests passing
- `pnpm -r typecheck` clean

The production check follows: repeated three-reviewer runs on a real pull request, verifying inline comments land on changed lines, the finding count on a small diff, and that `request_changes` completes the check as `failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIW-233]: https://blazity.atlassian.net/browse/AIW-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ