### PR TITLE
feat(worker): gate High findings on reviewer agreement and key reviews per head

### DIFF
--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -583,6 +583,48 @@ describe("GitHubAdapter", () => {
       expect(result).toEqual({ id: "701", commentIds: ["801", null] });
     });
 
+    it("recognises a review marked with a prior key", async () => {
+      mockOctokit.paginate
+        .mockResolvedValueOnce([
+          {
+            id: 701,
+            body:
+              "Published before the key was stable.\n\n" +
+              "<!-- ai-workflow-review:old-content-hash -->",
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: 801,
+            path: "src/index.ts",
+            line: 12,
+            start_line: 10,
+          },
+        ]);
+
+      const result = await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "round-key",
+        priorIdempotencyKeys: ["old-content-hash"],
+        headSha: "reviewed-head",
+        decision: "request_changes",
+        summary: "The same review.",
+        comments: [
+          {
+            path: "src/index.ts",
+            body: "Already published.",
+            startLine: 10,
+            endLine: 12,
+          },
+        ],
+      });
+
+      // The key the marker is written from changed with the release; the review
+      // on the pull request did not. Failing to recognise it here would greet
+      // every open pull request with a second copy of its own review.
+      expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
+      expect(result).toEqual({ id: "701", commentIds: ["801"] });
+    });
+
     it("falls back to a summary-only review when GitHub rejects inline positions", async () => {
       mockOctokit.paginate.mockResolvedValueOnce([]);
       const rejected = Object.assign(new Error("Validation failed"), {

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -517,13 +517,23 @@ export class GitHubAdapter
     prId: number,
     publication: PRReviewPublication,
   ): Promise<PRReviewPublicationResult> {
-    const marker = `<!-- ai-workflow-review:${publication.idempotencyKey} -->`;
+    const reviewMarker = (key: string) => `<!-- ai-workflow-review:${key} -->`;
+    const marker = reviewMarker(publication.idempotencyKey);
+    // Only `marker` is ever written. The prior keys are recognised as well
+    // because a review published before the key became a stable round identity
+    // carries one of those, and missing it would post a second review over it.
+    const knownMarkers = [
+      marker,
+      ...(publication.priorIdempotencyKeys ?? []).map(reviewMarker),
+    ];
     const existing = await this.octokit.paginate(this.octokit.pulls.listReviews, {
       ...this.ownerRepo,
       pull_number: prId,
       per_page: 100,
     });
-    const prior = existing.find((review) => review.body?.includes(marker));
+    const prior = existing.find((review) =>
+      knownMarkers.some((known) => review.body?.includes(known)),
+    );
     if (prior) {
       const comments = await this.octokit.paginate(
         this.octokit.pulls.listCommentsForReview,

--- a/apps/worker/src/adapters/vcs/gitlab.test.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.test.ts
@@ -656,6 +656,49 @@ describe("GitLabAdapter", () => {
       });
     });
 
+    it("recognises a summary and its discussions under a prior key", async () => {
+      mockMergeRequestNotes.all.mockResolvedValueOnce([
+        {
+          id: 555,
+          body:
+            "Published before the key was stable.\n\n" +
+            "<!-- ai-workflow-review:old-content-hash -->",
+        },
+      ]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([
+        {
+          id: "discussion-1",
+          notes: [
+            {
+              body: "<!-- ai-workflow-review-comment:old-content-hash:0 -->",
+            },
+          ],
+        },
+      ]);
+
+      const result = await glAdapter().publishPRReview(42, {
+        idempotencyKey: "round-key",
+        priorIdempotencyKeys: ["old-content-hash"],
+        headSha: "reviewed-head",
+        decision: "request_changes",
+        summary: "The same review.",
+        comments: [
+          {
+            path: "src/index.ts",
+            body: "First",
+            startLine: 10,
+            endLine: 10,
+          },
+        ],
+      });
+
+      // Both marker families have to accept the prior key, not just the summary
+      // note: recognising the note alone would leave every inline discussion to
+      // be posted a second time.
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toEqual({ id: "555", commentIds: ["discussion-1"] });
+    });
+
     it("publishes GitLab multiline positions and preserves id alignment", async () => {
       mockMergeRequestNotes.all.mockResolvedValueOnce([]);
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -525,7 +525,19 @@ export class GitLabAdapter implements
     prId: number,
     publication: PRReviewPublication,
   ): Promise<PRReviewPublicationResult> {
-    const marker = `<!-- ai-workflow-review:${publication.idempotencyKey} -->`;
+    const reviewMarker = (key: string) => `<!-- ai-workflow-review:${key} -->`;
+    const marker = reviewMarker(publication.idempotencyKey);
+    // Only the current key is ever written. Both marker families also recognise
+    // the keys earlier attempts used, because a review published before the key
+    // became a stable round identity carries those, and the per-comment family
+    // needs the same treatment as the summary note: recognising the note alone
+    // would still repost every inline discussion.
+    const priorKeys = publication.priorIdempotencyKeys ?? [];
+    const knownMarkers = [marker, ...priorKeys.map(reviewMarker)];
+    const knownCommentMarkers = (index: number) =>
+      [publication.idempotencyKey, ...priorKeys].map(
+        (key) => `<!-- ai-workflow-review-comment:${key}:${index} -->`,
+      );
     const existingNotes = (await this.gl.MergeRequestNotes.all(
       this.projectId,
       prId,
@@ -537,7 +549,9 @@ export class GitLabAdapter implements
       id?: string;
       notes?: Array<{ body?: string }>;
     }>;
-    const prior = existingNotes.find((note) => note.body?.includes(marker));
+    const prior = existingNotes.find((note) =>
+      knownMarkers.some((known) => note.body?.includes(known)),
+    );
     if (prior) {
       if (publication.decision === "approve") {
         await this.gitLabRest<unknown>(
@@ -548,11 +562,10 @@ export class GitLabAdapter implements
       return {
         id: prior.id === undefined ? publication.idempotencyKey : String(prior.id),
         commentIds: publication.comments.map((_, index) => {
-          const commentMarker =
-            `<!-- ai-workflow-review-comment:${publication.idempotencyKey}:${index} -->`;
+          const commentMarkers = knownCommentMarkers(index);
           const discussion = existingDiscussions.find((candidate) =>
             candidate.notes?.some((note) =>
-              note.body?.includes(commentMarker),
+              commentMarkers.some((known) => note.body?.includes(known)),
             ),
           );
           return discussion?.id ? String(discussion.id) : null;
@@ -580,8 +593,11 @@ export class GitLabAdapter implements
     for (const [index, comment] of publication.comments.entries()) {
       const commentMarker =
         `<!-- ai-workflow-review-comment:${publication.idempotencyKey}:${index} -->`;
+      const commentMarkers = knownCommentMarkers(index);
       const priorDiscussion = existingDiscussions.find((discussion) =>
-        discussion.notes?.some((note) => note.body?.includes(commentMarker)),
+        discussion.notes?.some((note) =>
+          commentMarkers.some((known) => note.body?.includes(known)),
+        ),
       );
       if (priorDiscussion) {
         commentIds.push(

--- a/apps/worker/src/adapters/vcs/types.ts
+++ b/apps/worker/src/adapters/vcs/types.ts
@@ -250,6 +250,15 @@ export function reviewFallbackBullet(comment: PRReviewInlineComment): string {
 
 export interface PRReviewPublication {
   idempotencyKey: string;
+  /**
+   * Keys earlier attempts at this same round may have marked a review with, to
+   * RECOGNISE and never to write. The key was derived from the review content
+   * before it became a stable round identity, so a review published back then
+   * carries one of these instead, and a publication that could not see it would
+   * post a duplicate beside it. Writing only the current key keeps the
+   * transition one-directional.
+   */
+  priorIdempotencyKeys?: string[];
   headSha: string;
   decision: "approve" | "request_changes";
   summary: string;

--- a/apps/worker/src/workflow-definition/scenarios/arthur-review.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/arthur-review.scenario.test.ts
@@ -18,6 +18,10 @@ import { hashHarnessProfileManifest } from "../../harness-profiles/manifest.js";
 import type { PrTriggerType } from "../../lib/trigger-events.js";
 import type { AgentWorkflowInput } from "../../workflows/agent-input.js";
 import { buildReviewAgentSuccessOutput } from "../../workflows/agent.js";
+import {
+  partitionReviewFindings,
+  reviewPublicationDecision,
+} from "../../workflows/pr-external-resources.js";
 import type { WorkflowBlockRegistryContext } from "../block-registry.js";
 import { clampBothEnds } from "../failure-message.js";
 import { validateHarnessProfileReferencesWithLoader } from "../harness-profile-runtime.js";
@@ -578,23 +582,31 @@ function scriptPrelude(
 }
 
 /**
- * Post PR review. ONLY the verdict follows production: `decision` is "approve"
- * only when every review approved, exactly as `publishRunOwnedPrReview` decides
- * it, and it is computed from the resolved inputs rather than fixed per
- * scenario, so the decision the Branch reads follows the findings the review
- * actually reported.
+ * Post PR review. ONLY the verdict follows production, and it is not reproduced
+ * here at all: `reviewPublicationDecision` IS the function
+ * `publishRunOwnedPrReview` calls, over the clusters `partitionReviewFindings`
+ * builds out of the resolved inputs. That matters most to this definition, which
+ * runs a single reviewer: the published gate demands agreement from at most as
+ * many reviewers as the graph has, so a rule change that forgot the single
+ * reviewer case fails here instead of quietly stopping this client's checks from
+ * ever going red.
+ *
+ * The empty file list is the single difference from the production call. That
+ * list decides only whether a finding can be anchored to the diff; the
+ * clustering the verdict reads is a pure function of the findings themselves.
  *
  * The two counts are contract filler, not aggregation. The block contract
  * requires them and no edge in this graph binds either one; production derives
- * them from `partitionReviewFindings`, which needs the provider's file list and
- * is not reproduced here.
+ * them from the same partition, which needs the provider's file list and is not
+ * reproduced here.
  */
 function scriptPostReview(scenario: Scenario, arm: ReviewArm): void {
   scenario.script({ nodeId: arm.postReview }, (_node, inputs) => {
     const results = inputs.reviewResults as ReviewResult[];
-    const decision = results.every((result) => result.decision === "approve")
-      ? "approve"
-      : "request_changes";
+    const decision = reviewPublicationDecision(
+      partitionReviewFindings(results, []).merged,
+      results.length,
+    );
     return {
       kind: "next",
       output: {

--- a/apps/worker/src/workflow-definition/scenarios/post-pr-review.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/post-pr-review.scenario.test.ts
@@ -8,6 +8,10 @@ import type {
 import type { PrTriggerType } from "../../lib/trigger-events.js";
 import type { AgentWorkflowInput } from "../../workflows/agent-input.js";
 import { buildReviewAgentSuccessOutput } from "../../workflows/agent.js";
+import {
+  partitionReviewFindings,
+  reviewPublicationDecision,
+} from "../../workflows/pr-external-resources.js";
 import { executionError } from "../interpreter.js";
 import {
   executorRunsOf,
@@ -177,24 +181,32 @@ function scriptReviews(
 }
 
 /**
- * Post PR review. ONLY the verdict follows production: `decision` is "approve"
- * only when every review approved, exactly as `publishRunOwnedPrReview` decides
- * it, and it is computed from the resolved inputs rather than fixed per
- * scenario, so the decision the Branch reads follows the findings the reviews
- * actually reported.
+ * Post PR review. ONLY the verdict follows production, and it is not reproduced
+ * here at all: `reviewPublicationDecision` IS the function
+ * `publishRunOwnedPrReview` calls, over the clusters `partitionReviewFindings`
+ * builds out of the resolved inputs. A rule change in production therefore
+ * reaches these scenarios instead of leaving them green against a graph that no
+ * longer behaves this way. The decision is computed from the resolved inputs
+ * rather than fixed per scenario, so what the Branch reads follows the findings
+ * the reviews actually reported.
+ *
+ * The empty file list is the single difference from the production call. That
+ * list decides only whether a finding can be anchored to the diff; the
+ * clustering the verdict reads is a pure function of the findings themselves.
  *
  * The two counts are contract filler, not aggregation. The block contract
  * requires them, and no edge in this graph binds either one. Production derives
- * them from `partitionReviewFindings`, which splits findings by whether they
- * could be placed on the diff; that split needs the provider's file list and is
- * not reproduced here.
+ * them from the same partition, which splits findings by whether they could be
+ * placed on the diff; that split needs the provider's file list and is not
+ * reproduced here.
  */
 function scriptPostReview(scenario: Scenario): void {
   scenario.script({ nodeId: "post-review" }, (_node, inputs) => {
     const results = inputs.reviewResults as ReviewResult[];
-    const decision = results.every((result) => result.decision === "approve")
-      ? "approve"
-      : "request_changes";
+    const decision = reviewPublicationDecision(
+      partitionReviewFindings(results, []).merged,
+      results.length,
+    );
     return {
       kind: "next",
       output: {
@@ -566,26 +578,33 @@ describe("post-PR review workflow: a blocking finding", () => {
     expectNeverInvoked(outcome, ["complete-success"]);
   });
 
-  it("holds the review back on a High finding too", async () => {
-    const high: ReviewResultFinding = {
+  it("holds the review back on a High two reviewers agree on", async () => {
+    const high = (description: string): ReviewResultFinding => ({
       file: "src/queue.ts",
-      description: "A failed job is retried without any backoff.",
+      description,
       severity: "High",
       startLine: 31,
-    };
+    });
     // "High" is the other half of the severity gate and the only one of the
-    // four severities no other scenario reaches. Strip
-    // `|| finding.severity === "High"` from the production derivation and the
-    // next assertion is what goes red.
+    // four severities no other scenario reaches. Two reviewers report the same
+    // line in their own words, which is the agreement the published gate asks
+    // for before a High may fail the check: production merges them into one
+    // cluster carrying two sources. Strip `|| finding.severity === "High"` from
+    // the production derivation, or the agreement branch from
+    // `reviewPublicationDecision`, and the next assertions are what go red.
     const outputs = [
       reviewOutputFor(REVIEWS[0], []),
-      reviewOutputFor(REVIEWS[1], [high]),
-      reviewOutputFor(REVIEWS[2], []),
+      reviewOutputFor(REVIEWS[1], [
+        high("A failed job is retried without any backoff."),
+      ]),
+      reviewOutputFor(REVIEWS[2], [
+        high("Nothing delays the next attempt, so the queue is hammered."),
+      ]),
     ];
     expect(outputs.map((output) => output.decision)).toEqual([
       "approve",
       "request_changes",
-      "approve",
+      "request_changes",
     ]);
     const scenario = templateScenario("trigger_pr_ready", "trigger-ready");
     scenario.barrier([...REVIEWS]);
@@ -600,15 +619,18 @@ describe("post-PR review workflow: a blocking finding", () => {
     expect(outcome.result.executionError).toBeUndefined();
     const postReview = executorRunsOf(outcome, "post-review");
     expect(postReview).toHaveLength(1);
-    // The dissent also comes from the middle member of the fan-out here, so the
-    // aggregate verdict cannot be reading the first review and stopping.
+    // The agreement is between the second and third members of the fan-out, so
+    // the aggregate verdict cannot be reading the first review and stopping.
+    // The count is 2 because `scriptPostReview` sums the reported findings, the
+    // pre-merge total: production would publish these two reports as one comment.
+    // Nothing in this graph binds the count, so the difference is inert here.
     expect(postReview[0].result).toEqual({
       kind: "next",
       output: {
         status: "ok",
         decision: "request_changes",
         summary: REQUEST_CHANGES_SUMMARY,
-        inlineCommentCount: 1,
+        inlineCommentCount: 2,
         summaryFallbackCount: 0,
       },
     });
@@ -621,6 +643,61 @@ describe("post-PR review workflow: a blocking finding", () => {
     });
     expect(completion.conclusion).toBe("failure");
     expectNeverInvoked(outcome, ["complete-success"]);
+  });
+
+  it("does not count a High only one of three reviewers reported as blocking", async () => {
+    const high: ReviewResultFinding = {
+      file: "src/queue.ts",
+      description: "A failed job is retried without any backoff.",
+      severity: "High",
+      startLine: 31,
+    };
+    const outputs = [
+      reviewOutputFor(REVIEWS[0], []),
+      reviewOutputFor(REVIEWS[1], [high]),
+      reviewOutputFor(REVIEWS[2], []),
+    ];
+    // THE REASON THE PUBLISHED GATE STOPPED READING THESE DECISIONS. The
+    // reviewer still asks for changes on a High of its own, and that
+    // per-reviewer rule is untouched: what changed is that one reviewer's
+    // unsupported High no longer decides the check, because it used to leave a
+    // green check nearly unreachable on real code.
+    expect(outputs.map((output) => output.decision)).toEqual([
+      "approve",
+      "request_changes",
+      "approve",
+    ]);
+    const scenario = templateScenario("trigger_pr_ready", "trigger-ready");
+    scenario.barrier([...REVIEWS]);
+    scriptPrelude(scenario);
+    scriptReviews(scenario, outputs);
+    scriptPostReview(scenario);
+    const completion = scriptCompletion(scenario, "complete-success");
+
+    const outcome = await scenario.execute();
+
+    expect(outcome.result.outcome).toBe("completed");
+    expect(outcome.result.executionError).toBeUndefined();
+    const postReview = executorRunsOf(outcome, "post-review");
+    expect(postReview).toHaveLength(1);
+    // Approving does not withhold the finding: it is still one published
+    // comment, it just no longer fails the check on its own.
+    expect(postReview[0].result).toEqual({
+      kind: "next",
+      output: {
+        status: "ok",
+        decision: "approve",
+        summary: APPROVED_SUMMARY,
+        inlineCommentCount: 1,
+        summaryFallbackCount: 0,
+      },
+    });
+    expect(portsOf(outcome, "review-approved")).toEqual(["true"]);
+    expect(
+      executorRunsOf(outcome, "complete-success")[0].resolvedInputs,
+    ).toEqual({ check: CHECK_REF });
+    expect(completion.conclusion).toBe("success");
+    expectNeverInvoked(outcome, ["complete-failure"]);
   });
 });
 

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -932,7 +932,7 @@ function postPrReviewDefinition(
       row: -1,
       configuration: {
         conclusion: "success",
-        details: "All configured reviews approved this commit.",
+        details: "No blocking findings on this commit.",
       },
       inputs: {
         check: {

--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -3,6 +3,8 @@ import type { ReviewResult } from "@shared/contracts";
 import { eq } from "drizzle-orm";
 import { createTestDb } from "../db/test-db.js";
 import {
+  workflowPrReviewPublicationComments,
+  workflowPrReviewPublications,
   workflowRunExternalChecks,
   workflowRuns,
 } from "../db/schema.js";
@@ -347,6 +349,45 @@ describe("PR review diff placement", () => {
     );
     expect(reviewCommentContentHash(comment, 0)).toBe(
       reviewCommentContentHash(comment, 0),
+    );
+  });
+
+  it("pins the hash of a comment partitionReviewFindings built", () => {
+    // A LITERAL DIGEST ON PURPOSE, and the comment has to come out of the
+    // partition rather than out of this test. The hash is JSON.stringify of the
+    // comment object, so the ORDER of the keys written in
+    // `partitionReviewFindings` is part of it: reorder them and every hash
+    // already stored for every published comment is rewritten, orphaning the
+    // rows that carry a provider reference. Comparing two computed hashes
+    // cannot see that, because both sides move together.
+    const partition = partitionReviewFindings(
+      [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Inline",
+              severity: "Blocker",
+              startLine: 3,
+              endLine: 4,
+            },
+          ],
+        },
+      ],
+      [
+        {
+          path: "src/a.ts",
+          additions: 2,
+          deletions: 0,
+          changeType: "modified",
+          patch: "@@ -3,2 +3,2 @@\n context\n+added",
+        },
+      ],
+    );
+
+    expect(reviewCommentContentHash(partition.comments[0]!, 0)).toBe(
+      "55af47956fe22fa8bb6a4902b60aca820a1d49704e98493e6fb7be6f46db3a50",
     );
   });
 });
@@ -823,9 +864,14 @@ describe("PR review publication scrub", () => {
     expect(commentBody).not.toContain("blazebot/memory/");
   });
 
-  // The gate reads the reviewers' own decisions, never the findings list, so
-  // collapsing three reports into one comment must not soften the verdict.
-  it("leaves the verdict to the reviewers even when every finding merges into one", async () => {
+  // The gate reads the merged findings, not the reviewers' own decisions: a
+  // Blocker always holds the review back, and a High does so only once
+  // min(2, reviewerCount) reviewers reported it independently. Collapsing two
+  // reports into one comment therefore must not soften the verdict either.
+  // This fixture agrees with the rule it replaced, so on its own it discriminates
+  // nothing; the two tests after it are the ones that separate the old gate from
+  // the new one, from either side.
+  it("requests changes on a High that two reviewers reported independently", async () => {
     const db = await createTestDb();
     await db.insert(workflowRuns).values({ runId: "run-merge" });
     const publishPRReview = vi
@@ -889,5 +935,467 @@ describe("PR review publication scrub", () => {
     expect(publishPRReview.mock.calls[0]![1].comments[0]!.body).toContain(
       "Reported by 2 of 2 reviewers.",
     );
+  });
+
+  // The regression the new rule exists for. One reviewer's High used to fail the
+  // check on its own, which made a green check nearly unreachable on real code.
+  it("approves a High only one of two reviewers reported, and still publishes it", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-lone-high" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-10", commentIds: ["comment-10"] });
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([
+        {
+          path: "src/a.ts",
+          additions: 2,
+          deletions: 0,
+          changeType: "modified",
+          patch: "@@ -3,2 +3,2 @@\n context\n+added",
+        },
+      ]),
+      publishPRReview,
+    });
+
+    const result = await publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#10",
+        ownerToken: "owner-10",
+        runId: "run-lone-high",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#10",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 10,
+        headSha: "head",
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: [
+        {
+          // The reviewer's own verdict is unchanged and still says this.
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Only this reviewer saw a problem here.",
+              severity: "High",
+              startLine: 4,
+              endLine: 4,
+            },
+          ],
+        },
+        { decision: "approve", findings: [] },
+      ],
+    });
+
+    expect(result.decision).toBe("approve");
+    // Approving is not the same as hiding: the finding is still published, it
+    // just no longer decides the check on its own.
+    expect(result.inlineCommentCount).toBe(1);
+    expect(publishPRReview.mock.calls[0]![1].decision).toBe("approve");
+    expect(publishPRReview.mock.calls[0]![1].comments[0]!.body).toBe(
+      "**High**: Only this reviewer saw a problem here.",
+    );
+  });
+
+  it("blocks a lone High when the graph has a single reviewer", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-single-reviewer" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-11", commentIds: ["comment-11"] });
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([
+        {
+          path: "src/a.ts",
+          additions: 2,
+          deletions: 0,
+          changeType: "modified",
+          patch: "@@ -3,2 +3,2 @@\n context\n+added",
+        },
+      ]),
+      publishPRReview,
+    });
+
+    const result = await publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#11",
+        ownerToken: "owner-11",
+        runId: "run-single-reviewer",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#11",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 11,
+        headSha: "head",
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "The only reviewer there is reported this.",
+              severity: "High",
+              startLine: 4,
+              endLine: 4,
+            },
+          ],
+        },
+      ],
+    });
+
+    // min(2, 1) is 1, so agreement cannot be demanded from a graph that has
+    // nobody to agree with. A client running one reviewer keeps today's gate.
+    expect(result.decision).toBe("request_changes");
+  });
+});
+
+describe("PR review publication idempotency", () => {
+  function reviewVcs(publishPRReview: ReturnType<typeof vi.fn>) {
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([
+        {
+          path: "src/a.ts",
+          additions: 2,
+          deletions: 0,
+          changeType: "modified",
+          patch: "@@ -3,2 +3,2 @@\n context\n+added",
+        },
+      ]),
+      publishPRReview,
+    });
+  }
+
+  function publish(
+    db: Awaited<ReturnType<typeof createTestDb>>,
+    args: {
+      runId: string;
+      prNumber: number;
+      headSha: string;
+      reviewResults: ReviewResult[];
+    },
+  ) {
+    return publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: `pr:github:acme/app#${args.prNumber}`,
+        ownerToken: "owner-idem",
+        runId: args.runId,
+      },
+      target: {
+        subjectKey: `pr:github:acme/app#${args.prNumber}`,
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: args.prNumber,
+        headSha: args.headSha,
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: args.reviewResults,
+    });
+  }
+
+  // Nothing else in this file exercises the idempotency decision, and it is the
+  // whole defence against a pull request collecting a second full review: the
+  // database probe short-circuits a round that already published, and the marker
+  // the adapters search for is the backstop when it cannot.
+  it("publishes one review per head and then reports what the pull request carries", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-idem" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-12", commentIds: ["comment-12"] });
+    reviewVcs(publishPRReview);
+
+    const first = await publish(db, {
+      runId: "run-idem",
+      prNumber: 12,
+      headSha: "head",
+      reviewResults: [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Reads the config twice.",
+              severity: "Blocker",
+              startLine: 4,
+              endLine: 4,
+            },
+          ],
+        },
+      ],
+    });
+    // A second run over the same commit whose reviewer reworded the finding and
+    // reached the opposite verdict: the two things that used to re-key the
+    // publication and walk it straight into the adapter's early return.
+    const second = await publish(db, {
+      runId: "run-idem",
+      prNumber: 12,
+      headSha: "head",
+      reviewResults: [
+        {
+          decision: "approve",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "The configuration is read a second time.",
+              severity: "Nit",
+              startLine: 4,
+              endLine: 4,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(publishPRReview).toHaveBeenCalledTimes(1);
+    // The published verdict and prose, not the second round's: the check run
+    // text and the Branch both read this, so they describe the review a reader
+    // can actually open.
+    expect(second).toEqual(first);
+    expect(second.decision).toBe("request_changes");
+    // One row and one comment reference for the round. A second row would claim
+    // a publication that never happened, and a second comment reference would
+    // attribute this round's comment to the earlier round's discussion.
+    const rows = await db.select().from(workflowPrReviewPublications);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.state).toBe("published");
+    const commentRows = await db
+      .select()
+      .from(workflowPrReviewPublicationComments);
+    expect(commentRows).toHaveLength(1);
+    expect(commentRows[0]!.providerReference).toBe("comment-12");
+  });
+
+  it("resumes a failed publication on the row it already created", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-resume" });
+    const reviewResults: ReviewResult[] = [
+      { decision: "approve", feedback: "Looks good.", findings: [] },
+    ];
+    const failing = vi.fn().mockRejectedValue(new Error("GitHub said no."));
+    reviewVcs(failing);
+    await expect(
+      publish(db, {
+        runId: "run-resume",
+        prNumber: 16,
+        headSha: "head",
+        reviewResults,
+      }),
+    ).rejects.toThrow(/PR review publication failed/);
+
+    const retry = vi
+      .fn()
+      .mockResolvedValue({ id: "review-16", commentIds: [] });
+    reviewVcs(retry);
+    await publish(db, {
+      runId: "run-resume",
+      prNumber: 16,
+      headSha: "head",
+      reviewResults,
+    });
+
+    // A round nobody managed to publish is not a published round: the retry must
+    // still reach the provider, and it must do so on the pending row rather than
+    // leaving an orphan behind.
+    expect(retry).toHaveBeenCalledTimes(1);
+    const rows = await db.select().from(workflowPrReviewPublications);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.state).toBe("published");
+    expect(rows[0]!.lastError).toBeNull();
+  });
+
+  // The only path that legitimately reaches the adapter twice at one head, and
+  // therefore the only place the round-stability of the key is observable. It is
+  // also the exact window where that key is the sole defence against AIW-234:
+  // nothing on record says a review was published, so a content-derived key would
+  // write a second marker and post a second review beside the first.
+  it("hands both attempts at one head the same key when the prose changes", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-round-key" });
+    const reported = (description: string): ReviewResult => ({
+      decision: "request_changes",
+      findings: [
+        {
+          file: "src/a.ts",
+          description,
+          severity: "Blocker",
+          startLine: 4,
+          endLine: 4,
+        },
+      ],
+    });
+    const failing = vi.fn().mockRejectedValue(new Error("GitHub said no."));
+    reviewVcs(failing);
+    await expect(
+      publish(db, {
+        runId: "run-round-key",
+        prNumber: 18,
+        headSha: "head",
+        reviewResults: [reported("Reads the config twice.")],
+      }),
+    ).rejects.toThrow(/PR review publication failed/);
+
+    const retry = vi
+      .fn()
+      .mockResolvedValue({ id: "review-18", commentIds: ["comment-18"] });
+    reviewVcs(retry);
+    await publish(db, {
+      runId: "run-round-key",
+      prNumber: 18,
+      headSha: "head",
+      reviewResults: [reported("The configuration is read a second time.")],
+    });
+
+    // Two rows with two different content hashes, which is what makes the next
+    // assertion mean something: the review content demonstrably moved between the
+    // two calls, and the key the provider is keyed by demonstrably did not.
+    const rows = await db.select().from(workflowPrReviewPublications);
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((row) => row.contentHash)).size).toBe(2);
+    expect(retry.mock.calls[0]![1].idempotencyKey).toBe(
+      failing.mock.calls[0]![1].idempotencyKey,
+    );
+  });
+
+  it("hands the adapter the keys earlier attempts marked a review with", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-prior-key" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-17", commentIds: [] });
+    reviewVcs(publishPRReview);
+    // A publication from before the key became a round identity, whose state
+    // update was lost: the review is on the pull request under a marker carrying
+    // this content hash, and nothing in the database says so.
+    await db.insert(workflowPrReviewPublications).values({
+      id: "publication-legacy",
+      runId: "run-prior-key",
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      provider: "github",
+      repository: "acme/app",
+      prNumber: 17,
+      headSha: "head",
+      contentHash: "legacy-content-hash",
+      decision: "request_changes",
+      summary: "## AI Workflow review",
+    });
+
+    await publish(db, {
+      runId: "run-prior-key",
+      prNumber: 17,
+      headSha: "head",
+      reviewResults: [{ decision: "approve", findings: [] }],
+    });
+
+    // Recognised, never written: the adapter can find that marker, so the review
+    // already on the pull request is not duplicated, while the marker this call
+    // writes is the round key alone.
+    const publication = publishPRReview.mock.calls[0]![1];
+    expect(publication.priorIdempotencyKeys).toEqual(["legacy-content-hash"]);
+    expect(publication.idempotencyKey).not.toBe("legacy-content-hash");
+  });
+
+  it("re-keys the marker once the head commit moves", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-idem-head" });
+    const reviewResults: ReviewResult[] = [
+      { decision: "approve", findings: [] },
+    ];
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-13", commentIds: [] });
+    reviewVcs(publishPRReview);
+    await publish(db, {
+      runId: "run-idem-head",
+      prNumber: 13,
+      headSha: "head",
+      reviewResults,
+    });
+
+    const nextPublish = vi
+      .fn()
+      .mockResolvedValue({ id: "review-14", commentIds: [] });
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head-2", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([]),
+      publishPRReview: nextPublish,
+    });
+    await publish(db, {
+      runId: "run-idem-head",
+      prNumber: 13,
+      headSha: "head-2",
+      reviewResults,
+    });
+
+    // A new commit is a new round and must get its own review, so the key has to
+    // move here even though nothing the reviewer said changed.
+    expect(nextPublish.mock.calls[0]![1].idempotencyKey).not.toBe(
+      publishPRReview.mock.calls[0]![1].idempotencyKey,
+    );
+  });
+
+  it("publishes once when the same review is replayed", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-replay" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-15", commentIds: [] });
+    reviewVcs(publishPRReview);
+    const reviewResults: ReviewResult[] = [
+      { decision: "approve", feedback: "Looks good.", findings: [] },
+    ];
+
+    await publish(db, {
+      runId: "run-replay",
+      prNumber: 15,
+      headSha: "head",
+      reviewResults,
+    });
+    await publish(db, {
+      runId: "run-replay",
+      prNumber: 15,
+      headSha: "head",
+      reviewResults,
+    });
+
+    // The published round short-circuits, so the provider is never asked a second
+    // time and the replay costs one select.
+    expect(publishPRReview).toHaveBeenCalledTimes(1);
+    const rows = await db.select().from(workflowPrReviewPublications);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.state).toBe("published");
   });
 });

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -560,6 +560,10 @@ export function partitionReviewFindings(
   options: { maxComments?: number } = {},
 ): {
   comments: PRReviewInlineComment[];
+  /** Every defect, whether or not it won an inline slot. The published verdict
+   * is read from this, so severity and cross-reviewer agreement must survive
+   * the conversion to comments, which keeps neither. */
+  merged: MergedReviewFinding[];
   fallback: MergedReviewFinding[];
   withheld: MergedReviewFinding[];
   reportedCount: number;
@@ -637,11 +641,52 @@ export function partitionReviewFindings(
 
   return {
     comments,
+    merged,
     fallback,
     withheld,
     reportedCount: candidates.length,
     distinctCount: merged.length,
   };
+}
+
+/**
+ * Reviewers that must independently report one High finding before it holds the
+ * check back. A Blocker never needs a second opinion.
+ */
+const HIGH_FINDING_BLOCKING_AGREEMENT = 2;
+
+/**
+ * The published verdict, read from the merged findings rather than from the
+ * reviewers' own decisions.
+ *
+ * Each reviewer already asks for changes on any Blocker or High it found on its
+ * own (`buildReviewAgentSuccessOutput`), so requiring all of them to approve
+ * turned one reviewer's lone High into a red check on nearly every commit. The
+ * gate therefore reads the clusters: a Blocker always blocks, a High blocks only
+ * when independent reviewers agreed on it, which is the strongest signal
+ * available that the finding is real. Per-reviewer decisions are untouched and
+ * still reach `fix_agent` verbatim.
+ *
+ * `sources.length` is the number of DISTINCT reviewers that reported the defect,
+ * because merging is cross-reviewer only: `mergeable` refuses a candidate from a
+ * reviewer already in the cluster.
+ *
+ * Math.min and never a bare 2: a graph with a single reviewer can never reach
+ * two sources, so a bare 2 would stop High from blocking anything at all there.
+ * The Arthur definition runs exactly one reviewer per pull request, and min(2, 1)
+ * keeps its behaviour identical to what it has today.
+ */
+export function reviewPublicationDecision(
+  merged: readonly MergedReviewFinding[],
+  reviewerCount: number,
+): "approve" | "request_changes" {
+  const agreement = Math.min(HIGH_FINDING_BLOCKING_AGREEMENT, reviewerCount);
+  const blocking = merged.some(
+    (finding) =>
+      finding.severity === "Blocker" ||
+      (finding.severity === "High" && finding.sources.length >= agreement),
+  );
+  return blocking ? "request_changes" : "approve";
 }
 
 function rangeContainsOnlyChangedSideLines(
@@ -750,6 +795,7 @@ export async function publishRunOwnedPrReview(args: {
   const files = await vcs.listPRFiles(args.target.prNumber);
   const {
     comments: placedComments,
+    merged,
     fallback,
     withheld,
     reportedCount,
@@ -763,11 +809,7 @@ export async function publishRunOwnedPrReview(args: {
     ...comment,
     body: scrubForPublication(comment.body),
   }));
-  const decision = args.reviewResults.every(
-    (result) => result.decision === "approve",
-  )
-    ? "approve"
-    : "request_changes";
+  const decision = reviewPublicationDecision(merged, args.reviewResults.length);
   const summary = scrubForPublication(
     reviewSummary(args.reviewResults, fallback, withheld, {
       reportedCount,
@@ -782,10 +824,43 @@ export async function publishRunOwnedPrReview(args: {
     decision,
     results: args.reviewResults,
   };
+  // The database key only: it records WHICH review was published, so it stays
+  // derived from the verdict and the reviewer output.
   const contentHash = createHash("sha256")
     .update(JSON.stringify(normalized))
     .digest("hex");
-  const [existing] = await args.db
+  // The provider marker, and deliberately not the content hash. Both adapters
+  // render this into the `<!-- ai-workflow-review:... -->` comment they search
+  // for to recognise a review they already published, so it has to identify the
+  // ROUND, one head commit of one pull request, and nothing else. While the
+  // content hash played that role, a reworded finding published a second full
+  // review (AIW-234), and any change to the verdict rule above would have
+  // published one on every pull request already reviewed.
+  //
+  // The cost, and it is a real one: the FIRST review of a head is the only one.
+  // Neither a rewording nor a flipped verdict can revise it or reach the reader,
+  // and the pull request keeps whatever the first round said until a new commit
+  // opens a new round. The check run reports that same published verdict, so the
+  // check and the review always agree.
+  const idempotencyKey = createHash("sha256")
+    .update(
+      JSON.stringify({
+        provider: args.target.provider,
+        repository: args.target.repoPath,
+        prNumber: args.target.prNumber,
+        headSha: args.target.headSha,
+      }),
+    )
+    .digest("hex");
+  // Keyed on the ROUND and never on the content hash, because that is how the
+  // provider gate now behaves: an adapter that recognises its own marker returns
+  // the review it already published without posting anything. A content-keyed
+  // probe let reworded prose miss the published row, insert a second one, take
+  // that early return, and then record a publication that never happened, with
+  // GitLab's positionally rebuilt comment ids attributing this round's comments
+  // to the previous round's discussions. One head is one review, in the database
+  // as well as on the pull request.
+  const roundRows = await args.db
     .select()
     .from(workflowPrReviewPublications)
     .where(
@@ -794,10 +869,34 @@ export async function publishRunOwnedPrReview(args: {
         eq(workflowPrReviewPublications.repository, args.target.repoPath),
         eq(workflowPrReviewPublications.prNumber, args.target.prNumber),
         eq(workflowPrReviewPublications.headSha, args.target.headSha),
-        eq(workflowPrReviewPublications.contentHash, contentHash),
       ),
     )
-    .limit(1);
+    .orderBy(asc(workflowPrReviewPublications.createdAt));
+  const publishedRound = roundRows.find((row) => row.state === "published");
+  if (publishedRound) {
+    // What is returned is what the pull request actually carries, not what this
+    // round's reviewers said: complete_pr_check binds this summary into the
+    // check run text and the Branch reads this decision, so returning fresh
+    // prose would describe a review nobody can open. The first review of a head
+    // wins, and a second opinion on the same commit is dropped rather than
+    // published beside it.
+    return {
+      decision:
+        publishedRound.decision === "approve" ? "approve" : "request_changes",
+      summary: publishedRound.summary,
+      inlineCommentCount: publishedRound.inlineCommentCount,
+      summaryFallbackCount: publishedRound.summaryFallbackCount,
+    };
+  }
+  // Markers earlier attempts at this round may have written, in no order that
+  // matters: the adapters test for membership. A row that never reached
+  // "published" can still have a review on the pull request, because the publish
+  // call can succeed and the state update that follows it can be lost, and before
+  // the key became round-stable that marker carried the row's content hash.
+  // Handing those to the adapter keeps such a review recognised instead of
+  // posting a second copy next to it.
+  const priorIdempotencyKeys = roundRows.map((row) => row.contentHash);
+  const existing = roundRows.find((row) => row.contentHash === contentHash);
   const publicationId = existing?.id ?? randomUUID();
   const commentRecords = comments.map((comment, index) => ({
     contentHash: reviewCommentContentHash(comment, index),
@@ -828,81 +927,83 @@ export async function publishRunOwnedPrReview(args: {
       );
     }
   }
-  if (existing?.state !== "published") {
-    const beforePublish = await vcs.getPRHead(args.target.prNumber);
-    if (
-      beforePublish.headSha !== args.target.headSha ||
-      beforePublish.state !== "open"
-    ) {
-      throw new Error(
-        "The pull request changed before the review could be published.",
-      );
-    }
-    let published;
-    try {
-      published = await vcs.publishPRReview(args.target.prNumber, {
-        idempotencyKey: contentHash,
-        headSha: args.target.headSha,
-        decision,
-        summary,
-        comments,
-      });
-    } catch (error) {
-      const diagnosticId = randomUUID();
-      console.error(
-        `[${diagnosticId}] PR review publication failed:`,
-        error instanceof Error ? error.message : String(error),
-      );
-      await args.db
-        .update(workflowPrReviewPublications)
-        .set({
-          lastError: "Provider review publication failed.",
-          diagnosticId,
-          updatedAt: new Date(),
-        })
-        .where(eq(workflowPrReviewPublications.id, publicationId));
-      throw new Error(
-        `PR review publication failed. Diagnostic ID: ${diagnosticId}`,
-      );
-    }
+  // Unconditional: a round with a published row returned above, so nothing here
+  // is on record as published. A review can still be on the pull request without
+  // a row that says so, and the adapter's marker lookup is what covers that.
+  const beforePublish = await vcs.getPRHead(args.target.prNumber);
+  if (
+    beforePublish.headSha !== args.target.headSha ||
+    beforePublish.state !== "open"
+  ) {
+    throw new Error(
+      "The pull request changed before the review could be published.",
+    );
+  }
+  let published;
+  try {
+    published = await vcs.publishPRReview(args.target.prNumber, {
+      idempotencyKey,
+      priorIdempotencyKeys,
+      headSha: args.target.headSha,
+      decision,
+      summary,
+      comments,
+    });
+  } catch (error) {
+    const diagnosticId = randomUUID();
+    console.error(
+      `[${diagnosticId}] PR review publication failed:`,
+      error instanceof Error ? error.message : String(error),
+    );
     await args.db
       .update(workflowPrReviewPublications)
       .set({
-        state: "published",
-        providerReference: published.id,
-        publishedAt: new Date(),
+        lastError: "Provider review publication failed.",
+        diagnosticId,
         updatedAt: new Date(),
-        lastError: null,
       })
       .where(eq(workflowPrReviewPublications.id, publicationId));
+    throw new Error(
+      `PR review publication failed. Diagnostic ID: ${diagnosticId}`,
+    );
+  }
+  await args.db
+    .update(workflowPrReviewPublications)
+    .set({
+      state: "published",
+      providerReference: published.id,
+      publishedAt: new Date(),
+      updatedAt: new Date(),
+      lastError: null,
+    })
+    .where(eq(workflowPrReviewPublications.id, publicationId));
+  await args.db
+    .update(workflowPrReviewPublicationComments)
+    .set({ state: "published", publishedAt: new Date() })
+    .where(
+      eq(
+        workflowPrReviewPublicationComments.publicationId,
+        publicationId,
+      ),
+    );
+  for (const [index, comment] of commentRecords.entries()) {
+    const providerReference = published.commentIds[index];
+    if (!providerReference) continue;
     await args.db
       .update(workflowPrReviewPublicationComments)
-      .set({ state: "published", publishedAt: new Date() })
+      .set({ providerReference })
       .where(
-        eq(
-          workflowPrReviewPublicationComments.publicationId,
-          publicationId,
+        and(
+          eq(
+            workflowPrReviewPublicationComments.publicationId,
+            publicationId,
+          ),
+          eq(
+            workflowPrReviewPublicationComments.contentHash,
+            comment.contentHash,
+          ),
         ),
       );
-    for (const [index, comment] of commentRecords.entries()) {
-      const providerReference = published.commentIds[index];
-      if (!providerReference) continue;
-      await args.db
-        .update(workflowPrReviewPublicationComments)
-        .set({ providerReference })
-        .where(
-          and(
-            eq(
-              workflowPrReviewPublicationComments.publicationId,
-              publicationId,
-            ),
-            eq(
-              workflowPrReviewPublicationComments.contentHash,
-              comment.contentHash,
-            ),
-          ),
-        );
-    }
   }
   return {
     decision,


### PR DESCRIPTION
Stacked on #215, review that one first.

Two changes to how an AI review reaches a pull request: what blocks it, and what counts as the same review.

## The blocking gate

Today a single reviewer requests changes on any `Blocker` or `High` (`agent.ts`), and the published decision approves only if every reviewer approved. That is an AND across three reviewers over a very low bar, so a green check is nearly unreachable on real code: production shows 10 `request_changes` against 4 `approve`.

New rule, computed from the merged clusters rather than from the per-reviewer decisions:

```
blocks = any cluster with severity Blocker
      || any cluster with severity High and sources.length >= min(2, reviewerCount)
```

`min(2, reviewerCount)` is load-bearing and must not be simplified. The Arthur deliverable runs exactly one reviewer per branch, so a bare `>= 2` would stop `High` from blocking anything at all for that client. With one reviewer the condition reduces to exactly today's behaviour, which the Arthur scenario asserts end to end, unchanged.

Measured before shipping, by replaying the real merge module over all 15 production runs that produced reviews: 1 run turns green, 10 stay red, 4 were green already. Agreement on serious findings is common, not rare: of the High clusters, 17 had one source, 12 had two, 2 had three.

The verdict now reads `merged`, every cluster, not the published comment list, so a `Blocker` pushed past the inline-comment cap still blocks.

Both scenario suites previously hand-reimplemented the production rule while claiming in a docblock to match it. They now import it, so they cannot drift silently.

## Round-keyed publication

One value was doing two jobs. `contentHash` (which includes reviewer prose) was both the database dedup key and the `idempotencyKey` the adapters render into their marker. Consequence: rewording any reviewer's prose produced a fresh marker and a second full review on the same commit. That is AIW-234.

- `idempotencyKey` becomes a stable round identity, `provider + repository + prNumber + headSha`. One commit head, one review, regardless of prose churn.
- The database probe is keyed on that same round, and an already-published round returns before inserting a row and before calling the adapter. Without this the two gates disagreed: a reworded second publish inserted a row, called the adapter, got an early return, and then flipped that row to `published` although nothing was posted, while writing GitLab comment references positionally against the previous round's discussions, so a stored reference pointed at a different defect.
- `priorIdempotencyKeys` lets both adapters RECOGNISE markers written under the old key for one release, so deploying does not repost a review onto every open pull request. Both adapters still write only the new key.

What this gives up, stated plainly: a review can no longer be revised without a new commit. Nothing is lost that we want, because neither adapter ever edited a review in place. Pre-change, a differing review at one head surfaced as a second review posted beside the first, which is the defect being removed.

## Verification

`pnpm --filter worker exec vitest run` over the review, publication, adapter and scenario suites: 170 passed. `pnpm -r typecheck` clean.

The new round-stability test was proven to discriminate, not assumed: folding the key back into the content makes it fail with mismatched hashes, and it was then reverted. The comment property-order invariant, which a review found was not actually pinned, is now pinned against a literal digest, and moving `body` to second position changes that digest.

## Known, narrow, and deliberate

In the crash window (row `pending` while the review is already on the merge request) a retry whose comment ordering changed still aligns GitLab comment ids positionally against the prior round's discussions. It is inherent to GitLab identifying a comment by its index, the fixes above shrank the window from every reworded republication to only a lost state update, and the affected column has no behavioural consumer today. Worth knowing before anything builds thread resolution on it.