### PR TITLE
feat(worker): allow multiple enabled webhook workflows (AIW-238)

### DIFF
--- a/apps/worker/drizzle/0042_drop_webhook_trigger_binding.sql
+++ b/apps/worker/drizzle/0042_drop_webhook_trigger_binding.sql
@@ -1,0 +1,1 @@
+DELETE FROM "workflow_definition_triggers" WHERE "trigger_type" = 'trigger_webhook';

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
 			"when": 1785943350463,
 			"tag": "0041_webhook_timestamp_replay",
 			"breakpoints": true
+		},
+		{
+			"idx": 42,
+			"version": "7",
+			"when": 1785943351463,
+			"tag": "0042_drop_webhook_trigger_binding",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/webhook/config.get.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/webhook/config.get.ts
@@ -9,7 +9,7 @@ import {
   mintWebhookEndpointsForDefinition,
   type WebhookEndpointRow,
 } from "../../../../../../../../webhook-trigger/endpoint-store.js";
-import { getEnabledWorkflowDefinitionForTrigger } from "../../../../../../../../workflow-definition/store.js";
+import { getEnabledDeployedDefinition } from "../../../../../../../../workflow-definition/store.js";
 import {
   auditWebhookAction,
   findDeployedWebhookNode,
@@ -54,13 +54,14 @@ export default defineEventHandler(
         };
       }
 
-      // Present and live, but is THIS definition the one currently receiving
-      // deliveries? Another enabled definition may own the webhook trigger, in
-      // which case this endpoint exists but every delivery to it is refused.
-      const owner = await getEnabledWorkflowDefinitionForTrigger(db, "trigger_webhook");
-      const isOwner = owner?.definition.id === target.definitionId;
+      // Present and live, but is THIS definition currently receiving deliveries?
+      // Routing is per endpoint, so its own definition must be enabled with a
+      // readable deployed head; otherwise the endpoint exists but every delivery
+      // to it is refused.
+      const live = await getEnabledDeployedDefinition(db, target.definitionId);
+      const isActive = Boolean(live?.current);
       return {
-        state: isOwner ? "active" : "inactive",
+        state: isActive ? "active" : "inactive",
         endpoint: await serializeWebhookEndpointConfig(db, event, endpoint),
       };
     } catch (error) {

--- a/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/webhook/endpoint-routes.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/webhook/endpoint-routes.test.ts
@@ -11,7 +11,6 @@ import {
   webhookTriggerEndpoints,
   webhookTriggerRejectionCounters,
   workflowDefinitions,
-  workflowDefinitionTriggers,
   workflowDefinitionVersions,
 } from "../../../../../../../../db/schema.js";
 import { createTestDb } from "../../../../../../../../db/test-db.js";
@@ -247,11 +246,12 @@ describe("GET .../webhook/config", () => {
     ]);
   });
 
-  it("reports inactive when a different definition is the enabled webhook owner", async () => {
+  it("reports inactive when its own definition is disabled", async () => {
     await deployWebhookDefinition();
     const { endpointId } = await mintEndpoint();
-    // This definition stops being the enabled owner (another one would hold the
-    // binding). Its endpoint still exists but every delivery to it is refused.
+    // Routing is per endpoint: once this endpoint's own definition is disabled it
+    // stops receiving deliveries. The endpoint row still exists but every delivery
+    // to it is refused, so the panel reads it as inactive.
     await db
       .update(workflowDefinitions)
       .set({ enabled: false })
@@ -618,34 +618,16 @@ describe("POST .../webhook/test-delivery", () => {
     expect(await db.select().from(webhookTriggerDeliveries)).toEqual([]);
   });
 
-  it("409s when a different definition is the enabled webhook owner", async () => {
+  it("409s when its own definition is disabled", async () => {
     await deployWebhookDefinition();
     await mintEndpoint();
-    // This definition is still enabled+deployed with the node, but a second
-    // definition holds the enabled webhook binding, so a live delivery here would
-    // be refused and the probe must be too.
-    await db.insert(workflowDefinitions).values({
-      id: 10,
-      name: "Other webhook",
-      enabled: true,
-      triggerTypes: ["trigger_webhook"],
-      createdById: "test",
-      createdByLabel: "Test",
-    });
-    await db.insert(workflowDefinitionVersions).values({
-      definitionId: 10,
-      version: 1,
-      definition: graph(),
-      createdById: "test",
-      createdByLabel: "Test",
-    });
+    // Routing is per endpoint: a probe is refused once THIS endpoint's own
+    // definition is no longer the enabled, deployed live head. Another
+    // definition's state cannot make a dead endpoint test green.
     await db
       .update(workflowDefinitions)
-      .set({ deployedVersion: 1 })
-      .where(eq(workflowDefinitions.id, 10));
-    await db
-      .insert(workflowDefinitionTriggers)
-      .values({ triggerType: "trigger_webhook", definitionId: 10 });
+      .set({ enabled: false })
+      .where(eq(workflowDefinitions.id, DEFINITION_ID));
 
     expect(
       (await call(testDeliveryPost, "POST", "/test-delivery", { payload: PAYLOAD }))

--- a/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/webhook/test-delivery.post.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions/[id]/triggers/[nodeId]/webhook/test-delivery.post.ts
@@ -15,7 +15,7 @@ import {
   mapWebhookPayload,
   type WebhookMappingConfig,
 } from "../../../../../../../../webhook-trigger/payload-mapping.js";
-import { getEnabledWorkflowDefinitionForTrigger } from "../../../../../../../../workflow-definition/store.js";
+import { getEnabledDeployedDefinition } from "../../../../../../../../workflow-definition/store.js";
 import { WEBHOOK_MAX_BODY_BYTES } from "../../../../../../../webhooks/custom/[endpointId].post.js";
 import {
   auditWebhookAction,
@@ -37,10 +37,9 @@ import {
  * digest of the body; this one is "test:" plus a UUID, so posting the same body
  * for real afterwards is still a first delivery rather than a replay of this.
  *
- * A dead endpoint must test red, not green: it is refused when revoked, when its
- * definition is not enabled+deployed, or when a different definition is the
- * enabled owner, so the probe never suggests a delivery would work when it would
- * be refused at the door.
+ * A dead endpoint must test red, not green: it is refused when revoked or when
+ * its definition is not enabled+deployed, so the probe never suggests a delivery
+ * would work when it would be refused at the door.
  */
 export default defineEventHandler(
   async (event): Promise<WebhookTestDeliveryResponse | undefined> => {
@@ -76,10 +75,10 @@ export default defineEventHandler(
         });
       }
 
-      // A live delivery to this endpoint is refused unless this definition is the
-      // enabled owner of the webhook trigger, so the probe must be too.
-      const owner = await getEnabledWorkflowDefinitionForTrigger(db, "trigger_webhook");
-      if (owner?.definition.id !== target.definitionId) {
+      // A live delivery to this endpoint is refused unless this definition is
+      // enabled with a readable deployed head, so the probe must be too.
+      const live = await getEnabledDeployedDefinition(db, target.definitionId);
+      if (!live || !live.current) {
         throw createError({
           statusCode: 409,
           statusMessage: "This definition is not the enabled webhook owner",

--- a/apps/worker/src/routes/webhooks/custom/[endpointId].post.test.ts
+++ b/apps/worker/src/routes/webhooks/custom/[endpointId].post.test.ts
@@ -9,7 +9,6 @@ import {
   webhookTriggerRateLimits,
   webhookTriggerRejectionCounters,
   workflowDefinitions,
-  workflowDefinitionTriggers,
   workflowDefinitionVersions,
 } from "../../../db/schema.js";
 import { createTestDb } from "../../../db/test-db.js";
@@ -156,6 +155,40 @@ async function delivery(deliveryId: string) {
   return rows[0];
 }
 
+/** A second enabled, deployed webhook definition with its own endpoint. Routing
+ *  is per endpoint (AIW-238), so several webhook definitions may be live at once. */
+async function setupWebhookDefinition(
+  definitionId: number,
+  nodeId: string,
+  name: string,
+): Promise<{ endpointId: string; secret: string }> {
+  await db.insert(workflowDefinitions).values({
+    id: definitionId,
+    name,
+    enabled: true,
+    triggerTypes: ["trigger_webhook"],
+    createdById: "test",
+    createdByLabel: "Test",
+  });
+  const nodes = graph().nodes.map((node) => ({ ...node, id: nodeId }));
+  await db.insert(workflowDefinitionVersions).values({
+    definitionId,
+    version: 1,
+    definition: { schemaVersion: 2, nodes, edges: [] },
+    createdById: "test",
+    createdByLabel: "Test",
+  });
+  await db
+    .update(workflowDefinitions)
+    .set({ deployedVersion: 1 })
+    .where(eq(workflowDefinitions.id, definitionId));
+  const minted = await mintWebhookEndpointsForDefinition(db, KEY, {
+    definitionId,
+    nodes,
+  });
+  return { endpointId: minted[0]!.endpointId, secret: minted[0]!.secret! };
+}
+
 beforeEach(async () => {
   db = await createTestDb();
   state.db = db;
@@ -182,12 +215,6 @@ beforeEach(async () => {
     .update(workflowDefinitions)
     .set({ deployedVersion: 1 })
     .where(eq(workflowDefinitions.id, DEFINITION_ID));
-  // Deterministic ownership of the trigger: the seeded default definition must
-  // never be the one this route resolves.
-  await db.delete(workflowDefinitionTriggers);
-  await db
-    .insert(workflowDefinitionTriggers)
-    .values({ triggerType: "trigger_webhook", definitionId: DEFINITION_ID });
 
   const minted = await mintWebhookEndpointsForDefinition(db, KEY, {
     definitionId: DEFINITION_ID,
@@ -342,8 +369,7 @@ describe("POST /webhooks/custom/:endpointId", () => {
     expect(await rejections()).toEqual([{ reason: "endpoint_disabled", count: 1 }]);
   });
 
-  it("404s when no enabled definition claims the webhook trigger anymore", async () => {
-    await db.delete(workflowDefinitionTriggers);
+  it("404s when its own definition is disabled", async () => {
     await db
       .update(workflowDefinitions)
       .set({ enabled: false })
@@ -372,6 +398,75 @@ describe("POST /webhooks/custom/:endpointId", () => {
 
     expect(response.status).toBe(404);
     expect(await rejections()).toEqual([{ reason: "endpoint_disabled", count: 1 }]);
+  });
+
+  it("routes each endpoint's delivery to its own definition, with no cross-talk", async () => {
+    // AIW-238: a second enabled webhook definition with its own endpoint. Routing
+    // is per endpoint, so a delivery to endpoint A starts definition A's run and a
+    // delivery to endpoint B starts definition B's run, never the other way.
+    const OTHER_DEFINITION_ID = 10;
+    const OTHER_NODE_ID = "entry2";
+    const other = await setupWebhookDefinition(
+      OTHER_DEFINITION_ID,
+      OTHER_NODE_ID,
+      "Second webhook flow",
+    );
+    // Two real runs start, so each needs its own id: workflow_runs is keyed on
+    // run_id and one id cannot be bound to two subjects.
+    mockStart
+      .mockResolvedValueOnce({ runId: "run-a" })
+      .mockResolvedValueOnce({ runId: "run-b" });
+
+    const toA = await handler()(signed(BODY, { headers: { "x-delivery-id": "d-a" } }));
+    const toB = await handler()(
+      signed(BODY, {
+        secret: other.secret,
+        id: other.endpointId,
+        headers: { "x-delivery-id": "d-b" },
+      }),
+    );
+
+    expect(toA.status).toBe(200);
+    expect(toB.status).toBe(200);
+    expect(mockStart).toHaveBeenCalledTimes(2);
+    // The dispatched target names the endpoint's own definition and node.
+    expect(mockStart.mock.calls[0]?.[1]?.[0]).toMatchObject({
+      endpointId,
+      definitionId: DEFINITION_ID,
+      nodeId: NODE_ID,
+    });
+    expect(mockStart.mock.calls[1]?.[1]?.[0]).toMatchObject({
+      endpointId: other.endpointId,
+      definitionId: OTHER_DEFINITION_ID,
+      nodeId: OTHER_NODE_ID,
+    });
+  });
+
+  it("refuses a delivery to a disabled definition's endpoint while a sibling stays live", async () => {
+    // AIW-238: disabling one webhook definition kills only its own endpoint. A
+    // delivery to the disabled definition's endpoint is refused (endpoint_disabled)
+    // even though a second webhook definition is still a live owner.
+    const other = await setupWebhookDefinition(10, "entry2", "Second webhook flow");
+    await db
+      .update(workflowDefinitions)
+      .set({ enabled: false })
+      .where(eq(workflowDefinitions.id, DEFINITION_ID));
+
+    const refused = await handler()(signed());
+
+    expect(refused.status).toBe(404);
+    expect(await rejections()).toEqual([{ reason: "endpoint_disabled", count: 1 }]);
+    expect(mockStart).not.toHaveBeenCalled();
+
+    // The still-enabled sibling accepts its own delivery.
+    const sibling = await handler()(
+      signed(BODY, {
+        secret: other.secret,
+        id: other.endpointId,
+        headers: { "x-delivery-id": "d-b" },
+      }),
+    );
+    expect(sibling.status).toBe(200);
   });
 
   it("requires Content-Length and tallies length_required", async () => {

--- a/apps/worker/src/routes/webhooks/custom/[endpointId].post.ts
+++ b/apps/worker/src/routes/webhooks/custom/[endpointId].post.ts
@@ -41,7 +41,7 @@ import {
 import { recordWebhookRejection } from "../../../webhook-trigger/rejection-counters.js";
 import { verifyWebhookAuth } from "../../../webhook-trigger/verify.js";
 import {
-  getEnabledWorkflowDefinitionForTrigger,
+  getEnabledDeployedDefinition,
   getWorkflowDefinitionVersion,
 } from "../../../workflow-definition/store.js";
 
@@ -306,8 +306,8 @@ async function ensureStillDispatchable(
   const endpoint = await getWebhookEndpointById(db, target.endpointId);
   if (!endpoint || endpoint.revokedAt) return "endpoint_revoked";
 
-  const live = await getEnabledWorkflowDefinitionForTrigger(db, "trigger_webhook");
-  if (!live || live.definition.id !== target.definitionId) return "definition_disabled";
+  const live = await getEnabledDeployedDefinition(db, target.definitionId);
+  if (!live || !live.current) return "definition_disabled";
 
   const pinned = await getWorkflowDefinitionVersion(
     db,
@@ -322,16 +322,16 @@ async function ensureStillDispatchable(
 
 /**
  * The endpoint's node in the live head, or null when this endpoint may not
- * receive anything right now: no enabled definition claims the webhook trigger,
- * a different definition claims it, the head is absent, or the head no longer
- * declares this node.
+ * receive anything right now: its own definition is disabled, archived, or has no
+ * readable deployed head, or that head no longer declares this node. Routing is
+ * per endpoint, so only this endpoint's own definition id decides.
  */
 async function resolveLiveWebhookTarget(
   db: Db,
   endpoint: WebhookEndpointRow,
 ): Promise<LiveWebhookTarget | null> {
-  const live = await getEnabledWorkflowDefinitionForTrigger(db, "trigger_webhook");
-  if (!live || live.definition.id !== endpoint.definitionId || !live.current) {
+  const live = await getEnabledDeployedDefinition(db, endpoint.definitionId);
+  if (!live || !live.current) {
     return null;
   }
   const node = webhookNodeOf(live.current.definition.nodes, endpoint.nodeId);

--- a/apps/worker/src/workflow-definition/store.test.ts
+++ b/apps/worker/src/workflow-definition/store.test.ts
@@ -438,6 +438,55 @@ describe("enabled-per-trigger overlap", () => {
     expect((await updateWorkflowDefinition(db, { definitionId: d.id, enabled: true, actor: ADMIN })).enabled).toBe(true);
   });
 
+  it("allows two webhook definitions to both be enabled at once", async () => {
+    // AIW-238: trigger_webhook routes per endpoint, not as a global singleton, so
+    // enabling a second webhook definition never conflicts with the first. Every
+    // other trigger stays a singleton (see the trigger_ticket_ai case above).
+    const webhookGraph = (): WorkflowDefinitionV2 => ({
+      schemaVersion: 2,
+      nodes: [
+        {
+          id: "hook",
+          type: "trigger_webhook",
+          x: 0,
+          y: 0,
+          configuration: {},
+          inputs: {},
+          additionalInputs: [],
+        },
+      ],
+      edges: [],
+    });
+    // The webhook block is only deployable when the encryption key is configured,
+    // so set it on the mocked env for this test's duration (mirrors the minting
+    // suite). Enabling itself needs no key: minting is best-effort.
+    const mutableEnv = env as { WEBHOOK_TRIGGER_ENCRYPTION_KEY?: string };
+    mutableEnv.WEBHOOK_TRIGGER_ENCRYPTION_KEY = "a".repeat(64);
+    try {
+      const a = await createDeployed("Webhook A", webhookGraph());
+      const b = await createDeployed("Webhook B", webhookGraph());
+
+      expect(
+        (await updateWorkflowDefinition(db, { definitionId: a.id, enabled: true, actor: ADMIN })).enabled,
+      ).toBe(true);
+      expect(
+        (await updateWorkflowDefinition(db, { definitionId: b.id, enabled: true, actor: ADMIN })).enabled,
+      ).toBe(true);
+
+      // "at once": re-read confirms enabling B did not disable A. Both remain
+      // enabled webhook owners at the same time, which a singleton would forbid.
+      const enabledWebhookDefs = (await listWorkflowDefinitions(db)).filter(
+        (definition) =>
+          definition.enabled && definition.triggerTypes.includes("trigger_webhook"),
+      );
+      expect(enabledWebhookDefs.map((definition) => definition.id).sort()).toEqual(
+        [a.id, b.id].sort(),
+      );
+    } finally {
+      delete mutableEnv.WEBHOOK_TRIGGER_ENCRYPTION_KEY;
+    }
+  });
+
   it("keeps an overlapping draft live-neutral and 409s only when it is deployed", async () => {
     const d = await createDeployed("Draft overlap", def(["trigger_pr_created"]));
     await updateWorkflowDefinition(db, { definitionId: d.id, enabled: true, actor: ADMIN });

--- a/apps/worker/src/workflow-definition/store.ts
+++ b/apps/worker/src/workflow-definition/store.ts
@@ -167,6 +167,16 @@ function triggerTypesOf(definition: WorkflowDefinition): WorkflowBlockType[] {
   return [...types];
 }
 
+/** Per-endpoint triggers route each delivery by its own unique endpoint id, so
+ *  several enabled definitions can declare one at the same time. They are never
+ *  singletons: they take no row in workflow_definition_triggers (whose
+ *  trigger_type PK would force a single owner) and are excluded from the overlap
+ *  check. Every other trigger stays a global singleton. This predicate is the one
+ *  source of truth for that distinction. */
+function isPerEndpointTrigger(type: WorkflowBlockType): boolean {
+  return type === "trigger_webhook";
+}
+
 function requireEditRole(role: DashboardRole): void {
   if (!canEditWorkflowDefinitions(role)) {
     throw new DashboardAuthError(403, "Forbidden");
@@ -477,6 +487,11 @@ export async function getEnabledWorkflowDefinitionForTrigger(
   db: Db,
   triggerType: WorkflowBlockType,
 ): Promise<{ definition: WorkflowDefinitionRow; current: WorkflowDefinitionVersionRow | null } | null> {
+  // Per-endpoint triggers (webhook) route by their own endpoint id, not through
+  // the singleton trigger binding, so this path never owns them. Returning early
+  // also stops the stale-binding heal below from re-inserting a webhook row after
+  // the migration removes it.
+  if (isPerEndpointTrigger(triggerType)) return null;
   // Route via the enabled trigger binding (its trigger_type PK guarantees at
   // most one owner), then reconcile against the head graph. A crashed
   // enable/disable/save can leave a binding pointing at a definition that is no
@@ -560,6 +575,32 @@ export async function getEnabledWorkflowDefinitionForTrigger(
   return { definition: mapDefinitionRow(defRow!, current?.version ?? 0), current };
 }
 
+/** Loads a definition by id, but only when it is a live handler: enabled, not
+ *  archived, and pointing at a readable deployed version. Returns the DEPLOYED
+ *  snapshot (never the draft head) in the same { definition, current } shape as
+ *  getEnabledWorkflowDefinitionForTrigger, so per-endpoint routing (which resolves
+ *  the owning definition directly from its endpoint id, not from a singleton
+ *  trigger binding) receives an identical result. Any unmet condition yields null. */
+export async function getEnabledDeployedDefinition(
+  db: Db,
+  definitionId: number,
+): Promise<{ definition: WorkflowDefinitionRow; current: WorkflowDefinitionVersionRow | null } | null> {
+  const defRows = await db
+    .select()
+    .from(workflowDefinitions)
+    .where(eq(workflowDefinitions.id, definitionId))
+    .limit(1);
+  const defRow = defRows[0];
+  if (!defRow || !defRow.enabled || defRow.archivedAt != null || defRow.deployedVersion == null) {
+    return null;
+  }
+  // Read the exact deployed pointer observed on the row. Version rows are
+  // immutable, so a null here means the pointer is dangling (not routable).
+  const current = await getWorkflowDefinitionVersion(db, defRow.id, defRow.deployedVersion);
+  if (!current) return null;
+  return { definition: mapDefinitionRow(defRow, current.version), current };
+}
+
 async function readTriggerBinding(
   db: Db,
   triggerType: WorkflowBlockType,
@@ -585,6 +626,11 @@ async function healMissingTriggerBinding(
   db: Db,
   triggerType: WorkflowBlockType,
 ): Promise<number | null> {
+  // Per-endpoint triggers (webhook) never own a workflow_definition_triggers row,
+  // so there is nothing to heal and re-inserting one would recreate the singleton
+  // the migration deletes. Skip without touching the table (this also keeps
+  // enabledDefinitionsDeclaringTrigger, its only caller, from running for them).
+  if (isPerEndpointTrigger(triggerType)) return null;
   const candidates = await enabledDefinitionsDeclaringTrigger(db, triggerType);
   if (candidates.length !== 1) {
     logger.warn({ triggerType, candidates }, "trigger_binding_unclaimed");
@@ -663,7 +709,11 @@ async function assertNoTriggerOverlap(
   db: Db,
   input: { definitionId: number; triggerTypes: WorkflowBlockType[] },
 ): Promise<void> {
-  if (input.triggerTypes.length === 0) return;
+  // Per-endpoint triggers (webhook) route by their own endpoint id, so a second
+  // enabled definition declaring one is not a conflict. Drop them before the
+  // probe; a list that is all per-endpoint can never overlap.
+  const singletonTriggers = input.triggerTypes.filter((type) => !isPerEndpointTrigger(type));
+  if (singletonTriggers.length === 0) return;
   const conflicts = await db
     .select({ name: workflowDefinitions.name })
     .from(workflowDefinitions)
@@ -672,7 +722,7 @@ async function assertNoTriggerOverlap(
         eq(workflowDefinitions.enabled, true),
         isNull(workflowDefinitions.archivedAt),
         ne(workflowDefinitions.id, input.definitionId),
-        arrayOverlaps(workflowDefinitions.triggerTypes, input.triggerTypes),
+        arrayOverlaps(workflowDefinitions.triggerTypes, singletonTriggers),
       ),
     )
     .limit(1);
@@ -957,6 +1007,12 @@ export async function deployWorkflowDefinition(
   await assertDeployableDefinitionWithPromptAuthoring(db, target.definition);
   const triggerTypes = triggerTypesOf(target.definition);
   const triggerArray = triggerArraySql(triggerTypes);
+  // The denormalized trigger_types column still mirrors the full graph (it feeds
+  // the editor badges and the API), but the singleton binding table must not
+  // claim per-endpoint triggers (webhook), so those are dropped from the insert.
+  const bindingTriggerArray = triggerArraySql(
+    triggerTypes.filter((type) => !isPerEndpointTrigger(type)),
+  );
 
   try {
     const result = await db.execute(sql`
@@ -980,7 +1036,7 @@ export async function deployWorkflowDefinition(
         INSERT INTO workflow_definition_triggers (trigger_type, definition_id)
         SELECT trigger_type, c.id
         FROM candidate c
-        CROSS JOIN LATERAL unnest(${triggerArray}) AS trigger_type
+        CROSS JOIN LATERAL unnest(${bindingTriggerArray}) AS trigger_type
         CROSS JOIN (SELECT count(*) FROM deleted_claims) AS delete_barrier
         WHERE c.enabled
         RETURNING trigger_type
@@ -1047,6 +1103,11 @@ export async function rollbackWorkflowDefinition(
   }
   const triggerTypes = triggerTypesOf(target.definition);
   const triggerArray = triggerArraySql(triggerTypes);
+  // trigger_types column mirrors the full graph; the singleton binding table must
+  // not claim per-endpoint triggers (webhook), so those are dropped from insert.
+  const bindingTriggerArray = triggerArraySql(
+    triggerTypes.filter((type) => !isPerEndpointTrigger(type)),
+  );
 
   try {
     const result = await db.execute(sql`
@@ -1070,7 +1131,7 @@ export async function rollbackWorkflowDefinition(
         INSERT INTO workflow_definition_triggers (trigger_type, definition_id)
         SELECT trigger_type, t.id
         FROM target t
-        CROSS JOIN LATERAL unnest(${triggerArray}) AS trigger_type
+        CROSS JOIN LATERAL unnest(${bindingTriggerArray}) AS trigger_type
         CROSS JOIN (SELECT count(*) FROM deleted_claims) AS delete_barrier
         WHERE t.enabled
         RETURNING trigger_type
@@ -1217,7 +1278,12 @@ export async function updateWorkflowDefinition(
       await assertNoTriggerOverlap(db, { definitionId: current.id, triggerTypes });
     }
 
-    const triggerArray = triggerArraySql(triggerTypes);
+    // This path only claims binding rows (it does not rewrite the trigger_types
+    // column), so drop per-endpoint triggers (webhook): they never take a
+    // singleton row in workflow_definition_triggers.
+    const triggerArray = triggerArraySql(
+      triggerTypes.filter((type) => !isPerEndpointTrigger(type)),
+    );
     try {
       const result = await db.execute(sql`
         WITH candidate AS (

--- a/docs/plans/aiw-238-webhook-per-endpoint-ownership.md
+++ b/docs/plans/aiw-238-webhook-per-endpoint-ownership.md
@@ -1,0 +1,67 @@
+# AIW-238: Webhook triggers per-endpoint, not a global singleton
+
+## Problem
+
+A tenant can only have ONE enabled workflow that owns a `trigger_webhook` block across the whole org. Enabling a second one returns `409 "Its trigger is already handled by the enabled definition ..."`. This blocks running, say, a Zendesk support-ticket workflow and a Sentry error-alert workflow at the same time, even though each already has its own distinct receiver URL. Verified in prod: with Zendesk (def 15) enabled, enabling Sentry (def 16) 409s.
+
+## Solution
+
+From the operator's point of view: enabling a second (third, ...) webhook-trigger workflow just works. Each webhook workflow keeps its own endpoint URL, and a delivery to endpoint A starts a run on definition A while a delivery to endpoint B starts a run on definition B, with no cross-talk. Nothing changes for the genuinely-shared source triggers (Jira ticket, GitHub PR events): those stay one-enabled-definition-per-type, and trying to enable a second still 409s.
+
+## User stories
+
+1. Jako operator chcę włączyć osobny workflow dla Zendesku i osobny dla Sentry jednocześnie, żeby oba źródła miały automatyzację bez wyłączania jednego dla drugiego.
+2. Jako operator chcę, żeby dostawa z danego źródła trafiła dokładnie do workflow przypisanego do jej endpointu, żeby nie było pomyłkowego routingu między webhookami.
+3. Jako operator nadal chcę, żeby system nie pozwolił na dwa włączone workflow dla tego samego współdzielonego triggera źródła (Jira ticket, PR), żeby uniknąć podwójnego przetwarzania tego samego zdarzenia.
+4. Jako operator chcę, żeby istniejący stan na prodzie sam się naprawił po wdrożeniu (bez ręcznego czyszczenia bazy), żeby oba webhooki dało się od razu włączyć.
+
+## Decyzje implementacyjne
+
+**Podział polityki.** Jedno źródło prawdy: `trigger_webhook` jest jedynym triggerem "per-endpoint"; wszystkie pozostałe (`trigger_ticket_ai`, `trigger_pr_created`, `trigger_pr_merged`, `trigger_pr_ready`, `trigger_pr_review`, `trigger_pr_updated`, `trigger_pr_checks_failed`, `trigger_plan_approved`) pozostają singletonami per typ. Reprezentacja: predykat `isPerEndpointTrigger(type)` (lub zbiór `SINGLETON_TRIGGER_TYPES` = wszystkie triggery poza webhook) w jednym miejscu, używany przez oba egzekwatory.
+
+**Dwa poziomy egzekwowania singletona (oba do zmiany).**
+- Kod (friendly precheck): `assertNoTriggerOverlap` liczy `arrayOverlaps` na `triggerTypes`. Ma filtrować listę do samych singletonów, zanim odpali zapytanie. Webhook nigdy nie liczy się jako overlap.
+- DB (race-safe binding): tabela `workflow_definition_triggers` z `trigger_type` jako PRIMARY KEY. Kod wpisuje binding przy enable/deploy (ścieżki rzucające `TRIGGER_TAKEN_MESSAGE`). Dla `trigger_webhook` binding NIE ma być wpisywany (bo jego unikalność jest per-endpoint w `webhook_trigger_endpoints`, nie per-type).
+
+**Routing DO PRZEPISANIA (kluczowa poprawka po pre-mortemie).** Wbrew pierwotnemu założeniu, webhook delivery NIE routuje się czysto per-endpoint. `resolveLiveWebhookTarget` (`routes/webhooks/custom/[endpointId].post.ts:333`) i `ensureStillDispatchable` (`:309`, wpięte w cron drain przez `poll.get.ts:241`) wołają `getEnabledWorkflowDefinitionForTrigger(db, "trigger_webhook")` i bramkują `live.definition.id !== endpoint.definitionId` (`:334`). Ten per-type single-owner JEST obecnym mechanizmem anty-cross-talk. Przy dwóch enabled webhookach `getEnabledWorkflowDefinitionForTrigger` (przez `readTriggerBinding`/`healMissingTriggerBinding`, gdzie `candidates.length===2` → null) zwróci null i ODRZUCI dostawy do OBU endpointów. Dlatego routing trzeba przepisać: dla webhooka pobierać definicję wprost po `endpoint.definitionId`, sprawdzać `enabled + deployed (current)` tej konkretnej definicji, i usunąć bramkę per-type ownera. To samo w `config.get.ts:60` (badge active/inactive) i `test-delivery.post.ts:81`. Nowy helper (kontrakt E1): `getEnabledDeployedDefinition(db, definitionId) → { definition, current } | null`. Po tym webhook nie zależy od `workflow_definition_triggers` w ogóle.
+
+**Heal do wyłączenia dla webhooka.** `healMissingTriggerBinding` (`store.ts:584`) i `enabledDefinitionsDeclaringTrigger` (`:612`) czerpią kandydatów z kolumny `trigger_types` i re-insertują binding, gdy dokładnie jeden webhook jest enabled. Po usunięciu bindingów migracją, przy jednym enabled webhooku heal by je NATYCHMIAST re-insertował (walka z migracją). Dlatego `getEnabledWorkflowDefinitionForTrigger`/heal muszą pomijać `trigger_webhook` (webhook nie jest już nigdy pytany tą drogą po przepisaniu routingu, ale trzeba jawnie wykluczyć, żeby heal nie ożywił wierszy).
+
+**Migracja danych.** Migracja usuwa istniejące wiersze `trigger_webhook` z `workflow_definition_triggers`. Bezpieczne dopiero PO tym, jak kod (E1) przestaje je czytać i re-insertować. `trigger_types` (denormalizowana kolumna) zostaje bez zmian, overlap-check i heal po prostu filtrują z niej webhook.
+
+**Race-safety.** Singletony nadal chroni PK `workflow_definition_triggers.trigger_type` + `retryOnUniqueViolation`/`isUniqueViolation`. Webhook nie potrzebuje DB-guardu (wiele dozwolone), więc pominięcie insertu jest bezpieczne. neon-http nie ma transakcji, więc bez `db.transaction()`.
+
+## Seamy i decyzje testowe
+
+| Seam | Obserwowane zachowanie | Prior art |
+|------|------------------------|-----------|
+| `assertNoTriggerOverlap` + binding insert/heal w `store.ts`, przez pglite w `store.test.ts` | Drugi webhook-workflow enable → OK; drugi `trigger_ticket_ai` → 409 | `store.test.ts`, `store.ts:662` (assertNoTriggerOverlap), `:1217` (call site), `:584` (heal), `:612` (enabledDefinitionsDeclaringTrigger) |
+| Delivery route: `resolveLiveWebhookTarget` / `ensureStillDispatchable` przez `[endpointId].post.ts` (+ HTTP-level test) | Delivery na endpoint A → run def A, endpoint B → run def B; dostawa na endpoint wyłączonej definicji → odrzucona | `routes/webhooks/custom/[endpointId].post.ts:333`, `:309`, `:334` (owner gate do usunięcia) |
+| `webhook_trigger_endpoints` lookup | endpointId → `{definitionId, nodeId}` | `webhook-trigger/endpoint-store.ts:187` |
+
+## Out of scope
+
+- Zmiana routingu/ownership dla triggerów źródeł (ticket, PR) - zostają singletonami.
+- UI dashboardu do zarządzania wieloma webhookami (o ile recon E1 nie wykaże twardego założenia "jeden webhook"). Jeśli wykaże, to osobny ticket.
+- Limit liczby jednoczesnie włączonych webhooków (brak limitu, każdy ma własny endpoint).
+
+## Założenia
+
+- **~~Zał. 1~~ (OBALONE przez pre-mortem, wcielone w plan):** webhook routing JEDNAK czytał `workflow_definition_triggers` przez `getEnabledWorkflowDefinitionForTrigger` w `resolveLiveWebhookTarget`/`ensureStillDispatchable`. Dlatego E2 przepisuje routing na `endpoint.definitionId`. Bez tego feature by się rozbił (obie dostawy odrzucone).
+- **Zał. 2:** Dashboard nie zakłada dokładnie jednego enabled webhook-workflow (lista/filtr/panel). Rekomendacja: E2 robi szybki grep po stronie dashboardu; jeśli zakłada, zgłoś jako follow-up, nie rozszerzaj tego planu.
+- **Zał. 3:** Poza wymienionymi (routing, overlap, heal), `trigger_types` nie jest używane do innego per-type single-ownera dla webhooka. E1 potwierdza greppem `getEnabledWorkflowDefinitionForTrigger` / `readTriggerBinding` / `"trigger_webhook"` przed zamknięciem zakresu.
+
+## Etapy
+
+| # | Etap | Seam | Zakres plików | Tier | Sceptyk | TDD | Delegacja | DoD |
+|---|------|------|---------------|------|---------|-----|-----------|-----|
+| E1 | Polityka + store: `isPerEndpointTrigger` (jedno źródło prawdy), filtr w `assertNoTriggerOverlap`, wykluczenie webhooka z insert/sync bindingów i z `healMissingTriggerBinding`/`enabledDefinitionsDeclaringTrigger`; nowy helper `getEnabledDeployedDefinition(db, definitionId)`; grep potwierdzający wszystkie czytniki `"trigger_webhook"` / `getEnabledWorkflowDefinitionForTrigger` | assertNoTriggerOverlap + binding/heal | `apps/worker/src/workflow-definition/store.ts` | opus | tak | nie | nie | `pnpm --filter worker typecheck` czysto; grep: webhook nie jest insertowany ani healowany do `workflow_definition_triggers`; helper wyeksportowany z sygnaturą dla E2 |
+| E2 | Routing rewrite: `resolveLiveWebhookTarget` i `ensureStillDispatchable` routują po `endpoint.definitionId` (helper z E1), usunięcie bramki per-type ownera (`:334`); to samo w `config.get.ts:60` i `test-delivery.post.ts:81`; szybki grep dashboardu (Zał.2) | delivery route | `apps/worker/src/routes/webhooks/custom/[endpointId].post.ts`, `.../webhook/config.get.ts`, `.../webhook/test-delivery.post.ts` | opus | tak | nie | nie | typecheck czysto; brak wywołań `getEnabledWorkflowDefinitionForTrigger("trigger_webhook")` na ścieżce dostawy; przegląd że dostawa na wyłączoną definicję nadal odrzucona |
+| E3 | Migracja `0042`: `DELETE FROM workflow_definition_triggers WHERE trigger_type = 'trigger_webhook'` + wpis w `meta/_journal.json` | - | `apps/worker/drizzle/0042_*.sql`, `apps/worker/drizzle/meta/_journal.json` | sonnet | nie | nie | nie | Format zgodny z 0041; journal spójny; jedno stwierdzenie SQL (bez transakcji) |
+| E4 | Testy po fakcie: (store) dwa webhook enable OK, drugi `trigger_ticket_ai` → 409; (route/HTTP) delivery A→run def A, B→run def B, delivery na wyłączoną definicję odrzucona | pglite `store.test.ts` + route test | `apps/worker/src/workflow-definition/store.test.ts`, `apps/worker/src/routes/webhooks/custom/[endpointId].post.test.ts` | opus | tak | nie | nie | `cd apps/worker && pnpm exec vitest run src/workflow-definition/store.test.ts src/routes/webhooks/custom/` zielone; oba scenariusze pokryte |
+
+Kolejność i współbieżność: **E1 pierwszy** (zamraża `isPerEndpointTrigger` + sygnaturę `getEnabledDeployedDefinition`). **E3 równolegle z E1** (rozłączne pliki: drizzle vs store; kontrakt "webhook wykluczony" ustalony w planie), ale wdrożenie migracji na prod dopiero po zmergowaniu E1+E2. **E2 po bramce E1** (potrzebuje helpera). **E4 po E1+E2**. E1/E2 rozłączne z E4 plikowo, ale E4 zależy od zachowania obu.
+
+## Rollout (poza tabelą, robi advisor po merge + deployu)
+
+Po zmergowaniu i deployu worker na prod: włączyć oba webhooki (def 15 Zendesk + def 16 Sentry) jednocześnie, wygenerować dostawę na każdy endpoint (Zendesk ticket + Sentry error) i potwierdzić, że każda odpala run właściwej definicji, oba PR-y otwierają się niezależnie. To bezpośrednia realizacja odpowiedzi usera "włącz oba i przetestuj dokładnie".


### PR DESCRIPTION
## What

Makes `trigger_webhook` exempt from the org-wide singleton so multiple webhook-triggered workflows can be enabled at once (e.g. one for Zendesk support tickets, one for Sentry error alerts). Each webhook workflow already mints its own unique endpoint; deliveries now route per `endpoint.definitionId` instead of through a single per-type owner. All other triggers (`trigger_ticket_ai`, `trigger_pr_*`, `trigger_plan_approved`) stay singletons.

## How

- **store.ts**: `isPerEndpointTrigger` (single source of truth); `assertNoTriggerOverlap` filters webhook before the overlap probe; webhook is excluded from every `workflow_definition_triggers` insert/sync and from `healMissingTriggerBinding`; new exported helper `getEnabledDeployedDefinition(db, definitionId)` returning the deployed snapshot.
- **routes**: `resolveLiveWebhookTarget` / `ensureStillDispatchable` (+ `config.get`, `test-delivery`) route by `endpoint.definitionId`, dropping the per-type owner gate.
- **migration 0042**: deletes existing `trigger_webhook` rows from `workflow_definition_triggers` (routing no longer uses them; heal no longer re-inserts).
- **tests**: two webhook definitions enabled at once (asserted simultaneously enabled), per-endpoint delivery routing with no cross-talk, disabled-sibling isolation; singleton regression for `trigger_ticket_ai` retained.

## Notes

- Race-safety of singletons unchanged (PK on `workflow_definition_triggers.trigger_type` + `retryOnUniqueViolation`). No `db.transaction()` (neon-http).
- Verified: worker typecheck clean; touched test files green (serialized to avoid the known `createTestDb` hook-timeout under parallel load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiple webhook workflows can now be enabled simultaneously.
  * Webhook endpoints route directly to their associated workflow, allowing independent endpoint management.
* **Bug Fixes**
  * Disabled, archived, or undeployed workflows are rejected for webhook delivery and testing.
  * Disabling one webhook workflow no longer affects other webhook endpoints.
* **Documentation**
  * Updated webhook behavior and implementation planning documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->