### PR TITLE
docs(worker): retire the AIW-233 serialization notes now that concurrency is on

### DIFF
--- a/apps/worker/env.ts
+++ b/apps/worker/env.ts
@@ -101,13 +101,22 @@ export const env = createEnv({
     /**
      * Operational ceiling on how many blocks of one run are dispatched at once.
      * Unset means the code-owned bound, which is what scenarios assert. This
-     * only ever lowers it, and the scheduler clamps whatever arrives here.
+     * only ever lowers it: the scheduler clamps whatever arrives here against
+     * V2_PRODUCTION_SCHEDULER_BOUNDS.maxConcurrency, so a larger value buys
+     * nothing. It is here to throttle fan-out operationally, not to hand out
+     * more parallelism than the code owns.
      *
-     * Set it to 1 while AIW-233 is open. The workflow runtime corrupts its own
-     * event log when several blocks suspend concurrently and then discards the
-     * whole run, with no failure of ours recorded, so a serialized run that
-     * finishes beats a parallel one that never does. Remove the variable, do not
-     * edit the code-owned bound, once the runtime is fixed.
+     * Concurrency is no longer known-broken. A real three-reviewer fan-out
+     * completes in production without a replay divergence, and what makes that
+     * safe is narrow: no block that can run beside a sibling may suspend on a
+     * Workflow wait. The SDK seeds a wait's expected resumeAt from Date.now()
+     * and corrects it only when that same consumer drains its own wait_created,
+     * which another block's deliveries can sit ahead of, and then the run dies
+     * as CORRUPTED_EVENT_LOG with no failure of ours recorded. A sleep() from
+     * "workflow" anywhere a block can reach reintroduces exactly that, so
+     * lowering this to 1 stays the emergency stop if it ever comes back. The SDK
+     * defect is pinned in workflow-sdk-tests/divergence/ and the workaround it
+     * forces lives in src/workflows/blocks/poll-delay.ts.
      */
     V2_MAX_BLOCK_CONCURRENCY: z.coerce.number().int().positive().optional(),
 

--- a/apps/worker/src/workflow-definition/v2-scheduler.test.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.test.ts
@@ -431,10 +431,11 @@ describe("executeV2Graph concurrency and failure", () => {
     });
   });
 
-  // The operational ceiling behind V2_MAX_BLOCK_CONCURRENCY. Production runs
-  // with it set to 1 while AIW-233 is open, because the workflow runtime
-  // corrupts its own event log when several blocks suspend at once and then
-  // discards the run. A fan-out must still complete, one block at a time.
+  // The floor of the operational ceiling behind V2_MAX_BLOCK_CONCURRENCY.
+  // Concurrent dispatch is the ordinary case now, but the lever can still be set
+  // to 1, whether to throttle a run deliberately or as the emergency stop
+  // described in env.ts, so a fan-out has to finish in that configuration too:
+  // one block at a time, admitting the next only as the previous one settles.
   it("runs a fan-out one block at a time when admission is capped at one", async () => {
     const gates = new Map(
       ["one", "two", "three"].map((id) => [id, deferred<void>()]),

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -5558,8 +5558,8 @@ async function agentWorkflowBody(
             executeBlock: executeV2Block,
             hooks: v2Hooks,
             // The env value is an operational ceiling only, never a raise: see
-            // V2_MAX_BLOCK_CONCURRENCY in env.ts for why production runs
-            // serialized while AIW-233 is open.
+            // V2_MAX_BLOCK_CONCURRENCY in env.ts for what it is for and what
+            // concurrent dispatch here depends on staying true.
             maxConcurrency: Math.min(
               env.V2_MAX_BLOCK_CONCURRENCY ??
                 V2_PRODUCTION_SCHEDULER_BOUNDS.maxConcurrency,

--- a/apps/worker/src/workflows/blocks/poll-delay.ts
+++ b/apps/worker/src/workflows/blocks/poll-delay.ts
@@ -12,12 +12,17 @@
  * CORRUPTED_EVENT_LOG. A step has no recomputed expectation: replay hands back
  * the recorded result and compares only the step name.
  *
- * The controlled matrix is in workflow-sdk-tests/v2-concurrent.test.ts. With a
- * wait, a three-block fan-out dies at concurrency 3 and survives at 1, and that
- * holds with the shared counter removed, with per-invocation counters, with
- * fixed-length waits, without the cancellation race, and with a single shared
- * wait for the whole run. With this step instead, the same shape survives at
- * concurrency 3.
+ * The controlled matrix lives in the divergence suite,
+ * workflow-sdk-tests/divergence/wdk-wait-divergence.test.ts, which is manual
+ * dispatch only (pnpm --filter worker test:workflow-sdk-divergence) because its
+ * rows assert the failure in real time. With a wait, a three-block fan-out dies
+ * at concurrency 3 and survives at 1, and that holds with the shared counter
+ * removed, with per-invocation counters, with fixed-length waits, without the
+ * cancellation race, and with a single shared wait for the whole run. With this
+ * step instead, the same shape survives at concurrency 3, and those green rows
+ * are in workflow-sdk-tests/v2-concurrent.test.ts, inside the default run. Start
+ * at the divergence suite when asking whether this workaround is still needed:
+ * its rows failing means the SDK fixed the defect and this module can go away.
  *
  * This lives in its own module so the poll loop's unit tests can substitute it
  * the way they already substitute checkPhaseDone, instead of really sleeping.

--- a/apps/worker/src/workflows/blocks/poll-phase.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.ts
@@ -12,9 +12,10 @@ import {
  *
  * The tick is a sleeping step rather than a Workflow sleep() wait. See
  * poll-delay.ts: a wait here corrupts the run's event log as soon as two blocks
- * poll concurrently, which is why AIW-233 pinned V2_MAX_BLOCK_CONCURRENCY to 1.
- * That module also records what the step costs against a wait, and why the tick
- * ceiling below is coupled to the deployed function's duration limit.
+ * poll concurrently, which is why production pinned V2_MAX_BLOCK_CONCURRENCY to 1
+ * until this path stopped waiting. That module also records what the step costs
+ * against a wait, and why the tick ceiling below is coupled to the deployed
+ * function's duration limit.
  */
 export async function pollPhaseUntilDone(
   sandboxId: string,

--- a/apps/worker/workflow-sdk-tests/v2-concurrent.test.ts
+++ b/apps/worker/workflow-sdk-tests/v2-concurrent.test.ts
@@ -13,20 +13,29 @@ import {
   type ProbeSharedBudgetInput,
 } from "../workflow-test-fixtures/v2-concurrent/workflow.js";
 
-// AIW-233. Three things live here, all driven against the real Workflow runtime.
+// AIW-233, resolved. Three things live here, all driven against the real Workflow
+// runtime, and all of them assert success. Nothing in this file is pinned as
+// failing any more: it is what guards our own fix in test:workflow-sdk, which CI
+// runs on every pull request, so a red row here is a regression of ours.
 //
-// 1. The deployed three-reviewer graph survives a concurrent fan-out, including
-//    simultaneous hook suspensions, step retries and in-VM work at every step
-//    boundary. These must stay green.
-// 2. A Workflow sleep() wait corrupts the run's event log as soon as two blocks
-//    poll concurrently. Those rows are PINNED AS FAILING: they assert the
-//    divergence, because the defect is in the SDK and not in code we own. They
-//    are the reason src/workflows/blocks/poll-delay.ts makes the poll tick a
-//    sleeping step, and the same rows with a step instead are green. If the SDK
-//    ever fixes this, the pins fail and poll-delay.ts can go away.
-// 3. The scheduler's Promise.race join can consume results in an order a replay
-//    does not reproduce, on graphs where a concurrent block has its own
-//    successor. Pinned as failing too, pending its own fix.
+// 1. The deployed three-reviewer graph survives a concurrent fan-out, from one
+//    block at a time up to maxConcurrency 3, including simultaneous hook
+//    suspensions, step retries, in-VM work at every step boundary, and one
+//    sibling failing beside the others.
+// 2. The scheduler's join consumes results in graph order, so a replay
+//    reproduces the recorded step-name sequence even where a concurrent block
+//    has its own successor. Those shapes were pinned as failing until the
+//    head-of-line consumption fix landed; they assert completion now.
+// 3. The agent poll tick as a step survives concurrency, with a run-global
+//    counter gating the loop and with no counter at all.
+//
+// What this file no longer asserts is the SDK defect underneath all of it, which
+// is still open: a Workflow sleep() wait cannot survive replay once two blocks of
+// one run poll concurrently. Those rows moved to
+// divergence/wdk-wait-divergence.test.ts, manual dispatch only because each one
+// drives real replay divergences in real time. Respect the hazard rather than the
+// calm of this file: a sleep() from "workflow" on any path a block can reach
+// while siblings run brings CORRUPTED_EVENT_LOG straight back.
 
 const SNAPSHOT = JSON.parse(
   readFileSync(

--- a/apps/worker/workflow-test-fixtures/v2-concurrent/workflow.ts
+++ b/apps/worker/workflow-test-fixtures/v2-concurrent/workflow.ts
@@ -14,11 +14,12 @@ import {
   type V2SchedulerHooks,
 } from "../../src/workflow-definition/v2-scheduler.js";
 
-// A probe for AIW-233: production pins V2_MAX_BLOCK_CONCURRENCY to 1 because a
-// fan-out of concurrent blocks corrupts the Workflow event log. Everything here
-// mirrors the production agent workflow's shape around executeV2Graph, because
-// the suspected non-determinism lives in the interleaving of step calls made by
-// concurrent invocations, not in any single block:
+// A probe for AIW-233: production pinned V2_MAX_BLOCK_CONCURRENCY to 1 for as
+// long as a fan-out of blocks that suspend on a Workflow wait could corrupt the
+// event log. Everything here mirrors the production agent workflow's shape
+// around executeV2Graph, because the suspected non-determinism lives in the
+// interleaving of step calls made by concurrent invocations, not in any single
+// block:
 //   - the interpreter runs inside a "use workflow" function
 //   - every persistence hook is a real "use step"
 //   - each agent block is a multi-step start/poll/finish chain whose steps take


### PR DESCRIPTION
Comments only. Seven files, and every one of the 119 changed lines starts with `//` or ` *`, verified mechanically rather than by eye.

## Why now

AIW-233 is resolved (#219) and the production ceiling is raised. Verified on four consecutive production runs at `V2_MAX_BLOCK_CONCURRENCY=3`, all green, no divergence, three reviewers genuinely overlapping in each:

| run | result | duration | max concurrent blocks |
|---|---|---|---|
| PR 316 | success | 163s | 3 |
| PR 315 | success | 193s | 3 |
| PR 313 | success | 198s | 3 |
| PR 314 | success | 202s | 3 |

Against 297 to 407s serialized, a repeatable 45 percent reduction. Three of those ran at once, so nine agent blocks were in flight on one instance.

So several comments asserted something false, and one asserted the opposite of the truth.

## What changed

**`env.ts`** and **`v2-scheduler.test.ts`** no longer say production runs serialized while AIW-233 is open. Neither comment was deleted: the env var is still a real operational lever and the test still covers a configuration the lever can produce. Both were rewritten around the invariant instead of the incident, which is the point of this PR: a comment that describes a broken state expires the moment the state changes, while one that names the condition correctness rests on keeps working. The new text says plainly that no block which can run beside a sibling may suspend on a Workflow wait, and that a `sleep()` from `"workflow"` on any path a block can reach brings `CORRUPTED_EVENT_LOG` straight back.

**`workflow-sdk-tests/v2-concurrent.test.ts`** had the actively misleading one. Its header still described rows as pinned-as-failing and consumption order as pending a fix, on a file that after the suite split holds only green rows. A reader trusting it would conclude the fix never landed. It now describes what the file guards, that CI runs it on every pull request so a red row is our regression, and that the SDK pins moved to `divergence/`.

**`poll-delay.ts`** pointed at a matrix that had moved, on the file a reader lands on when asking whether the workaround is still needed. Repointed, with the dispatch command and the signal to watch for: those rows failing means the SDK fixed the defect and the module can go away.

**`poll-phase.ts`** and **`agent.ts`** had present-tense claims about the pin; both now read as history. The `agent.ts` edit was checked against `harness.test.ts`, which greps 300 characters forward from `maxConcurrency: Math.min(`, so the comment sits outside the grepped window and the clamp body is byte-identical.

**`workflow-test-fixtures/v2-concurrent/workflow.ts`** claimed in the present tense that production pins the var to 1.

Two mentions in `divergence/wdk-wait-divergence.test.ts` were deliberately left: they sit next to the pinned failure they describe and read as history.

## Not changed

`V2_MAX_BLOCK_CONCURRENCY`'s schema, its default, and the `Math.min` clamp. No behaviour anywhere.

## Verification

`v2-scheduler.test.ts`, `scenarios/harness.test.ts` and `env.test.ts`: 80 passed. `pnpm --filter worker typecheck` exits 0.

Unrelated and pre-existing, flagged so it is not mistaken for this change: `pnpm -r typecheck` is currently red on `main` from two TS2307 errors in a stale generated `apps/dashboard/.next/types/validator.ts`, which references `app/api/approvals/route.js` and `workflow-definitions/[id]/restore/route.js`, neither of which exists in the tree. Reproduced identically on a clean tree; a fresh dashboard build clears it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow concurrency limits, scheduler behavior, production fan-out, and emergency throttling guidance.
  * Updated polling and wait-path documentation to explain concurrency constraints and divergence scenarios.
  * Refined comments describing concurrent workflow execution, result ordering, and failure handling.

* **Tests**
  * Clarified coverage for successful concurrent fan-out, graph-order results, and agent polling.
  * Documented that replay-divergence scenarios are covered separately in manual testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->