### PR TITLE
fix(worker): close five pre-release defects in the scheduler, review publication, and stores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [main, dev]
   merge_group:
+  # The e2e suites below are gated on the merge queue, and no merge queue is
+  # configured, so they had never run: 11 of 11 recorded runs skipped all three.
+  # A manual dispatch is the only way to exercise them without changing how
+  # merges work, and their secrets live in the `e2e` environment, which is
+  # reachable from Actions and nowhere else.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -39,7 +45,7 @@ jobs:
 
   e2e-orchestration:
     needs: [ci]
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: e2e
@@ -92,7 +98,7 @@ jobs:
 
   e2e-capacity:
     needs: [e2e-orchestration]
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: e2e
@@ -145,7 +151,7 @@ jobs:
 
   e2e-agent:
     needs: [e2e-capacity]
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  # The event belongs in the key. Without it a manual dispatch and the branch's
+  # pull-request runs share one group, and since the group cancels in progress,
+  # any push kills a dispatch already running. That makes the e2e suites, which
+  # take hours, impossible to finish by hand. Pushes still supersede each other
+  # within their own event, which is the behaviour this cancellation is for.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -581,6 +581,9 @@ describe("GitHubAdapter", () => {
             endLine: 12,
           },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "Handle this failure." }),
+        ],
       });
 
       expect(mockOctokit.pulls.createReview).toHaveBeenCalledWith({
@@ -666,6 +669,10 @@ describe("GitHubAdapter", () => {
             endLine: 3,
           },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "Already published." }),
+          reviewFindingDigest({ path: "src/missing.ts", body: "Provider omitted this comment." }),
+        ],
       });
 
       expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
@@ -709,6 +716,9 @@ describe("GitHubAdapter", () => {
             endLine: 12,
           },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "Already published." }),
+        ],
       });
 
       // The key the marker is written from changed with the release; the review
@@ -743,6 +753,7 @@ describe("GitHubAdapter", () => {
         decision: "approve",
         summary: "Nothing left.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       expect(graphqlCalls("minimizeComment")).toEqual([
@@ -778,6 +789,9 @@ describe("GitHubAdapter", () => {
         summary: "One finding.",
         comments: [
           { path: "src/index.ts", body: after, startLine: 12, endLine: 12 },
+        ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: after }),
         ],
       });
 
@@ -886,6 +900,7 @@ describe("GitHubAdapter", () => {
         decision: "approve",
         summary: "Nothing left.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       expect(graphqlCalls("minimizeComment")).toEqual([]);
@@ -915,6 +930,7 @@ describe("GitHubAdapter", () => {
         summary: "One finding, not shown inline.",
         // Not among the placed comments, and reported all the same.
         comments: [],
+        commentFindingDigests: [],
         deferredFindingDigests: [
           reviewFindingDigest({ path: "src/index.ts", body }),
         ],
@@ -948,6 +964,7 @@ describe("GitHubAdapter", () => {
         comments: [
           { path: "src/index.ts", body, startLine: 40, endLine: 40 },
         ],
+        commentFindingDigests: [reviewFindingDigest({ path: "src/index.ts", body })],
       });
 
       expect(graphqlCalls("resolveReviewThread")).toEqual([]);
@@ -992,6 +1009,10 @@ describe("GitHubAdapter", () => {
           { path: "src/index.ts", body: kept, startLine: 12, endLine: 12 },
           { path: "src/new.ts", body: "**Nit**: New one.", startLine: 7, endLine: 7 },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: kept }),
+          reviewFindingDigest({ path: "src/new.ts", body: "**Nit**: New one." }),
+        ],
       });
 
       expect(mockOctokit.pulls.createReview.mock.calls[0]![0].comments).toEqual([
@@ -1021,6 +1042,7 @@ describe("GitHubAdapter", () => {
         decision: "approve",
         summary: "Round two.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       expect(mockOctokit.issues.createComment).not.toHaveBeenCalled();
@@ -1063,6 +1085,7 @@ describe("GitHubAdapter", () => {
         decision: "approve",
         summary: "Nothing left.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       expect(graphqlCalls("minimizeComment")).toEqual([]);
@@ -1090,6 +1113,7 @@ describe("GitHubAdapter", () => {
           decision: "approve",
           summary: "Nothing left.",
           comments: [],
+          commentFindingDigests: [],
         }),
       ).rejects.toThrow("GitHub is down");
 
@@ -1140,6 +1164,7 @@ describe("GitHubAdapter", () => {
           decision: "approve",
           summary: "Nothing left.",
           comments: [],
+          commentFindingDigests: [],
         }),
       ).resolves.toEqual({ id: "711", commentIds: [] });
 
@@ -1171,6 +1196,9 @@ describe("GitHubAdapter", () => {
             startLine: 10,
             endLine: 12,
           },
+        ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "Handle this failure." }),
         ],
       });
 
@@ -1217,6 +1245,16 @@ describe("GitHubAdapter", () => {
             endLine: 4,
           },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({
+            path: "src/index.ts",
+            body: "**High**: Handle this failure.\n\nReported by 3 of 3 reviewers.",
+          }),
+          reviewFindingDigest({
+            path: "src/other.ts",
+            body: "**Medium**: Rename this helper.",
+          }),
+        ],
       });
 
       const body: string = mockOctokit.pulls.createReview.mock.calls[1]![0].body;
@@ -1261,6 +1299,9 @@ describe("GitHubAdapter", () => {
             endLine: 12,
           },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "Handle this failure." }),
+        ],
       });
 
       expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(2);
@@ -1298,6 +1339,7 @@ describe("GitHubAdapter", () => {
         decision: "approve",
         summary: "Approved.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(2);
@@ -1339,6 +1381,9 @@ describe("GitHubAdapter", () => {
             endLine: 12,
           },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "Handle this failure." }),
+        ],
       });
 
       expect(mockOctokit.pulls.createReview).toHaveBeenCalledTimes(3);
@@ -1368,6 +1413,7 @@ describe("GitHubAdapter", () => {
           decision: "approve",
           summary: "Approved.",
           comments: [],
+          commentFindingDigests: [],
         }),
       ).rejects.toBe(rejected);
 

--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GitHubAdapter } from "./github.js";
+import { reviewFindingDigest } from "./types.js";
 
 const mockOctokit = {
   paginate: vi.fn(),
+  graphql: vi.fn(),
   git: {
     getRef: vi.fn(),
     createRef: vi.fn(),
@@ -23,6 +25,7 @@ const mockOctokit = {
   issues: {
     listComments: vi.fn(),
     createComment: vi.fn(),
+    updateComment: vi.fn(),
   },
   checks: {
     create: vi.fn(),
@@ -47,6 +50,13 @@ function ghAdapter() {
 describe("GitHubAdapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // `clearAllMocks` forgets calls but keeps the queue `mockResolvedValueOnce`
+    // builds up, so a test that leaves one unconsumed hands it to the next test.
+    // These two are queued in nearly every review test, which is exactly where
+    // that leak is hardest to read.
+    mockOctokit.paginate.mockReset();
+    mockOctokit.paginate.mockResolvedValue([]);
+    mockOctokit.graphql.mockReset();
   });
 
   describe("branch ownership operations", () => {
@@ -471,6 +481,62 @@ describe("GitHubAdapter", () => {
   });
 
   describe("publishPRReview", () => {
+    /** One review thread as the GraphQL query returns it. */
+    function thread(options: {
+      id: string;
+      commentId?: string;
+      databaseId?: number;
+      body: string;
+      isResolved?: boolean;
+      viewerDidAuthor?: boolean;
+    }) {
+      return {
+        id: options.id,
+        isResolved: options.isResolved ?? false,
+        comments: {
+          nodes: [
+            {
+              id: options.commentId ?? `${options.id}-comment`,
+              databaseId: options.databaseId ?? null,
+              body: options.body,
+              viewerDidAuthor: options.viewerDidAuthor ?? true,
+            },
+          ],
+        },
+      };
+    }
+
+    function stubReviewThreads(nodes: unknown[]) {
+      mockOctokit.graphql.mockImplementation(async (query: string) =>
+        String(query).includes("reviewThreads(")
+          ? {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes,
+                  },
+                },
+              },
+            }
+          : {},
+      );
+    }
+
+    const graphqlCalls = (needle: string) =>
+      mockOctokit.graphql.mock.calls.filter(([query]) =>
+        String(query).includes(needle),
+      );
+
+    const findingMarker = (path: string, body: string) =>
+      `<!-- ai-workflow-review-finding:${reviewFindingDigest({ path, body })} -->`;
+
+    beforeEach(() => {
+      stubReviewThreads([]);
+      mockOctokit.issues.createComment.mockResolvedValue({ data: { id: 900 } });
+      mockOctokit.issues.updateComment.mockResolvedValue({ data: { id: 900 } });
+    });
+
     it("publishes against the exact head and returns persisted inline comment ids", async () => {
       mockOctokit.paginate
         .mockResolvedValueOnce([])
@@ -513,11 +579,18 @@ describe("GitHubAdapter", () => {
         pull_number: 42,
         commit_id: "reviewed-head",
         event: "REQUEST_CHANGES",
-        body: "Two findings.\n\n<!-- ai-workflow-review:review-hash -->",
+        // The verdict's review is per head and says so. The summary is not in it.
+        body: expect.stringContaining(
+          "<!-- ai-workflow-review-head:reviewed-head -->",
+        ),
         comments: [
           {
             path: "src/index.ts",
-            body: "Handle this failure.",
+            // The finding's own marker rides with the comment, because the thread
+            // it opens is what the next round has to recognise.
+            body:
+              "Handle this failure.\n\n" +
+              findingMarker("src/index.ts", "Handle this failure."),
             side: "RIGHT",
             line: 12,
             start_side: "RIGHT",
@@ -525,28 +598,31 @@ describe("GitHubAdapter", () => {
           },
         ],
       });
-      expect(mockOctokit.paginate).toHaveBeenLastCalledWith(
-        mockOctokit.pulls.listCommentsForReview,
-        {
-          owner: "test-org",
-          repo: "test-repo",
-          pull_number: 42,
-          review_id: 701,
-          per_page: 100,
-        },
+      expect(mockOctokit.pulls.createReview.mock.calls[0]![0].body).not.toContain(
+        "Two findings.",
       );
+      // The summary is the pull request's own comment, marked with the pull
+      // request's key so every later round finds it again.
+      expect(mockOctokit.issues.createComment).toHaveBeenCalledWith({
+        owner: "test-org",
+        repo: "test-repo",
+        issue_number: 42,
+        body: "Two findings.\n\n<!-- ai-workflow-review:review-hash -->",
+      });
       expect(result).toEqual({
         id: "701",
         commentIds: ["801"],
       });
     });
 
-    it("reuses an existing marked review without publishing a duplicate", async () => {
+    it("submits one verdict per head when the round is retried", async () => {
       mockOctokit.paginate
         .mockResolvedValueOnce([
           {
             id: 701,
-            body: "Already published.\n\n<!-- ai-workflow-review:review-hash -->",
+            body:
+              "## AI Workflow review\n\n" +
+              "<!-- ai-workflow-review-head:reviewed-head -->",
           },
         ])
         .mockResolvedValueOnce([
@@ -580,6 +656,10 @@ describe("GitHubAdapter", () => {
       });
 
       expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
+      // Recognising the round is not the same as having finished it: the publish
+      // call can succeed and the row that records it can be lost, so the summary
+      // still has to be written on the way out.
+      expect(mockOctokit.issues.createComment).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ id: "701", commentIds: ["801", null] });
     });
 
@@ -623,6 +703,262 @@ describe("GitHubAdapter", () => {
       // every open pull request with a second copy of its own review.
       expect(mockOctokit.pulls.createReview).not.toHaveBeenCalled();
       expect(result).toEqual({ id: "701", commentIds: ["801"] });
+    });
+
+    // AIW-236's main requirement. Measured on our own PR #224, two rounds of
+    // CodeRabbit left thirteen live threads and resolved, outdated or collapsed
+    // exactly none of them.
+    it("resolves and hides the thread of a finding this round no longer reports", async () => {
+      stubReviewThreads([
+        thread({
+          id: "thread-settled",
+          commentId: "comment-node-settled",
+          body: `Fixed since.\n\n${findingMarker("src/gone.ts", "Fixed since.")}`,
+        }),
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 706 },
+      });
+
+      await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "approve",
+        summary: "Nothing left.",
+        comments: [],
+      });
+
+      expect(graphqlCalls("resolveReviewThread")).toEqual([
+        [expect.any(String), { threadId: "thread-settled" }],
+      ]);
+      expect(graphqlCalls("minimizeComment")).toEqual([
+        [expect.any(String), { subjectId: "comment-node-settled" }],
+      ]);
+    });
+
+    // A finding the inline cap pushed into the summary is still standing. Settling
+    // its thread would put "resolved" on the thread and "still open" in the summary
+    // for one defect, which is worse than either alone.
+    it("keeps the thread of a finding this round reports into the summary", async () => {
+      const body = "**Nit**: Demoted by the cap this round.";
+      stubReviewThreads([
+        thread({
+          id: "thread-deferred",
+          databaseId: 814,
+          body: `${body}\n\n${findingMarker("src/index.ts", body)}`,
+        }),
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 712 },
+      });
+
+      await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "One finding, not shown inline.",
+        // Not among the placed comments, and reported all the same.
+        comments: [],
+        deferredFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body }),
+        ],
+      });
+
+      expect(graphqlCalls("resolveReviewThread")).toEqual([]);
+      expect(graphqlCalls("minimizeComment")).toEqual([]);
+    });
+
+    it("leaves a thread alone when this round still reports its finding", async () => {
+      const body = "**High**: Handle this failure.";
+      stubReviewThreads([
+        thread({
+          id: "thread-open",
+          databaseId: 811,
+          body: `${body}\n\n${findingMarker("src/index.ts", body)}`,
+        }),
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 707 },
+      });
+
+      const result = await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        // A force-push moved every line in the file and the finding came back at a
+        // different one. The digest carries no position, so the thread is still
+        // recognised and neither resolved nor restated.
+        headSha: "force-pushed-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          { path: "src/index.ts", body, startLine: 40, endLine: 40 },
+        ],
+      });
+
+      expect(graphqlCalls("resolveReviewThread")).toEqual([]);
+      expect(mockOctokit.pulls.createReview.mock.calls[0]![0].comments).toEqual(
+        [],
+      );
+      // The finding keeps the id of the thread it already has, so the run's record
+      // of it does not go blank the moment it stops being reposted.
+      expect(result.commentIds).toEqual(["811"]);
+      // And it is named in the summary. Without this line the finding would be in
+      // no artifact a reader treats as current, and an unfixed finding would read
+      // as fixed.
+      const summary = mockOctokit.issues.createComment.mock.calls[0]![0].body;
+      expect(summary).toContain("### Findings already open on this pull request");
+      expect(summary).toContain(
+        "- `src/index.ts:40` — **High**: Handle this failure.",
+      );
+    });
+
+    it("posts inline comments only for the findings this round adds", async () => {
+      const kept = "**High**: Still broken.";
+      stubReviewThreads([
+        thread({
+          id: "thread-open",
+          databaseId: 812,
+          body: `${kept}\n\n${findingMarker("src/index.ts", kept)}`,
+        }),
+      ]);
+      mockOctokit.paginate.mockResolvedValueOnce([]).mockResolvedValueOnce([
+        { id: 813, path: "src/new.ts", line: 7, start_line: null },
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 708 },
+      });
+
+      const result = await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "Two findings.",
+        comments: [
+          { path: "src/index.ts", body: kept, startLine: 12, endLine: 12 },
+          { path: "src/new.ts", body: "**Nit**: New one.", startLine: 7, endLine: 7 },
+        ],
+      });
+
+      expect(mockOctokit.pulls.createReview.mock.calls[0]![0].comments).toEqual([
+        expect.objectContaining({ path: "src/new.ts" }),
+      ]);
+      expect(result.commentIds).toEqual(["812", "813"]);
+    });
+
+    it("edits the one summary comment instead of adding a second", async () => {
+      mockOctokit.paginate
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { id: 5001, body: "A human said something else." },
+          {
+            id: 5002,
+            body: "Round one.\n\n<!-- ai-workflow-review:review-hash -->",
+          },
+        ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 709 },
+      });
+
+      await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "approve",
+        summary: "Round two.",
+        comments: [],
+      });
+
+      expect(mockOctokit.issues.createComment).not.toHaveBeenCalled();
+      expect(mockOctokit.issues.updateComment).toHaveBeenCalledWith({
+        owner: "test-org",
+        repo: "test-repo",
+        comment_id: 5002,
+        body: "Round two.\n\n<!-- ai-workflow-review:review-hash -->",
+      });
+    });
+
+    it("settles a thread opened before findings carried a marker", async () => {
+      stubReviewThreads([
+        thread({
+          id: "thread-legacy",
+          commentId: "comment-node-legacy",
+          body: "Reported before this adapter marked its findings.",
+          viewerDidAuthor: true,
+        }),
+        // Somebody else's thread, which this workflow has no business touching.
+        thread({
+          id: "thread-human",
+          body: "Please rename this.",
+          viewerDidAuthor: false,
+        }),
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 710 },
+      });
+
+      await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "approve",
+        summary: "Nothing left.",
+        comments: [],
+      });
+
+      expect(graphqlCalls("resolveReviewThread")).toEqual([
+        [expect.any(String), { threadId: "thread-legacy" }],
+      ]);
+    });
+
+    it("still publishes when GitHub refuses to hide a resolved comment", async () => {
+      stubReviewThreads([
+        thread({
+          id: "thread-settled",
+          body: `Fixed.\n\n${findingMarker("src/gone.ts", "Fixed.")}`,
+        }),
+      ]);
+      mockOctokit.graphql.mockImplementation(async (query: string) => {
+        if (String(query).includes("reviewThreads(")) {
+          return {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    thread({
+                      id: "thread-settled",
+                      body: `Fixed.\n\n${findingMarker("src/gone.ts", "Fixed.")}`,
+                    }),
+                  ],
+                },
+              },
+            },
+          };
+        }
+        if (String(query).includes("minimizeComment")) {
+          throw Object.assign(new Error("Resource not accessible"), {
+            status: 403,
+          });
+        }
+        return {};
+      });
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 711 },
+      });
+
+      await expect(
+        ghAdapter().publishPRReview(42, {
+          idempotencyKey: "review-hash",
+          headSha: "next-head",
+          decision: "approve",
+          summary: "Nothing left.",
+          comments: [],
+        }),
+      ).resolves.toEqual({ id: "711", commentIds: [] });
+
+      // Resolving carried the meaning and already happened; hiding the text is
+      // presentation, and a repository that forbids it must not cost the pull
+      // request its review.
+      expect(graphqlCalls("resolveReviewThread")).toHaveLength(1);
+      expect(mockOctokit.issues.createComment).toHaveBeenCalledTimes(1);
     });
 
     it("falls back to a summary-only review when GitHub rejects inline positions", async () => {
@@ -745,7 +1081,7 @@ describe("GitHubAdapter", () => {
           comments: [
             expect.objectContaining({
               path: "src/index.ts",
-              body: "Handle this failure.",
+              body: expect.stringContaining("Handle this failure."),
             }),
           ],
         }),

--- a/apps/worker/src/adapters/vcs/github.test.ts
+++ b/apps/worker/src/adapters/vcs/github.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GitHubAdapter } from "./github.js";
 import { reviewFindingDigest } from "./types.js";
+import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 
 const mockOctokit = {
   paginate: vi.fn(),
@@ -487,12 +488,13 @@ describe("GitHubAdapter", () => {
       commentId?: string;
       databaseId?: number;
       body: string;
-      isResolved?: boolean;
+      isMinimized?: boolean;
       viewerDidAuthor?: boolean;
+      /** Comments after the first. `viewerDidAuthor: false` is a human reply. */
+      replies?: Array<{ viewerDidAuthor: boolean }>;
     }) {
       return {
         id: options.id,
-        isResolved: options.isResolved ?? false,
         comments: {
           nodes: [
             {
@@ -500,7 +502,15 @@ describe("GitHubAdapter", () => {
               databaseId: options.databaseId ?? null,
               body: options.body,
               viewerDidAuthor: options.viewerDidAuthor ?? true,
+              isMinimized: options.isMinimized ?? false,
             },
+            ...(options.replies ?? []).map((reply, index) => ({
+              id: `${options.id}-reply-${index}`,
+              databaseId: null,
+              body: "A reply.",
+              viewerDidAuthor: reply.viewerDidAuthor,
+              isMinimized: false,
+            })),
           ],
         },
       };
@@ -602,12 +612,15 @@ describe("GitHubAdapter", () => {
         "Two findings.",
       );
       // The summary is the pull request's own comment, marked with the pull
-      // request's key so every later round finds it again.
+      // request's key so every later round finds it again, and with the bot marker
+      // so the comment event it raises does not start another review round.
       expect(mockOctokit.issues.createComment).toHaveBeenCalledWith({
         owner: "test-org",
         repo: "test-repo",
         issue_number: 42,
-        body: "Two findings.\n\n<!-- ai-workflow-review:review-hash -->",
+        body:
+          "Two findings.\n\n<!-- ai-workflow-review:review-hash -->\n\n" +
+          AI_WORKFLOW_COMMENT_MARKER,
       });
       expect(result).toEqual({
         id: "701",
@@ -708,7 +721,11 @@ describe("GitHubAdapter", () => {
     // AIW-236's main requirement. Measured on our own PR #224, two rounds of
     // CodeRabbit left thirteen live threads and resolved, outdated or collapsed
     // exactly none of them.
-    it("resolves and hides the thread of a finding this round no longer reports", async () => {
+    //
+    // Hidden as OUTDATED and deliberately NOT resolved: this adapter cannot tell
+    // "the defect was fixed" from "the reviewer worded it differently this round",
+    // and only the first of those justifies a resolved tick.
+    it("hides the thread of a finding this round no longer reports without resolving it", async () => {
       stubReviewThreads([
         thread({
           id: "thread-settled",
@@ -728,12 +745,151 @@ describe("GitHubAdapter", () => {
         comments: [],
       });
 
-      expect(graphqlCalls("resolveReviewThread")).toEqual([
-        [expect.any(String), { threadId: "thread-settled" }],
-      ]);
       expect(graphqlCalls("minimizeComment")).toEqual([
         [expect.any(String), { subjectId: "comment-node-settled" }],
       ]);
+      expect(graphqlCalls("resolveReviewThread")).toEqual([]);
+    });
+
+    // The case the digest cannot distinguish from a repair, and the reason the
+    // sweep stopped claiming one. Agent prose is regenerated every round, so the
+    // same defect routinely comes back under new wording and a new digest.
+    it("hides the old thread and opens a new one when a finding is reworded", async () => {
+      const before = "**High**: This can throw on an empty list.";
+      const after = "**High**: An empty list makes this throw.";
+      stubReviewThreads([
+        thread({
+          id: "thread-reworded",
+          commentId: "comment-node-reworded",
+          body: `${before}\n\n${findingMarker("src/index.ts", before)}`,
+        }),
+      ]);
+      mockOctokit.paginate.mockResolvedValueOnce([]).mockResolvedValueOnce([
+        { id: 830, path: "src/index.ts", line: 12, start_line: null },
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 713 },
+      });
+
+      await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          { path: "src/index.ts", body: after, startLine: 12, endLine: 12 },
+        ],
+      });
+
+      // The old thread collapses as outdated, which is true, rather than resolved,
+      // which would tell the reader a live defect was dealt with.
+      expect(graphqlCalls("minimizeComment")).toEqual([
+        [expect.any(String), { subjectId: "comment-node-reworded" }],
+      ]);
+      expect(graphqlCalls("resolveReviewThread")).toEqual([]);
+      expect(
+        mockOctokit.pulls.createReview.mock.calls[0]![0].comments[0].body,
+      ).toContain(after);
+    });
+
+    // The path production actually takes. The workflow passes its own digests, and
+    // they are deliberately NOT what the body hashes to: a published body carries
+    // the agreement note and the identity excludes it. An adapter that re-derived
+    // from the body would open threads under one identity and look them up under
+    // another, which is the mismatch this whole seam exists to prevent.
+    const callerDigest = "0123456789abcdef0123456789abcdef";
+    const notedBody = "**High**: Still broken.\n\nBoth reviewers reported this.";
+
+    it("marks a new thread with the caller's digest, not the body's", async () => {
+      mockOctokit.paginate.mockResolvedValueOnce([]).mockResolvedValueOnce([
+        { id: 840, path: "src/index.ts", line: 9, start_line: null },
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 715 },
+      });
+
+      await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          { path: "src/index.ts", body: notedBody, startLine: 9, endLine: 9 },
+        ],
+        commentFindingDigests: [callerDigest],
+      });
+
+      const posted =
+        mockOctokit.pulls.createReview.mock.calls[0]![0].comments[0].body;
+      expect(posted).toContain(
+        `<!-- ai-workflow-review-finding:${callerDigest} -->`,
+      );
+      expect(posted).not.toContain(
+        reviewFindingDigest({ path: "src/index.ts", body: notedBody }),
+      );
+    });
+
+    it("recognises an existing thread by the caller's digest", async () => {
+      stubReviewThreads([
+        thread({
+          id: "thread-open",
+          databaseId: 841,
+          // Opened last round, under wording this round no longer uses. The caller
+          // says it is the same finding, and the caller's word is what counts.
+          body: `Older wording.\n\n<!-- ai-workflow-review-finding:${callerDigest} -->`,
+        }),
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 716 },
+      });
+
+      const result = await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          { path: "src/index.ts", body: notedBody, startLine: 9, endLine: 9 },
+        ],
+        commentFindingDigests: [callerDigest],
+      });
+
+      // Carried over, so no second copy and no outdated tick on a live finding.
+      expect(
+        mockOctokit.pulls.createReview.mock.calls[0]![0].comments,
+      ).toEqual([]);
+      expect(result.commentIds).toEqual(["841"]);
+      expect(graphqlCalls("minimizeComment")).toEqual([]);
+    });
+
+    // The condition the plan set and the adapter could not previously even see:
+    // it only ever read the thread's first comment.
+    it("leaves a thread alone once a human has replied in it", async () => {
+      const body = "**Nit**: Rename this.";
+      stubReviewThreads([
+        thread({
+          id: "thread-discussed",
+          commentId: "comment-node-discussed",
+          body: `${body}\n\n${findingMarker("src/index.ts", body)}`,
+          replies: [{ viewerDidAuthor: false }],
+        }),
+      ]);
+      mockOctokit.pulls.createReview.mockResolvedValueOnce({
+        data: { id: 714 },
+      });
+
+      // This round no longer reports the finding, so the sweep would otherwise
+      // collapse the thread and the reader's reply along with it.
+      await ghAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "approve",
+        summary: "Nothing left.",
+        comments: [],
+      });
+
+      expect(graphqlCalls("minimizeComment")).toEqual([]);
+      expect(graphqlCalls("resolveReviewThread")).toEqual([]);
     });
 
     // A finding the inline cap pushed into the summary is still standing. Settling
@@ -872,11 +1028,17 @@ describe("GitHubAdapter", () => {
         owner: "test-org",
         repo: "test-repo",
         comment_id: 5002,
-        body: "Round two.\n\n<!-- ai-workflow-review:review-hash -->",
+        body:
+          "Round two.\n\n<!-- ai-workflow-review:review-hash -->\n\n" +
+          AI_WORKFLOW_COMMENT_MARKER,
       });
     });
 
-    it("settles a thread opened before findings carried a marker", async () => {
+    // Ownership needs the marker AND our authorship, so neither of these is ours.
+    // The pre-marker thread is the accepted cost: it stays open for good, which is
+    // the safe direction now that the sweep writes on other people's threads.
+    it("touches neither a pre-marker thread nor a marker somebody else pasted", async () => {
+      const body = "**High**: Quoted from our review.";
       stubReviewThreads([
         thread({
           id: "thread-legacy",
@@ -884,10 +1046,10 @@ describe("GitHubAdapter", () => {
           body: "Reported before this adapter marked its findings.",
           viewerDidAuthor: true,
         }),
-        // Somebody else's thread, which this workflow has no business touching.
+        // Carries our marker, written by somebody else.
         thread({
-          id: "thread-human",
-          body: "Please rename this.",
+          id: "thread-impostor",
+          body: `${body}\n\n${findingMarker("src/index.ts", body)}`,
           viewerDidAuthor: false,
         }),
       ]);
@@ -903,12 +1065,39 @@ describe("GitHubAdapter", () => {
         comments: [],
       });
 
-      expect(graphqlCalls("resolveReviewThread")).toEqual([
-        [expect.any(String), { threadId: "thread-legacy" }],
-      ]);
+      expect(graphqlCalls("minimizeComment")).toEqual([]);
+      expect(graphqlCalls("resolveReviewThread")).toEqual([]);
     });
 
-    it("still publishes when GitHub refuses to hide a resolved comment", async () => {
+    // Sweeping before the review exists left the pull request collapsed and
+    // review-less: every old thread hidden, nothing published to replace them.
+    it("hides nothing when the review itself fails to publish", async () => {
+      stubReviewThreads([
+        thread({
+          id: "thread-settled",
+          commentId: "comment-node-settled",
+          body: `Gone.\n\n${findingMarker("src/gone.ts", "Gone.")}`,
+        }),
+      ]);
+      mockOctokit.pulls.createReview.mockRejectedValueOnce(
+        Object.assign(new Error("GitHub is down"), { status: 500 }),
+      );
+
+      await expect(
+        ghAdapter().publishPRReview(42, {
+          idempotencyKey: "review-hash",
+          headSha: "next-head",
+          decision: "approve",
+          summary: "Nothing left.",
+          comments: [],
+        }),
+      ).rejects.toThrow("GitHub is down");
+
+      expect(graphqlCalls("minimizeComment")).toEqual([]);
+      expect(mockOctokit.issues.createComment).not.toHaveBeenCalled();
+    });
+
+    it("still publishes when GitHub refuses to hide an outdated comment", async () => {
       stubReviewThreads([
         thread({
           id: "thread-settled",
@@ -954,10 +1143,10 @@ describe("GitHubAdapter", () => {
         }),
       ).resolves.toEqual({ id: "711", commentIds: [] });
 
-      // Resolving carried the meaning and already happened; hiding the text is
-      // presentation, and a repository that forbids it must not cost the pull
-      // request its review.
-      expect(graphqlCalls("resolveReviewThread")).toHaveLength(1);
+      // Collapsing an old comment is presentation and the round's findings are
+      // already published by then, so a repository that forbids it must not cost
+      // the pull request its review.
+      expect(graphqlCalls("minimizeComment")).toHaveLength(1);
       expect(mockOctokit.issues.createComment).toHaveBeenCalledTimes(1);
     });
 

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -22,6 +22,7 @@ import type {
   ManualDispatchPullRequestSnapshot,
 } from "./types.js";
 import { reviewFallbackBullet, reviewFindingDigest } from "./types.js";
+import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 
 export interface GitHubConfig {
   auth: GitHubAppAuth;
@@ -58,9 +59,9 @@ function isSelfAuthoredReviewError(error: unknown): boolean {
   );
 }
 
-/** The marker family is this adapter's; the digest formula inside it is shared. */
-function reviewFindingMarker(comment: PRReviewInlineComment): string {
-  return `<!-- ai-workflow-review-finding:${reviewFindingDigest(comment)} -->`;
+/** The marker family is this adapter's; the digest inside it comes from the caller. */
+function reviewFindingMarker(digest: string): string {
+  return `<!-- ai-workflow-review-finding:${digest} -->`;
 }
 
 function readReviewFindingDigest(body: string): string | null {
@@ -89,6 +90,16 @@ function roundReviewBody(headMarker: string, sections: string[] = []): string {
   ].join("\n\n");
 }
 
+/**
+ * The whole thread, not just its opening comment: whether a HUMAN has replied is
+ * what decides if this workflow may touch the thread at all, and that answer lives
+ * in the comments after the first one.
+ *
+ * `first: 100` and no inner pagination. A review thread with more than a hundred
+ * comments is a conversation this workflow should keep its hands off regardless,
+ * and the guard below fails safe in exactly that direction: unread replies can only
+ * make a thread look more human-touched, never less.
+ */
 const REVIEW_THREADS_QUERY = `
   query reviewThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
     repository(owner: $owner, name: $repo) {
@@ -97,9 +108,8 @@ const REVIEW_THREADS_QUERY = `
           pageInfo { hasNextPage endCursor }
           nodes {
             id
-            isResolved
-            comments(first: 1) {
-              nodes { id databaseId body viewerDidAuthor }
+            comments(first: 100) {
+              nodes { id databaseId body viewerDidAuthor isMinimized }
             }
           }
         }
@@ -109,22 +119,20 @@ const REVIEW_THREADS_QUERY = `
 `;
 
 /**
- * GitHub's only resolve primitive, and it is GraphQL-only: REST exposes review
- * comments but not the thread they hang from, and "resolved" is a property of the
- * thread. https://docs.github.com/graphql, Mutation.resolveReviewThread.
- */
-const RESOLVE_REVIEW_THREAD_MUTATION = `
-  mutation resolveReviewThread($threadId: ID!) {
-    resolveReviewThread(input: { threadId: $threadId }) {
-      thread { isResolved }
-    }
-  }
-`;
-
-/**
- * The collapse half. Resolving already folds a thread away in the Files view;
- * minimizing is what marks the comment itself outdated and hides its text in the
- * conversation. https://docs.github.com/graphql, Mutation.minimizeComment.
+ * The one act this workflow performs on a thread it has moved past, and it is
+ * deliberately NOT `resolveReviewThread`.
+ *
+ * "Resolved" is a claim about the code: that the defect is gone. Nothing here can
+ * support that claim. A finding's identity is a hash of agent-authored prose that is
+ * regenerated every round with no canonicalisation, so a thread going unmatched
+ * means "this round did not report the same wording", which is not "the defect was
+ * fixed". Marking it resolved on that evidence puts a green tick on live defects.
+ *
+ * `OUTDATED` is true whenever it is applied: the thread was opened against an
+ * earlier commit and the round has moved on. It collapses the comment in the
+ * conversation, which is the tidying this ticket wanted, and it asserts nothing
+ * about whether the code was repaired.
+ * https://docs.github.com/graphql, Mutation.minimizeComment.
  */
 const MINIMIZE_COMMENT_MUTATION = `
   mutation minimizeComment($subjectId: ID!) {
@@ -138,13 +146,13 @@ interface ReviewThreadsConnection {
   pageInfo?: { hasNextPage?: boolean; endCursor?: string | null } | null;
   nodes?: Array<{
     id?: string;
-    isResolved?: boolean;
     comments?: {
       nodes?: Array<{
         id?: string;
         databaseId?: number | null;
         body?: string | null;
         viewerDidAuthor?: boolean;
+        isMinimized?: boolean;
       } | null> | null;
     } | null;
   } | null> | null;
@@ -158,11 +166,17 @@ interface ReviewThreadsPage {
 
 interface OwnedReviewThread {
   id: string;
-  isResolved: boolean;
+  isMinimized: boolean;
   /** Node id of the thread's first comment, the subject `minimizeComment` takes. */
   commentId: string;
   commentReference: string | null;
-  digest: string | null;
+  digest: string;
+  /**
+   * Somebody other than this workflow has commented in the thread. Such a thread is
+   * never touched: a reader's question collapsed under an OUTDATED tick is a worse
+   * outcome than a stale thread left open.
+   */
+  hasHumanReply: boolean;
 }
 
 export class GitHubAdapter
@@ -654,28 +668,22 @@ export class GitHubAdapter
     const headMarker = `<!-- ai-workflow-review-head:${publication.headSha} -->`;
 
     const threads = await this.ownReviewThreads(prId);
-    const digests = publication.comments.map(reviewFindingDigest);
+    // The caller's digests when it has its own recipe, and the comment body
+    // otherwise. Either way this adapter only carries the value.
+    const digests =
+      publication.commentFindingDigests ??
+      publication.comments.map(reviewFindingDigest);
     // Reported inline AND reported into the summary. A finding the cap pushed out
-    // of the inline set is still standing, so its thread must not read as resolved
-    // while the summary lists it: the two would say opposite things about one
-    // defect, which is the misleading state this whole change is about.
+    // of the inline set is still standing, so its thread must not be collapsed as
+    // outdated while the summary lists it: the two would say opposite things about
+    // one defect, which is the misleading state this whole change is about.
     const reported = new Set([
       ...digests,
       ...(publication.deferredFindingDigests ?? []),
     ]);
     const openByDigest = new Map<string, OwnedReviewThread>();
     for (const thread of threads) {
-      if (thread.digest !== null) openByDigest.set(thread.digest, thread);
-    }
-
-    // A thread this round no longer reports is settled: resolve it and hide it.
-    // Threads with no digest are the ones opened before that marker existed, and
-    // they are settled by the same rule: if their finding still held, this round
-    // reported it and has just opened a digest-marked thread for it.
-    for (const thread of threads) {
-      if (thread.digest !== null && reported.has(thread.digest)) continue;
-      if (thread.isResolved) continue;
-      await this.retireReviewThread(thread);
+      openByDigest.set(thread.digest, thread);
     }
 
     const carriedOver = new Map<number, string | null>();
@@ -718,6 +726,18 @@ export class GitHubAdapter
       reviewId: string,
       published: Array<string | null> | null,
     ): Promise<PRReviewPublicationResult> => {
+      // Only ever after a review for this round exists on the pull request. Run
+      // before publication, a failing createReview left every earlier thread
+      // collapsed with no new review to replace them, and the pull request read as
+      // reviewed and clean. Every caller of `finish` is past that point, including
+      // the retry that found the round already published.
+      for (const thread of threads) {
+        if (reported.has(thread.digest)) continue;
+        if (thread.isMinimized) continue;
+        // Somebody is talking in this thread. Leave it exactly as it is.
+        if (thread.hasHumanReply) continue;
+        await this.retireReviewThread(thread);
+      }
       await this.upsertReviewSummary(prId, knownMarkers, [
         publication.summary,
         ...this.carriedOverSummarySection(publication.comments, carriedOver),
@@ -755,12 +775,14 @@ export class GitHubAdapter
           ? ("APPROVE" as const)
           : ("REQUEST_CHANGES" as const),
       body: roundReviewBody(headMarker),
-      comments: fresh.map((comment) => ({
+      comments: fresh.map((comment, index) => ({
         path: comment.path,
         // The marker travels with the comment because the thread it opens is what
         // a later round has to recognise. GitHub returns comment bodies verbatim,
-        // so this is the anchor that survives a push.
-        body: `${comment.body}\n\n${reviewFindingMarker(comment)}`,
+        // so this is the anchor that survives a push. The digest is the caller's,
+        // never re-derived here, or the thread would be opened under one identity
+        // and looked up under another.
+        body: `${comment.body}\n\n${reviewFindingMarker(digests[freshIndexes[index]!]!)}`,
         side: "RIGHT" as const,
         line: comment.endLine,
         ...(comment.startLine !== comment.endLine
@@ -828,10 +850,16 @@ export class GitHubAdapter
   /**
    * The review threads on a pull request that belong to this workflow.
    *
-   * Ownership is the finding marker, and for threads opened before that marker
-   * existed, `viewerDidAuthor`. Without the second test those threads would be
-   * invisible to the resolve sweep and stay open forever on every pull request
-   * that was reviewed before this change shipped.
+   * Ownership needs BOTH tests, and it is the conjunction that matters. The finding
+   * marker alone is text anybody can paste, so a human comment quoting one of ours
+   * would be swept as if we had written it. `viewerDidAuthor` alone is true for
+   * every thread this token ever opened, so two installations sharing a repository
+   * would each retire the other's threads.
+   *
+   * The cost is that a thread opened before the marker existed is no longer ours to
+   * touch, and stays open for good. That is the deliberate trade: this sweep now
+   * writes an OUTDATED tick onto other people's conversations if it guesses wrong,
+   * and guessing wrong is worse than leaving a handful of pre-marker threads behind.
    */
   private async ownReviewThreads(prId: number): Promise<OwnedReviewThread[]> {
     const threads: OwnedReviewThread[] = [];
@@ -844,19 +872,25 @@ export class GitHubAdapter
       const connection: ReviewThreadsConnection | null | undefined =
         page?.repository?.pullRequest?.reviewThreads;
       for (const node of connection?.nodes ?? []) {
-        const first = node?.comments?.nodes?.[0];
+        const comments = (node?.comments?.nodes ?? []).filter(
+          (comment): comment is NonNullable<typeof comment> => Boolean(comment),
+        );
+        const first = comments[0];
         if (!node?.id || !first?.id) continue;
         const digest = readReviewFindingDigest(first.body ?? "");
-        if (digest === null && first.viewerDidAuthor !== true) continue;
+        if (digest === null || first.viewerDidAuthor !== true) continue;
         threads.push({
           id: node.id,
-          isResolved: node.isResolved === true,
+          isMinimized: first.isMinimized === true,
           commentId: first.id,
           commentReference:
             first.databaseId === undefined || first.databaseId === null
               ? null
               : String(first.databaseId),
           digest,
+          hasHumanReply: comments.some(
+            (comment) => comment.viewerDidAuthor !== true,
+          ),
         });
       }
       if (connection?.pageInfo?.hasNextPage !== true) break;
@@ -866,20 +900,21 @@ export class GitHubAdapter
     return threads;
   }
 
+  /**
+   * Marks a thread this round has moved past as outdated. It does not resolve it:
+   * see `MINIMIZE_COMMENT_MUTATION` for why a repair cannot be claimed here.
+   */
   private async retireReviewThread(thread: OwnedReviewThread): Promise<void> {
-    await this.octokit.graphql(RESOLVE_REVIEW_THREAD_MUTATION, {
-      threadId: thread.id,
-    });
     try {
       await this.octokit.graphql(MINIMIZE_COMMENT_MUTATION, {
         subjectId: thread.commentId,
       });
     } catch (error) {
-      // Resolving is the half that carries the meaning and it has already
-      // happened; hiding the text is presentation. A repository that refuses it
+      // Collapsing an old comment is presentation, and the round's findings have
+      // already been published by the time this runs. A repository that refuses it
       // must not cost the pull request its whole review.
       console.warn(
-        `GitHub refused to hide resolved review comment ${thread.commentId}: ` +
+        `GitHub refused to hide outdated review comment ${thread.commentId}: ` +
           (error instanceof Error ? error.message : String(error)),
       );
     }
@@ -895,7 +930,11 @@ export class GitHubAdapter
     knownMarkers: string[],
     sections: string[],
   ): Promise<void> {
-    const body = sections.join("\n\n");
+    // The bot marker is what trigger-events.ts reads to drop a comment event this
+    // workflow produced. Without it, an installation running on a personal access
+    // token rather than a GitHub App has no login to match against, and the first
+    // round on every pull request fires a fresh review trigger off its own summary.
+    const body = [...sections, AI_WORKFLOW_COMMENT_MARKER].join("\n\n");
     const comments = await this.octokit.paginate(
       this.octokit.issues.listComments,
       {

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -21,7 +21,7 @@ import type {
   ManualDispatchPrCapableVCS,
   ManualDispatchPullRequestSnapshot,
 } from "./types.js";
-import { reviewFallbackBullet, reviewFindingDigest } from "./types.js";
+import { readReviewFindingDigest, reviewFallbackBullet } from "./types.js";
 import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 
 export interface GitHubConfig {
@@ -62,10 +62,6 @@ function isSelfAuthoredReviewError(error: unknown): boolean {
 /** The marker family is this adapter's; the digest inside it comes from the caller. */
 function reviewFindingMarker(digest: string): string {
   return `<!-- ai-workflow-review-finding:${digest} -->`;
-}
-
-function readReviewFindingDigest(body: string): string | null {
-  return /<!-- ai-workflow-review-finding:([0-9a-f]+) -->/.exec(body)?.[1] ?? null;
 }
 
 /**
@@ -668,11 +664,8 @@ export class GitHubAdapter
     const headMarker = `<!-- ai-workflow-review-head:${publication.headSha} -->`;
 
     const threads = await this.ownReviewThreads(prId);
-    // The caller's digests when it has its own recipe, and the comment body
-    // otherwise. Either way this adapter only carries the value.
-    const digests =
-      publication.commentFindingDigests ??
-      publication.comments.map(reviewFindingDigest);
+    // The caller's digests. This adapter only carries the value.
+    const digests = publication.commentFindingDigests;
     // Reported inline AND reported into the summary. A finding the cap pushed out
     // of the inline set is still standing, so its thread must not be collapsed as
     // outdated while the summary lists it: the two would say opposite things about

--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -9,6 +9,7 @@ import type {
   PRFile,
   PRFilesCapableVCS,
   PRReviewCapableVCS,
+  PRReviewInlineComment,
   PRReviewPublication,
   PRReviewPublicationResult,
   PullRequest,
@@ -20,7 +21,7 @@ import type {
   ManualDispatchPrCapableVCS,
   ManualDispatchPullRequestSnapshot,
 } from "./types.js";
-import { reviewFallbackBullet } from "./types.js";
+import { reviewFallbackBullet, reviewFindingDigest } from "./types.js";
 
 export interface GitHubConfig {
   auth: GitHubAppAuth;
@@ -55,6 +56,113 @@ function isSelfAuthoredReviewError(error: unknown): boolean {
   return /review can not (?:request changes on|approve) your own pull request/i.test(
     details,
   );
+}
+
+/** The marker family is this adapter's; the digest formula inside it is shared. */
+function reviewFindingMarker(comment: PRReviewInlineComment): string {
+  return `<!-- ai-workflow-review-finding:${reviewFindingDigest(comment)} -->`;
+}
+
+function readReviewFindingDigest(body: string): string | null {
+  return /<!-- ai-workflow-review-finding:([0-9a-f]+) -->/.exec(body)?.[1] ?? null;
+}
+
+/**
+ * The body of the review that carries a round's verdict, and it deliberately does
+ * not carry the summary.
+ *
+ * GitHub has no way to change a submitted review's verdict: `pulls.updateReview`
+ * rewrites the body and nothing else. So a summary kept in a review body is frozen
+ * at whichever verdict the first round reached, and a first round that requested
+ * changes would keep blocking the merge after every later round approved. The
+ * verdict therefore stays one review per round, and the summary moves to the one
+ * pull-request comment this adapter rewrites in place.
+ */
+function roundReviewBody(headMarker: string, sections: string[] = []): string {
+  return [
+    "## AI Workflow review",
+    "The findings for this commit are the inline comments below. The full review " +
+      "summary is kept in a single comment on this pull request and is rewritten " +
+      "on every round.",
+    ...sections,
+    headMarker,
+  ].join("\n\n");
+}
+
+const REVIEW_THREADS_QUERY = `
+  query reviewThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            comments(first: 1) {
+              nodes { id databaseId body viewerDidAuthor }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * GitHub's only resolve primitive, and it is GraphQL-only: REST exposes review
+ * comments but not the thread they hang from, and "resolved" is a property of the
+ * thread. https://docs.github.com/graphql, Mutation.resolveReviewThread.
+ */
+const RESOLVE_REVIEW_THREAD_MUTATION = `
+  mutation resolveReviewThread($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread { isResolved }
+    }
+  }
+`;
+
+/**
+ * The collapse half. Resolving already folds a thread away in the Files view;
+ * minimizing is what marks the comment itself outdated and hides its text in the
+ * conversation. https://docs.github.com/graphql, Mutation.minimizeComment.
+ */
+const MINIMIZE_COMMENT_MUTATION = `
+  mutation minimizeComment($subjectId: ID!) {
+    minimizeComment(input: { subjectId: $subjectId, classifier: OUTDATED }) {
+      minimizedComment { isMinimized }
+    }
+  }
+`;
+
+interface ReviewThreadsConnection {
+  pageInfo?: { hasNextPage?: boolean; endCursor?: string | null } | null;
+  nodes?: Array<{
+    id?: string;
+    isResolved?: boolean;
+    comments?: {
+      nodes?: Array<{
+        id?: string;
+        databaseId?: number | null;
+        body?: string | null;
+        viewerDidAuthor?: boolean;
+      } | null> | null;
+    } | null;
+  } | null> | null;
+}
+
+interface ReviewThreadsPage {
+  repository?: {
+    pullRequest?: { reviewThreads?: ReviewThreadsConnection | null } | null;
+  } | null;
+}
+
+interface OwnedReviewThread {
+  id: string;
+  isResolved: boolean;
+  /** Node id of the thread's first comment, the subject `minimizeComment` takes. */
+  commentId: string;
+  commentReference: string | null;
+  digest: string | null;
 }
 
 export class GitHubAdapter
@@ -513,28 +621,117 @@ export class GitHubAdapter
     }));
   }
 
+  /**
+   * Three artifacts with three different lifetimes, which is what keeps a pull
+   * request from collecting a round's worth of everything on every push:
+   *
+   *  - one THREAD per finding, opened once and carried across rounds, marked
+   *    resolved and hidden as soon as the round stops reporting it;
+   *  - one inline comment per finding that is NEW to this round, so a finding
+   *    already under discussion is not restated;
+   *  - one SUMMARY comment for the whole pull request, rewritten in place.
+   *
+   * The verdict is the exception and stays one review per round, because GitHub
+   * cannot revise a submitted review's verdict (see `roundReviewBody`).
+   */
   async publishPRReview(
     prId: number,
     publication: PRReviewPublication,
   ): Promise<PRReviewPublicationResult> {
     const reviewMarker = (key: string) => `<!-- ai-workflow-review:${key} -->`;
     const marker = reviewMarker(publication.idempotencyKey);
-    // Only `marker` is ever written. The prior keys are recognised as well
-    // because a review published before the key became a stable round identity
-    // carries one of those, and missing it would post a second review over it.
+    // The pull request's marker, on the one summary comment. Only `marker` is ever
+    // written; the prior keys are recognised as well because a summary published
+    // before the key identified the pull request carries one of those, and missing
+    // it would leave that one behind and add a second summary next to it.
     const knownMarkers = [
       marker,
       ...(publication.priorIdempotencyKeys ?? []).map(reviewMarker),
     ];
+    // The round's marker, on the review that carries the verdict. This is what
+    // makes a retry at one head submit one verdict and not two, now that the
+    // summary marker no longer says which head it describes.
+    const headMarker = `<!-- ai-workflow-review-head:${publication.headSha} -->`;
+
+    const threads = await this.ownReviewThreads(prId);
+    const digests = publication.comments.map(reviewFindingDigest);
+    // Reported inline AND reported into the summary. A finding the cap pushed out
+    // of the inline set is still standing, so its thread must not read as resolved
+    // while the summary lists it: the two would say opposite things about one
+    // defect, which is the misleading state this whole change is about.
+    const reported = new Set([
+      ...digests,
+      ...(publication.deferredFindingDigests ?? []),
+    ]);
+    const openByDigest = new Map<string, OwnedReviewThread>();
+    for (const thread of threads) {
+      if (thread.digest !== null) openByDigest.set(thread.digest, thread);
+    }
+
+    // A thread this round no longer reports is settled: resolve it and hide it.
+    // Threads with no digest are the ones opened before that marker existed, and
+    // they are settled by the same rule: if their finding still held, this round
+    // reported it and has just opened a digest-marked thread for it.
+    for (const thread of threads) {
+      if (thread.digest !== null && reported.has(thread.digest)) continue;
+      if (thread.isResolved) continue;
+      await this.retireReviewThread(thread);
+    }
+
+    const carriedOver = new Map<number, string | null>();
+    const fresh: PRReviewInlineComment[] = [];
+    const freshIndexes: number[] = [];
+    publication.comments.forEach((comment, index) => {
+      const open = openByDigest.get(digests[index]!);
+      if (open) {
+        carriedOver.set(index, open.commentReference);
+        return;
+      }
+      fresh.push(comment);
+      freshIndexes.push(index);
+    });
+
     const existing = await this.octokit.paginate(this.octokit.pulls.listReviews, {
       ...this.ownerRepo,
       pull_number: prId,
       per_page: 100,
     });
+    // Prior keys are matched here too: a review published under the old scheme
+    // carried the round in this marker family, and it is the only record that the
+    // head it named was already reviewed.
+    const roundMarkers = [
+      headMarker,
+      ...(publication.priorIdempotencyKeys ?? []).map(reviewMarker),
+    ];
     const prior = existing.find((review) =>
-      knownMarkers.some((known) => review.body?.includes(known)),
+      roundMarkers.some((known) => review.body?.includes(known)),
     );
+
+    const commentIdsFor = (published: Array<string | null> | null) =>
+      publication.comments.map((_, index) => {
+        if (carriedOver.has(index)) return carriedOver.get(index) ?? null;
+        if (published === null) return null;
+        return published[freshIndexes.indexOf(index)] ?? null;
+      });
+
+    const finish = async (
+      reviewId: string,
+      published: Array<string | null> | null,
+    ): Promise<PRReviewPublicationResult> => {
+      await this.upsertReviewSummary(prId, knownMarkers, [
+        publication.summary,
+        ...this.carriedOverSummarySection(publication.comments, carriedOver),
+        marker,
+      ]);
+      return { id: reviewId, commentIds: commentIdsFor(published) };
+    };
+
     if (prior) {
+      // This head already has its verdict. Everything else still runs: the
+      // publish call can succeed and the state update that records it can be
+      // lost, so a retry has to be able to finish resolving threads and writing
+      // the summary rather than treating the review's existence as proof they
+      // happened.
       const comments = await this.octokit.paginate(
         this.octokit.pulls.listCommentsForReview,
         {
@@ -544,10 +741,10 @@ export class GitHubAdapter
           per_page: 100,
         },
       );
-      return {
-        id: String(prior.id),
-        commentIds: this.alignReviewCommentIds(publication.comments, comments),
-      };
+      return finish(
+        String(prior.id),
+        this.alignReviewCommentIds(fresh, comments),
+      );
     }
     const request: Parameters<Octokit["pulls"]["createReview"]>[0] = {
       ...this.ownerRepo,
@@ -557,10 +754,13 @@ export class GitHubAdapter
         publication.decision === "approve"
           ? ("APPROVE" as const)
           : ("REQUEST_CHANGES" as const),
-      body: `${publication.summary}\n\n${marker}`,
-      comments: publication.comments.map((comment) => ({
+      body: roundReviewBody(headMarker),
+      comments: fresh.map((comment) => ({
         path: comment.path,
-        body: comment.body,
+        // The marker travels with the comment because the thread it opens is what
+        // a later round has to recognise. GitHub returns comment bodies verbatim,
+        // so this is the anchor that survives a push.
+        body: `${comment.body}\n\n${reviewFindingMarker(comment)}`,
         side: "RIGHT" as const,
         line: comment.endLine,
         ...(comment.startLine !== comment.endLine
@@ -587,36 +787,30 @@ export class GitHubAdapter
         } catch (commentError) {
           if (
             (commentError as { status?: unknown }).status !== 422 ||
-            publication.comments.length === 0
+            fresh.length === 0
           ) {
             throw commentError;
           }
           ({ data } = await this.octokit.pulls.createReview({
             ...publishedRequest,
-            body: this.reviewBodyWithInlineFallbacks(publication, marker),
+            body: this.reviewBodyWithInlineFallbacks(fresh, headMarker),
             comments: [],
           }));
-          return {
-            id: String(data.id),
-            commentIds: publication.comments.map(() => null),
-          };
+          return finish(String(data.id), null);
         }
       } else {
         if (
           (error as { status?: unknown }).status !== 422 ||
-          publication.comments.length === 0
+          fresh.length === 0
         ) {
           throw error;
         }
         ({ data } = await this.octokit.pulls.createReview({
           ...publishedRequest,
-          body: this.reviewBodyWithInlineFallbacks(publication, marker),
+          body: this.reviewBodyWithInlineFallbacks(fresh, headMarker),
           comments: [],
         }));
-        return {
-          id: String(data.id),
-          commentIds: publication.comments.map(() => null),
-        };
+        return finish(String(data.id), null);
       }
     }
     const comments = await this.octokit.paginate(
@@ -628,10 +822,123 @@ export class GitHubAdapter
         per_page: 100,
       },
     );
-    return {
-      id: String(data.id),
-      commentIds: this.alignReviewCommentIds(publication.comments, comments),
-    };
+    return finish(String(data.id), this.alignReviewCommentIds(fresh, comments));
+  }
+
+  /**
+   * The review threads on a pull request that belong to this workflow.
+   *
+   * Ownership is the finding marker, and for threads opened before that marker
+   * existed, `viewerDidAuthor`. Without the second test those threads would be
+   * invisible to the resolve sweep and stay open forever on every pull request
+   * that was reviewed before this change shipped.
+   */
+  private async ownReviewThreads(prId: number): Promise<OwnedReviewThread[]> {
+    const threads: OwnedReviewThread[] = [];
+    let cursor: string | null = null;
+    for (;;) {
+      const page: ReviewThreadsPage = await this.octokit.graphql(
+        REVIEW_THREADS_QUERY,
+        { ...this.ownerRepo, number: prId, cursor },
+      );
+      const connection: ReviewThreadsConnection | null | undefined =
+        page?.repository?.pullRequest?.reviewThreads;
+      for (const node of connection?.nodes ?? []) {
+        const first = node?.comments?.nodes?.[0];
+        if (!node?.id || !first?.id) continue;
+        const digest = readReviewFindingDigest(first.body ?? "");
+        if (digest === null && first.viewerDidAuthor !== true) continue;
+        threads.push({
+          id: node.id,
+          isResolved: node.isResolved === true,
+          commentId: first.id,
+          commentReference:
+            first.databaseId === undefined || first.databaseId === null
+              ? null
+              : String(first.databaseId),
+          digest,
+        });
+      }
+      if (connection?.pageInfo?.hasNextPage !== true) break;
+      cursor = connection.pageInfo?.endCursor ?? null;
+      if (cursor === null) break;
+    }
+    return threads;
+  }
+
+  private async retireReviewThread(thread: OwnedReviewThread): Promise<void> {
+    await this.octokit.graphql(RESOLVE_REVIEW_THREAD_MUTATION, {
+      threadId: thread.id,
+    });
+    try {
+      await this.octokit.graphql(MINIMIZE_COMMENT_MUTATION, {
+        subjectId: thread.commentId,
+      });
+    } catch (error) {
+      // Resolving is the half that carries the meaning and it has already
+      // happened; hiding the text is presentation. A repository that refuses it
+      // must not cost the pull request its whole review.
+      console.warn(
+        `GitHub refused to hide resolved review comment ${thread.commentId}: ` +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    }
+  }
+
+  /**
+   * The one summary comment for the pull request. Created once and rewritten from
+   * then on, so a reader always has exactly one place that states where the review
+   * currently stands.
+   */
+  private async upsertReviewSummary(
+    prId: number,
+    knownMarkers: string[],
+    sections: string[],
+  ): Promise<void> {
+    const body = sections.join("\n\n");
+    const comments = await this.octokit.paginate(
+      this.octokit.issues.listComments,
+      {
+        ...this.ownerRepo,
+        issue_number: prId,
+        per_page: 100,
+      },
+    );
+    const existing = comments.find((comment) =>
+      knownMarkers.some((known) => comment.body?.includes(known)),
+    );
+    if (existing) {
+      await this.octokit.issues.updateComment({
+        ...this.ownerRepo,
+        comment_id: existing.id,
+        body,
+      });
+      return;
+    }
+    await this.octokit.issues.createComment({
+      ...this.ownerRepo,
+      issue_number: prId,
+      body,
+    });
+  }
+
+  /**
+   * Findings this round reports that already have a thread.
+   *
+   * They get no inline comment of their own, so without this section they would be
+   * absent from the one artifact a reader treats as the current state, and an
+   * unfixed finding would read as fixed.
+   */
+  private carriedOverSummarySection(
+    comments: PRReviewInlineComment[],
+    carriedOver: Map<number, string | null>,
+  ): string[] {
+    const carried = comments.filter((_, index) => carriedOver.has(index));
+    if (carried.length === 0) return [];
+    return [
+      "### Findings already open on this pull request",
+      carried.map(reviewFallbackBullet).join("\n"),
+    ];
   }
 
   private alignReviewCommentIds(
@@ -658,11 +965,17 @@ export class GitHubAdapter
   }
 
   private reviewBodyWithInlineFallbacks(
-    publication: PRReviewPublication,
-    marker: string,
+    comments: PRReviewInlineComment[],
+    headMarker: string,
   ): string {
-    const findings = publication.comments.map(reviewFallbackBullet);
-    return `${publication.summary}\n\n### Findings not placed inline\n${findings.join("\n")}\n\n${marker}`;
+    const findings = comments.map(reviewFallbackBullet);
+    // Stays on the round's review rather than moving to the summary comment: these
+    // findings are the ones GitHub refused to anchor at this head, so they belong
+    // with the verdict for that head and the next round will try to place them
+    // again.
+    return roundReviewBody(headMarker, [
+      `### Findings not placed inline\n${findings.join("\n")}`,
+    ]);
   }
 
   async createGateStatus(

--- a/apps/worker/src/adapters/vcs/gitlab.test.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.test.ts
@@ -611,6 +611,7 @@ describe("GitLabAdapter", () => {
         decision: "approve",
         summary: "Approved.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
@@ -669,6 +670,10 @@ describe("GitLabAdapter", () => {
             endLine: 12,
           },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "First" }),
+          reviewFindingDigest({ path: "src/index.ts", body: "Second" }),
+        ],
       });
 
       expect(result).toEqual({
@@ -719,6 +724,9 @@ describe("GitLabAdapter", () => {
             startLine: 10,
             endLine: 10,
           },
+        ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "First" }),
         ],
       });
 
@@ -773,6 +781,7 @@ describe("GitLabAdapter", () => {
         decision: "request_changes",
         summary: "Nothing left there.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       // /user, the summary note, then the explanation and the resolve. The sweep
@@ -831,6 +840,9 @@ describe("GitLabAdapter", () => {
         summary: "One finding.",
         comments: [
           { path: "src/index.ts", body: after, startLine: 12, endLine: 12 },
+        ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: after }),
         ],
       });
 
@@ -960,6 +972,7 @@ describe("GitLabAdapter", () => {
         decision: "approve",
         summary: "Nothing left.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       // /user, the summary note, the approval. No explanation note, no resolve.
@@ -1000,6 +1013,7 @@ describe("GitLabAdapter", () => {
         summary: "One finding, not shown inline.",
         // Not among the placed comments, and reported all the same.
         comments: [],
+        commentFindingDigests: [],
         deferredFindingDigests: [
           reviewFindingDigest({ path: "src/index.ts", body }),
         ],
@@ -1044,6 +1058,10 @@ describe("GitLabAdapter", () => {
           { path: "src/index.ts", body: kept, startLine: 40, endLine: 40 },
           { path: "src/new.ts", body: "**Nit**: New one.", startLine: 7, endLine: 7 },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: kept }),
+          reviewFindingDigest({ path: "src/new.ts", body: "**Nit**: New one." }),
+        ],
       });
 
       // Three calls: /user, the new discussion and the summary. No resolve, and no
@@ -1085,6 +1103,7 @@ describe("GitLabAdapter", () => {
         decision: "request_changes",
         summary: "Round two.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1146,6 +1165,7 @@ describe("GitLabAdapter", () => {
         decision: "approve",
         summary: "Nothing left.",
         comments: [],
+        commentFindingDigests: [],
       });
 
       // /user, the summary note, the approval. Nothing resolved, nothing explained.
@@ -1203,6 +1223,10 @@ describe("GitLabAdapter", () => {
             startOldLine: null,
             endOldLine: 11,
           },
+        ],
+        commentFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body: "Rejected" }),
+          reviewFindingDigest({ path: "src/index.ts", body: "Range" }),
         ],
       });
 
@@ -1283,6 +1307,12 @@ describe("GitLabAdapter", () => {
             endLine: 8,
           },
         ],
+        commentFindingDigests: [
+          reviewFindingDigest({
+            path: "src/index.ts",
+            body: "**High**: Handle this failure.\n\nReported by 3 of 3 reviewers.",
+          }),
+        ],
       });
 
       const noteBody = JSON.parse(String(mockFetch.mock.calls[1]?.[1]?.body));
@@ -1323,6 +1353,9 @@ describe("GitLabAdapter", () => {
               endLine: 8,
             },
           ],
+          commentFindingDigests: [
+            reviewFindingDigest({ path: "src/index.ts", body: "Retry this publication." }),
+          ],
         }),
       ).rejects.toThrow();
     });
@@ -1349,6 +1382,7 @@ describe("GitLabAdapter", () => {
           decision: "request_changes",
           summary: "Published.",
           comments: [],
+          commentFindingDigests: [],
         }),
       ).resolves.toEqual({
         id: "review-hash",

--- a/apps/worker/src/adapters/vcs/gitlab.test.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GitLabAdapter } from "./gitlab.js";
+import { reviewFindingDigest } from "./types.js";
 
 const mockBranches = {
   create: vi.fn(),
@@ -576,11 +577,16 @@ describe("GitLabAdapter", () => {
   });
 
   describe("publishPRReview", () => {
-    it("retries approval when the marked summary already exists", async () => {
+    const findingMarker = (path: string, body: string) =>
+      `<!-- ai-workflow-review-finding:${reviewFindingDigest({ path, body })} -->`;
+
+    it("retries approval when this head is already summarised", async () => {
       mockMergeRequestNotes.all.mockResolvedValueOnce([
         {
           id: 555,
-          body: "Approved.\n\n<!-- ai-workflow-review:review-hash -->",
+          body:
+            "Approved.\n\n<!-- ai-workflow-review:review-hash -->\n\n" +
+            "<!-- ai-workflow-review-head:reviewed-head -->",
         },
       ]);
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);
@@ -608,7 +614,9 @@ describe("GitLabAdapter", () => {
       mockMergeRequestNotes.all.mockResolvedValueOnce([
         {
           id: 555,
-          body: "Published.\n\n<!-- ai-workflow-review:review-hash -->",
+          body:
+            "Published.\n\n<!-- ai-workflow-review:review-hash -->\n\n" +
+            "<!-- ai-workflow-review-head:reviewed-head -->",
         },
       ]);
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([
@@ -656,7 +664,7 @@ describe("GitLabAdapter", () => {
       });
     });
 
-    it("recognises a summary and its discussions under a prior key", async () => {
+    it("adopts a summary and its discussions from a prior key", async () => {
       mockMergeRequestNotes.all.mockResolvedValueOnce([
         {
           id: 555,
@@ -675,6 +683,15 @@ describe("GitLabAdapter", () => {
           ],
         },
       ]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "reviewed-head",
+        diff_refs: {
+          base_sha: "base",
+          start_sha: "start",
+          head_sha: "reviewed-head",
+        },
+      });
+      mockFetch.mockResolvedValueOnce(gitLabResponse({ id: 555 }, { status: 200 }));
 
       const result = await glAdapter().publishPRReview(42, {
         idempotencyKey: "round-key",
@@ -694,9 +711,229 @@ describe("GitLabAdapter", () => {
 
       // Both marker families have to accept the prior key, not just the summary
       // note: recognising the note alone would leave every inline discussion to
-      // be posted a second time.
-      expect(mockFetch).not.toHaveBeenCalled();
+      // be posted a second time, and recognising neither would resolve a thread
+      // whose finding still stands.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/notes/555",
+        expect.objectContaining({ method: "PUT" }),
+      );
       expect(result).toEqual({ id: "555", commentIds: ["discussion-1"] });
+    });
+
+    // AIW-236's main requirement. Measured on our own PR #224, two rounds of
+    // CodeRabbit left thirteen live threads and resolved or collapsed none.
+    it("resolves the discussion of a finding this round no longer reports", async () => {
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([
+        {
+          id: "discussion-settled",
+          notes: [
+            {
+              body: `Fixed since.\n\n${findingMarker("src/gone.ts", "Fixed since.")}`,
+              resolved: false,
+            },
+          ],
+        },
+        // Somebody else's thread, which this workflow has no business touching.
+        { id: "discussion-human", notes: [{ body: "Please rename this." }] },
+      ]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      mockFetch
+        .mockResolvedValueOnce(gitLabResponse({}, { status: 200 }))
+        .mockResolvedValueOnce(gitLabResponse({ id: 556 }, { status: 201 }));
+
+      await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "Nothing left there.",
+        comments: [],
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[0]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/discussions/discussion-settled",
+      );
+      expect(mockFetch.mock.calls[0]![1]).toEqual(
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ resolved: true }),
+        }),
+      );
+    });
+
+    // A finding the inline cap pushed into the summary is still standing. Resolving
+    // its thread would put "resolved" on the thread and "still open" in the summary
+    // for one defect, which is worse than either alone.
+    it("keeps the discussion of a finding this round reports into the summary", async () => {
+      const body = "**Nit**: Demoted by the cap this round.";
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([
+        {
+          id: "discussion-deferred",
+          notes: [
+            {
+              body: `${body}\n\n${findingMarker("src/index.ts", body)}`,
+              resolved: false,
+            },
+          ],
+        },
+      ]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      mockFetch.mockResolvedValueOnce(gitLabResponse({ id: 559 }, { status: 201 }));
+
+      await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "One finding, not shown inline.",
+        // Not among the placed comments, and reported all the same.
+        comments: [],
+        deferredFindingDigests: [
+          reviewFindingDigest({ path: "src/index.ts", body }),
+        ],
+      });
+
+      // The summary note, and nothing else: no resolve call went out.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/notes",
+      );
+    });
+
+    it("posts a discussion only for the findings this round adds", async () => {
+      const kept = "**High**: Still broken.";
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([
+        {
+          id: "discussion-open",
+          notes: [
+            {
+              body: `${kept}\n\n${findingMarker("src/index.ts", kept)}`,
+              resolved: false,
+            },
+          ],
+        },
+      ]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      mockFetch
+        .mockResolvedValueOnce(
+          gitLabResponse({ id: "discussion-new" }, { status: 201 }),
+        )
+        .mockResolvedValueOnce(gitLabResponse({ id: 557 }, { status: 201 }));
+
+      const result = await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        // The finding came back at a different line after a rebase. The digest
+        // carries no position, so the discussion is recognised, kept unresolved and
+        // not restated.
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "Two findings.",
+        comments: [
+          { path: "src/index.ts", body: kept, startLine: 40, endLine: 40 },
+          { path: "src/new.ts", body: "**Nit**: New one.", startLine: 7, endLine: 7 },
+        ],
+      });
+
+      // Two calls: the new discussion and the summary. No resolve, and no second
+      // copy of the finding already under discussion.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const posted = JSON.parse(String(mockFetch.mock.calls[0]![1]?.body));
+      expect(posted.body).toContain("**Nit**: New one.");
+      expect(result.commentIds).toEqual(["discussion-open", "discussion-new"]);
+      // The carried-over finding is named in the summary. Without it the finding
+      // would be in no artifact a reader treats as current, and an unfixed finding
+      // would read as fixed.
+      const note = JSON.parse(String(mockFetch.mock.calls[1]![1]?.body));
+      expect(note.body).toContain(
+        "### Findings already open on this merge request",
+      );
+      expect(note.body).toContain("- `src/index.ts:40` — **High**: Still broken.");
+    });
+
+    it("edits the one summary note instead of adding another", async () => {
+      mockMergeRequestNotes.all.mockResolvedValueOnce([
+        { id: 999, body: "A human said something else." },
+        {
+          id: 555,
+          body:
+            "Round one.\n\n<!-- ai-workflow-review:review-hash -->\n\n" +
+            "<!-- ai-workflow-review-head:earlier-head -->",
+        },
+      ]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      mockFetch.mockResolvedValueOnce(gitLabResponse({ id: 555 }, { status: 200 }));
+
+      const result = await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "Round two.",
+        comments: [],
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/notes/555",
+      );
+      const note = JSON.parse(String(mockFetch.mock.calls[0]![1]?.body));
+      expect(note.body).toBe(
+        "Round two.\n\n<!-- ai-workflow-review:review-hash -->\n\n" +
+          "<!-- ai-workflow-review-head:next-head -->",
+      );
+      expect(result.id).toBe("555");
+    });
+
+    it("settles a discussion opened before findings carried a marker", async () => {
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([
+        {
+          id: "discussion-legacy",
+          notes: [
+            {
+              body: "Reported earlier.\n\n<!-- ai-workflow-review-comment:old-hash:3 -->",
+              resolved: false,
+            },
+          ],
+        },
+      ]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      mockFetch
+        .mockResolvedValueOnce(gitLabResponse({}, { status: 200 }))
+        .mockResolvedValueOnce(gitLabResponse({ id: 558 }, { status: 201 }))
+        .mockResolvedValueOnce(gitLabResponse({}, { status: 201 }));
+
+      await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "approve",
+        summary: "Nothing left.",
+        comments: [],
+      });
+
+      // Index 3 belongs to no finding this round reports, so the thread is settled
+      // rather than left open with no status on it.
+      expect(mockFetch.mock.calls[0]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/discussions/discussion-legacy",
+      );
     });
 
     it("publishes GitLab multiline positions and preserves id alignment", async () => {

--- a/apps/worker/src/adapters/vcs/gitlab.test.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GitLabAdapter } from "./gitlab.js";
 import { reviewFindingDigest } from "./types.js";
+import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 
 const mockBranches = {
   create: vi.fn(),
@@ -580,6 +581,18 @@ describe("GitLabAdapter", () => {
     const findingMarker = (path: string, body: string) =>
       `<!-- ai-workflow-review-finding:${reviewFindingDigest({ path, body })} -->`;
 
+    // The token's own username. A discussion counts as this workflow's only when
+    // its opening note carries a finding marker AND was written by this account,
+    // so every owned fixture below names it and the adapter looks it up via /user.
+    const BOT = "ai-workflow-bot";
+    const botNote = (body: string, resolved = false) => ({
+      body,
+      resolved,
+      author: { username: BOT },
+    });
+    const stubCurrentUser = () =>
+      mockFetch.mockResolvedValueOnce(gitLabResponse({ username: BOT }));
+
     it("retries approval when this head is already summarised", async () => {
       mockMergeRequestNotes.all.mockResolvedValueOnce([
         {
@@ -723,28 +736,36 @@ describe("GitLabAdapter", () => {
 
     // AIW-236's main requirement. Measured on our own PR #224, two rounds of
     // CodeRabbit left thirteen live threads and resolved or collapsed none.
-    it("resolves the discussion of a finding this round no longer reports", async () => {
+    //
+    // GitLab's only way to collapse a thread is to resolve it, and that word claims
+    // the defect is gone. The note is what stops the strip from lying, so it goes in
+    // first and the resolve follows.
+    it("explains a superseded discussion before resolving it", async () => {
       mockMergeRequestNotes.all.mockResolvedValueOnce([]);
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([
         {
           id: "discussion-settled",
           notes: [
-            {
-              body: `Fixed since.\n\n${findingMarker("src/gone.ts", "Fixed since.")}`,
-              resolved: false,
-            },
+            botNote(
+              `Fixed since.\n\n${findingMarker("src/gone.ts", "Fixed since.")}`,
+            ),
           ],
         },
         // Somebody else's thread, which this workflow has no business touching.
-        { id: "discussion-human", notes: [{ body: "Please rename this." }] },
+        {
+          id: "discussion-human",
+          notes: [{ body: "Please rename this.", author: { username: "dev" } }],
+        },
       ]);
       mockMergeRequests.show.mockResolvedValueOnce({
         sha: "next-head",
         diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
       });
+      stubCurrentUser();
       mockFetch
-        .mockResolvedValueOnce(gitLabResponse({}, { status: 200 }))
-        .mockResolvedValueOnce(gitLabResponse({ id: 556 }, { status: 201 }));
+        .mockResolvedValueOnce(gitLabResponse({ id: 556 }, { status: 201 }))
+        .mockResolvedValueOnce(gitLabResponse({}, { status: 201 }))
+        .mockResolvedValueOnce(gitLabResponse({}, { status: 200 }));
 
       await glAdapter().publishPRReview(42, {
         idempotencyKey: "review-hash",
@@ -754,16 +775,203 @@ describe("GitLabAdapter", () => {
         comments: [],
       });
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(mockFetch.mock.calls[0]![0]).toBe(
+      // /user, the summary note, then the explanation and the resolve. The sweep
+      // runs last: before the summary exists, a failure here would leave the merge
+      // request collapsed and unreviewed.
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(mockFetch.mock.calls[0]![0]).toBe("https://gitlab.com/api/v4/user");
+      expect(mockFetch.mock.calls[2]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/discussions/discussion-settled/notes",
+      );
+      const explanation = JSON.parse(String(mockFetch.mock.calls[2]![1]?.body));
+      expect(explanation.body).toContain("superseded, not verified as fixed");
+      expect(explanation.body).toContain(AI_WORKFLOW_COMMENT_MARKER);
+      expect(mockFetch.mock.calls[3]![0]).toBe(
         "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/discussions/discussion-settled",
       );
-      expect(mockFetch.mock.calls[0]![1]).toEqual(
+      expect(mockFetch.mock.calls[3]![1]).toEqual(
         expect.objectContaining({
           method: "PUT",
           body: JSON.stringify({ resolved: true }),
         }),
       );
+    });
+
+    // The case the digest cannot tell from a repair. Agent prose is regenerated
+    // every round, so the same defect routinely returns under new wording.
+    it("retires the old discussion and opens a new one when a finding is reworded", async () => {
+      const before = "**High**: This can throw on an empty list.";
+      const after = "**High**: An empty list makes this throw.";
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([
+        {
+          id: "discussion-reworded",
+          notes: [
+            botNote(`${before}\n\n${findingMarker("src/index.ts", before)}`),
+          ],
+        },
+      ]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      stubCurrentUser();
+      mockFetch
+        .mockResolvedValueOnce(
+          gitLabResponse({ id: "discussion-new" }, { status: 201 }),
+        )
+        .mockResolvedValueOnce(gitLabResponse({ id: 560 }, { status: 201 }))
+        .mockResolvedValueOnce(gitLabResponse({}, { status: 201 }))
+        .mockResolvedValueOnce(gitLabResponse({}, { status: 200 }));
+
+      const result = await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          { path: "src/index.ts", body: after, startLine: 12, endLine: 12 },
+        ],
+      });
+
+      const posted = JSON.parse(String(mockFetch.mock.calls[1]![1]?.body));
+      expect(posted.body).toContain(after);
+      expect(result.commentIds).toEqual(["discussion-new"]);
+      // The stale one is explained and resolved, never silently left behind.
+      expect(mockFetch.mock.calls[4]![1]).toEqual(
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ resolved: true }),
+        }),
+      );
+    });
+
+    // The path production actually takes. The workflow passes its own digests, and
+    // they are deliberately NOT what the body hashes to: a published body carries
+    // the agreement note and the identity excludes it. An adapter that re-derived
+    // from the body would open discussions under one identity and look them up
+    // under another.
+    const callerDigest = "0123456789abcdef0123456789abcdef";
+    const notedBody = "**High**: Still broken.\n\nBoth reviewers reported this.";
+
+    it("marks a new discussion with the caller's digest, not the body's", async () => {
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      mockFetch
+        .mockResolvedValueOnce(
+          gitLabResponse({ id: "discussion-new" }, { status: 201 }),
+        )
+        .mockResolvedValueOnce(gitLabResponse({ id: 562 }, { status: 201 }));
+
+      await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          { path: "src/index.ts", body: notedBody, startLine: 9, endLine: 9 },
+        ],
+        commentFindingDigests: [callerDigest],
+      });
+
+      const posted = JSON.parse(String(mockFetch.mock.calls[0]![1]?.body));
+      expect(posted.body).toContain(
+        `<!-- ai-workflow-review-finding:${callerDigest} -->`,
+      );
+      expect(posted.body).not.toContain(
+        reviewFindingDigest({ path: "src/index.ts", body: notedBody }),
+      );
+    });
+
+    it("recognises an existing discussion by the caller's digest", async () => {
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([
+        {
+          id: "discussion-open",
+          // Opened last round, under wording this round no longer uses.
+          notes: [
+            botNote(
+              `Older wording.\n\n<!-- ai-workflow-review-finding:${callerDigest} -->`,
+            ),
+          ],
+        },
+      ]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      stubCurrentUser();
+      mockFetch.mockResolvedValueOnce(
+        gitLabResponse({ id: 563 }, { status: 201 }),
+      );
+
+      const result = await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "request_changes",
+        summary: "One finding.",
+        comments: [
+          { path: "src/index.ts", body: notedBody, startLine: 9, endLine: 9 },
+        ],
+        commentFindingDigests: [callerDigest],
+      });
+
+      // Carried over: /user and the summary note only. No second copy of the
+      // finding, and no resolve on a discussion this round still reports.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result.commentIds).toEqual(["discussion-open"]);
+      expect(mockFetch.mock.calls[1]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/notes",
+      );
+    });
+
+    // The condition the plan set. GitLab hands the adapter every note in the
+    // discussion, and it previously read only the first.
+    it("leaves a discussion alone once a human has replied in it", async () => {
+      const body = "**Nit**: Rename this.";
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([
+        {
+          id: "discussion-discussed",
+          notes: [
+            botNote(`${body}\n\n${findingMarker("src/index.ts", body)}`),
+            { body: "Why?", author: { username: "dev" } },
+          ],
+        },
+      ]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "next-head",
+        diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
+      });
+      stubCurrentUser();
+      mockFetch
+        .mockResolvedValueOnce(gitLabResponse({ id: 561 }, { status: 201 }))
+        .mockResolvedValueOnce(gitLabResponse({}, { status: 201 }));
+
+      // This round no longer reports the finding, so the sweep would otherwise
+      // resolve the thread and stamp the reader's question as settled.
+      await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "next-head",
+        decision: "approve",
+        summary: "Nothing left.",
+        comments: [],
+      });
+
+      // /user, the summary note, the approval. No explanation note, no resolve.
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockFetch.mock.calls[1]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/notes",
+      );
+      expect(
+        mockFetch.mock.calls.some(([url]) =>
+          String(url).includes("/discussions/"),
+        ),
+      ).toBe(false);
     });
 
     // A finding the inline cap pushed into the summary is still standing. Resolving
@@ -775,18 +983,14 @@ describe("GitLabAdapter", () => {
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([
         {
           id: "discussion-deferred",
-          notes: [
-            {
-              body: `${body}\n\n${findingMarker("src/index.ts", body)}`,
-              resolved: false,
-            },
-          ],
+          notes: [botNote(`${body}\n\n${findingMarker("src/index.ts", body)}`)],
         },
       ]);
       mockMergeRequests.show.mockResolvedValueOnce({
         sha: "next-head",
         diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
       });
+      stubCurrentUser();
       mockFetch.mockResolvedValueOnce(gitLabResponse({ id: 559 }, { status: 201 }));
 
       await glAdapter().publishPRReview(42, {
@@ -801,9 +1005,9 @@ describe("GitLabAdapter", () => {
         ],
       });
 
-      // The summary note, and nothing else: no resolve call went out.
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(mockFetch.mock.calls[0]![0]).toBe(
+      // /user and the summary note: no explanation note and no resolve went out.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1]![0]).toBe(
         "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/notes",
       );
     });
@@ -814,18 +1018,14 @@ describe("GitLabAdapter", () => {
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([
         {
           id: "discussion-open",
-          notes: [
-            {
-              body: `${kept}\n\n${findingMarker("src/index.ts", kept)}`,
-              resolved: false,
-            },
-          ],
+          notes: [botNote(`${kept}\n\n${findingMarker("src/index.ts", kept)}`)],
         },
       ]);
       mockMergeRequests.show.mockResolvedValueOnce({
         sha: "next-head",
         diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
       });
+      stubCurrentUser();
       mockFetch
         .mockResolvedValueOnce(
           gitLabResponse({ id: "discussion-new" }, { status: 201 }),
@@ -846,16 +1046,16 @@ describe("GitLabAdapter", () => {
         ],
       });
 
-      // Two calls: the new discussion and the summary. No resolve, and no second
-      // copy of the finding already under discussion.
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      const posted = JSON.parse(String(mockFetch.mock.calls[0]![1]?.body));
+      // Three calls: /user, the new discussion and the summary. No resolve, and no
+      // second copy of the finding already under discussion.
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const posted = JSON.parse(String(mockFetch.mock.calls[1]![1]?.body));
       expect(posted.body).toContain("**Nit**: New one.");
       expect(result.commentIds).toEqual(["discussion-open", "discussion-new"]);
       // The carried-over finding is named in the summary. Without it the finding
       // would be in no artifact a reader treats as current, and an unfixed finding
       // would read as fixed.
-      const note = JSON.parse(String(mockFetch.mock.calls[1]![1]?.body));
+      const note = JSON.parse(String(mockFetch.mock.calls[2]![1]?.body));
       expect(note.body).toContain(
         "### Findings already open on this merge request",
       );
@@ -894,12 +1094,20 @@ describe("GitLabAdapter", () => {
       const note = JSON.parse(String(mockFetch.mock.calls[0]![1]?.body));
       expect(note.body).toBe(
         "Round two.\n\n<!-- ai-workflow-review:review-hash -->\n\n" +
-          "<!-- ai-workflow-review-head:next-head -->",
+          "<!-- ai-workflow-review-head:next-head -->\n\n" +
+          // Without it, an installation with no matchable bot login treats its own
+          // summary as a human comment and starts another round.
+          AI_WORKFLOW_COMMENT_MARKER,
       );
       expect(result.id).toBe("555");
     });
 
-    it("settles a discussion opened before findings carried a marker", async () => {
+    // Ownership needs the finding marker AND our authorship, so neither of these
+    // is ours. The pre-marker discussion is the accepted cost: it stays open for
+    // good, which is the safe direction now that retiring writes a note and a
+    // "Resolved" strip onto whatever it touches.
+    it("touches neither a pre-marker discussion nor a marker somebody else pasted", async () => {
+      const body = "**High**: Quoted from our review.";
       mockMergeRequestNotes.all.mockResolvedValueOnce([]);
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([
         {
@@ -908,6 +1116,17 @@ describe("GitLabAdapter", () => {
             {
               body: "Reported earlier.\n\n<!-- ai-workflow-review-comment:old-hash:3 -->",
               resolved: false,
+              author: { username: BOT },
+            },
+          ],
+        },
+        {
+          id: "discussion-impostor",
+          notes: [
+            {
+              body: `${body}\n\n${findingMarker("src/index.ts", body)}`,
+              resolved: false,
+              author: { username: "dev" },
             },
           ],
         },
@@ -916,8 +1135,8 @@ describe("GitLabAdapter", () => {
         sha: "next-head",
         diff_refs: { base_sha: "base", start_sha: "start", head_sha: "next-head" },
       });
+      stubCurrentUser();
       mockFetch
-        .mockResolvedValueOnce(gitLabResponse({}, { status: 200 }))
         .mockResolvedValueOnce(gitLabResponse({ id: 558 }, { status: 201 }))
         .mockResolvedValueOnce(gitLabResponse({}, { status: 201 }));
 
@@ -929,11 +1148,16 @@ describe("GitLabAdapter", () => {
         comments: [],
       });
 
-      // Index 3 belongs to no finding this round reports, so the thread is settled
-      // rather than left open with no status on it.
-      expect(mockFetch.mock.calls[0]![0]).toBe(
-        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/discussions/discussion-legacy",
+      // /user, the summary note, the approval. Nothing resolved, nothing explained.
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockFetch.mock.calls[1]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/notes",
       );
+      expect(
+        mockFetch.mock.calls.some(([url]) =>
+          String(url).includes("/discussions/"),
+        ),
+      ).toBe(false);
     });
 
     it("publishes GitLab multiline positions and preserves id alignment", async () => {

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -21,6 +21,22 @@ import type {
 } from "./types.js";
 import { reviewFallbackBullet, reviewFindingDigest } from "./types.js";
 import { clampBothEnds } from "../../workflow-definition/failure-message.js";
+import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
+
+/**
+ * Posted into a discussion just before it is resolved. GitLab's only way to collapse
+ * a thread is to mark it resolved, and that word on its own would tell a reader the
+ * defect was fixed. This note is what makes the strip mean what actually happened.
+ *
+ * Carries the bot marker so trigger-events.ts drops the note event instead of
+ * treating it as a human comment and starting another round.
+ */
+const SUPERSEDED_DISCUSSION_NOTE = [
+  "This thread was opened by an earlier review round and the current round no " +
+    "longer reports this finding under the same wording. Resolving it here means " +
+    "superseded, not verified as fixed: re-open it if the issue still stands.",
+  AI_WORKFLOW_COMMENT_MARKER,
+].join("\n\n");
 
 // Minimal shapes for gitbeaker responses we touch. Declared locally so we do
 // not depend on gitbeaker's deep generic return types, which have changed
@@ -112,6 +128,8 @@ export class GitLabAdapter implements
   private gl: InstanceType<typeof Gitlab>;
   private projectId: string;
   private baseBranch: string;
+  /** `undefined` until looked up; `null` when GitLab returned no username. */
+  private cachedUsername: string | null | undefined;
 
   constructor(private config: GitLabConfig) {
     this.gl = new Gitlab({
@@ -572,28 +590,75 @@ export class GitLabAdapter implements
       prId,
     )) as unknown as Array<{
       id?: string;
-      notes?: Array<{ body?: string; resolved?: boolean }>;
+      notes?: Array<{
+        body?: string;
+        resolved?: boolean;
+        system?: boolean;
+        author?: { username?: string };
+      }>;
     }>;
     const summaryNote = existingNotes.find((note) =>
       knownMarkers.some((known) => note.body?.includes(known)),
     );
-    const digests = publication.comments.map(reviewFindingDigest);
-    // The discussions that belong to the workflow. A legacy-marked one counts as
-    // ours as well, or it would be invisible to the resolve sweep and stay open
-    // forever on every merge request reviewed before this change shipped.
+    // The caller's digests when it has its own recipe, and the comment body
+    // otherwise. Either way this adapter only carries the value.
+    const digests =
+      publication.commentFindingDigests ??
+      publication.comments.map(reviewFindingDigest);
+    // The discussions that belong to the workflow: marked with a finding digest AND
+    // opened by this token. The marker alone is text anybody can paste, and the
+    // author alone matches every thread this token ever opened, so two installations
+    // on one project would retire each other's. Requiring both costs the pre-marker
+    // discussions, which are no longer ours to touch and stay open for good; putting
+    // a "Resolved" strip on somebody else's conversation is the worse error.
+    const botUsername = existingDiscussions.some((discussion) =>
+      readReviewFindingDigest(discussion.notes?.[0]?.body ?? ""),
+    )
+      ? await this.currentUsername()
+      : null;
     const owned = existingDiscussions.flatMap((discussion) => {
-      const first = discussion.notes?.[0];
-      const body = first?.body ?? "";
-      const digest = readReviewFindingDigest(body);
-      if (digest === null && !body.includes("<!-- ai-workflow-review-comment:")) {
+      const notes = discussion.notes ?? [];
+      const first = notes[0];
+      const digest = readReviewFindingDigest(first?.body ?? "");
+      if (digest === null) return [];
+      if (
+        botUsername === null ||
+        first?.author?.username !== botUsername
+      ) {
         return [];
       }
-      return [{ discussion, digest, resolved: first?.resolved === true }];
+      return [
+        {
+          discussion,
+          digest,
+          resolved: first?.resolved === true,
+          // Somebody else is talking in this thread. GitLab's only collapse is
+          // "Resolved", so retiring it would stamp a human's question as settled.
+          // System notes are GitLab's own bookkeeping, never a participant.
+          hasHumanReply: notes.some(
+            (note) =>
+              note.system !== true && note.author?.username !== botUsername,
+          ),
+          // Posting the note and resolving are two calls, so a failure between them
+          // is retried with the note already there. Free idempotence: these notes
+          // were fetched above.
+          hasSupersededNote: notes.some((note) =>
+            note.body?.includes(SUPERSEDED_DISCUSSION_NOTE),
+          ),
+        },
+      ];
     });
     const openByDigest = new Map<string, { id?: string }>();
     for (const entry of owned) {
-      if (entry.digest !== null) openByDigest.set(entry.digest, entry.discussion);
+      openByDigest.set(entry.digest, entry.discussion);
     }
+    // Reported inline AND reported into the summary. A finding the cap pushed out of
+    // the inline set is still standing, so its discussion must not be retired while
+    // the summary lists it.
+    const reported = new Set([
+      ...digests,
+      ...(publication.deferredFindingDigests ?? []),
+    ]);
     // Which finding each still-standing discussion is about. Digest first, then the
     // legacy index, and nothing else: an unmatched discussion of ours is one whose
     // finding this round no longer reports.
@@ -605,11 +670,6 @@ export class GitLabAdapter implements
         ),
       );
     const matched = publication.comments.map((_, index) => openFor(index));
-    const keptIds = new Set(
-      matched
-        .map((discussion) => discussion?.id)
-        .filter((id): id is string => id !== undefined),
-    );
 
     if (summaryNote?.body?.includes(headMarker) === true) {
       // This head has already been published. Re-approving is kept from the
@@ -621,6 +681,10 @@ export class GitLabAdapter implements
           { method: "POST", body: { sha: publication.headSha } },
         );
       }
+      // A retry has to be able to finish the sweep: the publish can succeed and the
+      // state update that records it can be lost, so the round already being on the
+      // merge request is not proof the sweep ran.
+      await this.retireSupersededDiscussions(prId, owned, reported);
       return {
         id:
           summaryNote.id === undefined
@@ -645,21 +709,6 @@ export class GitLabAdapter implements
       throw new FatalError(
         `GitLab merge request !${prId} no longer matches reviewed head ${publication.headSha}`,
       );
-    }
-
-    // A finding this round no longer reports is settled, so its thread is resolved,
-    // which is also how GitLab collapses it.
-    //
-    // "No longer reports" is not "not inline": a finding the cap pushed into the
-    // summary is still standing, and resolving its thread would have the thread and
-    // the summary say opposite things about one defect.
-    const deferred = new Set(publication.deferredFindingDigests ?? []);
-    for (const entry of owned) {
-      if (entry.resolved) continue;
-      if (entry.discussion.id === undefined) continue;
-      if (keptIds.has(entry.discussion.id)) continue;
-      if (entry.digest !== null && deferred.has(entry.digest)) continue;
-      await this.resolveMRDiscussion(prId, entry.discussion.id);
     }
 
     const commentIds: Array<string | null> = [];
@@ -744,6 +793,11 @@ export class GitLabAdapter implements
           ]),
       marker,
       headMarker,
+      // Read by trigger-events.ts to drop a note this workflow produced. An
+      // installation without a matchable bot login would otherwise fire a fresh
+      // review trigger off its own summary on the first round of every merge
+      // request.
+      AI_WORKFLOW_COMMENT_MARKER,
     ].join("\n\n");
     // Edited in place from the second round on, so the merge request carries one
     // summary rather than one per head.
@@ -763,10 +817,67 @@ export class GitLabAdapter implements
         { method: "POST", body: { sha: publication.headSha } },
       );
     }
+    // Only once this round's findings are on the merge request. Run earlier, a
+    // failure between the sweep and the summary left every superseded discussion
+    // resolved with nothing published in their place, and the merge request read as
+    // reviewed and clean.
+    await this.retireSupersededDiscussions(prId, owned, reported);
     return {
       id: note.id === undefined ? publication.idempotencyKey : String(note.id),
       commentIds,
     };
+  }
+
+  /**
+   * Retires the discussions whose finding this round no longer reports.
+   *
+   * GitLab has one collapse primitive and it is "Resolved", a word that claims the
+   * defect is gone. Nothing here can support that claim: a finding's identity is a
+   * hash of agent prose regenerated every round, so an unmatched discussion means
+   * "not reported under the same wording", not "fixed". The note is what keeps the
+   * strip from lying, and it is posted BEFORE the resolve so a failure in between
+   * leaves an explained open thread rather than a bare "Resolved" tick.
+   */
+  private async retireSupersededDiscussions(
+    prId: number,
+    owned: ReadonlyArray<{
+      discussion: { id?: string };
+      digest: string;
+      resolved: boolean;
+      hasHumanReply: boolean;
+      hasSupersededNote: boolean;
+    }>,
+    reported: ReadonlySet<string>,
+  ): Promise<void> {
+    for (const entry of owned) {
+      if (entry.resolved) continue;
+      if (entry.discussion.id === undefined) continue;
+      if (reported.has(entry.digest)) continue;
+      // Somebody is talking in this thread. Leave it exactly as it is.
+      if (entry.hasHumanReply) continue;
+      if (!entry.hasSupersededNote) {
+        await this.gitLabRest<unknown>(
+          `/projects/${this.encodedProjectId}/merge_requests/${prId}/discussions/${encodeURIComponent(entry.discussion.id)}/notes`,
+          { method: "POST", body: { body: SUPERSEDED_DISCUSSION_NOTE } },
+        );
+      }
+      await this.resolveMRDiscussion(prId, entry.discussion.id);
+    }
+  }
+
+  /**
+   * The current token's own username, read once per adapter instance. It is what
+   * separates a discussion this workflow opened from one that merely quotes its
+   * marker. https://docs.gitlab.com/ee/api/users.html, "List current user".
+   */
+  private async currentUsername(): Promise<string | null> {
+    if (this.cachedUsername === undefined) {
+      const user = await this.gitLabRest<{ username?: string }>("/user", {
+        method: "GET",
+      });
+      this.cachedUsername = user?.username ?? null;
+    }
+    return this.cachedUsername;
   }
 
   /**

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -9,6 +9,7 @@ import type {
   PRFile,
   PRFilesCapableVCS,
   PRReviewCapableVCS,
+  PRReviewInlineComment,
   PRReviewPublication,
   PRReviewPublicationResult,
   PullRequest,
@@ -18,7 +19,7 @@ import type {
   ManualDispatchPrCapableVCS,
   ManualDispatchPullRequestSnapshot,
 } from "./types.js";
-import { reviewFallbackBullet } from "./types.js";
+import { reviewFallbackBullet, reviewFindingDigest } from "./types.js";
 import { clampBothEnds } from "../../workflow-definition/failure-message.js";
 
 // Minimal shapes for gitbeaker responses we touch. Declared locally so we do
@@ -87,6 +88,11 @@ type GitLabCommitStatusState =
   | "skipped";
 
 const COMMIT_STATUS_409_RETRY_DELAYS_MS = [500, 1_000, 2_000];
+
+/** The marker family is this adapter's; the digest formula inside it is shared. */
+function readReviewFindingDigest(body: string): string | null {
+  return /<!-- ai-workflow-review-finding:([0-9a-f]+) -->/.exec(body)?.[1] ?? null;
+}
 
 export interface GitLabConfig {
   token: string;
@@ -208,7 +214,7 @@ export class GitLabAdapter implements
   private async gitLabRest<T>(
     path: string,
     options: {
-      method: "GET" | "POST";
+      method: "GET" | "POST" | "PUT";
       body?: Record<string, unknown>;
       retryOn409?: boolean;
     },
@@ -220,7 +226,7 @@ export class GitLabAdapter implements
   private async gitLabRestWithResponse<T>(
     path: string,
     options: {
-      method: "GET" | "POST";
+      method: "GET" | "POST" | "PUT";
       body?: Record<string, unknown>;
       retryOn409?: boolean;
     },
@@ -521,20 +527,39 @@ export class GitLabAdapter implements
     });
   }
 
+  /**
+   * Three artifacts with three different lifetimes, so a merge request does not
+   * collect a round's worth of everything on every push:
+   *
+   *  - one DISCUSSION per finding, opened once and carried across rounds, resolved
+   *    as soon as the round stops reporting it (GitLab collapses a resolved thread,
+   *    which is the same act here, since there is no separate hide call);
+   *  - one inline discussion per finding that is NEW to this round;
+   *  - one SUMMARY note for the whole merge request, edited in place.
+   */
   async publishPRReview(
     prId: number,
     publication: PRReviewPublication,
   ): Promise<PRReviewPublicationResult> {
     const reviewMarker = (key: string) => `<!-- ai-workflow-review:${key} -->`;
     const marker = reviewMarker(publication.idempotencyKey);
-    // Only the current key is ever written. Both marker families also recognise
-    // the keys earlier attempts used, because a review published before the key
-    // became a stable round identity carries those, and the per-comment family
-    // needs the same treatment as the summary note: recognising the note alone
-    // would still repost every inline discussion.
+    // The merge request's marker, on the one summary note. Only the current key is
+    // ever written; prior keys are recognised because a note published before the
+    // key identified the merge request carries one of those, and this is what turns
+    // such a note into the note every later round edits.
     const priorKeys = publication.priorIdempotencyKeys ?? [];
     const knownMarkers = [marker, ...priorKeys.map(reviewMarker)];
-    const knownCommentMarkers = (index: number) =>
+    // The round's marker, and on GitLab it rides in the summary note because there
+    // is no review object to hang it from. Its one job is to recognise a round this
+    // adapter has already published, now that the summary marker no longer says
+    // which head it describes.
+    const headMarker = `<!-- ai-workflow-review-head:${publication.headSha} -->`;
+    // The marker family from before findings had an identity of their own. Never
+    // written again, still recognised: within one round the index it carries does
+    // identify the finding, and the prior keys are the same round's earlier
+    // attempts, so an attempt that failed after posting its discussions does not
+    // post them twice.
+    const legacyCommentMarkers = (index: number) =>
       [publication.idempotencyKey, ...priorKeys].map(
         (key) => `<!-- ai-workflow-review-comment:${key}:${index} -->`,
       );
@@ -547,12 +572,49 @@ export class GitLabAdapter implements
       prId,
     )) as unknown as Array<{
       id?: string;
-      notes?: Array<{ body?: string }>;
+      notes?: Array<{ body?: string; resolved?: boolean }>;
     }>;
-    const prior = existingNotes.find((note) =>
+    const summaryNote = existingNotes.find((note) =>
       knownMarkers.some((known) => note.body?.includes(known)),
     );
-    if (prior) {
+    const digests = publication.comments.map(reviewFindingDigest);
+    // The discussions that belong to the workflow. A legacy-marked one counts as
+    // ours as well, or it would be invisible to the resolve sweep and stay open
+    // forever on every merge request reviewed before this change shipped.
+    const owned = existingDiscussions.flatMap((discussion) => {
+      const first = discussion.notes?.[0];
+      const body = first?.body ?? "";
+      const digest = readReviewFindingDigest(body);
+      if (digest === null && !body.includes("<!-- ai-workflow-review-comment:")) {
+        return [];
+      }
+      return [{ discussion, digest, resolved: first?.resolved === true }];
+    });
+    const openByDigest = new Map<string, { id?: string }>();
+    for (const entry of owned) {
+      if (entry.digest !== null) openByDigest.set(entry.digest, entry.discussion);
+    }
+    // Which finding each still-standing discussion is about. Digest first, then the
+    // legacy index, and nothing else: an unmatched discussion of ours is one whose
+    // finding this round no longer reports.
+    const openFor = (index: number): { id?: string } | undefined =>
+      openByDigest.get(digests[index]!) ??
+      existingDiscussions.find((candidate) =>
+        candidate.notes?.some((note) =>
+          legacyCommentMarkers(index).some((known) => note.body?.includes(known)),
+        ),
+      );
+    const matched = publication.comments.map((_, index) => openFor(index));
+    const keptIds = new Set(
+      matched
+        .map((discussion) => discussion?.id)
+        .filter((id): id is string => id !== undefined),
+    );
+
+    if (summaryNote?.body?.includes(headMarker) === true) {
+      // This head has already been published. Re-approving is kept from the
+      // original path: the approval is what a protected branch reads, and GitLab
+      // drops it whenever the merge request changes.
       if (publication.decision === "approve") {
         await this.gitLabRest<unknown>(
           `/projects/${this.encodedProjectId}/merge_requests/${prId}/approve`,
@@ -560,16 +622,13 @@ export class GitLabAdapter implements
         );
       }
       return {
-        id: prior.id === undefined ? publication.idempotencyKey : String(prior.id),
-        commentIds: publication.comments.map((_, index) => {
-          const commentMarkers = knownCommentMarkers(index);
-          const discussion = existingDiscussions.find((candidate) =>
-            candidate.notes?.some((note) =>
-              commentMarkers.some((known) => note.body?.includes(known)),
-            ),
-          );
-          return discussion?.id ? String(discussion.id) : null;
-        }),
+        id:
+          summaryNote.id === undefined
+            ? publication.idempotencyKey
+            : String(summaryNote.id),
+        commentIds: matched.map((discussion) =>
+          discussion?.id ? String(discussion.id) : null,
+        ),
       };
     }
     const mr = (await this.gl.MergeRequests.show(
@@ -588,21 +647,35 @@ export class GitLabAdapter implements
       );
     }
 
+    // A finding this round no longer reports is settled, so its thread is resolved,
+    // which is also how GitLab collapses it.
+    //
+    // "No longer reports" is not "not inline": a finding the cap pushed into the
+    // summary is still standing, and resolving its thread would have the thread and
+    // the summary say opposite things about one defect.
+    const deferred = new Set(publication.deferredFindingDigests ?? []);
+    for (const entry of owned) {
+      if (entry.resolved) continue;
+      if (entry.discussion.id === undefined) continue;
+      if (keptIds.has(entry.discussion.id)) continue;
+      if (entry.digest !== null && deferred.has(entry.digest)) continue;
+      await this.resolveMRDiscussion(prId, entry.discussion.id);
+    }
+
     const commentIds: Array<string | null> = [];
     const summaryFallbacks: string[] = [];
+    const carriedOver: PRReviewInlineComment[] = [];
     for (const [index, comment] of publication.comments.entries()) {
+      // The marker travels with the note because the discussion it opens is what a
+      // later round has to recognise.
       const commentMarker =
-        `<!-- ai-workflow-review-comment:${publication.idempotencyKey}:${index} -->`;
-      const commentMarkers = knownCommentMarkers(index);
-      const priorDiscussion = existingDiscussions.find((discussion) =>
-        discussion.notes?.some((note) =>
-          commentMarkers.some((known) => note.body?.includes(known)),
-        ),
-      );
+        `<!-- ai-workflow-review-finding:${digests[index]!} -->`;
+      const priorDiscussion = matched[index];
       if (priorDiscussion) {
         commentIds.push(
           priorDiscussion.id ? String(priorDiscussion.id) : null,
         );
+        carriedOver.push(comment);
         continue;
       }
       const position = {
@@ -652,17 +725,38 @@ export class GitLabAdapter implements
       }
     }
 
-    const summary =
-      summaryFallbacks.length === 0
-        ? publication.summary
-        : `${publication.summary}\n\n### Additional findings not placed inline\n${summaryFallbacks.join("\n")}`;
-    const note = await this.gitLabRest<{ id?: number }>(
-      `/projects/${this.encodedProjectId}/merge_requests/${prId}/notes`,
-      {
-        method: "POST",
-        body: { body: `${summary}\n\n${marker}` },
-      },
-    );
+    const body = [
+      publication.summary,
+      ...(summaryFallbacks.length === 0
+        ? []
+        : [
+            `### Additional findings not placed inline\n${summaryFallbacks.join("\n")}`,
+          ]),
+      // Findings this round reports that already have a discussion. They get no new
+      // note of their own, so without this section they would be missing from the
+      // one artifact a reader treats as the current state, and an unfixed finding
+      // would read as fixed.
+      ...(carriedOver.length === 0
+        ? []
+        : [
+            "### Findings already open on this merge request\n" +
+              carriedOver.map(reviewFallbackBullet).join("\n"),
+          ]),
+      marker,
+      headMarker,
+    ].join("\n\n");
+    // Edited in place from the second round on, so the merge request carries one
+    // summary rather than one per head.
+    const note =
+      summaryNote?.id === undefined
+        ? await this.gitLabRest<{ id?: number }>(
+            `/projects/${this.encodedProjectId}/merge_requests/${prId}/notes`,
+            { method: "POST", body: { body } },
+          )
+        : await this.gitLabRest<{ id?: number }>(
+            `/projects/${this.encodedProjectId}/merge_requests/${prId}/notes/${summaryNote.id}`,
+            { method: "PUT", body: { body } },
+          );
     if (publication.decision === "approve") {
       await this.gitLabRest<unknown>(
         `/projects/${this.encodedProjectId}/merge_requests/${prId}/approve`,
@@ -673,6 +767,26 @@ export class GitLabAdapter implements
       id: note.id === undefined ? publication.idempotencyKey : String(note.id),
       commentIds,
     };
+  }
+
+  /**
+   * GitLab's resolve primitive, and its collapse primitive as well: a resolved
+   * thread folds into a "Resolved" strip and stops counting against the merge
+   * request's unresolved threads. There is no separate hide call the way GitHub
+   * has `minimizeComment`.
+   *
+   * https://docs.gitlab.com/ee/api/discussions.html, "Resolve a merge request
+   * thread": `PUT /projects/:id/merge_requests/:iid/discussions/:discussion_id`
+   * with `resolved=true`.
+   */
+  private async resolveMRDiscussion(
+    prId: number,
+    discussionId: string,
+  ): Promise<void> {
+    await this.gitLabRest<unknown>(
+      `/projects/${this.encodedProjectId}/merge_requests/${prId}/discussions/${encodeURIComponent(discussionId)}`,
+      { method: "PUT", body: { resolved: true } },
+    );
   }
 
   private gitLabLineRangePosition(

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -19,7 +19,7 @@ import type {
   ManualDispatchPrCapableVCS,
   ManualDispatchPullRequestSnapshot,
 } from "./types.js";
-import { reviewFallbackBullet, reviewFindingDigest } from "./types.js";
+import { readReviewFindingDigest, reviewFallbackBullet } from "./types.js";
 import { clampBothEnds } from "../../workflow-definition/failure-message.js";
 import { AI_WORKFLOW_COMMENT_MARKER } from "../../lib/vcs-bot-identity.js";
 
@@ -105,17 +105,30 @@ type GitLabCommitStatusState =
 
 const COMMIT_STATUS_409_RETRY_DELAYS_MS = [500, 1_000, 2_000];
 
-/** The marker family is this adapter's; the digest formula inside it is shared. */
-function readReviewFindingDigest(body: string): string | null {
-  return /<!-- ai-workflow-review-finding:([0-9a-f]+) -->/.exec(body)?.[1] ?? null;
-}
-
 export interface GitLabConfig {
   token: string;
   projectId: string;
   baseBranch: string;
   /** Base URL for GitLab instance. Defaults to "https://gitlab.com". */
   host?: string;
+}
+
+interface OwnedReviewDiscussion {
+  discussion: { id?: string };
+  digest: string;
+  resolved: boolean;
+  /**
+   * Somebody other than this workflow has commented in the thread. Such a
+   * discussion is never touched: a reader's question resolved out from under
+   * them is a worse outcome than a stale discussion left open.
+   */
+  hasHumanReply: boolean;
+  /**
+   * A superseding note was already posted to this discussion. Posting the note
+   * and resolving are two calls, so a failure between them is retried without
+   * posting the note a second time.
+   */
+  hasSupersededNote: boolean;
 }
 
 export class GitLabAdapter implements
@@ -600,11 +613,8 @@ export class GitLabAdapter implements
     const summaryNote = existingNotes.find((note) =>
       knownMarkers.some((known) => note.body?.includes(known)),
     );
-    // The caller's digests when it has its own recipe, and the comment body
-    // otherwise. Either way this adapter only carries the value.
-    const digests =
-      publication.commentFindingDigests ??
-      publication.comments.map(reviewFindingDigest);
+    // The caller's digests. This adapter only carries the value.
+    const digests = publication.commentFindingDigests;
     // The discussions that belong to the workflow: marked with a finding digest AND
     // opened by this token. The marker alone is text anybody can paste, and the
     // author alone matches every thread this token ever opened, so two installations
@@ -616,7 +626,7 @@ export class GitLabAdapter implements
     )
       ? await this.currentUsername()
       : null;
-    const owned = existingDiscussions.flatMap((discussion) => {
+    const owned = existingDiscussions.flatMap((discussion): OwnedReviewDiscussion[] => {
       const notes = discussion.notes ?? [];
       const first = notes[0];
       const digest = readReviewFindingDigest(first?.body ?? "");
@@ -632,16 +642,11 @@ export class GitLabAdapter implements
           discussion,
           digest,
           resolved: first?.resolved === true,
-          // Somebody else is talking in this thread. GitLab's only collapse is
-          // "Resolved", so retiring it would stamp a human's question as settled.
           // System notes are GitLab's own bookkeeping, never a participant.
           hasHumanReply: notes.some(
             (note) =>
               note.system !== true && note.author?.username !== botUsername,
           ),
-          // Posting the note and resolving are two calls, so a failure between them
-          // is retried with the note already there. Free idempotence: these notes
-          // were fetched above.
           hasSupersededNote: notes.some((note) =>
             note.body?.includes(SUPERSEDED_DISCUSSION_NOTE),
           ),
@@ -840,13 +845,7 @@ export class GitLabAdapter implements
    */
   private async retireSupersededDiscussions(
     prId: number,
-    owned: ReadonlyArray<{
-      discussion: { id?: string };
-      digest: string;
-      resolved: boolean;
-      hasHumanReply: boolean;
-      hasSupersededNote: boolean;
-    }>,
+    owned: ReadonlyArray<OwnedReviewDiscussion>,
     reported: ReadonlySet<string>,
   ): Promise<void> {
     for (const entry of owned) {

--- a/apps/worker/src/adapters/vcs/types.ts
+++ b/apps/worker/src/adapters/vcs/types.ts
@@ -291,6 +291,21 @@ export interface PRReviewPublication {
    */
   priorIdempotencyKeys?: string[];
   /**
+   * The digest of each entry in `comments`, same order and same length.
+   *
+   * The RECIPE lives with the caller, not here. An adapter only carries a digest:
+   * it writes one into the marker on a comment it opens and reads it back verbatim
+   * on a later round, so it never needs to know how the string was derived. The
+   * workflow derives it from the finding's severity and prose alone, deliberately
+   * excluding the agreement note, because that note embeds the number of agreeing
+   * reviewers and whether the finding blocks the check: both can change while the
+   * defect does not, and a digest that moved with them would strand the thread.
+   *
+   * Optional, and the fallback derives it from the comment body. That keeps this a
+   * caller's choice rather than a break for any caller that has no separate recipe.
+   */
+  commentFindingDigests?: string[];
+  /**
    * Digests of findings this round STILL REPORTS but does not place inline: the
    * ones that lost an inline slot to the cap, and the ones whose line is no longer
    * in the diff. They are named in the summary instead.

--- a/apps/worker/src/adapters/vcs/types.ts
+++ b/apps/worker/src/adapters/vcs/types.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export interface PullRequest {
   id: number;
   url: string;
@@ -248,6 +250,35 @@ export function reviewFallbackBullet(comment: PRReviewInlineComment): string {
   return [`- \`${comment.path}:${range}\` — ${first}`, ...continuation].join("\n");
 }
 
+/**
+ * The identity of one finding's THREAD, and the reason a thread outlives the round
+ * that opened it.
+ *
+ * Path and prose only: no line numbers and no head commit. A finding that survives
+ * a push is reported again at whatever line the new diff puts it on, and a rebase
+ * or force-push moves every line in the file. Keyed on position, a thread would be
+ * unrecognisable after either, so a round would settle it and open an identical one
+ * beside it, which is the pile this exists to stop.
+ *
+ * The cost runs the other way: a reviewer that REWORDS a finding produces a
+ * different digest, so the earlier thread is settled and a new one opens with the
+ * new wording. One live thread per finding either way, which is the property that
+ * matters; a fuzzy match could not tell "the same defect, reworded" from "a
+ * different defect on the same symbol".
+ *
+ * One formula for both providers. The MARKER FAMILIES stay provider-local, because
+ * each adapter reads only what it wrote, but a digest that differed between them
+ * would be a difference with no reason to exist.
+ */
+export function reviewFindingDigest(
+  comment: Pick<PRReviewInlineComment, "path" | "body">,
+): string {
+  return createHash("sha256")
+    .update(`${comment.path} ${comment.body}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
 export interface PRReviewPublication {
   idempotencyKey: string;
   /**
@@ -259,6 +290,19 @@ export interface PRReviewPublication {
    * transition one-directional.
    */
   priorIdempotencyKeys?: string[];
+  /**
+   * Digests of findings this round STILL REPORTS but does not place inline: the
+   * ones that lost an inline slot to the cap, and the ones whose line is no longer
+   * in the diff. They are named in the summary instead.
+   *
+   * An adapter settles a thread when the round stops reporting its finding, and
+   * `comments` alone cannot tell that apart from "reported, just not inline". Left
+   * out, a finding demoted by the cap would have its thread marked resolved while
+   * the summary still lists it as standing, and the two artifacts would say
+   * opposite things about the same defect. Threads named here stay open and stay
+   * untouched.
+   */
+  deferredFindingDigests?: string[];
   headSha: string;
   decision: "approve" | "request_changes";
   summary: string;

--- a/apps/worker/src/adapters/vcs/types.ts
+++ b/apps/worker/src/adapters/vcs/types.ts
@@ -279,6 +279,16 @@ export function reviewFindingDigest(
     .slice(0, 32);
 }
 
+/**
+ * Reads the digest a provider wrote into its finding marker, if the comment body
+ * carries one. Shared because both providers currently write the same marker
+ * family; a provider that diverged would keep its own reader local instead of
+ * bending this one to fit two shapes.
+ */
+export function readReviewFindingDigest(body: string): string | null {
+  return /<!-- ai-workflow-review-finding:([0-9a-f]+) -->/.exec(body)?.[1] ?? null;
+}
+
 export interface PRReviewPublication {
   idempotencyKey: string;
   /**
@@ -300,11 +310,8 @@ export interface PRReviewPublication {
    * excluding the agreement note, because that note embeds the number of agreeing
    * reviewers and whether the finding blocks the check: both can change while the
    * defect does not, and a digest that moved with them would strand the thread.
-   *
-   * Optional, and the fallback derives it from the comment body. That keeps this a
-   * caller's choice rather than a break for any caller that has no separate recipe.
    */
-  commentFindingDigests?: string[];
+  commentFindingDigests: string[];
   /**
    * Digests of findings this round STILL REPORTS but does not place inline: the
    * ones that lost an inline slot to the cap, and the ones whose line is no longer

--- a/apps/worker/src/db/builtin-prompt-resync-migration.test.ts
+++ b/apps/worker/src/db/builtin-prompt-resync-migration.test.ts
@@ -5,10 +5,19 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_AGENT_PROMPTS } from "@shared/contracts";
 
 const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
-const resyncSql = readFileSync(
-  `${migrationsDir}0038_builtin_prompt_resync.sql`,
-  "utf8",
-);
+/** The newest resync migration, picked up by suffix rather than a pinned
+ *  filename: a fresh resync (e.g. 0044 superseding 0038) must make this suite
+ *  exercise the new file, or the test would keep passing while checking a
+ *  migration that no longer sits at the head of the guard's history. */
+const latestResyncFile = readdirSync(migrationsDir)
+  .filter((file) => file.endsWith("_builtin_prompt_resync.sql"))
+  .sort()
+  .at(-1);
+if (!latestResyncFile) {
+  throw new Error("No *_builtin_prompt_resync.sql migration found in drizzle/");
+}
+const latestResyncPrefix = latestResyncFile.slice(0, 4);
+const resyncSql = readFileSync(`${migrationsDir}${latestResyncFile}`, "utf8");
 /** Fixed past timestamp the parent rows are pinned to, so "was updated_at
  *  bumped" is decided by a real comparison rather than by clock resolution. */
 const PINNED_UPDATED_AT = "2000-01-01 00:00:00+00";
@@ -61,9 +70,9 @@ async function pinUpdatedAt(client: PGlite, slugs: string[]): Promise<void> {
   `);
 }
 
-describe("0038 built-in prompt resync migration", () => {
+describe(`${latestResyncPrefix} built-in prompt resync migration`, () => {
   it("corrects the untouched seed and is a strict no-op when replayed", async () => {
-    const client = await migrateThrough("0038");
+    const client = await migrateThrough(latestResyncPrefix);
 
     // The seed is now byte-identical to the constants, still at one version.
     const applied = await readBuiltIns(client);
@@ -212,5 +221,46 @@ describe("0038 built-in prompt resync migration", () => {
     expect(new Date(mine.rows[0]!.updated_at).toISOString()).toBe(
       new Date(PINNED_UPDATED_AT).toISOString(),
     );
+  });
+
+  it("preserves a tenant's own rewrite of a built-in prompt through the resync, including a replay", async () => {
+    // Pins the product decision this migration currently makes for a body a
+    // tenant has actually rewritten (not just appended to): the guard reads
+    // authorship off the version row's created_by_id / created_by_label, and
+    // savePromptVersion always stamps the acting account there, so a tenant
+    // save can never carry 'system' / 'System migration' and is therefore
+    // never a candidate for correction, silently. This is "survives" rather
+    // than "overwritten and reported" - see the open question about whether
+    // that is the semantics the product wants long-term.
+    const client = await migrateThrough("0033");
+    await client.exec(`
+      INSERT INTO prompt_library_versions
+        (prompt_id, version, body, created_by_id, created_by_label, restored_from_version)
+      SELECT id, 2, 'tenant-rewritten review checklist', 'u_tenant', 'Tenant Admin', NULL
+      FROM prompt_library WHERE slug = 'review'
+    `);
+    const before = await readBuiltIns(client);
+    const tenantXminBefore = before.find(
+      ({ slug, version }) => slug === "review" && version === 2,
+    )!.version_xmin;
+
+    await client.exec(resyncSql);
+    // A replay (the migration re-applied, or an older resync file re-run
+    // against a database that already has a newer one) must not touch it
+    // either.
+    await client.exec(resyncSql);
+
+    const after = await readBuiltIns(client);
+    const tenantVersion = after.find(
+      ({ slug, version }) => slug === "review" && version === 2,
+    )!;
+    expect(tenantVersion.body).toBe("tenant-rewritten review checklist");
+    expect(tenantVersion.version_xmin).toBe(tenantXminBefore);
+
+    // The platform's own version 1 underneath it is still corrected.
+    const systemVersion = after.find(
+      ({ slug, version }) => slug === "review" && version === 1,
+    )!;
+    expect(systemVersion.body).toBe(DEFAULT_AGENT_PROMPTS.review);
   });
 });

--- a/apps/worker/src/harness-profiles/store.ts
+++ b/apps/worker/src/harness-profiles/store.ts
@@ -49,6 +49,7 @@ import {
   type DashboardRole,
 } from "../lib/auth/roles.js";
 import { DashboardAuthError } from "../lib/auth/users-read.js";
+import { isUniqueViolation } from "../lib/unique-violation.js";
 import {
   compileHarnessProfileManifest,
   HarnessProfileManifestError,
@@ -1526,16 +1527,3 @@ async function throwWriteMiss(
   throw new HarnessProfileStoreError(409, "Profile draft revision conflict");
 }
 
-function isUniqueViolation(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
-  const candidate = error as {
-    code?: string;
-    cause?: { code?: string };
-    message?: string;
-  };
-  return (
-    candidate.code === "23505" ||
-    candidate.cause?.code === "23505" ||
-    candidate.message?.includes("duplicate key") === true
-  );
-}

--- a/apps/worker/src/lib/trigger-delivery-store.ts
+++ b/apps/worker/src/lib/trigger-delivery-store.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, sql } from "drizzle-orm";
 import type { Db } from "../db/client.js";
 import { activeRuns, triggerDeliveries } from "../db/schema.js";
+import { isUniqueViolation } from "./unique-violation.js";
 import type { PrTriggerType, TriggerEvent } from "./trigger-events.js";
 
 export type TriggerScope = "workflow_owned" | "any";
@@ -338,15 +339,6 @@ export async function acknowledgeStartedTriggerDelivery(
 
 function rawRows<T = { deliveryId: string }>(result: unknown): T[] {
   return ((result as { rows?: T[] }).rows ?? []) as T[];
-}
-
-function isUniqueViolation(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: string }).code === "23505"
-  );
 }
 
 function mapDelivery(row: typeof triggerDeliveries.$inferSelect): StoredTriggerDelivery {

--- a/apps/worker/src/lib/unique-violation.test.ts
+++ b/apps/worker/src/lib/unique-violation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { Db } from "../db/client.js";
+import {
+  triggerDeliveries,
+  workflowDefinitions,
+  workflowDefinitionVersions,
+} from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+import { isUniqueViolation } from "./unique-violation.js";
+
+/** Minimal valid row for the trigger_deliveries table, only varying the
+ *  delivery id, so two inserts collide on subject_key while pending. */
+function pendingDeliveryRow(deliveryId: string, definitionId: number) {
+  return {
+    provider: "github" as const,
+    deliveryId,
+    producer: "github-actions",
+    triggerType: "trigger_pr_checks_failed",
+    subjectKey: "pr:github:acme/api#1",
+    headSha: "sha",
+    definitionId,
+    definitionVersion: 1,
+    payload: {},
+    pending: true,
+  };
+}
+
+describe("isUniqueViolation", () => {
+  it("recognizes a real unique-constraint violation raised through drizzle", async () => {
+    // Same partial unique index (trigger_deliveries_one_pending_per_subject_idx)
+    // that coalescePendingTrigger's retry loop guards against, hit directly so
+    // the error comes from the real driver, not a hand-built object. Drizzle
+    // wraps that driver error in its own DrizzleQueryError and hangs the
+    // original off `cause`, so SQLSTATE 23505 is one level down, not on top.
+    const db: Db = await createTestDb();
+    const [definition] = await db
+      .insert(workflowDefinitions)
+      .values({
+        name: "Unique violation probe",
+        createdById: "test",
+        createdByLabel: "Test",
+      })
+      .returning();
+    await db.insert(workflowDefinitionVersions).values({
+      definitionId: definition!.id,
+      version: 1,
+      definition: {},
+      createdById: "test",
+      createdByLabel: "Test",
+    });
+
+    await db
+      .insert(triggerDeliveries)
+      .values(pendingDeliveryRow("d-1", definition!.id));
+    const error: unknown = await db
+      .insert(triggerDeliveries)
+      .values(pendingDeliveryRow("d-2", definition!.id))
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(isUniqueViolation(error)).toBe(true);
+  });
+
+  it("does not misclassify an unrelated error or a non-error value", () => {
+    expect(isUniqueViolation(new Error("boom"))).toBe(false);
+    expect(isUniqueViolation({ code: "23503" })).toBe(false);
+    expect(isUniqueViolation(null)).toBe(false);
+    expect(isUniqueViolation(undefined)).toBe(false);
+  });
+
+  it("stops walking the cause chain past the depth cap", () => {
+    let error: { message: string; cause?: unknown } = { message: "root", cause: { code: "23505" } };
+    for (let i = 0; i < 6; i += 1) {
+      error = { message: `wrap-${i}`, cause: error };
+    }
+    expect(isUniqueViolation(error)).toBe(false);
+  });
+});

--- a/apps/worker/src/lib/unique-violation.ts
+++ b/apps/worker/src/lib/unique-violation.ts
@@ -1,0 +1,26 @@
+/**
+ * A unique-constraint violation (Postgres SQLSTATE 23505), read from wherever
+ * it landed in the error's cause chain.
+ *
+ * The chain walk is required, not defensive: drizzle wraps a driver error in
+ * its own query error and hangs the original off `cause`, so the SQLSTATE is
+ * not on the error the caller catches. Depth is capped because a cause chain
+ * is attacker-independent but still worth not trusting to be acyclic.
+ *
+ * No imports on purpose: this is shared into code paths that run inside a
+ * Workflow step's isolate bundle, which has no node: builtins.
+ */
+export function isUniqueViolation(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; current !== null && current !== undefined && depth < 5; depth += 1) {
+    if (
+      typeof current === "object" &&
+      "code" in current &&
+      (current as { code?: string }).code === "23505"
+    ) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}

--- a/apps/worker/src/webhook-trigger/delivery-store.ts
+++ b/apps/worker/src/webhook-trigger/delivery-store.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, isNotNull, lt, sql } from "drizzle-orm";
 import type { WebhookDeliveryOutcome } from "@shared/contracts";
 import type { Db } from "../db/client.js";
 import { activeRuns, webhookTriggerDeliveries } from "../db/schema.js";
+import { isUniqueViolation } from "../lib/unique-violation.js";
 import type { WebhookTriggerEntry } from "./payload-mapping.js";
 import type { WebhookVerifiedWith } from "./verify.js";
 
@@ -419,15 +420,6 @@ export async function sweepWebhookDeliveries(
 
 function rawRows<T = { deliveryId: string }>(result: unknown): T[] {
   return ((result as { rows?: T[] }).rows ?? []) as T[];
-}
-
-function isUniqueViolation(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: string }).code === "23505"
-  );
 }
 
 function mapDelivery(

--- a/apps/worker/src/workflow-definition/interpreter.test.ts
+++ b/apps/worker/src/workflow-definition/interpreter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { WorkflowRunCancelledError } from "workflow/errors";
 import type {
+  BlockOutput,
   BlockRunState,
   WorkflowBlockTypeV1,
   WorkflowDefinitionV1,
@@ -1749,6 +1750,84 @@ describe("executeGraph steps propagation", () => {
     });
     expect(rec.failures).toEqual([
       expect.objectContaining({ phase: "engine", nodeId: "ghost" }),
+    ]);
+  });
+});
+
+describe("executeGraph resists the v2 loop-region duplication class of bug", () => {
+  /**
+   * The same customer-authored shape as
+   * scenarios/loop-branch-early-exit.scenario.test.ts (AIW-228/AIW-242), rebuilt
+   * here with v1's node/edge shape: a Loop whose body a Branch can exit early,
+   * wired both directly from outside the loop ("seed" to "loop") and through the
+   * Loop's own "continue" port ("loop" to "work").
+   *
+   * In v2 that shape duplicated the region: an activation-scope model let a
+   * fresh child scope re-run "work" after the Branch had already left it
+   * (AIW-242). v1 has no activation scopes to duplicate, for two mechanical
+   * reasons this test pins:
+   *
+   *   1. buildRuntimeGraph's outEdges map keeps one target per (node, port)
+   *      pair. "seed" wires to both "loop" and "work" on its default port here,
+   *      and the second edge silently overwrites the first rather than opening
+   *      a second live path.
+   *   2. executeGraph walks a single `current` cursor through the graph. There
+   *      is no scope for that cursor to fork into, so nothing can admit the
+   *      same node twice within one pass.
+   */
+  it("executes a block in a contested loop region exactly once per pass", async () => {
+    const graph = graphFrom(
+      [
+        node("trig", "trigger_ticket_ai"),
+        node("seed", "generic_agent"),
+        node("loop", "loop", { maxAttempts: 3, onExhaust: "fail" }),
+        node("work", "generic_agent"),
+        node("gate", "branch", {
+          condition: "steps.work.output.verdict == 'accept'",
+        }),
+        node("done", "terminate", { terminalStatus: "done" }),
+        node("giveup", "terminate", { terminalStatus: "failed" }),
+      ],
+      [
+        { from: "trig", to: "seed" },
+        // Both leave "seed" on its default port: the second wins in v1's
+        // outEdges map, which is mechanism 1 above.
+        { from: "seed", to: "loop" },
+        { from: "seed", to: "work" },
+        { from: "loop", to: "work", fromPort: "continue" },
+        { from: "work", to: "gate" },
+        { from: "gate", to: "loop", fromPort: "false" },
+        { from: "gate", to: "done", fromPort: "true" },
+        { from: "loop", to: "giveup", fromPort: "exhausted" },
+      ],
+    );
+    const rec = makeRecorder();
+    const workCalls: number[] = [];
+    const executor: BlockExecutor = async (block) => {
+      const output: BlockOutput =
+        block.id === "work"
+          ? { status: "completed", verdict: "accept" }
+          : { status: "completed" };
+      if (block.id === "work") workCalls.push(workCalls.length + 1);
+      return { kind: "next", output };
+    };
+
+    const result = await executeGraph({
+      graph,
+      entryTriggerId: "trig",
+      triggerOutput: { status: "ok" },
+      executeBlock: executor,
+      hooks: rec.hooks,
+    });
+
+    expect(workCalls).toEqual([1]);
+    expect(attemptsFor(rec, "work")).toEqual([1]);
+    // Mechanism 1, pinned directly: "seed"'s edge to "loop" was overwritten by
+    // its edge to "work", so the walk never reaches "loop" at all on this pass.
+    expect(attemptsFor(rec, "loop")).toEqual([]);
+    expect(result.outcome).toBe("stopped");
+    expect(rec.terminations).toEqual([
+      { params: { terminalStatus: "done", postComment: undefined }, nodeId: "done" },
     ]);
   });
 });

--- a/apps/worker/src/workflow-definition/scenarios/loop-branch-early-exit.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/loop-branch-early-exit.scenario.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   executorRunsOf,
   expectNeverInvoked,
+  expectStartsAfterFinishOf,
   portsOf,
 } from "./assertions.js";
 import { createScenario } from "./harness.js";
@@ -49,23 +50,32 @@ const REGISTRY_CONTEXT: WorkflowBlockRegistryContext = {
  * take its `true` port and leave the region while the Loop has attempts left.
  *
  * AIW-228 predicts an `executionError { category: "engine", phase: "loop" }` on
- * exactly this shape, from the boundary being resolved twice. That crash does not
- * happen, because `setEdgeToken` treats a write of the value an edge already
- * carries as a no-op rather than a contradiction (`v2-scheduler.ts:830`).
+ * exactly this shape, from the boundary being resolved twice. It does not fire,
+ * but not because a repeated write is harmless. `setEdgeToken` only tolerates a
+ * write of the value an edge already carries (`v2-scheduler.ts:841`); writing
+ * "active" over an "inactive" a first pass left is still a contradiction, and a
+ * region with two exits produces exactly that write. What keeps the boundary
+ * consistent is the deferral: a member resolves only the edges its own selected
+ * port takes, leaves the rest of the region's boundary unresolved because a
+ * retry may still select it, and `settleLoopBoundaryEdges` fills in the leftover
+ * once, never rewriting a decision already recorded. On this first shape there is
+ * one member with one exit, so there is nothing to contradict; the two-exit
+ * scenarios at the bottom of this file are where that claim is actually tested.
  *
- * What happens instead is quieter, and for an agent block worse. `seed -> loop`
- * goes active the moment `seed` finishes, and a node is admitted when *any*
- * incoming edge is active rather than when a particular one is
- * (`resolveNodeIfReady`, `v2-scheduler.ts:922-923`). Whichever port `gate` picks,
- * the Loop is therefore never skipped: it is admitted, and its fresh branch
- * spawns an iteration (`v2-scheduler.ts:1298`) that re-runs the whole region in a
- * child scope, alongside the exit the Branch has already selected. The run's own
- * bookkeeping is reconciled afterwards, so the outcome reads `completed` with no
- * error while `work` really did execute twice.
+ * What the shape really tests is quieter, and for an agent block worse.
+ * `seed -> loop` goes active the moment `seed` finishes, and a node is admitted
+ * when *any* incoming edge is active rather than when a particular one is
+ * (`resolveNodeIfReady`, `v2-scheduler.ts:923-926`), so the Loop's own arm going
+ * inactive is not enough to keep it from running. AIW-242 was exactly that: the
+ * Loop was admitted after `gate` had already left the region, and its fresh
+ * branch spawned an iteration (`v2-scheduler.ts:1330`) that re-ran the whole
+ * region in a child scope. Nothing surfaced it, because the run's bookkeeping is
+ * reconciled afterwards and the outcome reads `completed` with no error while
+ * `work` had really executed twice.
  *
- * The scenarios below pin that duplicate as an assertion rather than describe it
- * in prose, so the day it is fixed the pin fails and the fix is visible instead
- * of silent.
+ * The requirement the scenarios below hold is that leaving the region ends the
+ * pass: one logical pass is one execution of each body block, and the Loop
+ * retries only when the Branch hands control back to it.
  */
 
 const TICKET_ENTRY: AgentWorkflowInput = {
@@ -84,11 +94,19 @@ const TICKET_CONTEXT = {
   comments: [],
 };
 
-function snapshotDefinition(): WorkflowDefinitionV2 {
+function snapshotDefinition(path: string = SNAPSHOT.path): WorkflowDefinitionV2 {
   const raw = JSON.parse(
-    readFileSync(new URL(`./snapshots/${SNAPSHOT.path}`, import.meta.url), "utf8"),
+    readFileSync(new URL(`./snapshots/${path}`, import.meta.url), "utf8"),
   );
   return workflowDefinitionSchema.parse(raw) as WorkflowDefinitionV2;
+}
+
+function noValidationIssues(path: string): unknown[] {
+  return validateWorkflowDefinitionIssuesForDeployment(
+    snapshotDefinition(path),
+    REGISTRY_CONTEXT,
+    { checkEnvironmentAvailability: false },
+  );
 }
 
 function scenarioFor(verdict: string) {
@@ -132,12 +150,12 @@ describe("customer-authored loop with a contested boundary", () => {
     expect(outcome.result.outcome).toBe("completed");
   });
 
-  it("runs the region twice for one logical pass, which is the defect", async () => {
-    // Pinned, not endorsed. One pass through the graph executes the agent block
-    // twice, in two activation scopes, and the run reports success either way.
-    // `generic_agent` can hold a workspace open, commit, and cost money, so a
-    // second silent execution is not bookkeeping. The outcome above stays clean,
-    // which is exactly why nothing surfaces this today.
+  it("runs the region once for one logical pass", async () => {
+    // One pass through the graph is one execution of the agent block, in one
+    // activation scope. `generic_agent` can hold a workspace open, commit, and
+    // cost money, so an extra execution the user never authored is not
+    // bookkeeping, and the clean outcome above would hide it. The Branch left
+    // the region through `true`, so the Loop's retry never starts.
     const outcome = await scenarioFor("accept").execute();
 
     expect(
@@ -145,11 +163,12 @@ describe("customer-authored loop with a contested boundary", () => {
         attempt: invocation.attempt,
         activationScopeId: invocation.activationScopeId,
       })),
-    ).toEqual([
-      { attempt: 1, activationScopeId: "root" },
-      { attempt: 2, activationScopeId: "root/loop:loop:1" },
-    ]);
-    expect(portsOf(outcome, "gate")).toEqual(["true", "true"]);
+    ).toEqual([{ attempt: 1, activationScopeId: "root" }]);
+    expect(portsOf(outcome, "gate")).toEqual(["true"]);
+    // The control-level statement of the same requirement: the Loop leaves by no
+    // port at all. It is recorded once, skipped, so it never selected `continue`
+    // and never opened a second activation scope.
+    expect(portsOf(outcome, "loop")).toEqual([undefined]);
   });
 
   it("still reaches the Loop's exhausted port when the Branch keeps rejecting", async () => {
@@ -186,5 +205,190 @@ describe("customer-authored loop with a contested boundary", () => {
       diagnosticId: "AIW-DIAG-test-run-giveup-1",
     });
     expectNeverInvoked(outcome, ["done"]);
+  });
+});
+
+/**
+ * The same region, plus the most ordinary thing a customer adds to a block
+ * inside a loop: a second edge out of the SAME port, to something outside the
+ * region ("tell the reporter we started"). `work -> gate` keeps the pass inside
+ * the region and `work -> notify` leaves it, on one port.
+ *
+ * That is not an exit, and reading it as one costs the customer their retries:
+ * the Loop would be skipped on the first pass and `maxAttempts` would be
+ * silently ignored, on a graph whose whole point is to retry. Control is only
+ * leaving the region when the selected port does not continue to another member.
+ * An edge back to the Loop node is not such a continuation, which is why
+ * "terminates before an ordinary same-port body edge can return to Loop" in
+ * v2-scheduler.test.ts still ends its loop.
+ */
+const SIDE_OUTPUT_SNAPSHOT = { path: "loop-region-side-output-v1.json" };
+
+function sideOutputScenario(verdictAt: (attempt: number) => string) {
+  const scenario = createScenario({
+    snapshot: SIDE_OUTPUT_SNAPSHOT,
+    entry: TICKET_ENTRY,
+    entryTriggerId: "trigger",
+    ticket: TICKET_CONTEXT,
+  });
+  scenario.script({ nodeId: "seed" }, {
+    kind: "next",
+    output: { status: "completed", body: "First draft." },
+  });
+  scenario.script({ nodeId: "notify" }, {
+    kind: "next",
+    output: { status: "completed", body: "Progress posted." },
+  });
+  scenario.script({ nodeId: "work" }, (_node, _inputs, context) => {
+    const verdict = verdictAt(context.attempt);
+    return {
+      kind: "next",
+      output: { status: "completed", verdict, data: { verdict } },
+    };
+  });
+  return scenario;
+}
+
+describe("loop region with a side output on the same port", () => {
+  it("deploys with no validation issues", () => {
+    expect(noValidationIssues(SIDE_OUTPUT_SNAPSHOT.path)).toEqual([]);
+  });
+
+  it("keeps every Loop attempt when a member fans out past the region", async () => {
+    const outcome = await sideOutputScenario(() => "reject").execute();
+
+    // Identical arithmetic to the reject case above: the side output changes
+    // nothing about how many attempts the customer bought.
+    expect(executorRunsOf(outcome, "work")).toHaveLength(4);
+    expect(portsOf(outcome, "loop")).toEqual([
+      "exhausted",
+      "continue",
+      "continue",
+      undefined,
+    ]);
+    expect(outcome.result.outcome).toBe("failed");
+    expect(executorRunsOf(outcome, "giveup")).toHaveLength(1);
+    expectNeverInvoked(outcome, ["done"]);
+  });
+
+  it("leaves through the exit a retry selects, with the side branch resolved", async () => {
+    // The exit arrives on a later pass, so the boundary is resolved twice over
+    // the run: once by `work` for its own side branch, once by the Loop when the
+    // Branch finally leaves. Both writes have to stand, or the run fails with
+    // "resolved more than once" (AIW-228) on a graph the editor accepts.
+    const outcome = await sideOutputScenario((attempt) =>
+      attempt >= 2 ? "accept" : "reject",
+    ).execute();
+
+    expect(outcome.result.executionError).toBeUndefined();
+    expect(executorRunsOf(outcome, "work")).toHaveLength(2);
+    expect(portsOf(outcome, "gate")).toEqual(["false", "true"]);
+    expectNeverInvoked(outcome, ["giveup"]);
+  });
+
+  it("runs the side branch once per pass that reaches it", async () => {
+    // `notify` sits outside the region, so only the externally entered pass can
+    // reach it: retries run in an activation that does not contain it. Pinned
+    // because it is the boundary's other half, not because it is desirable.
+    const outcome = await sideOutputScenario(() => "reject").execute();
+
+    expect(executorRunsOf(outcome, "notify")).toHaveLength(1);
+  });
+});
+
+/**
+ * Two members of one region, each with its own exit. One logical pass can select
+ * both, and both are authored, so both have to run.
+ *
+ * The region is `{loop, workA, gateA, workB, gateB}`: every arm returns to the
+ * Loop, so the strongly connected component spans them all, and `seed` enters
+ * two of them from outside. Resolving the whole boundary on the first exit made
+ * the second one a contradiction (`edge "..." resolved more than once`, a failed
+ * run) in the initial activation, and made it disappear inside a retry, where
+ * the Loop had already ended and the second exit was dropped with the run still
+ * reporting success.
+ */
+const TWO_EXITS_SNAPSHOT = { path: "loop-two-region-exits-v1.json" };
+
+function twoExitsScenario(verdictAt: (attempt: number) => string) {
+  const scenario = createScenario({
+    snapshot: TWO_EXITS_SNAPSHOT,
+    entry: TICKET_ENTRY,
+    entryTriggerId: "trigger",
+    ticket: TICKET_CONTEXT,
+  });
+  scenario.script({ nodeId: "seed" }, {
+    kind: "next",
+    output: { status: "completed", body: "First draft." },
+  });
+  for (const nodeId of ["workA", "workB"]) {
+    scenario.script({ nodeId }, (_node, _inputs, context) => {
+      const verdict = verdictAt(context.attempt);
+      return {
+        kind: "next",
+        output: { status: "completed", verdict, data: { verdict } },
+      };
+    });
+  }
+  for (const nodeId of ["doneA", "doneB"]) {
+    scenario.script({ nodeId }, {
+      kind: "next",
+      output: { status: "completed", body: "Published." },
+    });
+  }
+  return scenario;
+}
+
+describe("loop region with two member exits", () => {
+  it("deploys with no validation issues", () => {
+    expect(noValidationIssues(TWO_EXITS_SNAPSHOT.path)).toEqual([]);
+  });
+
+  it("resolves the Loop only after every member of its region", async () => {
+    // The invariant the initial activation's correctness rests on, and the only
+    // reason the test below cannot crash: the Loop settles the region's boundary
+    // when it is skipped, so if it were skipped while `gateB` still had `true` to
+    // select, that exit would be frozen inactive (silently skipped) or crash the
+    // run on the contradicting write. It cannot be, because the region is a
+    // strongly connected component: `gateB -> loop` resolves only after `gateB`,
+    // and the Loop waits on all of its incoming edges.
+    //
+    // Nothing about this is local to the scheduler's loop code, which is why it
+    // is pinned here as well as asserted in `assertRegionDecidedBeforeLoop`:
+    // admitting only part of a region into a scope, by widening
+    // `hasExternalBodyEntry` or `allowedNodeIds`, would break it from a distance.
+    const outcome = await twoExitsScenario(() => "accept").execute();
+
+    const [loopRecord] = outcome.invocationsOf("loop");
+    expect(loopRecord).toBeDefined();
+    for (const memberId of ["workA", "workB", "gateA", "gateB"]) {
+      const [memberRecord] = outcome.invocationsOf(memberId);
+      expect(memberRecord).toBeDefined();
+      expectStartsAfterFinishOf(loopRecord!, memberRecord!);
+    }
+  });
+
+  it("runs both exits one pass selects in the initial activation", async () => {
+    const outcome = await twoExitsScenario(() => "accept").execute();
+
+    expect(outcome.result.executionError).toBeUndefined();
+    expect(outcome.result.outcome).toBe("completed");
+    expect(executorRunsOf(outcome, "doneA")).toHaveLength(1);
+    expect(executorRunsOf(outcome, "doneB")).toHaveLength(1);
+    expectNeverInvoked(outcome, ["giveup"]);
+  });
+
+  it("runs both exits one pass selects inside a retry", async () => {
+    const outcome = await twoExitsScenario((attempt) =>
+      attempt >= 2 ? "accept" : "reject",
+    ).execute();
+
+    expect(outcome.result.executionError).toBeUndefined();
+    expect(outcome.result.outcome).toBe("completed");
+    expect(executorRunsOf(outcome, "workA")).toHaveLength(2);
+    expect(executorRunsOf(outcome, "workB")).toHaveLength(2);
+    expect(executorRunsOf(outcome, "doneA")).toHaveLength(1);
+    expect(executorRunsOf(outcome, "doneB")).toHaveLength(1);
+    expectNeverInvoked(outcome, ["giveup"]);
   });
 });

--- a/apps/worker/src/workflow-definition/scenarios/snapshots/loop-region-side-output-v1.json
+++ b/apps/worker/src/workflow-definition/scenarios/snapshots/loop-region-side-output-v1.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": 2,
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger_ticket_ai",
+      "name": "Ticket moved to AI",
+      "x": 40,
+      "y": 200,
+      "configuration": {},
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "seed",
+      "type": "generic_agent",
+      "name": "Seed the region",
+      "x": 300,
+      "y": 200,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Produce the first draft.",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "loop",
+      "type": "loop",
+      "name": "Retry until accepted",
+      "x": 560,
+      "y": 340,
+      "configuration": { "maxAttempts": 3, "onExhaust": "fail" },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "work",
+      "type": "generic_agent",
+      "name": "Revise the draft",
+      "x": 820,
+      "y": 200,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Revise the draft and report a verdict.",
+        "outputSchema": "{\"type\":\"object\",\"properties\":{\"verdict\":{\"type\":\"string\"}},\"required\":[\"verdict\"],\"additionalProperties\":false}",
+        "outputSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "notify",
+      "type": "generic_agent",
+      "name": "Tell the reporter work started",
+      "x": 820,
+      "y": 40,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Post a short progress note.",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "gate",
+      "type": "branch",
+      "name": "Accepted?",
+      "x": 1080,
+      "y": 200,
+      "configuration": {
+        "combinator": "all",
+        "conditions": [
+          {
+            "reference": "steps.work.output.verdict",
+            "operator": "equals",
+            "value": "accept"
+          }
+        ]
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "done",
+      "type": "terminate",
+      "name": "Accepted",
+      "x": 1340,
+      "y": 120,
+      "configuration": { "terminalStatus": "done" },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "giveup",
+      "type": "terminate",
+      "name": "Gave up",
+      "x": 1340,
+      "y": 440,
+      "configuration": { "terminalStatus": "failed" },
+      "inputs": {},
+      "additionalInputs": []
+    }
+  ],
+  "edges": [
+    { "id": "e01-trigger-seed", "from": "trigger", "to": "seed" },
+    { "id": "e02-seed-loop", "from": "seed", "to": "loop" },
+    { "id": "e03-seed-work", "from": "seed", "to": "work" },
+    { "id": "e04-loop-continue-work", "from": "loop", "fromPort": "continue", "to": "work" },
+    { "id": "e05-work-gate", "from": "work", "to": "gate" },
+    { "id": "e06-work-notify", "from": "work", "to": "notify" },
+    { "id": "e07-gate-false-loop", "from": "gate", "fromPort": "false", "to": "loop" },
+    { "id": "e08-gate-true-done", "from": "gate", "fromPort": "true", "to": "done" },
+    { "id": "e09-loop-exhausted-giveup", "from": "loop", "fromPort": "exhausted", "to": "giveup" }
+  ]
+}

--- a/apps/worker/src/workflow-definition/scenarios/snapshots/loop-two-region-exits-v1.json
+++ b/apps/worker/src/workflow-definition/scenarios/snapshots/loop-two-region-exits-v1.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": 2,
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger_ticket_ai",
+      "name": "Ticket moved to AI",
+      "x": 40,
+      "y": 300,
+      "configuration": {},
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "seed",
+      "type": "generic_agent",
+      "name": "Seed both arms",
+      "x": 300,
+      "y": 300,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Produce the first draft.",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "loop",
+      "type": "loop",
+      "name": "Retry both arms",
+      "x": 560,
+      "y": 520,
+      "configuration": { "maxAttempts": 2, "onExhaust": "continue" },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "workA",
+      "type": "generic_agent",
+      "name": "Revise the copy",
+      "x": 820,
+      "y": 160,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Revise the copy and report a verdict.",
+        "outputSchema": "{\"type\":\"object\",\"properties\":{\"verdict\":{\"type\":\"string\"}},\"required\":[\"verdict\"],\"additionalProperties\":false}",
+        "outputSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "workB",
+      "type": "generic_agent",
+      "name": "Revise the tests",
+      "x": 820,
+      "y": 400,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Revise the tests and report a verdict.",
+        "outputSchema": "{\"type\":\"object\",\"properties\":{\"verdict\":{\"type\":\"string\"}},\"required\":[\"verdict\"],\"additionalProperties\":false}",
+        "outputSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "gateA",
+      "type": "branch",
+      "name": "Copy accepted?",
+      "x": 1080,
+      "y": 160,
+      "configuration": {
+        "combinator": "all",
+        "conditions": [
+          {
+            "reference": "steps.workA.output.verdict",
+            "operator": "equals",
+            "value": "accept"
+          }
+        ]
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "gateB",
+      "type": "branch",
+      "name": "Tests accepted?",
+      "x": 1080,
+      "y": 400,
+      "configuration": {
+        "combinator": "all",
+        "conditions": [
+          {
+            "reference": "steps.workB.output.verdict",
+            "operator": "equals",
+            "value": "accept"
+          }
+        ]
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "doneA",
+      "type": "generic_agent",
+      "name": "Publish the copy",
+      "x": 1340,
+      "y": 100,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Publish the accepted copy.",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "doneB",
+      "type": "generic_agent",
+      "name": "Publish the tests",
+      "x": 1340,
+      "y": 340,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Publish the accepted tests.",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "giveup",
+      "type": "generic_agent",
+      "name": "Escalate",
+      "x": 1340,
+      "y": 580,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Escalate to a human.",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    }
+  ],
+  "edges": [
+    { "id": "e01-trigger-seed", "from": "trigger", "to": "seed" },
+    { "id": "e02-seed-workA", "from": "seed", "to": "workA" },
+    { "id": "e03-seed-workB", "from": "seed", "to": "workB" },
+    { "id": "e04-loop-continue-workA", "from": "loop", "fromPort": "continue", "to": "workA" },
+    { "id": "e05-loop-continue-workB", "from": "loop", "fromPort": "continue", "to": "workB" },
+    { "id": "e06-workA-gateA", "from": "workA", "to": "gateA" },
+    { "id": "e07-workB-gateB", "from": "workB", "to": "gateB" },
+    { "id": "e08-gateA-false-loop", "from": "gateA", "fromPort": "false", "to": "loop" },
+    { "id": "e09-gateB-false-loop", "from": "gateB", "fromPort": "false", "to": "loop" },
+    { "id": "e10-gateA-true-doneA", "from": "gateA", "fromPort": "true", "to": "doneA" },
+    { "id": "e11-gateB-true-doneB", "from": "gateB", "fromPort": "true", "to": "doneB" },
+    { "id": "e12-loop-exhausted-giveup", "from": "loop", "fromPort": "exhausted", "to": "giveup" }
+  ]
+}

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -1075,18 +1075,27 @@ class V2SchedulerRuntime {
   ): void {
     const region = this.graph.loopRegions.get(loopNodeId);
     if (!region) return;
-    const undecided = [...region.memberNodeIds].filter((memberId) => {
-      const status = scope.nodeStates[memberId]?.status;
-      return (
-        status === "waiting" || status === "ready" || status === "running"
-      );
-    });
+    const undecided = this.undecidedRegionMembers(region, scope);
     if (undecided.length === 0) return;
     throw new V2SchedulerDefinitionError(
       `loop "${loopNodeId}" settled its region boundary in scope "${scope.id}" while ${undecided
         .map((memberId) => `"${memberId}"`)
         .join(", ")} had not decided`,
     );
+  }
+
+  /** Region members still `waiting`, `ready` or `running` in `scope`. Counting is
+   * all this does; whether that is a problem is the caller's call. */
+  private undecidedRegionMembers(
+    region: V2LoopRegion,
+    scope: V2ActivationScopeState,
+  ): string[] {
+    return [...region.memberNodeIds].filter((memberId) => {
+      const status = scope.nodeStates[memberId]?.status;
+      return (
+        status === "waiting" || status === "ready" || status === "running"
+      );
+    });
   }
 
   /**
@@ -1137,13 +1146,7 @@ class V2SchedulerRuntime {
     if (!(scope.loopRegionExited ?? []).includes(loopNodeId)) return;
     const region = this.graph.loopRegions.get(loopNodeId);
     if (!region) return;
-    const undecided = [...region.memberNodeIds].some((memberId) => {
-      const status = scope.nodeStates[memberId]?.status;
-      return (
-        status === "waiting" || status === "ready" || status === "running"
-      );
-    });
-    if (undecided) return;
+    if (this.undecidedRegionMembers(region, scope).length > 0) return;
     this.settleLoopBoundaryEdges(loopNodeId, scopeId, activeLoop.ownerScopeId);
   }
 

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -91,6 +91,17 @@ export interface V2ActivationScopeState {
   nodeStates: Record<string, V2NodeRuntimeState>;
   outputs: Record<string, BlockOutput>;
   loop?: V2LoopActivation;
+  /**
+   * Loop ids whose region control has already left in this activation, written
+   * the moment a member selects a port that leaves the region.
+   *
+   * Recorded rather than re-derived from edge tokens later. An active edge
+   * crossing the region's boundary does not mean the region was left: a member
+   * may fan out past the region on a port that also continues inside it, and
+   * that is a side branch, not an exit. Reading the fact off the tokens made
+   * such a fan-out cancel the Loop's remaining attempts.
+   */
+  loopRegionExited?: string[];
 }
 
 export interface V2ReadyInvocation {
@@ -846,29 +857,29 @@ class V2SchedulerRuntime {
     selectedPort: string | undefined,
   ): void {
     const scope = this.scope(scopeId);
-    const initialLoopRegion =
-      scope.loop === undefined && scope.parentScopeId === null
-        ? this.loopRegionContaining(nodeId)
-        : undefined;
-    const selectedBoundaryEdgeIds = new Set(
-      initialLoopRegion
-        ? (this.graph.outgoing.get(nodeId) ?? [])
-            .filter(
-              (edge) =>
-                edge.port === selectedPort &&
-                !initialLoopRegion.memberNodeIds.has(edge.to),
-            )
-            .map((edge) => edge.id)
-        : [],
-    );
+    const region = this.loopRegionContaining(nodeId);
+    const initialActivation =
+      scope.loop === undefined && scope.parentScopeId === null;
+    if (
+      region &&
+      this.regionExitEdges(region, nodeId, selectedPort).length > 0
+    ) {
+      this.recordLoopRegionExit(scope, region.loopNodeId);
+    }
     for (const edge of this.graph.outgoing.get(nodeId) ?? []) {
       if (
-        initialLoopRegion &&
-        !initialLoopRegion.memberNodeIds.has(edge.to)
+        region &&
+        initialActivation &&
+        !region.memberNodeIds.has(edge.to) &&
+        edge.port !== selectedPort
       ) {
-        // A non-selected exit may be chosen by a later retry. Keep it
-        // unresolved until this initial activation exits the region or the
-        // Loop reaches a terminal transition.
+        // An edge out of the region this pass did not select may still be
+        // selected by a retry, and a retry resolves it in this same scope.
+        // Leave it unresolved until the region's fate is settled. The edges
+        // this pass DID select are resolved here, by this member alone: the
+        // region's other members have their own decisions to make, and
+        // resolving the whole boundary on the first one crashed the run when a
+        // second member left too.
         continue;
       }
       this.setEdgeToken(
@@ -877,16 +888,46 @@ class V2SchedulerRuntime {
         edge.port === selectedPort ? "active" : "inactive",
       );
     }
-    if (initialLoopRegion && selectedBoundaryEdgeIds.size > 0) {
-      for (const edge of this.loopBoundaryEdges(initialLoopRegion.loopNodeId)) {
-        this.setEdgeToken(
-          scopeId,
-          edge.id,
-          selectedBoundaryEdgeIds.has(edge.id) ? "active" : "inactive",
-        );
-      }
-    }
     this.drainResolutionQueue();
+    this.settleLoopRegion(scopeId);
+  }
+
+  /**
+   * The edges a member's selected port takes out of its region, and only when
+   * that port is the pass leaving the region.
+   *
+   * A port that also continues to another member is not an exit: control is
+   * still inside the region, so the outside targets are a side branch running
+   * alongside it and the Loop keeps its remaining attempts. An edge back to the
+   * Loop node itself is not such a continuation. It asks for a retry, and an
+   * exit selected on the same port overrules it, which is the behaviour
+   * "terminates before an ordinary same-port body edge can return to Loop"
+   * pins in v2-scheduler.test.ts.
+   */
+  private regionExitEdges(
+    region: V2LoopRegion,
+    nodeId: string,
+    selectedPort: string | undefined,
+  ): V2ResolvedControlEdge[] {
+    if (selectedPort === undefined) return [];
+    const selected = (this.graph.outgoing.get(nodeId) ?? []).filter(
+      (edge) => edge.port === selectedPort,
+    );
+    const continuesInside = selected.some(
+      (edge) =>
+        edge.to !== region.loopNodeId && region.memberNodeIds.has(edge.to),
+    );
+    if (continuesInside) return [];
+    return selected.filter((edge) => !region.memberNodeIds.has(edge.to));
+  }
+
+  private recordLoopRegionExit(
+    scope: V2ActivationScopeState,
+    loopNodeId: string,
+  ): void {
+    const exited = scope.loopRegionExited ?? [];
+    if (exited.includes(loopNodeId)) return;
+    scope.loopRegionExited = [...exited, loopNodeId];
   }
 
   private selectedTransition(
@@ -920,7 +961,10 @@ class V2SchedulerRuntime {
     if (incoming.length === 0) return;
     const tokens = incoming.map((edge) => scope.edgeTokens[edge.id]);
     if (tokens.some((token) => token === "unresolved")) return;
-    if (tokens.some((token) => token === "active")) {
+    if (
+      tokens.some((token) => token === "active") &&
+      !this.loopRegionAlreadyLeft(scope, nodeId)
+    ) {
       const sequence = this.checkpoint.nextReadySequence;
       this.checkpoint.nextReadySequence += 1;
       state.status = "ready";
@@ -944,15 +988,44 @@ class V2SchedulerRuntime {
       }),
     );
     if (scope.loop?.loopNodeId === nodeId) {
+      // The pass is over. This scope's Loop resolves after every other member
+      // of its region, because every member has a path back to the Loop inside
+      // the strongly connected component and an edge resolves only once its
+      // source has, so the region's decisions are complete here and can be
+      // lifted into the scope that owns them.
+      this.settleLoopRegion(scopeId);
       return;
     }
     if (
       this.graph.nodes.get(nodeId)?.type === "loop" &&
       scope.loop?.loopNodeId !== nodeId
     ) {
-      this.resolveSkippedLoopBoundaryEdges(scopeId, nodeId);
+      this.assertRegionDecidedBeforeLoop(scope, nodeId);
+      this.settleLoopBoundaryEdges(nodeId, scopeId, scopeId);
     }
     this.propagatePort(scopeId, nodeId, undefined);
+  }
+
+  /**
+   * True when control has already left this Loop's region in this activation, so
+   * the Loop must not start a retry the same pass already overruled.
+   *
+   * A node is admitted when ANY incoming edge is active, not when a particular
+   * one is, and an activation can carry an active edge into the Loop from
+   * outside its region (`seed -> loop` next to `seed -> work`). Without this
+   * check the Loop is therefore admitted even after a member has taken an exit:
+   * it spawns an iteration that re-runs the whole region in a child scope, so
+   * one logical pass executes every body block twice while the run still reports
+   * success (AIW-242).
+   *
+   * The fact is read from the scope, never inferred from edge tokens. Only
+   * `regionExitEdges` decides what an exit is.
+   */
+  private loopRegionAlreadyLeft(
+    scope: V2ActivationScopeState,
+    nodeId: string,
+  ): boolean {
+    return (scope.loopRegionExited ?? []).includes(nodeId);
   }
 
   private loopRegionContaining(nodeId: string): V2LoopRegion | undefined {
@@ -973,41 +1046,114 @@ class V2SchedulerRuntime {
   }
 
   /**
-   * A skipped Loop never runs, so it has to resolve what its region deferred.
-   * In an initial activation the members defer every edge leaving the region
-   * and nothing else would ever resolve them: the run would report "completed"
-   * while the nodes past the boundary sat in "waiting", a silently skipped
-   * subgraph. In any other scope the members resolve those edges themselves and
-   * this only settles the remainder.
+   * The invariant every read of a settled boundary rests on: in the scope a
+   * region's members decide in, the Loop resolves after all of them, so the
+   * decisions being lifted are complete.
    *
-   * The region may already have been left through a selected exit in this same
-   * scope, which is what skipped the Loop in the first place: the exit marked
-   * the Loop's own arm inactive. That decision stands, so only the boundary
-   * edges still unresolved become inactive here.
+   * It is not an accident of ordering, it is forced. `memberNodeIds` is a
+   * strongly connected component, so every member has a path to the Loop that
+   * stays inside the region; a node resolves only once ALL of its incoming edges
+   * are resolved (`resolveNodeIfReady`); and an edge resolves only when its
+   * source propagates. Walk that path backwards and the Loop cannot resolve
+   * until every member on it already has.
+   *
+   * The one way an edge resolves without its source propagating is the
+   * pre-resolution in `initialCheckpoint`, and it reaches a member's arm only
+   * when that member is outside `allowedNodeIds`. Every member is inside it
+   * exactly when the region has an external body entry, which is the only case
+   * where members run in this scope at all. So the invariant is held up by
+   * `hasExternalBodyEntry` and `allowedNodeIds` together, not on its own:
+   * admitting only part of a region into a scope would let the Loop settle while
+   * a member still had an exit to select, and that exit would either be frozen
+   * inactive and its subgraph silently skipped, or crash the run on the
+   * contradicting write. Both are AIW-242 and AIW-228 back again, and both are
+   * quiet, so this refuses to settle a half-decided region instead.
    */
-  private resolveSkippedLoopBoundaryEdges(
-    scopeId: string,
+  private assertRegionDecidedBeforeLoop(
+    scope: V2ActivationScopeState,
     loopNodeId: string,
   ): void {
-    const scope = this.scope(scopeId);
+    const region = this.graph.loopRegions.get(loopNodeId);
+    if (!region) return;
+    const undecided = [...region.memberNodeIds].filter((memberId) => {
+      const status = scope.nodeStates[memberId]?.status;
+      return (
+        status === "waiting" || status === "ready" || status === "running"
+      );
+    });
+    if (undecided.length === 0) return;
+    throw new V2SchedulerDefinitionError(
+      `loop "${loopNodeId}" settled its region boundary in scope "${scope.id}" while ${undecided
+        .map((memberId) => `"${memberId}"`)
+        .join(", ")} had not decided`,
+    );
+  }
+
+  /**
+   * Fills in the edges leaving a region that the pass in `decisionScopeId` left
+   * unresolved, in the scope that owns the region.
+   *
+   * Members defer every edge out of the region they did not select, because a
+   * retry may select it later, and nothing else would ever resolve them: the run
+   * would report "completed" while the nodes past the boundary sat in "waiting",
+   * a silently skipped subgraph. So once the pass is over, whatever it did not
+   * decide becomes inactive, and whatever it did decide is lifted from its own
+   * tokens. Decisions already recorded in the owner scope are never rewritten,
+   * which is what keeps a second exit, or a side branch leaving the region, from
+   * failing the run with "resolved more than once".
+   */
+  private settleLoopBoundaryEdges(
+    loopNodeId: string,
+    decisionScopeId: string,
+    ownerScopeId: string,
+  ): void {
+    const decisions = this.scope(decisionScopeId);
+    const owner = this.scope(ownerScopeId);
     for (const edge of this.loopBoundaryEdges(loopNodeId)) {
-      if (scope.edgeTokens[edge.id] !== "unresolved") continue;
-      this.setEdgeToken(scopeId, edge.id, "inactive");
+      if (owner.edgeTokens[edge.id] !== "unresolved") continue;
+      this.setEdgeToken(
+        ownerScopeId,
+        edge.id,
+        decisions.edgeTokens[edge.id] === "active" ? "active" : "inactive",
+      );
     }
     this.drainResolutionQueue();
   }
 
-  private resolveLoopBoundaryEdges(
-    ownerScopeId: string,
-    loopNodeId: string,
-    selectedEdgeIds: ReadonlySet<string>,
-  ): void {
-    for (const edge of this.loopBoundaryEdges(loopNodeId)) {
-      this.setEdgeToken(
-        ownerScopeId,
-        edge.id,
-        selectedEdgeIds.has(edge.id) ? "active" : "inactive",
+  /**
+   * Settles the boundary for an iteration scope, once that pass can no longer
+   * change its mind: the region was left, and no member is still waiting, ready
+   * or running. Called from every member resolution, so the last member to
+   * decide is the one that settles, whichever member that turns out to be.
+   *
+   * An initial activation settles through its Loop's own skip instead: there the
+   * boundary edges live in the same scope the members decided in.
+   */
+  private settleLoopRegion(scopeId: string): void {
+    const scope = this.scope(scopeId);
+    const activeLoop = scope.loop;
+    if (!activeLoop) return;
+    const loopNodeId = activeLoop.loopNodeId;
+    if (!(scope.loopRegionExited ?? []).includes(loopNodeId)) return;
+    const region = this.graph.loopRegions.get(loopNodeId);
+    if (!region) return;
+    const undecided = [...region.memberNodeIds].some((memberId) => {
+      const status = scope.nodeStates[memberId]?.status;
+      return (
+        status === "waiting" || status === "ready" || status === "running"
       );
+    });
+    if (undecided) return;
+    this.settleLoopBoundaryEdges(loopNodeId, scopeId, activeLoop.ownerScopeId);
+  }
+
+  /** Activates the exit a member selected, in the scope that owns the region. */
+  private activateRegionExit(
+    ownerScopeId: string,
+    exitEdges: readonly V2ResolvedControlEdge[],
+  ): void {
+    for (const edge of exitEdges) {
+      this.setEdgeToken(ownerScopeId, edge.id, "active");
     }
     this.drainResolutionQueue();
   }
@@ -1526,11 +1672,8 @@ class V2SchedulerRuntime {
       "exhausted",
       new Set(exhaustedEdges.map((edge) => edge.id)),
     );
-    this.resolveLoopBoundaryEdges(
-      ownerScopeId,
-      node.id,
-      new Set(exhaustedEdges.map((edge) => edge.id)),
-    );
+    this.activateRegionExit(ownerScopeId, exhaustedEdges);
+    this.settleLoopBoundaryEdges(node.id, ownerScopeId, ownerScopeId);
     this.propagatePort(ownerScopeId, node.id, "exhausted");
   }
 
@@ -1826,16 +1969,19 @@ class V2SchedulerRuntime {
     if (!activeLoop) return;
     const region = this.graph.loopRegions.get(activeLoop.loopNodeId);
     if (!region?.memberNodeIds.has(nodeId)) return;
-    const selectedBoundaryEdges = (this.graph.outgoing.get(nodeId) ?? [])
-      .filter(
-        (edge) =>
-          edge.port === selectedPort &&
-          !region.memberNodeIds.has(edge.to),
-      );
+    const selectedBoundaryEdges = this.regionExitEdges(
+      region,
+      nodeId,
+      selectedPort,
+    );
     if (selectedBoundaryEdges.length === 0) return;
 
     const owner = this.scope(activeLoop.ownerScopeId);
     const ownerState = owner.nodeStates[activeLoop.loopNodeId];
+    // A second member of the same pass can leave the region after the first one
+    // already ended the Loop here. The Loop's own transition belongs to that
+    // first exit and is not rewritten, but this exit is authored too: its edges
+    // are settled from this scope's decisions rather than dropped.
     if (ownerState?.status !== "waiting_loop") return;
     const childLoopState =
       iterationScope.nodeStates[activeLoop.loopNodeId];
@@ -1917,11 +2063,8 @@ class V2SchedulerRuntime {
       selectedPort,
       new Set(selectedBoundaryEdges.map((edge) => edge.id)),
     );
-    this.resolveLoopBoundaryEdges(
-      activeLoop.ownerScopeId,
-      activeLoop.loopNodeId,
-      new Set(selectedBoundaryEdges.map((edge) => edge.id)),
-    );
+    this.activateRegionExit(activeLoop.ownerScopeId, selectedBoundaryEdges);
+    this.settleLoopRegion(iterationScopeId);
   }
 
   private async failNode(
@@ -2230,10 +2373,11 @@ class V2SchedulerRuntime {
         status: "completed",
         attempt: resumedAttempt,
       };
+      const exhaustedEdges = (
+        this.graph.outgoing.get(clarification.nodeId) ?? []
+      ).filter((edge) => edge.port === "exhausted");
       const exhaustedEdgeIds = new Set(
-        (this.graph.outgoing.get(clarification.nodeId) ?? [])
-          .filter((edge) => edge.port === "exhausted")
-          .map((edge) => edge.id),
+        exhaustedEdges.map((edge) => edge.id),
       );
       this.finishHook(
         clarification.scopeId,
@@ -2248,10 +2392,15 @@ class V2SchedulerRuntime {
         "exhausted",
         exhaustedEdgeIds,
       );
-      this.resolveLoopBoundaryEdges(
-        clarification.scopeId,
+      // The same two steps `exhaustLoop` takes, and in the same order: the exit
+      // this Loop is leaving by is activated first, so that settling the rest of
+      // the boundary reads it as decided instead of freezing it inactive and
+      // contradicting the propagation below.
+      this.activateRegionExit(clarification.scopeId, exhaustedEdges);
+      this.settleLoopBoundaryEdges(
         clarification.nodeId,
-        exhaustedEdgeIds,
+        clarification.scopeId,
+        clarification.scopeId,
       );
       this.propagatePort(
         clarification.scopeId,

--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -24,6 +24,7 @@ import {
   mergedReviewFindingCommentBody,
   type MergedReviewFinding,
 } from "./review-finding-merge.js";
+import { reviewFindingDigest } from "../adapters/vcs/types.js";
 
 const { mockUpdateGateStatus, mockCreateRepositoryVCS, mockAssertActiveRunOwner } =
   vi.hoisted(() => ({
@@ -1840,7 +1841,11 @@ describe("PR review publication idempotency", () => {
     expect(publication.idempotencyKey).not.toBe("legacy-content-hash");
   });
 
-  it("re-keys the marker once the head commit moves", async () => {
+  // Round two, and what becomes of round one (AIW-236). The old assertion here
+  // only checked that a new commit got its own review and said nothing about the
+  // round it superseded, which is how a pull request came to carry one summary per
+  // head and a growing pile of threads nobody had marked as settled.
+  it("publishes the next round under the pull request's own publication identity", async () => {
     const db = await createTestDb();
     await db.insert(workflowRuns).values({ runId: "run-idem-head" });
     const reviewResults: ReviewResult[] = [
@@ -1874,11 +1879,135 @@ describe("PR review publication idempotency", () => {
       reviewResults,
     });
 
-    // A new commit is a new round and must get its own review, so the key has to
-    // move here even though nothing the reviewer said changed.
-    expect(nextPublish.mock.calls[0]![1].idempotencyKey).not.toBe(
+    // A new commit is a new round, so it still reaches the provider, and it
+    // reaches it pinned to the new head.
+    expect(nextPublish).toHaveBeenCalledTimes(1);
+    expect(nextPublish.mock.calls[0]![1].headSha).toBe("head-2");
+    // The identity it publishes under is the PULL REQUEST, unchanged from round
+    // one: that key is the marker both adapters search for to find the one
+    // summary they keep on the pull request, so round two edits round one's
+    // summary instead of adding a second one beside it.
+    expect(nextPublish.mock.calls[0]![1].idempotencyKey).toBe(
       publishPRReview.mock.calls[0]![1].idempotencyKey,
     );
+    // Round one's own key is NOT offered as one to recognise. The keys in this
+    // list mean "a review already on the pull request that is MINE and for THIS
+    // round", so a key from an earlier head would have the adapter hand back
+    // round one's review and leave head-2 unreviewed.
+    expect(nextPublish.mock.calls[0]![1].priorIdempotencyKeys).toEqual([]);
+  });
+
+  // The lost-update case for a summary that is now a single comment edited in
+  // place: two review passes on one pull request must not be able to rewrite each
+  // other's text out of order. The defence is the head guard, and it is the reason
+  // the round stays head-scoped even though the publication identity no longer is.
+  it("refuses a round whose head the pull request has already left", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-stale-round" });
+    const publishPRReview = vi.fn();
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "head-2", state: "open", baseRef: "main" }),
+      listPRFiles: vi.fn().mockResolvedValue([]),
+      publishPRReview,
+    });
+
+    await expect(
+      publish(db, {
+        runId: "run-stale-round",
+        prNumber: 19,
+        headSha: "head",
+        reviewResults: [{ decision: "approve", findings: [] }],
+      }),
+    ).rejects.toThrow(/changed before the review could be published/);
+
+    // Nothing reached the provider, so the newer round's summary text survives.
+    expect(publishPRReview).not.toHaveBeenCalled();
+  });
+
+  // The link that makes the deferred list work at all. The digest the adapters keep
+  // a thread alive by has to be the same string the thread was OPENED under, so this
+  // pins the demoted finding's digest against the digest of that same finding when
+  // it still had an inline slot. Compute it two different ways and they must agree,
+  // or the whole defence is inert and nothing else in the suite would notice.
+  it("defers the digest a demoted finding was published under", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-deferred" });
+    // Twelve changed lines, so every finding below can be anchored and the inline
+    // cap is the only thing that decides which ones are placed.
+    const patch = ["@@ -1,0 +1,12 @@", ...Array.from({ length: 12 }, () => "+added")].join(
+      "\n",
+    );
+    const nit: ReviewResultFinding = {
+      file: "src/a.ts",
+      description: "Lowest-ranked finding on the pull request.",
+      severity: "Nit",
+      startLine: 11,
+      endLine: 11,
+    };
+    const reviewVcsWithPatch = (publishPRReview: ReturnType<typeof vi.fn>, headSha: string) => {
+      mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+      mockCreateRepositoryVCS.mockReset().mockReturnValue({
+        getPRHead: vi.fn().mockResolvedValue({ headSha, state: "open", baseRef: "main" }),
+        listPRFiles: vi.fn().mockResolvedValue([
+          { path: "src/a.ts", additions: 12, deletions: 0, changeType: "modified", patch },
+        ]),
+        publishPRReview,
+      });
+    };
+
+    // Round one reports the Nit on its own, so it wins an inline slot and opens a
+    // thread.
+    const first = vi.fn().mockResolvedValue({ id: "review-20", commentIds: ["c-20"] });
+    reviewVcsWithPatch(first, "head");
+    await publish(db, {
+      runId: "run-deferred",
+      prNumber: 20,
+      headSha: "head",
+      reviewResults: [{ decision: "request_changes", findings: [nit] }],
+    });
+    const placed = first.mock.calls[0]![1].comments;
+    expect(placed).toHaveLength(1);
+    const openedUnder = reviewFindingDigest({
+      path: placed[0]!.path,
+      body: placed[0]!.body,
+    });
+
+    // Round two adds ten findings that outrank it, so the cap pushes the Nit out of
+    // the inline set and into the summary. It is still reported.
+    const second = vi.fn().mockResolvedValue({ id: "review-21", commentIds: [] });
+    reviewVcsWithPatch(second, "head-2");
+    await publish(db, {
+      runId: "run-deferred",
+      prNumber: 20,
+      headSha: "head-2",
+      reviewResults: [
+        {
+          decision: "request_changes",
+          findings: [
+            ...Array.from({ length: 10 }, (_, index) => ({
+              file: "src/a.ts",
+              description: `Blocking finding ${index}.`,
+              severity: "Blocker" as const,
+              startLine: index + 1,
+              endLine: index + 1,
+            })),
+            nit,
+          ],
+        },
+      ],
+    });
+
+    const publication = second.mock.calls[0]![1];
+    // The cap is what did this, not the reviewer: ten inline comments and the Nit
+    // is not one of them.
+    expect(publication.comments).toHaveLength(10);
+    expect(
+      publication.comments.map((comment: { body: string }) => comment.body),
+    ).not.toContain(placed[0]!.body);
+    expect(publication.deferredFindingDigests).toContain(openedUnder);
   });
 
   it("publishes once when the same review is replayed", async () => {

--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
 import type { ReviewResult, ReviewResultFinding } from "@shared/contracts";
 import { eq } from "drizzle-orm";
 import { createTestDb } from "../db/test-db.js";
@@ -1837,8 +1838,43 @@ describe("PR review publication idempotency", () => {
     // already on the pull request is not duplicated, while the marker this call
     // writes is the round key alone.
     const publication = publishPRReview.mock.calls[0]![1];
-    expect(publication.priorIdempotencyKeys).toEqual(["legacy-content-hash"]);
+    expect(publication.priorIdempotencyKeys).toContain("legacy-content-hash");
     expect(publication.idempotencyKey).not.toBe("legacy-content-hash");
+  });
+
+  // The key the RUNNING release writes. It is head-scoped, and no row of ours
+  // records it, so it can only be reconstructed. Without it, a publish whose state
+  // write was lost, followed by a deploy, leaves the deployed summary unrecognised
+  // and this round posts a second summary and a second verdict for one head.
+  it("offers the deployed head-scoped key as one to recognise", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "run-deployed-key" });
+    const publishPRReview = vi
+      .fn()
+      .mockResolvedValue({ id: "review-18", commentIds: [] });
+    reviewVcs(publishPRReview);
+
+    await publish(db, {
+      runId: "run-deployed-key",
+      prNumber: 17,
+      headSha: "head",
+      reviewResults: [{ decision: "approve", findings: [] }],
+    });
+
+    const publication = publishPRReview.mock.calls[0]![1];
+    const deployed = createHash("sha256")
+      .update(
+        JSON.stringify({
+          provider: "github",
+          repository: "acme/app",
+          prNumber: 17,
+          headSha: "head",
+        }),
+      )
+      .digest("hex");
+    expect(publication.priorIdempotencyKeys).toContain(deployed);
+    // Recognised only. What this round WRITES stays the pull-request key.
+    expect(publication.idempotencyKey).not.toBe(deployed);
   });
 
   // Round two, and what becomes of round one (AIW-236). The old assertion here
@@ -1890,11 +1926,24 @@ describe("PR review publication idempotency", () => {
     expect(nextPublish.mock.calls[0]![1].idempotencyKey).toBe(
       publishPRReview.mock.calls[0]![1].idempotencyKey,
     );
-    // Round one's own key is NOT offered as one to recognise. The keys in this
+    // Nothing from round one is offered as a key to recognise. The keys in this
     // list mean "a review already on the pull request that is MINE and for THIS
-    // round", so a key from an earlier head would have the adapter hand back
-    // round one's review and leave head-2 unreviewed.
-    expect(nextPublish.mock.calls[0]![1].priorIdempotencyKeys).toEqual([]);
+    // round", so a key naming an earlier head would have the adapter hand back
+    // round one's review and leave head-2 unreviewed. Exactly one key survives:
+    // the deployed scheme's, pinned to head-2 for that very reason.
+    const deployedForHead2 = createHash("sha256")
+      .update(
+        JSON.stringify({
+          provider: "github",
+          repository: "acme/app",
+          prNumber: 13,
+          headSha: "head-2",
+        }),
+      )
+      .digest("hex");
+    expect(nextPublish.mock.calls[0]![1].priorIdempotencyKeys).toEqual([
+      deployedForHead2,
+    ]);
   });
 
   // The lost-update case for a summary that is now a single comment edited in

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -606,6 +606,9 @@ export function partitionReviewFindings(
   } = {},
 ): {
   comments: PRReviewInlineComment[];
+  /** The finding behind each entry of `comments`, same order. Carries the identity
+   * a comment cannot: `comments` keeps only the rendered body. */
+  placed: MergedReviewFinding[];
   /** Every defect, whether or not it won an inline slot. The published verdict
    * is read from this, so severity and cross-reviewer agreement must survive
    * the conversion to comments, which keeps neither. */
@@ -679,25 +682,26 @@ export function partitionReviewFindings(
   const chosen = ranked.slice(0, maxComments);
   const withheld = ranked.slice(maxComments);
 
-  const comments = [...chosen]
-    .sort(compareMergedFindingsForDisplay)
-    .map((finding) => ({
-      // Property order is load-bearing: reviewCommentContentHash stringifies
-      // this object, so reordering these keys rewrites every stored hash.
-      path: finding.anchor!.path,
-      startLine: finding.anchor!.startLine,
-      endLine: finding.anchor!.endLine,
-      startOldLine: finding.anchor!.startOldLine,
-      endOldLine: finding.anchor!.endOldLine,
-      body: mergedReviewFindingCommentBody(
-        finding,
-        results.length,
-        reviewFindingBlocksPublication(finding, results.length),
-      ),
-    }));
+  const placed = [...chosen].sort(compareMergedFindingsForDisplay);
+  const comments = placed.map((finding) => ({
+    // Property order is load-bearing: reviewCommentContentHash stringifies
+    // this object, so reordering these keys rewrites every stored hash.
+    path: finding.anchor!.path,
+    startLine: finding.anchor!.startLine,
+    endLine: finding.anchor!.endLine,
+    startOldLine: finding.anchor!.startOldLine,
+    endOldLine: finding.anchor!.endOldLine,
+    body: mergedReviewFindingCommentBody(
+      finding,
+      results.length,
+      reviewFindingBlocksPublication(finding, results.length),
+    ),
+  }));
 
   return {
     comments,
+    /** The finding behind each entry of `comments`, same order. */
+    placed,
     merged,
     fallback,
     withheld,
@@ -912,38 +916,51 @@ export function reviewSummary(
 }
 
 /**
+ * The identity of one finding's thread, and the ONE recipe both call sites use.
+ *
+ * Severity and prose only. The published comment also carries the agreement note,
+ * and the note is deliberately NOT hashed: it embeds how many reviewers agreed and
+ * whether the finding blocks the check, so a second reviewer agreeing, or the
+ * blocking threshold being met, rewrites the note while the defect is unchanged.
+ * Hashing it made the thread unrecognisable on the next round for a reason that has
+ * nothing to do with the code, and every round then opened a fresh thread beside the
+ * old one.
+ *
+ * What this digest is NOT is a claim that the defect was fixed. Reviewer prose is
+ * regenerated from scratch each round with no canonicalisation, so a match is
+ * evidence of sameness and a mismatch is evidence of nothing. That is why the
+ * adapters mark a thread OUTDATED, which is true whenever the round moved on, rather
+ * than RESOLVED, which would assert a repair nobody verified.
+ *
+ * The head template mirrors `mergedReviewFindingCommentBody` in
+ * review-finding-merge.ts, minus its note. The path is the anchor's when there is
+ * one, and otherwise the cluster's group key, which is the same normalised path an
+ * anchor would have carried.
+ */
+export function reviewFindingIdentityDigest(
+  finding: MergedReviewFinding,
+): string {
+  return reviewFindingDigest({
+    path: finding.anchor?.path ?? finding.sources[0]!.groupKey,
+    body: scrubForPublication(`**${finding.severity}**: ${finding.description}`),
+  });
+}
+
+/**
  * Thread digests for the findings this round reports into the SUMMARY rather than
  * inline: the ones the inline cap pushed out, and the ones whose line is no longer
  * part of the diff.
  *
- * The adapters settle a thread when the round stops reporting its finding, and the
+ * The adapters retire a thread when the round stops reporting its finding, and the
  * placed comments alone cannot distinguish that from "still reported, just not
- * inline". Without this list a finding demoted by the cap kept its thread and had it
- * marked resolved, while the same finding was listed as standing three lines below
+ * inline". Without this list a finding demoted by the cap would have its thread
+ * hidden as outdated while the same finding was listed as standing three lines below
  * in the summary.
- *
- * The body is built by the same function and scrubbed by the same pass as a placed
- * comment (`partitionReviewFindings`), because the digest has to come out identical
- * to the one the thread was opened under. The path is the anchor's when there is
- * one, and otherwise the cluster's group key, which is the same normalised path an
- * anchor would have carried.
  */
 export function deferredReviewFindingDigests(
   deferred: readonly MergedReviewFinding[],
-  reviewerCount: number,
 ): string[] {
-  return deferred.map((finding) =>
-    reviewFindingDigest({
-      path: finding.anchor?.path ?? finding.sources[0]!.groupKey,
-      body: scrubForPublication(
-        mergedReviewFindingCommentBody(
-          finding,
-          reviewerCount,
-          reviewFindingBlocksPublication(finding, reviewerCount),
-        ),
-      ),
-    }),
-  );
+  return deferred.map(reviewFindingIdentityDigest);
 }
 
 export function reviewCommentContentHash(
@@ -1001,6 +1018,7 @@ export async function publishRunOwnedPrReview(args: {
   }
   const {
     comments: placedComments,
+    placed,
     merged,
     fallback,
     withheld,
@@ -1127,16 +1145,37 @@ export async function publishRunOwnedPrReview(args: {
   // Markers earlier attempts at THIS round may have written, in no order that
   // matters: the adapters test for membership. A row that never reached
   // "published" can still have a review on the pull request, because the publish
-  // call can succeed and the state update that follows it can be lost, and before
-  // the key became stable that marker carried the row's content hash. Handing
+  // call can succeed and the state update that follows it can be lost. Handing
   // those to the adapter keeps such a review recognised instead of posting a
   // second copy next to it.
+  //
+  // TWO marker families live here, not one. The content hashes come from the rows
+  // above, from when the marker carried the row's content hash. The other is the
+  // scheme currently deployed, which keys the round on the head commit as well;
+  // anything published by the running release carries THAT and no row of ours
+  // records it. Left out, a lost state write plus a deploy would leave the old
+  // summary unrecognised, and this round would add a second summary and a second
+  // verdict for one head.
   //
   // Same head only, and that is load-bearing: these rows come from the round query
   // above. A key from an earlier head would name a review of code that has since
   // been pushed over, and the adapter would hand that review back instead of
-  // reviewing the current head.
-  const priorIdempotencyKeys = roundRows.map((row) => row.contentHash);
+  // reviewing the current head. The deployed key below is head-scoped for the same
+  // reason.
+  const deployedIdempotencyKey = createHash("sha256")
+    .update(
+      JSON.stringify({
+        provider: args.target.provider,
+        repository: args.target.repoPath,
+        prNumber: args.target.prNumber,
+        headSha: args.target.headSha,
+      }),
+    )
+    .digest("hex");
+  const priorIdempotencyKeys = [
+    ...roundRows.map((row) => row.contentHash),
+    deployedIdempotencyKey,
+  ];
   const existing = roundRows.find((row) => row.contentHash === contentHash);
   const publicationId = existing?.id ?? randomUUID();
   const commentRecords = comments.map((comment, index) => ({
@@ -1185,13 +1224,16 @@ export async function publishRunOwnedPrReview(args: {
     published = await vcs.publishPRReview(args.target.prNumber, {
       idempotencyKey,
       priorIdempotencyKeys,
+      // One recipe for both lists, so a finding that moves between them across
+      // rounds keeps the same thread.
+      commentFindingDigests: placed.map(reviewFindingIdentityDigest),
       // Everything still reported that no inline comment carries. Both adapters
-      // leave these threads open, so a finding demoted out of the inline set does
-      // not read as resolved while the summary still lists it.
-      deferredFindingDigests: deferredReviewFindingDigests(
-        [...fallback, ...withheld],
-        args.reviewResults.length,
-      ),
+      // leave these threads open, so a finding demoted out of the inline set is not
+      // hidden as outdated while the summary still lists it.
+      deferredFindingDigests: deferredReviewFindingDigests([
+        ...fallback,
+        ...withheld,
+      ]),
       headSha: args.target.headSha,
       decision,
       summary,

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -15,6 +15,7 @@ import {
   hasGateStatusCapability,
   hasPRFilesCapability,
   hasPRReviewCapability,
+  reviewFindingDigest,
   type GateStatusUpdate,
   type PRFile,
   type PRReviewInlineComment,
@@ -910,6 +911,41 @@ export function reviewSummary(
   return lines.join("\n");
 }
 
+/**
+ * Thread digests for the findings this round reports into the SUMMARY rather than
+ * inline: the ones the inline cap pushed out, and the ones whose line is no longer
+ * part of the diff.
+ *
+ * The adapters settle a thread when the round stops reporting its finding, and the
+ * placed comments alone cannot distinguish that from "still reported, just not
+ * inline". Without this list a finding demoted by the cap kept its thread and had it
+ * marked resolved, while the same finding was listed as standing three lines below
+ * in the summary.
+ *
+ * The body is built by the same function and scrubbed by the same pass as a placed
+ * comment (`partitionReviewFindings`), because the digest has to come out identical
+ * to the one the thread was opened under. The path is the anchor's when there is
+ * one, and otherwise the cluster's group key, which is the same normalised path an
+ * anchor would have carried.
+ */
+export function deferredReviewFindingDigests(
+  deferred: readonly MergedReviewFinding[],
+  reviewerCount: number,
+): string[] {
+  return deferred.map((finding) =>
+    reviewFindingDigest({
+      path: finding.anchor?.path ?? finding.sources[0]!.groupKey,
+      body: scrubForPublication(
+        mergedReviewFindingCommentBody(
+          finding,
+          reviewerCount,
+          reviewFindingBlocksPublication(finding, reviewerCount),
+        ),
+      ),
+    }),
+  );
+}
+
 export function reviewCommentContentHash(
   comment: PRReviewInlineComment,
   index: number,
@@ -1015,37 +1051,51 @@ export async function publishRunOwnedPrReview(args: {
   const contentHash = createHash("sha256")
     .update(JSON.stringify(normalized))
     .digest("hex");
-  // The provider marker, and deliberately not the content hash. Both adapters
-  // render this into the `<!-- ai-workflow-review:... -->` comment they search
-  // for to recognise a review they already published, so it has to identify the
-  // ROUND, one head commit of one pull request, and nothing else. While the
-  // content hash played that role, a reworded finding published a second full
-  // review (AIW-234), and any change to the verdict rule above would have
-  // published one on every pull request already reviewed.
+  // WHAT A ROUND IS (AIW-236), because two things below are keyed differently and
+  // the difference is the whole feature.
   //
-  // The cost, and it is a real one: the FIRST review of a head is the only one.
-  // Neither a rewording nor a flipped verdict can revise it or reach the reader,
-  // and the pull request keeps whatever the first round said until a new commit
-  // opens a new round. The check run reports that same published verdict, so the
-  // check and the review always agree.
+  // A round is one reviewed head commit of one pull request: the tuple
+  // (provider, repository, prNumber, headSha). Every push opens a new round. The
+  // round is what the database probe further down dedupes on, and that is the only
+  // place `headSha` may be dropped from, and dropping it there resolves the probe to
+  // a pull request that was already reviewed once and leaves the newest code with
+  // no review at all.
+  //
+  // A round is NOT the identity of anything the reader sees, and that is the
+  // change: the summary is ONE comment per pull request that every round edits in
+  // place, and an inline thread belongs to a FINDING and outlives the round that
+  // opened it, staying anchored across a force-push or a rebase. So the key handed
+  // to the adapter identifies the PULL REQUEST and nothing narrower. Both adapters
+  // render it into the `<!-- ai-workflow-review:... -->` marker they search for to
+  // find that one summary. The head commit travels separately in `headSha`, and
+  // each adapter writes it into a marker of its own so it can still recognise a
+  // round it already published.
+  //
+  // Deliberately not the content hash, ever. While the marker carried it, a
+  // reworded finding published a second full review (AIW-234), and any change to
+  // the verdict rule above would have published one on every pull request already
+  // reviewed.
   const idempotencyKey = createHash("sha256")
     .update(
       JSON.stringify({
         provider: args.target.provider,
         repository: args.target.repoPath,
         prNumber: args.target.prNumber,
-        headSha: args.target.headSha,
       }),
     )
     .digest("hex");
-  // Keyed on the ROUND and never on the content hash, because that is how the
-  // provider gate now behaves: an adapter that recognises its own marker returns
-  // the review it already published without posting anything. A content-keyed
-  // probe let reworded prose miss the published row, insert a second one, take
-  // that early return, and then record a publication that never happened, with
-  // GitLab's positionally rebuilt comment ids attributing this round's comments
-  // to the previous round's discussions. One head is one review, in the database
-  // as well as on the pull request.
+  // The round probe: keyed on the head commit and never on the content hash. A
+  // content-keyed probe let reworded prose miss the published row, insert a second
+  // one, and then record a publication that never happened, with GitLab's
+  // positionally rebuilt comment ids attributing this round's comments to the
+  // previous round's discussions. One head is one review, in the database as well
+  // as on the pull request.
+  //
+  // The cost, and it is a real one: the FIRST review of a head is the only one.
+  // Neither a rewording nor a flipped verdict can revise it or reach the reader,
+  // and the pull request keeps whatever the first round said until a new commit
+  // opens a new round. The check run reports that same published verdict, so the
+  // check and the review always agree.
   const roundRows = await args.db
     .select()
     .from(workflowPrReviewPublications)
@@ -1074,13 +1124,18 @@ export async function publishRunOwnedPrReview(args: {
       summaryFallbackCount: publishedRound.summaryFallbackCount,
     };
   }
-  // Markers earlier attempts at this round may have written, in no order that
+  // Markers earlier attempts at THIS round may have written, in no order that
   // matters: the adapters test for membership. A row that never reached
   // "published" can still have a review on the pull request, because the publish
   // call can succeed and the state update that follows it can be lost, and before
-  // the key became round-stable that marker carried the row's content hash.
-  // Handing those to the adapter keeps such a review recognised instead of
-  // posting a second copy next to it.
+  // the key became stable that marker carried the row's content hash. Handing
+  // those to the adapter keeps such a review recognised instead of posting a
+  // second copy next to it.
+  //
+  // Same head only, and that is load-bearing: these rows come from the round query
+  // above. A key from an earlier head would name a review of code that has since
+  // been pushed over, and the adapter would hand that review back instead of
+  // reviewing the current head.
   const priorIdempotencyKeys = roundRows.map((row) => row.contentHash);
   const existing = roundRows.find((row) => row.contentHash === contentHash);
   const publicationId = existing?.id ?? randomUUID();
@@ -1130,6 +1185,13 @@ export async function publishRunOwnedPrReview(args: {
     published = await vcs.publishPRReview(args.target.prNumber, {
       idempotencyKey,
       priorIdempotencyKeys,
+      // Everything still reported that no inline comment carries. Both adapters
+      // leave these threads open, so a finding demoted out of the inline set does
+      // not read as resolved while the summary still lists it.
+      deferredFindingDigests: deferredReviewFindingDigests(
+        [...fallback, ...withheld],
+        args.reviewResults.length,
+      ),
       headSha: args.target.headSha,
       decision,
       summary,


### PR DESCRIPTION
Five tickets from the pre-release backlog, each a separate commit so any one can be reverted alone. Deviation from the plan worth naming: the plan called for a branch per stage; the stages landed on one branch because their file scopes are disjoint and CI is worth running once rather than five times. Rollback granularity is preserved by the commit boundaries.

## AIW-242 + AIW-228 — a loop region runs once per logical pass

One pass through a graph executed every block inside a Loop region **twice**, in two activation scopes, while the run reported success. A `generic_agent` in that region holds a workspace, commits, and costs money, so the second execution is real damage rather than bookkeeping.

The first attempt inferred "the region was left" from edge tokens and a sceptic refuted it: `propagatePort` resolves boundary edges whenever a member's selected port has any target outside the region, **even when the same port also targets a member**. An ordinary editor graph — a block inside the loop that also posts a notification — would therefore skip the Loop entirely, silently ignoring `maxAttempts`. That is worse than the defect being fixed.

The shipped fix records the exit explicitly (`loopRegionExited` on the activation scope), set only when the selected port has no in-region target. Three regressions pin the three failure modes: silent duplication, the `V2SchedulerDefinitionError` crash when two members own exits (AIW-228), and a second member's exit being discarded inside an iteration scope.

Also fixed here: an incomplete rename left `resolveLoopBoundaryEdges` called on the clarification-resume path, which a Loop takes when it exhausts with `onExhaust: "human"` and a person answers. No test anywhere covers `loop_exhausted`, so this would have thrown in production after the human had already replied. Filed as AIW-244.

The v1 interpreter was measured, not assumed: it cannot represent the defect, because its edge map keys one successor per (node, port), so the second edge out of a default port overwrites the first, and its walker holds a single cursor with no activation scopes.

## AIW-236 — a pull request shows only the current review round

Previously the idempotency key carried `headSha`, so every push began a round from zero, and neither adapter had a single call to collapse or resolve a thread. Rounds accumulated.

CodeRabbit was measured rather than recalled, on our own PR #224: round one 12 threads, round two 1, and zero resolved, outdated, or collapsed. Copying it would reproduce the very complaint, so this goes further.

The important decision is what a retired thread is allowed to claim. Finding identity is a digest of the finding's prose, and that prose is regenerated by an agent each round, so carrying a thread across rounds is unreliable by construction. Marking such a thread **resolved** would assert a repair we cannot prove. It is therefore marked **outdated**, which is true unconditionally: the thread refers to an older commit. GitHub minimizes as `OUTDATED`; GitLab, which has no minimize, resolves but always posts a note saying the thread was superseded and not verified as fixed.

A thread a human has replied to is left completely alone. The adapters previously fetched one comment per thread and so could not even see a reply.

Further: thread ownership now requires both the finding marker and authorship, so two installations on one repository cannot retire each other's threads; the sweep runs after a successful publication rather than before it, so a failed `createReview` can no longer leave a pull request looking clean; the summary comment carries the bot marker that suppresses recursion; and the currently deployed idempotency key is included among the prior keys, so a lost state write plus a deploy cannot produce a second summary and a second verdict on one head.

## AIW-237 — one predicate for a unique-constraint violation

The predicate read `error.code` off the caught error, but drizzle wraps driver errors and the SQLSTATE lands on `cause`, so it never matched and the retry it guarded was unreachable. A real race for a coalescing slot answered the sender with HTTP 500 instead of coalescing, manufacturing the redelivery traffic the coalescer exists to absorb.

Six copies of this predicate existed, three of them wrong. One shared implementation now walks the cause chain with a bounded depth. It has no imports, because it is bundled into a Workflow step isolate. The three correct copies outside the touched files and `auth.ts` are named in the commit and left alone deliberately.

The test constructs a genuine constraint violation through the same path production uses; a test fabricating an error object would have passed against the broken implementation.

## AIW-201 — the built-in prompt resync gate

The ticket reported drift between the seeded prompts and the constant in code. Measured: there is none. The newest resync migration and a freshly generated one are byte-identical apart from comments, because the last content change and that migration came from the same commit. No migration ships.

What did ship is the gate that would have caught it: the test hardcoded `0038_builtin_prompt_resync.sql`, so any future resync migration would have passed through it unexamined. It now takes the newest resync file, and a fixture proves a prompt a tenant rewrote survives the migration and its replay.

## AIW-227 — no change required

The flaky test is neither of the two candidates named in the ticket. It was `captureDefaultBranchFilesStep` in `repo-memory-steps.test.ts`, and it was fixed on 2026-08-04 by a commit already in this branch's history, after the last captured CI failure. Verified by ancestry and by the test no longer depending on real time.

---

## Where the unique-violation predicate now lives, site by site

The acceptance criterion for AIW-237 asked for every site to be named with a decision, so here they are.

Consolidated into `lib/unique-violation.ts`:

- `lib/trigger-delivery-store.ts` — read only the top-level `code`, so the retry it guarded at `:217` was unreachable.
- `webhook-trigger/delivery-store.ts` — same defect, guarding the retry at `:230`.
- `harness-profiles/store.ts` — looked one level into `cause` but did not loop, so it worked only when the wrapping happened to be exactly one deep. Its message-substring fallback was dropped deliberately: no test anywhere pinned it, and matching a driver error by prose is fragile across driver and locale versions.

Left alone deliberately, all three already correct:

- `schedule-trigger/occurrence-store.ts` — the implementation the shared one was modelled on.
- `workflow-definition/store.ts` and `prompt-library/store.ts` — correct, but each carries a message-regex fallback, so folding them in would have changed behaviour rather than removing duplication.
- `auth.ts` — correct, recursive, and on the signup/session collision path. Out of scope on purpose: not a file to touch in a change whose subject is a different module.

## Two deviations recorded rather than smuggled

**GitLab marks a superseded thread resolved.** The rule this change adopts is that a retired thread claims *outdated*, never *resolved*, because "resolved" asserts a repair that finding identity cannot prove. GitLab has no minimize primitive, so resolving is the only way to collapse a thread there at all. It is therefore used, but always preceded by a bot note saying the thread was superseded and not verified as fixed, so the resolved state asserts nothing on its own. GitHub, which does have minimize, no longer resolves at all.

**The clarification-resume fix rides along in the AIW-242 commit.** An incomplete rename left a call to a removed method on the path a Loop takes when it exhausts with `onExhaust: "human"` and a person answers. It is scope creep against the ticket, and it was not optional: the branch could not typecheck without it, and no test anywhere covers `loop_exhausted`, so it would otherwise have reached production. The missing coverage is filed as AIW-244.

## On the v1 engine

The claim that v1 cannot reproduce the defect is a measurement, not an argument from reading: the same topology was built through `buildRuntimeGraph` and executed through `executeGraph` with a call counter, and the region's block ran once. The first probe deleted its own scratch file, leaving the result unverifiable, so the measurement is now a permanent test next to the interpreter — the point being to stop someone from later "fixing" v1 into having the defect without noticing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable pull request reviews with inline findings, persistent discussion threads, deferred findings, and updated summaries.
  * Reviews now safely handle retries, changing commit heads, human replies, and findings that move between inline comments and summaries.
  * Improved workflow loop handling for branching exits, retries, exhaustion, and multiple completion paths.
  * Added manual execution support for end-to-end validation workflows.

* **Bug Fixes**
  * Prevented duplicate review comments and protected discussions owned or updated by people.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->