### PR TITLE
chore(ci): raise the ci job ceiling above the measured suite duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,14 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # `pnpm run test` alone measured 16:52, 17:52, 17:55 and 18:58 across four
+    # branches on one day, so a 20 minute job left one to three minutes for
+    # everything else and cancelled mid-step whenever a runner was slow. A
+    # cancelled check reads as neither red nor green, which is worse than a
+    # failure: it is easy to merge past. The suite's cost is dominated by
+    # per-file database setup rather than test count, so this ceiling has to
+    # cover that until the database fixture is shared.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
The `ci` job has been cancelling mid-step, and a cancelled check is worse than a failing one: it reads as neither red nor green, so it is easy to merge past. Three consecutive runs on one branch died at exactly 20:00 with everything green up to the last step.

## Measurement, not guesswork

Per-step timings from a cancelled run:

```
Set up job + checkout + pnpm + node + install     0:45
Run pnpm run typecheck                            0:24
Run pnpm run test                                18:17
Run pnpm run test:release-notes                   0:03
Run pnpm run test:workflow-sdk          CANCELLED after 68s
```

`pnpm run test` alone, across four different branches on the same day:

| branch | duration |
|---|---|
| `fix/singular-merged-finding-2` | 16:52 |
| `outof-place/aiw-232-...` | 17:52 |
| `feat/merge-review-summary-prose` | 17:55 |
| `feat/review-gate-and-round-keyed-publication` | 18:58 |

So the shared suite consumes 84 to 95 percent of a 20 minute budget on its own, leaving one to three minutes for install, typecheck, release notes and the workflow SDK suite. Every pull request in the repository is one slow runner away from a spurious cancellation, and the two-line change in #220 passed only because its run happened to land at the fast end of that range.

This is not caused by any one branch's tests. The suite's cost is dominated by per-file database setup rather than test count, so it scales with file count and will keep creeping.

## The change

`timeout-minutes: 20` becomes `35`, with the measurements recorded in a comment so the next person to look does not have to re-derive them.

35 gives roughly 15 minutes of headroom over the worst observed run, which is enough to absorb a slow runner without hiding a genuine hang. The proper fix is sharing the database fixture rather than paying setup per file, and that stays a separate piece of work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the automated build and test process timeout to accommodate longer-running checks.
  * Added documentation clarifying test duration and database setup overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->