### PR TITLE
fix(worker): count a single merged review finding in the singular

### DIFF
--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -1338,6 +1338,10 @@ describe("PR review publication scrub", () => {
     expect(publishPRReview.mock.calls[0]![1].comments[0]!.body).toContain(
       "Reported by 2 of 2 reviewers.",
     );
+    // Two reports collapsing into one defect is the most common shape this line
+    // reports, and it read "1 distinct findings" on a real client pull request.
+    expect(result.summary).toContain("1 distinct finding merged from 2");
+    expect(result.summary).not.toContain("1 distinct findings");
   });
 
   // The regression the new rule exists for. One reviewer's High used to fail the

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -768,9 +768,12 @@ function reviewSummary(
     .filter((value): value is string => Boolean(value));
   const lines = ["## AI Workflow review"];
   if (counts.reportedCount > counts.distinctCount) {
+    // Singular when three reviewers all described one defect, which is the most
+    // common shape this line reports and the one a reader sees first.
+    const noun = counts.distinctCount === 1 ? "finding" : "findings";
     lines.push(
       "",
-      `_${counts.distinctCount} distinct findings merged from ${counts.reportedCount} reported by ${results.length} reviewers._`,
+      `_${counts.distinctCount} distinct ${noun} merged from ${counts.reportedCount} reported by ${results.length} reviewers._`,
     );
   }
   if (fallback.length > 0) {


### PR DESCRIPTION
Found on a live client pull request during a production stability round, not in a test.

The published review summary on PR 316 read:

```
_1 distinct findings merged from 2 reported by 3 reviewers._
```

Two reviewers describing one defect is the most common shape this line reports, so the singular case is the one a reader hits most often. Nothing pinned the string, so it shipped.

This is the same defect class as the withheld-findings heading fixed earlier today in a different line of the same function, which is why the new assertion is negative as well as positive: it fails both if the noun stops agreeing and if the plural form comes back.

## Verification

`pr-external-resources.test.ts`: 37 passed. The assertion rides on the existing two-reviewer merge test, which already produces exactly `distinctCount === 1` with `reportedCount === 2`, so it covers the real shape rather than a synthetic one.