### PR TITLE
fix(worker): keep a merged review comment inside its fallback bullet

### DIFF
--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -619,6 +619,47 @@ describe("GitHubAdapter", () => {
       expect(result).toEqual({ id: "702", commentIds: [null] });
     });
 
+    // A merged review comment carries its agreement note after a blank line.
+    // Left unindented, that blank line closes the markdown list, detaching the
+    // note and starting a fresh list for every finding after it.
+    it("keeps a merged comment's agreement note inside its own bullet", async () => {
+      mockOctokit.paginate.mockResolvedValueOnce([]);
+      const rejected = Object.assign(new Error("Validation failed"), {
+        status: 422,
+      });
+      mockOctokit.pulls.createReview
+        .mockRejectedValueOnce(rejected)
+        .mockResolvedValueOnce({ data: { id: 703 } });
+
+      await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "reviewed-head",
+        decision: "request_changes",
+        summary: "Two findings.",
+        comments: [
+          {
+            path: "src/index.ts",
+            body: "**High**: Handle this failure.\n\nReported by 3 of 3 reviewers.",
+            startLine: 10,
+            endLine: 12,
+          },
+          {
+            path: "src/other.ts",
+            body: "**Medium**: Rename this helper.",
+            startLine: 4,
+            endLine: 4,
+          },
+        ],
+      });
+
+      const body: string = mockOctokit.pulls.createReview.mock.calls[1]![0].body;
+      expect(body).toContain(
+        "- `src/index.ts:10-12` — **High**: Handle this failure.\n\n  Reported by 3 of 3 reviewers.",
+      );
+      // The bullet after a merged one still belongs to the same list.
+      expect(body).toContain("\n- `src/other.ts:4` — **Medium**: Rename this helper.");
+    });
+
     it("publishes findings as a comment review when the app cannot request changes on its own pull request", async () => {
       mockOctokit.paginate
         .mockResolvedValueOnce([])

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -20,6 +20,7 @@ import type {
   ManualDispatchPrCapableVCS,
   ManualDispatchPullRequestSnapshot,
 } from "./types.js";
+import { reviewFallbackBullet } from "./types.js";
 
 export interface GitHubConfig {
   auth: GitHubAppAuth;
@@ -650,13 +651,7 @@ export class GitHubAdapter
     publication: PRReviewPublication,
     marker: string,
   ): string {
-    const findings = publication.comments.map((comment) => {
-      const range =
-        comment.startLine === comment.endLine
-          ? String(comment.startLine)
-          : `${comment.startLine}-${comment.endLine}`;
-      return `- \`${comment.path}:${range}\` — ${comment.body}`;
-    });
+    const findings = publication.comments.map(reviewFallbackBullet);
     return `${publication.summary}\n\n### Findings not placed inline\n${findings.join("\n")}\n\n${marker}`;
   }
 

--- a/apps/worker/src/adapters/vcs/gitlab.test.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.test.ts
@@ -742,6 +742,51 @@ describe("GitLabAdapter", () => {
       );
     });
 
+    // GitLab rejects an inline position per comment, so this fallback list is
+    // the path Arthur's two GitLab repositories exercise most. A merged comment
+    // carries its agreement note after a blank line, and an unindented blank
+    // line closes the markdown list, detaching the note from its finding.
+    it("keeps a merged comment's agreement note inside its own bullet", async () => {
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "reviewed-head",
+        diff_refs: {
+          base_sha: "base",
+          start_sha: "start",
+          head_sha: "reviewed-head",
+        },
+      });
+      mockFetch
+        .mockResolvedValueOnce(
+          gitLabResponse(
+            { message: "position is invalid" },
+            { status: 400, statusText: "Bad Request" },
+          ),
+        )
+        .mockResolvedValueOnce(gitLabResponse({ id: 556 }, { status: 201 }));
+
+      await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "reviewed-head",
+        decision: "request_changes",
+        summary: "Published.",
+        comments: [
+          {
+            path: "src/index.ts",
+            body: "**High**: Handle this failure.\n\nReported by 3 of 3 reviewers.",
+            startLine: 8,
+            endLine: 8,
+          },
+        ],
+      });
+
+      const noteBody = JSON.parse(String(mockFetch.mock.calls[1]?.[1]?.body));
+      expect(noteBody.body).toContain(
+        "- `src/index.ts:8` — **High**: Handle this failure.\n\n  Reported by 3 of 3 reviewers.",
+      );
+    });
+
     it("propagates GitLab server failures instead of degrading them to the summary", async () => {
       mockMergeRequestNotes.all.mockResolvedValueOnce([]);
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -18,6 +18,7 @@ import type {
   ManualDispatchPrCapableVCS,
   ManualDispatchPullRequestSnapshot,
 } from "./types.js";
+import { reviewFallbackBullet } from "./types.js";
 import { clampBothEnds } from "../../workflow-definition/failure-message.js";
 
 // Minimal shapes for gitbeaker responses we touch. Declared locally so we do
@@ -631,13 +632,7 @@ export class GitLabAdapter implements
           `GitLab rejected inline review position ${comment.path}:${comment.startLine}-${comment.endLine}; including it in the summary instead.`,
         );
         commentIds.push(null);
-        const range =
-          comment.startLine === comment.endLine
-            ? String(comment.startLine)
-            : `${comment.startLine}-${comment.endLine}`;
-        summaryFallbacks.push(
-          `- \`${comment.path}:${range}\` — ${comment.body}`,
-        );
+        summaryFallbacks.push(reviewFallbackBullet(comment));
       }
     }
 

--- a/apps/worker/src/adapters/vcs/types.ts
+++ b/apps/worker/src/adapters/vcs/types.ts
@@ -228,6 +228,26 @@ export interface PRReviewInlineComment {
   endOldLine?: number | null;
 }
 
+/**
+ * Renders one finding as a markdown list item, for the list a provider falls
+ * back to when it refuses an inline position.
+ *
+ * Continuation lines are indented into the item deliberately. A merged review
+ * comment carries its agreement note after a blank line, and an unindented
+ * blank line closes a markdown list: the note would detach into its own
+ * paragraph and every finding after it would start a fresh list. Indenting
+ * keeps the note inside its own bullet, which is what a reader expects.
+ */
+export function reviewFallbackBullet(comment: PRReviewInlineComment): string {
+  const range =
+    comment.startLine === comment.endLine
+      ? String(comment.startLine)
+      : `${comment.startLine}-${comment.endLine}`;
+  const [first = "", ...rest] = comment.body.split("\n");
+  const continuation = rest.map((line) => (line.trim() === "" ? "" : `  ${line}`));
+  return [`- \`${comment.path}:${range}\` — ${first}`, ...continuation].join("\n");
+}
+
 export interface PRReviewPublication {
   idempotencyKey: string;
   headSha: string;


### PR DESCRIPTION
A defect introduced by the cross-reviewer merge in #212, found by reading the provider fallback paths rather than by a failing test.

## What breaks

Both providers render the fallback list by interpolating a comment body into one markdown list item:

```
- `${comment.path}:${range}` — ${comment.body}
```

`github.ts` uses it when `createReview` 422s on inline positions; `gitlab.ts` uses it per comment on a 400. A merged comment now carries its agreement note after a blank line:

```
**High**: Pagination start offset is wrong.

Reported by 3 of 3 reviewers.
```

An unindented blank line closes a markdown list. The note therefore detaches into its own paragraph and **every finding after it starts a fresh list**, so the fallback renders as fragmented lists with orphaned sentences.

This matters most for GitLab, where the fallback is per comment rather than all-or-nothing, and GitLab is two of Arthur's three repositories.

## The fix

One shared pure helper, `reviewFallbackBullet` in `adapters/vcs/types.ts`, used by both adapters. Continuation lines are indented by two spaces, which keeps them inside their own list item as a second paragraph and leaves the list intact.

## Tests

- `github.test.ts`: a merged multi-line comment followed by a single-line one; asserts the indented continuation **and** that the following bullet is still part of the same list
- `gitlab.test.ts`: the same through the per-comment 400 fallback, which had no coverage for a multi-line body at all

Neither assertion can pass against the old code: it emitted the note at column zero, so `"\n\n  Reported by"` cannot appear.

- `src/adapters`, `src/workflows`, `src/workflow-definition`: 110 files, 2102 tests passing
- `pnpm -r typecheck` clean

## Note on how this was found

The merge feature was verified on production against GitHub, where inline positions were accepted and the fallback never ran. The bug sits on a path that only fires when a provider rejects a position, which is exactly the path the unverifiable GitLab configuration would take. Reading it was the only way to catch this before a client did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request review summaries when inline comments cannot be placed.
  - Ensured fallback findings remain correctly grouped as Markdown bullets, including line ranges and multiline comments.
  - Preserved agreement notes and subsequent findings in the correct list structure across GitHub and GitLab reviews.

- **Tests**
  - Added coverage for fallback rendering, blank lines, multiline notes, and rejected inline comment positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->