### PR TITLE
fix(worker): make concurrent block execution replay-safe

### DIFF
--- a/.github/workflows/workflow-sdk-divergence.yml
+++ b/.github/workflows/workflow-sdk-divergence.yml
@@ -1,0 +1,38 @@
+name: Workflow SDK Divergence (Manual)
+
+# Pins a Workflow DevKit defect, not our code: a sleep() wait cannot replay once
+# two blocks of one run poll concurrently. Every row asserts the failure, so a
+# failure here most likely means the SDK fixed it and src/workflows/blocks/
+# poll-delay.ts can go back to a plain sleep(). See
+# apps/worker/workflow-sdk-tests/divergence/wdk-wait-divergence.test.ts.
+#
+# Manual dispatch only, and deliberately not part of the `ci` job in ci.yml: these
+# rows guard someone else's code and cost most of the durable-workflow wall clock,
+# and that job's 20 minute timeout is shared by every pull request in the repo.
+# Run this when bumping the `workflow` package, and periodically as the tripwire
+# for the upstream fix landing.
+#
+# Needs no secrets, no database and no environment: the suite runs the real
+# runtime in-process against the local world.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  divergence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          # Node 24 to match the ci job and the Vercel runtime.
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter worker test:workflow-sdk-divergence

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -8,6 +8,7 @@
     "preview": "nitro preview",
     "test": "pnpm build:shared && vitest run",
     "test:workflow-sdk": "pnpm build:shared && vitest run --config vitest.run-control-workflow.config.ts",
+    "test:workflow-sdk-divergence": "pnpm build:shared && vitest run --config vitest.workflow-divergence.config.ts",
     "test:watch": "vitest",
     "typecheck": "pnpm build:shared && tsc --noEmit",
     "validate:pre-sandbox": "tsx scripts/validate-pre-sandbox-config.ts",

--- a/apps/worker/src/workflow-definition/v2-scheduler.test.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.test.ts
@@ -1020,6 +1020,48 @@ describe("executeV2Graph clarification and cancellation", () => {
     await expect(run).rejects.toBe(fatal);
     expect(siblingQuiesced).toBe(true);
   });
+
+  // The same scenario with the declaration order reversed, so the block that
+  // parks forever is the head of the graph order and the one that fails is
+  // behind it. The scheduler consumes results in graph order, so this is the
+  // case that catches any design which waits for the head before noticing that a
+  // sibling cannot continue: it would hang here rather than fail.
+  it("rethrows a run-control error raised behind a parked head block", async () => {
+    const fatal = new Error("active run ownership was lost");
+    const bothStarted = deferred<void>();
+    let started = 0;
+    let siblingQuiesced = false;
+    const run = executeV2Graph({
+      maxConcurrency: 2,
+      definition: definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("sibling", "generic_agent"),
+          node("owner-check", "generic_agent"),
+        ],
+        [
+          { id: "trigger-sibling", from: "trigger", to: "sibling" },
+          { id: "trigger-owner", from: "trigger", to: "owner-check" },
+        ],
+      ),
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "ok" },
+      shouldRethrowExecutionError: (error) => error === fatal,
+      executeBlock: async (current, _steps, _inputs, invocation) => {
+        started += 1;
+        if (started === 2) bothStarted.resolve();
+        await bothStarted.promise;
+        if (current.id === "owner-check") throw fatal;
+        await invocation.cancellation.wait();
+        siblingQuiesced = true;
+        invocation.cancellation.throwIfCancelled();
+        return { kind: "next", output: successfulOutput(current) };
+      },
+    });
+
+    await expect(run).rejects.toBe(fatal);
+    expect(siblingQuiesced).toBe(true);
+  });
 });
 
 describe("executeV2Graph loop scopes", () => {

--- a/apps/worker/src/workflow-definition/v2-scheduler.test.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.test.ts
@@ -1062,6 +1062,127 @@ describe("executeV2Graph clarification and cancellation", () => {
     await expect(run).rejects.toBe(fatal);
     expect(siblingQuiesced).toBe(true);
   });
+
+  // A sibling that finished before the head failed already ran its side effects:
+  // its review comments are posted, its check run exists. Recording it as
+  // cancelled and dropping its output would make the run record contradict the
+  // pull request on exactly the runs somebody triages.
+  it("records a settled sibling's real result when the head fails behind it", async () => {
+    const fastSettled = deferred<void>();
+    const finishes: Array<{
+      nodeId: string;
+      runtimeState: string;
+      status: string;
+    }> = [];
+    const result = await executeV2Graph({
+      maxConcurrency: 2,
+      definition: definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("head", "generic_agent"),
+          node("fast", "generic_agent"),
+        ],
+        [
+          { id: "trigger-head", from: "trigger", to: "head" },
+          { id: "trigger-fast", from: "trigger", to: "fast" },
+        ],
+      ),
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "ok" },
+      hooks: {
+        onNodeFinish(event) {
+          finishes.push({
+            nodeId: event.nodeId,
+            runtimeState: event.runtimeState,
+            status: event.state.status,
+          });
+        },
+      },
+      executeBlock: async (current) => {
+        if (current.id === "fast") {
+          fastSettled.resolve();
+          return { kind: "next", output: successfulOutput(current) };
+        }
+        // Let "fast" settle into the buffer well before the head fails, so the
+        // head is consumed first and drags the finished sibling into quiesce.
+        await fastSettled.promise;
+        for (let hop = 0; hop < 20; hop += 1) await Promise.resolve();
+        return {
+          kind: "execution_error",
+          error: {
+            category: "provider",
+            message: "The provider could not complete this block.",
+            detail: "raw provider failure",
+          },
+        };
+      },
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.executionError).toMatchObject({ nodeId: "head" });
+    expect(finishes).toEqual([
+      { nodeId: "head", runtimeState: "failed", status: "fail" },
+      { nodeId: "fast", runtimeState: "completed", status: "ok" },
+    ]);
+    expect(result.state.scopes.root!.nodeStates.fast).toMatchObject({
+      status: "completed",
+    });
+    expect(result.steps.fast?.output).toEqual(successfulOutput(node("fast", "generic_agent")));
+  });
+
+  // The third liveness path, and the one production actually hits: a review agent
+  // fails behind a slower earlier-declared sibling. Both other canaries go
+  // through abortForRethrow; this one goes through the execution_error promotion,
+  // which is the only branch that can notice a failure the head-of-line order has
+  // not reached yet. failNode cancels the scheduler, which is what lets the
+  // parked head quiesce instead of holding the run open forever.
+  it("promotes a failure raised behind a parked head block and quiesces the head", async () => {
+    let headQuiesced = false;
+    const result = await executeV2Graph({
+      maxConcurrency: 2,
+      definition: definition(
+        [
+          node("trigger", "trigger_ticket_ai"),
+          node("head", "generic_agent"),
+          node("late-failure", "generic_agent"),
+        ],
+        [
+          { id: "trigger-head", from: "trigger", to: "head" },
+          { id: "trigger-late", from: "trigger", to: "late-failure" },
+        ],
+      ),
+      entryTriggerId: "trigger",
+      triggerOutput: { status: "ok" },
+      executeBlock: async (current, _steps, _inputs, invocation) => {
+        if (current.id === "late-failure") {
+          return {
+            kind: "execution_error",
+            error: {
+              category: "provider",
+              message: "The provider could not complete this block.",
+              detail: "raw provider failure",
+            },
+          };
+        }
+        // Parks until the sibling's failure cancels the run. Without that cancel
+        // this await never returns and the run hangs here.
+        await invocation.cancellation.wait();
+        headQuiesced = true;
+        invocation.cancellation.throwIfCancelled();
+        return { kind: "next", output: successfulOutput(current) };
+      },
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.executionError).toMatchObject({
+      nodeId: "late-failure",
+      category: "provider",
+    });
+    expect(headQuiesced).toBe(true);
+    expect(result.state.scopes.root!.nodeStates.head).toMatchObject({
+      status: "cancelled",
+    });
+  });
 });
 
 describe("executeV2Graph loop scopes", () => {

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -1989,8 +1989,48 @@ class V2SchedulerRuntime {
     const running = [...this.running.entries()];
     for (const [key] of running) {
       const { scopeId, nodeId } = this.invocationIds(key);
-      const state = this.scope(scopeId).nodeStates[nodeId];
+      const scope = this.scope(scopeId);
+      const state = scope.nodeStates[nodeId];
       if (!state || state.status !== "running") continue;
+      // A sibling that had already finished is not cancelled, whatever the run
+      // does next: its side effects have happened. Its review comments are
+      // posted and its check run exists, so recording it as cancelled and
+      // dropping its output would leave the run record contradicting the pull
+      // request it already changed, on exactly the runs somebody triages.
+      //
+      // Only the terminal record is written. Ports are deliberately NOT
+      // propagated and the output contract is deliberately NOT revalidated: the
+      // run is ending, nothing downstream may be admitted on the strength of
+      // this, and a second failure here would only bury the real one.
+      const settled = this.settledInvocations.get(key);
+      const finished =
+        settled?.kind === "result" &&
+        (settled.result.kind === "next" || settled.result.kind === "ended")
+          ? settled.result
+          : undefined;
+      if (settled?.kind === "result" && finished) {
+        const output = finished.output;
+        scope.outputs[nodeId] = structuredClone(output);
+        scope.nodeStates[nodeId] = {
+          status: "completed",
+          attempt: settled.attempt,
+        };
+        this.pendingHookCalls.push(() =>
+          settled.context.observations.emit({ kind: "output", value: output }),
+        );
+        this.finishHook(
+          scopeId,
+          nodeId,
+          settled.attempt,
+          {
+            status: finished.kind === "ended" ? "warn" : "ok",
+            attempt: settled.attempt,
+            output,
+          },
+          "completed",
+        );
+        continue;
+      }
       state.status = "cancelled";
       this.finishHook(
         scopeId,

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -452,6 +452,13 @@ class V2SchedulerRuntime {
     createV2InvocationCancellationController();
   private readonly cancellation: V2InvocationCancellation;
   private readonly running = new Map<string, Promise<SettledInvocation>>();
+  /**
+   * Invocations that have finished but have not been consumed yet, keyed the same
+   * way as `running`. Settling records here instead of being handed straight to
+   * the scheduler, so consumption can follow the graph's order rather than the
+   * order the event loop happened to resume each block in.
+   */
+  private readonly settledInvocations = new Map<string, SettledInvocation>();
   private readonly pendingHookCalls: Array<() => void | Promise<void>> = [];
   private readonly resolutionQueue: Array<{ scopeId: string; nodeId: string }> = [];
   private hookFlushTail: Promise<void> = Promise.resolve();
@@ -562,6 +569,25 @@ class V2SchedulerRuntime {
         continue;
       }
 
+      // Consume the head invocation as soon as it has settled. "Head" is the
+      // lowest (scope sequence, nodeOrder) still running, both definition-derived,
+      // so consumption order is the graph's order and never the order the
+      // invocations happened to finish in. That is what a replay can reproduce.
+      const head = this.settledHeadInvocation();
+      if (head) {
+        this.running.delete(head.key);
+        this.settledInvocations.delete(head.key);
+        if (head.kind === "rethrow") {
+          return this.abortForRethrow(head);
+        }
+        await this.processResult(head);
+        continue;
+      }
+
+      // The head has not settled yet, so wait for something to change. The race
+      // is over every invocation that has not settled, which is what lets a
+      // failing block stop its siblings from any declaration order. It decides
+      // only WHEN to look again, never WHICH result is consumed.
       const cancellation = this.cancellation.wait().then(
         (): SettledInvocation => ({
           kind: "rethrow",
@@ -569,30 +595,79 @@ class V2SchedulerRuntime {
           error: new Error(this.cancellation.reason ?? "Workflow run cancelled."),
         }),
       );
-      const settled = await Promise.race([
-        ...this.running.values(),
+      const signalled = await Promise.race([
+        ...[...this.running.entries()]
+          .filter(([key]) => !this.settledInvocations.has(key))
+          .map(([, invocation]) => invocation),
         cancellation,
       ]);
-      if (settled.kind === "rethrow") {
-        if (settled.key) this.running.delete(settled.key);
-        this.schedulerCancellation.cancel(
-          settled.error instanceof Error
-            ? settled.error.message
-            : "Workflow run cancelled.",
-        );
-        await this.quiesceRunningSiblings(
-          settled.key
-            ? "Cancelled because another block could not continue."
-            : "Cancelled because the workflow run was stopped.",
-        );
-        if (!settled.key && this.cancellation.cancelled) {
-          throw new V2InvocationCancelledError(this.cancellation.reason);
+      if (signalled.kind === "rethrow") {
+        if (signalled.key) {
+          this.running.delete(signalled.key);
+          this.settledInvocations.delete(signalled.key);
         }
-        throw settled.error;
+        return this.abortForRethrow(signalled);
       }
-      this.running.delete(settled.key);
-      await this.processResult(settled);
+      // A block that failed does not wait its turn: promoting it now is what
+      // stops admission and keeps its siblings from burning more budget behind a
+      // run that is already lost. Which of several simultaneous failures is
+      // promoted is not replay-stable, but the run ends either way, so no later
+      // step sequence depends on it.
+      if (signalled.result.kind === "execution_error") {
+        this.running.delete(signalled.key);
+        this.settledInvocations.delete(signalled.key);
+        await this.processResult(signalled);
+      }
     }
+  }
+
+  /**
+   * The lowest-ordered running invocation, if it has settled. Ordering is
+   * (scope sequence, nodeOrder): both come from the definition, so two replays
+   * of the same event log agree on it, which is the whole point. Wall-clock
+   * completion order and microtask depth are deliberately not consulted.
+   */
+  private settledHeadInvocation(): SettledInvocation | undefined {
+    let headKey: string | undefined;
+    let headRank: [number, number] | undefined;
+    for (const key of this.running.keys()) {
+      const { scopeId, nodeId } = this.invocationIds(key);
+      const rank: [number, number] = [
+        this.scope(scopeId).sequence,
+        this.graph.nodeOrder.get(nodeId) ?? 0,
+      ];
+      if (
+        headRank === undefined ||
+        rank[0] < headRank[0] ||
+        (rank[0] === headRank[0] && rank[1] < headRank[1])
+      ) {
+        headKey = key;
+        headRank = rank;
+      }
+    }
+    return headKey === undefined
+      ? undefined
+      : this.settledInvocations.get(headKey);
+  }
+
+  /** Cancels every sibling and rethrows, for a run-control error or a stop. */
+  private async abortForRethrow(
+    settled: Extract<SettledInvocation, { kind: "rethrow" }>,
+  ): Promise<never> {
+    this.schedulerCancellation.cancel(
+      settled.error instanceof Error
+        ? settled.error.message
+        : "Workflow run cancelled.",
+    );
+    await this.quiesceRunningSiblings(
+      settled.key
+        ? "Cancelled because another block could not continue."
+        : "Cancelled because the workflow run was stopped.",
+    );
+    if (!settled.key && this.cancellation.cancelled) {
+      throw new V2InvocationCancelledError(this.cancellation.reason);
+    }
+    throw settled.error;
   }
 
   private initialCheckpoint(): V2SchedulerCheckpoint {
@@ -937,13 +1012,19 @@ class V2SchedulerRuntime {
     this.drainResolutionQueue();
   }
 
+  /**
+   * Admission order, from the definition alone: activation scope first, then the
+   * node's position in the graph. `sequence` (the order results were consumed in)
+   * is only the final tiebreak, so which sibling of a fan-out finished first can
+   * no longer decide which downstream block is admitted first.
+   */
   private sortReadyQueue(): void {
     this.checkpoint.readyQueue.sort(
       (left, right) =>
-        left.sequence - right.sequence ||
         this.scope(left.scopeId).sequence - this.scope(right.scopeId).sequence ||
         (this.graph.nodeOrder.get(left.nodeId) ?? 0) -
-          (this.graph.nodeOrder.get(right.nodeId) ?? 0),
+          (this.graph.nodeOrder.get(right.nodeId) ?? 0) ||
+        left.sequence - right.sequence,
     );
   }
 
@@ -1516,7 +1597,13 @@ class V2SchedulerRuntime {
           ),
         };
       }
-    })();
+    })().then((settled) => {
+      // Buffer rather than deliver. run() picks the head of the graph order from
+      // here, so a sibling that finished earlier in wall-clock terms cannot jump
+      // the queue and change the recorded step sequence.
+      this.settledInvocations.set(settled.key, settled);
+      return settled;
+    });
     this.running.set(key, promise);
   }
 
@@ -1921,7 +2008,10 @@ class V2SchedulerRuntime {
 
     await this.flushHookCalls();
     await Promise.allSettled(running.map(([, invocation]) => invocation));
-    for (const [key] of running) this.running.delete(key);
+    for (const [key] of running) {
+      this.running.delete(key);
+      this.settledInvocations.delete(key);
+    }
   }
 
   private cancelWaitingLoopAttempts(reason: string): void {

--- a/apps/worker/src/workflows/agent-budget.test.ts
+++ b/apps/worker/src/workflows/agent-budget.test.ts
@@ -8,6 +8,7 @@ import {
   modelsRequiringPriceLookupForRun,
   recordPrePrFixCycleUsages,
   shouldReconcilePhaseUsageOnBlockFinish,
+  soleActiveBlockId,
 } from "./agent.js";
 import { buildRuntimeGraph } from "../workflow-definition/interpreter.js";
 import {
@@ -105,6 +106,24 @@ describe("agent workflow budget integration", () => {
   it("does not reconcile still-running sibling usage on v2 block finishes", () => {
     expect(shouldReconcilePhaseUsageOnBlockFinish(1)).toBe(true);
     expect(shouldReconcilePhaseUsageOnBlockFinish(2)).toBe(false);
+  });
+
+  it("blames a run-level failure on the only block in flight, and the engine otherwise", () => {
+    // One block in flight: it owns the failure, which is the serial behaviour.
+    expect(soleActiveBlockId(new Set(["security-review"]))).toBe(
+      "security-review",
+    );
+    // Nothing in flight: the engine owns it.
+    expect(soleActiveBlockId(new Set())).toBeNull();
+    // Several in flight: no honest answer, so the engine owns it rather than
+    // whichever sibling was inserted last. Both orders must agree, because
+    // insertion order under concurrency is a wall-clock accident.
+    expect(
+      soleActiveBlockId(new Set(["security-review", "quality-review"])),
+    ).toBeNull();
+    expect(
+      soleActiveBlockId(new Set(["quality-review", "security-review"])),
+    ).toBeNull();
   });
 
   it("keeps workflow block status state summary-only", () => {

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -718,6 +718,24 @@ export function blockRunStateSummary(state: BlockRunState): BlockRunState {
   return summary;
 }
 
+/**
+ * Who a run-level failure belongs to, given the blocks in flight.
+ *
+ * One block in flight means the failure is that block's. Several means there is
+ * no honest answer, so return null and let the caller report the engine rather
+ * than blaming a sibling. Reading the last entry of the set would do exactly
+ * that: Set iteration is insertion order, so it attributes a shared failure to
+ * whichever block happened to start last in wall-clock terms, which under
+ * concurrency is an accident and lands a real failure on an innocent block.
+ */
+export function soleActiveBlockId(
+  activeBlockIds: ReadonlySet<string>,
+): string | null {
+  if (activeBlockIds.size !== 1) return null;
+  const [onlyActive] = activeBlockIds;
+  return onlyActive ?? null;
+}
+
 export function resolveSlackMessageInput(
   params: Record<string, unknown>,
   resolvedInputs: Record<string, unknown>,
@@ -3015,6 +3033,11 @@ async function agentWorkflowBody(
   );
   let currentBlockId: string | null = null;
   const activeBlockIds = new Set<string>();
+  // Attribution for the terminal diagnostic on the catch path, which reads
+  // currentBlockId for its nodeId, category and phase. See soleActiveBlockId.
+  const syncCurrentBlockId = (): void => {
+    currentBlockId = soleActiveBlockId(activeBlockIds);
+  };
   const writeBlockStatuses = () =>
     recordBlockStatusesStep({
       runId: workflowRunId,
@@ -5118,8 +5141,8 @@ async function agentWorkflowBody(
           ),
         async onBlockStart(nodeId, attempt) {
           await enforceBudgetAtBoundary(true);
-          currentBlockId = nodeId;
           activeBlockIds.add(nodeId);
+          syncCurrentBlockId();
           state.attempt = attempt;
           blockStatuses[nodeId] = { status: "running", attempt };
           await writeBlockStatuses();
@@ -5134,7 +5157,7 @@ async function agentWorkflowBody(
           blockStatuses[nodeId] = blockRunStateSummary(state);
           await writeBlockStatuses();
           activeBlockIds.delete(nodeId);
-          currentBlockId = [...activeBlockIds].at(-1) ?? null;
+          syncCurrentBlockId();
           await enforceBudgetAtBoundary(false);
         },
         clarificationExit,

--- a/apps/worker/src/workflows/blocks/poll-delay.ts
+++ b/apps/worker/src/workflows/blocks/poll-delay.ts
@@ -22,9 +22,29 @@
  * This lives in its own module so the poll loop's unit tests can substitute it
  * the way they already substitute checkPhaseDone, instead of really sleeping.
  *
- * Retries are deliberately left at the SDK default rather than pinned to 0:
- * sleeping again is idempotent, so a step invocation the platform kills
- * mid-sleep should poll later instead of failing the run.
+ * WHAT THIS COSTS. A wait is scheduled by the platform and holds nothing open; a
+ * step is a live function invocation for its whole duration. At the 30s ceiling
+ * in poll-phase.ts and the 25 minute phase cap (MAX_MINUTES in generic-agent.ts,
+ * DEFAULT_MAX_MINUTES in fix-agent.ts) that is up to 50 invocations per phase per
+ * block, and up to three blocks poll at once. An idle step burns almost no active
+ * CPU, so the bill is invocations plus provisioned memory for the span, not
+ * compute. There is no timeout risk because the deployed step function ships
+ * maxDuration "max" (see .vercel/output/functions/.well-known/workflow/v1/
+ * step.func/.vc-config.json), but that is the constraint to respect: the 30s
+ * ceiling must stay under whatever the deployed function limit is, so raising one
+ * without checking the other is how this starts failing.
+ *
+ * RETRIES ARE DELIBERATELY THE SDK DEFAULT, NOT 0. Do not pin maxRetries = 0 for
+ * symmetry with killPhaseCommand in poll-phase.ts. Sleeping again is idempotent,
+ * so a tick whose invocation the platform kills should poll later rather than
+ * fail the whole run. Know the accounting that follows, and do not "fix" it: the
+ * SDK default is 3 retries, so 4 attempts, and poll-phase.ts:70 advances
+ * phaseElapsedMs by the requested tick exactly once however many attempts it
+ * took. A fully retried tick therefore burns up to four times its wall clock
+ * against one tick of the phase budget, which makes maxMinutes a floor rather
+ * than a ceiling. That is intentional: the real bound is the run-global duration
+ * budget, re-read every iteration at poll-phase.ts:34 and :76, and it is measured
+ * from the clock rather than counted in ticks, so it already covers the overrun.
  */
 export async function delayPhasePollStep(ms: number): Promise<void> {
   "use step";

--- a/apps/worker/src/workflows/blocks/poll-delay.ts
+++ b/apps/worker/src/workflows/blocks/poll-delay.ts
@@ -1,0 +1,32 @@
+/**
+ * The agent poll tick, as a step that sleeps rather than a Workflow sleep() wait.
+ *
+ * That distinction is the whole point of AIW-233. The SDK seeds a wait's expected
+ * resumeAt from Date.now() at call time (createSleep in @workflow/core, via
+ * parseDurationToDate) and corrects it only if the same consumer also consumes
+ * its own wait_created event. When several blocks of one run execute
+ * concurrently, the events drain can pass a wait_created before the owning
+ * block's continuation has reinstalled its consumer, so the expectation stays a
+ * wall-clock value that can never match the recording. The run then dies with a
+ * replay divergence and, after the runtime's recovery replays, with
+ * CORRUPTED_EVENT_LOG. A step has no recomputed expectation: replay hands back
+ * the recorded result and compares only the step name.
+ *
+ * The controlled matrix is in workflow-sdk-tests/v2-concurrent.test.ts. With a
+ * wait, a three-block fan-out dies at concurrency 3 and survives at 1, and that
+ * holds with the shared counter removed, with per-invocation counters, with
+ * fixed-length waits, without the cancellation race, and with a single shared
+ * wait for the whole run. With this step instead, the same shape survives at
+ * concurrency 3.
+ *
+ * This lives in its own module so the poll loop's unit tests can substitute it
+ * the way they already substitute checkPhaseDone, instead of really sleeping.
+ *
+ * Retries are deliberately left at the SDK default rather than pinned to 0:
+ * sleeping again is idempotent, so a step invocation the platform kills
+ * mid-sleep should poll later instead of failing the run.
+ */
+export async function delayPhasePollStep(ms: number): Promise<void> {
+  "use step";
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/worker/src/workflows/blocks/poll-phase.test.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.test.ts
@@ -1,17 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  sleep: vi.fn().mockResolvedValue(undefined),
+  delay: vi.fn().mockResolvedValue(undefined),
   checkPhaseDone: vi.fn(),
   sandboxGet: vi.fn(),
   getCommand: vi.fn(),
   kill: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("workflow", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("workflow")>()),
-  sleep: mocks.sleep,
-}));
+// The poll tick is a sleeping step, not a Workflow wait (see poll-delay.ts).
+// Substituting it keeps these tests instant and lets them assert the requested
+// delay in milliseconds.
+vi.mock("./poll-delay.js", () => ({ delayPhasePollStep: mocks.delay }));
 vi.mock("../../sandbox/poll-agent.js", () => ({ checkPhaseDone: mocks.checkPhaseDone }));
 vi.mock("../../sandbox/credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
 vi.mock("@vercel/sandbox", () => ({ Sandbox: { get: mocks.sandboxGet } }));
@@ -42,7 +42,7 @@ describe("pollPhaseUntilDone", () => {
     mocks.sandboxGet.mockResolvedValue({ getCommand: mocks.getCommand });
   });
 
-  it("caps each Workflow sleep to the remaining active duration", async () => {
+  it("caps each poll tick to the remaining active duration", async () => {
     const observeBudget = vi
       .fn()
       .mockResolvedValueOnce(ok(12_345))
@@ -53,7 +53,7 @@ describe("pollPhaseUntilDone", () => {
       pollPhaseUntilDone("sbx-1", "/tmp/done", 25, "cmd-1", observeBudget),
     ).resolves.toBe(true);
 
-    expect(mocks.sleep).toHaveBeenCalledWith("12345ms");
+    expect(mocks.delay).toHaveBeenCalledWith(12_345);
     expect(mocks.checkPhaseDone).toHaveBeenCalledWith("sbx-1", "/tmp/done");
     expect(observeBudget.mock.calls).toEqual([[true], [false]]);
   });
@@ -118,7 +118,7 @@ describe("pollPhaseUntilDone", () => {
       failure: durationFailure,
     });
 
-    expect(mocks.sleep).toHaveBeenCalledWith("5000ms");
+    expect(mocks.delay).toHaveBeenCalledWith(5_000);
     expect(mocks.sandboxGet).toHaveBeenCalledWith({ sandboxId: "sbx-1" });
     expect(mocks.getCommand).toHaveBeenCalledWith("cmd-9");
     expect(mocks.kill).toHaveBeenCalledOnce();
@@ -147,7 +147,7 @@ describe("pollPhaseUntilDone", () => {
 
     expect(mocks.getCommand).toHaveBeenCalledWith("cmd-0");
     expect(mocks.kill).toHaveBeenCalledOnce();
-    expect(mocks.sleep).not.toHaveBeenCalled();
+    expect(mocks.delay).not.toHaveBeenCalled();
     expect(mocks.checkPhaseDone).not.toHaveBeenCalled();
   });
 
@@ -166,7 +166,7 @@ describe("pollPhaseUntilDone", () => {
   it("kills the exact detached command when a sibling cancels the invocation", async () => {
     const controller = createV2InvocationCancellationController();
     const observeBudget = vi.fn().mockResolvedValue(ok(60_000));
-    mocks.sleep.mockImplementationOnce(async () => {
+    mocks.delay.mockImplementationOnce(async () => {
       controller.cancel("another block failed");
     });
 

--- a/apps/worker/src/workflows/blocks/poll-phase.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.ts
@@ -13,6 +13,8 @@ import {
  * The tick is a sleeping step rather than a Workflow sleep() wait. See
  * poll-delay.ts: a wait here corrupts the run's event log as soon as two blocks
  * poll concurrently, which is why AIW-233 pinned V2_MAX_BLOCK_CONCURRENCY to 1.
+ * That module also records what the step costs against a wait, and why the tick
+ * ceiling below is coupled to the deployed function's duration limit.
  */
 export async function pollPhaseUntilDone(
   sandboxId: string,

--- a/apps/worker/src/workflows/blocks/poll-phase.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.ts
@@ -9,6 +9,10 @@ import {
  * Returns false when the phase stopped without finishing or the cap ran out.
  * Plain async orchestration (not a "use step"): it drives the checkPhaseDone
  * step, so it is safe to share between block executors.
+ *
+ * The tick is a sleeping step rather than a Workflow sleep() wait. See
+ * poll-delay.ts: a wait here corrupts the run's event log as soon as two blocks
+ * poll concurrently, which is why AIW-233 pinned V2_MAX_BLOCK_CONCURRENCY to 1.
  */
 export async function pollPhaseUntilDone(
   sandboxId: string,
@@ -18,7 +22,7 @@ export async function pollPhaseUntilDone(
   observeBudget: (requireRemainingDuration?: boolean) => Promise<RunBudgetObservation>,
   cancellation?: V2InvocationCancellation,
 ): Promise<boolean> {
-  const { sleep } = await import("workflow");
+  const { delayPhasePollStep } = await import("./poll-delay.js");
   const { checkPhaseDone } = await import("../../sandbox/poll-agent.js");
   const phaseLimitMs = maxMinutes * 60_000;
   let phaseElapsedMs = 0;
@@ -47,8 +51,13 @@ export async function pollPhaseUntilDone(
     }
 
     if (cancellation) {
+      // Racing a step promise against the cancellation promise stays replay-safe:
+      // the cancellation side is a plain in-memory promise resolved by an
+      // in-process cancel() call (see createV2InvocationCancellationController),
+      // so it produces no event of its own and cannot lose the race to a
+      // recorded resolution.
       const cancelled = await Promise.race([
-        sleep(`${Math.ceil(sleepMs)}ms`).then(() => false),
+        delayPhasePollStep(Math.ceil(sleepMs)).then(() => false),
         cancellation.wait().then(() => true),
       ]);
       if (cancelled) {
@@ -56,7 +65,7 @@ export async function pollPhaseUntilDone(
         throw new V2InvocationCancelledError(cancellation.reason);
       }
     } else {
-      await sleep(`${Math.ceil(sleepMs)}ms`);
+      await delayPhasePollStep(Math.ceil(sleepMs));
     }
     phaseElapsedMs += sleepMs;
 

--- a/apps/worker/vitest.workflow-divergence.config.ts
+++ b/apps/worker/vitest.workflow-divergence.config.ts
@@ -1,0 +1,39 @@
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { workflow } from "@workflow/vitest";
+import { defineConfig } from "vitest/config";
+
+const workerRoot = fileURLToPath(new URL("./", import.meta.url));
+const workflowRoot = fileURLToPath(
+  new URL("./workflow-test-fixtures/", import.meta.url),
+);
+
+// The manual-dispatch suite that pins the Workflow SDK's concurrent-wait replay
+// defect. Separate from vitest.run-control-workflow.config.ts so those rows stay
+// out of every pull request's budget: see
+// workflow-sdk-tests/divergence/wdk-wait-divergence.test.ts for what they are for
+// and when to run them. Its own dataDir and outDir so a dispatch run cannot
+// disturb the default suite's builder cache.
+//
+// @workflow/vitest's builder and client transform both derive stable function
+// ids from process.cwd(). Keep the dedicated test process rooted at the small
+// fixture while Vitest itself still discovers the test from the worker root.
+process.chdir(workflowRoot);
+
+export default defineConfig({
+  plugins: workflow({
+    cwd: workflowRoot,
+    rootDir: workerRoot,
+    dataDir: resolve(tmpdir(), "ai-workflow-divergence-vitest-data"),
+    outDir: join(workerRoot, ".workflow-vitest", "divergence"),
+  }),
+  root: workerRoot,
+  test: {
+    environment: "node",
+    include: ["workflow-sdk-tests/divergence/*.test.ts"],
+    // Each pinned row waits out four replay divergences and three recovery
+    // replays, and the serial baselines walk a real multi-block poll loop.
+    testTimeout: 180_000,
+  },
+});

--- a/apps/worker/workflow-sdk-tests/divergence/wdk-sleep-repro.test.ts
+++ b/apps/worker/workflow-sdk-tests/divergence/wdk-sleep-repro.test.ts
@@ -3,11 +3,17 @@ import { start } from "workflow/api";
 import {
   probeConcurrentSleep,
   type ConcurrentSleepInput,
-} from "../workflow-test-fixtures/wdk-sleep-repro/workflow.js";
+} from "../../workflow-test-fixtures/wdk-sleep-repro/workflow.js";
 
 // The standalone reproduction to attach to an upstream report. It depends on
 // nothing but the "workflow" package: no scheduler, no graph, no contracts.
 // See the fixture for the diagnosis.
+//
+// Manual dispatch only, like the rest of this directory. See
+// wdk-wait-divergence.test.ts for what the suite is for, when to run it, and what
+// a failure means. The single-branch and step-based rows travel with the pinned
+// row on purpose: they are its controls, and a pinned failure is meaningless
+// without them.
 
 function input(
   overrides: Partial<ConcurrentSleepInput> = {},

--- a/apps/worker/workflow-sdk-tests/divergence/wdk-wait-divergence.test.ts
+++ b/apps/worker/workflow-sdk-tests/divergence/wdk-wait-divergence.test.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { start } from "workflow/api";
+import {
+  probeV2SharedBudgetGate,
+  type ProbeSharedBudgetInput,
+} from "../../workflow-test-fixtures/v2-concurrent/workflow.js";
+
+/**
+ * WHAT THIS SUITE IS FOR
+ *
+ * It pins a defect in the Workflow DevKit, not in code we own: a Workflow sleep()
+ * wait cannot survive replay once two blocks of one run poll concurrently.
+ * createSleep seeds the wait's expected resumeAt from Date.now() at call time and
+ * corrects it only if the same consumer also consumes its own wait_created event.
+ * Under concurrency the events drain can pass that wait_created before the owning
+ * block's continuation has reinstalled its consumer, so the expectation stays a
+ * wall-clock value that can never match the recording, and the run dies with a
+ * replay divergence and then CORRUPTED_EVENT_LOG.
+ *
+ * Every row here therefore ASSERTS THE FAILURE. They are the reason
+ * src/workflows/blocks/poll-delay.ts makes the agent poll tick a sleeping step
+ * instead of a wait.
+ *
+ * WHY IT IS NOT IN THE DEFAULT RUN
+ *
+ * Each row deliberately drives four replay divergences through the runtime's three
+ * recovery replays, and the serial baselines walk a full multi-block poll loop in
+ * real time. Together they are most of the wall clock of the durable-workflow
+ * tests, and they guard someone else's code, so they do not belong in the budget
+ * of every pull request. What guards OUR fix is fast and stays in
+ * test:workflow-sdk: the two "tick is a step" rows in v2-concurrent.test.ts.
+ *
+ * HOW TO RUN IT
+ *
+ *   pnpm --filter worker test:workflow-sdk-divergence
+ *
+ * or the "Workflow SDK divergence" workflow in GitHub Actions, which is manual
+ * dispatch only. Run it when upgrading the workflow package, and periodically:
+ * this is the tripwire for the upstream fix landing.
+ *
+ * WHAT A FAILURE HERE MEANS
+ *
+ * Not a regression in this repository. Either
+ *   (a) the SDK fixed the defect, which is good news: poll-delay.ts can go back to
+ *       a plain sleep(), these pins can be deleted, and the held-invocation cost
+ *       documented in poll-delay.ts goes away; or
+ *   (b) the SDK changed how it drains events, so the reproduction no longer
+ *       provokes it while the underlying hazard may still exist.
+ * Tell them apart by running the standalone reproduction in
+ * divergence/wdk-sleep-repro.test.ts, which depends on nothing but the workflow
+ * package, before concluding anything.
+ */
+
+/**
+ * Asserts the run died the way AIW-233 dies in production: a replay divergence the
+ * runtime retried and then gave up on as a corrupted event log.
+ */
+async function expectCorruptedEventLog(run: {
+  returnValue: Promise<unknown>;
+}): Promise<void> {
+  let failure: unknown;
+  try {
+    await run.returnValue;
+  } catch (error) {
+    failure = error;
+  }
+  if (failure === undefined) {
+    throw new Error(
+      "expected the run to fail with a replay divergence, but it completed",
+    );
+  }
+  const text = [
+    failure instanceof Error ? failure.message : String(failure),
+    failure instanceof Error && failure.cause instanceof Error
+      ? failure.cause.message
+      : "",
+  ].join("\n");
+  expect(text).toContain("Workflow replay diverged");
+  expect(text).toContain("Replay divergence");
+}
+
+describe("Workflow sleep() cannot replay under concurrency", () => {
+  // Three concurrent blocks, NO successors, so the scheduler's join is out of the
+  // picture and the only variable is what the poll tick suspends on. The loop is a
+  // faithful copy of blocks/poll-phase.ts against a faithful copy of agent.ts's
+  // observeBudgetAtBoundary.
+  function sharedInput(
+    overrides: Partial<ProbeSharedBudgetInput> = {},
+  ): ProbeSharedBudgetInput {
+    return {
+      runId: `probe-budget-${randomUUID()}`,
+      maxConcurrency: 3,
+      limitMs: 900,
+      phaseLimitMs: 1_200,
+      tickMs: 60,
+      gateMode: "sleep",
+      budgetScope: "run-global",
+      blocks: [
+        { id: "alpha", doneAtTick: 9, workUnits: 0 },
+        { id: "beta", doneAtTick: 9, workUnits: 250_000 },
+        { id: "gamma", doneAtTick: 9, workUnits: 1_500_000 },
+      ],
+      ...overrides,
+    };
+  }
+
+  const FIXED_TICK_BLOCKS = [
+    { id: "alpha", doneAtTick: 6, workUnits: 0 },
+    { id: "beta", doneAtTick: 6, workUnits: 250_000 },
+    { id: "gamma", doneAtTick: 6, workUnits: 1_500_000 },
+  ];
+
+  /**
+   * Every way a wait reaches the log, and every attempt to make the wait safe by
+   * changing what feeds it. The list is the argument: the divergence is not caused
+   * by our shared budget counter, nor by its scope, nor by the cancellation race,
+   * nor by having more than one wait in flight. It is the wait itself.
+   */
+  const PINNED_WAIT_VARIANTS: Array<{
+    label: string;
+    overrides: Partial<ProbeSharedBudgetInput>;
+  }> = [
+    {
+      label: "a run-global counter shortens the wait",
+      overrides: { gateMode: "sleep" },
+    },
+    {
+      label: "a run-global counter only decides whether to loop again",
+      overrides: { gateMode: "continue", limitMs: 700, tickMs: 50 },
+    },
+    {
+      label: "the counter is per-invocation and shortens the wait",
+      overrides: { gateMode: "sleep", budgetScope: "per-invocation" },
+    },
+    {
+      label: "the counter is per-invocation and only gates the loop",
+      overrides: {
+        gateMode: "continue",
+        budgetScope: "per-invocation",
+        limitMs: 700,
+        tickMs: 50,
+      },
+    },
+    {
+      label: "there is no counter and every wait is a fixed length",
+      overrides: {
+        gateMode: "constant-wait",
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      },
+    },
+    {
+      label: "the cancellation race is removed entirely",
+      overrides: {
+        gateMode: "constant-wait-no-race",
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      },
+    },
+    {
+      label: "the whole run shares a single tick wait",
+      overrides: {
+        gateMode: "shared-wait",
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      },
+    },
+    {
+      label: "the whole run shares one tick wait and races it",
+      overrides: {
+        gateMode: "shared-wait-race",
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      },
+    },
+  ];
+
+  for (const variant of PINNED_WAIT_VARIANTS) {
+    it(`PINNED FAILING: diverges at concurrency 3 when ${variant.label}`, async () => {
+      await expectCorruptedEventLog(
+        await start(probeV2SharedBudgetGate, [sharedInput(variant.overrides)]),
+      );
+    }, 120_000);
+  }
+
+  // The serial baselines: every variant above, including all the wait ones,
+  // completes when only one block runs at a time. That is what production bought
+  // with V2_MAX_BLOCK_CONCURRENCY=1, and it is what proves the pinned rows are
+  // about concurrency rather than about the probe being broken. These walk a real
+  // multi-block poll loop, so they are the slowest thing here.
+  for (const gateMode of [
+    "sleep",
+    "continue",
+    "continue-no-wait",
+    "constant-wait",
+    "constant-wait-no-race",
+    "constant-step",
+    "shared-wait",
+    "shared-wait-race",
+  ] as const) {
+    it(`completes one block at a time via ${gateMode}`, async () => {
+      const run = await start(probeV2SharedBudgetGate, [
+        sharedInput({
+          maxConcurrency: 1,
+          gateMode,
+          tickMs: 40,
+          blocks: FIXED_TICK_BLOCKS,
+        }),
+      ]);
+      const result = (await run.returnValue) as Awaited<
+        ReturnType<typeof probeV2SharedBudgetGate>
+      >;
+      expect({
+        outcome: result.outcome,
+        executionError: result.executionError,
+      }).toMatchObject({ outcome: "completed", executionError: null });
+    }, 120_000);
+  }
+});

--- a/apps/worker/workflow-sdk-tests/v2-concurrent.test.ts
+++ b/apps/worker/workflow-sdk-tests/v2-concurrent.test.ts
@@ -105,36 +105,6 @@ async function waitForHook(token: string): Promise<{ runId: string }> {
   throw lastError ?? new Error(`hook ${token} was not registered`);
 }
 
-/**
- * Asserts the run died exactly the way AIW-233 dies in production: a replay
- * divergence the runtime retried and then gave up on as a corrupted event log.
- * Used to pin defects we do not own, so the suite stays green while still
- * failing loudly the day the behaviour changes.
- */
-async function expectCorruptedEventLog(run: {
-  returnValue: Promise<unknown>;
-}): Promise<void> {
-  let failure: unknown;
-  try {
-    await run.returnValue;
-  } catch (error) {
-    failure = error;
-  }
-  if (failure === undefined) {
-    throw new Error(
-      "expected the run to fail with a replay divergence, but it completed",
-    );
-  }
-  const text = [
-    failure instanceof Error ? failure.message : String(failure),
-    failure instanceof Error && failure.cause instanceof Error
-      ? failure.cause.message
-      : "",
-  ].join("\n");
-  expect(text).toContain("Workflow replay diverged");
-  expect(text).toContain("Replay divergence");
-}
-
 function expectCompleted(result: ProbeResult): void {
   expect({
     outcome: result.outcome,
@@ -298,11 +268,16 @@ describe("executeV2Graph result-consumption order across replays", () => {
   }
 });
 
-describe("Workflow sleep() under concurrency versus a sleeping step", () => {
-  // Three concurrent blocks, NO successors, so the scheduler's join is out of the
-  // picture and the only variable is what the poll tick suspends on. The loop is
-  // a faithful copy of blocks/poll-phase.ts against a faithful copy of
-  // agent.ts's observeBudgetAtBoundary.
+describe("the agent poll tick as a step survives concurrency", () => {
+  // The fix itself: three concurrent blocks running a faithful copy of
+  // blocks/poll-phase.ts against a faithful copy of agent.ts's
+  // observeBudgetAtBoundary, with the tick as a sleeping step. No successors, so
+  // the scheduler's join is out of the picture and the tick is the only variable.
+  //
+  // The counterpart rows, where the tick is a Workflow sleep() wait and the run
+  // dies, are pinned in workflow-sdk-tests/divergence/. They guard the SDK rather
+  // than us and cost most of the wall clock, so they are manual dispatch only:
+  // pnpm --filter worker test:workflow-sdk-divergence.
   function sharedInput(
     overrides: Partial<ProbeSharedBudgetInput> = {},
   ): ProbeSharedBudgetInput {
@@ -312,7 +287,7 @@ describe("Workflow sleep() under concurrency versus a sleeping step", () => {
       limitMs: 900,
       phaseLimitMs: 1_200,
       tickMs: 60,
-      gateMode: "sleep",
+      gateMode: "continue-no-wait",
       budgetScope: "run-global",
       blocks: [
         { id: "alpha", doneAtTick: 9, workUnits: 0 },
@@ -323,16 +298,10 @@ describe("Workflow sleep() under concurrency versus a sleeping step", () => {
     };
   }
 
-  async function runProbe(
-    overrides: Partial<ProbeSharedBudgetInput>,
-  ): Promise<{ returnValue: Promise<unknown> }> {
-    return start(probeV2SharedBudgetGate, [sharedInput(overrides)]);
-  }
-
   async function expectProbeCompleted(
     overrides: Partial<ProbeSharedBudgetInput>,
   ): Promise<void> {
-    const run = await runProbe(overrides);
+    const run = await start(probeV2SharedBudgetGate, [sharedInput(overrides)]);
     const result = (await run.returnValue) as Awaited<
       ReturnType<typeof probeV2SharedBudgetGate>
     >;
@@ -342,86 +311,7 @@ describe("Workflow sleep() under concurrency versus a sleeping step", () => {
     }).toMatchObject({ outcome: "completed", executionError: null });
   }
 
-  const FIXED_TICK_BLOCKS = [
-    { id: "alpha", doneAtTick: 6, workUnits: 0 },
-    { id: "beta", doneAtTick: 6, workUnits: 250_000 },
-    { id: "gamma", doneAtTick: 6, workUnits: 1_500_000 },
-  ];
-
-  /**
-   * Every way a wait reaches the log, and every attempt to make the wait safe by
-   * changing what feeds it. All pinned failing: the divergence is the SDK
-   * seeding a wait's expected resumeAt from Date.now() and trusting that value
-   * whenever the consumer misses its own wait_created event.
-   */
-  const PINNED_WAIT_VARIANTS: Array<{
-    label: string;
-    overrides: Partial<ProbeSharedBudgetInput>;
-  }> = [
-    {
-      label: "a run-global counter shortens the wait",
-      overrides: { gateMode: "sleep" },
-    },
-    {
-      label: "a run-global counter only decides whether to loop again",
-      overrides: { gateMode: "continue", limitMs: 700, tickMs: 50 },
-    },
-    {
-      label: "the counter is per-invocation and shortens the wait",
-      overrides: { gateMode: "sleep", budgetScope: "per-invocation" },
-    },
-    {
-      label: "the counter is per-invocation and only gates the loop",
-      overrides: {
-        gateMode: "continue",
-        budgetScope: "per-invocation",
-        limitMs: 700,
-        tickMs: 50,
-      },
-    },
-    {
-      label: "there is no counter and every wait is a fixed length",
-      overrides: {
-        gateMode: "constant-wait",
-        tickMs: 40,
-        blocks: FIXED_TICK_BLOCKS,
-      },
-    },
-    {
-      label: "the cancellation race is removed entirely",
-      overrides: {
-        gateMode: "constant-wait-no-race",
-        tickMs: 40,
-        blocks: FIXED_TICK_BLOCKS,
-      },
-    },
-    {
-      label: "the whole run shares a single tick wait",
-      overrides: {
-        gateMode: "shared-wait",
-        tickMs: 40,
-        blocks: FIXED_TICK_BLOCKS,
-      },
-    },
-    {
-      label: "the whole run shares one tick wait and races it",
-      overrides: {
-        gateMode: "shared-wait-race",
-        tickMs: 40,
-        blocks: FIXED_TICK_BLOCKS,
-      },
-    },
-  ];
-
-  for (const variant of PINNED_WAIT_VARIANTS) {
-    it(`PINNED FAILING: diverges at concurrency 3 when ${variant.label}`, async () => {
-      await expectCorruptedEventLog(await runProbe(variant.overrides));
-    }, 120_000);
-  }
-
-  // The fix. Identical graph, identical concurrency, identical block asymmetry,
-  // identical tick timings. The only change is that the tick is a step.
-  it("completes at concurrency 3 when the tick is a step and a counter gates the loop", async () => {
+  it("completes at concurrency 3 when a run-global counter gates the loop", async () => {
     await expectProbeCompleted({
       gateMode: "continue-no-wait",
       limitMs: 700,
@@ -429,34 +319,15 @@ describe("Workflow sleep() under concurrency versus a sleeping step", () => {
     });
   }, 120_000);
 
-  it("completes at concurrency 3 when the tick is a step and there is no counter", async () => {
+  it("completes at concurrency 3 when there is no counter at all", async () => {
     await expectProbeCompleted({
       gateMode: "constant-step",
       tickMs: 40,
-      blocks: FIXED_TICK_BLOCKS,
+      blocks: [
+        { id: "alpha", doneAtTick: 6, workUnits: 0 },
+        { id: "beta", doneAtTick: 6, workUnits: 250_000 },
+        { id: "gamma", doneAtTick: 6, workUnits: 1_500_000 },
+      ],
     });
   }, 120_000);
-
-  // The serial baselines: everything above, including every pinned wait variant,
-  // completes when only one block runs at a time. That is what production has
-  // been buying with V2_MAX_BLOCK_CONCURRENCY=1.
-  for (const gateMode of [
-    "sleep",
-    "continue",
-    "continue-no-wait",
-    "constant-wait",
-    "constant-wait-no-race",
-    "constant-step",
-    "shared-wait",
-    "shared-wait-race",
-  ] as const) {
-    it(`completes one block at a time via ${gateMode}`, async () => {
-      await expectProbeCompleted({
-        maxConcurrency: 1,
-        gateMode,
-        tickMs: 40,
-        blocks: FIXED_TICK_BLOCKS,
-      });
-    }, 120_000);
-  }
 });

--- a/apps/worker/workflow-sdk-tests/v2-concurrent.test.ts
+++ b/apps/worker/workflow-sdk-tests/v2-concurrent.test.ts
@@ -232,47 +232,70 @@ describe("executeV2Graph fan-out against the real Workflow runtime", () => {
 describe("executeV2Graph result-consumption order across replays", () => {
   // Each branch has its own successor calling a differently named step, so the
   // order the scheduler consumes results in IS the recorded step-name sequence.
-  //
-  // Only one shape is asserted. Two others (a fast branch settling with the most
-  // microtask hops, and branches differing only in step duration) diverge in
-  // most runs but not all: the flip depends on microtask timing, so an assertion
-  // either way would be flaky. This shape failed in every run observed so far and
-  // is the one a join fix has to make green. Do not read a passing run of a
-  // flaky shape as evidence the join is sound.
-  const RELIABLE_SHAPE: ProbeDivergentSuccessorsInput["branches"] = [
-    { id: "alpha", delayMs: 25, hops: 0 },
-    { id: "beta", delayMs: 12, hops: 80 },
-    { id: "gamma", delayMs: 4, hops: 200 },
+  // Before the head-of-line consumption fix, the shapes below diverged at
+  // concurrency 3 and were green at 1: the first reliably, the other two
+  // intermittently, because the flip depends on microtask timing. They are
+  // asserted green now because consumption order no longer depends on timing at
+  // all, so the flakiness has no input left to vary. If any of them starts
+  // failing again, the scheduler has gone back to consuming in completion order.
+  const SHAPES: Array<{
+    label: string;
+    branches: ProbeDivergentSuccessorsInput["branches"];
+  }> = [
+    {
+      label: "the slowest branch settles with the fewest microtask hops",
+      branches: [
+        { id: "alpha", delayMs: 25, hops: 0 },
+        { id: "beta", delayMs: 12, hops: 80 },
+        { id: "gamma", delayMs: 4, hops: 200 },
+      ],
+    },
+    {
+      label: "the fastest branch settles with the most microtask hops",
+      branches: [
+        { id: "alpha", delayMs: 3, hops: 400 },
+        { id: "beta", delayMs: 5, hops: 40 },
+        { id: "gamma", delayMs: 7, hops: 0 },
+      ],
+    },
+    {
+      label: "branches differ only in step duration",
+      branches: [
+        { id: "alpha", delayMs: 25, hops: 0 },
+        { id: "beta", delayMs: 12, hops: 0 },
+        { id: "gamma", delayMs: 4, hops: 0 },
+      ],
+    },
   ];
 
-  it("PINNED FAILING: diverges at concurrency 3 when settle latency is lopsided", async () => {
-    const run = await start(probeV2ConsumptionOrder, [
-      {
-        runId: `probe-order-${randomUUID()}`,
-        maxConcurrency: 3,
-        branches: RELIABLE_SHAPE,
-      },
-    ]);
-    await expectCorruptedEventLog(run);
-  }, 60_000);
-
-  it("completes the same shape one block at a time", async () => {
-    const run = await start(probeV2ConsumptionOrder, [
-      {
-        runId: `probe-order-serial-${randomUUID()}`,
-        maxConcurrency: 1,
-        branches: RELIABLE_SHAPE,
-      },
-    ]);
-    const result = (await run.returnValue) as Awaited<
-      ReturnType<typeof probeV2ConsumptionOrder>
-    >;
-    expect({
-      outcome: result.outcome,
-      executionError: result.executionError,
-    }).toMatchObject({ outcome: "completed", executionError: null });
-    expect(result.consumptionOrder).toHaveLength(6);
-  }, 60_000);
+  for (const shape of SHAPES) {
+    for (const maxConcurrency of [3, 1]) {
+      it(`completes at concurrency ${maxConcurrency} when ${shape.label}`, async () => {
+        const run = await start(probeV2ConsumptionOrder, [
+          {
+            runId: `probe-order-${randomUUID()}`,
+            maxConcurrency,
+            branches: shape.branches,
+          },
+        ]);
+        const result = (await run.returnValue) as Awaited<
+          ReturnType<typeof probeV2ConsumptionOrder>
+        >;
+        expect({
+          outcome: result.outcome,
+          executionError: result.executionError,
+        }).toMatchObject({ outcome: "completed", executionError: null });
+        expect(result.consumptionOrder).toHaveLength(6);
+        // The point of the fix: results are consumed in graph order, so the
+        // branches always finish in declaration order however fast each ran.
+        expect(
+          result.consumptionOrder.filter((id) =>
+            ["alpha", "beta", "gamma"].includes(id),
+          ),
+        ).toEqual(["alpha", "beta", "gamma"]);
+      }, 60_000);
+    }
+  }
 });
 
 describe("Workflow sleep() under concurrency versus a sleeping step", () => {

--- a/apps/worker/workflow-sdk-tests/v2-concurrent.test.ts
+++ b/apps/worker/workflow-sdk-tests/v2-concurrent.test.ts
@@ -1,0 +1,439 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { getHookByToken, resumeHook, start } from "workflow/api";
+import type { WorkflowDefinitionV2 } from "@shared/contracts";
+import {
+  probeV2ConcurrentFanOut,
+  probeV2ConsumptionOrder,
+  probeV2SharedBudgetGate,
+  type ProbeConcurrentInput,
+  type ProbeDivergentSuccessorsInput,
+  type ProbeSharedBudgetInput,
+} from "../workflow-test-fixtures/v2-concurrent/workflow.js";
+
+// AIW-233. Three things live here, all driven against the real Workflow runtime.
+//
+// 1. The deployed three-reviewer graph survives a concurrent fan-out, including
+//    simultaneous hook suspensions, step retries and in-VM work at every step
+//    boundary. These must stay green.
+// 2. A Workflow sleep() wait corrupts the run's event log as soon as two blocks
+//    poll concurrently. Those rows are PINNED AS FAILING: they assert the
+//    divergence, because the defect is in the SDK and not in code we own. They
+//    are the reason src/workflows/blocks/poll-delay.ts makes the poll tick a
+//    sleeping step, and the same rows with a step instead are green. If the SDK
+//    ever fixes this, the pins fail and poll-delay.ts can go away.
+// 3. The scheduler's Promise.race join can consume results in an order a replay
+//    does not reproduce, on graphs where a concurrent block has its own
+//    successor. Pinned as failing too, pending its own fix.
+
+const SNAPSHOT = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL(
+        "../src/workflow-definition/scenarios/snapshots/post-pr-review-v1.json",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  ),
+) as WorkflowDefinitionV2;
+
+const REVIEWS = ["security-review", "quality-review", "requirements-review"];
+
+type ProbeResult = Awaited<ReturnType<typeof probeV2ConcurrentFanOut>>;
+
+/** The measured production spread: three reviewers finishing in an order that is
+ * neither their admission order nor their declaration order (104/111/68s). */
+function timingsFor(jitter: number): ProbeConcurrentInput["timings"] {
+  return {
+    "create-check": { startMs: 3, pollMs: 0, ticks: 0 },
+    prepare: { startMs: 3, pollMs: 0, ticks: 0 },
+    "security-review": { startMs: 5 + jitter, pollMs: 11, ticks: 4 },
+    "quality-review": { startMs: 2, pollMs: 17 + jitter, ticks: 3 },
+    "requirements-review": { startMs: 11, pollMs: 5, ticks: 6 + (jitter % 3) },
+    "post-review": { startMs: 3, pollMs: 0, ticks: 0 },
+    "complete-success": { startMs: 3, pollMs: 0, ticks: 0 },
+    "complete-failure": { startMs: 3, pollMs: 0, ticks: 0 },
+  };
+}
+
+function probeInput(
+  overrides: Partial<ProbeConcurrentInput> = {},
+): ProbeConcurrentInput {
+  return {
+    runId: `probe-${randomUUID()}`,
+    definition: SNAPSHOT,
+    entryTriggerId: "trigger-ready",
+    triggerOutput: {
+      status: "fired",
+      pr: {
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 7,
+        prUrl: "https://github.test/acme/app/pull/7",
+        headRef: "feature",
+        headSha: "abc123",
+        baseRef: "main",
+        title: "Add scenarios",
+        author: "contributor",
+        isDraft: false,
+      },
+    },
+    maxConcurrency: 3,
+    timings: timingsFor(0),
+    parks: [],
+    flakyPolls: [],
+    vmWorkPerStep: 0,
+    failNodes: [],
+    ...overrides,
+  };
+}
+
+async function waitForHook(token: string): Promise<{ runId: string }> {
+  const deadline = Date.now() + 25_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      return await getHookByToken(token);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+  throw lastError ?? new Error(`hook ${token} was not registered`);
+}
+
+/**
+ * Asserts the run died exactly the way AIW-233 dies in production: a replay
+ * divergence the runtime retried and then gave up on as a corrupted event log.
+ * Used to pin defects we do not own, so the suite stays green while still
+ * failing loudly the day the behaviour changes.
+ */
+async function expectCorruptedEventLog(run: {
+  returnValue: Promise<unknown>;
+}): Promise<void> {
+  let failure: unknown;
+  try {
+    await run.returnValue;
+  } catch (error) {
+    failure = error;
+  }
+  if (failure === undefined) {
+    throw new Error(
+      "expected the run to fail with a replay divergence, but it completed",
+    );
+  }
+  const text = [
+    failure instanceof Error ? failure.message : String(failure),
+    failure instanceof Error && failure.cause instanceof Error
+      ? failure.cause.message
+      : "",
+  ].join("\n");
+  expect(text).toContain("Workflow replay diverged");
+  expect(text).toContain("Replay divergence");
+}
+
+function expectCompleted(result: ProbeResult): void {
+  expect({
+    outcome: result.outcome,
+    executionError: result.executionError,
+  }).toMatchObject({ outcome: "completed", executionError: null });
+  expect(result.startOrder.filter((id) => REVIEWS.includes(id)).sort()).toEqual(
+    [...REVIEWS].sort(),
+  );
+}
+
+describe("executeV2Graph fan-out against the real Workflow runtime", () => {
+  it("completes a three-reviewer fan-out one block at a time", async () => {
+    const run = await start(probeV2ConcurrentFanOut, [
+      probeInput({ maxConcurrency: 1 }),
+    ]);
+    const result = (await run.returnValue) as ProbeResult;
+    expectCompleted(result);
+    expect(result.finishOrder.filter((id) => REVIEWS.includes(id))).toEqual(
+      REVIEWS,
+    );
+  });
+
+  it("completes repeated three-reviewer fan-outs at maxConcurrency 3", async () => {
+    // Timings are jittered per iteration because the reported corruption is
+    // intermittent: a single lucky interleaving proves nothing.
+    for (let iteration = 0; iteration < 5; iteration += 1) {
+      const run = await start(probeV2ConcurrentFanOut, [
+        probeInput({ timings: timingsFor(iteration * 3) }),
+      ]);
+      const result = (await run.returnValue) as ProbeResult;
+      expectCompleted(result);
+    }
+  }, 180_000);
+
+  it("completes a fan-out whose polls retry under concurrency", async () => {
+    const run = await start(probeV2ConcurrentFanOut, [
+      probeInput({
+        flakyPolls: [
+          { nodeId: "security-review", tick: 2 },
+          { nodeId: "quality-review", tick: 1 },
+          { nodeId: "requirements-review", tick: 3 },
+        ],
+      }),
+    ]);
+    const result = (await run.returnValue) as ProbeResult;
+    expectCompleted(result);
+  });
+
+  it("completes a fan-out with in-VM work at every step boundary", async () => {
+    const run = await start(probeV2ConcurrentFanOut, [
+      probeInput({ vmWorkPerStep: 2_000_000 }),
+    ]);
+    const result = (await run.returnValue) as ProbeResult;
+    expectCompleted(result);
+  }, 120_000);
+
+  it("completes a fan-out where all three siblings suspend on hooks at once", async () => {
+    const parks = REVIEWS.map((nodeId, index) => ({
+      nodeId,
+      token: `probe-park:${nodeId}:${randomUUID()}`,
+      tick: index + 1,
+    }));
+    const run = await start(probeV2ConcurrentFanOut, [probeInput({ parks })]);
+
+    // Wait until every sibling has parked, so the run really is suspended with
+    // three blocks in flight, then resume them out of declaration order.
+    for (const park of parks) {
+      const hook = await waitForHook(park.token);
+      expect(hook.runId).toBe(run.runId);
+    }
+    for (const park of [parks[2]!, parks[0]!, parks[1]!]) {
+      await resumeHook(park.token, { answer: "keep going" });
+    }
+
+    const result = (await run.returnValue) as ProbeResult;
+    expectCompleted(result);
+  });
+
+  // The deployed graph fans three reviewers straight back into one block, so on
+  // the all-success path every consumption order leads to the same next step
+  // name. A mixed fan-in removes that cover: a failing reviewer reports through
+  // logProbeExecutionErrorStep while a succeeding one writes block statuses.
+  for (const failing of REVIEWS) {
+    it(`fails cleanly when ${failing} fails beside its concurrent siblings`, async () => {
+      const run = await start(probeV2ConcurrentFanOut, [
+        probeInput({ failNodes: [failing] }),
+      ]);
+      const result = (await run.returnValue) as ProbeResult;
+      expect(result.outcome).toBe("failed");
+      expect(result.executionError).toMatchObject({ nodeId: failing });
+    }, 60_000);
+  }
+});
+
+describe("executeV2Graph result-consumption order across replays", () => {
+  // Each branch has its own successor calling a differently named step, so the
+  // order the scheduler consumes results in IS the recorded step-name sequence.
+  //
+  // Only one shape is asserted. Two others (a fast branch settling with the most
+  // microtask hops, and branches differing only in step duration) diverge in
+  // most runs but not all: the flip depends on microtask timing, so an assertion
+  // either way would be flaky. This shape failed in every run observed so far and
+  // is the one a join fix has to make green. Do not read a passing run of a
+  // flaky shape as evidence the join is sound.
+  const RELIABLE_SHAPE: ProbeDivergentSuccessorsInput["branches"] = [
+    { id: "alpha", delayMs: 25, hops: 0 },
+    { id: "beta", delayMs: 12, hops: 80 },
+    { id: "gamma", delayMs: 4, hops: 200 },
+  ];
+
+  it("PINNED FAILING: diverges at concurrency 3 when settle latency is lopsided", async () => {
+    const run = await start(probeV2ConsumptionOrder, [
+      {
+        runId: `probe-order-${randomUUID()}`,
+        maxConcurrency: 3,
+        branches: RELIABLE_SHAPE,
+      },
+    ]);
+    await expectCorruptedEventLog(run);
+  }, 60_000);
+
+  it("completes the same shape one block at a time", async () => {
+    const run = await start(probeV2ConsumptionOrder, [
+      {
+        runId: `probe-order-serial-${randomUUID()}`,
+        maxConcurrency: 1,
+        branches: RELIABLE_SHAPE,
+      },
+    ]);
+    const result = (await run.returnValue) as Awaited<
+      ReturnType<typeof probeV2ConsumptionOrder>
+    >;
+    expect({
+      outcome: result.outcome,
+      executionError: result.executionError,
+    }).toMatchObject({ outcome: "completed", executionError: null });
+    expect(result.consumptionOrder).toHaveLength(6);
+  }, 60_000);
+});
+
+describe("Workflow sleep() under concurrency versus a sleeping step", () => {
+  // Three concurrent blocks, NO successors, so the scheduler's join is out of the
+  // picture and the only variable is what the poll tick suspends on. The loop is
+  // a faithful copy of blocks/poll-phase.ts against a faithful copy of
+  // agent.ts's observeBudgetAtBoundary.
+  function sharedInput(
+    overrides: Partial<ProbeSharedBudgetInput> = {},
+  ): ProbeSharedBudgetInput {
+    return {
+      runId: `probe-budget-${randomUUID()}`,
+      maxConcurrency: 3,
+      limitMs: 900,
+      phaseLimitMs: 1_200,
+      tickMs: 60,
+      gateMode: "sleep",
+      budgetScope: "run-global",
+      blocks: [
+        { id: "alpha", doneAtTick: 9, workUnits: 0 },
+        { id: "beta", doneAtTick: 9, workUnits: 250_000 },
+        { id: "gamma", doneAtTick: 9, workUnits: 1_500_000 },
+      ],
+      ...overrides,
+    };
+  }
+
+  async function runProbe(
+    overrides: Partial<ProbeSharedBudgetInput>,
+  ): Promise<{ returnValue: Promise<unknown> }> {
+    return start(probeV2SharedBudgetGate, [sharedInput(overrides)]);
+  }
+
+  async function expectProbeCompleted(
+    overrides: Partial<ProbeSharedBudgetInput>,
+  ): Promise<void> {
+    const run = await runProbe(overrides);
+    const result = (await run.returnValue) as Awaited<
+      ReturnType<typeof probeV2SharedBudgetGate>
+    >;
+    expect({
+      outcome: result.outcome,
+      executionError: result.executionError,
+    }).toMatchObject({ outcome: "completed", executionError: null });
+  }
+
+  const FIXED_TICK_BLOCKS = [
+    { id: "alpha", doneAtTick: 6, workUnits: 0 },
+    { id: "beta", doneAtTick: 6, workUnits: 250_000 },
+    { id: "gamma", doneAtTick: 6, workUnits: 1_500_000 },
+  ];
+
+  /**
+   * Every way a wait reaches the log, and every attempt to make the wait safe by
+   * changing what feeds it. All pinned failing: the divergence is the SDK
+   * seeding a wait's expected resumeAt from Date.now() and trusting that value
+   * whenever the consumer misses its own wait_created event.
+   */
+  const PINNED_WAIT_VARIANTS: Array<{
+    label: string;
+    overrides: Partial<ProbeSharedBudgetInput>;
+  }> = [
+    {
+      label: "a run-global counter shortens the wait",
+      overrides: { gateMode: "sleep" },
+    },
+    {
+      label: "a run-global counter only decides whether to loop again",
+      overrides: { gateMode: "continue", limitMs: 700, tickMs: 50 },
+    },
+    {
+      label: "the counter is per-invocation and shortens the wait",
+      overrides: { gateMode: "sleep", budgetScope: "per-invocation" },
+    },
+    {
+      label: "the counter is per-invocation and only gates the loop",
+      overrides: {
+        gateMode: "continue",
+        budgetScope: "per-invocation",
+        limitMs: 700,
+        tickMs: 50,
+      },
+    },
+    {
+      label: "there is no counter and every wait is a fixed length",
+      overrides: {
+        gateMode: "constant-wait",
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      },
+    },
+    {
+      label: "the cancellation race is removed entirely",
+      overrides: {
+        gateMode: "constant-wait-no-race",
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      },
+    },
+    {
+      label: "the whole run shares a single tick wait",
+      overrides: {
+        gateMode: "shared-wait",
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      },
+    },
+    {
+      label: "the whole run shares one tick wait and races it",
+      overrides: {
+        gateMode: "shared-wait-race",
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      },
+    },
+  ];
+
+  for (const variant of PINNED_WAIT_VARIANTS) {
+    it(`PINNED FAILING: diverges at concurrency 3 when ${variant.label}`, async () => {
+      await expectCorruptedEventLog(await runProbe(variant.overrides));
+    }, 120_000);
+  }
+
+  // The fix. Identical graph, identical concurrency, identical block asymmetry,
+  // identical tick timings. The only change is that the tick is a step.
+  it("completes at concurrency 3 when the tick is a step and a counter gates the loop", async () => {
+    await expectProbeCompleted({
+      gateMode: "continue-no-wait",
+      limitMs: 700,
+      tickMs: 50,
+    });
+  }, 120_000);
+
+  it("completes at concurrency 3 when the tick is a step and there is no counter", async () => {
+    await expectProbeCompleted({
+      gateMode: "constant-step",
+      tickMs: 40,
+      blocks: FIXED_TICK_BLOCKS,
+    });
+  }, 120_000);
+
+  // The serial baselines: everything above, including every pinned wait variant,
+  // completes when only one block runs at a time. That is what production has
+  // been buying with V2_MAX_BLOCK_CONCURRENCY=1.
+  for (const gateMode of [
+    "sleep",
+    "continue",
+    "continue-no-wait",
+    "constant-wait",
+    "constant-wait-no-race",
+    "constant-step",
+    "shared-wait",
+    "shared-wait-race",
+  ] as const) {
+    it(`completes one block at a time via ${gateMode}`, async () => {
+      await expectProbeCompleted({
+        maxConcurrency: 1,
+        gateMode,
+        tickMs: 40,
+        blocks: FIXED_TICK_BLOCKS,
+      });
+    }, 120_000);
+  }
+});

--- a/apps/worker/workflow-sdk-tests/wdk-sleep-repro.test.ts
+++ b/apps/worker/workflow-sdk-tests/wdk-sleep-repro.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { start } from "workflow/api";
+import {
+  probeConcurrentSleep,
+  type ConcurrentSleepInput,
+} from "../workflow-test-fixtures/wdk-sleep-repro/workflow.js";
+
+// The standalone reproduction to attach to an upstream report. It depends on
+// nothing but the "workflow" package: no scheduler, no graph, no contracts.
+// See the fixture for the diagnosis.
+
+function input(
+  overrides: Partial<ConcurrentSleepInput> = {},
+): ConcurrentSleepInput {
+  return {
+    branches: 3,
+    ticks: 6,
+    tickMs: 40,
+    workUnits: [0, 250_000, 1_500_000],
+    tickKind: "wait",
+    ...overrides,
+  };
+}
+
+async function failureTextOf(run: {
+  returnValue: Promise<unknown>;
+}): Promise<string> {
+  try {
+    await run.returnValue;
+  } catch (error) {
+    return [
+      error instanceof Error ? error.message : String(error),
+      error instanceof Error && error.cause instanceof Error
+        ? error.cause.message
+        : "",
+    ].join("\n");
+  }
+  return "";
+}
+
+describe("Workflow sleep() replay divergence with concurrent branches", () => {
+  it("PINNED FAILING: three branches sleeping concurrently corrupt the event log", async () => {
+    const run = await start(probeConcurrentSleep, [input()]);
+    const text = await failureTextOf(run);
+    expect(text).toContain("Workflow replay diverged");
+    expect(text).toContain("Replay divergence: wait_completed event");
+    expect(text).toContain("but the current wait consumer expects");
+  }, 120_000);
+
+  it("completes with a single branch sleeping", async () => {
+    const run = await start(probeConcurrentSleep, [
+      input({ branches: 1, workUnits: [1_500_000] }),
+    ]);
+    await expect(run.returnValue).resolves.toMatchObject({ branches: 1 });
+  }, 120_000);
+
+  it("completes with three branches when the tick is a step instead of a wait", async () => {
+    const run = await start(probeConcurrentSleep, [input({ tickKind: "step" })]);
+    await expect(run.returnValue).resolves.toMatchObject({ branches: 3 });
+  }, 120_000);
+});

--- a/apps/worker/workflow-test-fixtures/v2-concurrent/workflow.ts
+++ b/apps/worker/workflow-test-fixtures/v2-concurrent/workflow.ts
@@ -1,0 +1,897 @@
+import { createHook } from "workflow";
+import type {
+  BlockOutput,
+  BlockRunState,
+  JsonValue,
+  WorkflowDefinitionV2,
+  WorkflowDefinitionV2Node,
+} from "@shared/contracts";
+import type { V2InvocationObservation } from "../../src/workflow-definition/invocation-context.js";
+import {
+  executeV2Graph,
+  type V2BlockExecutor,
+  type V2InvocationIdentity,
+  type V2SchedulerHooks,
+} from "../../src/workflow-definition/v2-scheduler.js";
+
+// A probe for AIW-233: production pins V2_MAX_BLOCK_CONCURRENCY to 1 because a
+// fan-out of concurrent blocks corrupts the Workflow event log. Everything here
+// mirrors the production agent workflow's shape around executeV2Graph, because
+// the suspected non-determinism lives in the interleaving of step calls made by
+// concurrent invocations, not in any single block:
+//   - the interpreter runs inside a "use workflow" function
+//   - every persistence hook is a real "use step"
+//   - each agent block is a multi-step start/poll/finish chain whose steps take
+//     different real time, so completion order differs from admission order
+//   - scheduler hooks write closure state and then await a step
+//   - replay capture is a fire-and-forget promise chain of steps, exactly like
+//     createV2RunObservationHooks
+
+async function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// --- Steps (each one is a durable event-log entry, like agent.ts's) ---
+
+async function readProbeClockStep(): Promise<number> {
+  "use step";
+  return Date.now();
+}
+readProbeClockStep.maxRetries = 0;
+
+async function recordProbeBlockStatusesStep(payload: {
+  runId: string;
+  blockStatuses: Record<string, BlockRunState>;
+}): Promise<void> {
+  "use step";
+  probeStatusWrites.push(payload.runId);
+}
+recordProbeBlockStatusesStep.maxRetries = 0;
+const probeStatusWrites: string[] = [];
+
+async function startProbeAgentStep(payload: {
+  nodeId: string;
+  delayMs: number;
+}): Promise<{ sandboxId: string }> {
+  "use step";
+  await sleep(payload.delayMs);
+  return { sandboxId: `sbx-${payload.nodeId}` };
+}
+startProbeAgentStep.maxRetries = 0;
+
+async function pollProbeAgentStep(payload: {
+  nodeId: string;
+  tick: number;
+  delayMs: number;
+  ticks: number;
+  flakyOnce: boolean;
+}): Promise<{ done: boolean }> {
+  "use step";
+  await sleep(payload.delayMs);
+  // Production steps retry. A retry adds step_retrying events and moves the
+  // completion of one sibling relative to the others, so the probe covers it.
+  if (payload.flakyOnce) {
+    const key = `${payload.nodeId}:${payload.tick}`;
+    if (!probeFlakedPolls.has(key)) {
+      probeFlakedPolls.add(key);
+      throw new Error(`transient poll failure for ${key}`);
+    }
+  }
+  return { done: payload.tick >= payload.ticks };
+}
+const probeFlakedPolls = new Set<string>();
+
+async function finishProbeAgentStep(payload: {
+  nodeId: string;
+  delayMs: number;
+}): Promise<{ feedback: string }> {
+  "use step";
+  await sleep(payload.delayMs);
+  return { feedback: `${payload.nodeId} reviewed the head commit.` };
+}
+finishProbeAgentStep.maxRetries = 0;
+
+async function runProbeActionStep(payload: {
+  nodeId: string;
+  delayMs: number;
+}): Promise<void> {
+  "use step";
+  await sleep(payload.delayMs);
+}
+runProbeActionStep.maxRetries = 0;
+
+async function persistProbeAttemptStartStep(payload: {
+  nodeId: string;
+  attempt: number;
+  activationScopeId: string;
+}): Promise<number> {
+  "use step";
+  probeAttemptIds += 1;
+  return probeAttemptIds;
+}
+persistProbeAttemptStartStep.maxRetries = 0;
+let probeAttemptIds = 0;
+
+async function persistProbeObservationStep(payload: {
+  attemptId: number;
+  kind: string;
+}): Promise<void> {
+  "use step";
+  probeObservationWrites.push(`${payload.attemptId}:${payload.kind}`);
+}
+persistProbeObservationStep.maxRetries = 0;
+const probeObservationWrites: string[] = [];
+
+async function logProbeExecutionErrorStep(payload: {
+  nodeId: string;
+  diagnosticId: string;
+}): Promise<void> {
+  "use step";
+}
+logProbeExecutionErrorStep.maxRetries = 0;
+
+async function persistProbeAttemptFinishStep(payload: {
+  attemptId: number;
+  state: string;
+}): Promise<void> {
+  "use step";
+}
+persistProbeAttemptFinishStep.maxRetries = 0;
+
+// --- Probe input ---
+
+export interface ProbeConcurrentInput {
+  runId: string;
+  definition: WorkflowDefinitionV2;
+  entryTriggerId: string;
+  triggerOutput: BlockOutput;
+  maxConcurrency: number;
+  /** Per-node step timings, so completion order differs from admission order
+   * the way three real review agents at 104s / 111s / 68s do. */
+  timings: Record<string, { startMs: number; pollMs: number; ticks: number }>;
+  /** Nodes that park on a hook mid-flight, so several blocks suspend at once
+   * and each resumes across a real replay. */
+  parks: Array<{ nodeId: string; token: string; tick: number }>;
+  /** Poll ticks that fail once before succeeding, exercising step retries. */
+  flakyPolls: Array<{ nodeId: string; tick: number }>;
+  /** Synchronous in-VM work per step boundary, standing in for the prompt
+   * compilation and output sanitizing a production block does between steps. */
+  vmWorkPerStep: number;
+  /** Nodes that fail. A failing block reports through a differently named step
+   * than a succeeding one, so on a mixed fan-in the order the scheduler consumes
+   * results in IS the recorded step-name sequence, even though the graph fans
+   * straight back into one block. */
+  failNodes: string[];
+}
+
+interface PendingCapture {
+  attemptId: Promise<number | null>;
+  observations: V2InvocationObservation[];
+  tail: Promise<void>;
+}
+
+export async function probeV2ConcurrentFanOut(input: ProbeConcurrentInput) {
+  "use workflow";
+
+  // Closure state written from inside block execution and from the hooks,
+  // exactly as agent.ts holds it around executeV2Graph.
+  const blockStatuses: Record<string, BlockRunState> = {};
+  const activeBlockIds = new Set<string>();
+  let currentBlockId: string | null = null;
+  const startOrder: string[] = [];
+  const finishOrder: string[] = [];
+  let lastAttempt = 1;
+
+  const writeBlockStatuses = () =>
+    recordProbeBlockStatusesStep({
+      runId: input.runId,
+      blockStatuses: { ...blockStatuses },
+    }).catch(() => {});
+
+  // Fire-and-forget durable capture, mirroring createV2RunObservationHooks:
+  // the scheduler never awaits these, so their step calls land between the
+  // authored blocks' step calls at whatever moment the event loop allows.
+  const captures = new Map<string, PendingCapture>();
+  const captureTasks = new Set<Promise<void>>();
+  const track = (task: Promise<void>): void => {
+    captureTasks.add(task);
+    void task.finally(() => captureTasks.delete(task));
+  };
+  const captureKey = (identity: V2InvocationIdentity): string =>
+    `${identity.activationScopeId}\0${identity.nodeId}\0${identity.attempt}`;
+  const beginCapture = (identity: V2InvocationIdentity): void => {
+    const key = captureKey(identity);
+    if (captures.has(key)) return;
+    captures.set(key, {
+      attemptId: persistProbeAttemptStartStep({
+        nodeId: identity.nodeId,
+        attempt: identity.attempt,
+        activationScopeId: identity.activationScopeId,
+      }).then(
+        (id) => id,
+        () => null,
+      ),
+      observations: [],
+      tail: Promise.resolve(),
+    });
+  };
+  const flushCapture = (identity: V2InvocationIdentity, state: string): void => {
+    const key = captureKey(identity);
+    const capture = captures.get(key);
+    if (!capture) return;
+    captures.delete(key);
+    const observations = capture.observations.splice(0);
+    const task = capture.tail
+      .then(async () => {
+        const attemptId = await capture.attemptId;
+        if (attemptId === null) return;
+        for (const observation of observations) {
+          await persistProbeObservationStep({
+            attemptId,
+            kind: observation.kind,
+          });
+        }
+        await persistProbeAttemptFinishStep({ attemptId, state });
+      })
+      .catch(() => {});
+    capture.tail = task;
+    track(task);
+  };
+
+  const timingFor = (nodeId: string) =>
+    input.timings[nodeId] ?? { startMs: 0, pollMs: 0, ticks: 0 };
+
+  // Deterministic in-VM work: it burns microtasks and CPU between a step
+  // delivery and the next step call, which is where the runtime's grace window
+  // for consuming the next recorded event lives.
+  const burnVmWork = (units: number): number => {
+    let acc = 0;
+    for (let index = 0; index < units; index += 1) {
+      acc = (acc * 31 + index) % 1_000_003;
+    }
+    return acc;
+  };
+  let vmWorkSink = 0;
+
+  const executeBlock: V2BlockExecutor = async (
+    node,
+    _steps,
+    resolvedInputs,
+    invocation,
+  ) => {
+    invocation.cancellation.throwIfCancelled();
+    // The unrecorded closure write AIW-233 suspects: concurrent invocations
+    // clobber each other's value here.
+    lastAttempt = invocation.attempt;
+    const timing = timingFor(node.id);
+
+    if (node.type === "review_agent") {
+      vmWorkSink += burnVmWork(input.vmWorkPerStep);
+      const sandbox = await startProbeAgentStep({
+        nodeId: node.id,
+        delayMs: timing.startMs,
+      });
+      for (let tick = 1; tick <= timing.ticks; tick += 1) {
+        const park = input.parks.find(
+          (entry) => entry.nodeId === node.id && entry.tick === tick,
+        );
+        if (park) {
+          // A real cross-process suspension in the middle of the fan-out: the
+          // siblings keep polling while this one parks on a hook.
+          const hook = createHook<{ answer: string }>({ token: park.token });
+          try {
+            await hook;
+          } finally {
+            hook.dispose();
+          }
+        }
+        vmWorkSink += burnVmWork(input.vmWorkPerStep);
+        const poll = await pollProbeAgentStep({
+          nodeId: node.id,
+          tick,
+          delayMs: timing.pollMs,
+          ticks: timing.ticks,
+          flakyOnce: input.flakyPolls.some(
+            (entry) => entry.nodeId === node.id && entry.tick === tick,
+          ),
+        });
+        if (poll.done) break;
+      }
+      vmWorkSink += burnVmWork(input.vmWorkPerStep);
+      if (input.failNodes.includes(node.id)) {
+        return {
+          kind: "execution_error",
+          error: {
+            nodeId: node.id,
+            category: "provider",
+            message: "The review agent could not complete.",
+            detail: `${node.id} failed`,
+          },
+        } as Awaited<ReturnType<V2BlockExecutor>>;
+      }
+      const finished = await finishProbeAgentStep({
+        nodeId: node.id,
+        delayMs: timing.pollMs,
+      });
+      return {
+        kind: "next",
+        output: {
+          status: "reviewed",
+          decision: "approve",
+          feedback: `${finished.feedback} (${sandbox.sandboxId})`,
+          findings: [],
+        },
+      };
+    }
+
+    await runProbeActionStep({ nodeId: node.id, delayMs: timing.startMs });
+    switch (node.type) {
+      case "create_pr_check":
+        return {
+          kind: "next",
+          output: {
+            status: "ok",
+            check: { id: "check-1", headSha: "abc123", name: "AI / Review" },
+          },
+        };
+      case "prepare_workspace":
+        return {
+          kind: "next",
+          output: {
+            status: "ok",
+            sandboxId: "sbx-probe",
+            repositories: ["github:acme/app"],
+            workspace: {
+              id: "sbx-probe",
+              repositories: ["github:acme/app"],
+            },
+          },
+        };
+      case "post_pr_review":
+        return {
+          kind: "next",
+          output: {
+            status: "ok",
+            decision: "approve",
+            summary: "Every review approved this commit.",
+            inlineCommentCount: 0,
+            summaryFallbackCount: 0,
+          },
+        };
+      case "complete_pr_check":
+        return {
+          kind: "next",
+          output: {
+            status: "ok",
+            check: resolvedInputs.check as BlockOutput[string],
+            conclusion: node.configuration.conclusion ?? "success",
+          },
+        };
+      default:
+        return { kind: "next", output: { status: "ok" } };
+    }
+  };
+
+  const hooks: V2SchedulerHooks = {
+    onTriggerActivated(event) {
+      beginCapture(event);
+      flushCapture(event, "completed");
+    },
+    async onNodeStart(event) {
+      // agent.ts's onBlockStart: a budget step, then closure writes, then a
+      // status step. Order matters because siblings run the same code.
+      await readProbeClockStep();
+      currentBlockId = event.nodeId;
+      activeBlockIds.add(event.nodeId);
+      startOrder.push(event.nodeId);
+      blockStatuses[event.nodeId] = {
+        status: "running",
+        attempt: event.attempt,
+      };
+      await writeBlockStatuses();
+      beginCapture(event);
+    },
+    async onNodeFinish(event) {
+      flushCapture(event, event.runtimeState);
+      blockStatuses[event.nodeId] = event.state;
+      finishOrder.push(event.nodeId);
+      await writeBlockStatuses();
+      activeBlockIds.delete(event.nodeId);
+      // Set iteration order is insertion order, so this reads back whichever
+      // sibling happened to start last in wall-clock terms.
+      currentBlockId = [...activeBlockIds].at(-1) ?? null;
+      await readProbeClockStep();
+    },
+    async onNodeSkipped(event) {
+      blockStatuses[event.nodeId] = { status: "ok", attempt: event.attempt };
+      await writeBlockStatuses();
+    },
+    async onExecutionError(event) {
+      // agent.ts logs a failure through its own step, which is a different step
+      // name from the status write a success takes.
+      await logProbeExecutionErrorStep({
+        nodeId: event.state.nodeId,
+        diagnosticId: event.state.diagnosticId,
+      });
+    },
+    observationHooksFor: (identity) => {
+      const capture = captures.get(captureKey(identity));
+      return {
+        emit(observation) {
+          if (!capture) return;
+          capture.observations.push(structuredClone(observation));
+        },
+      };
+    },
+  };
+
+  const walk = await executeV2Graph({
+    runId: input.runId,
+    definition: input.definition,
+    entryTriggerId: input.entryTriggerId,
+    triggerOutput: input.triggerOutput,
+    executeBlock,
+    hooks,
+    maxConcurrency: input.maxConcurrency,
+  });
+
+  await Promise.allSettled([...captureTasks]);
+
+  return {
+    outcome: walk.outcome,
+    executionError: walk.executionError ?? null,
+    startOrder,
+    finishOrder,
+    currentBlockId,
+    lastAttempt,
+    statusWrites: probeStatusWrites.length,
+    observationWrites: probeObservationWrites.length,
+    vmWorkSink,
+    blockStatuses: walk.state.scopes.root
+      ? Object.fromEntries(
+          Object.entries(walk.state.scopes.root.nodeStates).map(
+            ([nodeId, nodeState]) => [nodeId, nodeState.status],
+          ),
+        )
+      : {},
+  };
+}
+
+// --- Probe 2: does result-consumption order survive a replay? ---
+//
+// The fan-out probe above cannot answer that, and this is why: post-pr-review
+// fans three reviewers straight back into one Post PR review block, so whichever
+// order the scheduler consumes the three results in, the next step call is the
+// same one. Consuming out of order is therefore invisible to the runtime's
+// divergence check, which compares the step NAME behind a correlation id, not
+// its arguments.
+//
+// This probe removes that cover: each concurrent block has its own successor,
+// and each successor calls a DIFFERENTLY NAMED step. Now consumption order is
+// the step-name sequence. If the scheduler's Promise.race over the running
+// invocations can pick a different winner on a replay than the event log
+// recorded, this run must die with a replay divergence.
+//
+// The asymmetry is deliberate: after its own step resolves, each block burns a
+// different number of microtask hops before its invocation promise settles.
+// That is the exact hazard the SDK documents for hook/wait deliveries and
+// guards with pendingDeliveryBarriers, a mechanism that covers hook and wait
+// deliveries only, never step completions.
+
+async function branchStepAlpha(delayMs: number): Promise<string> {
+  "use step";
+  await sleep(delayMs);
+  return "alpha";
+}
+branchStepAlpha.maxRetries = 0;
+
+async function branchStepBeta(delayMs: number): Promise<string> {
+  "use step";
+  await sleep(delayMs);
+  return "beta";
+}
+branchStepBeta.maxRetries = 0;
+
+async function branchStepGamma(delayMs: number): Promise<string> {
+  "use step";
+  await sleep(delayMs);
+  return "gamma";
+}
+branchStepGamma.maxRetries = 0;
+
+async function successorStepAlpha(): Promise<string> {
+  "use step";
+  return "alpha-done";
+}
+successorStepAlpha.maxRetries = 0;
+
+async function successorStepBeta(): Promise<string> {
+  "use step";
+  return "beta-done";
+}
+successorStepBeta.maxRetries = 0;
+
+async function successorStepGamma(): Promise<string> {
+  "use step";
+  return "gamma-done";
+}
+successorStepGamma.maxRetries = 0;
+
+export interface ProbeDivergentSuccessorsInput {
+  runId: string;
+  maxConcurrency: number;
+  /** Per-branch step delay and post-step microtask hop count. */
+  branches: Array<{ id: string; delayMs: number; hops: number }>;
+}
+
+function genericNode(id: string): WorkflowDefinitionV2Node {
+  return {
+    id,
+    type: "generic_agent",
+    x: 0,
+    y: 0,
+    configuration: { workspaceMode: "none" } as Record<string, JsonValue>,
+    inputs: {},
+    additionalInputs: [],
+  };
+}
+
+export async function probeV2ConsumptionOrder(
+  input: ProbeDivergentSuccessorsInput,
+) {
+  "use workflow";
+
+  const branchSteps: Record<string, (delayMs: number) => Promise<string>> = {
+    alpha: branchStepAlpha,
+    beta: branchStepBeta,
+    gamma: branchStepGamma,
+  };
+  const successorSteps: Record<string, () => Promise<string>> = {
+    alpha: successorStepAlpha,
+    beta: successorStepBeta,
+    gamma: successorStepGamma,
+  };
+
+  const nodes: WorkflowDefinitionV2Node[] = [
+    {
+      id: "trigger",
+      type: "trigger_ticket_ai",
+      x: 0,
+      y: 0,
+      configuration: {},
+      inputs: {},
+      additionalInputs: [],
+    },
+  ];
+  const edges: WorkflowDefinitionV2["edges"] = [];
+  for (const branch of input.branches) {
+    nodes.push(genericNode(branch.id), genericNode(`${branch.id}-next`));
+    edges.push({ id: `trigger-${branch.id}`, from: "trigger", to: branch.id });
+    edges.push({
+      id: `${branch.id}-next-edge`,
+      from: branch.id,
+      to: `${branch.id}-next`,
+    });
+  }
+
+  const consumptionOrder: string[] = [];
+  const executeBlock: V2BlockExecutor = async (node) => {
+    const branch = input.branches.find((entry) => entry.id === node.id);
+    if (branch) {
+      await branchSteps[branch.id]!(branch.delayMs);
+      // Asymmetric settle latency: the invocation promise this block hands to
+      // the scheduler's Promise.race resolves a different number of microtask
+      // hops after its step did.
+      for (let hop = 0; hop < branch.hops; hop += 1) {
+        await Promise.resolve();
+      }
+      return { kind: "next", output: { status: "completed", body: node.id } };
+    }
+    const successorId = node.id.replace(/-next$/, "");
+    await successorSteps[successorId]!();
+    return { kind: "next", output: { status: "completed", body: node.id } };
+  };
+
+  const walk = await executeV2Graph({
+    runId: input.runId,
+    definition: { schemaVersion: 2, nodes, edges },
+    entryTriggerId: "trigger",
+    triggerOutput: { status: "fired", ticket: { identifier: "AIW-1" } },
+    executeBlock,
+    maxConcurrency: input.maxConcurrency,
+    hooks: {
+      onNodeFinish(event) {
+        // Records the order the scheduler consumed the results in, which is the
+        // order it admitted the successors in.
+        consumptionOrder.push(event.nodeId);
+      },
+    },
+  });
+
+  return {
+    outcome: walk.outcome,
+    executionError: walk.executionError ?? null,
+    consumptionOrder,
+  };
+}
+
+// --- Probe 3: the shared budget counter that gates step calls ---
+//
+// This is the production shape from run wrun_01KZ9AZCJY5GSPM9X3F4J8RH26, whose
+// divergence named two steps called from INSIDE concurrent blocks
+// (writeAndStartPhase against readRunBudgetClockStep), never a successor's step.
+//
+// It mirrors agent.ts:2941-2952 and blocks/poll-phase.ts:25-87 exactly:
+//   observeSharedBudget() is observeBudgetAtBoundary: a read-modify-write of
+//   run-global activeElapsedMs / lastClockMs across an await on a clock step.
+//   Every concurrently running block calls it from its own poll loop.
+//   pollLoop() is pollPhaseUntilDone: it derives its sleep length from that
+//   run-global remainingDurationMs, adds it to a local phase counter, and loops
+//   until the counter reaches the cap. So the run-global counter decides HOW
+//   MANY times each block calls its steps.
+//
+// The graph deliberately has NO successors after the concurrent blocks. If this
+// diverges, the scheduler's join cannot be the cause and the shared counter is.
+
+async function probeReadClockStep(): Promise<number> {
+  "use step";
+  // agent.ts's readRunBudgetClockStep: a real wall clock, recorded per call.
+  return Date.now();
+}
+probeReadClockStep.maxRetries = 0;
+
+async function probeStartPhaseStep(payload: { nodeId: string }): Promise<string> {
+  "use step";
+  return `${payload.nodeId}-command`;
+}
+probeStartPhaseStep.maxRetries = 0;
+
+async function probeTickStep(payload: { ms: number }): Promise<void> {
+  "use step";
+  await sleep(payload.ms);
+}
+probeTickStep.maxRetries = 0;
+
+async function probeCheckDoneStep(payload: {
+  nodeId: string;
+  tick: number;
+  doneAtTick: number;
+}): Promise<boolean> {
+  "use step";
+  return payload.tick >= payload.doneAtTick;
+}
+probeCheckDoneStep.maxRetries = 0;
+
+export interface ProbeSharedBudgetInput {
+  runId: string;
+  maxConcurrency: number;
+  /** The run-global duration budget, the thing every block charges against. */
+  limitMs: number;
+  /** Per-block poll cap, pollPhaseUntilDone's maxMinutes. */
+  phaseLimitMs: number;
+  /** The 30s poll tick. */
+  tickMs: number;
+  /**
+   * Which way the shared counter reaches the event log.
+   *  - "sleep": it shortens the wait, exactly as poll-phase.ts:35 does, so a
+   *    divergent counter shows up as a differing wait resumeAt.
+   *  - "continue": every wait is the full tick and the counter only decides
+   *    whether to loop again, as poll-phase.ts:36 and :75 also do.
+   *  - "continue-no-wait": as "continue", but the tick is a sleeping STEP rather
+   *    than a workflow wait. With no wait in the loop the runtime has no
+   *    resumeAt to check, so the only signal left is the global step index, and
+   *    the divergence surfaces as the production error text: a step_created
+   *    belonging to one function consumed by another.
+   */
+  gateMode:
+    | "sleep"
+    | "continue"
+    | "continue-no-wait"
+    | "constant-wait"
+    | "constant-wait-no-race"
+    | "constant-step"
+    | "shared-wait"
+    | "shared-wait-race";
+  /**
+   * Where the elapsed-time counter lives. "run-global" is production today:
+   * agent.ts:2939-2946 holds budgetState and lastBudgetClockMs outside every
+   * block, so concurrent blocks interleave their read-modify-writes into it.
+   * "per-invocation" gives each block its own, which is the proposed fix.
+   */
+  budgetScope: "run-global" | "per-invocation";
+  blocks: Array<{ id: string; doneAtTick: number; workUnits: number }>;
+}
+
+export async function probeV2SharedBudgetGate(input: ProbeSharedBudgetInput) {
+  "use workflow";
+
+  // The run-global budget state agent.ts holds outside every block.
+  let activeElapsedMs = 0;
+  let lastClockMs = await probeReadClockStep();
+
+  interface BudgetCell {
+    activeElapsedMs: number;
+    lastClockMs: number;
+  }
+  const perInvocation = new Map<string, BudgetCell>();
+
+  // Both scopes make the SAME number of clock step calls in the same places, so
+  // the only difference between them is whether siblings share the accumulator.
+  const observeBudget = async (nodeId: string): Promise<number> => {
+    const now = await probeReadClockStep();
+    if (input.budgetScope === "run-global") {
+      activeElapsedMs += Math.max(0, now - lastClockMs);
+      lastClockMs = Math.max(lastClockMs, now);
+      return Math.max(0, input.limitMs - activeElapsedMs);
+    }
+    const cell = perInvocation.get(nodeId) ?? {
+      activeElapsedMs: 0,
+      lastClockMs: now,
+    };
+    cell.activeElapsedMs += Math.max(0, now - cell.lastClockMs);
+    cell.lastClockMs = Math.max(cell.lastClockMs, now);
+    perInvocation.set(nodeId, cell);
+    return Math.max(0, input.limitMs - cell.activeElapsedMs);
+  };
+
+  const burn = (units: number): number => {
+    let acc = 0;
+    for (let index = 0; index < units; index += 1) {
+      acc = (acc * 31 + index) % 1_000_003;
+    }
+    return acc;
+  };
+  let burnSink = 0;
+
+  const nodes: WorkflowDefinitionV2Node[] = [
+    {
+      id: "trigger",
+      type: "trigger_ticket_ai",
+      x: 0,
+      y: 0,
+      configuration: {},
+      inputs: {},
+      additionalInputs: [],
+    },
+  ];
+  const edges: WorkflowDefinitionV2["edges"] = [];
+  for (const block of input.blocks) {
+    nodes.push(genericNode(block.id));
+    edges.push({ id: `trigger-${block.id}`, from: "trigger", to: block.id });
+  }
+
+  const ticksByNode: Record<string, number> = {};
+  const { sleep: workflowSleep } = await import("workflow");
+  // Stands in for the invocation cancellation promise poll-phase.ts races the
+  // sleep against. It never resolves in a healthy run, exactly like the real one.
+  const cancellationOf = (_nodeId: string): Promise<void> =>
+    new Promise<void>(() => {});
+
+  // One tick wait per RUN rather than one per block. Whichever poller reaches
+  // the tick first creates the single sleep; the others await the same promise,
+  // so the runtime only ever has one wait in flight and only ever installs one
+  // wait consumer. The slot is cleared when the wait resolves so the next tick
+  // creates the next one.
+  let sharedTickWait: Promise<void> | null = null;
+  let sharedTickCreations = 0;
+  const awaitSharedTick = async (ms: number): Promise<void> => {
+    if (!sharedTickWait) {
+      sharedTickCreations += 1;
+      const pending = workflowSleep(`${ms}ms`).then(() => {
+        if (sharedTickWait === pending) sharedTickWait = null;
+      });
+      sharedTickWait = pending;
+    }
+    await sharedTickWait;
+  };
+
+  const executeBlock: V2BlockExecutor = async (node) => {
+    const block = input.blocks.find((entry) => entry.id === node.id)!;
+    burnSink += burn(block.workUnits);
+    await probeStartPhaseStep({ nodeId: node.id });
+
+    // The controls that remove the shared counter entirely: a fixed number of
+    // fixed-length waits, so nothing in the loop reads any mutable state. If
+    // these diverge, concurrent waits alone are the cause and no amount of
+    // budget-state scoping can fix it. "constant-wait" keeps
+    // poll-phase.ts:50-53's Promise.race against the cancellation promise;
+    // "constant-wait-no-race" awaits the wait directly.
+    if (
+      input.gateMode === "constant-wait" ||
+      input.gateMode === "constant-wait-no-race" ||
+      input.gateMode === "constant-step" ||
+      input.gateMode === "shared-wait" ||
+      input.gateMode === "shared-wait-race"
+    ) {
+      for (let tick = 1; tick <= block.doneAtTick; tick += 1) {
+        burnSink += burn(block.workUnits);
+        if (input.gateMode === "constant-wait") {
+          const cancelled = await Promise.race([
+            workflowSleep(`${input.tickMs}ms`).then(() => false),
+            cancellationOf(node.id).then(() => true),
+          ]);
+          if (cancelled) break;
+        } else if (input.gateMode === "shared-wait") {
+          await awaitSharedTick(input.tickMs);
+        } else if (input.gateMode === "shared-wait-race") {
+          const cancelled = await Promise.race([
+            awaitSharedTick(input.tickMs).then(() => false),
+            cancellationOf(node.id).then(() => true),
+          ]);
+          if (cancelled) break;
+        } else if (input.gateMode === "constant-step") {
+          // Identical shape, identical timing, but the tick is a step rather
+          // than a workflow wait. This is the only variable that changes.
+          await probeTickStep({ ms: input.tickMs });
+        } else {
+          await workflowSleep(`${input.tickMs}ms`);
+        }
+        await probeCheckDoneStep({
+          nodeId: node.id,
+          tick,
+          doneAtTick: block.doneAtTick,
+        });
+      }
+      ticksByNode[node.id] = block.doneAtTick;
+      return {
+        kind: "next",
+        output: { status: "completed", body: node.id },
+      };
+    }
+    let phaseElapsedMs = 0;
+    let ticks = 0;
+    while (phaseElapsedMs < input.phaseLimitMs) {
+      const remainingDurationMs = await observeBudget(node.id);
+      const sleepMs =
+        input.gateMode === "sleep"
+          ? Math.min(
+              input.tickMs,
+              input.phaseLimitMs - phaseElapsedMs,
+              remainingDurationMs,
+            )
+          : Math.min(input.tickMs, input.phaseLimitMs - phaseElapsedMs);
+      if (sleepMs <= 0 || remainingDurationMs <= 0) break;
+      // Asymmetric work between the shared read-modify-write and the next step
+      // call, which is what production has as prompt compilation and sanitizing.
+      burnSink += burn(block.workUnits);
+      if (input.gateMode === "continue-no-wait") {
+        await probeTickStep({ ms: Math.ceil(sleepMs) });
+      } else {
+        await workflowSleep(`${Math.ceil(sleepMs)}ms`);
+      }
+      phaseElapsedMs += sleepMs;
+      ticks += 1;
+      if ((await observeBudget(node.id)) <= 0) break;
+      const done = await probeCheckDoneStep({
+        nodeId: node.id,
+        tick: ticks,
+        doneAtTick: block.doneAtTick,
+      });
+      if (done) break;
+    }
+    ticksByNode[node.id] = ticks;
+    return {
+      kind: "next",
+      output: { status: "completed", body: `${node.id}:${ticks}` },
+    };
+  };
+
+  const walk = await executeV2Graph({
+    runId: input.runId,
+    definition: { schemaVersion: 2, nodes, edges },
+    entryTriggerId: "trigger",
+    triggerOutput: { status: "fired", ticket: { identifier: "AIW-1" } },
+    executeBlock,
+    maxConcurrency: input.maxConcurrency,
+  });
+
+  return {
+    outcome: walk.outcome,
+    executionError: walk.executionError ?? null,
+    ticksByNode,
+    activeElapsedMs,
+    sharedTickCreations,
+    burnSink,
+  };
+}

--- a/apps/worker/workflow-test-fixtures/v2-concurrent/workflow.ts
+++ b/apps/worker/workflow-test-fixtures/v2-concurrent/workflow.ts
@@ -398,8 +398,12 @@ export async function probeV2ConcurrentFanOut(input: ProbeConcurrentInput) {
       finishOrder.push(event.nodeId);
       await writeBlockStatuses();
       activeBlockIds.delete(event.nodeId);
-      // Set iteration order is insertion order, so this reads back whichever
-      // sibling happened to start last in wall-clock terms.
+      // Deliberately still the pre-fix shape that agent.ts carried when the
+      // corrupted production runs happened, not the soleActiveBlockId rule that
+      // replaced it. This probe's job is to be faithful to those runs, so it
+      // keeps reading back whichever sibling happened to start last in wall-clock
+      // terms. Do not "modernize" this line: agent.ts is where the rule lives and
+      // agent-budget.test.ts is where it is asserted.
       currentBlockId = [...activeBlockIds].at(-1) ?? null;
       await readProbeClockStep();
     },

--- a/apps/worker/workflow-test-fixtures/wdk-sleep-repro/workflow.ts
+++ b/apps/worker/workflow-test-fixtures/wdk-sleep-repro/workflow.ts
@@ -1,0 +1,91 @@
+import { sleep } from "workflow";
+
+// Minimal, standalone reproduction of a Workflow DevKit replay divergence.
+//
+// Diagnosis: createSleep seeds resumeAt from Date.now() and treats a missing
+// wait_created as licence to trust the recomputed value.
+//
+// In @workflow/core, createSleep computes the wait's expected resumeAt with
+// parseDurationToDate(param), which is new Date(Date.now() + durationMs). The
+// consumer overwrites that expectation only when it consumes its own
+// wait_created event; when it does not, the wait_completed check falls back to
+// the locally recomputed wall-clock value and compares it against the recorded
+// one. Those can never be equal.
+//
+// With several concurrent branches in one run, the events drain can pass a
+// wait_created before the owning branch's continuation has reinstalled its wait
+// consumer, because that continuation is queued behind other branches'
+// deliveries. The run then fails with:
+//
+//   Replay divergence: wait_completed event for wait_... has resumeAt "...",
+//   but the current wait consumer expects "..."
+//
+// and, after the runtime's recovery replays, with CORRUPTED_EVENT_LOG.
+//
+// Depends on nothing but the "workflow" package. Run one branch and it passes;
+// run several and it fails. Replace the sleep with the sleeping step below and
+// several branches pass, which isolates the wait as the cause.
+
+/** A durable step, for comparison: replay hands back its recorded result. */
+async function recordTickStep(label: string): Promise<string> {
+  "use step";
+  return label;
+}
+
+/** The same tick as a step that sleeps, rather than as a workflow wait. */
+async function sleepingTickStep(ms: number): Promise<void> {
+  "use step";
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Synchronous work between a delivery and the next suspension point. Branches
+ * burn different amounts, which is what real concurrent work looks like and what
+ * makes one branch's continuation lag behind another's.
+ */
+function burn(units: number): number {
+  let acc = 0;
+  for (let index = 0; index < units; index += 1) {
+    acc = (acc * 31 + index) % 1_000_003;
+  }
+  return acc;
+}
+
+export interface ConcurrentSleepInput {
+  /** How many branches run at once. 1 passes, 3 fails. */
+  branches: number;
+  /** Poll iterations per branch. */
+  ticks: number;
+  /** Tick length in milliseconds. */
+  tickMs: number;
+  /** Per-branch synchronous work, so the branches are not symmetric. */
+  workUnits: number[];
+  /** "wait" uses sleep(); "step" uses a step that sleeps for the same time. */
+  tickKind: "wait" | "step";
+}
+
+export async function probeConcurrentSleep(input: ConcurrentSleepInput) {
+  "use workflow";
+
+  const runBranch = async (branch: number): Promise<string> => {
+    const units = input.workUnits[branch] ?? 0;
+    let last = "";
+    for (let tick = 0; tick < input.ticks; tick += 1) {
+      burn(units);
+      if (input.tickKind === "wait") {
+        await sleep(`${input.tickMs}ms`);
+      } else {
+        await sleepingTickStep(input.tickMs);
+      }
+      last = await recordTickStep(`b${branch}t${tick}`);
+    }
+    return last;
+  };
+
+  const results = await Promise.all(
+    Array.from({ length: input.branches }, (_unused, branch) =>
+      runBranch(branch),
+    ),
+  );
+  return { branches: results.length, last: results };
+}


### PR DESCRIPTION
Production runs with `V2_MAX_BLOCK_CONCURRENCY=1` because concurrency corrupted the run's event log and discarded the run. Restoring it is worth 45 to 50 percent of the wall clock of every review run (measured: three reviewers at 104/111/68s, 148/112/72s and 73/76/75s, serialized against parallel).

Two prior attempts failed. This one starts from a local reproduction and a control matrix instead of a theory.

## The cause, established by experiment

**Any WDK `sleep()` at all, while blocks run concurrently.** Not the number of waits, not shared mutable state, not `Promise.race`.

`@workflow/core/dist/workflow/sleep.js` seeds the expected `resumeAt` from the real wall clock (`new Date(Date.now() + ms)`), and corrects it only if that same consumer consumes its own `wait_created`. Under concurrency the events consumer's drain passes a `wait_created` before the owning block's continuation has reinstalled its wait consumer, because that continuation sits behind other blocks' deliveries on `ctx.promiseQueue`. The expectation stays the wall-clock value, and comparing a fresh `Date.now()` against a recording can never match. Steps are immune: `step.js` recomputes nothing and compares only the step name.

Control matrix, every row green at concurrency 1:

| variant | conc 3 |
|---|---|
| run-global counter shortens the wait | fails |
| run-global counter gates only the loop | fails |
| **run-global counter, tick is a step** | **passes** |
| per-invocation counter, either shape | fails |
| no counter, fixed waits, with or without the cancellation race | fails |
| one shared tick wait for the whole run | fails |
| **no counter, ticks are steps** | **passes** |

Row 3 is the load-bearing one: it keeps a run-global counter shared by three concurrent blocks deciding how many steps each calls, and passes. So in-memory interleaving IS reproduced once every suspension point is a step. It also explains why a previous PR that made the sleep budget-derived changed nothing: duration is irrelevant.

## Three commits

**1. Poll an agent phase through a step.** `poll-phase.ts` held the only WDK `sleep()` in the repository (swept; GitLab's `sleep` is a local `setTimeout` inside a step). It becomes `delayPhasePollStep`. Confirmed to the primitive that `cancellation.wait()` is a plain in-process promise emitting no event, so the poll loop now suspends on steps only.

**2. Report the engine when several blocks are active at a failure.** `currentBlockId` was written unconditionally on block start and read back as `[...activeBlockIds].at(-1)`, so a concurrent run blamed whichever sibling was inserted last for a run-level failure. Now a single `soleActiveBlockId` helper returns the one block in flight or `null`, and `null` already means "engine".

**3. Consume block results in declaration order.** A separate defect, reachable on any graph where a concurrent block has its own successor, which the editor allows. The scheduler still races every unsettled invocation, so liveness and the deadlock canary are untouched, but consumption takes the head, the lowest `(scope.sequence, nodeOrder)` still running, and `sortReadyQueue` demotes `readySequence` to the final tiebreak. Both inputs are definition data, so there is no timing input left and no empirical assumption to defend. Progress is structural: each iteration either consumes the head or races a strictly smaller set.

A design based on crossing a macrotask boundary was approved and then abandoned as unbuildable: the workflow VM replaces `setTimeout`, `setInterval` and `setImmediate` with functions that throw, and the SDK's own comment forbids downgrading that boundary to a microtask.

## Accepted tradeoffs

- A finished block holds its concurrency slot until earlier-ordered running blocks are consumed. Zero cost on a pure fan-in like post-pr-review, since the join needs all branches anyway. Latency, not correctness, where a branch has its own successor.
- Failure promotion stays deliberately un-ordered so a failure can stop siblings burning budget. The run ends either way, so no later step sequence depends on which failure won.

## Verification

`v2-scheduler.test.ts` 28 passed, including the existing deadlock canary and a NEW permanent canary with the declaration order reversed, so the block parked forever on `cancellation.wait()` is the head. `src/workflow-definition/` in full: 37 files, 771 passed. `pnpm test:workflow-sdk`: 5 files, 46 passed. `agent-budget`, telemetry, terminal-disposition, poll-phase, step-registration and import-boundary: 38 passed. `pnpm typecheck` clean.

Both fixture sets are committed. Nine matrix rows assert the divergence rather than its absence, so they fail loudly if the SDK is ever fixed and this workaround can be removed. Three rows are green because of the fix. `wdk-sleep-repro` imports nothing but `workflow` and is the standalone upstream reproduction.

## Not in this PR

`V2_MAX_BLOCK_CONCURRENCY` is unchanged, and the comments in `v2-scheduler.test.ts` and `env.ts` still say production is serialized. The env lever and those comments come off together after a production canary at raised concurrency.

Two semantic defects found during the audit are deliberately left for separate tickets: budget accounting under-counts by up to Nx under concurrency because `addActiveElapsed` advances one run-global cursor, and two once-guards are set after the await they guard so concurrent blocks can both perform an idempotent write.

## Added after review

A fourth commit fixes a regression commit 3 introduced and adds the canary the reviewer's probe showed was missing.

**A settled sibling's real outcome is now recorded when a run ends early.** Before it, a block that finished successfully while an earlier-ordered sibling failed was recorded as `cancelled` with its output dropped, even though its side effects (posted comments, created check runs) had already happened. So the run record contradicted the pull request on exactly the runs somebody triages. Only `next` and `ended` get their true terminal state; `needs_human_input` stays `cancelled`, because a block that asked a question genuinely did not finish its work. Port propagation and output revalidation are both deliberately skipped, and the code says why, so a downstream block cannot be admitted on the strength of a run that is ending and a contract complaint cannot bury the real cause.

**New canary: a failure raised behind a parked head block.** Both existing canaries exercise the rethrow path. The branch that fires when a review agent fails behind a slower earlier-declared sibling is the promotion path, and no unit test reached it. `schedulerCancellation.cancel()` in `failNode` is what unparks the head, verified from source rather than assumed.

Three comment nits also landed: the held-compute tradeoff of the sleeping step (up to 50 invocations per phase per block against a 30s ceiling, billed as invocations and provisioned memory rather than active CPU, coupled to the deployed `maxDuration`), the retry accounting (`maxRetries` default 3 means up to four attempts advancing `phaseElapsedMs` once, so `maxMinutes` is a floor and the run-global duration budget is the real bound), and why the probe fixture deliberately keeps the pre-commit-2 `currentBlockId` shape.

**Second accepted tradeoff, stated explicitly:** failure promotion is deliberately not replay-stable. A failed block short-circuits ahead of its turn so it can stop siblings burning budget, so which of several simultaneous failures becomes `primaryFailure` is not deterministic. The run ends either way, so no later step sequence depends on it.

Verification after this commit: `src/workflow-definition/` plus the touched workflow tests, 41 files and 793 passed; `pnpm --filter worker test:workflow-sdk`, 5 files and 46 passed; `v2-scheduler.test.ts` 30 passed with three canaries; typecheck clean.
