### PR TITLE
fix(worker): count a single withheld review finding in the singular

### DIFF
--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -166,6 +166,67 @@ describe("PR review diff placement", () => {
     expect(alone?.body).not.toContain("Reported by");
   });
 
+  // The first production run after the cap shipped withheld exactly one
+  // finding, and the heading read "1 further findings". Client-facing text.
+  it("counts a single withheld finding in the singular", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-one-withheld" });
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([
+        {
+          path: "src/a.ts",
+          additions: 30,
+          deletions: 0,
+          changeType: "modified",
+          patch: `@@ -1,30 +1,30 @@\n${Array.from({ length: 30 }, (_, i) => `+line${i}`).join("\n")}`,
+        },
+      ]),
+      publishPRReview: vi
+        .fn()
+        .mockResolvedValue({ id: "review-11", commentIds: [] }),
+    });
+
+    const result = await publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#11",
+        ownerToken: "owner-11",
+        runId: "run-one-withheld",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#11",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 11,
+        headSha: "head",
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: [
+        {
+          decision: "request_changes",
+          findings: Array.from({ length: 11 }, (_, index) => ({
+            file: "src/a.ts",
+            description: `Unrelated defect ${index} about subject ${"y".repeat(index)}.`,
+            severity: "Medium" as const,
+            startLine: index * 2 + 1,
+            endLine: index * 2 + 1,
+          })),
+        },
+      ],
+    });
+
+    expect(result.inlineCommentCount).toBe(10);
+    expect(result.summary).toContain("1 further finding not shown inline");
+    expect(result.summary).not.toContain("1 further findings");
+  });
+
   it("caps the inline comments and names the rest in the summary", () => {
     const patch = `@@ -1,40 +1,40 @@\n${Array.from({ length: 40 }, (_, i) => `+line${i}`).join("\n")}`;
     const results: ReviewResult[] = [

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -698,7 +698,8 @@ function reviewSummary(
   if (withheld.length > 0) {
     // The count belongs in the heading: a cap that truncates silently reads as
     // "nothing else was found", which is the opposite of what happened.
-    lines.push("", `### ${withheld.length} further findings not shown inline`);
+    const noun = withheld.length === 1 ? "finding" : "findings";
+    lines.push("", `### ${withheld.length} further ${noun} not shown inline`);
     for (const finding of withheld) {
       lines.push(reviewSummaryLine(finding, results.length));
     }


### PR DESCRIPTION
The first production run after the cap shipped withheld exactly one finding, and the summary heading read `### 1 further findings not shown inline`.

Small, but it is text a client reads on their own pull request, and the review flow exists to look trustworthy.

The test goes through `publishRunOwnedPrReview` rather than the partition helper, because the heading is built in a module-private function and a reader only ever sees it via the published summary. It asserts both the singular form and the absence of the plural, so the assertion cannot pass for the wrong reason.

## Verification

- `pr-external-resources.test.ts`, 23 tests passing
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)