### PR TITLE
feat(worker): merge review findings across reviewers into one review

### DIFF
--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -119,6 +119,114 @@ describe("PR review diff placement", () => {
     ]);
   });
 
+  // Reproduces production run wrun_...4N9DD3: three reviewers, three findings
+  // each, and only six distinct defects between them.
+  it("publishes one comment per defect when reviewers overlap", () => {
+    const patch = "@@ -1,6 +1,6 @@\n+one\n+two\n+three\n+four\n+five\n+six";
+    const at = (line: number, description: string) => ({
+      file: "src/a.ts",
+      description,
+      severity: "High" as const,
+      startLine: line,
+      endLine: line,
+    });
+    const results: ReviewResult[] = [
+      {
+        decision: "request_changes",
+        findings: [
+          at(3, "Delete removes the last record when findIndex reports minus one."),
+          at(5, "The listing endpoint leaks every customer when the filter is empty."),
+        ],
+      },
+      {
+        decision: "request_changes",
+        findings: [
+          at(3, "Deleting with an unknown id splices index minus one and drops a row."),
+        ],
+      },
+      {
+        decision: "request_changes",
+        findings: [
+          at(3, "Removing a refund needs no credentials, which the criteria forbid."),
+        ],
+      },
+    ];
+
+    const partition = partitionReviewFindings(results, [
+      { path: "src/a.ts", additions: 6, deletions: 0, changeType: "modified", patch },
+    ]);
+
+    expect(partition.reportedCount).toBe(4);
+    expect(partition.distinctCount).toBe(2);
+    expect(partition.comments).toHaveLength(2);
+
+    const merged = partition.comments.find((comment) => comment.startLine === 3);
+    expect(merged?.body).toContain("Reported by 3 of 3 reviewers.");
+    const alone = partition.comments.find((comment) => comment.startLine === 5);
+    expect(alone?.body).not.toContain("Reported by");
+  });
+
+  it("caps the inline comments and names the rest in the summary", () => {
+    const patch = `@@ -1,40 +1,40 @@\n${Array.from({ length: 40 }, (_, i) => `+line${i}`).join("\n")}`;
+    const results: ReviewResult[] = [
+      {
+        decision: "request_changes",
+        findings: Array.from({ length: 14 }, (_, index) => ({
+          file: "src/a.ts",
+          // Distinct lines far apart and distinct wording, so nothing merges.
+          description: `Defect number ${index} concerns an unrelated subject ${"x".repeat(index)}.`,
+          severity: "Medium" as const,
+          startLine: index * 2 + 1,
+          endLine: index * 2 + 1,
+        })),
+      },
+    ];
+
+    const partition = partitionReviewFindings(results, [
+      { path: "src/a.ts", additions: 40, deletions: 0, changeType: "modified", patch },
+    ]);
+
+    expect(partition.distinctCount).toBe(14);
+    expect(partition.comments).toHaveLength(10);
+    expect(partition.withheld).toHaveLength(4);
+    // Nothing vanishes: everything not inline is accounted for.
+    expect(
+      partition.comments.length + partition.fallback.length + partition.withheld.length,
+    ).toBe(partition.distinctCount);
+  });
+
+  it("gives the inline slots to the most severe and most agreed findings", () => {
+    const patch = `@@ -1,20 +1,20 @@\n${Array.from({ length: 20 }, (_, i) => `+line${i}`).join("\n")}`;
+    const shared = "Both reviewers describe the identical unbounded page size problem.";
+    const results: ReviewResult[] = [
+      {
+        decision: "request_changes",
+        findings: [
+          { file: "a.ts", description: "A nit about naming only.", severity: "Nit", startLine: 1, endLine: 1 },
+          { file: "a.ts", description: shared, severity: "Medium", startLine: 5, endLine: 5 },
+          { file: "a.ts", description: "A blocking authorization hole.", severity: "Blocker", startLine: 9, endLine: 9 },
+        ],
+      },
+      {
+        decision: "request_changes",
+        findings: [
+          { file: "a.ts", description: shared, severity: "Medium", startLine: 5, endLine: 5 },
+          { file: "a.ts", description: "A lone medium about logging.", severity: "Medium", startLine: 13, endLine: 13 },
+        ],
+      },
+    ];
+
+    const partition = partitionReviewFindings(results, [
+      { path: "a.ts", additions: 20, deletions: 0, changeType: "modified", patch },
+    ], { maxComments: 2 });
+
+    const bodies = partition.comments.map((comment) => comment.body).join("\n");
+    expect(bodies).toContain("Blocker");
+    // The Medium two reviewers agreed on outranks the Medium only one raised.
+    expect(bodies).toContain("Reported by 2 of 2 reviewers.");
+    expect(partition.withheld.map((finding) => finding.severity)).toContain("Nit");
+  });
+
   it("preserves legitimate a/ and b/ repository paths", () => {
     const results: ReviewResult[] = [
       {
@@ -652,5 +760,73 @@ describe("PR review publication scrub", () => {
     const commentBody: string = publication.comments[0]!.body;
     expect(commentBody.endsWith("Reads the config twice.")).toBe(true);
     expect(commentBody).not.toContain("blazebot/memory/");
+  });
+
+  // The gate reads the reviewers' own decisions, never the findings list, so
+  // collapsing three reports into one comment must not soften the verdict.
+  it("leaves the verdict to the reviewers even when every finding merges into one", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-merge" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-9", commentIds: ["comment-9"] });
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([
+        {
+          path: "src/a.ts",
+          additions: 2,
+          deletions: 0,
+          changeType: "modified",
+          patch: "@@ -3,2 +3,2 @@\n context\n+added",
+        },
+      ]),
+      publishPRReview,
+    });
+
+    const finding = (description: string) => ({
+      file: "src/a.ts",
+      description,
+      severity: "High" as const,
+      startLine: 4,
+      endLine: 4,
+    });
+
+    const result = await publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#9",
+        ownerToken: "owner-9",
+        runId: "run-merge",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#9",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 9,
+        headSha: "head",
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: [
+        { decision: "approve", findings: [finding("One reviewer worded it this way.")] },
+        {
+          decision: "request_changes",
+          findings: [finding("Another worded the same defect differently.")],
+        },
+      ],
+    });
+
+    expect(result.decision).toBe("request_changes");
+    expect(result.inlineCommentCount).toBe(1);
+    expect(publishPRReview.mock.calls[0]![1].comments).toHaveLength(1);
+    expect(publishPRReview.mock.calls[0]![1].comments[0]!.body).toContain(
+      "Reported by 2 of 2 reviewers.",
+    );
   });
 });

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -20,6 +20,15 @@ import {
   type PRReviewInlineComment,
 } from "../adapters/vcs/types.js";
 import { assertActiveRunOwner, type ActiveRunOwner } from "../lib/active-run-owner.js";
+import {
+  compareMergedFindingsForDisplay,
+  compareMergedFindingsForPublication,
+  MAX_PUBLISHED_INLINE_REVIEW_COMMENTS,
+  mergeReviewFindings,
+  mergedReviewFindingCommentBody,
+  type MergedReviewFinding,
+  type ReviewFindingCandidate,
+} from "./review-finding-merge.js";
 import { scrubForPublication } from "../lib/publication-scrub.js";
 import type { PrTriggerPayload } from "./agent-input.js";
 
@@ -537,12 +546,24 @@ function changedNewSidePositions(
   return lines;
 }
 
+/**
+ * Turns every reviewer's findings into one comment per defect.
+ *
+ * Anchoring is unchanged; what is new is that findings are merged across
+ * reviewers first, and that the cap applies to the review a reader sees rather
+ * than to each reviewer separately. Nothing is dropped: a defect that loses its
+ * inline slot is listed in the summary with a visible count.
+ */
 export function partitionReviewFindings(
   results: ReviewResult[],
   files: PRFile[],
+  options: { maxComments?: number } = {},
 ): {
   comments: PRReviewInlineComment[];
-  fallback: Array<ReviewResult["findings"][number]>;
+  fallback: MergedReviewFinding[];
+  withheld: MergedReviewFinding[];
+  reportedCount: number;
+  distinctCount: number;
 } {
   const fileLines = new Map(
     files.map((file) => [
@@ -552,10 +573,9 @@ export function partitionReviewFindings(
         : new Map<number, number | null>(),
     ]),
   );
-  const comments: PRReviewInlineComment[] = [];
-  const fallback: Array<ReviewResult["findings"][number]> = [];
-  for (const result of results) {
-    for (const finding of result.findings) {
+  const candidates: ReviewFindingCandidate[] = [];
+  for (const [reviewerIndex, result] of results.entries()) {
+    for (const [findingIndex, finding] of result.findings.entries()) {
       const path = normalizedPath(finding.file, fileLines);
       const start = finding.startLine;
       const end = finding.endLine ?? start;
@@ -570,21 +590,58 @@ export function partitionReviewFindings(
         changed !== undefined &&
         rangeLength <= changed.size &&
         rangeContainsOnlyChangedSideLines(new Set(changed.keys()), start, end);
-      if (!locatable) {
-        fallback.push(finding);
-        continue;
-      }
-      comments.push({
-        path,
-        startLine: start,
-        endLine: end,
-        startOldLine: changed.get(start) ?? null,
-        endOldLine: changed.get(end) ?? null,
-        body: `**${finding.severity}**: ${finding.description}`,
+      candidates.push({
+        reviewerIndex,
+        findingIndex,
+        finding,
+        // The normalized path groups `a/x.ts` with `x.ts`; the raw file is the
+        // fallback so an unresolvable path still only ever matches itself.
+        groupKey: path ?? finding.file.trim(),
+        anchor: locatable
+          ? {
+              path,
+              startLine: start,
+              endLine: end,
+              startOldLine: changed.get(start) ?? null,
+              endOldLine: changed.get(end) ?? null,
+            }
+          : null,
       });
     }
   }
-  return { comments, fallback };
+
+  const merged = mergeReviewFindings(candidates);
+  const placeable: MergedReviewFinding[] = [];
+  const fallback: MergedReviewFinding[] = [];
+  for (const finding of merged) {
+    (finding.anchor === null ? fallback : placeable).push(finding);
+  }
+
+  const maxComments = options.maxComments ?? MAX_PUBLISHED_INLINE_REVIEW_COMMENTS;
+  const ranked = [...placeable].sort(compareMergedFindingsForPublication);
+  const chosen = ranked.slice(0, maxComments);
+  const withheld = ranked.slice(maxComments);
+
+  const comments = [...chosen]
+    .sort(compareMergedFindingsForDisplay)
+    .map((finding) => ({
+      // Property order is load-bearing: reviewCommentContentHash stringifies
+      // this object, so reordering these keys rewrites every stored hash.
+      path: finding.anchor!.path,
+      startLine: finding.anchor!.startLine,
+      endLine: finding.anchor!.endLine,
+      startOldLine: finding.anchor!.startOldLine,
+      endOldLine: finding.anchor!.endOldLine,
+      body: mergedReviewFindingCommentBody(finding, results.length),
+    }));
+
+  return {
+    comments,
+    fallback,
+    withheld,
+    reportedCount: candidates.length,
+    distinctCount: merged.length,
+  };
 }
 
 function rangeContainsOnlyChangedSideLines(
@@ -598,22 +655,52 @@ function rangeContainsOnlyChangedSideLines(
   return true;
 }
 
+function reviewSummaryLine(
+  finding: MergedReviewFinding,
+  reviewerCount: number,
+): string {
+  const location = finding.startLine
+    ? `${finding.file}:${finding.startLine}${finding.endLine && finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}`
+    : finding.file;
+  const agreement =
+    finding.sources.length > 1
+      ? ` (reported by ${finding.sources.length} of ${reviewerCount} reviewers)`
+      : "";
+  return `- **${finding.severity}** \`${location}\`${agreement}: ${finding.description}`;
+}
+
 function reviewSummary(
   results: ReviewResult[],
-  fallback: Array<ReviewResult["findings"][number]>,
+  fallback: MergedReviewFinding[],
+  withheld: MergedReviewFinding[] = [],
+  counts: { reportedCount: number; distinctCount: number } = {
+    reportedCount: 0,
+    distinctCount: 0,
+  },
 ): string {
   const feedback = results
     .map((result) => result.feedback?.trim())
     .filter((value): value is string => Boolean(value));
   const lines = ["## AI Workflow review"];
   if (feedback.length > 0) lines.push("", ...feedback.map((value) => `- ${value}`));
+  if (counts.reportedCount > counts.distinctCount) {
+    lines.push(
+      "",
+      `_${counts.distinctCount} distinct findings merged from ${counts.reportedCount} reported by ${results.length} reviewers._`,
+    );
+  }
   if (fallback.length > 0) {
     lines.push("", "### Findings not placed inline");
     for (const finding of fallback) {
-      const location = finding.startLine
-        ? `${finding.file}:${finding.startLine}${finding.endLine && finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}`
-        : finding.file;
-      lines.push(`- **${finding.severity}** \`${location}\`: ${finding.description}`);
+      lines.push(reviewSummaryLine(finding, results.length));
+    }
+  }
+  if (withheld.length > 0) {
+    // The count belongs in the heading: a cap that truncates silently reads as
+    // "nothing else was found", which is the opposite of what happened.
+    lines.push("", `### ${withheld.length} further findings not shown inline`);
+    for (const finding of withheld) {
+      lines.push(reviewSummaryLine(finding, results.length));
     }
   }
   if (results.every((result) => result.findings.length === 0) && feedback.length === 0) {
@@ -660,10 +747,13 @@ export async function publishRunOwnedPrReview(args: {
     throw new Error("The pull request changed before the review could be published.");
   }
   const files = await vcs.listPRFiles(args.target.prNumber);
-  const { comments: placedComments, fallback } = partitionReviewFindings(
-    args.reviewResults,
-    files,
-  );
+  const {
+    comments: placedComments,
+    fallback,
+    withheld,
+    reportedCount,
+    distinctCount,
+  } = partitionReviewFindings(args.reviewResults, files);
   // Review feedback and finding descriptions are agent-authored prose. Scrubbing
   // the summary here rather than at the publish call also covers the value
   // returned to the workflow, which complete_pr_check binds into the check run
@@ -677,7 +767,12 @@ export async function publishRunOwnedPrReview(args: {
   )
     ? "approve"
     : "request_changes";
-  const summary = scrubForPublication(reviewSummary(args.reviewResults, fallback));
+  const summary = scrubForPublication(
+    reviewSummary(args.reviewResults, fallback, withheld, {
+      reportedCount,
+      distinctCount,
+    }),
+  );
   const normalized = {
     provider: args.target.provider,
     repository: args.target.repoPath,

--- a/apps/worker/src/workflows/review-finding-merge.test.ts
+++ b/apps/worker/src/workflows/review-finding-merge.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it } from "vitest";
+import type { ReviewResultFinding } from "@shared/contracts";
+import {
+  MAX_PUBLISHED_INLINE_REVIEW_COMMENTS,
+  mergeReviewFindings,
+  mergedReviewFindingCommentBody,
+  reviewDescriptionSimilarity,
+  type ReviewFindingCandidate,
+} from "./review-finding-merge.js";
+
+function candidate(
+  reviewerIndex: number,
+  findingIndex: number,
+  finding: ReviewResultFinding,
+  anchored = true,
+): ReviewFindingCandidate {
+  return {
+    reviewerIndex,
+    findingIndex,
+    finding,
+    groupKey: finding.file,
+    anchor: anchored && typeof finding.startLine === "number"
+      ? {
+          path: finding.file,
+          startLine: finding.startLine,
+          endLine: finding.endLine ?? finding.startLine,
+          startOldLine: null,
+          endOldLine: null,
+        }
+      : null,
+  };
+}
+
+/**
+ * The real findings of production run wrun_...4N9DD3: three reviewers, three
+ * findings each, six distinct defects. `refunds:50` was reported by all three
+ * and `payments:40` by two, both at an identical start line.
+ */
+const PRODUCTION_RUN: ReviewFindingCandidate[] = [
+  candidate(0, 0, {
+    file: "app/api/refunds/route.ts",
+    startLine: 50,
+    severity: "High",
+    description:
+      "DELETE mutates refunds without any authorization check, and an unknown id deletes the last record because findIndex returns -1.",
+  }),
+  candidate(0, 1, {
+    file: "app/api/refunds/route.ts",
+    startLine: 29,
+    severity: "High",
+    description:
+      "GET treats customerId as optional and uses substring matching, so an empty value returns every customer's refunds.",
+  }),
+  candidate(0, 2, {
+    file: "app/api/invoices/route.ts",
+    startLine: 15,
+    severity: "Medium",
+    description:
+      "Each public invoices request synchronously fans out to the configured upstream with retries and no timeout.",
+  }),
+  candidate(1, 0, {
+    file: "app/api/payments/route.ts",
+    startLine: 40,
+    severity: "High",
+    description:
+      "Pagination uses page * perPage as the slice start, so page 1 skips the first page of results entirely.",
+  }),
+  candidate(1, 1, {
+    file: "app/api/refunds/route.ts",
+    startLine: 50,
+    severity: "High",
+    description:
+      "DELETE removes the last refund when the requested id is not found, because splice(-1, 1) drops the final element.",
+  }),
+  candidate(1, 2, {
+    file: "app/api/refunds/route.ts",
+    startLine: 32,
+    severity: "Medium",
+    description:
+      "The response mixes substring filtering for items with exact-match aggregation for the total, so the two disagree.",
+  }),
+  candidate(2, 0, {
+    file: "app/api/refunds/route.ts",
+    startLine: 50,
+    severity: "High",
+    description:
+      "Deleting a refund is unauthenticated, which the acceptance criteria forbid for finance endpoints.",
+  }),
+  candidate(2, 1, {
+    file: "app/api/payments/route.ts",
+    startLine: 40,
+    severity: "High",
+    description:
+      "Pagination is off by one. The slice start is computed as page * perPage, so page 1 starts at index perPage.",
+  }),
+  candidate(2, 2, {
+    file: "app/api/refunds/route.ts",
+    startLine: 19,
+    severity: "Medium",
+    description:
+      "GET returns inconsistent totals for partial or case-insensitive customer filters.",
+  }),
+];
+
+describe("mergeReviewFindings", () => {
+  it("collapses the production run's nine findings into six defects", () => {
+    const merged = mergeReviewFindings(PRODUCTION_RUN);
+
+    expect(merged).toHaveLength(6);
+
+    const refundsDelete = merged.find(
+      (f) => f.file === "app/api/refunds/route.ts" && f.startLine === 50,
+    );
+    expect(refundsDelete?.sources.map((s) => s.reviewerIndex)).toEqual([0, 1, 2]);
+
+    const pagination = merged.find(
+      (f) => f.file === "app/api/payments/route.ts" && f.startLine === 40,
+    );
+    expect(pagination?.sources.map((s) => s.reviewerIndex)).toEqual([1, 2]);
+  });
+
+  it("merges a one-line disagreement when the wording agrees", () => {
+    const merged = mergeReviewFindings([
+      candidate(0, 0, {
+        file: "a.ts",
+        startLine: 40,
+        severity: "High",
+        description:
+          "Pagination slice start is page multiplied by perPage, so page one skips the first page of rows.",
+      }),
+      candidate(1, 0, {
+        file: "a.ts",
+        startLine: 41,
+        severity: "High",
+        description:
+          "Pagination start offset multiplies page by perPage, so page one skips the first rows of the page.",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+  });
+
+  // The reason the line window is not the only gate. These two defects really
+  // sat four lines apart in one function on the reviewed pull request.
+  it("keeps two different defects a few lines apart apart", () => {
+    const pagination: ReviewResultFinding = {
+      file: "a.ts",
+      startLine: 40,
+      severity: "High",
+      description:
+        "Pagination slice start is page multiplied by perPage, so page one skips the first page of rows.",
+    };
+    const floatMoney: ReviewResultFinding = {
+      file: "a.ts",
+      startLine: 45,
+      severity: "High",
+      description:
+        "Monetary totals accumulate amountMinor divided by 100 in a float, which loses cents on large sums.",
+    };
+
+    expect(
+      mergeReviewFindings([candidate(0, 0, pagination), candidate(1, 0, floatMoney)]),
+    ).toHaveLength(2);
+
+    // Adjacent as well: only the wording gate can separate them here, so this
+    // is the assertion that fails if someone deletes it as redundant.
+    expect(
+      mergeReviewFindings([
+        candidate(0, 0, pagination),
+        candidate(1, 0, { ...floatMoney, startLine: 41 }),
+      ]),
+    ).toHaveLength(2);
+  });
+
+  it("never collapses one reviewer's own two findings", () => {
+    const merged = mergeReviewFindings([
+      candidate(0, 0, {
+        file: "a.ts",
+        startLine: 50,
+        severity: "Blocker",
+        description: "Unauthenticated delete removes arbitrary refunds.",
+      }),
+      candidate(0, 1, {
+        file: "a.ts",
+        startLine: 50,
+        severity: "Nit",
+        description: "Unauthenticated delete removes arbitrary refunds.",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+  });
+
+  it("does not chain a whole file into one cluster", () => {
+    const wording = (line: number) => ({
+      file: "a.ts",
+      startLine: line,
+      severity: "Medium" as const,
+      description:
+        "The query parameter is parsed without an upper bound, so a caller can request an unbounded page.",
+    });
+    const merged = mergeReviewFindings([
+      candidate(0, 0, wording(40)),
+      candidate(1, 0, wording(42)),
+      candidate(2, 0, wording(44)),
+    ]);
+
+    // 42 merges into 40, but 44 is compared against the primary at 40, not
+    // against 42, so it stays on its own.
+    expect(merged).toHaveLength(2);
+    expect(merged[0]?.sources).toHaveLength(2);
+    expect(merged[1]?.sources).toHaveLength(1);
+  });
+
+  // Two reviewers grading one defect differently, which is what the same-line
+  // severity rule exists for. The descriptions have to agree, because on an
+  // exact line match a graded disagreement is the only case where wording is
+  // the deciding evidence.
+  it("takes the highest severity and its wording as the cluster's own", () => {
+    const merged = mergeReviewFindings([
+      candidate(0, 0, {
+        file: "a.ts",
+        startLine: 10,
+        severity: "Nit",
+        description:
+          "The delete handler splices by an index that findIndex may report as minus one.",
+      }),
+      candidate(1, 0, {
+        file: "a.ts",
+        startLine: 10,
+        severity: "Blocker",
+        description:
+          "The delete handler splices by minus one when findIndex finds no record, dropping the last row.",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.severity).toBe("Blocker");
+    expect(merged[0]?.description).toContain("dropping the last row");
+  });
+
+  it("keeps two unrelated findings on one line apart despite the shared line", () => {
+    const merged = mergeReviewFindings([
+      candidate(0, 0, {
+        file: "a.ts",
+        startLine: 10,
+        severity: "Nit",
+        description: "Consider renaming this helper for readability.",
+      }),
+      candidate(1, 0, {
+        file: "a.ts",
+        startLine: 10,
+        severity: "Blocker",
+        description: "This helper deletes the wrong record for an unknown id.",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+  });
+
+  it("never merges a file-level finding with a line-level one", () => {
+    const merged = mergeReviewFindings([
+      candidate(0, 0, {
+        file: "a.ts",
+        severity: "Medium",
+        description: "This module has no tests covering the pagination helper.",
+      }),
+      candidate(1, 0, {
+        file: "a.ts",
+        startLine: 40,
+        severity: "Medium",
+        description: "This module has no tests covering the pagination helper.",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+  });
+
+  it("publishes a cluster inline when any reviewer could place it", () => {
+    const merged = mergeReviewFindings([
+      candidate(
+        0,
+        0,
+        {
+          file: "a.ts",
+          startLine: 50,
+          severity: "High",
+          description: "Unauthenticated delete removes arbitrary refunds.",
+        },
+        false,
+      ),
+      candidate(1, 0, {
+        file: "a.ts",
+        startLine: 50,
+        severity: "High",
+        description: "Deleting a refund requires no credentials at all.",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.anchor).not.toBeNull();
+  });
+
+  it("produces the same clusters whatever order the reviewers finish in", () => {
+    const shape = (list: ReviewFindingCandidate[]) =>
+      mergeReviewFindings(list)
+        .map((f) => `${f.file}:${f.startLine ?? "-"}:${f.sources.length}`)
+        .sort();
+
+    const rotated = [...PRODUCTION_RUN.slice(3), ...PRODUCTION_RUN.slice(0, 3)];
+
+    expect(shape(rotated)).toEqual(shape(PRODUCTION_RUN));
+  });
+});
+
+describe("merged review comment body", () => {
+  it("leaves a single reviewer's comment byte for byte as before", () => {
+    const [single] = mergeReviewFindings([
+      candidate(0, 0, {
+        file: "a.ts",
+        startLine: 7,
+        severity: "Blocker",
+        description: "The refund amount is parsed with parseFloat.",
+      }),
+    ]);
+
+    expect(mergedReviewFindingCommentBody(single!, 3)).toBe(
+      "**Blocker**: The refund amount is parsed with parseFloat.",
+    );
+  });
+
+  it("states the agreement when several reviewers found the same defect", () => {
+    const merged = mergeReviewFindings(PRODUCTION_RUN);
+    const refundsDelete = merged.find((f) => f.startLine === 50)!;
+
+    const body = mergedReviewFindingCommentBody(refundsDelete, 3);
+
+    expect(body).toContain("Reported by 3 of 3 reviewers.");
+    // The first line stays self-contained: GitHub's inline fallback renders each
+    // body as one markdown bullet, and a leading newline would break the list.
+    expect(body.split("\n")[0]).toContain("**High**:");
+  });
+});
+
+describe("reviewDescriptionSimilarity", () => {
+  it("scores shared content words and ignores boilerplate", () => {
+    expect(
+      reviewDescriptionSimilarity(
+        "Pagination slice start multiplies page by perPage",
+        "Pagination start offset multiplies page by perPage",
+      ),
+    ).toBeGreaterThan(REVIEW_FINDING_MERGE_NEARBY);
+    expect(
+      reviewDescriptionSimilarity(
+        "Pagination slice start multiplies page by perPage",
+        "Monetary totals accumulate in a float and lose cents",
+      ),
+    ).toBeLessThan(REVIEW_FINDING_MERGE_NEARBY);
+  });
+
+  it("splits camelCase so an identifier matches its words", () => {
+    expect(
+      reviewDescriptionSimilarity("parseFloat drops cents", "parse float drops cents"),
+    ).toBe(1);
+  });
+
+  it("scores nothing when a description carries no meaningful token", () => {
+    expect(reviewDescriptionSimilarity("", "anything at all here")).toBe(0);
+  });
+});
+
+const REVIEW_FINDING_MERGE_NEARBY = 0.4;
+
+describe("published comment cap", () => {
+  it("caps the whole review rather than each reviewer", () => {
+    expect(MAX_PUBLISHED_INLINE_REVIEW_COMMENTS).toBe(10);
+  });
+});

--- a/apps/worker/src/workflows/review-finding-merge.ts
+++ b/apps/worker/src/workflows/review-finding-merge.ts
@@ -1,0 +1,272 @@
+import type { ReviewResultFinding } from "@shared/contracts";
+
+/**
+ * Collapses the findings of several review agents into one finding per defect.
+ *
+ * Three reviewers with different prompts routinely report one defect three
+ * times, which is the "a lot of noise for very low signal" complaint this
+ * review flow exists to answer. Merging happens here, at publication, and
+ * nowhere else: the raw per-reviewer results still reach `fix_agent` verbatim
+ * and still key the publication content hash, so neither may be rewritten.
+ *
+ * THREE DELIBERATE ABSENCES, each of which looks like an oversight:
+ *
+ * 1. No merge when one finding has a line and the other does not. A file-level
+ *    remark and a line-level one are different claims, and guessing that they
+ *    are the same would hide the specific one behind the vague one.
+ * 2. No model call. The merge must be a pure function of its input because
+ *    GitLab identifies a published comment by its index in the comment array,
+ *    so a re-publication that reorders comments re-keys every one of them.
+ * 3. No configurable thresholds. Same reason: a value read from the
+ *    environment would make comment identity depend on deployment config.
+ */
+
+/** Where a finding sits on the reviewed diff. Null when it cannot be placed. */
+export interface ReviewFindingAnchor {
+  path: string;
+  startLine: number;
+  endLine: number;
+  startOldLine: number | null;
+  endOldLine: number | null;
+}
+
+export interface ReviewFindingCandidate {
+  /** Index in reviewResults, i.e. the reference list's declaration order. */
+  reviewerIndex: number;
+  /** Index within that reviewer's own findings. */
+  findingIndex: number;
+  finding: ReviewResultFinding;
+  /** Provider-normalized path when one resolved, else the raw file. */
+  groupKey: string;
+  anchor: ReviewFindingAnchor | null;
+}
+
+/**
+ * One defect. Extends the finding shape so the existing summary rendering keeps
+ * working on it unchanged.
+ */
+export interface MergedReviewFinding extends ReviewResultFinding {
+  /** Every candidate that reported this defect, in declaration order. */
+  sources: ReviewFindingCandidate[];
+  anchor: ReviewFindingAnchor | null;
+}
+
+/**
+ * Frozen on purpose. These numbers decide which comments a reader sees, so they
+ * belong to the code that is reviewed and tested, not to a deployment.
+ */
+export const REVIEW_FINDING_MERGE = Object.freeze({
+  /** Lines each range grows by before testing for overlap. */
+  lineWindow: 2,
+  /** Wording agreement required when the line matches but the severity differs. */
+  sameLineDifferentSeverity: 0.25,
+  /** Wording agreement required when only the ranges are close. */
+  nearbyLine: 0.4,
+  /** Wording agreement required when neither finding carries a line. */
+  noLine: 0.5,
+});
+
+/**
+ * The cap on inline comments for the whole review rather than per reviewer.
+ * A reader experiences one review, so that is the number that has to be bounded.
+ * Mirrors MAX_REVIEW_FINDINGS in sandbox/agents/types.ts, restated rather than
+ * imported so this module never pulls the sandbox agent bundle into the
+ * workflow graph.
+ */
+export const MAX_PUBLISHED_INLINE_REVIEW_COMMENTS = 10;
+
+const SEVERITY_RANK: Record<ReviewResultFinding["severity"], number> = {
+  Blocker: 4,
+  High: 3,
+  Medium: 2,
+  Nit: 1,
+};
+
+/** Words carried by almost every finding, so they say nothing about identity. */
+const STOPWORDS = new Set([
+  "the", "and", "for", "that", "this", "with", "from", "into", "when", "then",
+  "there", "which", "while", "would", "should", "could", "will", "not", "but",
+  "any", "all", "its", "has", "have", "are", "was", "were", "can", "may",
+  "line", "lines", "code", "file", "function", "method", "value", "values",
+  "instead", "because", "means", "makes", "make", "used", "uses", "use",
+]);
+
+function descriptionTokens(value: string): Set<string> {
+  const spaced = value
+    // Split camelCase so `parseFloat` also contributes `parse` and `float`.
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ");
+  const tokens = new Set<string>();
+  for (const token of spaced.split(" ")) {
+    if (token.length < 3 || STOPWORDS.has(token)) continue;
+    tokens.add(token);
+  }
+  return tokens;
+}
+
+/**
+ * Token-set Jaccard overlap of two finding descriptions, 0 to 1. Zero when
+ * either side carries no meaningful token, so an empty description never drags
+ * an unrelated finding into a cluster.
+ */
+export function reviewDescriptionSimilarity(a: string, b: string): number {
+  const left = descriptionTokens(a);
+  const right = descriptionTokens(b);
+  if (left.size === 0 || right.size === 0) return 0;
+  let shared = 0;
+  for (const token of left) if (right.has(token)) shared += 1;
+  const union = left.size + right.size - shared;
+  return union === 0 ? 0 : shared / union;
+}
+
+function rangeOf(finding: ReviewResultFinding): { start: number; end: number } | null {
+  if (typeof finding.startLine !== "number") return null;
+  return { start: finding.startLine, end: finding.endLine ?? finding.startLine };
+}
+
+function locationMatches(
+  primary: ReviewResultFinding,
+  candidate: ReviewResultFinding,
+): boolean {
+  const a = rangeOf(primary);
+  const b = rangeOf(candidate);
+
+  // A file-level claim and a line-level claim stay separate: see absence 1.
+  if ((a === null) !== (b === null)) return false;
+
+  const similarity = reviewDescriptionSimilarity(
+    primary.description,
+    candidate.description,
+  );
+
+  if (a === null || b === null) {
+    return similarity >= REVIEW_FINDING_MERGE.noLine;
+  }
+
+  if (a.start === b.start) {
+    // No wording gate here, and that is the point of the whole change. Three
+    // reviewers describe one defect in three unrelated vocabularies ("no
+    // authentication" against "missing auth per AC-3" share no token), so a
+    // similarity gate on an exact line match would reject precisely the
+    // duplicates this exists to collapse.
+    if (primary.severity === candidate.severity) return true;
+    return similarity >= REVIEW_FINDING_MERGE.sameLineDifferentSeverity;
+  }
+
+  const window = REVIEW_FINDING_MERGE.lineWindow;
+  const overlaps = a.start - window <= b.end && b.start - window <= a.end;
+  if (!overlaps) return false;
+  // A nearby line is weak evidence on its own: a real pair sat four lines
+  // apart in one function and was two unrelated defects. The wording has to
+  // agree as well.
+  return similarity >= REVIEW_FINDING_MERGE.nearbyLine;
+}
+
+interface Cluster {
+  sources: ReviewFindingCandidate[];
+}
+
+function mergeable(cluster: Cluster, candidate: ReviewFindingCandidate): boolean {
+  const primary = cluster.sources[0]!;
+  // Cross-reviewer only. One reviewer's own list is left alone, which removes
+  // the failure mode where its Nit swallows its own Blocker on the same line.
+  if (cluster.sources.some((s) => s.reviewerIndex === candidate.reviewerIndex)) {
+    return false;
+  }
+  if (primary.groupKey !== candidate.groupKey) return false;
+  return locationMatches(primary.finding, candidate.finding);
+}
+
+function resolveCluster(cluster: Cluster): MergedReviewFinding {
+  // Highest severity leads, ties broken by declaration order, so the most
+  // serious reading of a defect is the one a reader sees first.
+  const lead = cluster.sources.reduce((best, source) =>
+    SEVERITY_RANK[source.finding.severity] > SEVERITY_RANK[best.finding.severity]
+      ? source
+      : best,
+  );
+  const anchored = cluster.sources.find((source) => source.anchor !== null);
+  return {
+    file: lead.finding.file,
+    description: lead.finding.description,
+    severity: lead.finding.severity,
+    ...(typeof lead.finding.startLine === "number"
+      ? { startLine: lead.finding.startLine }
+      : {}),
+    ...(typeof lead.finding.endLine === "number"
+      ? { endLine: lead.finding.endLine }
+      : {}),
+    sources: cluster.sources,
+    // A cluster mixing an anchored and an unanchored report is published
+    // inline: one reviewer managed to place it, so the reader gets it in place
+    // rather than in the summary.
+    anchor: anchored?.anchor ?? null,
+  };
+}
+
+/**
+ * Groups candidates into one entry per defect. Candidates must arrive in
+ * declaration order; the result preserves it, which is what keeps the published
+ * comment array stable for a given input.
+ */
+export function mergeReviewFindings(
+  candidates: readonly ReviewFindingCandidate[],
+): MergedReviewFinding[] {
+  const clusters: Cluster[] = [];
+  for (const candidate of candidates) {
+    // Compared against the cluster's first member only. Comparing against every
+    // member would chain 40 to 41 to 42 to 43 and swallow a whole file.
+    const target = clusters.find((cluster) => mergeable(cluster, candidate));
+    if (target) target.sources.push(candidate);
+    else clusters.push({ sources: [candidate] });
+  }
+  return clusters.map(resolveCluster);
+}
+
+/**
+ * The published comment body. A single-source cluster renders byte for byte as
+ * it did before merging existed, which is what keeps single-reviewer
+ * deployments and the existing tests untouched.
+ */
+export function mergedReviewFindingCommentBody(
+  finding: MergedReviewFinding,
+  reviewerCount: number,
+): string {
+  const head = `**${finding.severity}**: ${finding.description}`;
+  if (finding.sources.length < 2) return head;
+  // Agreement between independent reviewers is the strongest signal available
+  // that a finding is real, so it is stated rather than discarded.
+  return `${head}\n\nReported by ${finding.sources.length} of ${reviewerCount} reviewers.`;
+}
+
+/** Orders clusters for the inline slots: severity, then agreement, then order. */
+export function compareMergedFindingsForPublication(
+  a: MergedReviewFinding,
+  b: MergedReviewFinding,
+): number {
+  const severity = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+  if (severity !== 0) return severity;
+  const agreement = b.sources.length - a.sources.length;
+  if (agreement !== 0) return agreement;
+  const first = a.sources[0]!;
+  const second = b.sources[0]!;
+  if (first.reviewerIndex !== second.reviewerIndex) {
+    return first.reviewerIndex - second.reviewerIndex;
+  }
+  return first.findingIndex - second.findingIndex;
+}
+
+/** Orders the chosen clusters for display: by file, then by line. */
+export function compareMergedFindingsForDisplay(
+  a: MergedReviewFinding,
+  b: MergedReviewFinding,
+): number {
+  // Plain comparison, never localeCompare: the locale would make published
+  // comment order, and therefore GitLab's comment identity, machine dependent.
+  if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+  const left = a.startLine ?? 0;
+  const right = b.startLine ?? 0;
+  if (left !== right) return left - right;
+  return compareMergedFindingsForPublication(a, b);
+}


### PR DESCRIPTION
Three reviewers with different prompts are the point of the Post-PR review flow. Publishing their findings unmerged is not: one defect became several comments, which is the "a lot of noise for very low signal" complaint the flow exists to answer. Tracked as [AIW-235](https://blazity.atlassian.net/browse/AIW-235).

## The measurement this is built from

Production run `wrun_...4N9DD3`, a 65-line diff over two files:

| | |
| --- | --- |
| findings reported | 9, three per reviewer |
| **distinct defects** | **6** |
| `app/api/refunds/route.ts:50` | reported by 3 of 3 reviewers |
| `app/api/payments/route.ts:40` | reported by 2 of 3 reviewers |

In that run the duplicates carried an identical file and an identical start line, so a deterministic key is enough and no model call is needed.

## What changed

Merging happens at publication and nowhere else. `normalizeReviewResultsInput` still returns raw per-reviewer results, because the same normalizer feeds `fix_agent` verbatim and the publication `contentHash` is keyed on those raw results. `decision`, `normalized` and `contentHash` are untouched, and a test pins that collapsing every finding into one comment still yields `request_changes` when any reviewer asked for changes.

New `review-finding-merge.ts` clusters candidates in one greedy pass. A candidate joins a cluster only if it comes from a reviewer not already in it, the normalized path matches, and the location matches:

| Situation | Rule |
| --- | --- |
| same start line, same severity | merge, no wording gate |
| same start line, different severity | description similarity >= 0.25 |
| ranges overlap after growing both by 2 lines | similarity >= 0.4 |
| neither carries a line | similarity >= 0.5 |
| one carries a line, the other does not | never merge |

Two details are load-bearing and easy to "clean up" by mistake:

- **No wording gate on an exact line match.** Three reviewers describe one defect in three unrelated vocabularies ("no authentication" versus "missing auth per AC-3" share no token), so a similarity gate there would reject exactly the duplicates this removes.
- **Candidates are compared against the cluster's first member only.** Comparing against every member would chain 40 to 41 to 42 to 43 and swallow a whole file.

The cap is now 10 for the whole review rather than 10 per reviewer, since a reader experiences one review. Inline slots go to the most severe findings first and, on a tie, to the ones the most reviewers agreed on: agreement is the best available evidence that a finding is real. Nothing is dropped, the remainder is listed in the summary under a heading that states the count.

A merged comment reads:

```
**High**: Pagination start offset uses `page * perPage` instead of `(page - 1) * perPage`.

Reported by 3 of 3 reviewers.
```

A single-reviewer comment is byte for byte what it was before, which is what keeps the Arthur single-reviewer shape and the existing tests untouched.

## Verification

- `review-finding-merge.test.ts`, 16 tests, including three negatives: two different defects four lines apart stay apart, the same pair moved to adjacent lines still stays apart (the assertion that fails if the wording gate is deleted), and one reviewer's own two findings are never collapsed into each other
- `pr-external-resources.test.ts`, 22 tests. The 18 that existed pass **unmodified**, which is the regression net for single-reviewer behaviour
- `src/workflows`, `src/workflow-definition`, `src/sandbox`: 127 files, 2252 tests passing
- `pnpm -r typecheck` clean

Production check to follow: a push to the seeded-defect pull request should publish fewer comments than findings, with the multi-reviewer defect appearing once and carrying its agreement line, and the check still concluding `failure`.

## Deliberately not here

Comments accumulating across successive pushes (four pushes left 21 live comments on one pull request) is a different mechanism, provider-side thread resolution, and gets its own ticket rather than being mixed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIW-235]: https://blazity.atlassian.net/browse/AIW-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Related review findings from multiple reviewers are now merged into consolidated comments.
  * Merged findings prioritize higher-severity issues and show reviewer agreement.
  * Inline review comments are capped, with additional findings retained in the review summary.
  * Review summaries now include reported and distinct finding counts, merge details, and withheld findings.
* **Bug Fixes**
  * Preserved reviewer verdicts when overlapping findings are consolidated.
  * Improved handling of findings without publishable file or line locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->