### PR TITLE
fix(worker): collapse reviewer notes instead of deleting them and state the blocking rule

### DIFF
--- a/apps/worker/src/workflow-definition/scenarios/post-pr-review.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/post-pr-review.scenario.test.ts
@@ -12,7 +12,9 @@ import {
   partitionReviewFindings,
   reviewPublicationDecision,
 } from "../../workflows/pr-external-resources.js";
+import { clampBothEnds } from "../failure-message.js";
 import { executionError } from "../interpreter.js";
+import { workflowDefinitionTemplate } from "../templates.js";
 import {
   executorRunsOf,
   expectNeverInvoked,
@@ -73,6 +75,20 @@ const CHECK_REF = {
 
 const APPROVED_SUMMARY = "Every review approved this commit.";
 const REQUEST_CHANGES_SUMMARY = "One blocking finding must be resolved.";
+
+/**
+ * The failure check text the template carries, restated here rather than
+ * imported, exactly as `FAILURE_DETAILS` is restated in
+ * arthur-review.scenario.test.ts: the point of the assertion is that the shipped
+ * graph says this, so reading the value from the graph would assert nothing.
+ *
+ * It is FIXED and not bound to the review summary. `details` reaches GitHub as a
+ * check-run title sliced to 200 characters and GitLab as a commit-status
+ * description clamped to 255, and both triggers accept both providers, so a bound
+ * markdown summary reached a client as a truncated fragment of itself.
+ */
+const FAILURE_DETAILS =
+  "The review requested changes. See the review on this pull request.";
 
 function prEntry(triggerType: PrTriggerType): AgentWorkflowInput {
   return {
@@ -559,16 +575,12 @@ describe("post-PR review workflow: a blocking finding", () => {
     expect(portsOf(outcome, "review-approved")).toEqual(["false"]);
     const failed = executorRunsOf(outcome, "complete-failure");
     expect(failed).toHaveLength(1);
-    // The graph hands the review summary to the failure completion as the
-    // `details` INPUT, while the node's own configuration carries only an empty
-    // string. Which of the two the published check text is taken from is the
-    // executor's precedence rule (`blocks/complete-pr-check.ts`), which the
-    // harness substitutes and no test in this suite currently covers.
-    expect(completion.details).toBe("");
-    expect(failed[0].resolvedInputs).toEqual({
-      check: CHECK_REF,
-      details: REQUEST_CHANGES_SUMMARY,
-    });
+    // The check text comes from the node's own configuration and NOTHING binds
+    // the review summary to it: the only input the failure completion resolves is
+    // the check handle. `blocks/complete-pr-check.ts` prefers a `details` input
+    // over the configured string, so a binding here would silently win.
+    expect(completion.details).toBe(FAILURE_DETAILS);
+    expect(failed[0].resolvedInputs).toEqual({ check: CHECK_REF });
     expect(completion.conclusion).toBe("failure");
     expect(failed[0].result).toEqual({
       kind: "next",
@@ -637,10 +649,7 @@ describe("post-PR review workflow: a blocking finding", () => {
     expect(portsOf(outcome, "review-approved")).toEqual(["false"]);
     const failed = executorRunsOf(outcome, "complete-failure");
     expect(failed).toHaveLength(1);
-    expect(failed[0].resolvedInputs).toEqual({
-      check: CHECK_REF,
-      details: REQUEST_CHANGES_SUMMARY,
-    });
+    expect(failed[0].resolvedInputs).toEqual({ check: CHECK_REF });
     expect(completion.conclusion).toBe("failure");
     expectNeverInvoked(outcome, ["complete-success"]);
   });
@@ -772,6 +781,38 @@ describe("post-PR review workflow: a block that fails", () => {
     });
     expect(outcome.invocationsOf("review-approved")).toEqual([]);
     expectNeverInvoked(outcome, [...REVIEWS, "post-review", ...COMPLETIONS]);
+  });
+});
+
+describe("post-PR review workflow: the failure check text", () => {
+  it("keeps a fixed sentence inside both providers' plain-text clamps", () => {
+    const definition = workflowDefinitionTemplate(
+      TEMPLATE.id,
+      TEMPLATE.options,
+    )!.definition;
+    if (definition.schemaVersion !== 2) {
+      throw new Error("The post-PR review template must use schema version 2");
+    }
+    const failure = definition.nodes.find(
+      (node) => node.id === "complete-failure",
+    );
+
+    expect(failure?.configuration.details).toBe(FAILURE_DETAILS);
+    // Nothing binds the review summary in. A `details` input would take
+    // precedence over the configured text in `blocks/complete-pr-check.ts`, so
+    // the absence of that key is the whole claim.
+    expect(failure?.inputs).toEqual({
+      check: {
+        kind: "reference",
+        reference: "steps.create-check.output.check",
+      },
+    });
+    // GitLab puts this through exactly this clamp as a commit-status
+    // description, and GitHub slices it to 200 as a check-run title. A fixed
+    // sentence survives both untouched; a bound review summary would not, and
+    // would arrive as plain text with its markdown showing.
+    expect(clampBothEnds(FAILURE_DETAILS, 255)).toBe(FAILURE_DETAILS);
+    expect(FAILURE_DETAILS.slice(0, 200)).toBe(FAILURE_DETAILS);
   });
 });
 

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -836,6 +836,23 @@ function reviewedTicketDefinition(
   ]);
 }
 
+/**
+ * The failure check text is FIXED, not bound to the review summary.
+ *
+ * `complete_pr_check` details reaches GitHub as a check-run TITLE sliced to 200
+ * characters, plain text with no markdown, and GitLab as a commit-status
+ * description clamped to 255. The review summary is markdown, is as long as the
+ * findings make it, and opens with agent-authored material, so through that clamp
+ * a client read a truncated fragment of it as the whole verdict. The review itself
+ * is published in full by Post PR review, which is where its text belongs.
+ *
+ * The Arthur definition already made this call for its own graph; see
+ * `FAILURE_DETAILS` in scenarios/arthur-review.scenario.test.ts. This template had
+ * diverged from it.
+ */
+const POST_PR_REVIEW_FAILURE_DETAILS =
+  "The review requested changes. See the review on this pull request.";
+
 function postPrReviewDefinition(
   provider: HarnessProvider,
   profileReference?: HarnessProfileReference,
@@ -947,15 +964,14 @@ function postPrReviewDefinition(
       name: "Fail review check",
       column: 6,
       row: 1,
-      configuration: { conclusion: "failure", details: "" },
+      configuration: {
+        conclusion: "failure",
+        details: POST_PR_REVIEW_FAILURE_DETAILS,
+      },
       inputs: {
         check: {
           kind: "reference",
           reference: "steps.create-check.output.check",
-        },
-        details: {
-          kind: "reference",
-          reference: "steps.post-review.output.summary",
         },
       },
     },

--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -165,7 +165,11 @@ describe("PR review diff placement", () => {
     const merged = partition.comments.find((comment) => comment.startLine === 3);
     expect(merged?.body).toContain("Reported by 3 of 3 reviewers.");
     const alone = partition.comments.find((comment) => comment.startLine === 5);
-    expect(alone?.body).not.toContain("Reported by");
+    // The lone High is never presented as agreed, and it now states the opposite
+    // outright, because on its own it no longer fails the check.
+    expect(alone?.body).toContain(
+      "Reported by 1 of 3 reviewers. A High blocks only when two reviewers report it independently.",
+    );
   });
 
   // The first production run after the cap shipped withheld exactly one
@@ -855,13 +859,165 @@ describe("PR review publication scrub", () => {
     });
 
     expect(result.summary).toBe(
-      "## AI Workflow review\n\n- The retry path is now covered.",
+      "## AI Workflow review\n\n" +
+        "<details><summary>Reviewer notes (1)</summary>\n\n" +
+        "- The retry path is now covered.\n\n" +
+        "</details>",
     );
     const publication = publishPRReview.mock.calls[0]![1];
     expect(publication.summary).toBe(result.summary);
     const commentBody: string = publication.comments[0]!.body;
     expect(commentBody.endsWith("Reads the config twice.")).toBe(true);
     expect(commentBody).not.toContain("blazebot/memory/");
+  });
+
+  it("collapses three reviewers' prose without dropping a word of it", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-prose-merge" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-21", commentIds: [] });
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([]),
+      publishPRReview,
+    });
+    // Production run on PR 33, verbatim, minus the reviewer that reached for the
+    // longest wording. A reader saw all three of these, one after another.
+    const kept =
+      "`findIndex()` returns `-1`, and `REFUNDS.splice(-1, 1)` removes the last " +
+      "refund (`ref-3`) while the handler still reports success. This makes a bad " +
+      "request mutate data.";
+    const restated =
+      "`findIndex()` returns `-1`, and `REFUNDS.splice(-1, 1)` removes the tail " +
+      "element while the handler still returns `{ deleted: <missing id> }`, which " +
+      "is silent data corruption.";
+    const restatedAgain =
+      "`findIndex()` returns `-1`, and `REFUNDS.splice(-1, 1)` removes the last " +
+      "refund entry, so any caller can erase the final record.";
+
+    const result = await publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#21",
+        ownerToken: "owner-21",
+        runId: "run-prose-merge",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#21",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 21,
+        headSha: "head",
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: [
+        {
+          decision: "request_changes",
+          feedback: `${kept}\n\nThe pagination guard is also off by one.`,
+          findings: [],
+        },
+        { decision: "request_changes", feedback: restated, findings: [] },
+        {
+          decision: "request_changes",
+          feedback: `${restatedAgain}\n\nNothing else stood out.`,
+          findings: [],
+        },
+      ],
+    });
+
+    // Exact bytes, covering the whole section at once. Two earlier attempts tried
+    // to publish only one of these three explanations, and both could delete a
+    // finding nobody restated, so the repetition is now moved out of the reader's
+    // way instead of removed: every reviewer's every paragraph is still here, in
+    // order, each continuation indented inside its own bullet, and the count in the
+    // summary line says how many notes are folded away.
+    expect(result.summary).toBe(
+      [
+        "## AI Workflow review",
+        "",
+        "<details><summary>Reviewer notes (3)</summary>",
+        "",
+        `- ${kept}`,
+        "",
+        "  The pagination guard is also off by one.",
+        `- ${restated}`,
+        `- ${restatedAgain}`,
+        "",
+        "  Nothing else stood out.",
+        "",
+        "</details>",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps a reviewer's every paragraph inside that reviewer's own bullet", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-prose" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-20", commentIds: [] });
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([]),
+      publishPRReview,
+    });
+
+    const result = await publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#20",
+        ownerToken: "owner-20",
+        runId: "run-prose",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#20",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 20,
+        headSha: "head",
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: [
+        {
+          decision: "approve",
+          feedback: "I read the diff.\n\nThe migration looks reversible.",
+          findings: [],
+        },
+        { decision: "approve", feedback: "No security concerns.", findings: [] },
+      ],
+    });
+
+    // The exact bytes, because the defect is invisible in the string and only
+    // shows in the rendering: two leading spaces on the second paragraph keep it
+    // inside the first bullet. Unindented, that blank line would close the list
+    // and the reviewer after it would open a new one.
+    expect(result.summary).toBe(
+      [
+        "## AI Workflow review",
+        "",
+        "<details><summary>Reviewer notes (2)</summary>",
+        "",
+        "- I read the diff.",
+        "",
+        "  The migration looks reversible.",
+        "- No security concerns.",
+        "",
+        "</details>",
+      ].join("\n"),
+    );
   });
 
   // The gate reads the merged findings, not the reviewers' own decisions: a
@@ -1004,7 +1160,8 @@ describe("PR review publication scrub", () => {
     expect(result.inlineCommentCount).toBe(1);
     expect(publishPRReview.mock.calls[0]![1].decision).toBe("approve");
     expect(publishPRReview.mock.calls[0]![1].comments[0]!.body).toBe(
-      "**High**: Only this reviewer saw a problem here.",
+      "**High**: Only this reviewer saw a problem here.\n\n" +
+        "Reported by 1 of 2 reviewers. A High blocks only when two reviewers report it independently.",
     );
   });
 

--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ReviewResult } from "@shared/contracts";
+import type { ReviewResult, ReviewResultFinding } from "@shared/contracts";
 import { eq } from "drizzle-orm";
 import { createTestDb } from "../db/test-db.js";
 import {
@@ -18,7 +18,12 @@ import {
   publishRunOwnedPrReview,
   reconcilePendingPrChecks,
   reviewCommentContentHash,
+  reviewFindingBlocksPublication,
 } from "./pr-external-resources.js";
+import {
+  mergedReviewFindingCommentBody,
+  type MergedReviewFinding,
+} from "./review-finding-merge.js";
 
 const { mockUpdateGateStatus, mockCreateRepositoryVCS, mockAssertActiveRunOwner } =
   vi.hoisted(() => ({
@@ -168,7 +173,7 @@ describe("PR review diff placement", () => {
     // The lone High is never presented as agreed, and it now states the opposite
     // outright, because on its own it no longer fails the check.
     expect(alone?.body).toContain(
-      "Reported by 1 of 3 reviewers. A High blocks only when two reviewers report it independently.",
+      "Reported by 1 of 3 reviewers. A High blocks only when 2 reviewers report it independently.",
     );
   });
 
@@ -231,6 +236,175 @@ describe("PR review diff placement", () => {
     expect(result.inlineCommentCount).toBe(10);
     expect(result.summary).toContain("1 further finding not shown inline");
     expect(result.summary).not.toContain("1 further findings");
+  });
+
+  /**
+   * The summary bullet is the OTHER surface the note reaches, and the two ways a
+   * finding lands on it are covered one each: this test loses its inline position
+   * (a line the diff does not carry) and the next one loses its inline slot to
+   * the cap. Both assert the whole summary byte for byte, because the note's
+   * indent is invisible in a substring match and is what keeps the bullet from
+   * splitting the list in two.
+   */
+  it("carries the blocking rule into a bullet no inline comment could hold", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-fallback-high" });
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([
+        {
+          path: "src/a.ts",
+          additions: 2,
+          deletions: 0,
+          changeType: "modified",
+          patch: "@@ -3,2 +3,2 @@\n context\n+added",
+        },
+      ]),
+      publishPRReview: vi
+        .fn()
+        .mockResolvedValue({ id: "review-30", commentIds: [] }),
+    });
+
+    const result = await publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#30",
+        ownerToken: "owner-30",
+        runId: "run-fallback-high",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#30",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 30,
+        headSha: "head",
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: [
+        { decision: "approve", findings: [] },
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              // Line 50 is outside the only hunk, so no provider would accept an
+              // inline comment there and the finding falls into the summary.
+              file: "src/a.ts",
+              description: "A failed job is retried without any backoff.",
+              severity: "High",
+              startLine: 50,
+              endLine: 50,
+            },
+          ],
+        },
+        { decision: "approve", findings: [] },
+      ],
+    });
+
+    expect(result.inlineCommentCount).toBe(0);
+    expect(result.summaryFallbackCount).toBe(1);
+    expect(result.decision).toBe("approve");
+    expect(result.summary).toBe(
+      [
+        "## AI Workflow review",
+        "",
+        "### Findings not placed inline",
+        "- **High** `src/a.ts:50`: A failed job is retried without any backoff.",
+        "",
+        "  Reported by 1 of 3 reviewers. A High blocks only when 2 reviewers report it independently.",
+      ].join("\n"),
+    );
+  });
+
+  it("carries the blocking rule into a bullet the inline cap withheld", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-withheld-high" });
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([
+        {
+          path: "src/a.ts",
+          additions: 30,
+          deletions: 0,
+          changeType: "modified",
+          patch: `@@ -1,30 +1,30 @@\n${Array.from({ length: 30 }, (_, i) => `+line${i}`).join("\n")}`,
+        },
+      ]),
+      publishPRReview: vi
+        .fn()
+        .mockResolvedValue({ id: "review-31", commentIds: [] }),
+    });
+
+    const result = await publishRunOwnedPrReview({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#31",
+        ownerToken: "owner-31",
+        runId: "run-withheld-high",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#31",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 31,
+        headSha: "head",
+        baseRef: "main",
+      },
+      nodeId: "post-review",
+      attempt: 1,
+      activationScope: "root",
+      reviewResults: [
+        {
+          // Ten Blockers outrank the High for every inline slot, which is the
+          // only way a High reaches the withheld section: the ranking puts
+          // severity first.
+          decision: "request_changes",
+          findings: Array.from({ length: 10 }, (_, index) => ({
+            file: "src/a.ts",
+            description: `Blocking defect ${index} about subject ${"z".repeat(index)}.`,
+            severity: "Blocker" as const,
+            startLine: index * 2 + 1,
+            endLine: index * 2 + 1,
+          })),
+        },
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "A failed job is retried without any backoff.",
+              severity: "High",
+              startLine: 22,
+              endLine: 22,
+            },
+          ],
+        },
+        { decision: "approve", findings: [] },
+      ],
+    });
+
+    expect(result.inlineCommentCount).toBe(10);
+    // The Blockers request changes, and the withheld High still states why it
+    // was not the reason: a reader must not read the red check off this bullet.
+    expect(result.decision).toBe("request_changes");
+    expect(result.summary).toBe(
+      [
+        "## AI Workflow review",
+        "",
+        "### 1 further finding not shown inline",
+        "- **High** `src/a.ts:22`: A failed job is retried without any backoff.",
+        "",
+        "  Reported by 1 of 3 reviewers. A High blocks only when 2 reviewers report it independently.",
+      ].join("\n"),
+    );
   });
 
   it("caps the inline comments and names the rest in the summary", () => {
@@ -392,6 +566,89 @@ describe("PR review diff placement", () => {
 
     expect(reviewCommentContentHash(partition.comments[0]!, 0)).toBe(
       "55af47956fe22fa8bb6a4902b60aca820a1d49704e98493e6fb7be6f46db3a50",
+    );
+  });
+});
+
+/**
+ * The one rule three surfaces read: the check's verdict, the inline comment body
+ * and the summary bullet. Asserted here directly rather than only through a
+ * published review, because the last test in this block cannot be written any
+ * other way: it reads the threshold OUT of the rule and demands the published
+ * sentence quote the same number.
+ */
+describe("the High agreement rule", () => {
+  const FILES = [
+    {
+      path: "src/a.ts",
+      additions: 4,
+      deletions: 0,
+      changeType: "modified" as const,
+      patch: "@@ -1,4 +1,4 @@\n+one\n+two\n+three\n+four",
+    },
+  ];
+
+  /**
+   * One defect that `reporters` of `reviewerCount` reviewers reported, built by
+   * the production partition so its `sources` are the ones merging produces.
+   * Same line and same severity, which is what merges without a wording gate.
+   */
+  function oneDefect(
+    severity: ReviewResultFinding["severity"],
+    reporters: number,
+    reviewerCount: number,
+  ): MergedReviewFinding {
+    const results: ReviewResult[] = Array.from(
+      { length: reviewerCount },
+      (_, index) => ({
+        decision: "request_changes" as const,
+        findings:
+          index < reporters
+            ? [
+                {
+                  file: "src/a.ts",
+                  description: `Reviewer ${index} worded it this way.`,
+                  severity,
+                  startLine: 2,
+                  endLine: 2,
+                },
+              ]
+            : [],
+      }),
+    );
+    const partition = partitionReviewFindings(results, FILES);
+    expect(partition.merged).toHaveLength(1);
+    expect(partition.merged[0]!.sources).toHaveLength(reporters);
+    return partition.merged[0]!;
+  }
+
+  it("blocks a Blocker alone and a High only once reviewers agree", () => {
+    expect(reviewFindingBlocksPublication(oneDefect("Blocker", 1, 3), 3)).toBe(true);
+    expect(reviewFindingBlocksPublication(oneDefect("High", 1, 3), 3)).toBe(false);
+    expect(reviewFindingBlocksPublication(oneDefect("High", 2, 3), 3)).toBe(true);
+    // Neither of the lower severities blocks at any level of agreement.
+    expect(reviewFindingBlocksPublication(oneDefect("Medium", 3, 3), 3)).toBe(false);
+    expect(reviewFindingBlocksPublication(oneDefect("Nit", 3, 3), 3)).toBe(false);
+    // min(2, 1): a graph with one reviewer has nobody to agree with, so its High
+    // keeps blocking on its own. This is the Arthur definition's shape.
+    expect(reviewFindingBlocksPublication(oneDefect("High", 1, 1), 1)).toBe(true);
+  });
+
+  it("publishes the threshold it enforces and never a numeral beside it", () => {
+    // Read out of the rule, not written down: the smallest agreement the gate
+    // accepts for a High in a three-reviewer graph.
+    const enforced = [1, 2, 3].find((reporters) =>
+      reviewFindingBlocksPublication(oneDefect("High", reporters, 3), 3),
+    );
+
+    expect(enforced).toBe(2);
+    // Raise the threshold and this is what used to keep publishing "two" on a
+    // client pull request while the check enforced something else.
+    expect(
+      mergedReviewFindingCommentBody(oneDefect("High", 1, 3), 3, false),
+    ).toBe(
+      "**High**: Reviewer 0 worded it this way.\n\n" +
+        `Reported by 1 of 3 reviewers. A High blocks only when ${enforced} reviewers report it independently.`,
     );
   });
 });
@@ -860,7 +1117,7 @@ describe("PR review publication scrub", () => {
 
     expect(result.summary).toBe(
       "## AI Workflow review\n\n" +
-        "<details><summary>Reviewer notes (1)</summary>\n\n" +
+        "<details><summary>Reviewer notes</summary>\n\n" +
         "- The retry path is now covered.\n\n" +
         "</details>",
     );
@@ -936,13 +1193,12 @@ describe("PR review publication scrub", () => {
     // to publish only one of these three explanations, and both could delete a
     // finding nobody restated, so the repetition is now moved out of the reader's
     // way instead of removed: every reviewer's every paragraph is still here, in
-    // order, each continuation indented inside its own bullet, and the count in the
-    // summary line says how many notes are folded away.
+    // order, each continuation indented inside its own bullet.
     expect(result.summary).toBe(
       [
         "## AI Workflow review",
         "",
-        "<details><summary>Reviewer notes (3)</summary>",
+        "<details><summary>Reviewer notes</summary>",
         "",
         `- ${kept}`,
         "",
@@ -1008,7 +1264,7 @@ describe("PR review publication scrub", () => {
       [
         "## AI Workflow review",
         "",
-        "<details><summary>Reviewer notes (2)</summary>",
+        "<details><summary>Reviewer notes</summary>",
         "",
         "- I read the diff.",
         "",
@@ -1161,7 +1417,7 @@ describe("PR review publication scrub", () => {
     expect(publishPRReview.mock.calls[0]![1].decision).toBe("approve");
     expect(publishPRReview.mock.calls[0]![1].comments[0]!.body).toBe(
       "**High**: Only this reviewer saw a problem here.\n\n" +
-        "Reported by 1 of 2 reviewers. A High blocks only when two reviewers report it independently.",
+        "Reported by 1 of 2 reviewers. A High blocks only when 2 reviewers report it independently.",
     );
   });
 

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -26,6 +26,7 @@ import {
   MAX_PUBLISHED_INLINE_REVIEW_COMMENTS,
   mergeReviewFindings,
   mergedReviewFindingCommentBody,
+  nonBlockingHighNote,
   type MergedReviewFinding,
   type ReviewFindingCandidate,
 } from "./review-finding-merge.js";
@@ -636,7 +637,11 @@ export function partitionReviewFindings(
       endLine: finding.anchor!.endLine,
       startOldLine: finding.anchor!.startOldLine,
       endOldLine: finding.anchor!.endOldLine,
-      body: mergedReviewFindingCommentBody(finding, results.length),
+      body: mergedReviewFindingCommentBody(
+        finding,
+        results.length,
+        reviewFindingBlocksPublication(finding, results.length),
+      ),
     }));
 
   return {
@@ -656,6 +661,34 @@ export function partitionReviewFindings(
 const HIGH_FINDING_BLOCKING_AGREEMENT = 2;
 
 /**
+ * Whether one defect holds the check back on its own.
+ *
+ * `sources.length` is the number of DISTINCT reviewers that reported it, because
+ * merging is cross-reviewer only: `mergeable` refuses a candidate from a reviewer
+ * already in the cluster.
+ *
+ * Math.min and never a bare 2: a graph with a single reviewer can never reach two
+ * sources, so a bare 2 would stop High from blocking anything at all there. The
+ * Arthur definition runs exactly one reviewer per pull request, and min(2, 1)
+ * keeps its behaviour identical to what it has today.
+ *
+ * The published comment body reads this too, so a High that did not block can say
+ * so. One rule, two readers: a second copy of it would let the check and the
+ * comment disagree about the same finding.
+ */
+export function reviewFindingBlocksPublication(
+  finding: MergedReviewFinding,
+  reviewerCount: number,
+): boolean {
+  if (finding.severity === "Blocker") return true;
+  if (finding.severity !== "High") return false;
+  return (
+    finding.sources.length >=
+    Math.min(HIGH_FINDING_BLOCKING_AGREEMENT, reviewerCount)
+  );
+}
+
+/**
  * The published verdict, read from the merged findings rather than from the
  * reviewers' own decisions.
  *
@@ -666,27 +699,16 @@ const HIGH_FINDING_BLOCKING_AGREEMENT = 2;
  * when independent reviewers agreed on it, which is the strongest signal
  * available that the finding is real. Per-reviewer decisions are untouched and
  * still reach `fix_agent` verbatim.
- *
- * `sources.length` is the number of DISTINCT reviewers that reported the defect,
- * because merging is cross-reviewer only: `mergeable` refuses a candidate from a
- * reviewer already in the cluster.
- *
- * Math.min and never a bare 2: a graph with a single reviewer can never reach
- * two sources, so a bare 2 would stop High from blocking anything at all there.
- * The Arthur definition runs exactly one reviewer per pull request, and min(2, 1)
- * keeps its behaviour identical to what it has today.
  */
 export function reviewPublicationDecision(
   merged: readonly MergedReviewFinding[],
   reviewerCount: number,
 ): "approve" | "request_changes" {
-  const agreement = Math.min(HIGH_FINDING_BLOCKING_AGREEMENT, reviewerCount);
-  const blocking = merged.some(
-    (finding) =>
-      finding.severity === "Blocker" ||
-      (finding.severity === "High" && finding.sources.length >= agreement),
-  );
-  return blocking ? "request_changes" : "approve";
+  return merged.some((finding) =>
+    reviewFindingBlocksPublication(finding, reviewerCount),
+  )
+    ? "request_changes"
+    : "approve";
 }
 
 function rangeContainsOnlyChangedSideLines(
@@ -711,7 +733,32 @@ function reviewSummaryLine(
     finding.sources.length > 1
       ? ` (reported by ${finding.sources.length} of ${reviewerCount} reviewers)`
       : "";
-  return `- **${finding.severity}** \`${location}\`${agreement}: ${finding.description}`;
+  // The same sentence the inline comment carries, for the same reason. A finding
+  // reaches this line because it could not be anchored or lost its inline slot,
+  // which changes nothing about the verdict it earned: without this, a
+  // non-blocking High reads as a blocking one purely because of where it landed.
+  const advisory =
+    finding.severity === "High" &&
+    !reviewFindingBlocksPublication(finding, reviewerCount)
+      ? ` ${nonBlockingHighNote(reviewerCount)}`
+      : "";
+  return `- **${finding.severity}** \`${location}\`${agreement}: ${finding.description}${advisory}`;
+}
+
+/**
+ * One reviewer's feedback as a single list item.
+ *
+ * Continuation lines are indented into the item, exactly as `reviewFallbackBullet`
+ * does it and for the same reason: feedback is multi-paragraph prose, and an
+ * unindented blank line closes a markdown list. Without the indent the second
+ * paragraph detaches into its own block, every reviewer after it opens a fresh
+ * list, and the section renders as a wall of text instead of one item per
+ * reviewer.
+ */
+function reviewFeedbackBullet(feedback: string): string {
+  const [first = "", ...rest] = feedback.split("\n");
+  const continuation = rest.map((line) => (line.trim() === "" ? "" : `  ${line}`));
+  return [`- ${first}`, ...continuation].join("\n");
 }
 
 function reviewSummary(
@@ -727,7 +774,29 @@ function reviewSummary(
     .map((result) => result.feedback?.trim())
     .filter((value): value is string => Boolean(value));
   const lines = ["## AI Workflow review"];
-  if (feedback.length > 0) lines.push("", ...feedback.map((value) => `- ${value}`));
+  // Collapsed, never edited. Three reviewers explaining one defect repeat each
+  // other, and the repetition is what made this section unreadable, but removing
+  // it means deciding which prose is a restatement. Two attempts at that failed:
+  // a similarity gate cannot separate "the same defect" from "a different defect
+  // on the same symbol", and the unit is wrong anyway, because a model writes a
+  // whole list of unrelated findings without a blank line between them, so
+  // dropping a "paragraph" dropped findings nobody restated. A disclosure moves
+  // the repetition out of the reader's way while keeping every word one click
+  // away, which is the only version where a lost finding is impossible.
+  //
+  // The blank lines inside the block are required: both providers only parse the
+  // body as markdown when the tags are separated from it, and without them the
+  // list renders literally.
+  if (feedback.length > 0) {
+    lines.push(
+      "",
+      `<details><summary>Reviewer notes (${feedback.length})</summary>`,
+      "",
+      ...feedback.map(reviewFeedbackBullet),
+      "",
+      "</details>",
+    );
+  }
   if (counts.reportedCount > counts.distinctCount) {
     lines.push(
       "",

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -23,10 +23,11 @@ import { assertActiveRunOwner, type ActiveRunOwner } from "../lib/active-run-own
 import {
   compareMergedFindingsForDisplay,
   compareMergedFindingsForPublication,
+  highFindingBlockingAgreement,
   MAX_PUBLISHED_INLINE_REVIEW_COMMENTS,
   mergeReviewFindings,
   mergedReviewFindingCommentBody,
-  nonBlockingHighNote,
+  mergedReviewFindingNote,
   type MergedReviewFinding,
   type ReviewFindingCandidate,
 } from "./review-finding-merge.js";
@@ -655,26 +656,16 @@ export function partitionReviewFindings(
 }
 
 /**
- * Reviewers that must independently report one High finding before it holds the
- * check back. A Blocker never needs a second opinion.
- */
-const HIGH_FINDING_BLOCKING_AGREEMENT = 2;
-
-/**
  * Whether one defect holds the check back on its own.
  *
  * `sources.length` is the number of DISTINCT reviewers that reported it, because
  * merging is cross-reviewer only: `mergeable` refuses a candidate from a reviewer
  * already in the cluster.
  *
- * Math.min and never a bare 2: a graph with a single reviewer can never reach two
- * sources, so a bare 2 would stop High from blocking anything at all there. The
- * Arthur definition runs exactly one reviewer per pull request, and min(2, 1)
- * keeps its behaviour identical to what it has today.
- *
- * The published comment body reads this too, so a High that did not block can say
- * so. One rule, two readers: a second copy of it would let the check and the
- * comment disagree about the same finding.
+ * The agreement threshold comes from `highFindingBlockingAgreement` because the
+ * published note quotes that number at the reader. One rule, two readers: a
+ * second copy of it would let the check and the review disagree about the same
+ * finding, and a hand-written numeral in the note would say a third thing.
  */
 export function reviewFindingBlocksPublication(
   finding: MergedReviewFinding,
@@ -682,10 +673,7 @@ export function reviewFindingBlocksPublication(
 ): boolean {
   if (finding.severity === "Blocker") return true;
   if (finding.severity !== "High") return false;
-  return (
-    finding.sources.length >=
-    Math.min(HIGH_FINDING_BLOCKING_AGREEMENT, reviewerCount)
-  );
+  return finding.sources.length >= highFindingBlockingAgreement(reviewerCount);
 }
 
 /**
@@ -722,6 +710,22 @@ function rangeContainsOnlyChangedSideLines(
   return true;
 }
 
+/**
+ * One finding as a markdown list item, for the summary sections that name the
+ * findings no inline comment could carry.
+ *
+ * The note is the SAME string the inline comment body carries, on its own
+ * indented continuation line, exactly as `reviewFallbackBullet` renders that body
+ * when a provider refuses an inline position. A finding reaches this line because
+ * it could not be anchored or lost its inline slot, which changes nothing about
+ * what it earned: with a wording of its own here, a non-blocking High read as a
+ * blocking one purely because of where it landed, and the agreement note read as
+ * a different kind of remark from the identical sentence one section above.
+ *
+ * The indent is load-bearing for the same reason it is in `reviewFallbackBullet`:
+ * an unindented blank line closes a markdown list, so the note would detach into
+ * its own paragraph and every finding after it would open a fresh list.
+ */
 function reviewSummaryLine(
   finding: MergedReviewFinding,
   reviewerCount: number,
@@ -729,20 +733,13 @@ function reviewSummaryLine(
   const location = finding.startLine
     ? `${finding.file}:${finding.startLine}${finding.endLine && finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}`
     : finding.file;
-  const agreement =
-    finding.sources.length > 1
-      ? ` (reported by ${finding.sources.length} of ${reviewerCount} reviewers)`
-      : "";
-  // The same sentence the inline comment carries, for the same reason. A finding
-  // reaches this line because it could not be anchored or lost its inline slot,
-  // which changes nothing about the verdict it earned: without this, a
-  // non-blocking High reads as a blocking one purely because of where it landed.
-  const advisory =
-    finding.severity === "High" &&
-    !reviewFindingBlocksPublication(finding, reviewerCount)
-      ? ` ${nonBlockingHighNote(reviewerCount)}`
-      : "";
-  return `- **${finding.severity}** \`${location}\`${agreement}: ${finding.description}${advisory}`;
+  const head = `- **${finding.severity}** \`${location}\`: ${finding.description}`;
+  const note = mergedReviewFindingNote(
+    finding,
+    reviewerCount,
+    reviewFindingBlocksPublication(finding, reviewerCount),
+  );
+  return note === "" ? head : `${head}\n\n  ${note}`;
 }
 
 /**
@@ -774,29 +771,6 @@ function reviewSummary(
     .map((result) => result.feedback?.trim())
     .filter((value): value is string => Boolean(value));
   const lines = ["## AI Workflow review"];
-  // Collapsed, never edited. Three reviewers explaining one defect repeat each
-  // other, and the repetition is what made this section unreadable, but removing
-  // it means deciding which prose is a restatement. Two attempts at that failed:
-  // a similarity gate cannot separate "the same defect" from "a different defect
-  // on the same symbol", and the unit is wrong anyway, because a model writes a
-  // whole list of unrelated findings without a blank line between them, so
-  // dropping a "paragraph" dropped findings nobody restated. A disclosure moves
-  // the repetition out of the reader's way while keeping every word one click
-  // away, which is the only version where a lost finding is impossible.
-  //
-  // The blank lines inside the block are required: both providers only parse the
-  // body as markdown when the tags are separated from it, and without them the
-  // list renders literally.
-  if (feedback.length > 0) {
-    lines.push(
-      "",
-      `<details><summary>Reviewer notes (${feedback.length})</summary>`,
-      "",
-      ...feedback.map(reviewFeedbackBullet),
-      "",
-      "</details>",
-    );
-  }
   if (counts.reportedCount > counts.distinctCount) {
     lines.push(
       "",
@@ -820,6 +794,48 @@ function reviewSummary(
   }
   if (results.every((result) => result.findings.length === 0) && feedback.length === 0) {
     lines.push("", "No findings.");
+  }
+  // LAST, and collapsed, and never edited.
+  //
+  // Collapsed because three reviewers explaining one defect repeat each other,
+  // and that repetition is what made this section unreadable. Never edited
+  // because removing it means deciding which prose is a restatement, and two
+  // attempts at that failed: a similarity gate cannot separate "the same defect"
+  // from "a different defect on the same symbol", and the unit is wrong anyway,
+  // because a model writes a whole list of unrelated findings without a blank
+  // line between them, so dropping a "paragraph" dropped findings nobody
+  // restated. A disclosure moves the repetition out of the reader's way while
+  // keeping every word one click away, which is the only version where a lost
+  // finding is impossible.
+  //
+  // Last for two reasons beyond ordering the verdict before its supporting
+  // material. This string is also read as PLAIN TEXT: the deployed
+  // post-pr-review definition binds it into complete_pr_check, which reaches
+  // GitHub as a check-run title sliced to 200 characters and GitLab as a
+  // commit-status description clamped to 255, and with the block on top the
+  // client's first 200 characters began "<details><summary>Reviewer notes".
+  // (The shipped template no longer binds it, but a definition deployed before
+  // that change still does, and it cannot be revised in place.) And reviewer
+  // prose is agent-authored: a reviewer that writes a bare `<details>` of its own
+  // would otherwise swallow the findings sections below it into this box.
+  //
+  // No count in the label. `scrubForPublication` runs over the assembled summary
+  // after this point and can empty a reviewer's prose, so any number here is a
+  // claim about content this block might not contain: "Reviewer notes (2)" over
+  // an empty box is exactly the loss the disclosure exists to rule out.
+  //
+  // The blank lines inside the block are required: both providers only parse the
+  // body as markdown when the tags are separated from it, and without them the
+  // list renders literally.
+  if (feedback.length > 0) {
+    lines.push(
+      "",
+      "<details><summary>Reviewer notes</summary>",
+      "",
+      ...feedback.map(reviewFeedbackBullet),
+      "",
+      "</details>",
+    );
   }
   return lines.join("\n");
 }

--- a/apps/worker/src/workflows/review-finding-merge.test.ts
+++ b/apps/worker/src/workflows/review-finding-merge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { ReviewResultFinding } from "@shared/contracts";
 import {
+  highFindingBlockingAgreement,
   MAX_PUBLISHED_INLINE_REVIEW_COMMENTS,
   mergeReviewFindings,
   mergedReviewFindingCommentBody,
@@ -344,7 +345,13 @@ describe("merged review comment body", () => {
     // kind of High this is.
     expect(mergedReviewFindingCommentBody(alone!, 3, false)).toBe(
       "**High**: A failed job is retried without any backoff.\n\n" +
-        "Reported by 1 of 3 reviewers. A High blocks only when two reviewers report it independently.",
+        "Reported by 1 of 3 reviewers. A High blocks only when 2 reviewers report it independently.",
+    );
+    // The threshold in that sentence is the one the gate enforces, not a numeral
+    // written beside it: `highFindingBlockingAgreement` is the only place the
+    // number exists, so raising it cannot leave the published text behind.
+    expect(mergedReviewFindingCommentBody(alone!, 3, false)).toContain(
+      `only when ${highFindingBlockingAgreement(3)} reviewers`,
     );
     // The same finding in a single-reviewer graph blocks, so it keeps the
     // pre-merge bytes. This is the Arthur definition's shape.

--- a/apps/worker/src/workflows/review-finding-merge.test.ts
+++ b/apps/worker/src/workflows/review-finding-merge.test.ts
@@ -324,8 +324,32 @@ describe("merged review comment body", () => {
       }),
     ]);
 
-    expect(mergedReviewFindingCommentBody(single!, 3)).toBe(
+    expect(mergedReviewFindingCommentBody(single!, 3, true)).toBe(
       "**Blocker**: The refund amount is parsed with parseFloat.",
+    );
+  });
+
+  it("states the blocking rule when a High stood alone", () => {
+    const [alone] = mergeReviewFindings([
+      candidate(0, 0, {
+        file: "a.ts",
+        startLine: 7,
+        severity: "High",
+        description: "A failed job is retried without any backoff.",
+      }),
+    ]);
+
+    // A green check that says "No blocking findings on this commit." next to an
+    // unqualified **High** reads as a contradiction, so the comment states which
+    // kind of High this is.
+    expect(mergedReviewFindingCommentBody(alone!, 3, false)).toBe(
+      "**High**: A failed job is retried without any backoff.\n\n" +
+        "Reported by 1 of 3 reviewers. A High blocks only when two reviewers report it independently.",
+    );
+    // The same finding in a single-reviewer graph blocks, so it keeps the
+    // pre-merge bytes. This is the Arthur definition's shape.
+    expect(mergedReviewFindingCommentBody(alone!, 1, true)).toBe(
+      "**High**: A failed job is retried without any backoff.",
     );
   });
 
@@ -333,7 +357,7 @@ describe("merged review comment body", () => {
     const merged = mergeReviewFindings(PRODUCTION_RUN);
     const refundsDelete = merged.find((f) => f.startLine === 50)!;
 
-    const body = mergedReviewFindingCommentBody(refundsDelete, 3);
+    const body = mergedReviewFindingCommentBody(refundsDelete, 3, true);
 
     expect(body).toContain("Reported by 3 of 3 reviewers.");
     // The first line stays self-contained: GitHub's inline fallback renders each

--- a/apps/worker/src/workflows/review-finding-merge.ts
+++ b/apps/worker/src/workflows/review-finding-merge.ts
@@ -134,24 +134,28 @@ export function reviewDescriptionSimilarity(a: string, b: string): number {
 }
 
 /**
- * Why a High did not request changes, phrased as the rule and never as this
- * check's colour.
- *
- * "It did not fail the check" was the first attempt and it is false on the normal
- * failing pull request: one Blocker plus a lone High turns the check red while
- * that sentence sits on the same review claiming otherwise.
- *
- * It also has to avoid reading as a confidence vote. The reviewers have disjoint
- * remits by construction, so "1 of 3" is the EXPECTED count for a real defect
- * that falls inside exactly one reviewer's remit, and a reader who learns to
- * discount lone Highs has learned the wrong lesson. Naming the severity and the
- * rule states why this one did not block without implying it is doubtful.
- *
- * "two reviewers" is exact wherever this sentence can appear: a lone High only
- * fails to block when there are at least two reviewers for it to be alone among.
+ * Reviewers that must independently report one High finding before it holds the
+ * check back. A Blocker never needs a second opinion.
  */
-export function nonBlockingHighNote(reviewerCount: number): string {
-  return `Reported by 1 of ${reviewerCount} reviewers. A High blocks only when two reviewers report it independently.`;
+const HIGH_FINDING_BLOCKING_AGREEMENT = 2;
+
+/**
+ * How many reviewers have to agree before a High blocks, in a graph running this
+ * many of them.
+ *
+ * Math.min and never a bare 2: a graph with a single reviewer can never reach two
+ * sources, so a bare 2 would stop High from blocking anything at all there. The
+ * Arthur definition runs exactly one reviewer per pull request, and min(2, 1)
+ * keeps its behaviour identical to what it has today.
+ *
+ * The threshold lives here rather than beside the publication gate that applies
+ * it, because `mergedReviewFindingNote` PUBLISHES this number on a client pull
+ * request. While the constant sat in the other module and the sentence spelled
+ * its numeral out by hand, raising the constant printed a falsehood on every
+ * non-blocking High and nothing failed.
+ */
+export function highFindingBlockingAgreement(reviewerCount: number): number {
+  return Math.min(HIGH_FINDING_BLOCKING_AGREEMENT, reviewerCount);
 }
 
 function rangeOf(finding: ReviewResultFinding): { start: number; end: number } | null {
@@ -259,6 +263,53 @@ export function mergeReviewFindings(
 }
 
 /**
+ * What a finding says about who reported it, or "" when it says nothing.
+ *
+ * ONE note for every surface that shows the finding: the inline comment body
+ * below, and the summary bullet in pr-external-resources. Those two used to word
+ * the same fact differently, one as a lowercase parenthetical and one as a
+ * sentence, which put two registers in one bulleted list of client-facing text
+ * and let them drift apart.
+ *
+ * "It did not fail the check" was the first attempt at the High sentence and it
+ * is false on the normal failing pull request: one Blocker plus a lone High turns
+ * the check red while that sentence sits on the same review claiming otherwise.
+ *
+ * It also has to avoid reading as a confidence vote. The reviewers have disjoint
+ * remits by construction, so "1 of 3" is the EXPECTED count for a real defect
+ * that falls inside exactly one reviewer's remit, and a reader who learns to
+ * discount lone Highs has learned the wrong lesson. Naming the severity and the
+ * rule states why this one did not block without implying it is doubtful.
+ *
+ * The High branch is tested BEFORE the agreement branch, and the order matters
+ * only if the threshold ever rises: today the two cannot both apply, because a
+ * High stops blocking only while it has one source, but at an agreement of three
+ * a two-source High would reach both, and why it did not block is the more
+ * informative of the two facts.
+ */
+export function mergedReviewFindingNote(
+  finding: MergedReviewFinding,
+  reviewerCount: number,
+  blocksTheCheck: boolean,
+): string {
+  // Agreement between independent reviewers is the strongest signal available
+  // that a finding is real, so it is stated rather than discarded.
+  const agreement = `Reported by ${finding.sources.length} of ${reviewerCount} reviewers.`;
+  if (finding.severity === "High" && !blocksTheCheck) {
+    // A High nobody else reported does not request changes on its own. Without
+    // this line a reader sees a High and has to guess whether it is why the check
+    // is red, and the note deliberately states the rule rather than this check's
+    // colour, because a Blocker elsewhere in the same review can make it red.
+    //
+    // The threshold is read from the rule and never spelled out here. The plural
+    // "reviewers" is safe at any threshold: a High reaches this branch only when
+    // the effective agreement is at least two, or it would have blocked alone.
+    return `${agreement} A High blocks only when ${highFindingBlockingAgreement(reviewerCount)} reviewers report it independently.`;
+  }
+  return finding.sources.length > 1 ? agreement : "";
+}
+
+/**
  * The published comment body.
  *
  * A single-source cluster renders byte for byte as it did before merging existed,
@@ -276,20 +327,8 @@ export function mergedReviewFindingCommentBody(
   blocksTheCheck: boolean,
 ): string {
   const head = `**${finding.severity}**: ${finding.description}`;
-  if (finding.sources.length > 1) {
-    // Agreement between independent reviewers is the strongest signal available
-    // that a finding is real, so it is stated rather than discarded.
-    return `${head}\n\nReported by ${finding.sources.length} of ${reviewerCount} reviewers.`;
-  }
-  if (finding.severity === "High" && !blocksTheCheck) {
-    // A High nobody else reported does not request changes on its own. Without
-    // this line a reader sees a High and has to guess whether it is why the check
-    // is red, and the note deliberately states the rule rather than this check's
-    // colour, because a Blocker elsewhere in the same review can make it red.
-    // Always a single-source cluster: one more source and the High would block.
-    return `${head}\n\n${nonBlockingHighNote(reviewerCount)}`;
-  }
-  return head;
+  const note = mergedReviewFindingNote(finding, reviewerCount, blocksTheCheck);
+  return note === "" ? head : `${head}\n\n${note}`;
 }
 
 /** Orders clusters for the inline slots: severity, then agreement, then order. */

--- a/apps/worker/src/workflows/review-finding-merge.ts
+++ b/apps/worker/src/workflows/review-finding-merge.ts
@@ -9,6 +9,19 @@ import type { ReviewResultFinding } from "@shared/contracts";
  * nowhere else: the raw per-reviewer results still reach `fix_agent` verbatim
  * and still key the publication content hash, so neither may be rewritten.
  *
+ * FINDINGS ONLY. Reviewer feedback PROSE is never deduplicated, anywhere. Two
+ * attempts are worth not repeating: a similarity gate cannot separate "the same
+ * defect restated" from "a different defect in the same code", because the two
+ * score distributions measurably overlap (0.13 to 0.21 for one production
+ * duplicate set against 0.13 to 0.21 for unique remarks beside it), and there is
+ * no unit to gate on either, because one blank-line-separated chunk of model
+ * prose routinely carries several unrelated findings as a bullet list, so
+ * suppressing a chunk on the strength of its first item silently deleted three
+ * real defects. Prose is published verbatim behind a disclosure instead, which
+ * costs a reader one click and cannot lose a sentence. A finding is a structured
+ * object with a file, a line and a severity, which is why merging is safe here
+ * and only here.
+ *
  * THREE DELIBERATE ABSENCES, each of which looks like an oversight:
  *
  * 1. No merge when one finding has a line and the other does not. A file-level
@@ -120,6 +133,27 @@ export function reviewDescriptionSimilarity(a: string, b: string): number {
   return union === 0 ? 0 : shared / union;
 }
 
+/**
+ * Why a High did not request changes, phrased as the rule and never as this
+ * check's colour.
+ *
+ * "It did not fail the check" was the first attempt and it is false on the normal
+ * failing pull request: one Blocker plus a lone High turns the check red while
+ * that sentence sits on the same review claiming otherwise.
+ *
+ * It also has to avoid reading as a confidence vote. The reviewers have disjoint
+ * remits by construction, so "1 of 3" is the EXPECTED count for a real defect
+ * that falls inside exactly one reviewer's remit, and a reader who learns to
+ * discount lone Highs has learned the wrong lesson. Naming the severity and the
+ * rule states why this one did not block without implying it is doubtful.
+ *
+ * "two reviewers" is exact wherever this sentence can appear: a lone High only
+ * fails to block when there are at least two reviewers for it to be alone among.
+ */
+export function nonBlockingHighNote(reviewerCount: number): string {
+  return `Reported by 1 of ${reviewerCount} reviewers. A High blocks only when two reviewers report it independently.`;
+}
+
 function rangeOf(finding: ReviewResultFinding): { start: number; end: number } | null {
   if (typeof finding.startLine !== "number") return null;
   return { start: finding.startLine, end: finding.endLine ?? finding.startLine };
@@ -225,19 +259,37 @@ export function mergeReviewFindings(
 }
 
 /**
- * The published comment body. A single-source cluster renders byte for byte as
- * it did before merging existed, which is what keeps single-reviewer
- * deployments and the existing tests untouched.
+ * The published comment body.
+ *
+ * A single-source cluster renders byte for byte as it did before merging existed,
+ * with one exception: a High that did not block says so. Single-reviewer
+ * deployments still see the pre-merge bytes for every severity, because a lone
+ * reviewer's High always blocks (see `reviewFindingBlocksPublication`).
+ *
+ * `blocksTheCheck` is passed in rather than derived here. The rule belongs to the
+ * publication gate, and computing it twice would let the comment claim one thing
+ * while the check reports another.
  */
 export function mergedReviewFindingCommentBody(
   finding: MergedReviewFinding,
   reviewerCount: number,
+  blocksTheCheck: boolean,
 ): string {
   const head = `**${finding.severity}**: ${finding.description}`;
-  if (finding.sources.length < 2) return head;
-  // Agreement between independent reviewers is the strongest signal available
-  // that a finding is real, so it is stated rather than discarded.
-  return `${head}\n\nReported by ${finding.sources.length} of ${reviewerCount} reviewers.`;
+  if (finding.sources.length > 1) {
+    // Agreement between independent reviewers is the strongest signal available
+    // that a finding is real, so it is stated rather than discarded.
+    return `${head}\n\nReported by ${finding.sources.length} of ${reviewerCount} reviewers.`;
+  }
+  if (finding.severity === "High" && !blocksTheCheck) {
+    // A High nobody else reported does not request changes on its own. Without
+    // this line a reader sees a High and has to guess whether it is why the check
+    // is red, and the note deliberately states the rule rather than this check's
+    // colour, because a Blocker elsewhere in the same review can make it red.
+    // Always a single-source cluster: one more source and the High would block.
+    return `${head}\n\n${nonBlockingHighNote(reviewerCount)}`;
+  }
+  return head;
 }
 
 /** Orders clusters for the inline slots: severity, then agreement, then order. */


### PR DESCRIPTION
Two problems with the text an AI review publishes, and one abandoned mechanism.

## The summary was a wall of repeated text

Each reviewer's `feedback` was pasted as `- ${value}`. `feedback` is multi-paragraph, and an unindented blank line closes a markdown list, so the second paragraph detached from its bullet and every later reviewer opened a fresh list. Continuation lines are now indented into the item, exactly as `reviewFallbackBullet` already does it for the same reason.

Three reviewers explaining one defect also repeat each other. Production PR 33 explained the same `splice(-1, 1)` bug three times in one summary.

**Two attempts to remove the repetition were built, measured, and abandoned. Neither is in this PR.** Recording why, so nobody rebuilds them:

1. **Drop whole `feedback` blobs by similarity.** No threshold exists. Measured with the real `reviewDescriptionSimilarity`: duplicate pairs scored 0.194 / 0.258 / 0.391 while the best-scoring genuinely unique remark scored 0.208. A second fixture put duplicates at 0.130 and a unique remark at 0.133. Jaccard scores the volume of shared vocabulary, not its distinctiveness, and the two orderings overlap.
2. **Drop paragraphs that cite the same code identifier and clear a cutoff.** Narrows the population but does not discriminate inside it. Eight realistic same-symbol / different-defect pairs were measured and four were silently deleted, including "no signature verification" losing to "not idempotent" at 0.214. And no cutoff can fix it: our own duplicates sat at 0.130 while false positives sat at 0.125 and 0.133, on both sides of every possible line. Worse, the unit was wrong: splitting on blank lines makes a bullet list one chunk, so a four-item list of unrelated findings was deleted because its first item restated another reviewer, taking an AC violation and a non-constant-time token comparison with it.

So the repetition is now **collapsed, not removed**. All reviewer prose goes inside one `<details>` block, verbatim, in order. Nothing is deleted, reordered or reattributed, there is no threshold to calibrate, and a lost finding is structurally impossible. The findings themselves are already published as inline comments, so prose is supporting material and collapsed-by-default is the right default.

## The published review contradicted itself

A `High` that did not block the check said so: `Reported by 1 of 3 reviewers, so it did not fail the check.` That sentence is false on the normal failing pull request. One `Blocker` plus one lone `High` turns the check red while the comment claims it did not fail.

It was also teaching the wrong lesson. The three reviewers have disjoint remits by construction, so "1 of 3" is the EXPECTED count for a real defect inside exactly one reviewer's remit. Framing it as a vote this finding lost trains developers to stop reading lone Highs.

Now: `Reported by 1 of 3 reviewers. A High blocks only when two reviewers report it independently.` True whatever colour the check is, and it states the rule instead of describing a tally. The same qualifier now also reaches `reviewSummaryLine`, so a non-blocking High that could not be anchored, or one pushed past the inline cap, no longer prints bare next to a green check while an anchored one explains itself.

The per-finding rule is a single function both the check verdict and the comment body read, so they cannot disagree.

## Verification

`review-finding-merge`, `pr-external-resources`, all scenario suites and both VCS adapter suites: **200 passed**. `pnpm -r typecheck` clean.

`scrubForPublication` was checked and does not touch HTML, and the blank lines inside the disclosure are required for both providers to parse the body as markdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * High-severity findings now require independent reports from up to two reviewers to block approval.
  * Blocker findings still block approval independently, while lower-severity findings do not.
  * Review comments explain agreement thresholds for non-blocking High findings.
  * Reviewer feedback is preserved in collapsible, properly formatted summaries.

* **Bug Fixes**
  * Aligned inline comments, summaries, and approval-blocking behavior.
  * Preserved multiline feedback and continuation paragraphs.
  * Clarified post-review failure messages while keeping detailed findings in the review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->