### PR TITLE
feat(worker): pin the Claude harness to opus-4-8 and honor the agent label

### DIFF
--- a/.claude/skills/init-agent/SKILL.md
+++ b/.claude/skills/init-agent/SKILL.md
@@ -34,7 +34,7 @@ Walk the user through https://console.anthropic.com/settings/keys to create an A
 
 Collect:
 - `ANTHROPIC_API_KEY` (starts with `sk-ant-`)
-- `CLAUDE_MODEL` (default `claude-opus-4-6`; only override if requested)
+- `CLAUDE_MODEL` (default `claude-opus-4-8`; only override if requested)
 
 Emit:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -175,7 +175,7 @@ Pick one — controlled by `AGENT_KIND`.
 - Configure either a standard Console API key or a Claude Code OAuth token as
   `ANTHROPIC_API_KEY`. The same credential is used for execution and pinned-CLI
   Harness Profile discovery.
-- Optionally pin a model: `CLAUDE_MODEL=claude-opus-4-6` (default).
+- Optionally pin a model: `CLAUDE_MODEL=claude-opus-4-8` (default).
 
 **Codex:**
 
@@ -294,7 +294,7 @@ This is enough for password-only dashboard login. SSO and Resend are optional wo
 | `SLACK_ALLOWED_USER_IDS`                      | empty (anyone)                                                                                                                                              | Comma-separated user IDs allowed to run slash commands                                                                           |
 | `CRON_SECRET`                                 | unset                                                                                                                                                       | Generate: `openssl rand -hex 32`. Without it, `/cron/poll` accepts unauthenticated callers — strongly recommended in production. |
 | `JIRA_WEBHOOK_SECRET`                         | unset                                                                                                                                                       | Generate: `openssl rand -hex 32`. Without it, dispatch is cron-bound (1-min latency).                                            |
-| `CLAUDE_MODEL`                                | `claude-opus-4-6`                                                                                                                                           | Anthropic model                                                                                                                  |
+| `CLAUDE_MODEL`                                | `claude-opus-4-8`                                                                                                                                           | Anthropic model                                                                                                                  |
 | `CODEX_MODEL`                                 | `gpt-5-codex`                                                                                                                                               | Codex model                                                                                                                      |
 | `MAX_CONCURRENT_AGENTS`                       | `3`                                                                                                                                                         | Parallel sandbox cap                                                                                                             |
 | `JOB_TIMEOUT_MS`                              | `1800000` (30 min)                                                                                                                                          | Per-run timeout                                                                                                                  |

--- a/apps/dashboard/lib/harness-profiles/editor.test.ts
+++ b/apps/dashboard/lib/harness-profiles/editor.test.ts
@@ -91,7 +91,7 @@ test("switching providers applies one complete code-owned harness contract", () 
     cliVersion: "2.1.216",
     protocolVersion: "claude-json-2.1.216",
   });
-  assert.equal(next.model.id, "claude-opus-4-6");
+  assert.equal(next.model.id, "claude-opus-4-8");
   assert.deepEqual(next.model.options, {});
   assert.deepEqual(next.homeFiles, [
     { path: "CLAUDE.md", content: "Shared instructions", mode: 0o644 },

--- a/apps/shared/contracts/harness-profiles.ts
+++ b/apps/shared/contracts/harness-profiles.ts
@@ -437,7 +437,7 @@ export const HARNESS_SKILL_IMPORT_LIMITS = {
 const CLAUDE_COMPATIBILITY_MANIFEST = {
   schemaVersion: 1,
   profileId: BUILTIN_HARNESS_PROFILE_IDS.claude,
-  version: 1,
+  version: 2,
   slug: "claude",
   displayName: "Claude",
   description: "Code-owned Claude compatibility profile.",
@@ -449,7 +449,7 @@ const CLAUDE_COMPATIBILITY_MANIFEST = {
     protocolVersion: "claude-json-2.1.216",
   },
   model: {
-    id: "claude-opus-4-6",
+    id: "claude-opus-4-8",
     options: {},
   },
   homeFiles: [],

--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -69,7 +69,7 @@ AGENT_KIND=claude
 
 # Claude (standard API keys and Claude Code OAuth tokens are both accepted)
 ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxx
-CLAUDE_MODEL=claude-opus-4-6
+CLAUDE_MODEL=claude-opus-4-8
 
 # Codex (active when AGENT_KIND=codex — one of API_KEY or OAUTH_TOKEN required)
 # CODEX_API_KEY=

--- a/apps/worker/env.ts
+++ b/apps/worker/env.ts
@@ -62,7 +62,7 @@ export const env = createEnv({
 
     // Agent
     ANTHROPIC_API_KEY: z.string().min(1).optional(),
-    CLAUDE_MODEL: z.string().default("claude-opus-4-6"),
+    CLAUDE_MODEL: z.string().default("claude-opus-4-8"),
     // Optional overrides for the git identity used inside the sandbox.
     // - GitHub: when both are unset, the identity is derived from the App so
     //   commits render with the App's avatar and the `[bot]` badge in the UI.

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -356,7 +356,7 @@ describe("GET /api/v1/workflow-definitions", () => {
       ).configuration.harnessProfile,
     ).toEqual({
       profileId: BUILTIN_HARNESS_PROFILE_IDS.claude,
-      version: 1,
+      version: 2,
     });
     expect(body.templates.map((template: { name: string }) => template.name)).toEqual([
       "Ticket workflow",
@@ -487,7 +487,7 @@ describe("POST /api/v1/workflow-definitions", () => {
       ).configuration.harnessProfile,
     ).toEqual({
       profileId: BUILTIN_HARNESS_PROFILE_IDS.claude,
-      version: 1,
+      version: 2,
     });
     expect(body.draft.nodes.some((n: { type: string }) => n.type === "review_agent")).toBe(
       true,
@@ -1776,7 +1776,7 @@ describe("POST /api/v1/workflow-definitions/:id/prompt-preview", () => {
         expect.objectContaining({
           kind: "profile",
           id: BUILTIN_HARNESS_PROFILE_IDS.claude,
-          version: 1,
+          version: 2,
         }),
       ]),
       unresolvedSources: expect.arrayContaining([

--- a/apps/worker/src/workflow-definition/default-v2.test.ts
+++ b/apps/worker/src/workflow-definition/default-v2.test.ts
@@ -43,13 +43,13 @@ describe("built-in Harness Profiles", () => {
 
     expect(claude).toMatchObject({
       profileId: BUILTIN_HARNESS_PROFILE_IDS.claude,
-      version: 1,
+      version: 2,
       harness: {
         provider: "claude",
         cliVersion: "2.1.216",
         protocolVersion: "claude-json-2.1.216",
       },
-      model: { id: "claude-opus-4-6" },
+      model: { id: "claude-opus-4-8" },
     });
     expect(codex).toMatchObject({
       profileId: BUILTIN_HARNESS_PROFILE_IDS.codex,

--- a/apps/worker/src/workflow-definition/harness-profile-runtime.test.ts
+++ b/apps/worker/src/workflow-definition/harness-profile-runtime.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
-import type { WorkflowDefinitionV1 } from "@shared/contracts";
+import type {
+  HarnessProfileManifestV1,
+  HarnessProfileReference,
+  HarnessProfileResolvedVersion,
+  WorkflowDefinitionV1,
+  WorkflowDefinitionV2,
+} from "@shared/contracts";
+import {
+  BUILTIN_HARNESS_PROFILE_MANIFESTS,
+  builtinHarnessProfileReference,
+} from "@shared/contracts";
+import { parseAgentKindOverride } from "../sandbox/agents/index.js";
+import { hashHarnessProfileManifest } from "../harness-profiles/manifest.js";
 import { resolveHarnessRuntimesWithLoader } from "./harness-profile-runtime.js";
 
 describe("V1 Harness Profile compatibility resolution", () => {
@@ -48,6 +60,205 @@ describe("V1 Harness Profile compatibility resolution", () => {
     });
     expect(JSON.parse(JSON.stringify(runtimes.planning))).toEqual(
       runtimes.planning,
+    );
+  });
+});
+
+describe("ticket agent label over a pinned Harness Profile", () => {
+  const ORG_CLAUDE_PROFILE: HarnessProfileManifestV1 = {
+    ...structuredClone(BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-claude"]),
+    profileId: "org-claude",
+    version: 4,
+    slug: "org-claude",
+    displayName: "Org Claude",
+    system: false,
+    model: { id: "claude-org-pinned", options: {} },
+  };
+
+  const publishedVersion = (
+    manifest: HarnessProfileManifestV1,
+  ): HarnessProfileResolvedVersion => {
+    const cloned = structuredClone(manifest);
+    return {
+      manifest: cloned,
+      manifestHash: hashHarnessProfileManifest(cloned),
+      skillArtifacts: [],
+    };
+  };
+
+  const catalog = (): HarnessProfileManifestV1[] => [
+    structuredClone(BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-claude"]),
+    structuredClone(BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-codex"]),
+    ORG_CLAUDE_PROFILE,
+  ];
+
+  const loaderOver = (manifests: HarnessProfileManifestV1[]) =>
+    vi.fn(async ({ profileId, version }: { profileId: string; version: number }) => {
+      const manifest = manifests.find(
+        (candidate) =>
+          candidate.profileId === profileId && candidate.version === version,
+      );
+      return manifest ? publishedVersion(manifest) : null;
+    });
+
+  const definition = (
+    reference: HarnessProfileReference,
+  ): WorkflowDefinitionV2 => ({
+    schemaVersion: 2,
+    nodes: [
+      {
+        id: "implement",
+        type: "implementation_agent",
+        name: "Implementation agent",
+        x: 0,
+        y: 0,
+        configuration: {
+          harnessProfile: { ...reference },
+          prompt: "Implement the ticket.",
+        },
+        inputs: {},
+        additionalInputs: [],
+      },
+    ],
+    edges: [],
+  });
+
+  const codexPinned = definition(builtinHarnessProfileReference("codex"));
+  const claudePinned = definition(builtinHarnessProfileReference("claude"));
+
+  it("redirects a codex pin to Claude for an agent:claude ticket", async () => {
+    const load = loaderOver(catalog());
+
+    const runtimes = await resolveHarnessRuntimesWithLoader(
+      codexPinned,
+      "codex",
+      load,
+      parseAgentKindOverride(["agent:claude"]),
+    );
+
+    expect(runtimes.implement.manifest).toMatchObject({
+      profileId: "builtin-claude",
+      harness: { provider: "claude" },
+      model: { id: "claude-opus-4-8" },
+    });
+    expect(runtimes.implement.cliSpec.kind).toBe("claude");
+  });
+
+  // The rollback lever: if the Claude default misbehaves, an `agent:codex` label
+  // is what moves one ticket back without redeploying a definition.
+  it("redirects a Claude pin to codex for an agent:codex ticket", async () => {
+    const load = loaderOver(catalog());
+
+    const runtimes = await resolveHarnessRuntimesWithLoader(
+      claudePinned,
+      "claude",
+      load,
+      parseAgentKindOverride(["agent:codex"]),
+    );
+
+    expect(runtimes.implement.manifest).toMatchObject({
+      profileId: "builtin-codex",
+      harness: { provider: "codex" },
+      model: { id: "gpt-5.4" },
+    });
+    expect(runtimes.implement.cliSpec.kind).toBe("codex");
+  });
+
+  it("keeps the codex pin when the ticket carries no agent label", async () => {
+    const load = loaderOver(catalog());
+
+    const runtimes = await resolveHarnessRuntimesWithLoader(
+      codexPinned,
+      "claude",
+      load,
+      parseAgentKindOverride(["needs-review"]),
+    );
+
+    expect(runtimes.implement.manifest).toMatchObject({
+      profileId: "builtin-codex",
+      harness: { provider: "codex" },
+      model: { id: "gpt-5.4" },
+    });
+    // The pinned version is the only one loaded, so the default path costs
+    // exactly what it cost before the label could redirect anything.
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(load).toHaveBeenCalledWith(builtinHarnessProfileReference("codex"));
+  });
+
+  it("keeps an organization profile that already runs the demanded provider", async () => {
+    const load = loaderOver(catalog());
+
+    const runtimes = await resolveHarnessRuntimesWithLoader(
+      definition({
+        profileId: ORG_CLAUDE_PROFILE.profileId,
+        version: ORG_CLAUDE_PROFILE.version,
+      }),
+      "codex",
+      load,
+      parseAgentKindOverride(["agent:claude"]),
+    );
+
+    expect(runtimes.implement.manifest).toMatchObject({
+      profileId: "org-claude",
+      harness: { provider: "claude" },
+      model: { id: "claude-org-pinned" },
+    });
+  });
+
+  it("fails the run when the demanded system profile is unpublished", async () => {
+    const load = loaderOver(
+      catalog().filter((manifest) => manifest.profileId !== "builtin-claude"),
+    );
+
+    await expect(
+      resolveHarnessRuntimesWithLoader(
+        codexPinned,
+        "codex",
+        load,
+        parseAgentKindOverride(["agent:claude"]),
+      ),
+    ).rejects.toThrow(
+      /"agent:claude" label cannot be honoured for block "implement"/,
+    );
+  });
+
+  it("names the redirected profile when its workspace cannot serve the block", async () => {
+    const load = loaderOver([
+      structuredClone(BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-codex"]),
+      {
+        ...structuredClone(BUILTIN_HARNESS_PROFILE_MANIFESTS["builtin-claude"]),
+        workspace: { mode: "managed", preserveAcrossBlocks: false },
+      },
+    ]);
+
+    // The pin would have satisfied the block, so naming it here would send an
+    // operator to repair the wrong profile.
+    await expect(
+      resolveHarnessRuntimesWithLoader(
+        codexPinned,
+        "codex",
+        load,
+        parseAgentKindOverride(["agent:claude"]),
+      ),
+    ).rejects.toThrow(
+      /Harness Profile "builtin-claude" version 2 cannot be used by block "implement"/,
+    );
+  });
+
+  it("reports the unavailable pin rather than the label when the pin cannot resolve", async () => {
+    const load = loaderOver(catalog());
+
+    // A label cannot rescue a definition whose own pin is gone: the pin is
+    // resolved first, and its failure is the one an operator has to fix.
+    await expect(
+      resolveHarnessRuntimesWithLoader(
+        definition({ profileId: "org-retired", version: 9 }),
+        "codex",
+        load,
+        parseAgentKindOverride(["agent:claude"]),
+      ),
+    ).rejects.toThrow(
+      /Harness Profile "org-retired" version 9 is unavailable for block "implement"/,
     );
   });
 });

--- a/apps/worker/src/workflow-definition/harness-profile-runtime.ts
+++ b/apps/worker/src/workflow-definition/harness-profile-runtime.ts
@@ -1,5 +1,6 @@
 import { eq } from "drizzle-orm";
 import type {
+  HarnessProfileReference,
   HarnessProfileResolvedVersion,
   HarnessRunManifestRecord,
   WorkflowBlockType,
@@ -64,6 +65,7 @@ export async function resolveHarnessRuntimesForDefinition(
     definition: WorkflowDefinition;
     organizationId: string;
     defaultProvider: "claude" | "codex";
+    providerOverride?: "claude" | "codex" | null;
   },
 ): Promise<Record<string, ResolvedHarnessRuntime>> {
   const versions = new Map<
@@ -86,13 +88,20 @@ export async function resolveHarnessRuntimesForDefinition(
       }
       return pending;
     },
+    input.providerOverride ?? null,
   );
 }
 
+/**
+ * `providerOverride` is the provider a ticket's `agent:<kind>` label demanded.
+ * It is deliberately separate from `defaultProvider`: the default is consulted
+ * only when a block pins nothing, whereas the label has to beat a pin.
+ */
 export async function resolveHarnessRuntimesWithLoader(
   definition: WorkflowDefinition,
   defaultProvider: "claude" | "codex",
   load: HarnessProfileVersionLoader,
+  providerOverride: "claude" | "codex" | null = null,
 ): Promise<Record<string, ResolvedHarnessRuntime>> {
   const runtimes: Record<string, ResolvedHarnessRuntime> = {};
   for (const node of definition.nodes) {
@@ -159,22 +168,35 @@ export async function resolveHarnessRuntimesWithLoader(
     const explicitReference = isHarnessProfileReference(
       configuration.harnessProfile,
     );
-    const resolved =
+    const pinned =
       (await load(reference)) ??
       (!explicitReference
         ? builtinResolvedVersion(reference.profileId)
         : null);
-    if (!resolved) {
+    if (!pinned) {
       throw new Error(
         `Harness Profile "${reference.profileId}" version ${reference.version} is unavailable for block "${node.id}".`,
       );
     }
+    // A v2 block must pin an exact published profile, and that pin answers the
+    // provider question before any run-wide default is consulted. So the only
+    // way to honour a ticket's `agent:<kind>` label is to resolve a different
+    // profile: the system one of the demanded provider. A pin that already runs
+    // on the demanded provider is kept as authored, because the label asks for a
+    // provider and has no quarrel with that profile's skills or instructions.
+    const overridden =
+      providerOverride !== null &&
+      pinned.manifest.harness.provider !== providerOverride
+        ? await systemProfileForProvider(providerOverride, node.id, load)
+        : null;
+    const effectiveReference = overridden?.reference ?? reference;
+    const resolved = overridden?.resolved ?? pinned;
     if (
       codeWorkspaceRequired(node.type, workspaceMode) &&
       !resolved.manifest.workspace.preserveAcrossBlocks
     ) {
       throw new Error(
-        `Harness Profile "${reference.profileId}" version ${reference.version} cannot be used by block "${node.id}" because its managed workspace is not preserved across blocks.`,
+        `Harness Profile "${effectiveReference.profileId}" version ${effectiveReference.version} cannot be used by block "${node.id}" because its managed workspace is not preserved across blocks.`,
       );
     }
     runtimes[node.id] = resolveHarnessRuntime({
@@ -296,6 +318,29 @@ function codeWorkspaceRequired(
     CODE_WORKSPACE_AGENT_BLOCK_TYPES.has(nodeType) ||
     (nodeType === "generic_agent" && workspaceMode !== "none")
   );
+}
+
+/**
+ * The system profile a ticket label redirects a block to. A run that cannot get
+ * it must fail loudly: a label the run accepted and then dropped would send the
+ * work to the provider the operator explicitly steered away from.
+ */
+async function systemProfileForProvider(
+  provider: "claude" | "codex",
+  nodeId: string,
+  load: HarnessProfileVersionLoader,
+): Promise<{
+  reference: HarnessProfileReference;
+  resolved: HarnessProfileResolvedVersion;
+}> {
+  const reference = builtinHarnessProfileReference(provider);
+  const resolved = await load(reference);
+  if (!resolved) {
+    throw new Error(
+      `The "agent:${provider}" label cannot be honoured for block "${nodeId}" because Harness Profile "${reference.profileId}" version ${reference.version} is unavailable.`,
+    );
+  }
+  return { reference, resolved };
 }
 
 function builtinResolvedVersion(

--- a/apps/worker/src/workflow-definition/scenarios/arthur-review.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/arthur-review.scenario.test.ts
@@ -66,10 +66,17 @@ const CHECK_NAME = "AI Workflow / Review";
 /** The pinned Harness Profile. The client's own profile, the one carrying the
  * private review skills, does not exist yet; this pin is the built-in profile
  * the installation always has, and the profile test below proves it satisfies
- * the workspace requirement `harness-profile-runtime.ts` enforces. */
+ * the workspace requirement `harness-profile-runtime.ts` enforces.
+ *
+ * The version tracks the code-owned catalog, NOT whatever a live installation
+ * pinned. A deployed definition keeps the version it was authored against, and
+ * its database keeps that row immutably, so Arthur's live pin may still be
+ * version 1 on claude-opus-4-6 until someone repins it. This constant is a
+ * fixture: `resolveBuiltinHarnessProfile` only resolves the current catalog
+ * version, so a scenario can only ever exercise that one. */
 const PINNED_PROFILE: HarnessProfileReference = {
   profileId: "builtin-claude",
-  version: 1,
+  version: 2,
 };
 
 const PINNED_PROVIDERS: VcsProviderKind[] = ["github", "gitlab"];
@@ -718,7 +725,7 @@ describe("Arthur post-PR review: the committed definition", () => {
         (node) => node.type === "review_agent",
       );
       expect(reviewers.map((node) => node.configuration.harnessProfile)).toEqual(
-        reviewers.map(() => ({ profileId: "builtin-claude", version: 1 })),
+        reviewers.map(() => ({ profileId: "builtin-claude", version: 2 })),
       );
       // The requirement `harness-profile-runtime.ts` enforces for every
       // review_agent: without a preserved managed workspace the review has no

--- a/apps/worker/src/workflow-definition/scenarios/snapshots/arthur-post-pr-review-v1.json
+++ b/apps/worker/src/workflow-definition/scenarios/snapshots/arthur-post-pr-review-v1.json
@@ -84,7 +84,7 @@
       "configuration": {
         "harnessProfile": {
           "profileId": "builtin-claude",
-          "version": 1
+          "version": 2
         },
         "prompt": "Review this pull request against the Arthur review skills attached to this Harness Profile. Load arthur-review-core first, then the one repository skill that matches the repository under review. Do not modify files. Report concrete findings only."
       },

--- a/apps/worker/src/workflow-definition/scenarios/snapshots/post-pr-review-v1.json
+++ b/apps/worker/src/workflow-definition/scenarios/snapshots/post-pr-review-v1.json
@@ -64,7 +64,7 @@
       "configuration": {
         "harnessProfile": {
           "profileId": "builtin-claude",
-          "version": 1
+          "version": 2
         },
         "prompt": "Review the implementation for security vulnerabilities, unsafe trust boundaries, credential exposure, and abuse cases. Do not modify files. Report concrete findings only."
       },
@@ -80,7 +80,7 @@
       "configuration": {
         "harnessProfile": {
           "profileId": "builtin-claude",
-          "version": 1
+          "version": 2
         },
         "prompt": "Review the implementation for correctness, maintainability, test coverage, regressions, and adherence to repository conventions. Do not modify files. Report concrete findings only."
       },
@@ -96,7 +96,7 @@
       "configuration": {
         "harnessProfile": {
           "profileId": "builtin-claude",
-          "version": 1
+          "version": 2
         },
         "prompt": "Review the implementation against the ticket, approved plan, and acceptance criteria. Do not modify files. Report concrete gaps only."
       },

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -2186,12 +2186,16 @@ async function resolveAgentKindOverride(labels: readonly string[]): Promise<Agen
 async function resolveHarnessRuntimesStep(
   definition: WorkflowDefinition,
   defaultProvider: AgentKind,
+  providerOverride: AgentKind | null,
 ): Promise<Record<string, ResolvedHarnessRuntime>> {
   "use step";
   if (definition.schemaVersion === 1) {
     const { resolveHarnessRuntimesWithLoader } = await import(
       "../workflow-definition/harness-profile-runtime.js"
     );
+    // V1 needs no redirect: `defaultProvider` already carries the ticket label,
+    // and a v1 block reads its provider from `configuration.provider` with that
+    // value as the fallback, which is also what `resolveBlockAgent` executes.
     return resolveHarnessRuntimesWithLoader(
       definition,
       defaultProvider,
@@ -2213,6 +2217,7 @@ async function resolveHarnessRuntimesStep(
     definition,
     organizationId,
     defaultProvider,
+    providerOverride,
   });
 }
 resolveHarnessRuntimesStep.maxRetries = 0;
@@ -2921,6 +2926,7 @@ async function agentWorkflowBody(
   const harnessRuntimes = await resolveHarnessRuntimesStep(
     plan.definition,
     runDefaultKind,
+    agentKindOverride,
   );
   const harnessManifests: HarnessRunManifestRecord[] = Object.values(
     harnessRuntimes,

--- a/apps/worker/src/workflows/effective-prompt.test.ts
+++ b/apps/worker/src/workflows/effective-prompt.test.ts
@@ -643,7 +643,7 @@ describe("resolveProfileInstructions", () => {
       }),
     ).resolves.toMatchObject({
       profileId: "builtin-claude",
-      version: 1,
+      version: 2,
       name: "Claude",
     });
   });

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -234,7 +234,7 @@ per-variable reference lives in `SETUP.md`; the groups are:
 - **Messaging:** `CHAT_SDK_SLACK_TOKEN`, `CHAT_SDK_CHANNEL_ID`, `CHAT_SDK_BOT_NAME` (default
   `blazebot`), `SLACK_SIGNING_SECRET`, `SLACK_ALLOWED_USER_IDS`. (There is no `CHAT_SDK_API_KEY`.)
 - **Agent:** `AGENT_KIND` (`claude` default | `codex`), `ANTHROPIC_API_KEY`, `CLAUDE_MODEL`
-  (default `claude-opus-4-6`), `CODEX_API_KEY` / `CODEX_CHATGPT_OAUTH_TOKEN`, `CODEX_MODEL`
+  (default `claude-opus-4-8`), `CODEX_API_KEY` / `CODEX_CHATGPT_OAUTH_TOKEN`, `CODEX_MODEL`
   (default `gpt-5-codex`), Codex pricing feed (`CODEX_PRICING_URL`, `CODEX_PRICING_TTL_MS`),
   `COMMIT_AUTHOR` / `COMMIT_EMAIL` (optional, no default — when unset the identity is derived from
   the GitHub App, or falls back to `ai-workflow-blazity` on GitLab).


### PR DESCRIPTION
Moves the built-in Claude harness onto `claude-opus-4-8`, and makes the `agent:` ticket label actually select a provider instead of silently doing nothing.

## Why the label did nothing

A v2 definition pins a `harnessProfile` onto every agent node at authoring time, and a pinned profile beats the run-wide default kind (`harness-profile-runtime.ts`, `agent.ts`). The label was folded into that default (`runDefaultKind = label ?? env.AGENT_KIND`), so it inherited the loser's position. A ticket labelled `agent:claude` ran Codex without a word.

Verified on production data: a run labelled `agent:claude` recorded `gpt-5.4`, which is the `builtin-codex` manifest model, while this environment's `CODEX_MODEL` is `gpt-5.4-mini`. Only the manifest could have produced that string.

## What changes

- `CLAUDE_COMPATIBILITY_MANIFEST` goes to version 2 with `model.id: claude-opus-4-8`. `cliVersion` and `protocolVersion` are deliberately untouched, they are a separate axis. The version bump is mandatory: the docblock defines it as the monotonic code-owned catalog revision.
- `providerOverride` becomes an axis of its own, distinct from the run default, resolved at harness resolution. That is the one choke point every v2 consumer reads, so a single redirect covers provider, model, cliSpec, workspace agents and the price prefetch.
- A pin that already runs the demanded provider is kept as authored, so `agent:claude` on a custom Claude profile does not strip that profile's skills and instructions.
- An unhonourable label fails the run with a message naming the label, rather than quietly running the other provider.
- With no label the v2 path is behaviourally identical: same single `load` call, same objects. A test pins that.

## Release steps this PR does not perform

1. **Repin the deployed definitions.** They pin `{builtin-codex, version 2}` and `resolveHarnessProfileVersion` loads that immutable row, so merging this changes nothing in production until each live definition is repinned to `builtin-claude` version 2 and redeployed. Verify afterwards from the run's `harnessManifests`, not from the run's `model` column, which is a default recorded early and overwritten only by an implementation block.
2. **Move `CLAUDE_MODEL` in the production environment.** `env.ts` carries only a default; production explicitly sets `claude-opus-4-6`, so the default change is inert there.
3. **Rollback is not a code revert.** `ensureSystemHarnessProfiles` refuses to republish a stale catalog, so reverting this PR leaves `builtin-claude` v2 published and pinned definitions still resolving it. The rollback is repinning definitions, or `agent:codex` per ticket, which this PR makes work and covers with a test.

## Verification

`pnpm --filter worker exec vitest run env.test.ts src/workflow-definition/resolve-agent.test.ts src/workflow-definition/harness-profile-runtime.test.ts src/workflow-definition/default-v2.test.ts src/sandbox/agents/index.test.ts` — 70 passed.
Scenarios, routes and effective-prompt — 171 passed. Dashboard harness-profile editor — 7 passed. `pnpm -r typecheck` clean.

## Known, reported rather than fixed

`resolveBuiltinHarnessProfile` matches profileId AND version, so a pin at a non-current version resolves to null. Two consequences, neither reachable at run time: `resolve-agent.ts` falls back silently to the default kind (every live v2 consumer prefers `harnessRuntimes` and fails closed without it), and deployment validation checks agent credentials against the installation default provider instead of the pinned one (`schema.ts` with `block-registry.ts`). The second is pre-existing for org-owned profiles and is widened by this bump. It becomes real only if Codex credentials are removed after the switch, so it wants a ticket rather than a blocker here.