### PR TITLE
feat(worker): add the schedule trigger (AIW-223)

### DIFF
--- a/apps/worker/src/workflows/workspace-gate.test.ts
+++ b/apps/worker/src/workflows/workspace-gate.test.ts
@@ -210,6 +210,50 @@ describe("workspace gate", () => {
     ).rejects.toThrow("Run Workspace is not clean");
   });
 
+  it("names the cause when the workspace cannot be inspected at the boundary", async () => {
+    // A production scheduled run died here with a message that named only the
+    // boundary, so the operator could not tell a vanished sandbox from an agent
+    // that left work uncommitted. The distinct causes must reach the run record.
+    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+      version: 7,
+      config: {
+        repositories: [{
+          provider: "github",
+          repoPath: "acme/web",
+          commands: ["pnpm test"],
+        }],
+      },
+    });
+
+    dirty.add("/vercel/sandbox");
+    await expect(
+      assertCurrentWorkspaceGate({
+        sandboxId: "sbx-1",
+        workspaceManifest: manifest,
+        gate: null,
+      }),
+    ).rejects.toMatchObject({
+      code: "workspace_unverifiable",
+      message: expect.stringContaining("Run Workspace is not clean"),
+    });
+
+    dirty.clear();
+    manifestRaw = JSON.stringify({
+      ...manifest,
+      repositories: [{ ...manifest.repositories[0], repoPath: "foreign/repo" }],
+    });
+    await expect(
+      assertCurrentWorkspaceGate({
+        sandboxId: "sbx-1",
+        workspaceManifest: manifest,
+        gate: null,
+      }),
+    ).rejects.toMatchObject({
+      code: "workspace_unverifiable",
+      message: expect.stringContaining("does not match"),
+    });
+  });
+
   it("does not require a gate when configuration is absent or inapplicable", async () => {
     await expect(
       assertCurrentWorkspaceGate({

--- a/apps/worker/src/workflows/workspace-gate.ts
+++ b/apps/worker/src/workflows/workspace-gate.ts
@@ -101,10 +101,16 @@ export async function assertCurrentWorkspaceGate(input: {
       input.sandboxId,
       input.workspaceManifest,
     );
-  } catch {
+  } catch (error) {
+    // Inspection fails for materially different reasons (the sandbox is gone,
+    // the manifest file is missing, the on-disk manifest disagrees with the
+    // trusted one), and swallowing them left a production failure whose only
+    // message named the boundary rather than the cause. Carry the reason, and
+    // bound it so a provider error object cannot become the run status.
+    const reason = error instanceof Error ? error.message : String(error);
     throw new WorkspaceGateError(
       "workspace_unverifiable",
-      "The Run Workspace could not be verified at the publication boundary.",
+      `The Run Workspace could not be verified at the publication boundary: ${reason.slice(0, 200)}`,
     );
   }
 
@@ -166,7 +172,10 @@ async function inspectWorkspaceForGateStep(
 
   const manifestResult = await sandbox.runCommand("cat", [WORKSPACE_MANIFEST_PATH]);
   if (manifestResult.exitCode !== 0) {
-    throw new Error("Run Workspace manifest is unavailable");
+    const stderr = (await manifestResult.stderr()).trim().slice(0, 120);
+    throw new Error(
+      `Run Workspace manifest is unavailable (exit ${manifestResult.exitCode}${stderr ? `: ${stderr}` : ""})`,
+    );
   }
   const manifest = parseVerifiedWorkspaceManifest(
     await manifestResult.stdout(),


### PR DESCRIPTION
Adds the last missing way to start a workflow: a schedule. Until now a run could only begin from an external event (a ticket moved to the AI column, a pull request event, or a signed webhook), so anything recurring needed a person or a foreign scheduler.

## Design

**Occurrence identity is computed, not received.** The key is `(schedule_id, occurrence_at)`, where the instant comes from the cron expression. That is a stronger guarantee than the webhook trigger has: a webhook without a delivery id falls back to a body hash bucketed in time, and a bucket has an edge; re-evaluating the same occurrence reproduces an identical key with no edge at all. The row is inserted before dispatch, so two overlapping poll invocations cannot both fire, and a retry replays the recorded outcome.

**No future invocation is materialised.** Only a past watermark is stored and the next occurrence is computed on demand, so editing a schedule cannot orphan a scheduled future invocation: there is none. An edit takes effect immediately because the next occurrence is derived from the current expression.

**The watermark advances on evaluation, not on success.** An occurrence skipped by the overlap policy or dropped past the catch-up window still advances it. The opposite would retry the same occurrence forever.

**The overlap policy is the shape of the subject key**, not a new mechanism: `skip` and `queue` share `schedule:<id>`, `allow` uses `schedule:<id>:<epoch>` with a ceiling of two in flight. Capacity exhaustion is deliberately not treated as overlap — it always leaves the occurrence pending for the next tick, in all three policies, because a foreign run holding the pool is not the same event as this schedule's own run still working.

**Each occurrence owns its identity**, `schedule-<id>-<YYYYMMDDTHHmm>`, so it branches and publishes independently. Sharing one identity across occurrences would push occurrence 2 onto occurrence 1's branch, reuse its pull request, edit the same Slack post, and dead-end on `branch has diverged` the first time a human pushed a fix.

## Notable constraints this respects

- `workflow_definition_triggers.trigger_type` is a primary key, so a schedule may not take a row there or only one workflow in the whole system could own a schedule. Schedules route themselves from their own row, so they are excluded from all three exclusive inserts and from the denormalised overlap check.
- Liveness is resolved fail-closed on every tick against the deployed head. A schedule whose node was removed, or whose definition was disabled or archived, is revoked rather than fired.
- Vercel runs crons on production deployments only, so a schedule cannot fire on preview or demo. The manual `/cron/poll` path already used by the e2e helpers covers those.
- Minimum period is 15 minutes, validated at deploy time, because agent runs occupy a small shared pool.
- Graphs that can park on a human are rejected at deploy: an unattended recurring trigger has nobody to answer.

## Verification

Full worker and dashboard suites pass. Beyond that, the feature was exercised on production against a real repository:

- **11 occurrences, 10 runs, 7 successes, 7 pull requests**, one run per occurrence, no occurrence orphaned in `pending`.
- **Overlap `skip`**: an occurrence arriving while the subject was held recorded `skipped_overlap` with the blocking run id and started nothing.
- **Overlap `queue`**: the same collision left the occurrence `pending`; the drain started it once the subject freed, and it published its own instant rather than the one that displaced it.
- **Backlog**: a watermark moved three hours back produced exactly one run and `dropped_count = 11`.
- **Revocation**: disabling a definition revoked its schedule on the next tick with zero occurrences created.
- **Pause survives redeploy**, and a deploy resyncs the authored cron into the row.
- **Three workflows owning schedules were enabled simultaneously**, which the trigger-binding table could not have allowed before.

## Incidental fix

The publication boundary caught inspection failures with an empty `catch`, so a production failure reported only that the workspace "could not be verified" while hiding which of four unrelated causes applied: a vanished sandbox, a missing manifest, a manifest disagreeing with the trusted copy, or uncommitted tracked work. The reason is now carried into the message, bounded so a provider error object cannot become a run status, and the manifest read reports its exit code. A regression test pins the cause rather than the error type.

## Follow-up filed

AIW-243: binding a block's `prompt` input silently discards its authored prompt, which is how the first two production occurrences failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace verification errors now provide more specific explanations, such as detected uncommitted changes or manifest mismatches.
  - Manifest retrieval failures include the command’s exit code and a shortened error message for easier troubleshooting.
  - Workspace verification continues to report failures consistently while preserving the underlying cause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->