### PR TITLE
feat(worker): add cross-repo PR review and bounded autofix

### DIFF
--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -35,6 +35,8 @@ export interface RunPullRequest {
   repoPath: string;
   id: number;
   url: string;
+  /** Head observed when the workflow published the PR, when available. */
+  headSha?: string;
 }
 
 /** Provider-native reference: GitHub numbers PRs `#12`, GitLab MRs `!12`. */

--- a/apps/shared/contracts/review-result.ts
+++ b/apps/shared/contracts/review-result.ts
@@ -6,6 +6,8 @@ export interface ReviewResultFinding {
   severity: "Blocker" | "High" | "Medium" | "Nit";
   startLine?: number;
   endLine?: number;
+  /** Canonical owner/name repository path when the finding targets a sibling. */
+  repo?: string;
 }
 
 export interface ReviewResult {
@@ -44,6 +46,7 @@ export const REVIEW_RESULT_JSON_SCHEMA: JsonSchema202012 = {
           },
           startLine: { type: "number" },
           endLine: { type: "number" },
+          repo: { type: "string" },
         },
         required: ["file", "description", "severity"],
         additionalProperties: true,

--- a/apps/shared/contracts/workflow-graph.ts
+++ b/apps/shared/contracts/workflow-graph.ts
@@ -200,7 +200,7 @@ export const BLOCK_PARAM_KEYS: Record<WorkflowBlockType, readonly string[]> = {
   post_ticket_comment: ["body"],
   post_pr_comment: ["body", "target"],
   create_pr_check: ["checkName"],
-  complete_pr_check: ["conclusion", "details"],
+  complete_pr_check: ["conclusion", "details", "refreshHead"],
   post_pr_review: [],
   send_slack_message: ["message", "sendOn"],
   send_plan_approval: ["mirrorComment"],

--- a/apps/worker/drizzle/0044_workflow_run_prs_lookup.sql
+++ b/apps/worker/drizzle/0044_workflow_run_prs_lookup.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "workflow_runs_prs_gin_idx" ON "workflow_runs" USING gin ("prs" jsonb_path_ops);

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1786173588155,
       "tag": "0043_schedule_trigger",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1786369000000,
+      "tag": "0044_workflow_run_prs_lookup",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/adapters/vcs/repository-directory.ts
+++ b/apps/worker/src/adapters/vcs/repository-directory.ts
@@ -299,4 +299,11 @@ export interface SelectedRepository {
   defaultBranch: string;
   selectedRationale: string;
   workflowOwnedBranch?: WorkflowOwnedBranch;
+  /** PR context for a read-only sibling checkout. It never grants write scope. */
+  reviewPullRequest?: {
+    id: number;
+    url: string;
+    branch: string;
+    headSha?: string;
+  };
 }

--- a/apps/worker/src/db/queries/run-pr-siblings.test.ts
+++ b/apps/worker/src/db/queries/run-pr-siblings.test.ts
@@ -3,6 +3,7 @@ import type { RunPullRequest } from "@shared/contracts";
 import { createTestDb } from "../test-db.js";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
+import { publicationPrsForTelemetry } from "../../workflows/publication-prs-for-telemetry.js";
 import { findRunPrSiblings } from "./run-pr-siblings.js";
 
 let db: Db;
@@ -15,6 +16,7 @@ const githubPr = (repoPath: string, id: number): RunPullRequest => ({
   repoPath,
   id,
   url: `https://github.test/${repoPath}/pull/${id}`,
+  headSha: "after",
 });
 
 const gitlabPr = (repoPath: string, id: number): RunPullRequest => ({
@@ -22,9 +24,22 @@ const gitlabPr = (repoPath: string, id: number): RunPullRequest => ({
   repoPath,
   id,
   url: `https://gitlab.test/${repoPath}/-/merge_requests/${id}`,
+  headSha: "after",
 });
 
 async function seed(prs: RunPullRequest[]): Promise<void> {
+  const persistedPrs = publicationPrsForTelemetry({
+    status: "published",
+    prs: prs.map((pr) => ({ ...pr, branch: "blazebot/aiw-1", isNew: true })),
+    repositories: prs.map((pr) => ({
+      provider: pr.provider,
+      repoPath: pr.repoPath,
+      branchName: "blazebot/aiw-1",
+      defaultBranch: "main",
+      expectedHead: "before",
+      pushedHead: pr.headSha ?? "after",
+    })),
+  });
   await db.insert(workflowRuns).values({
     runId: "run-siblings",
     workflowId: "workflow",
@@ -33,7 +48,7 @@ async function seed(prs: RunPullRequest[]): Promise<void> {
     ticketKey: "AIW-1",
     ticketTitle: "Sibling PRs",
     model: "claude",
-    prs,
+    prs: persistedPrs,
   });
 }
 

--- a/apps/worker/src/db/queries/run-pr-siblings.test.ts
+++ b/apps/worker/src/db/queries/run-pr-siblings.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { RunPullRequest } from "@shared/contracts";
+import { createTestDb } from "../test-db.js";
+import type { Db } from "../client.js";
+import { workflowRuns } from "../schema.js";
+import { findRunPrSiblings } from "./run-pr-siblings.js";
+
+let db: Db;
+beforeEach(async () => {
+  db = await createTestDb();
+});
+
+const githubPr = (repoPath: string, id: number): RunPullRequest => ({
+  provider: "github",
+  repoPath,
+  id,
+  url: `https://github.test/${repoPath}/pull/${id}`,
+});
+
+const gitlabPr = (repoPath: string, id: number): RunPullRequest => ({
+  provider: "gitlab",
+  repoPath,
+  id,
+  url: `https://gitlab.test/${repoPath}/-/merge_requests/${id}`,
+});
+
+async function seed(prs: RunPullRequest[]): Promise<void> {
+  await db.insert(workflowRuns).values({
+    runId: "run-siblings",
+    workflowId: "workflow",
+    workflowName: "Workflow",
+    status: "success",
+    ticketKey: "AIW-1",
+    ticketTitle: "Sibling PRs",
+    model: "claude",
+    prs,
+  });
+}
+
+describe("findRunPrSiblings", () => {
+  it("round-trips GitHub PRs from the persisted writer shape", async () => {
+    await seed([githubPr("acme/web", 12), githubPr("acme/api", 13)]);
+
+    await expect(
+      findRunPrSiblings({
+        db,
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 12,
+      }),
+    ).resolves.toEqual({
+      status: "siblings",
+      runId: "run-siblings",
+      current: githubPr("acme/web", 12),
+      siblings: [githubPr("acme/api", 13)],
+    });
+  });
+
+  it("round-trips nested GitLab MRs and distinguishes a single PR", async () => {
+    await seed([gitlabPr("group/platform/web", 4)]);
+
+    await expect(
+      findRunPrSiblings({
+        db,
+        provider: "gitlab",
+        repoPath: "group/platform/web",
+        prNumber: 4,
+      }),
+    ).resolves.toMatchObject({
+      status: "none",
+      runId: "run-siblings",
+      current: gitlabPr("group/platform/web", 4),
+    });
+  });
+
+  it("returns unknown when the run is absent and when the query fails", async () => {
+    await expect(
+      findRunPrSiblings({
+        db,
+        provider: "github",
+        repoPath: "missing/repo",
+        prNumber: 1,
+      }),
+    ).resolves.toEqual({ status: "unknown", reason: "run_not_found" });
+
+    const failingDb = {
+      select: () => {
+        throw new Error("database unavailable");
+      },
+    } as unknown as Db;
+    await expect(
+      findRunPrSiblings({
+        db: failingDb,
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 12,
+      }),
+    ).resolves.toEqual({
+      status: "unknown",
+      reason: "database unavailable",
+    });
+  });
+});

--- a/apps/worker/src/db/queries/run-pr-siblings.ts
+++ b/apps/worker/src/db/queries/run-pr-siblings.ts
@@ -1,4 +1,5 @@
 import type { RunPullRequest } from "@shared/contracts";
+import { desc, sql } from "drizzle-orm";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
 
@@ -38,7 +39,18 @@ export async function findRunPrSiblings(input: {
   try {
     const rows = await input.db
       .select({ runId: workflowRuns.runId, prs: workflowRuns.prs })
-      .from(workflowRuns);
+      .from(workflowRuns)
+      .where(
+        sql`${workflowRuns.prs} @> ${JSON.stringify([
+          {
+            provider: input.provider,
+            repoPath: input.repoPath,
+            id: input.prNumber,
+          },
+        ])}::jsonb`,
+      )
+      .orderBy(desc(workflowRuns.createdAt), desc(workflowRuns.runId))
+      .limit(1);
     for (const row of rows) {
       if (!Array.isArray(row.prs)) continue;
       const prs = row.prs.filter(isRunPullRequest);

--- a/apps/worker/src/db/queries/run-pr-siblings.ts
+++ b/apps/worker/src/db/queries/run-pr-siblings.ts
@@ -1,0 +1,64 @@
+import type { RunPullRequest } from "@shared/contracts";
+import type { Db } from "../client.js";
+import { workflowRuns } from "../schema.js";
+
+export type RunPrSiblingLookup =
+  | {
+      status: "siblings";
+      runId: string;
+      current: RunPullRequest;
+      siblings: RunPullRequest[];
+    }
+  | { status: "none"; runId: string; current: RunPullRequest }
+  | { status: "unknown"; reason: string };
+
+function isRunPullRequest(value: unknown): value is RunPullRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    (candidate.provider === "github" || candidate.provider === "gitlab") &&
+    typeof candidate.repoPath === "string" &&
+    typeof candidate.id === "number" &&
+    typeof candidate.url === "string"
+  );
+}
+
+/**
+ * Finds the durable run that opened a PR/MR and returns the other PRs from the
+ * same publication. A missing row and a database failure deliberately remain
+ * distinguishable: callers use this lookup fail-open for review context but
+ * fail-closed for workflow-owned pushes.
+ */
+export async function findRunPrSiblings(input: {
+  db: Db;
+  provider: "github" | "gitlab";
+  repoPath: string;
+  prNumber: number;
+}): Promise<RunPrSiblingLookup> {
+  try {
+    const rows = await input.db
+      .select({ runId: workflowRuns.runId, prs: workflowRuns.prs })
+      .from(workflowRuns);
+    for (const row of rows) {
+      if (!Array.isArray(row.prs)) continue;
+      const prs = row.prs.filter(isRunPullRequest);
+      const current = prs.find(
+        (pr) =>
+          pr.provider === input.provider &&
+          pr.repoPath === input.repoPath &&
+          pr.id === input.prNumber,
+      );
+      if (!current) continue;
+      const siblings = prs.filter((pr) => pr !== current);
+      return siblings.length > 0
+        ? { status: "siblings", runId: row.runId, current, siblings }
+        : { status: "none", runId: row.runId, current };
+    }
+    return { status: "unknown", reason: "run_not_found" };
+  } catch (error) {
+    return {
+      status: "unknown",
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/apps/worker/src/db/queries/workflow-owned-branches.ts
+++ b/apps/worker/src/db/queries/workflow-owned-branches.ts
@@ -146,6 +146,45 @@ export async function findWorkflowOwnedPullRequest(
   };
 }
 
+/** Reads ownership by provider PR identity for webhook anti-recursion. The
+ * caller compares the event head to publishedHeadSha; this query deliberately
+ * does not treat a changed human head as workflow-owned. */
+export async function findWorkflowOwnedPullRequestIdentity(
+  db: Db,
+  input: {
+    provider: VcsProvider;
+    repoPath: string;
+    prNumber: number;
+  },
+): Promise<WorkflowOwnedBranchRecord | null> {
+  const rows = await db
+    .select()
+    .from(workflowOwnedBranches)
+    .where(
+      and(
+        eq(workflowOwnedBranches.provider, input.provider),
+        eq(workflowOwnedBranches.repoPath, input.repoPath),
+        eq(workflowOwnedBranches.prId, input.prNumber),
+      ),
+    )
+    .limit(1);
+  const row = rows[0];
+  if (!row || row.prId === null || !row.prUrl || !row.prBranchName) return null;
+  return {
+    ticketKey: row.ticketKey,
+    provider: row.provider as VcsProvider,
+    repoPath: row.repoPath,
+    branchName: row.prBranchName,
+    ...(row.prPublishedHeadSha ?? row.publishedHeadSha
+      ? { publishedHeadSha: row.prPublishedHeadSha ?? row.publishedHeadSha! }
+      : {}),
+    ...(row.prTargetBranch ?? row.targetBranch
+      ? { targetBranch: (row.prTargetBranch ?? row.targetBranch) as string }
+      : {}),
+    pr: { id: row.prId, url: row.prUrl, branch: row.prBranchName },
+  };
+}
+
 /**
  * Find the exact workflow-owned branch/head that may be about to receive a PR.
  * PR identity is intentionally not part of this lookup: callers must treat a

--- a/apps/worker/src/db/run-pr-siblings-migration.test.ts
+++ b/apps/worker/src/db/run-pr-siblings-migration.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it } from "vitest";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+
+async function migrateThrough(lastPrefix: string): Promise<PGlite> {
+  const client = new PGlite();
+  const files = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith(".sql") && file.slice(0, 4) <= lastPrefix)
+    .sort();
+  for (const file of files) {
+    await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+  }
+  return client;
+}
+
+describe("0044 workflow run PR lookup migration", () => {
+  it("adds the jsonb containment index used by sibling lookup", async () => {
+    const client = await migrateThrough("0044");
+    const result = await client.query<{ indexdef: string }>(`
+      SELECT indexdef FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = 'workflow_runs_prs_gin_idx'
+    `);
+    expect(result.rows[0]?.indexdef).toContain(
+      "USING gin (prs jsonb_path_ops)",
+    );
+  });
+});

--- a/apps/worker/src/lib/trigger-events.test.ts
+++ b/apps/worker/src/lib/trigger-events.test.ts
@@ -123,6 +123,40 @@ describe("normalizeGitHubEvent", () => {
     expect(evt?.triggerType).toBe("trigger_pr_updated");
   });
 
+  it("suppresses a synchronize whose SHA was published by the workflow", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request",
+        { action: "synchronize", repository: githubRepo(), pull_request: githubPr() },
+        { ...options, workflowPublishedHeadSha: "abc123" },
+      ),
+    ).toBeNull();
+  });
+
+  it("uses the bot-login fallback for an owned legacy PR without a SHA", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request",
+        { action: "synchronize", repository: githubRepo(), pull_request: githubPr() },
+        { ...options, workflowOwnedPullRequest: true, workflowPublishedHeadSha: undefined },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not suppress a human synchronize when the head differs", () => {
+    expect(
+      normalizeGitHubEvent(
+        "pull_request",
+        {
+          action: "synchronize",
+          repository: githubRepo(),
+          pull_request: githubPr({ head: { ref: "feature", sha: "human123" }, user: { login: "alice" } }),
+        },
+        { ...options, workflowPublishedHeadSha: "abc123", workflowOwnedPullRequest: true },
+      )?.triggerType,
+    ).toBe("trigger_pr_updated");
+  });
+
   it("passes the draft flag through", () => {
     const evt = normalizeGitHubEvent(
       "pull_request",
@@ -820,6 +854,31 @@ describe("normalizeGitLabEvent", () => {
         (event) => event.triggerType,
       ),
     ).toEqual(["trigger_pr_ready", "trigger_pr_updated"]);
+  });
+
+  it("suppresses a GitLab update for the workflow-published SHA", () => {
+    const payload = mrPayload("update");
+    payload.oldrev = "old-head";
+    payload.object_attributes.last_commit = { id: "sha1" };
+    expect(
+      normalizeGitLabEvent("Merge Request Hook", payload, {
+        botUsername: "blazebot",
+        workflowPublishedHeadSha: "sha1",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps a human GitLab update when the published SHA differs", () => {
+    const payload = mrPayload("update");
+    payload.oldrev = "old-head";
+    payload.object_attributes.last_commit = { id: "human-sha" };
+    payload.user.username = "alice";
+    expect(
+      normalizeGitLabEvent("Merge Request Hook", payload, {
+        botUsername: "blazebot",
+        workflowPublishedHeadSha: "sha1",
+      })?.triggerType,
+    ).toBe("trigger_pr_updated");
   });
 
   it("maps a merged merge request to trigger_pr_merged", () => {

--- a/apps/worker/src/lib/trigger-events.ts
+++ b/apps/worker/src/lib/trigger-events.ts
@@ -42,6 +42,10 @@ export interface NormalizeGitHubOptions {
    * full-permission agent, so it must be opted into explicitly.
    */
   reviewStates?: readonly string[];
+  /** Exact head previously published by the workflow for this PR. */
+  workflowPublishedHeadSha?: string;
+  /** Legacy ownership signal used only when the persisted row has no SHA. */
+  workflowOwnedPullRequest?: boolean;
 }
 
 export const DEFAULT_REVIEW_STATES: readonly string[] = ["changes_requested"];
@@ -83,10 +87,21 @@ export function normalizeGitHubEvent(
       };
     }
     if (action === "synchronize") {
+      const mapped = mapGitHubPullRequest(pr, repo);
+      const workflowPublishedPush =
+        typeof options.workflowPublishedHeadSha === "string" &&
+        options.workflowPublishedHeadSha.length > 0 &&
+        mapped.headSha === options.workflowPublishedHeadSha;
+      const legacyWorkflowPush =
+        options.workflowOwnedPullRequest === true &&
+        !workflowPublishedPush &&
+        !options.workflowPublishedHeadSha &&
+        vcsLoginsMatch(body?.sender?.login ?? pr.user?.login, options.botLogin);
+      if (workflowPublishedPush || legacyWorkflowPush) return null;
       return {
         delivery: githubDelivery(options.deliveryId, body?.sender?.login ?? pr.user?.login),
         triggerType: "trigger_pr_updated",
-        pr: mapGitHubPullRequest(pr, repo),
+        pr: mapped,
       };
     }
     if (action === "reopened" && pr.draft !== true) {
@@ -287,6 +302,8 @@ export function normalizeGitLabEvent(
     botUsername?: string;
     reviewStates?: readonly string[];
     gateCheckNames?: readonly string[];
+    workflowPublishedHeadSha?: string;
+    workflowOwnedPullRequest?: boolean;
   } = {},
 ): TriggerEvent | null {
   const producer = body?.user?.username ?? body?.user?.name ?? "unknown";
@@ -325,10 +342,21 @@ export function normalizeGitLabEvent(
             : undefined;
       const nextHead = attrs.last_commit?.id ?? attrs.sha;
       if (oldHead && nextHead && oldHead !== nextHead) {
+        const mapped = mapGitLabMergeRequest(attrs, project, body?.user);
+        const workflowPublishedPush =
+          typeof options.workflowPublishedHeadSha === "string" &&
+          options.workflowPublishedHeadSha.length > 0 &&
+          mapped.headSha === options.workflowPublishedHeadSha;
+        const legacyWorkflowPush =
+          options.workflowOwnedPullRequest === true &&
+          !workflowPublishedPush &&
+          !options.workflowPublishedHeadSha &&
+          vcsLoginsMatch(producer, options.botUsername);
+        if (workflowPublishedPush || legacyWorkflowPush) return null;
         return {
           delivery: gitLabDelivery(options.deliveryId, producer),
           triggerType: "trigger_pr_updated",
-          pr: mapGitLabMergeRequest(attrs, project, body?.user),
+          pr: mapped,
         };
       }
       const previousDraft =

--- a/apps/worker/src/lib/workflow-push-suppression.ts
+++ b/apps/worker/src/lib/workflow-push-suppression.ts
@@ -2,6 +2,24 @@ import type { VcsProvider } from "../adapters/vcs/repository-directory.js";
 import type { Db } from "../db/client.js";
 import { findWorkflowOwnedPullRequestIdentity } from "../db/queries/workflow-owned-branches.js";
 import { logger } from "./logger.js";
+import { vcsLoginsMatch } from "./vcs-bot-identity.js";
+
+export function isWorkflowGeneratedPush(input: {
+  currentHeadSha?: string;
+  producer?: string;
+  botIdentity?: string;
+  workflowPublishedHeadSha?: string;
+  workflowOwnedPullRequest?: boolean;
+}): boolean {
+  const exactPublishedHead =
+    Boolean(input.workflowPublishedHeadSha) &&
+    input.currentHeadSha === input.workflowPublishedHeadSha;
+  const legacyBotPush =
+    input.workflowOwnedPullRequest === true &&
+    !input.workflowPublishedHeadSha &&
+    vcsLoginsMatch(input.producer, input.botIdentity);
+  return exactPublishedHead || legacyBotPush;
+}
 
 export async function workflowPushNormalizationOptions(input: {
   db: Db;

--- a/apps/worker/src/lib/workflow-push-suppression.ts
+++ b/apps/worker/src/lib/workflow-push-suppression.ts
@@ -1,0 +1,39 @@
+import type { VcsProvider } from "../adapters/vcs/repository-directory.js";
+import type { Db } from "../db/client.js";
+import { findWorkflowOwnedPullRequestIdentity } from "../db/queries/workflow-owned-branches.js";
+import { logger } from "./logger.js";
+
+export async function workflowPushNormalizationOptions(input: {
+  db: Db;
+  provider: VcsProvider;
+  repoPath: string;
+  prNumber: number;
+}): Promise<{
+  workflowPublishedHeadSha?: string;
+  workflowOwnedPullRequest?: boolean;
+}> {
+  try {
+    const owned = await findWorkflowOwnedPullRequestIdentity(input.db, input);
+    if (!owned) return {};
+    return {
+      workflowOwnedPullRequest: true,
+      ...(owned.publishedHeadSha
+        ? { workflowPublishedHeadSha: owned.publishedHeadSha }
+        : {}),
+    };
+  } catch (error) {
+    // A failed ownership lookup must not turn a human webhook into a 500. The
+    // exact-SHA gate is fail-open here; the next dispatch still has its normal
+    // subject and delivery deduplication protections.
+    logger.warn(
+      {
+        provider: input.provider,
+        repoPath: input.repoPath,
+        prNumber: input.prNumber,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "workflow_push_suppression_lookup_failed",
+    );
+    return {};
+  }
+}

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -364,6 +364,7 @@ describe("GET /api/v1/workflow-definitions", () => {
       "Review & fix after PR",
       "Reviewed ticket workflow",
       "Post-PR review",
+      "Post-PR review with autofix",
       "Fully modular",
       "Ticket triage (webhook)",
     ]);

--- a/apps/worker/src/routes/webhooks/github.post.test.ts
+++ b/apps/worker/src/routes/webhooks/github.post.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   },
   getVcsBotLogin: vi.fn(),
   isRepoAllowed: vi.fn(),
+  findWorkflowOwnedPullRequestIdentity: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({
@@ -31,6 +32,10 @@ vi.mock("../../post-pr-gate/config.js", () => ({
 }));
 
 vi.mock("../../db/client.js", () => ({ getDb: () => ({}) }));
+vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
+  findWorkflowOwnedPullRequestIdentity: (...args: any[]) =>
+    mocks.findWorkflowOwnedPullRequestIdentity(...args),
+}));
 
 const mockDispatchTriggerEvent = vi.fn();
 vi.mock("../../lib/dispatch-trigger.js", () => ({
@@ -93,6 +98,7 @@ describe("POST /webhooks/github", () => {
     mocks.env.GITHUB_BOT_LOGIN = undefined;
     mocks.getVcsBotLogin.mockReturnValue("github-app[bot]");
     mocks.isRepoAllowed.mockReturnValue(true);
+    mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValue(undefined);
     mockDispatchPostPrGateWebhook.mockResolvedValue({ status: "dispatched", runId: "gate_run" });
     mockDispatchTriggerEvent.mockResolvedValue({ result: "no_definition" });
   });
@@ -268,6 +274,24 @@ describe("POST /webhooks/github", () => {
       expect.anything(),
     );
     expect(mockDispatchPostPrGateWebhook).toHaveBeenCalled();
+  });
+
+  it("suppresses a workflow-published synchronize before definition and legacy dispatch", async () => {
+    mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValueOnce({
+      ticketKey: "AIW-1",
+      publishedHeadSha: "abc123",
+      pr: { id: 7 },
+    });
+
+    const response = await makeApp()(makeRequest(pullRequestBody("synchronize")));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "workflow_generated_push",
+    });
+    expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
 
   it("keeps the gate for a non-bot PR that an enabled definition ignores", async () => {

--- a/apps/worker/src/routes/webhooks/github.post.ts
+++ b/apps/worker/src/routes/webhooks/github.post.ts
@@ -12,7 +12,10 @@ import { logger } from "../../lib/logger.js";
 import { dispatchPostPrGateWebhook } from "../../lib/post-pr-gate-dispatch.js";
 import { isRepoAllowed } from "../../lib/repo-allowlist.js";
 import { normalizeGitHubEvents } from "../../lib/trigger-events.js";
-import { workflowPushNormalizationOptions } from "../../lib/workflow-push-suppression.js";
+import {
+  isWorkflowGeneratedPush,
+  workflowPushNormalizationOptions,
+} from "../../lib/workflow-push-suppression.js";
 import {
   gateCheckNameAliases,
   ticketKeyFromBranch,
@@ -77,6 +80,18 @@ export default defineEventHandler(async (event) => {
           prNumber: body.pull_request?.number,
         })
       : {};
+  if (
+    ghEvent === "pull_request" &&
+    body.action === "synchronize" &&
+    isWorkflowGeneratedPush({
+      currentHeadSha: body.pull_request?.head?.sha,
+      producer: body?.sender?.login ?? body.pull_request?.user?.login,
+      botIdentity: botLogin,
+      ...workflowPushOptions,
+    })
+  ) {
+    return { status: "ignored", reason: "workflow_generated_push" };
+  }
   const reviewStates =
     ghEvent === "pull_request_review"
       ? ["changes_requested", "commented"] as const

--- a/apps/worker/src/routes/webhooks/github.post.ts
+++ b/apps/worker/src/routes/webhooks/github.post.ts
@@ -12,6 +12,7 @@ import { logger } from "../../lib/logger.js";
 import { dispatchPostPrGateWebhook } from "../../lib/post-pr-gate-dispatch.js";
 import { isRepoAllowed } from "../../lib/repo-allowlist.js";
 import { normalizeGitHubEvents } from "../../lib/trigger-events.js";
+import { workflowPushNormalizationOptions } from "../../lib/workflow-push-suppression.js";
 import {
   gateCheckNameAliases,
   ticketKeyFromBranch,
@@ -66,6 +67,16 @@ export default defineEventHandler(async (event) => {
   // snapshot that it pins, avoiding a load-then-deploy race in this route.
   // Comment events (inline diff + PR conversation) can only ever be "commented".
   const botLogin = getVcsBotLogin("github");
+  const db = getDb();
+  const workflowPushOptions =
+    ghEvent === "pull_request" && body.action === "synchronize"
+      ? await workflowPushNormalizationOptions({
+          db,
+          provider: "github",
+          repoPath: ownerRepo,
+          prNumber: body.pull_request?.number,
+        })
+      : {};
   const reviewStates =
     ghEvent === "pull_request_review"
       ? ["changes_requested", "commented"] as const
@@ -76,11 +87,11 @@ export default defineEventHandler(async (event) => {
     gateCheckNames,
     deliveryId,
     botLogin,
+    ...workflowPushOptions,
     ...(reviewStates ? { reviewStates } : {}),
   });
 
   if (events.length > 0) {
-    const db = getDb();
     let result: DispatchTriggerResult = { result: "no_definition" };
     let claimedEvent = events[0]!;
     for (const candidate of events) {

--- a/apps/worker/src/routes/webhooks/gitlab.post.test.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   listRepositories: vi.fn(),
   fetch: vi.fn(),
   isRepoAllowed: vi.fn(),
+  findWorkflowOwnedPullRequestIdentity: vi.fn(),
 }));
 
 global.fetch = mocks.fetch;
@@ -36,6 +37,10 @@ vi.mock("../../lib/dispatch-trigger.js", () => ({
 }));
 
 vi.mock("../../db/client.js", () => ({ getDb: () => ({}) }));
+vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
+  findWorkflowOwnedPullRequestIdentity: (...args: any[]) =>
+    mocks.findWorkflowOwnedPullRequestIdentity(...args),
+}));
 vi.mock("../../lib/repo-allowlist.js", () => ({
   isRepoAllowed: (...args: any[]) => mocks.isRepoAllowed(...args),
 }));
@@ -134,6 +139,7 @@ describe("POST /webhooks/gitlab", () => {
     mocks.env.GITLAB_BOT_LOGIN = undefined;
     mocks.getVcsBotLogin.mockReturnValue("blazebot");
     mocks.isRepoAllowed.mockReturnValue(true);
+    mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValue(undefined);
     mockDispatchTriggerEvent.mockResolvedValue({ result: "no_definition" });
     mocks.getConfiguredVcsProviders.mockReturnValue([
       {
@@ -421,6 +427,26 @@ describe("POST /webhooks/gitlab", () => {
       expect.objectContaining({ triggerType: "trigger_pr_ready" }),
       expect.anything(),
     );
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
+  it("suppresses a workflow-published update before definition and legacy dispatch", async () => {
+    mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValueOnce({
+      ticketKey: "AIW-32",
+      publishedHeadSha: "sha1",
+      pr: { id: 42 },
+    });
+    const payload = JSON.parse(validMergeRequestPayload());
+    payload.object_attributes.action = "update";
+
+    const response = await makeApp()(makeRequest(JSON.stringify(payload)));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "workflow_generated_push",
+    });
+    expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
   });
 

--- a/apps/worker/src/routes/webhooks/gitlab.post.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.ts
@@ -19,7 +19,10 @@ import { recordIngestionFailure } from "../../lib/ingestion-diagnostic.js";
 import { dispatchPostPrGateWebhook } from "../../lib/post-pr-gate-dispatch.js";
 import { isRepoAllowed } from "../../lib/repo-allowlist.js";
 import { normalizeGitLabEvents } from "../../lib/trigger-events.js";
-import { workflowPushNormalizationOptions } from "../../lib/workflow-push-suppression.js";
+import {
+  isWorkflowGeneratedPush,
+  workflowPushNormalizationOptions,
+} from "../../lib/workflow-push-suppression.js";
 import { ticketKeyFromBranch } from "../../lib/workflow-naming.js";
 
 const ALLOWED_ACTIONS = new Set(["opened", "update", "reopened"]);
@@ -72,6 +75,19 @@ export default defineEventHandler(async (event) => {
           prNumber: body.object_attributes?.iid,
         })
       : {};
+  if (
+    gitLabEvent === "Merge Request Hook" &&
+    body.object_attributes?.action === "update" &&
+    isWorkflowGeneratedPush({
+      currentHeadSha:
+        body.object_attributes?.last_commit?.id ?? body.object_attributes?.sha,
+      producer: body?.user?.username ?? body?.user_username,
+      botIdentity: botUsername,
+      ...workflowPushOptions,
+    })
+  ) {
+    return { status: "ignored", reason: "workflow_generated_push" };
+  }
   // A GitLab note is structurally a `commented` review. The dispatcher applies
   // the enabled definition's selector from the exact version it pins.
   const reviewStates = gitLabEvent === "Note Hook"

--- a/apps/worker/src/routes/webhooks/gitlab.post.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.ts
@@ -19,6 +19,7 @@ import { recordIngestionFailure } from "../../lib/ingestion-diagnostic.js";
 import { dispatchPostPrGateWebhook } from "../../lib/post-pr-gate-dispatch.js";
 import { isRepoAllowed } from "../../lib/repo-allowlist.js";
 import { normalizeGitLabEvents } from "../../lib/trigger-events.js";
+import { workflowPushNormalizationOptions } from "../../lib/workflow-push-suppression.js";
 import { ticketKeyFromBranch } from "../../lib/workflow-naming.js";
 
 const ALLOWED_ACTIONS = new Set(["opened", "update", "reopened"]);
@@ -61,6 +62,16 @@ export default defineEventHandler(async (event) => {
   }
 
   const botUsername = getVcsBotLogin("gitlab");
+  const db = getDb();
+  const workflowPushOptions =
+    gitLabEvent === "Merge Request Hook" && body.object_attributes?.action === "update"
+      ? await workflowPushNormalizationOptions({
+          db,
+          provider: "gitlab",
+          repoPath: body.project?.path_with_namespace ?? "",
+          prNumber: body.object_attributes?.iid,
+        })
+      : {};
   // A GitLab note is structurally a `commented` review. The dispatcher applies
   // the enabled definition's selector from the exact version it pins.
   const reviewStates = gitLabEvent === "Note Hook"
@@ -69,11 +80,11 @@ export default defineEventHandler(async (event) => {
   const events = normalizeGitLabEvents(gitLabEvent, body, {
     deliveryId,
     botUsername,
+    ...workflowPushOptions,
     ...(reviewStates ? { reviewStates } : {}),
   });
 
   if (events.length > 0) {
-    const db = getDb();
     let result: DispatchTriggerResult = { result: "no_definition" };
     let claimedEvent = events[0]!;
     for (const candidate of events) {

--- a/apps/worker/src/sandbox/agents/claude.test.ts
+++ b/apps/worker/src/sandbox/agents/claude.test.ts
@@ -324,6 +324,7 @@ describe("schema constants", () => {
       "severity",
       "startLine",
       "endLine",
+      "repo",
     ]);
     expect(s.properties.issues.items.properties.startLine.type).toEqual([
       "integer",

--- a/apps/worker/src/sandbox/agents/types.ts
+++ b/apps/worker/src/sandbox/agents/types.ts
@@ -90,6 +90,7 @@ const reviewIssueSchema = z.object({
   severity: z.enum(["Blocker", "High", "Medium", "Nit"]),
   startLine: z.number().int().nullish(),
   endLine: z.number().int().nullish(),
+  repo: z.string().nullish(),
 });
 
 // Truncate before validating the cap so a provider that ignores `maxItems`
@@ -128,6 +129,7 @@ export const REVIEW_SCHEMA = JSON.stringify({
           },
           startLine: { type: ["integer", "null"] },
           endLine: { type: ["integer", "null"] },
+          repo: { type: ["string", "null"] },
         },
         required: [
           "file",

--- a/apps/worker/src/sandbox/agents/types.ts
+++ b/apps/worker/src/sandbox/agents/types.ts
@@ -137,6 +137,7 @@ export const REVIEW_SCHEMA = JSON.stringify({
           "severity",
           "startLine",
           "endLine",
+          "repo",
         ],
         additionalProperties: false,
       },

--- a/apps/worker/src/sandbox/context.test.ts
+++ b/apps/worker/src/sandbox/context.test.ts
@@ -582,6 +582,48 @@ describe("runtime-only context assembly", () => {
 });
 
 describe("assembleReviewContext", () => {
+  it("renders read-only sibling repositories with their local path, URL, and SHA", () => {
+    const result = assembleReviewContext({
+      ticket: {
+        identifier: "TEST-SIBLING",
+        title: "Cross-repository review",
+        description: "Check the API contract.",
+        acceptanceCriteria: "The caller matches the API.",
+        comments: [],
+      },
+      prompt: "",
+      researchPlanMarkdown: "plan",
+      selectedRepositories: [
+        {
+          provider: "github",
+          repoPath: "acme/web",
+          defaultBranch: "main",
+          selectedRationale: "current PR",
+          workflowOwnedBranch: { branchName: "feature", pr: { id: 1, url: "https://github/web/pull/1", branch: "feature" } },
+        },
+        {
+          provider: "github",
+          repoPath: "acme/api",
+          defaultBranch: "main",
+          selectedRationale: "sibling PR",
+          reviewPullRequest: {
+            id: 2,
+            url: "https://github/api/pull/2",
+            branch: "main",
+            headSha: "api-sha",
+          },
+        },
+      ],
+    });
+
+    expect(result).toContain("## Review Sibling Repositories");
+    expect(result).toContain("acme/api");
+    expect(result).toContain("/vercel/sandbox/repos/github__acme__api");
+    expect(result).toContain("https://github/api/pull/2");
+    expect(result).toContain("api-sha");
+    expect(result).toContain("set its `repo` field");
+  });
+
   it("includes plan and prompt", () => {
     const result = assembleReviewContext({
       ticket: {

--- a/apps/worker/src/sandbox/context.ts
+++ b/apps/worker/src/sandbox/context.ts
@@ -206,6 +206,10 @@ export function assembleReviewContext(input: ReviewContextInput): string {
   const attachmentsSection = renderAttachmentsSection(attachments);
   const preSandboxSection = renderPreSandboxAdditions(preSandboxAdditions);
   const selectedRepositoriesSection = renderSelectedRepositories(selectedRepositories, input.workspaceManifest);
+  const siblingRepositoriesSection = renderReviewSiblingRepositories(
+    selectedRepositories,
+    input.workspaceManifest,
+  );
   const clarificationsSection = renderClarificationsSection(ticket.clarifications);
   const reviewFeedbackSection = reviewFeedback
     ? `\n## Pull request review feedback\n\nState: ${reviewFeedback.state}\n\n${reviewFeedback.author}: ${reviewFeedback.body}\n`
@@ -227,7 +231,7 @@ ${clarificationsSection}
 ## Research & Plan
 
 ${researchPlanMarkdown}
-${reviewFeedbackSection}${selectedRepositoriesSection}
+${reviewFeedbackSection}${selectedRepositoriesSection}${siblingRepositoriesSection}
 ${preSandboxSection}`;
   return prompt.length > 0
     ? `${runtimeData}
@@ -237,6 +241,29 @@ ${preSandboxSection}`;
 ${prompt}
 `
     : runtimeData;
+}
+
+function renderReviewSiblingRepositories(
+  repositories: SelectedRepository[] | undefined,
+  manifest: WorkspaceManifest | undefined,
+): string {
+  const siblings = (repositories ?? []).filter(
+    (repo) => repo.reviewPullRequest && !repo.workflowOwnedBranch,
+  );
+  if (siblings.length === 0) return "";
+  const lines = siblings.map((repo) => {
+    const index = repositories!.indexOf(repo);
+    const localPath = resolveSelectedRepositoryPath(repo, index, manifest);
+    const pr = repo.reviewPullRequest!;
+    return `- \`${repo.repoPath}\` at \`${localPath}\` (read-only), PR: ${pr.url}, reviewed SHA: \`${pr.headSha ?? "unknown"}\``;
+  });
+  return `
+## Review Sibling Repositories
+
+These repositories belong to the same workflow run. Inspect them for cross-repository consistency, but do not modify them. If a finding targets one, set its \`repo\` field to the exact repository path above.
+
+${lines.join("\n")}
+`;
 }
 
 export interface FixContextInput {

--- a/apps/worker/src/workflow-definition/available-values.ts
+++ b/apps/worker/src/workflow-definition/available-values.ts
@@ -792,6 +792,17 @@ function loopScopedGuarantee(
   consumerId: string,
   regionsByNodeId: ReadonlyMap<string, AuthoringLoopRegion>,
 ): boolean | null {
+  const sourceRegion = regionsByNodeId.get(sourceId);
+  if (
+    sourceRegion?.loopNodeId === sourceId &&
+    !regionsByNodeId.has(consumerId)
+  ) {
+    // The owner scope materializes the Loop output when a child exits through
+    // either a boundary or exhaustion. Downstream nodes outside the cycle may
+    // therefore consume its carried values without falling back to a stale
+    // child step output.
+    return true;
+  }
   const region = regionsByNodeId.get(consumerId);
   if (!region) return null;
   if (!region.memberNodeIds.has(sourceId)) {

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -889,7 +889,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       "Completes a check created by this workflow run.",
       "●",
     ),
-    defaults: { conclusion: "success", details: "" },
+    defaults: { conclusion: "success", details: "", refreshHead: false },
     inputs: {
       check: input(workflowPrCheckRefType, true),
       details: input(stringType(), false),

--- a/apps/worker/src/workflow-definition/default-v2.test.ts
+++ b/apps/worker/src/workflow-definition/default-v2.test.ts
@@ -222,7 +222,7 @@ describe("v2 built-in authoring definitions", () => {
         provider,
       });
 
-      expect(templates).toHaveLength(7);
+      expect(templates).toHaveLength(8);
       for (const template of templates) {
         expect(template.definition.schemaVersion).toBe(2);
         if (template.definition.schemaVersion !== 2) continue;
@@ -240,6 +240,36 @@ describe("v2 built-in authoring definitions", () => {
       }
     },
   );
+
+  it("keeps multi-repo PR review separate from the optional autofix loop", () => {
+    const templates = workflowDefinitionTemplates({
+      includeReview: true,
+      provider: "claude",
+    });
+    const review = templates.find((template) => template.id === "post-pr-review")!
+      .definition;
+    const autofix = templates.find((template) => template.id === "post-pr-autofix")!
+      .definition;
+    if (review.schemaVersion !== 2 || autofix.schemaVersion !== 2) {
+      throw new Error("Post-PR templates must use schema version 2");
+    }
+
+    expect(review.nodes.some((node) => node.type === "prepare_workspace")).toBe(true);
+    expect(review.nodes.some((node) => node.type === "fix_agent")).toBe(false);
+    expect(review.nodes.some((node) => node.type === "loop")).toBe(false);
+    expect(
+      review.nodes
+        .filter((node) => node.type === "trigger_pr_ready" || node.type === "trigger_pr_updated")
+        .map((node) => node.configuration.scope),
+    ).toEqual(["any", "any"]);
+    expect(autofix.nodes.some((node) => node.type === "fix_agent")).toBe(true);
+    expect(autofix.nodes.some((node) => node.type === "loop")).toBe(true);
+    expect(
+      autofix.nodes
+        .filter((node) => node.type === "trigger_pr_ready" || node.type === "trigger_pr_updated")
+        .map((node) => node.configuration.scope),
+    ).toEqual(["workflow_owned", "workflow_owned"]);
+  });
 
   it("builds the editable reviewed ticket retry graph", () => {
     const template = workflowDefinitionTemplate("reviewed-ticket-workflow", {

--- a/apps/worker/src/workflow-definition/scenarios/loop-branch-early-exit.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/loop-branch-early-exit.scenario.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import type { WorkflowDefinitionV2 } from "@shared/contracts";
+import type { AgentWorkflowInput } from "../../workflows/agent-input.js";
+import type { WorkflowBlockRegistryContext } from "../block-registry.js";
+import {
+  validateWorkflowDefinitionIssuesForDeployment,
+  workflowDefinitionSchema,
+} from "../schema.js";
+import {
+  executorRunsOf,
+  expectNeverInvoked,
+  portsOf,
+} from "./assertions.js";
+import { createScenario } from "./harness.js";
+
+const SNAPSHOT = { path: "loop-branch-early-exit-v1.json" };
+
+const REGISTRY_CONTEXT: WorkflowBlockRegistryContext = {
+  agentProviders: { claude: true, codex: true },
+  llmProviders: { claude: true, codex: true },
+  defaultAgent: { provider: "claude", model: "claude-scenario" },
+  vcsProviders: ["github", "gitlab"],
+  vcsBotIdentities: ["github", "gitlab"],
+  slackConfigured: true,
+  arthurConfigured: true,
+  webhookTriggerConfigured: true,
+};
+
+/**
+ * A customer-authored Loop shape that no shipped template can reach.
+ *
+ * The six built-in templates all wire a Loop with exactly one incoming edge, so
+ * none of them exercises what happens when a Branch inside a loop region selects
+ * an exit while the Loop is still live. The editor imposes no such restriction,
+ * and the product's premise is that customers draw their own graphs, so this
+ * shape is reachable in the field even though the catalog never produces it.
+ *
+ * The graph in `loop-branch-early-exit-v1.json` satisfies both conditions the
+ * scheduler needs to build a region with a contested boundary:
+ *
+ *   1. the Loop carries an incoming edge from outside its own region
+ *      (`seed -> loop`, alongside the in-region `gate -> loop`), and
+ *   2. the region has an external body entry, an edge from outside into a member
+ *      that is not the Loop itself (`seed -> work`).
+ *
+ * The strongly connected component is therefore `{loop, work, gate}`, and `work`
+ * is reachable without passing through the Loop. On the first pass `gate` can
+ * take its `true` port and leave the region while the Loop has attempts left.
+ *
+ * AIW-228 predicts an `executionError { category: "engine", phase: "loop" }` on
+ * exactly this shape, from the boundary being resolved twice. That crash does not
+ * happen, because `setEdgeToken` treats a write of the value an edge already
+ * carries as a no-op rather than a contradiction (`v2-scheduler.ts:830`).
+ *
+ * What happens instead is quieter, and for an agent block worse. `seed -> loop`
+ * goes active the moment `seed` finishes, and a node is admitted when *any*
+ * incoming edge is active rather than when a particular one is
+ * (`resolveNodeIfReady`, `v2-scheduler.ts:922-923`). Whichever port `gate` picks,
+ * the Loop is therefore never skipped: it is admitted, and its fresh branch
+ * spawns an iteration (`v2-scheduler.ts:1298`) that re-runs the whole region in a
+ * child scope, alongside the exit the Branch has already selected. The run's own
+ * bookkeeping is reconciled afterwards, so the outcome reads `completed` with no
+ * error while `work` really did execute twice.
+ *
+ * The scenarios below pin that duplicate as an assertion rather than describe it
+ * in prose, so the day it is fixed the pin fails and the fix is visible instead
+ * of silent.
+ */
+
+const TICKET_ENTRY: AgentWorkflowInput = {
+  kind: "ticket",
+  subjectKey: "AIW-228",
+  ticketKey: "AIW-228",
+  ownerToken: "owner-1",
+};
+
+const TICKET_CONTEXT = {
+  identifier: "AIW-228",
+  title: "Loop boundary resolves twice when a Branch exits a running region",
+  description: "A customer-authored graph, not a shipped template.",
+  acceptanceCriteria: "The engine does not fail a legal graph.",
+  labels: ["ai"],
+  comments: [],
+};
+
+function snapshotDefinition(): WorkflowDefinitionV2 {
+  const raw = JSON.parse(
+    readFileSync(new URL(`./snapshots/${SNAPSHOT.path}`, import.meta.url), "utf8"),
+  );
+  return workflowDefinitionSchema.parse(raw) as WorkflowDefinitionV2;
+}
+
+function scenarioFor(verdict: string) {
+  const scenario = createScenario({
+    snapshot: SNAPSHOT,
+    entry: TICKET_ENTRY,
+    entryTriggerId: "trigger",
+    ticket: TICKET_CONTEXT,
+  });
+  scenario.script({ nodeId: "seed" }, {
+    kind: "next",
+    output: { status: "completed", body: "First draft." },
+  });
+  scenario.script({ nodeId: "work" }, {
+    kind: "next",
+    output: { status: "completed", verdict, data: { verdict } },
+  });
+  return scenario;
+}
+
+describe("customer-authored loop with a contested boundary", () => {
+  it("deploys with no validation issues", () => {
+    // Load bearing for everything below: the point of these scenarios is that a
+    // customer can draw this graph and ship it. If validation refused it, the
+    // engine behaviour would be unreachable and this file would assert nothing.
+    expect(
+      validateWorkflowDefinitionIssuesForDeployment(
+        snapshotDefinition(),
+        REGISTRY_CONTEXT,
+        { checkEnvironmentAvailability: false },
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not fail the run when a Branch exits a region the Loop still owns", async () => {
+    // The graph is legal in the editor, so an engine error would be unreadable
+    // advice: the user has no way to act on "resolved more than once".
+    const outcome = await scenarioFor("accept").execute();
+
+    expect(outcome.result.executionError).toBeUndefined();
+    expect(outcome.result.outcome).toBe("completed");
+  });
+
+  it("runs the region twice for one logical pass, which is the defect", async () => {
+    // Pinned, not endorsed. One pass through the graph executes the agent block
+    // twice, in two activation scopes, and the run reports success either way.
+    // `generic_agent` can hold a workspace open, commit, and cost money, so a
+    // second silent execution is not bookkeeping. The outcome above stays clean,
+    // which is exactly why nothing surfaces this today.
+    const outcome = await scenarioFor("accept").execute();
+
+    expect(
+      executorRunsOf(outcome, "work").map((invocation) => ({
+        attempt: invocation.attempt,
+        activationScopeId: invocation.activationScopeId,
+      })),
+    ).toEqual([
+      { attempt: 1, activationScopeId: "root" },
+      { attempt: 2, activationScopeId: "root/loop:loop:1" },
+    ]);
+    expect(portsOf(outcome, "gate")).toEqual(["true", "true"]);
+  });
+
+  it("still reaches the Loop's exhausted port when the Branch keeps rejecting", async () => {
+    // The other half of the boundary: with the exit never selected, the region
+    // runs its attempts out and leaves through `exhausted`. The failure below is
+    // the graph's own Terminate, not an engine fault, and Terminate is never
+    // scripted, so this is the production dispatcher's result.
+    const outcome = await scenarioFor("reject").execute();
+
+    // The externally entered pass plus one per attempt: `maxAttempts: 3` buys
+    // four decisions, the same arithmetic the shipped reviewed-ticket template
+    // shows as four review passes.
+    expect(portsOf(outcome, "gate")).toEqual([
+      "false",
+      "false",
+      "false",
+      "false",
+    ]);
+    expect(portsOf(outcome, "loop")).toEqual([
+      "exhausted",
+      "continue",
+      "continue",
+      undefined,
+    ]);
+    expect(executorRunsOf(outcome, "giveup")).toHaveLength(1);
+    expect(outcome.result.outcome).toBe("failed");
+    expect(outcome.result.executionError).toEqual({
+      nodeId: "giveup",
+      attempt: 1,
+      category: "engine",
+      phase: "terminate",
+      message:
+        "The workflow engine could not continue. (Terminated by workflow.)",
+      diagnosticId: "AIW-DIAG-test-run-giveup-1",
+    });
+    expectNeverInvoked(outcome, ["done"]);
+  });
+});

--- a/apps/worker/src/workflow-definition/scenarios/post-pr-autofix.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/post-pr-autofix.scenario.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import type { BlockOutput, ReviewResultFinding } from "@shared/contracts";
+import type { AgentWorkflowInput } from "../../workflows/agent-input.js";
+import { buildReviewAgentSuccessOutput } from "../../workflows/agent.js";
+import {
+  executorRunsOf,
+  expectNeverInvoked,
+  portsOf,
+} from "./assertions.js";
+import { createScenario, type Scenario } from "./harness.js";
+import { executionError } from "../interpreter.js";
+
+const TEMPLATE = {
+  id: "post-pr-autofix",
+  options: { includeReview: true, provider: "claude" as const },
+};
+const SNAPSHOT = { path: "post-pr-autofix-v1.json" };
+
+const REVIEWS = [
+  "security-review",
+  "quality-review",
+  "requirements-review",
+] as const;
+
+const CHECK = {
+  id: "check-1",
+  headSha: "abc123",
+  name: "AI Workflow / Review",
+};
+
+const ENTRY: AgentWorkflowInput = {
+  kind: "pr_trigger",
+  triggerType: "trigger_pr_ready",
+  subjectKey: "pr:github:acme/app#7",
+  ownerToken: "owner-1",
+  definitionId: 1,
+  definitionVersion: 1,
+  scope: "workflow_owned",
+  pr: {
+    provider: "github",
+    repoPath: "acme/app",
+    prNumber: 7,
+    prUrl: "https://github.test/acme/app/pull/7",
+    headRef: "feature",
+    headSha: "abc123",
+    baseRef: "main",
+    title: "Autofix review",
+    author: "contributor",
+    isDraft: false,
+  },
+};
+
+const FINDING: ReviewResultFinding = {
+  file: "src/index.ts",
+  description: "The implementation needs a correction.",
+  severity: "High",
+  startLine: 10,
+  endLine: 10,
+};
+
+function scenario(source: "template" | "snapshot"): Scenario {
+  return source === "template"
+    ? createScenario({
+        template: TEMPLATE,
+        entry: ENTRY,
+        entryTriggerId: "trigger-ready",
+      })
+    : createScenario({
+        snapshot: SNAPSHOT,
+        entry: ENTRY,
+        entryTriggerId: "trigger-ready",
+      });
+}
+
+function reviewOutput(
+  nodeId: string,
+  decision: "approve" | "request_changes",
+  pass: number,
+): BlockOutput {
+  return buildReviewAgentSuccessOutput({
+    feedback: `${nodeId} pass ${pass}`,
+    issues: decision === "approve" ? [] : [FINDING],
+  });
+}
+
+function scriptPrelude(scenarioToScript: Scenario): void {
+  scenarioToScript.script({ nodeId: "create-check" }, {
+    kind: "next",
+    output: { status: "ok", check: CHECK },
+  });
+  scenarioToScript.script({ nodeId: "prepare" }, {
+    kind: "next",
+    output: {
+      status: "ok",
+      sandboxId: "sbx-scenario",
+      repositories: ["github:acme/app"],
+      workspace: { id: "sbx-scenario", repositories: ["github:acme/app"] },
+    },
+  });
+  scenarioToScript.script({ nodeId: "fix" }, {
+    kind: "next",
+    output: {
+      status: "fixed",
+      workspaceId: "sbx-scenario",
+      commits: [],
+      resolvedConflicts: [],
+      unresolvedConflicts: [],
+      summary: "Fixed the review findings.",
+    },
+  });
+}
+
+function scriptReviews(
+  scenarioToScript: Scenario,
+  approveAfterFix: boolean,
+): void {
+  for (const nodeId of REVIEWS) {
+    scenarioToScript.script({ nodeId }, (_node, _inputs, context) => {
+      const decision =
+        approveAfterFix && context.activationScopeId !== "root"
+          ? "approve"
+          : "request_changes";
+      return {
+        kind: "next",
+        output: reviewOutput(
+          nodeId,
+          decision,
+          context.activationScopeId === "root" ? 1 : 2,
+        ),
+      };
+    });
+  }
+}
+
+function scriptPostReview(
+  scenarioToScript: Scenario,
+  nodeId: "post-review-approved" | "post-review-exhausted",
+): void {
+  scenarioToScript.script({ nodeId }, (_node, inputs) => {
+    const results = inputs.reviewResults as Array<{ decision: string; findings: unknown[] }>;
+    const approved = results.every((result) => result.decision === "approve");
+    return {
+      kind: "next",
+      output: {
+        status: "ok",
+        decision: approved ? "approve" : "request_changes",
+        summary: approved ? "Approved." : "Unresolved findings.",
+        inlineCommentCount: results.reduce(
+          (count, result) => count + result.findings.length,
+          0,
+        ),
+        summaryFallbackCount: 0,
+      },
+    };
+  });
+}
+
+function scriptCompletion(
+  scenarioToScript: Scenario,
+  nodeId: "complete-success" | "complete-failure",
+): void {
+  scenarioToScript.script({ nodeId }, (_node, inputs) => ({
+    kind: "next",
+    output: {
+      status: "ok",
+      check: inputs.check as typeof CHECK,
+      conclusion: nodeId === "complete-success" ? "success" : "failure",
+    },
+  }));
+}
+
+describe("post-PR autofix workflow", () => {
+  it.each(["template", "snapshot"] as const)(
+    "approves after one fix and publishes exactly once (%s)",
+    async (source) => {
+    const scenarioToRun = scenario(source);
+    scriptPrelude(scenarioToRun);
+    scriptReviews(scenarioToRun, true);
+    scriptPostReview(scenarioToRun, "post-review-approved");
+    scriptCompletion(scenarioToRun, "complete-success");
+
+    const outcome = await scenarioToRun.execute();
+
+    expect(outcome.result.executionError).toBeUndefined();
+    expect(outcome.result.outcome).toBe("completed");
+    expect(executorRunsOf(outcome, "fix")).toHaveLength(1);
+    for (const nodeId of REVIEWS) {
+      expect(executorRunsOf(outcome, nodeId)).toHaveLength(2);
+    }
+    expect(portsOf(outcome, "review-approved")).toEqual(["false", "true"]);
+    expect(executorRunsOf(outcome, "post-review-approved")).toHaveLength(1);
+    expect(
+      executorRunsOf(outcome, "post-review-approved")[0].resolvedInputs?.reviewResults,
+    ).toEqual(
+      REVIEWS.map((nodeId) =>
+        expect.objectContaining({ decision: "approve" }),
+      ),
+    );
+    expectNeverInvoked(outcome, ["post-review-exhausted", "exhausted-message", "complete-failure"]);
+    },
+  );
+
+  it.each(["template", "snapshot"] as const)(
+    "exhausts after two fixes and publishes the failure review exactly once (%s)",
+    async (source) => {
+    const scenarioToRun = scenario(source);
+    scriptPrelude(scenarioToRun);
+    scriptReviews(scenarioToRun, false);
+    scriptPostReview(scenarioToRun, "post-review-exhausted");
+    scenarioToRun.script({ nodeId: "exhausted-message" }, {
+      kind: "next",
+      output: { status: "ok" },
+    });
+    scriptCompletion(scenarioToRun, "complete-failure");
+
+    const outcome = await scenarioToRun.execute();
+
+    expect(outcome.result.executionError).toBeUndefined();
+    expect(outcome.result.outcome).toBe("completed");
+    expect(executorRunsOf(outcome, "fix")).toHaveLength(2);
+    for (const nodeId of REVIEWS) {
+      expect(executorRunsOf(outcome, nodeId)).toHaveLength(3);
+    }
+    expect(executorRunsOf(outcome, "post-review-exhausted")).toHaveLength(1);
+    expect(executorRunsOf(outcome, "exhausted-message")).toHaveLength(1);
+    expectNeverInvoked(outcome, ["post-review-approved", "complete-success"]);
+    },
+  );
+
+  it.each(["template", "snapshot"] as const)(
+    "does not publish a stale review when the second round dies (%s)",
+    async (source) => {
+      const scenarioToRun = scenario(source);
+      scriptPrelude(scenarioToRun);
+      for (const nodeId of REVIEWS) {
+        scenarioToRun.script({ nodeId }, (_node, _inputs, context) => {
+          if (nodeId === "quality-review" && context.activationScopeId !== "root") {
+            return executionError("The review provider connection dropped.", {
+              category: "provider",
+              phase: "agent",
+            });
+          }
+          return {
+            kind: "next",
+            output: reviewOutput(nodeId, "request_changes", context.activationScopeId === "root" ? 1 : 2),
+          };
+        });
+      }
+
+      const outcome = await scenarioToRun.execute();
+
+      expect(outcome.result.outcome).toBe("failed");
+      expect(outcome.result.executionError).toMatchObject({
+        nodeId: "quality-review",
+        category: "provider",
+      });
+      expectNeverInvoked(outcome, [
+        "post-review-approved",
+        "post-review-exhausted",
+        "exhausted-message",
+        "complete-success",
+        "complete-failure",
+      ]);
+    },
+  );
+});

--- a/apps/worker/src/workflow-definition/scenarios/snapshots/loop-branch-early-exit-v1.json
+++ b/apps/worker/src/workflow-definition/scenarios/snapshots/loop-branch-early-exit-v1.json
@@ -1,0 +1,104 @@
+{
+  "schemaVersion": 2,
+  "nodes": [
+    {
+      "id": "trigger",
+      "type": "trigger_ticket_ai",
+      "name": "Ticket moved to AI",
+      "x": 40,
+      "y": 200,
+      "configuration": {},
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "seed",
+      "type": "generic_agent",
+      "name": "Seed the region",
+      "x": 300,
+      "y": 200,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Produce the first draft.",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "loop",
+      "type": "loop",
+      "name": "Retry until accepted",
+      "x": 560,
+      "y": 320,
+      "configuration": { "maxAttempts": 3, "onExhaust": "fail" },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "work",
+      "type": "generic_agent",
+      "name": "Revise the draft",
+      "x": 820,
+      "y": 200,
+      "configuration": {
+        "harnessProfile": { "profileId": "builtin-claude", "version": 2 },
+        "prompt": "Revise the draft and report a verdict.",
+        "outputSchema": "{\"type\":\"object\",\"properties\":{\"verdict\":{\"type\":\"string\"}},\"required\":[\"verdict\"],\"additionalProperties\":false}",
+        "outputSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
+        "workspaceMode": "none"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "gate",
+      "type": "branch",
+      "name": "Accepted?",
+      "x": 1080,
+      "y": 200,
+      "configuration": {
+        "combinator": "all",
+        "conditions": [
+          {
+            "reference": "steps.work.output.verdict",
+            "operator": "equals",
+            "value": "accept"
+          }
+        ]
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "done",
+      "type": "terminate",
+      "name": "Accepted",
+      "x": 1340,
+      "y": 120,
+      "configuration": { "terminalStatus": "done" },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "giveup",
+      "type": "terminate",
+      "name": "Gave up",
+      "x": 1340,
+      "y": 420,
+      "configuration": { "terminalStatus": "failed" },
+      "inputs": {},
+      "additionalInputs": []
+    }
+  ],
+  "edges": [
+    { "id": "e01-trigger-seed", "from": "trigger", "to": "seed" },
+    { "id": "e02-seed-loop", "from": "seed", "to": "loop" },
+    { "id": "e03-seed-work", "from": "seed", "to": "work" },
+    { "id": "e04-loop-continue-work", "from": "loop", "fromPort": "continue", "to": "work" },
+    { "id": "e05-work-gate", "from": "work", "to": "gate" },
+    { "id": "e06-gate-false-loop", "from": "gate", "fromPort": "false", "to": "loop" },
+    { "id": "e07-gate-true-done", "from": "gate", "fromPort": "true", "to": "done" },
+    { "id": "e08-loop-exhausted-giveup", "from": "loop", "fromPort": "exhausted", "to": "giveup" }
+  ]
+}

--- a/apps/worker/src/workflow-definition/scenarios/snapshots/post-pr-autofix-v1.json
+++ b/apps/worker/src/workflow-definition/scenarios/snapshots/post-pr-autofix-v1.json
@@ -1,0 +1,591 @@
+{
+  "schemaVersion": 2,
+  "nodes": [
+    {
+      "id": "trigger-ready",
+      "type": "trigger_pr_ready",
+      "name": "PR ready for review",
+      "x": 40,
+      "y": 100,
+      "configuration": {
+        "providers": [
+          "github",
+          "gitlab"
+        ],
+        "scope": "workflow_owned"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "trigger-updated",
+      "type": "trigger_pr_updated",
+      "name": "PR updated",
+      "x": 40,
+      "y": 460,
+      "configuration": {
+        "providers": [
+          "github",
+          "gitlab"
+        ],
+        "scope": "workflow_owned"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "create-check",
+      "type": "create_pr_check",
+      "name": "Create review check",
+      "x": 300,
+      "y": 280,
+      "configuration": {
+        "checkName": "AI Workflow / Review"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "prepare",
+      "type": "prepare_workspace",
+      "name": "Prepare exact-head workspace",
+      "x": 560,
+      "y": 280,
+      "configuration": {},
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "security-review",
+      "type": "review_agent",
+      "name": "Security review",
+      "x": 820,
+      "y": 100,
+      "configuration": {
+        "harnessProfile": {
+          "profileId": "builtin-claude",
+          "version": 2
+        },
+        "prompt": "Review the implementation for security vulnerabilities, unsafe trust boundaries, credential exposure, and abuse cases. Do not modify files. Report concrete findings only."
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "quality-review",
+      "type": "review_agent",
+      "name": "Code quality review",
+      "x": 820,
+      "y": 280,
+      "configuration": {
+        "harnessProfile": {
+          "profileId": "builtin-claude",
+          "version": 2
+        },
+        "prompt": "Review the implementation for correctness, maintainability, test coverage, regressions, and adherence to repository conventions. Do not modify files. Report concrete findings only."
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "requirements-review",
+      "type": "review_agent",
+      "name": "Requirements review",
+      "x": 820,
+      "y": 460,
+      "configuration": {
+        "harnessProfile": {
+          "profileId": "builtin-claude",
+          "version": 2
+        },
+        "prompt": "Review the implementation against the ticket, approved plan, and acceptance criteria. Do not modify files. Report concrete gaps only."
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "review-approved",
+      "type": "branch",
+      "name": "Review approved?",
+      "x": 1340,
+      "y": 460,
+      "configuration": {
+        "combinator": "all",
+        "conditions": [
+          {
+            "reference": "steps.security-review.output.decision",
+            "operator": "equals",
+            "value": "approve"
+          },
+          {
+            "reference": "steps.quality-review.output.decision",
+            "operator": "equals",
+            "value": "approve"
+          },
+          {
+            "reference": "steps.requirements-review.output.decision",
+            "operator": "equals",
+            "value": "approve"
+          }
+        ]
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "retry",
+      "type": "loop",
+      "name": "Retry review fixes",
+      "x": 1080,
+      "y": 460,
+      "configuration": {
+        "maxAttempts": 2,
+        "onExhaust": "fail",
+        "carry": [
+          {
+            "name": "check",
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "headSha": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "headSha",
+                "name"
+              ],
+              "additionalProperties": false
+            },
+            "binding": {
+              "kind": "reference",
+              "reference": "steps.create-check.output.check"
+            }
+          },
+          {
+            "name": "securityReview",
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "decision": {
+                  "type": "string",
+                  "enum": [
+                    "approve",
+                    "request_changes"
+                  ]
+                },
+                "findings": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "severity": {
+                        "type": "string",
+                        "enum": [
+                          "Blocker",
+                          "High",
+                          "Medium",
+                          "Nit"
+                        ]
+                      },
+                      "startLine": {
+                        "type": "number"
+                      },
+                      "endLine": {
+                        "type": "number"
+                      },
+                      "repo": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "file",
+                      "description",
+                      "severity"
+                    ],
+                    "additionalProperties": true
+                  }
+                },
+                "feedback": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "decision",
+                "findings"
+              ],
+              "additionalProperties": true
+            },
+            "binding": {
+              "kind": "reference",
+              "reference": "steps.security-review.output"
+            }
+          },
+          {
+            "name": "qualityReview",
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "decision": {
+                  "type": "string",
+                  "enum": [
+                    "approve",
+                    "request_changes"
+                  ]
+                },
+                "findings": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "severity": {
+                        "type": "string",
+                        "enum": [
+                          "Blocker",
+                          "High",
+                          "Medium",
+                          "Nit"
+                        ]
+                      },
+                      "startLine": {
+                        "type": "number"
+                      },
+                      "endLine": {
+                        "type": "number"
+                      },
+                      "repo": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "file",
+                      "description",
+                      "severity"
+                    ],
+                    "additionalProperties": true
+                  }
+                },
+                "feedback": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "decision",
+                "findings"
+              ],
+              "additionalProperties": true
+            },
+            "binding": {
+              "kind": "reference",
+              "reference": "steps.quality-review.output"
+            }
+          },
+          {
+            "name": "requirementsReview",
+            "schema": {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "decision": {
+                  "type": "string",
+                  "enum": [
+                    "approve",
+                    "request_changes"
+                  ]
+                },
+                "findings": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "file": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "severity": {
+                        "type": "string",
+                        "enum": [
+                          "Blocker",
+                          "High",
+                          "Medium",
+                          "Nit"
+                        ]
+                      },
+                      "startLine": {
+                        "type": "number"
+                      },
+                      "endLine": {
+                        "type": "number"
+                      },
+                      "repo": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "file",
+                      "description",
+                      "severity"
+                    ],
+                    "additionalProperties": true
+                  }
+                },
+                "feedback": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "decision",
+                "findings"
+              ],
+              "additionalProperties": true
+            },
+            "binding": {
+              "kind": "reference",
+              "reference": "steps.requirements-review.output"
+            }
+          }
+        ]
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "fix",
+      "type": "fix_agent",
+      "name": "Fix review findings",
+      "x": 1600,
+      "y": 460,
+      "configuration": {
+        "harnessProfile": {
+          "profileId": "builtin-claude",
+          "version": 2
+        },
+        "instructions": "Resolve the supplied review findings, verify the changes, and commit the fix.",
+        "maxMinutes": 25
+      },
+      "inputs": {
+        "reviewResults": {
+          "kind": "reference_list",
+          "references": [
+            "steps.retry.output.values.securityReview",
+            "steps.retry.output.values.qualityReview",
+            "steps.retry.output.values.requirementsReview"
+          ]
+        }
+      },
+      "additionalInputs": []
+    },
+    {
+      "id": "post-review-approved",
+      "type": "post_pr_review",
+      "name": "Post approved review",
+      "x": 1860,
+      "y": 100,
+      "configuration": {},
+      "inputs": {
+        "reviewResults": {
+          "kind": "reference_list",
+          "references": [
+            "steps.retry.output.values.securityReview",
+            "steps.retry.output.values.qualityReview",
+            "steps.retry.output.values.requirementsReview"
+          ]
+        }
+      },
+      "additionalInputs": []
+    },
+    {
+      "id": "post-review-exhausted",
+      "type": "post_pr_review",
+      "name": "Post exhausted review",
+      "x": 1860,
+      "y": 460,
+      "configuration": {},
+      "inputs": {
+        "reviewResults": {
+          "kind": "reference_list",
+          "references": [
+            "steps.retry.output.values.securityReview",
+            "steps.retry.output.values.qualityReview",
+            "steps.retry.output.values.requirementsReview"
+          ]
+        }
+      },
+      "additionalInputs": []
+    },
+    {
+      "id": "exhausted-message",
+      "type": "send_slack_message",
+      "name": "Report unresolved review findings",
+      "x": 2120,
+      "y": 460,
+      "configuration": {
+        "message": "The workflow could not resolve all review findings after two fix attempts.",
+        "sendOn": "always"
+      },
+      "inputs": {},
+      "additionalInputs": []
+    },
+    {
+      "id": "complete-success",
+      "type": "complete_pr_check",
+      "name": "Pass review check",
+      "x": 2380,
+      "y": 100,
+      "configuration": {
+        "conclusion": "success",
+        "details": "No blocking findings on this commit."
+      },
+      "inputs": {
+        "check": {
+          "kind": "reference",
+          "reference": "steps.retry.output.values.check"
+        }
+      },
+      "additionalInputs": []
+    },
+    {
+      "id": "complete-failure",
+      "type": "complete_pr_check",
+      "name": "Fail review check",
+      "x": 2380,
+      "y": 460,
+      "configuration": {
+        "conclusion": "failure",
+        "details": "The review requested changes. See the review on this pull request."
+      },
+      "inputs": {
+        "check": {
+          "kind": "reference",
+          "reference": "steps.retry.output.values.check"
+        }
+      },
+      "additionalInputs": []
+    }
+  ],
+  "edges": [
+    {
+      "id": "builtin-post-pr-autofix-01-trigger-ready-out-create-check",
+      "from": "trigger-ready",
+      "to": "create-check"
+    },
+    {
+      "id": "builtin-post-pr-autofix-02-trigger-updated-out-create-check",
+      "from": "trigger-updated",
+      "to": "create-check"
+    },
+    {
+      "id": "builtin-post-pr-autofix-03-create-check-out-prepare",
+      "from": "create-check",
+      "to": "prepare"
+    },
+    {
+      "id": "builtin-post-pr-autofix-04-prepare-out-security-review",
+      "from": "prepare",
+      "to": "security-review"
+    },
+    {
+      "id": "builtin-post-pr-autofix-05-prepare-out-quality-review",
+      "from": "prepare",
+      "to": "quality-review"
+    },
+    {
+      "id": "builtin-post-pr-autofix-06-prepare-out-requirements-review",
+      "from": "prepare",
+      "to": "requirements-review"
+    },
+    {
+      "id": "builtin-post-pr-autofix-07-security-review-out-review-approved",
+      "from": "security-review",
+      "to": "review-approved"
+    },
+    {
+      "id": "builtin-post-pr-autofix-08-quality-review-out-review-approved",
+      "from": "quality-review",
+      "to": "review-approved"
+    },
+    {
+      "id": "builtin-post-pr-autofix-09-requirements-review-out-review-approved",
+      "from": "requirements-review",
+      "to": "review-approved"
+    },
+    {
+      "id": "builtin-post-pr-autofix-10-review-approved-true-post-review-approved",
+      "from": "review-approved",
+      "to": "post-review-approved",
+      "fromPort": "true"
+    },
+    {
+      "id": "builtin-post-pr-autofix-11-fix-out-security-review",
+      "from": "fix",
+      "to": "security-review"
+    },
+    {
+      "id": "builtin-post-pr-autofix-12-fix-out-quality-review",
+      "from": "fix",
+      "to": "quality-review"
+    },
+    {
+      "id": "builtin-post-pr-autofix-13-fix-out-requirements-review",
+      "from": "fix",
+      "to": "requirements-review"
+    },
+    {
+      "id": "builtin-post-pr-autofix-14-review-approved-false-retry",
+      "from": "review-approved",
+      "to": "retry",
+      "fromPort": "false"
+    },
+    {
+      "id": "builtin-post-pr-autofix-15-retry-continue-fix",
+      "from": "retry",
+      "to": "fix",
+      "fromPort": "continue"
+    },
+    {
+      "id": "builtin-post-pr-autofix-16-retry-exhausted-post-review-exhausted",
+      "from": "retry",
+      "to": "post-review-exhausted",
+      "fromPort": "exhausted"
+    },
+    {
+      "id": "builtin-post-pr-autofix-17-post-review-approved-out-complete-success",
+      "from": "post-review-approved",
+      "to": "complete-success"
+    },
+    {
+      "id": "builtin-post-pr-autofix-18-post-review-exhausted-out-exhausted-message",
+      "from": "post-review-exhausted",
+      "to": "exhausted-message"
+    },
+    {
+      "id": "builtin-post-pr-autofix-19-exhausted-message-out-complete-failure",
+      "from": "exhausted-message",
+      "to": "complete-failure"
+    }
+  ]
+}

--- a/apps/worker/src/workflow-definition/scenarios/snapshots/post-pr-autofix-v1.json
+++ b/apps/worker/src/workflow-definition/scenarios/snapshots/post-pr-autofix-v1.json
@@ -458,7 +458,8 @@
       "y": 100,
       "configuration": {
         "conclusion": "success",
-        "details": "No blocking findings on this commit."
+        "details": "No blocking findings on this commit.",
+        "refreshHead": true
       },
       "inputs": {
         "check": {
@@ -476,7 +477,8 @@
       "y": 460,
       "configuration": {
         "conclusion": "failure",
-        "details": "The review requested changes. See the review on this pull request."
+        "details": "The review requested changes. See the review on this pull request.",
+        "refreshHead": true
       },
       "inputs": {
         "check": {

--- a/apps/worker/src/workflow-definition/schema.test.ts
+++ b/apps/worker/src/workflow-definition/schema.test.ts
@@ -1122,7 +1122,7 @@ describe("workflowDefinitionSchema block-executor node types", () => {
 });
 
 describe("validateWorkflowGraph fixtures", () => {
-  it("ships seven deployable starter templates with the production ticket workflow first", () => {
+  it("ships eight deployable starter templates with the production ticket workflow first", () => {
     const templates = workflowDefinitionTemplates({ includeReview: true });
     expect(templates.map((template) => template.name)).toEqual([
       "Ticket workflow",
@@ -1130,6 +1130,7 @@ describe("validateWorkflowGraph fixtures", () => {
       "Review & fix after PR",
       "Reviewed ticket workflow",
       "Post-PR review",
+      "Post-PR review with autofix",
       "Fully modular",
       "Ticket triage (webhook)",
     ]);

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -750,6 +750,7 @@ const v2CompletePrCheckConfiguration = z
   .object({
     conclusion: z.enum(["success", "failure", "neutral"]),
     details: z.string().max(10_000).optional(),
+    refreshHead: z.boolean().optional(),
   })
   .strict();
 const v2LoopConfiguration = z

--- a/apps/worker/src/workflow-definition/store.test.ts
+++ b/apps/worker/src/workflow-definition/store.test.ts
@@ -191,7 +191,7 @@ describe("migration seed", () => {
 });
 
 describe("starter template seed", () => {
-  it("adds the six disabled starter workflows exactly once", async () => {
+  it("adds the seven disabled starter workflows exactly once", async () => {
     await seedWorkflowDefinitionTemplates(db, { includeReview: true });
     await seedWorkflowDefinitionTemplates(db, { includeReview: true });
 
@@ -202,11 +202,13 @@ describe("starter template seed", () => {
       "Review & fix after PR",
       "Reviewed ticket workflow",
       "Post-PR review",
+      "Post-PR review with autofix",
       "Fully modular",
       "Ticket triage (webhook)",
     ]);
     expect(defs.map((definition) => definition.enabled)).toEqual([
       true,
+      false,
       false,
       false,
       false,
@@ -221,8 +223,10 @@ describe("starter template seed", () => {
       1,
       1,
       1,
+      1,
     ]);
     expect(defs.slice(1).map((definition) => definition.deployedVersion)).toEqual([
+      1,
       1,
       1,
       1,
@@ -234,6 +238,7 @@ describe("starter template seed", () => {
       ["trigger_ticket_ai", "trigger_plan_approved"],
       ["trigger_pr_checks_failed", "trigger_pr_review"],
       ["trigger_ticket_ai"],
+      ["trigger_pr_ready", "trigger_pr_updated"],
       ["trigger_pr_ready", "trigger_pr_updated"],
       ["trigger_ticket_ai"],
       ["trigger_webhook"],

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -3,6 +3,7 @@ import {
   type HarnessProvider,
   type HarnessProfileReference,
   type WorkflowDefinitionTemplate,
+  type WorkflowDataReferenceV2,
   type WorkflowDefinitionV2,
 } from "@shared/contracts";
 import {
@@ -566,6 +567,12 @@ const REVIEW_TASKS = {
     "Review the implementation against the ticket, approved plan, and acceptance criteria. Do not modify files. Report concrete gaps only.",
 } as const;
 
+const REVIEW_IDS = [
+  "security-review",
+  "quality-review",
+  "requirements-review",
+] as const;
+
 function reviewedTicketDefinition(
   provider: HarnessProvider,
   profileReference?: HarnessProfileReference,
@@ -992,6 +999,238 @@ function postPrReviewDefinition(
   ]);
 }
 
+function postPrAutofixDefinition(
+  provider: HarnessProvider,
+  profileReference?: HarnessProfileReference,
+): WorkflowDefinitionV2 {
+  const profile = () =>
+    builtinHarnessProfileConfiguration(provider, profileReference);
+  const checkSchema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      headSha: { type: "string" },
+      name: { type: "string" },
+    },
+    required: ["id", "headSha", "name"],
+    additionalProperties: false,
+  };
+  const reviewResultReferences = (): WorkflowDataReferenceV2[] =>
+    REVIEW_IDS.map(
+      (reviewer) =>
+        `steps.retry.output.values.${reviewer.replace("-review", "Review")}` as WorkflowDataReferenceV2,
+    );
+  const specs: V2BlockSpec[] = [
+    {
+      id: "trigger-ready",
+      type: "trigger_pr_ready",
+      name: "PR ready for review",
+      column: 0,
+      row: -1,
+      configuration: {
+        providers: ["github", "gitlab"],
+        scope: "workflow_owned",
+      },
+    },
+    {
+      id: "trigger-updated",
+      type: "trigger_pr_updated",
+      name: "PR updated",
+      column: 0,
+      row: 1,
+      configuration: {
+        providers: ["github", "gitlab"],
+        scope: "workflow_owned",
+      },
+    },
+    {
+      id: "create-check",
+      type: "create_pr_check",
+      name: "Create review check",
+      column: 1,
+      configuration: { checkName: "AI Workflow / Review" },
+    },
+    {
+      id: "prepare",
+      type: "prepare_workspace",
+      name: "Prepare exact-head workspace",
+      column: 2,
+    },
+    ...([
+      ["security-review", "Security review", REVIEW_TASKS.security, -1],
+      ["quality-review", "Code quality review", REVIEW_TASKS.quality, 0],
+      [
+        "requirements-review",
+        "Requirements review",
+        REVIEW_TASKS.requirements,
+        1,
+      ],
+    ] as const).map(
+      ([id, name, prompt, row]) =>
+        ({
+          id,
+          type: "review_agent",
+          name,
+          column: 3,
+          row,
+          configuration: { ...profile(), prompt },
+        }) satisfies V2BlockSpec,
+    ),
+    {
+      id: "review-approved",
+      type: "branch",
+      name: "Review approved?",
+      column: 5,
+      row: 1,
+      configuration: {
+        combinator: "all",
+        conditions: REVIEW_IDS.map((reviewer) => ({
+          reference: `steps.${reviewer}.output.decision`,
+          operator: "equals",
+          value: "approve",
+        })),
+      },
+    },
+    {
+      id: "retry",
+      type: "loop",
+      name: "Retry review fixes",
+      column: 4,
+      row: 1,
+      configuration: {
+        maxAttempts: 2,
+        onExhaust: "fail",
+        carry: [
+          {
+            name: "check",
+            schema: checkSchema,
+            binding: {
+              kind: "reference",
+              reference: "steps.create-check.output.check" as WorkflowDataReferenceV2,
+            },
+          },
+          ...REVIEW_IDS.map((reviewer) => ({
+            name: reviewer.replace("-review", "Review"),
+            schema: REVIEW_RESULT_JSON_SCHEMA,
+            binding: {
+              kind: "reference",
+              reference: `steps.${reviewer}.output` as WorkflowDataReferenceV2,
+            },
+          })),
+        ],
+      },
+    },
+    {
+      id: "fix",
+      type: "fix_agent",
+      name: "Fix review findings",
+      column: 6,
+      row: 1,
+      configuration: {
+        ...profile(),
+        instructions:
+          "Resolve the supplied review findings, verify the changes, and commit the fix.",
+        maxMinutes: 25,
+      },
+      inputs: {
+        reviewResults: {
+          kind: "reference_list",
+          references: reviewResultReferences(),
+        },
+      },
+    },
+    ...([
+      ["post-review-approved", "Post approved review"],
+      ["post-review-exhausted", "Post exhausted review"],
+    ] as const).map(
+      ([id, name]) =>
+        ({
+          id,
+          type: "post_pr_review",
+          name,
+          column: 7,
+          row: id === "post-review-approved" ? -1 : 1,
+          inputs: {
+            reviewResults: {
+              kind: "reference_list",
+              references: reviewResultReferences(),
+            },
+          },
+        }) satisfies V2BlockSpec,
+    ),
+    {
+      id: "exhausted-message",
+      type: "send_slack_message",
+      name: "Report unresolved review findings",
+      column: 8,
+      row: 1,
+      configuration: {
+        message:
+          "The workflow could not resolve all review findings after two fix attempts.",
+        sendOn: "always",
+      },
+    },
+    {
+      id: "complete-success",
+      type: "complete_pr_check",
+      name: "Pass review check",
+      column: 9,
+      row: -1,
+      configuration: {
+        conclusion: "success",
+        details: "No blocking findings on this commit.",
+        refreshHead: true,
+      },
+      inputs: {
+        check: {
+          kind: "reference",
+          reference: "steps.retry.output.values.check" as WorkflowDataReferenceV2,
+        },
+      },
+    },
+    {
+      id: "complete-failure",
+      type: "complete_pr_check",
+      name: "Fail review check",
+      column: 9,
+      row: 1,
+      configuration: {
+        conclusion: "failure",
+        details: POST_PR_REVIEW_FAILURE_DETAILS,
+        refreshHead: true,
+      },
+      inputs: {
+        check: {
+          kind: "reference",
+          reference: "steps.retry.output.values.check" as WorkflowDataReferenceV2,
+        },
+      },
+    },
+  ];
+  return buildBuiltinV2Definition("post-pr-autofix", specs, [
+    { from: "trigger-ready", to: "create-check" },
+    { from: "trigger-updated", to: "create-check" },
+    { from: "create-check", to: "prepare" },
+    { from: "prepare", to: "security-review" },
+    { from: "prepare", to: "quality-review" },
+    { from: "prepare", to: "requirements-review" },
+    { from: "security-review", to: "review-approved" },
+    { from: "quality-review", to: "review-approved" },
+    { from: "requirements-review", to: "review-approved" },
+    { from: "review-approved", fromPort: "true", to: "post-review-approved" },
+    { from: "fix", to: "security-review" },
+    { from: "fix", to: "quality-review" },
+    { from: "fix", to: "requirements-review" },
+    { from: "review-approved", fromPort: "false", to: "retry" },
+    { from: "retry", fromPort: "continue", to: "fix" },
+    { from: "retry", fromPort: "exhausted", to: "post-review-exhausted" },
+    { from: "post-review-approved", to: "complete-success" },
+    { from: "post-review-exhausted", to: "exhausted-message" },
+    { from: "exhausted-message", to: "complete-failure" },
+  ]);
+}
+
 export function workflowDefinitionTemplates({
   includeReview,
   includeLeakReview = false,
@@ -1038,6 +1277,13 @@ export function workflowDefinitionTemplates({
       description:
         "Reviews ready and updated pull requests in parallel, publishes findings, and completes an exact-head check.",
       definition: postPrReviewDefinition(provider, profileReference),
+    },
+    {
+      id: "post-pr-autofix",
+      name: "Post-PR review with autofix",
+      description:
+        "Reviews an open pull request, fixes findings in a bounded loop, and publishes one final review.",
+      definition: postPrAutofixDefinition(provider, profileReference),
     },
     {
       id: "fully-modular",

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -1870,10 +1870,23 @@ class V2SchedulerRuntime {
         `loop "${activeLoop.loopNodeId}" lost its owner attempt`,
       );
     }
-    const carriedValues = this.resolveLoopCarryValues(
-      iterationScopeId,
-      this.graph.nodes.get(activeLoop.loopNodeId)!,
-    );
+    let carriedValues: Record<string, JsonValue>;
+    try {
+      carriedValues = this.resolveLoopCarryValues(
+        iterationScopeId,
+        this.graph.nodes.get(activeLoop.loopNodeId)!,
+      );
+    } catch (error) {
+      await this.failNode(
+        activeLoop.ownerScopeId,
+        activeLoop.loopNodeId,
+        ownerAttempt,
+        runtimeError(error instanceof Error ? error.message : String(error), {
+          phase: "loop",
+        }).error,
+      );
+      return;
+    }
     const output: BlockOutput = {
       status: "ok",
       attempt: activeLoop.iteration,

--- a/apps/worker/src/workflow-definition/v2-scheduler.ts
+++ b/apps/worker/src/workflow-definition/v2-scheduler.ts
@@ -1209,10 +1209,14 @@ class V2SchedulerRuntime {
     const scope = this.scope(scopeId);
     const activeLoop = scope.loop;
     if (activeLoop?.loopNodeId === node.id) {
+      const carryValues = this.resolveLoopCarryValues(scopeId, node);
       scope.nodeStates[node.id] = { status: "completed", attempt };
       const output: BlockOutput = {
         status: "ok",
         attempt: activeLoop.iteration,
+        ...(Object.keys(carryValues).length === 0
+          ? {}
+          : { values: structuredClone(carryValues) }),
       };
       await context.observations.emit({ kind: "output", value: output });
       scope.outputs[node.id] = output;
@@ -1231,7 +1235,6 @@ class V2SchedulerRuntime {
         continues ? "continue" : undefined,
       );
       if (continues) {
-        const carryValues = this.resolveLoopCarryValues(scopeId, node);
         this.spawnLoopIteration(
           activeLoop.ownerScopeId,
           node,
@@ -1447,9 +1450,20 @@ class V2SchedulerRuntime {
   ): Promise<void> {
     const owner = this.scope(ownerScopeId);
     const maxAttempts = this.loopMaxAttempts(node);
+    const lastIteration = Object.values(this.checkpoint.scopes)
+      .filter(
+        (scope) =>
+          scope.loop?.loopNodeId === node.id &&
+          scope.loop.ownerScopeId === ownerScopeId,
+      )
+      .sort((left, right) => right.sequence - left.sequence)[0];
+    const carriedValues = lastIteration?.outputs[node.id]?.values;
     const output: BlockOutput = {
       status: "exhausted",
       attempt: maxAttempts,
+      ...(carriedValues === undefined
+        ? {}
+        : { values: structuredClone(carriedValues) }),
     };
     await context.observations.emit({ kind: "output", value: output });
     owner.outputs[node.id] = output;
@@ -1856,9 +1870,16 @@ class V2SchedulerRuntime {
         `loop "${activeLoop.loopNodeId}" lost its owner attempt`,
       );
     }
+    const carriedValues = this.resolveLoopCarryValues(
+      iterationScopeId,
+      this.graph.nodes.get(activeLoop.loopNodeId)!,
+    );
     const output: BlockOutput = {
       status: "ok",
       attempt: activeLoop.iteration,
+      ...(Object.keys(carriedValues).length === 0
+        ? {}
+        : { values: structuredClone(carriedValues) }),
     };
     await this.invocationContext(
       activeLoop.ownerScopeId,

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -117,6 +117,7 @@ import {
 import { loadInvocationRepositoryInstructionSources } from "./repository-instructions.js";
 import type { HumanDecision } from "../lib/human-decisions-memory.js";
 import type { WorkspacePublicationResult } from "./workspace-publication.js";
+import { publicationPrsForTelemetry } from "./publication-prs-for-telemetry.js";
 import {
   invalidateWorkspaceGate,
   recordSuccessfulWorkspaceGate,
@@ -837,33 +838,6 @@ function publicationPrForTelemetry(
   if (publication?.status !== "published") return null;
   const primary = publication.prs[0];
   return primary ? { url: primary.url, number: primary.id } : null;
-}
-
-/** Every PR/MR the publication opened, for the run's durable PR list. Kept
- * alongside publicationPrForTelemetry rather than replacing it: the single
- * prUrl/prNumber columns are still written (gate runs share them) and stay the
- * first entry, while this preserves the repositories the first entry drops. */
-function publicationPrsForTelemetry(
-  publication: WorkspacePublicationResult | null | undefined,
-): RunPullRequest[] | null {
-  if (publication?.status !== "published" || publication.prs.length === 0) return null;
-  return publication.prs.map((pr) => ({
-    provider: pr.provider,
-    repoPath: pr.repoPath,
-    id: pr.id,
-    url: pr.url,
-    ...(publication.repositories.find(
-      (repository) =>
-        repository.provider === pr.provider && repository.repoPath === pr.repoPath,
-    )?.pushedHead
-      ? {
-          headSha: publication.repositories.find(
-            (repository) =>
-              repository.provider === pr.provider && repository.repoPath === pr.repoPath,
-          )!.pushedHead,
-        }
-      : {}),
-  }));
 }
 
 /** Append one durable answer round without duplicating a retry of the same answer. */

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -464,6 +464,7 @@ export function buildReviewAgentSuccessOutput(
         severity: finding.severity,
         ...(startLine === undefined ? {} : { startLine }),
         ...(endLine === undefined ? {} : { endLine }),
+        ...(typeof finding.repo === "string" ? { repo: finding.repo } : {}),
       };
     }),
     decision: review.issues.some(
@@ -851,6 +852,17 @@ function publicationPrsForTelemetry(
     repoPath: pr.repoPath,
     id: pr.id,
     url: pr.url,
+    ...(publication.repositories.find(
+      (repository) =>
+        repository.provider === pr.provider && repository.repoPath === pr.repoPath,
+    )?.pushedHead
+      ? {
+          headSha: publication.repositories.find(
+            (repository) =>
+              repository.provider === pr.provider && repository.repoPath === pr.repoPath,
+          )!.pushedHead,
+        }
+      : {}),
   }));
 }
 

--- a/apps/worker/src/workflows/blocks/complete-pr-check.test.ts
+++ b/apps/worker/src/workflows/blocks/complete-pr-check.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkflowDefinitionNode } from "@shared/contracts";
+
+const mocks = vi.hoisted(() => ({
+  completeRunOwnedPrCheck: vi.fn(),
+  prRunTarget: vi.fn(() => ({ kind: "target" })),
+}));
+
+vi.mock("../../db/client.js", () => ({ getDb: () => ({ kind: "db" }) }));
+vi.mock("../pr-external-resources.js", () => ({
+  completeRunOwnedPrCheck: mocks.completeRunOwnedPrCheck,
+  prRunTarget: mocks.prRunTarget,
+}));
+
+import { execute } from "./complete-pr-check.js";
+import { makeCtx } from "./test-support.js";
+
+describe("complete_pr_check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.completeRunOwnedPrCheck.mockResolvedValue(undefined);
+  });
+
+  it("refreshes the pull request head when the workflow fixed and pushed it", async () => {
+    const ctx = makeCtx({
+      entry: {
+        kind: "pr_trigger",
+        triggerType: "trigger_pr_updated",
+        subjectKey: "pr:github:acme/app#7",
+        ownerToken: "owner:test",
+        definitionId: 1,
+        definitionVersion: 1,
+        scope: "workflow_owned",
+        pr: {
+          provider: "github",
+          repoPath: "acme/app",
+          prNumber: 7,
+          prUrl: "https://github.test/acme/app/pull/7",
+          headRef: "feature",
+          headSha: "old-head",
+          baseRef: "main",
+          title: "Fix contract",
+          author: "workflow-bot",
+          isDraft: false,
+        },
+      },
+    });
+    const check = {
+      id: "check-1",
+      headSha: "old-head",
+      name: "AI Workflow / Review",
+    };
+
+    const result = await execute(
+      {
+        id: "complete",
+        type: "complete_pr_check",
+        x: 0,
+        y: 0,
+        params: {
+          conclusion: "success",
+          details: "Fixed.",
+          refreshHead: true,
+        },
+        inputs: {},
+      } as unknown as WorkflowDefinitionNode,
+      {},
+      ctx,
+      { check },
+    );
+
+    expect(result.kind).toBe("next");
+    expect(mocks.completeRunOwnedPrCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshHead: true }),
+    );
+  });
+});

--- a/apps/worker/src/workflows/blocks/complete-pr-check.ts
+++ b/apps/worker/src/workflows/blocks/complete-pr-check.ts
@@ -28,6 +28,7 @@ async function completePrCheckStep(
     reference: WorkflowPrCheckReference;
     conclusion: "success" | "failure" | "neutral";
     details: string;
+    refreshHead?: boolean;
   },
 ) {
   "use step";
@@ -43,6 +44,7 @@ async function completePrCheckStep(
     reference: args.reference,
     conclusion: args.conclusion,
     details: args.details,
+    refreshHead: args.refreshHead,
   });
 }
 completePrCheckStep.maxRetries = 0;
@@ -89,6 +91,7 @@ export const execute: BlockExecuteFn = async (
       : typeof block.params.details === "string"
         ? block.params.details
         : "";
+  const refreshHead = block.params.refreshHead === true;
   try {
     await completePrCheckStep({
       owner: {
@@ -100,6 +103,7 @@ export const execute: BlockExecuteFn = async (
       reference,
       conclusion,
       details,
+      refreshHead,
     });
     return {
       kind: "next",

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   createRepositoryVCS: vi.fn(),
@@ -60,6 +60,13 @@ const repoWithPr: WorkspaceRepositoryInput = {
     pr: { id: 7, url: "https://pr/7", branch: "blazebot/awt-1" },
   },
 };
+
+const originalAllowedRepos = process.env.AGENT_ALLOWED_REPOS;
+
+afterEach(() => {
+  if (originalAllowedRepos === undefined) delete process.env.AGENT_ALLOWED_REPOS;
+  else process.env.AGENT_ALLOWED_REPOS = originalAllowedRepos;
+});
 
 describe("fetch_pr_context paramsSchema", () => {
   it("accepts only empty params", () => {
@@ -275,5 +282,57 @@ describe("PR trigger multi-repo review selection", () => {
       },
     });
     expect(repositories[1]?.workflowOwnedBranch).toBeUndefined();
+  });
+
+  it("does not read a sibling repository outside the agent allowlist", async () => {
+    process.env.AGENT_ALLOWED_REPOS = "acme/web";
+    const pr = makePrPayload();
+    mocks.findRunPrSiblings.mockResolvedValue({
+      status: "siblings",
+      runId: "implementation-run",
+      current: {
+        provider: pr.provider,
+        repoPath: pr.repoPath,
+        id: pr.prNumber,
+        url: pr.prUrl,
+        headSha: pr.headSha,
+      },
+      siblings: [
+        {
+          provider: "gitlab",
+          repoPath: "acme/api-contract",
+          id: 13,
+          url: "https://gitlab.test/acme/api-contract/-/merge_requests/13",
+          headSha: "published-sha",
+        },
+      ],
+    });
+    mocks.listRepositories.mockResolvedValue([
+      {
+        provider: "gitlab",
+        repoPath: "acme/api-contract",
+        name: "api-contract",
+        owner: "acme",
+        defaultBranch: "main",
+        description: "",
+        webUrl: "https://gitlab.test/acme/api-contract",
+        topics: [],
+        archived: false,
+        private: true,
+      },
+    ]);
+
+    const repositories = await blockPrTriggerRepositoriesWithSiblingsStep(
+      "review-run",
+      pr,
+    );
+
+    expect(repositories).toHaveLength(1);
+    expect(repositories[0]?.repoPath).toBe(pr.repoPath);
+    expect(mocks.createRepositoryVCS).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ repoPath: "acme/api-contract" }),
+      "review_sibling_repository_not_allowed",
+    );
   });
 });

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
@@ -4,6 +4,9 @@ const mocks = vi.hoisted(() => ({
   createRepositoryVCS: vi.fn(),
   getDb: vi.fn(),
   listWorkflowOwnedBranchesForTicket: vi.fn(),
+  findRunPrSiblings: vi.fn(),
+  listRepositories: vi.fn(),
+  warn: vi.fn(),
 }));
 
 vi.mock("../../lib/vcs-runtime.js", () => ({
@@ -16,9 +19,36 @@ vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
   listWorkflowOwnedBranchesForTicket: mocks.listWorkflowOwnedBranchesForTicket,
 }));
 
+vi.mock("../../db/queries/run-pr-siblings.js", () => ({
+  findRunPrSiblings: mocks.findRunPrSiblings,
+}));
+
+vi.mock("../../adapters/vcs/repository-directory.js", () => ({
+  createRepositoryDirectoryForProviders: () => ({
+    listRepositories: mocks.listRepositories,
+  }),
+}));
+
+vi.mock("../../../env.js", () => ({
+  getConfiguredVcsProviders: () => [{ kind: "github" }, { kind: "gitlab" }],
+}));
+
+vi.mock("../../lib/logger.js", () => ({
+  logger: { warn: mocks.warn },
+}));
+
 import type { WorkspaceRepositoryInput } from "../../sandbox/repo-workspace.js";
-import { execute, paramsSchema } from "./fetch-pr-context.js";
-import { makeCtx, makeNode, makePrPayload, runControlErrorCases } from "./test-support.js";
+import {
+  blockPrTriggerRepositoriesWithSiblingsStep,
+  execute,
+  paramsSchema,
+} from "./fetch-pr-context.js";
+import {
+  makeCtx,
+  makeNode,
+  makePrPayload,
+  runControlErrorCases,
+} from "./test-support.js";
 
 const repoWithPr: WorkspaceRepositoryInput = {
   provider: "github",
@@ -153,7 +183,9 @@ describe("fetch_pr_context execute", () => {
   it("fails when no repositories are in scope", async () => {
     const result = await execute(makeNode("fetch_pr_context"), {}, makeCtx());
     expect(result.kind).toBe("execution_error");
-    if (result.kind === "execution_error") expect(result.error.detail).toContain("no repositories in scope");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("no repositories in scope");
+    }
   });
 
   it.each(runControlErrorCases())("rethrows %s from context loading", async (_label, error) => {
@@ -170,5 +202,78 @@ describe("fetch_pr_context execute", () => {
         makeCtx({ selectedRepositories: [repoWithPr] }),
       ),
     ).rejects.toBe(error);
+  });
+});
+
+describe("PR trigger multi-repo review selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDb.mockReturnValue({ db: true });
+  });
+
+  it("adds a sibling PR as read-only context at its current head", async () => {
+    const pr = makePrPayload();
+    mocks.findRunPrSiblings.mockResolvedValue({
+      status: "siblings",
+      runId: "implementation-run",
+      current: {
+        provider: pr.provider,
+        repoPath: pr.repoPath,
+        id: pr.prNumber,
+        url: pr.prUrl,
+        headSha: pr.headSha,
+      },
+      siblings: [
+        {
+          provider: "gitlab",
+          repoPath: "acme/api-contract",
+          id: 13,
+          url: "https://gitlab.test/acme/api-contract/-/merge_requests/13",
+          headSha: "published-sha",
+        },
+      ],
+    });
+    mocks.listRepositories.mockResolvedValue([
+      {
+        provider: "gitlab",
+        repoPath: "acme/api-contract",
+        name: "api-contract",
+        owner: "acme",
+        defaultBranch: "main",
+        description: "",
+        webUrl: "https://gitlab.test/acme/api-contract",
+        topics: [],
+        archived: false,
+        private: true,
+      },
+    ]);
+    mocks.createRepositoryVCS.mockReturnValue({
+      getPRHead: vi.fn().mockResolvedValue({
+        state: "open",
+        headRef: "feature/api-contract",
+        headSha: "current-sibling-sha",
+      }),
+    });
+
+    const repositories = await blockPrTriggerRepositoriesWithSiblingsStep(
+      "review-run",
+      pr,
+    );
+
+    expect(repositories).toHaveLength(2);
+    expect(repositories[0]).toMatchObject({
+      repoPath: pr.repoPath,
+      workflowOwnedBranch: { branchName: pr.headRef },
+    });
+    expect(repositories[1]).toMatchObject({
+      provider: "gitlab",
+      repoPath: "acme/api-contract",
+      reviewPullRequest: {
+        id: 13,
+        branch: "feature/api-contract",
+        headSha: "current-sibling-sha",
+      },
+    });
+    expect(repositories[1]?.workflowOwnedBranch).toBeUndefined();
   });
 });

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.ts
@@ -31,6 +31,100 @@ export async function blockPrTriggerRepositoriesStep(
   ];
 }
 
+/** Attach up to three PR siblings as read-only repositories. Optional provider
+ * failures degrade to the primary PR review. */
+export async function blockPrTriggerRepositoriesWithSiblingsStep(
+  runId: string,
+  pr: PrTriggerPayload,
+): Promise<SelectedRepository[]> {
+  "use step";
+  const primary = await blockPrTriggerRepositoriesStep(pr.prUrl, pr);
+  const { findRunPrSiblings } = await import("../../db/queries/run-pr-siblings.js");
+  const { createRepositoryDirectoryForProviders } = await import(
+    "../../adapters/vcs/repository-directory.js",
+  );
+  const { getConfiguredVcsProviders } = await import("../../../env.js");
+  const { createRepositoryVCS } = await import("../../lib/vcs-runtime.js");
+  const { getDb } = await import("../../db/client.js");
+  const { logger } = await import("../../lib/logger.js");
+
+  const lookup = await findRunPrSiblings({
+    db: getDb(),
+    provider: pr.provider,
+    repoPath: pr.repoPath,
+    prNumber: pr.prNumber,
+  });
+  if (lookup.status !== "siblings") return primary;
+
+  let catalog;
+  try {
+    catalog = await createRepositoryDirectoryForProviders(
+      getConfiguredVcsProviders(),
+    ).listRepositories();
+  } catch (error) {
+    logger.warn(
+      { runId, error: error instanceof Error ? error.message : String(error) },
+      "review_sibling_repository_listing_failed",
+    );
+    return primary;
+  }
+
+  const selectedSiblings: SelectedRepository[] = [];
+  for (const sibling of lookup.siblings.slice(0, 3)) {
+    const metadata = catalog.find(
+      (repository) =>
+        repository.provider === sibling.provider &&
+        repository.repoPath === sibling.repoPath,
+    );
+    if (!metadata || metadata.archived || !metadata.defaultBranch) {
+      logger.warn(
+        { runId, provider: sibling.provider, repoPath: sibling.repoPath },
+        "review_sibling_repository_skipped",
+      );
+      continue;
+    }
+    try {
+      const head = await createRepositoryVCS({
+        provider: sibling.provider,
+        repoPath: sibling.repoPath,
+        baseBranch: metadata.defaultBranch,
+      }).getPRHead(sibling.id);
+      const branch = head.state === "open" && head.headRef
+        ? head.headRef
+        : metadata.defaultBranch;
+      selectedSiblings.push({
+        provider: sibling.provider,
+        repoPath: sibling.repoPath,
+        defaultBranch: metadata.defaultBranch,
+        selectedRationale: "read-only sibling PR from the same workflow run",
+        reviewPullRequest: {
+          id: sibling.id,
+          url: sibling.url,
+          branch,
+          headSha: head.headSha,
+        },
+      });
+    } catch (error) {
+      logger.warn(
+        {
+          runId,
+          provider: sibling.provider,
+          repoPath: sibling.repoPath,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "review_sibling_repository_unavailable",
+      );
+    }
+  }
+  if (lookup.siblings.length > 3) {
+    logger.warn(
+      { runId, omitted: lookup.siblings.length - 3 },
+      "review_sibling_repository_limit_reached",
+    );
+  }
+  return [...primary, ...selectedSiblings];
+}
+
 /**
  * Fetch PR comments, check results, and conflict status for every repository
  * with a workflow-owned PR. Mirrors agent.ts's fetchSelectedRepositoryPRContexts.
@@ -48,7 +142,7 @@ export async function blockFetchPrContextsStep(
       if (!isRepoAllowedForScope(repo, repositoryScope)) {
         throw new Error(`Refusing to read PR context for ${repo.repoPath}: not in AGENT_ALLOWED_REPOS`);
       }
-      const pr = repo.workflowOwnedBranch?.pr;
+      const pr = repo.workflowOwnedBranch?.pr ?? repo.reviewPullRequest;
       if (!pr) {
         return {
           repository: repo,
@@ -114,7 +208,10 @@ export const execute: BlockExecuteFn = async (_block, _steps, ctx): Promise<Bloc
   try {
     let repositories: SelectedRepository[] = ctx.selectedRepositories;
     if (repositories.length === 0 && ctx.entry.kind === "pr_trigger") {
-      repositories = await blockPrTriggerRepositoriesStep(ctx.ticket.identifier, ctx.entry.pr);
+      repositories = await blockPrTriggerRepositoriesStep(
+        ctx.ticket.identifier,
+        ctx.entry.pr,
+      );
     }
     if (repositories.length === 0) {
       return executionError(

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.ts
@@ -47,6 +47,7 @@ export async function blockPrTriggerRepositoriesWithSiblingsStep(
   const { createRepositoryVCS } = await import("../../lib/vcs-runtime.js");
   const { getDb } = await import("../../db/client.js");
   const { logger } = await import("../../lib/logger.js");
+  const { isRepoAllowed } = await import("../../lib/repo-allowlist.js");
 
   const lookup = await findRunPrSiblings({
     db: getDb(),
@@ -71,6 +72,13 @@ export async function blockPrTriggerRepositoriesWithSiblingsStep(
 
   const selectedSiblings: SelectedRepository[] = [];
   for (const sibling of lookup.siblings.slice(0, 3)) {
+    if (!isRepoAllowed(sibling.repoPath)) {
+      logger.warn(
+        { runId, provider: sibling.provider, repoPath: sibling.repoPath },
+        "review_sibling_repository_not_allowed",
+      );
+      continue;
+    }
     const metadata = catalog.find(
       (repository) =>
         repository.provider === sibling.provider &&

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -19,6 +19,9 @@ const mocks = vi.hoisted(() => ({
   prepareHarnessAgentInvocation: vi.fn(),
   pollPhaseUntilDone: vi.fn().mockResolvedValue(true),
   findRunPrSiblings: vi.fn(),
+  publishTrustedWorkspaceFromSandbox: vi.fn(),
+  findWorkflowOwnedPullRequestIdentity: vi.fn(),
+  upsertWorkflowOwnedBranch: vi.fn(),
 }));
 
 vi.mock("workflow", async (importOriginal) => ({
@@ -70,6 +73,16 @@ vi.mock("./fix-workspace-state.js", async (importOriginal) => ({
 vi.mock("../../db/client.js", () => ({ getDb: () => ({}) }));
 vi.mock("../../db/queries/run-pr-siblings.js", () => ({
   findRunPrSiblings: mocks.findRunPrSiblings,
+}));
+vi.mock("../../sandbox/trusted-workspace-publisher.js", () => ({
+  publishTrustedWorkspaceFromSandbox: (...args: any[]) =>
+    mocks.publishTrustedWorkspaceFromSandbox(...args),
+}));
+vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
+  findWorkflowOwnedPullRequestIdentity: (...args: any[]) =>
+    mocks.findWorkflowOwnedPullRequestIdentity(...args),
+  upsertWorkflowOwnedBranch: (...args: any[]) =>
+    mocks.upsertWorkflowOwnedBranch(...args),
 }));
 
 import { execute, paramsSchema } from "./fix-agent.js";
@@ -165,6 +178,12 @@ describe("fix_agent execute", () => {
         : { cmdId: "cmd-2", exitCode: null },
     );
     mocks.pollPhaseUntilDone.mockResolvedValue(true);
+    mocks.publishTrustedWorkspaceFromSandbox.mockResolvedValue({
+      pushed: true,
+      repositories: [],
+    });
+    mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValue(undefined);
+    mocks.upsertWorkflowOwnedBranch.mockResolvedValue(undefined);
   });
 
   it("implicitly ensures a workspace when none is attached", async () => {
@@ -649,6 +668,73 @@ describe("fix_agent execute", () => {
         "Merge conflicts remain in github:acme/api (src/conflict.ts). How should they be resolved before publication?",
       ],
     });
+    expect(mocks.publishTrustedWorkspaceFromSandbox).not.toHaveBeenCalled();
+  });
+
+  it("fails the block when any repository publication reports a failure", async () => {
+    mocks.parseAgentOutput.mockReturnValue({ result: "implemented", summary: "patched" });
+    mocks.findRunPrSiblings.mockResolvedValueOnce({
+      status: "none",
+      runId: "published-run",
+      current: {
+        provider: "github",
+        repoPath: "acme/api",
+        id: 7,
+        url: "https://github.com/acme/api/pull/7",
+      },
+    });
+    mocks.publishTrustedWorkspaceFromSandbox.mockResolvedValueOnce({
+      pushed: false,
+      repositories: [
+        {
+          provider: "github",
+          repoPath: "acme/api",
+          branchName: "blazebot/awt-1",
+          defaultBranch: "main",
+          changed: true,
+          pushed: false,
+          failureKind: "push_failed",
+          error: "lease rejected",
+        },
+      ],
+    });
+    const pr = makePrPayload();
+    const ctx = makeCtx({
+      entry: {
+        kind: "pr_trigger",
+        triggerType: "trigger_pr_updated",
+        subjectKey: "ticket:jira:AWT-1",
+        ticketKey: "AWT-1",
+        ownerToken: "owner:test",
+        definitionId: 1,
+        definitionVersion: 1,
+        scope: "workflow_owned",
+        pr,
+      },
+      workspaceManifest: {
+        version: 2,
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/api",
+            slug: "acme__api",
+            localPath: "/vercel/sandbox",
+            defaultBranch: "main",
+            branchName: pr.headRef,
+            selectedRationale: "PR fix",
+            access: "write",
+          },
+        ],
+      },
+    });
+
+    const result = await execute(makeNode("fix_agent"), {}, ctx);
+
+    expect(result.kind).toBe("execution_error");
+    if (result.kind === "execution_error") {
+      expect(result.error.detail).toContain("lease rejected");
+    }
+    expect(mocks.upsertWorkflowOwnedBranch).not.toHaveBeenCalled();
   });
 
   it("maps a failed agent result to an execution error without output", async () => {

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   inspectFixWorkspace: vi.fn(),
   prepareHarnessAgentInvocation: vi.fn(),
   pollPhaseUntilDone: vi.fn().mockResolvedValue(true),
+  findRunPrSiblings: vi.fn(),
 }));
 
 vi.mock("workflow", async (importOriginal) => ({
@@ -66,6 +67,10 @@ vi.mock("./fix-workspace-state.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./fix-workspace-state.js")>()),
   inspectFixWorkspace: mocks.inspectFixWorkspace,
 }));
+vi.mock("../../db/client.js", () => ({ getDb: () => ({}) }));
+vi.mock("../../db/queries/run-pr-siblings.js", () => ({
+  findRunPrSiblings: mocks.findRunPrSiblings,
+}));
 
 import { execute, paramsSchema } from "./fix-agent.js";
 import {
@@ -113,6 +118,11 @@ describe("fix_agent paramsSchema", () => {
 describe("fix_agent execute", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.findRunPrSiblings.mockResolvedValue({
+      status: "none",
+      runId: "published-run",
+      current: { provider: "github", repoPath: "acme/api", id: 42, url: "https://github/pr/42" },
+    });
     mocks.assembleFixContext.mockReturnValue("FIX INPUT");
     mocks.artifactPaths.mockImplementation((phase: string) => pathsFor(phase));
     mocks.buildPhaseScript.mockReturnValue("#!/bin/bash");
@@ -329,6 +339,32 @@ describe("fix_agent execute", () => {
       { name: "ci", status: "completed", conclusion: "failure", logs: "Details: https://ci" },
     ]);
     expect(input.prComments).toEqual([{ author: "bob", body: "rename this", liked: false }]);
+  });
+
+  it("refuses a v2 fix when the PR ownership lookup is unknown", async () => {
+    mocks.findRunPrSiblings.mockResolvedValue({ status: "unknown", reason: "database unavailable" });
+    const ctx = makeCtx({
+      schemaVersion: 2,
+      entry: {
+        kind: "pr_trigger",
+        triggerType: "trigger_pr_updated",
+        subjectKey: "pr:github:acme/api#42",
+        ownerToken: "owner:test",
+        definitionId: 1,
+        definitionVersion: 1,
+        scope: "any",
+        pr: makePrPayload({ prNumber: 42, repoPath: "acme/api" }),
+      },
+    });
+
+    const result = await execute(makeNode("fix_agent"), {}, ctx);
+
+    expect(result).toMatchObject({
+      kind: "execution_error",
+      error: { category: "provider" },
+    });
+    expect(JSON.stringify(result)).toContain("ownership is unknown");
+    expect(mocks.ensureWorkspace).not.toHaveBeenCalled();
   });
 
   it("prefers explicitly bound review feedback and avoids provider-comment duplicates", async () => {

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -110,6 +110,14 @@ async function publishPrFixStep(input: {
     repositoryScope: input.ctx.repositoryScope,
   });
   if (result.error) throw new Error(`Fix push failed: ${result.error}`);
+  const failedRepository = result.repositories.find(
+    (repository) => repository.failureKind !== undefined,
+  );
+  if (failedRepository) {
+    throw new Error(
+      `Fix push failed for ${failedRepository.provider}:${failedRepository.repoPath}: ${failedRepository.error ?? failedRepository.failureKind}.`,
+    );
+  }
 
   const { getDb } = await import("../../db/client.js");
   const {
@@ -117,6 +125,12 @@ async function publishPrFixStep(input: {
     upsertWorkflowOwnedBranch,
   } = await import("../../db/queries/workflow-owned-branches.js");
   for (const repository of result.repositories) {
+    if (
+      repository.provider !== input.ctx.entry.pr.provider ||
+      repository.repoPath !== input.ctx.entry.pr.repoPath
+    ) {
+      continue;
+    }
     if (!repository.pushed || !repository.pushedHead) continue;
     const owned = await findWorkflowOwnedPullRequestIdentity(getDb(), {
       provider: repository.provider,
@@ -557,9 +571,6 @@ export const execute: BlockExecuteFn = async (
     if (output.result === "failed") {
       return executionError(output.error ?? "unknown", { category: "provider" });
     }
-    if (output.result === "implemented") {
-      await publishPrFixStep({ ctx, sandboxId });
-    }
     if (after.unresolvedConflicts.length > 0) {
       const questions = [formatUnresolvedConflictQuestion(after)];
       return {
@@ -571,6 +582,9 @@ export const execute: BlockExecuteFn = async (
         },
         questions,
       };
+    }
+    if (output.result === "implemented") {
+      await publishPrFixStep({ ctx, sandboxId });
     }
     return {
       kind: "next",

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -9,6 +9,7 @@ import type {
   PhaseUsage,
 } from "../../sandbox/agents/types.js";
 import type { CheckRunResult, PRComment } from "../../adapters/vcs/types.js";
+import type { PrTriggerPayload } from "../agent-input.js";
 import { resolveBlockAgent } from "../../workflow-definition/resolve-agent.js";
 import type { ResolvedHarnessRuntime } from "../../sandbox/harness-runtime.js";
 import { isRunControlError } from "../run-control-error.js";
@@ -61,6 +62,79 @@ export const paramsSchema = z
 
 const DEFAULT_MAX_MINUTES = 25;
 const usageLabel = (blockId: string) => `Fix ${blockId}`;
+
+async function assertFixPrOwnershipStep(pr: PrTriggerPayload, runId: string): Promise<void> {
+  "use step";
+  const { getDb } = await import("../../db/client.js");
+  const { findRunPrSiblings } = await import("../../db/queries/run-pr-siblings.js");
+  const lookup = await findRunPrSiblings({
+    db: getDb(),
+    provider: pr.provider,
+    repoPath: pr.repoPath,
+    prNumber: pr.prNumber,
+  });
+  if (lookup.status === "unknown") {
+    throw new Error(
+      `Refusing to push a fix for ${pr.provider}:${pr.repoPath}#${pr.prNumber}: workflow PR ownership is unknown (${lookup.reason}).`,
+    );
+  }
+  if (
+    lookup.current.provider !== pr.provider ||
+    lookup.current.repoPath !== pr.repoPath ||
+    lookup.current.id !== pr.prNumber
+  ) {
+    throw new Error(
+      `Refusing to push a fix for ${pr.provider}:${pr.repoPath}#${pr.prNumber}: the PR is not present in a workflow publication.`,
+    );
+  }
+  void runId;
+}
+
+async function publishPrFixStep(input: {
+  ctx: Parameters<BlockExecuteFn>[2];
+  sandboxId: string;
+}): Promise<void> {
+  "use step";
+  if (input.ctx.workspaceManifest?.version !== 2 || input.ctx.entry.kind !== "pr_trigger") {
+    return;
+  }
+  const { publishTrustedWorkspaceFromSandbox } = await import(
+    "../../sandbox/trusted-workspace-publisher.js",
+  );
+  const result = await publishTrustedWorkspaceFromSandbox({
+    sourceSandboxId: input.sandboxId,
+    workspaceManifest: input.ctx.workspaceManifest,
+    subjectKey: input.ctx.entry.subjectKey,
+    ownerToken: input.ctx.entry.ownerToken,
+    runId: input.ctx.runId,
+    repositoryScope: input.ctx.repositoryScope,
+  });
+  if (result.error) throw new Error(`Fix push failed: ${result.error}`);
+
+  const { getDb } = await import("../../db/client.js");
+  const {
+    findWorkflowOwnedPullRequestIdentity,
+    upsertWorkflowOwnedBranch,
+  } = await import("../../db/queries/workflow-owned-branches.js");
+  for (const repository of result.repositories) {
+    if (!repository.pushed || !repository.pushedHead) continue;
+    const owned = await findWorkflowOwnedPullRequestIdentity(getDb(), {
+      provider: repository.provider,
+      repoPath: repository.repoPath,
+      prNumber: input.ctx.entry.pr.prNumber,
+    });
+    if (!owned?.pr) continue;
+    await upsertWorkflowOwnedBranch(getDb(), {
+      ticketKey: owned.ticketKey,
+      provider: repository.provider,
+      repoPath: repository.repoPath,
+      branchName: repository.branchName,
+      publishedHeadSha: repository.pushedHead,
+      targetBranch: repository.defaultBranch,
+      pr: owned.pr,
+    });
+  }
+}
 
 async function blockFixAgentCommitGuardStep(
   sandboxId: string,
@@ -282,6 +356,17 @@ export const execute: BlockExecuteFn = async (
   resolvedInputs = {},
   execution,
 ): Promise<BlockExecutionResult> => {
+  if (ctx.schemaVersion === 2 && ctx.entry.kind === "pr_trigger") {
+    try {
+      await assertFixPrOwnershipStep(ctx.entry.pr, ctx.runId);
+    } catch (error) {
+      if (isRunControlError(error)) throw error;
+      return executionError(error instanceof Error ? error.message : String(error), {
+        category: "provider",
+        phase: "fix-pr-ownership",
+      });
+    }
+  }
   const workspace = await ensureWorkspace(ctx, execution);
   if (workspace.kind !== "next") return workspace;
   // A fix block on a ticket graph without a planning node runs on an all-read
@@ -323,6 +408,13 @@ export const execute: BlockExecuteFn = async (
     }
     const reviewResults = normalizeReviewResultsInput(
       resolvedInputs.reviewResults,
+      ctx.schemaVersion === 2
+        ? {
+            knownRepositories: ctx.selectedRepositories.map(
+              (repository) => repository.repoPath,
+            ),
+          }
+        : {},
     );
     if (!reviewResults.ok) {
       return executionError("invalid reviewResults binding", {
@@ -464,6 +556,9 @@ export const execute: BlockExecuteFn = async (
     }
     if (output.result === "failed") {
       return executionError(output.error ?? "unknown", { category: "provider" });
+    }
+    if (output.result === "implemented") {
+      await publishPrFixStep({ ctx, sandboxId });
     }
     if (after.unresolvedConflicts.length > 0) {
       const questions = [formatUnresolvedConflictQuestion(after)];

--- a/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
@@ -45,6 +45,7 @@ vi.mock("../../pre-sandbox/runner.js", () => ({
 vi.mock("./fetch-pr-context.js", () => ({
   blockFetchPrContextsStep: mocks.blockFetchPrContextsStep,
   blockPrTriggerRepositoriesStep: mocks.blockPrTriggerRepositoriesStep,
+  blockPrTriggerRepositoriesWithSiblingsStep: mocks.blockPrTriggerRepositoriesStep,
 }));
 vi.mock("../repository-promotion.js", () => ({
   promoteRepositoryWriteScopeStep: mocks.promoteRepositoryWriteScopeStep,
@@ -904,7 +905,7 @@ describe("prepare_workspace execute", () => {
 
     const result = await execute(makeNode("prepare_workspace"), {}, ctx);
 
-    expect(mocks.blockPrTriggerRepositoriesStep).toHaveBeenCalledWith("AWT-1", pr);
+    expect(mocks.blockPrTriggerRepositoriesStep).toHaveBeenCalledWith("run-1", pr);
     expect(mocks.runPreSandboxPhase).not.toHaveBeenCalled();
     expect(result.kind).toBe("next");
   });
@@ -1439,7 +1440,7 @@ describe("prepare_workspace execute", () => {
     const result = await execute(makeNode("prepare_workspace"), {}, ctx);
 
     expect(mocks.blockPrTriggerRepositoriesStep).toHaveBeenCalledWith(
-      "pr:github:acme/api#42",
+      "run-1",
       pr,
     );
     expect(result.kind).toBe("next");

--- a/apps/worker/src/workflows/blocks/prepare-workspace.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.ts
@@ -18,7 +18,10 @@ import { captureDefaultBranchFilesStep } from "../repo-memory-steps.js";
 import { seedRepoMemoryStep } from "../repo-seed-steps.js";
 import { invalidateWorkspaceGate } from "../workspace-gate.js";
 import { emitRepositoryWorkflowObservation } from "../../run-observability/agent-observations.js";
-import { blockFetchPrContextsStep, blockPrTriggerRepositoriesStep } from "./fetch-pr-context.js";
+import {
+  blockFetchPrContextsStep,
+  blockPrTriggerRepositoriesWithSiblingsStep,
+} from "./fetch-pr-context.js";
 import {
   agentProtocolExecutionError,
   executionError,
@@ -645,8 +648,8 @@ export async function ensureWorkspace(
         ]),
       );
     } else if (ctx.entry.kind === "pr_trigger") {
-      selected = await blockPrTriggerRepositoriesStep(
-        ctx.entry.ticketKey ?? ctx.entry.subjectKey,
+      selected = await blockPrTriggerRepositoriesWithSiblingsStep(
+        ctx.runId,
         ctx.entry.pr,
       );
     } else {

--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -15,6 +15,7 @@ import {
   createRunOwnedPrCheck,
   partitionReviewFindings,
   publishRunOwnedPrReview,
+  reviewSummary,
   reconcilePendingPrChecks,
   reviewCommentContentHash,
   reviewFindingBlocksPublication,
@@ -42,6 +43,43 @@ function gateStatusVcs() {
 }
 
 describe("PR review diff placement", () => {
+  it("keeps a sibling finding out of inline placement and out of the verdict", () => {
+    const result: ReviewResult = {
+      decision: "request_changes",
+      findings: [
+        {
+          repo: "acme/api",
+          file: "src/index.ts",
+          description: "The API contract does not match the caller.",
+          severity: "Blocker",
+          startLine: 2,
+          endLine: 2,
+        },
+      ],
+    };
+    const siblings = new Map([
+      ["acme/api", { url: "https://github.com/acme/api/pull/13", headSha: "api-sha" }],
+    ]);
+    const partition = partitionReviewFindings(
+      [result],
+      [{ path: "src/index.ts", additions: 1, deletions: 0, changeType: "modified", patch: "@@ -1 +1 @@\n+same" }],
+      { currentRepository: "acme/web", siblingRepositories: siblings },
+    );
+
+    expect(partition.comments).toEqual([]);
+    expect(partition.fallback[0]).toMatchObject({
+      repo: "acme/api",
+      crossRepository: true,
+    });
+    expect(reviewFindingBlocksPublication(partition.merged[0]!, 1)).toBe(false);
+    expect(
+      reviewSummary([result], partition.fallback, [], {
+        reportedCount: 1,
+        distinctCount: 1,
+      }, siblings),
+    ).toContain("[acme/api @ api-sha](https://github.com/acme/api/pull/13)");
+  });
+
   it("places only complete safe ranges inline and falls back otherwise", () => {
     const results: ReviewResult[] = [
       {
@@ -1042,6 +1080,74 @@ describe("PR check verdicts", () => {
       );
     },
   );
+
+  it("rebinds the check to the latest head after a fix push", async () => {
+    mockUpdateGateStatus.mockReset().mockResolvedValue(undefined);
+    mockAssertActiveRunOwner.mockReset().mockResolvedValue(undefined);
+    const createGateStatus = vi.fn().mockResolvedValue({ provider: "github", id: 99 });
+    mockCreateRepositoryVCS.mockReset().mockReturnValue({
+      ...gateStatusVcs(),
+      createGateStatus,
+      getPRHead: vi.fn().mockResolvedValue({ headSha: "fixed-head", state: "open", baseRef: "main" }),
+    });
+    const db = await createTestDb();
+    await db.insert(workflowRuns).values({ runId: "verdict-refresh" });
+    await db.insert(workflowRunExternalChecks).values({
+      id: "refresh-check",
+      runId: "verdict-refresh",
+      nodeId: "create-check",
+      attempt: 1,
+      activationScope: "root",
+      subjectKey: "pr:github:acme/app#7",
+      provider: "github",
+      repository: "acme/app",
+      prNumber: 7,
+      headSha: "trigger-head",
+      name: "AI Workflow / Review",
+      providerReference: { provider: "github", id: 12 },
+      state: "pending",
+    });
+
+    await completeRunOwnedPrCheck({
+      db,
+      owner: {
+        subjectKey: "pr:github:acme/app#7",
+        ownerToken: "owner-1",
+        runId: "verdict-refresh",
+      },
+      target: {
+        subjectKey: "pr:github:acme/app#7",
+        provider: "github",
+        repoPath: "acme/app",
+        prNumber: 7,
+        headSha: "trigger-head",
+        baseRef: "main",
+      },
+      reference: {
+        id: "refresh-check",
+        headSha: "trigger-head",
+        name: "AI Workflow / Review",
+      },
+      conclusion: "success",
+      details: "fixed",
+      refreshHead: true,
+    });
+
+    expect(createGateStatus).toHaveBeenCalledWith(
+      "AI Workflow / Review",
+      "fixed-head",
+      "refresh-check",
+    );
+    expect(mockUpdateGateStatus).toHaveBeenCalledWith(
+      { provider: "github", id: 99 },
+      expect.objectContaining({ conclusion: "success" }),
+    );
+    const [row] = await db
+      .select()
+      .from(workflowRunExternalChecks)
+      .where(eq(workflowRunExternalChecks.id, "refresh-check"));
+    expect(row.headSha).toBe("fixed-head");
+  });
 });
 
 describe("PR review publication scrub", () => {

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -33,6 +33,8 @@ import {
 } from "./review-finding-merge.js";
 import { scrubForPublication } from "../lib/publication-scrub.js";
 import type { PrTriggerPayload } from "./agent-input.js";
+import { findRunPrSiblings } from "../db/queries/run-pr-siblings.js";
+import { logger } from "../lib/logger.js";
 
 export type CheckBusinessConclusion = "success" | "failure" | "neutral";
 export type CheckTerminalIntent =
@@ -187,24 +189,68 @@ export async function completeRunOwnedPrCheck(args: {
   reference: WorkflowPrCheckReference;
   conclusion: CheckBusinessConclusion;
   details: string;
+  refreshHead?: boolean;
 }): Promise<void> {
-  const [check] = await args.db
+  const [storedCheck] = await args.db
     .select()
     .from(workflowRunExternalChecks)
     .where(eq(workflowRunExternalChecks.id, args.reference.id))
     .limit(1);
+  if (!storedCheck || storedCheck.runId !== args.owner.runId || storedCheck.name !== args.reference.name) {
+    throw new Error(
+      "The PR check does not belong to this workflow run and pull request head.",
+    );
+  }
+  if (storedCheck.state === "completed") return;
+  let check = storedCheck;
+  let target = args.target;
+  const { createRepositoryVCS } = await import("../lib/vcs-runtime.js");
+  const vcs = createRepositoryVCS({
+    provider: args.target.provider,
+    repoPath: args.target.repoPath,
+    baseBranch: args.target.baseRef,
+  });
+  if (args.refreshHead) {
+    await assertActiveRunOwner(args.db, args.owner);
+    const latest = await vcs.getPRHead(args.target.prNumber);
+    if (latest.state !== "open") {
+      throw new Error("The pull request is no longer open.");
+    }
+    target = { ...args.target, headSha: latest.headSha };
+    if (latest.headSha !== check.headSha) {
+      if (!hasGateStatusCapability(vcs)) {
+        throw new Error(`${args.target.provider} does not support workflow PR checks.`);
+      }
+      const providerReference = await vcs.createGateStatus(
+        check.name,
+        latest.headSha,
+        check.id,
+      );
+      await args.db
+        .update(workflowRunExternalChecks)
+        .set({
+          headSha: latest.headSha,
+          providerReference,
+          state: "pending",
+          updatedAt: new Date(),
+        })
+        .where(eq(workflowRunExternalChecks.id, check.id));
+      check = {
+        ...check,
+        headSha: latest.headSha,
+        providerReference,
+        state: "pending",
+      };
+    }
+  }
   if (
-    !check ||
-    check.runId !== args.owner.runId ||
-    check.headSha !== args.target.headSha ||
-    check.headSha !== args.reference.headSha ||
-    check.name !== args.reference.name
+    check.headSha !== target.headSha ||
+    (!args.refreshHead && check.headSha !== args.reference.headSha)
   ) {
     throw new Error(
       "The PR check does not belong to this workflow run and pull request head.",
     );
   }
-  if (check.state === "completed") return;
   if (!check.providerReference) {
     throw new Error("The PR check provider reference is unavailable.");
   }
@@ -217,18 +263,12 @@ export async function completeRunOwnedPrCheck(args: {
       updatedAt: new Date(),
     })
     .where(eq(workflowRunExternalChecks.id, check.id));
-  const { createRepositoryVCS } = await import("../lib/vcs-runtime.js");
-  const vcs = createRepositoryVCS({
-    provider: args.target.provider,
-    repoPath: args.target.repoPath,
-    baseBranch: args.target.baseRef,
-  });
   if (!hasGateStatusCapability(vcs)) {
     throw new Error(`${args.target.provider} does not support workflow PR checks.`);
   }
   const current = await vcs.getPRHead(args.target.prNumber);
   if (
-    current.headSha !== args.target.headSha ||
+    current.headSha !== target.headSha ||
     current.state !== "open"
   ) {
     await vcs.updateGateStatus(
@@ -555,7 +595,14 @@ function changedNewSidePositions(
 export function partitionReviewFindings(
   results: ReviewResult[],
   files: PRFile[],
-  options: { maxComments?: number } = {},
+  options: {
+    maxComments?: number;
+    currentRepository?: string;
+    siblingRepositories?: ReadonlyMap<
+      string,
+      { url: string; headSha?: string }
+    >;
+  } = {},
 ): {
   comments: PRReviewInlineComment[];
   /** Every defect, whether or not it won an inline slot. The published verdict
@@ -578,6 +625,10 @@ export function partitionReviewFindings(
   const candidates: ReviewFindingCandidate[] = [];
   for (const [reviewerIndex, result] of results.entries()) {
     for (const [findingIndex, finding] of result.findings.entries()) {
+      const crossRepository =
+        typeof finding.repo === "string" &&
+        finding.repo.length > 0 &&
+        finding.repo !== options.currentRepository;
       const path = normalizedPath(finding.file, fileLines);
       const start = finding.startLine;
       const end = finding.endLine ?? start;
@@ -598,8 +649,10 @@ export function partitionReviewFindings(
         finding,
         // The normalized path groups `a/x.ts` with `x.ts`; the raw file is the
         // fallback so an unresolvable path still only ever matches itself.
-        groupKey: path ?? finding.file.trim(),
-        anchor: locatable
+        groupKey: `${finding.repo ?? options.currentRepository ?? ""}:${path ?? finding.file.trim()}`,
+        anchor: crossRepository
+          ? null
+          : locatable
           ? {
               path,
               startLine: start,
@@ -608,6 +661,7 @@ export function partitionReviewFindings(
               endOldLine: changed.get(end) ?? null,
             }
           : null,
+        ...(crossRepository ? { crossRepository: true } : {}),
       });
     }
   }
@@ -667,6 +721,7 @@ export function reviewFindingBlocksPublication(
   finding: MergedReviewFinding,
   reviewerCount: number,
 ): boolean {
+  if (finding.crossRepository) return false;
   if (finding.severity === "Blocker") return true;
   if (finding.severity !== "High") return false;
   return finding.sources.length >= highFindingBlockingAgreement(reviewerCount);
@@ -725,11 +780,18 @@ function rangeContainsOnlyChangedSideLines(
 function reviewSummaryLine(
   finding: MergedReviewFinding,
   reviewerCount: number,
+  siblingRepositories?: ReadonlyMap<string, { url: string; headSha?: string }>,
 ): string {
   const location = finding.startLine
     ? `${finding.file}:${finding.startLine}${finding.endLine && finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}`
     : finding.file;
-  const head = `- **${finding.severity}** \`${location}\`: ${finding.description}`;
+  const sibling = finding.crossRepository && finding.repo
+    ? siblingRepositories?.get(finding.repo)
+    : undefined;
+  const attribution = finding.crossRepository && finding.repo
+    ? ` [${finding.repo}${sibling?.headSha ? ` @ ${sibling.headSha}` : ""}]${sibling?.url ? `(${sibling.url})` : ""}`
+    : "";
+  const head = `- **${finding.severity}**${attribution} \`${location}\`: ${finding.description}`;
   const note = mergedReviewFindingNote(
     finding,
     reviewerCount,
@@ -754,7 +816,7 @@ function reviewFeedbackBullet(feedback: string): string {
   return [`- ${first}`, ...continuation].join("\n");
 }
 
-function reviewSummary(
+export function reviewSummary(
   results: ReviewResult[],
   fallback: MergedReviewFinding[],
   withheld: MergedReviewFinding[] = [],
@@ -762,6 +824,7 @@ function reviewSummary(
     reportedCount: 0,
     distinctCount: 0,
   },
+  siblingRepositories: ReadonlyMap<string, { url: string; headSha?: string }> = new Map(),
 ): string {
   const feedback = results
     .map((result) => result.feedback?.trim())
@@ -779,7 +842,7 @@ function reviewSummary(
   if (fallback.length > 0) {
     lines.push("", "### Findings not placed inline");
     for (const finding of fallback) {
-      lines.push(reviewSummaryLine(finding, results.length));
+      lines.push(reviewSummaryLine(finding, results.length, siblingRepositories));
     }
   }
   if (withheld.length > 0) {
@@ -788,7 +851,15 @@ function reviewSummary(
     const noun = withheld.length === 1 ? "finding" : "findings";
     lines.push("", `### ${withheld.length} further ${noun} not shown inline`);
     for (const finding of withheld) {
-      lines.push(reviewSummaryLine(finding, results.length));
+      lines.push(reviewSummaryLine(finding, results.length, siblingRepositories));
+    }
+  }
+  if (siblingRepositories.size > 0) {
+    lines.push("", "### Related pull requests");
+    for (const [repo, sibling] of siblingRepositories) {
+      lines.push(
+        `- [${repo}](${sibling.url})${sibling.headSha ? ` @ \`${sibling.headSha}\`` : ""}`,
+      );
     }
   }
   if (results.every((result) => result.findings.length === 0) && feedback.length === 0) {
@@ -877,6 +948,21 @@ export async function publishRunOwnedPrReview(args: {
     throw new Error("The pull request changed before the review could be published.");
   }
   const files = await vcs.listPRFiles(args.target.prNumber);
+  const siblingLookup = await findRunPrSiblings({
+    db: args.db,
+    provider: args.target.provider,
+    repoPath: args.target.repoPath,
+    prNumber: args.target.prNumber,
+  });
+  const siblingRepositories = new Map<string, { url: string; headSha?: string }>();
+  if (siblingLookup.status === "siblings") {
+    for (const sibling of siblingLookup.siblings) {
+      siblingRepositories.set(sibling.repoPath, {
+        url: sibling.url,
+        ...(sibling.headSha ? { headSha: sibling.headSha } : {}),
+      });
+    }
+  }
   const {
     comments: placedComments,
     merged,
@@ -884,7 +970,23 @@ export async function publishRunOwnedPrReview(args: {
     withheld,
     reportedCount,
     distinctCount,
-  } = partitionReviewFindings(args.reviewResults, files);
+  } = partitionReviewFindings(args.reviewResults, files, {
+    currentRepository: args.target.repoPath,
+    siblingRepositories,
+  });
+  const crossRepositoryFindingCount = merged.filter(
+    (finding) => finding.crossRepository,
+  ).length;
+  logger.info(
+    {
+      runId: args.owner.runId,
+      pr: `${args.target.provider}:${args.target.repoPath}#${args.target.prNumber}`,
+      siblingLookup: siblingLookup.status,
+      siblingRepositories: siblingRepositories.size,
+      crossRepositoryFindingCount,
+    },
+    "post_pr_review_context",
+  );
   // Review feedback and finding descriptions are agent-authored prose. Scrubbing
   // the summary here rather than at the publish call also covers the value
   // returned to the workflow, which complete_pr_check binds into the check run
@@ -898,7 +1000,7 @@ export async function publishRunOwnedPrReview(args: {
     reviewSummary(args.reviewResults, fallback, withheld, {
       reportedCount,
       distinctCount,
-    }),
+    }, siblingRepositories),
   );
   const normalized = {
     provider: args.target.provider,

--- a/apps/worker/src/workflows/publication-prs-for-telemetry.ts
+++ b/apps/worker/src/workflows/publication-prs-for-telemetry.ts
@@ -1,0 +1,22 @@
+import type { RunPullRequest } from "@shared/contracts";
+import type { WorkspacePublicationResult } from "./workspace-publication.js";
+
+/** Project a workspace publication into the exact durable workflow_runs.prs shape. */
+export function publicationPrsForTelemetry(
+  publication: WorkspacePublicationResult | null | undefined,
+): RunPullRequest[] | null {
+  if (publication?.status !== "published" || publication.prs.length === 0) return null;
+  return publication.prs.map((pr) => {
+    const repository = publication.repositories.find(
+      (candidate) =>
+        candidate.provider === pr.provider && candidate.repoPath === pr.repoPath,
+    );
+    return {
+      provider: pr.provider,
+      repoPath: pr.repoPath,
+      id: pr.id,
+      url: pr.url,
+      ...(repository?.pushedHead ? { headSha: repository.pushedHead } : {}),
+    };
+  });
+}

--- a/apps/worker/src/workflows/review-finding-merge.ts
+++ b/apps/worker/src/workflows/review-finding-merge.ts
@@ -52,6 +52,8 @@ export interface ReviewFindingCandidate {
   /** Provider-normalized path when one resolved, else the raw file. */
   groupKey: string;
   anchor: ReviewFindingAnchor | null;
+  /** A finding explicitly attributed to a sibling repository. */
+  crossRepository?: boolean;
 }
 
 /**
@@ -62,6 +64,7 @@ export interface MergedReviewFinding extends ReviewResultFinding {
   /** Every candidate that reported this defect, in declaration order. */
   sources: ReviewFindingCandidate[];
   anchor: ReviewFindingAnchor | null;
+  crossRepository?: boolean;
 }
 
 /**
@@ -235,7 +238,11 @@ function resolveCluster(cluster: Cluster): MergedReviewFinding {
     ...(typeof lead.finding.endLine === "number"
       ? { endLine: lead.finding.endLine }
       : {}),
+    ...(lead.finding.repo ? { repo: lead.finding.repo } : {}),
     sources: cluster.sources,
+    ...(cluster.sources.some((source) => source.crossRepository)
+      ? { crossRepository: true }
+      : {}),
     // A cluster mixing an anchored and an unanchored report is published
     // inline: one reviewer managed to place it, so the reader gets it in place
     // rather than in the summary.

--- a/apps/worker/src/workflows/review-results.test.ts
+++ b/apps/worker/src/workflows/review-results.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { normalizeReviewResultsInput } from "./review-results.js";
+import {
+  isCrossRepositoryFinding,
+  normalizeReviewResultsInput,
+} from "./review-results.js";
 
 describe("normalizeReviewResultsInput", () => {
   it("projects compatible envelopes onto the canonical ordered result", () => {
@@ -75,5 +78,81 @@ describe("normalizeReviewResultsInput", () => {
       message:
         "reviewResults[0].findings[0].endLine must be greater than or equal to startLine.",
     });
+  });
+
+  it("keeps only repository attribution recognized in this run", () => {
+    const result = normalizeReviewResultsInput(
+      [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/a.ts",
+              description: "Sibling issue.",
+              severity: "High",
+              repo: "acme/api",
+            },
+            {
+              file: "src/b.ts",
+              description: "Unknown owner.",
+              severity: "Medium",
+              repo: "api",
+            },
+            {
+              file: "src/c.ts",
+              description: "Unknown URL.",
+              severity: "Nit",
+              repo: "https://github.com/acme/web",
+            },
+            {
+              file: "src/d.ts",
+              description: "Not selected in this run.",
+              severity: "Nit",
+              repo: "acme/other",
+            },
+          ],
+        },
+      ],
+      { knownRepositories: ["acme/web", "acme/api"] },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      value: [
+        {
+          decision: "request_changes",
+          findings: [
+            expect.objectContaining({ repo: "acme/api" }),
+            expect.not.objectContaining({ repo: expect.anything() }),
+            expect.not.objectContaining({ repo: expect.anything() }),
+            expect.not.objectContaining({ repo: expect.anything() }),
+          ],
+        },
+      ],
+    });
+  });
+
+  it("classifies a recognized sibling finding without changing old findings", () => {
+    expect(
+      isCrossRepositoryFinding(
+        {
+          file: "src/api.ts",
+          description: "The endpoint differs.",
+          severity: "High",
+          repo: "acme/api",
+        },
+        "acme/web",
+      ),
+    ).toBe(true);
+    expect(
+      isCrossRepositoryFinding(
+        {
+          file: "src/app.ts",
+          description: "The local code differs.",
+          severity: "Medium",
+        },
+        "acme/web",
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/worker/src/workflows/review-results.test.ts
+++ b/apps/worker/src/workflows/review-results.test.ts
@@ -80,18 +80,12 @@ describe("normalizeReviewResultsInput", () => {
     });
   });
 
-  it("keeps only repository attribution recognized in this run", () => {
+  it("rejects repository attribution not recognized in this run", () => {
     const result = normalizeReviewResultsInput(
       [
         {
           decision: "request_changes",
           findings: [
-            {
-              file: "src/a.ts",
-              description: "Sibling issue.",
-              severity: "High",
-              repo: "acme/api",
-            },
             {
               file: "src/b.ts",
               description: "Unknown owner.",
@@ -117,18 +111,9 @@ describe("normalizeReviewResultsInput", () => {
     );
 
     expect(result).toEqual({
-      ok: true,
-      value: [
-        {
-          decision: "request_changes",
-          findings: [
-            expect.objectContaining({ repo: "acme/api" }),
-            expect.not.objectContaining({ repo: expect.anything() }),
-            expect.not.objectContaining({ repo: expect.anything() }),
-            expect.not.objectContaining({ repo: expect.anything() }),
-          ],
-        },
-      ],
+      ok: false,
+      message:
+        "reviewResults[0].findings[0].repo must identify a repository selected for this run.",
     });
   });
 

--- a/apps/worker/src/workflows/review-results.ts
+++ b/apps/worker/src/workflows/review-results.ts
@@ -65,6 +65,9 @@ function normalizedFinding(
     return `${location}.endLine must be greater than or equal to startLine.`;
   }
   const repo = normalizeFindingRepository(value.repo, options.knownRepositories);
+  if (value.repo !== undefined && repo === undefined) {
+    return `${location}.repo must identify a repository selected for this run.`;
+  }
   return {
     file: value.file as string,
     description: value.description as string,

--- a/apps/worker/src/workflows/review-results.ts
+++ b/apps/worker/src/workflows/review-results.ts
@@ -9,10 +9,35 @@ export type ReviewResultsResolution =
   | { ok: true; value: ReviewResult[] | undefined }
   | { ok: false; message: string };
 
+export interface ReviewResultsNormalizationOptions {
+  /** Repositories selected for this run, in canonical provider repoPath form. */
+  knownRepositories?: readonly string[];
+}
+
+export function normalizeFindingRepository(
+  value: unknown,
+  knownRepositories: readonly string[] = [],
+): string | undefined {
+  if (typeof value !== "string" || !/^\S+\/\S+$/.test(value)) {
+    return undefined;
+  }
+  return knownRepositories.length === 0 || knownRepositories.includes(value)
+    ? value
+    : undefined;
+}
+
+export function isCrossRepositoryFinding(
+  finding: ReviewResultFinding,
+  currentRepository: string,
+): boolean {
+  return finding.repo !== undefined && finding.repo !== currentRepository;
+}
+
 function normalizedFinding(
   value: Record<string, unknown>,
   resultIndex: number,
   findingIndex: number,
+  options: ReviewResultsNormalizationOptions,
 ): ReviewResultFinding | string {
   const startLine = value.startLine;
   const endLine = value.endLine;
@@ -39,10 +64,12 @@ function normalizedFinding(
   ) {
     return `${location}.endLine must be greater than or equal to startLine.`;
   }
+  const repo = normalizeFindingRepository(value.repo, options.knownRepositories);
   return {
     file: value.file as string,
     description: value.description as string,
     severity: value.severity as ReviewResultFinding["severity"],
+    ...(repo === undefined ? {} : { repo }),
     ...(typeof startLine === "number" ? { startLine } : {}),
     ...(typeof endLine === "number" ? { endLine } : {}),
   };
@@ -50,6 +77,7 @@ function normalizedFinding(
 
 export function normalizeReviewResultsInput(
   value: unknown,
+  options: ReviewResultsNormalizationOptions = {},
 ): ReviewResultsResolution {
   if (value === undefined) return { ok: true, value: undefined };
   if (!Array.isArray(value) || value.length === 0) {
@@ -80,6 +108,7 @@ export function normalizeReviewResultsInput(
         candidateFinding as Record<string, unknown>,
         resultIndex,
         findingIndex,
+        options,
       );
       if (typeof finding === "string") {
         return { ok: false, message: finding };

--- a/docs/plans/2026-08-10-cross-repo-review-and-autofix-loop.md
+++ b/docs/plans/2026-08-10-cross-repo-review-and-autofix-loop.md
@@ -99,7 +99,7 @@ Fail-open dotyczy **całego kanału**, nie tylko lookupu: brak uprawnień tokenu
 
 Nowy szablon (id `post-pr-autofix`), silnik v2, maxAttempts 2, onExhaust `fail`, publikacja komentarzy dokładnie raz:
 
-```
+```text
 trigger-ready / trigger-updated -> create-check -> prepare
 prepare -> {security-review, quality-review, requirements-review}
 reviews -> review-approved (branch, combinator "all" na decision === approve)

--- a/docs/plans/2026-08-10-cross-repo-review-and-autofix-loop.md
+++ b/docs/plans/2026-08-10-cross-repo-review-and-autofix-loop.md
@@ -1,0 +1,201 @@
+# Cross-repo review i pętla autofix na otwartym PR
+
+Data: 2026-08-10. Źródło: ustalenia ze spotkania tygodniowego (transkrypcja), grilling z userem 2026-08-10, pre-mortem sceptyka (10 znalezisk, triaż poniżej).
+
+## Problem
+
+Jeden ticket rozkłada się dziś na wiele repozytoriów i produkuje osobny PR w każdym z nich. Recenzent AI ogląda każdy PR w izolacji: nie wie, że powstały z jednej zmiany, nie umie powiedzieć "to wywołanie nie zgadza się z kontraktem, który zmieniłeś w drugim repo", i nie linkuje do PR-a rodzeństwa. Człowiek składa obraz z dwóch zakładek.
+
+Druga rzecz: recenzent tylko mówi. Kiedy zgłosi High, ktoś musi ręcznie wrócić do implementera z tymi uwagami. Na otwartym PR-ze nie ma dziś pętli, która zrobiłaby to sama.
+
+Jest też cichy błąd, który wyjdzie natychmiast po dodaniu widoczności wielu repo: finding nie nosi informacji o repozytorium, a kotwiczenie komentarza idzie po samej ścieżce pliku (`pr-external-resources.ts:581,601`). Recenzent widzący dwa repo i zgłaszający problem w `src/index.ts` repo B dostanie komentarz przyklejony do `src/index.ts` w repo A. To komentarz w złym miejscu, nie brak komentarza, więc jest gorszy od braku funkcji.
+
+## Rozwiązanie
+
+Z perspektywy człowieka czytającego PR:
+
+1. Podsumowanie review w każdym PR-ze wymienia pozostałe PR-y tego samego zadania, z linkami i z SHA, na którym recenzent je czytał.
+2. Recenzent ma na dysku repozytoria rodzeństwa (tylko do czytania) i wolno mu zgłosić finding wskazujący plik w innym repo. Taki finding jest oznaczony repozytorium, nie kotwiczy się w cudzym pliku o tej samej nazwie, i jest informacją dla człowieka, nie zadaniem dla automatu.
+3. Nowy szablon workflow, który po review otwartego PR-a sam odpala poprawkę, pushuje ją do gałęzi tego PR-a i recenzuje ponownie, do zatwierdzenia albo do wyczerpania prób. Komentarze trafiają na PR raz, po wyjściu z pętli.
+4. Check na PR-ze pokazuje status commita, który człowiek widzi, także po tym jak workflow dołożył poprawkę.
+5. Push zrobiony przez workflow nie odpala tego samego workflow ponownie.
+
+## User stories
+
+1. Jako reviewer człowiek chcę w komentarzu review widzieć linki do pozostałych PR-ów tego zadania, żeby nie szukać ich ręcznie po organizacjach.
+2. Jako reviewer człowiek chcę, żeby recenzent AI wskazał niespójność między repozytoriami (np. frontend woła endpoint w kształcie, którego backend już nie ma), żeby nie łapać tego na integracji.
+3. Jako reviewer człowiek chcę, żeby finding o pliku w innym repozytorium był podpisany tym repozytorium i SHA, żeby móc go zweryfikować, a nie zgadywać, co recenzent widział.
+4. Jako właściciel zadania chcę, żeby uwagi review dotyczące MOJEGO repo były naprawione automatycznie na gałęzi PR-a, żeby dostać wersję już poprawioną.
+5. Jako właściciel zadania chcę widzieć jawną porażkę runu, gdy poprawki nie domknęły uwag po wyczerpaniu prób, żeby wiedzieć, że sprawa wraca do człowieka.
+6. Jako właściciel zadania chcę, żeby check na PR-ze odnosił się do najnowszego commita, żeby status nie wyglądał jak brak sprawdzenia.
+7. Jako opiekun kosztów chcę twardy limit prób pętli i brak samowywołania po pushu, żeby jeden PR nie generował serii runów.
+8. Jako kontrybutor człowiek chcę, żeby workflow nigdy nie pushował do gałęzi PR-a, którego nie otworzył sam.
+
+## Decyzje implementacyjne
+
+### Ścieżki review
+
+Dwie i zostają rozdzielone. Ścieżka A to review wewnątrz runu przed otwarciem PR-a (`reviewed-ticket-workflow`, `templates.ts:799-836`), ma pętlę review → fix → re-review od dawna. Ścieżka B to review otwartego PR-a (`postPrReviewDefinition`, `templates.ts:856-992`), triggerowana zdarzeniem PR-a, bez pętli i bez fix agenta. Cała ta praca dotyczy B. Szablon `post-pr-review` zostaje nietknięty jako plik, ale patrz "Granica zakresu" niżej.
+
+### Dostępność szablonu i wzajemne wykluczenie (rozstrzygnięte faktami)
+
+Nowy szablon wbudowany trafia do istniejących projektów sam: `seedWorkflowDefinitionTemplates` (`workflow-definition/template-seed.ts:18-89`) wstawia idempotentnie jeden wyłączony wiersz startowy per szablon i jest wołany z `scripts/db-migrate.ts:78-83` przy każdym buildzie, czyli przy każdym deployu. Lista szablonów jest czytana z kodu na żądanie (`routes/api/v1/workflow-definitions.get.ts:92-97`), nie z tabeli. Migracja nie jest potrzebna, QA po deployu tylko włącza definicję.
+
+Wykluczenie jest wymuszone schematem, nie kodem: `workflowDefinitionTriggers.triggerType` jest kluczem głównym (`db/schema.ts:762`), a `getEnabledWorkflowDefinitionForTrigger` zwraca dokładnie jedną definicję (`workflow-definition/store.ts:505-517`). Konsekwencja produktowa, którą trzeba nazwać wprost: **włączenie autofixu odbiera binding triggera szablonowi `post-pr-review`**. Nie da się mieć obu naraz na jednym triggerze i nie da się przez to podwójnych runów na jedno zdarzenie.
+
+### Atrybucja repozytorium w findingu
+
+```ts
+export interface ReviewResultFinding {
+  file: string;
+  description: string;
+  severity: "Blocker" | "High" | "Medium" | "Nit";
+  startLine?: number;
+  endLine?: number;
+  /** `owner/name`. Brak oznacza repozytorium recenzowanego PR-a. */
+  repo?: string;
+}
+```
+
+Opcjonalność jest wymuszona wstecz: koperty custom agentów przechodzą przez `additionalProperties: true` (`contracts/review-result.ts:49,55`), a stary recenzent zwraca findingi bez tego pola. Normalizacja musi obsłużyć wartość nierozpoznaną (surowa nazwa bez ownera, URL, nazwa nieobecna wśród repozytoriów runu): taka wartość jest traktowana jak brak pola, czyli jak repozytorium recenzowanego PR-a. Inaczej custom agent tenanta, który już dziś zwraca własne `repo`, cicho straci kotwice inline.
+
+### Findingi cross-repo są informacją, nie zadaniem
+
+To odwrócenie pierwotnego założenia po pre-mortemie. Finding z niepustym i obcym `repo`:
+
+- **nie liczy się** do `decision` recenzenta ani do `review-approved`, czyli nie napędza pętli,
+- **nie wchodzi** do wejścia `fix_agent.reviewResults`,
+- **trafia** do podsumowania z prefiksem repozytorium i SHA.
+
+Bez tego pierwszy realny finding cross-repo daje gwarantowaną porażkę runu: uwaga dotyczy pliku w checkoucie read-only, fix nie może jej naprawić, pętla nie zbiega i kończy się `exhausted` po dwunastu wywołaniach agenta. Findingi cross-repo są jednocześnie najmniej weryfikowalne (obce repo, ruchomy ref) i najtrudniej naprawialne, więc nie mają prawa blokować.
+
+### Wykrycie rodzeństwa
+
+Źródłem prawdy jest `workflowRuns.prs`, jsonb z listą PR-ów jednego runu (`db/schema.ts:317`, typ `RunPullRequest` w `contracts/domain.ts:33-38`). Akcesor odpowiada na pytanie "dla PR-a podaj run, który go otworzył, i pozostałe PR-y tego runu".
+
+Klucz jest miejscem, w którym to najłatwiej zawodzi cicho: GitLab ma `iid` obok `id`, ścieżki z podgrupami nie są `owner/name`, repo można przemianować w trakcie runu. Dlatego wymagany jest test round-trip od pisarza `prs` (`workflows/agent.ts:845-855`) do akcesora, na kształtach GitHuba i GitLaba, a nie test na ręcznie zbudowanym wierszu.
+
+Akcesor zwraca trzy stany, nie dwa: `siblings`, `none` (run znaleziony, jeden PR) i `unknown` (runu nie znaleziono albo zapytanie padło). Rozróżnienie jest nośne, bo wykrycie rodzeństwa jest fail-open, a bramka pushu fail-closed, i obie czytają ten sam akcesor.
+
+### Obserwowalność (nowy warunek)
+
+Fail-open bez logu to nie degradacja, to niewidzialność. Każdy run ścieżki B loguje jednym zdarzeniem: stan akcesora, liczbę dopiętych repozytoriów rodzeństwa z ich SHA, liczbę findingów odrzuconych z kotwiczenia jako cross-repo. QA z limitem 2h dziennie musi umieć odróżnić "run miał jedno repo" od "lookup padł" bez wchodzenia do bazy.
+
+### Kontekst recenzenta
+
+`assembleReviewContext` (`sandbox/context.ts:196`) dostaje sekcję rodzeństwa: repozytorium, ścieżka lokalnego checkoutu, URL PR-a, SHA. Prompt musi jawnie pozwolić na finding wskazujący plik w rodzeństwie i wymagać wypełnienia `repo`, inaczej pole zostanie puste i finding zakotwiczy się w złym pliku.
+
+Konwencję ścieżek checkoutu rodzeństwa **posiada etap dopięcia workspace'u**, a kontekst ją tylko konsumuje. Odwrotna kolejność obiecuje agentowi katalog, którego nie ma, i agent traci minuty na globowanie.
+
+Uwaga na granicę: `assembleReviewContext` to builder po stronie kodu, gate dryfu promptów wbudowanych go nie dotyczy (`prompt-library/builtin-prompt-drift.ts:258-509` chodzi po snapshotach z bazy, nie po katalogu w kodzie). Jeśli okaże się, że instrukcja recenzenta siedzi w `DEFAULT_AGENT_PROMPTS`, zmiana treści wymaga migracji resync (wzór `drizzle/0034_builtin_prompt_resync.sql`) i przejścia gate'u, bo inaczej edycja jest bezskuteczna dla istniejących definicji.
+
+### Checkout rodzeństwa
+
+Ścieżka B ma zapisywalny checkout gałęzi recenzowanego PR-a: `fetch-pr-context.ts:15-32` nadaje `workflowOwnedBranch: pr.headRef`, `prepare-workspace.ts:773-779` podnosi to do `access: "write"`. Rodzeństwo dopina się obok jako `access: "read"`. Ref: gałąź PR-a rodzeństwa gdy otwarty, gałąź domyślna gdy zamknięty, zmergowany albo z forka (gałąź forka nie istnieje w repo docelowym). Rozwiązany SHA jest przypinany i wypisywany w podsumowaniu, żeby finding był falsyfikowalny.
+
+Fail-open dotyczy **całego kanału**, nie tylko lookupu: brak uprawnień tokenu do repo rodzeństwa, repo zarchiwizowane, usunięte, clone albo fetch po timeoucie. Każda z tych rzeczy degraduje do review bez rodzeństwa i loguje powód. Nigdy nie wywraca `prepare`, bo ten kod jest współdzielony z nietkniętą ścieżką `post-pr-review`. Limit twardy: maksymalnie 3 repozytoria rodzeństwa i pominięcie tych, których clone przekracza budżet czasu, bo monorepo rodzeństwa wysadzi sandbox.
+
+### Kształt pętli
+
+Nowy szablon (id `post-pr-autofix`), silnik v2, maxAttempts 2, onExhaust `fail`, publikacja komentarzy dokładnie raz:
+
+```
+trigger-ready / trigger-updated -> create-check -> prepare
+prepare -> {security-review, quality-review, requirements-review}
+reviews -> review-approved (branch, combinator "all" na decision === approve)
+review-approved:true  -> post-review-approved -> complete-success
+review-approved:false -> retry (loop)
+retry:continue        -> fix -> {security-review, quality-review, requirements-review}
+retry:exhausted       -> post-review-exhausted -> exhausted-message -> complete-failure
+```
+
+Publikacja jest rozdzielona na dwa path-specific węzły poza regionem pętli. Pierwsza ocena wchodzi do `retry`, żeby zarówno approve, jak i exhaustion miały jeden stabilny owner-output. Pętla niesie trzy review results oraz check jako `steps.retry.output.values.*`; przy zwykłym boundary i przy exhaustion scheduler zapisuje ostatni carry do ownera. Oba terminalne węzły czytają ten sam carry, a ścieżki są wzajemnie wykluczające, więc dokładnie jeden publikuje komentarz na run. To zastępuje pierwotny pomysł jednego `post-review` z dwoma wejściami i omija niebezpieczny fallback child → owner opisany w `v2-scheduler.ts`.
+
+### Check-run po pushu
+
+`create-check` wykonuje się przed pętlą, więc check wisi na SHA z momentu triggera. Po pushu fixa head PR-a się przesuwa i człowiek widzi commit bez żadnego checka. Domknięcie checka musi rozwiązać head ponownie po wyjściu z pętli i zamknąć status na aktualnym commicie.
+
+Kotwice inline tego problemu nie mają: `publishRunOwnedPrReview` pobiera pliki PR-a w momencie publikacji (`pr-external-resources.ts:879`), czyli już po pętli, więc pozycje liczą się względem aktualnego diffu.
+
+### Tłumienie rekurencji
+
+Stan wyjściowy jest łagodniejszy, niż wyglądał: `active_runs.subject_key` jest kluczem głównym na `pr:{provider}:{repoPath}#{prNumber}` (`db/schema.ts:47`, `lib/subject-key.ts:7-12`), a druga rezerwacja tego samego subjectu dostaje `already_claimed` (`lib/dispatch.ts:217-230`). Do tego `trigger_deliveries` dopuszcza najwyżej jeden wiersz pending per subject (`db/schema.ts:114-116`). Czyli push fixa w trakcie runu nie tworzy drugiego runu współbieżnie: zdarzenie parkuje się i wchodzi po zakończeniu, jako jeden następca. Lawiny nie ma, jest łańcuch, w którym każdy run rodzi najwyżej jednego następcę.
+
+To nadal jest do zamknięcia, bo łańcuch kończy się dopiero na runie, który nic nie pushnął, a każde ogniwo to trzy review. Tłumienie po SHA jest lepsze niż po tożsamości i jest wykonalne na istniejącym magazynie: workflow zapisuje pushnięty head (`workflow_owned_branches.published_head_sha` / `pr_published_head_sha`, `db/schema.ts:638,642`, pisane w `workspace-publication.ts:201,240`). Zdarzenie `synchronize`, którego head SHA równa się zapisanemu pushowi workflow, nie tworzy runu. Dopasowanie po bot loginie zostaje jako fallback, nie zamiennik: jest wrażliwe na konfigurację (tenant z PAT-em człowieka wycisza pushy tego człowieka), natomiast zarzut o `something[bot]` jest nietrafiony, bo `normalizeVcsLogin` obcina sufiks `[bot]` (`lib/vcs-bot-identity.ts:34-41`).
+
+Wymagane sprawdzenie w etapie: czy push fix agenta na ścieżce B przechodzi przez `workspace-publication`, które zapisuje `publishedHeadSha`. Ścieżka B nie ma kroku publikacji, więc zapis może wymagać dołożenia po stronie fixa.
+
+### Granica zakresu (poprawka po pre-mortemie)
+
+Zdanie "szablon `post-pr-review` nietknięty" jest prawdziwe formalnie i mylące behawioralnie: etapy dotykające `trigger-events`, `pr-external-resources`, `context` i `prepare-workspace` zmieniają zachowanie także tej ścieżki, bo to kod współdzielony. Dlatego każdy z tych etapów ma w DoD regresję istniejącego scenariusza `post-pr-review`, a domyślną wartością każdej nowej gałęzi jest zachowanie dzisiejsze.
+
+## Seamy i decyzje testowe
+
+| Seam | Obserwowane zachowanie | Prior art |
+|---|---|---|
+| harness scenariuszowy (`scenarios/harness.ts:44-65`) | graf robi review → fix → re-review, każdy węzeł raz na logiczne przejście, publikacja raz na obu wyjściach | `reviewed-ticket.scenario.test.ts:217-251`, `loop-branch-early-exit.scenario.test.ts:126-190` |
+| `partitionReviewFindings` (`pr-external-resources.ts:555`) | finding z obcego repo nie kotwiczy się inline, trafia do podsumowania z prefiksem i SHA | istniejące testy partycjonowania |
+| `assembleReviewContext` (`sandbox/context.ts:196`) | prompt zawiera rodzeństwo, jego ścieżki, URL-e i SHA | `context.test.ts:239-265` (ta sama funkcja, kontekst research) |
+| `deriveTriggerEvent` (`lib/trigger-events.ts`) | `synchronize` o SHA pushniętym przez workflow nie tworzy runu, push człowieka tworzy | `trigger-events.ts:153,178`, `dispatch-trigger.ts:345-346` |
+| akcesor rodzeństwa (nowy, `db/queries`) | trzy stany (`siblings`/`none`/`unknown`), round-trip od pisarza `prs` na GitHubie i GitLabie | `run-detail-read.ts:92,153` |
+
+Wszystkie mają po dwa adaptery (GitHub i GitLab dla publikacji, triggerów i akcesora; research i review dla kontekstu), więc żaden nie jest hipotetyczny.
+
+## Out of scope
+
+- Naprawa AIW-242 (podwójne wykonanie regionu przy spornej granicy). Etap 0 tylko ustala, czy nasz kształt jest dotknięty.
+- Pętla self-improvement na ścieżce A. Istnieje i nie dostaje tu testów.
+- Dociąganie repozytoriów, których run nigdy nie dotknął.
+- Zmiana szablonów `post-pr-review` i `reviewed-ticket-workflow` jako plików.
+- Publikacja komentarzy po każdej rundzie pętli.
+- Wariant "po wyczerpaniu oddaj człowiekowi bez porażki". Wybrana jest porażka.
+- Naprawianie findingów cross-repo automatycznie. Są informacją dla człowieka.
+
+## Założenia
+
+Po triażu pre-mortemu. To niepewności nierozstrzygnięte z userem, każda z przyjętą rekomendacją.
+
+1. **Publikacja komentarzy raz, po pętli.** Koszt: jeśli run umrze w środku pętli (timeout sandboxa, restart workera), nie powstanie żaden komentarz, podczas gdy dziś review byłoby już opublikowane. Przez czas trwania pętli PR ma tylko check in-progress. Przyjęte, bo komentowanie co runda wystawia uwagi, które fix zaraz naprawia. Etap 9 ma to pokryć testem "run umiera w rundzie 2".
+2. **maxAttempts 2.** Jedna próba to trzy review plus fix. Ryzyko: dwie próby mogą nie domknąć realnych uwag. Po wyłączeniu findingów cross-repo z kryterium zbieżności to ryzyko jest znacznie mniejsze niż przed pre-mortemem.
+3. **`repo` opcjonalne, wartość nierozpoznana traktowana jak brak.** Alternatywa (pole wymagane) wywraca stare snapshoty i koperty custom agentów.
+4. **Limit 3 repozytoria rodzeństwa.** Liczba wzięta z realnego kształtu zadań (backend plus frontend, czasem shared). Ryzyko: run dotykający czterech repo dostanie niepełny kontekst, co jest logowane, nie ciche.
+5. **Tłumienie po SHA z fallbackiem na bot login.** Ryzyko: tenant z PAT-em człowieka jako bot login nadal wycisza pushy tego człowieka, ale to zachowanie istniejące dla zdarzeń review, nie regresja.
+6. **Fail-open dla całego kanału rodzeństwa, fail-closed dla pushu i tłumienia.** Brak rodzeństwa degraduje funkcję, brak bramki pushu psuje czyjeś repo, brak tłumienia mnoży runy.
+7. **Bez podłogi severity dla findingów cross-repo, ale i bez wpływu na pętlę.** Zwykła skala w podsumowaniu, zero wpływu na `review-approved` i na zadanie fixa.
+
+### Znaleziska sceptyka odrzucone, z powodem
+
+- **"Nowy szablon nie dojdzie do istniejących projektów, brak migracji"**: nietrafione. `seedWorkflowDefinitionTemplates` (`template-seed.ts:18-89`) jest idempotentne i biegnie z `db-migrate.ts:78-83` przy każdym deployu, wstawiając wyłączony wiersz startowy.
+- **"Dwa szablony na to samo zdarzenie dadzą dwa runy"**: nietrafione. `workflowDefinitionTriggers.triggerType` to klucz główny (`db/schema.ts:762`), jedna definicja per typ triggera.
+- **"Kotwice inline będą nieaktualne po pushu"**: nietrafione. Pliki PR-a pobierane są w momencie publikacji (`pr-external-resources.ts:879`), czyli po pętli. Część o check-runie była trafiona i weszła do zakresu.
+- **"Bot z GitHub Appa nie dopasuje się jako `something[bot]`"**: nietrafione, `normalizeVcsLogin` obcina ten sufiks (`vcs-bot-identity.ts:34-41`).
+
+## Etapy
+
+| # | Etap | Seam | Zakres plików | Tier | Sceptyk | TDD | Delegacja | DoD |
+|---|---|---|---|---|---|---|---|---|
+| 0 | Bramka STOP: snapshot docelowego grafu B plus scenariusz na OBU wyjściach pętli | harness scenariuszowy | `templates.ts`, `v2-scheduler.ts`, `available-values.ts`, `scenarios/post-pr-autofix.scenario.test.ts`, `scenarios/snapshots/post-pr-autofix-v1.json` | opus | nie | tak | nie | test zielony i asertuje przez `executorRunsOf`: (a) ścieżka approve po jednej poprawce, dokładnie 1 przebieg `fix`, po 2 każdego recenzenta, dokładnie 1 `post-review-approved` i 0 `post-review-exhausted`; (b) ścieżka `exhausted`, dokładnie 2 przebiegi `fix`, dokładnie 1 `post-review-exhausted` i 0 `post-review-approved`. Snapshot deklaruje `schemaVersion: 2` i przechodzi walidację deploymentową. Jeśli region się dubluje: STOP planu, raport do usera, ticket na AIW-242 |
+| 1 | Kontrakt findingu z `repo`, normalizacja wartości nierozpoznanych, klasyfikacja obcego repo | kontrakt review | `apps/shared/contracts/review-result.ts`, `apps/worker/src/workflows/review-results.ts` i jego test | sonnet | nie | tak | nie | test zielony i pokrywa: brak pola, repo własne, repo obce, wartość bez ownera, URL, repo nieobecne w runie. `pnpm --filter worker typecheck` i `pnpm --filter dashboard typecheck` czyste |
+| 2 | Akcesor rodzeństwa (3 stany) plus test round-trip od pisarza `prs` | akcesor rodzeństwa | nowy plik w `apps/worker/src/db/queries/` i jego test | sonnet | nie | tak | nie | test zielony i zawiera round-trip: wiersz `prs` zapisany ścieżką z `agent.ts:845-855` dla GitHuba i dla GitLaba jest odczytywalny tym akcesorem. Trzy stany rozróżnialne, awaria zapytania daje `unknown`, nie wyjątek |
+| 3 | Zapis pushniętego SHA na ścieżce B plus tłumienie `synchronize` po SHA, fallback bot login | `deriveTriggerEvent` | `apps/worker/src/lib/trigger-events.ts`, `apps/worker/src/workflows/workspace-publication.ts` i ich testy | opus | tak | tak | nie | testy zielone: push workflow nie tworzy `trigger_pr_updated`, push człowieka tworzy, brak zapisanego SHA spada na dopasowanie loginu. Regresja: istniejące testy `trigger-events` bez zmian w oczekiwaniach |
+| 4 | Repo-aware partycjonowanie, wykluczenie cross-repo ze zbieżności, linki i SHA rodzeństwa w podsumowaniu | `partitionReviewFindings` | `apps/worker/src/workflows/pr-external-resources.ts`, `apps/worker/src/workflows/review-finding-merge.ts` i ich testy | opus | tak | tak | nie | testy zielone: dwa repo z identyczną ścieżką pliku bez kotwicy w obcym PR-ze; finding cross-repo nie zmienia `decision`; podsumowanie zawiera link i SHA brata. Regresja scenariusza `post-pr-review` zielona. Startuje po bramkach 1 i 2 |
+| 5 | Dopięcie rodzeństwa read-only, fail-open całego kanału, limit 3, WŁAŚCICIEL konwencji ścieżek | workspace ścieżki B | `apps/worker/src/workflows/blocks/fetch-pr-context.ts`, `apps/worker/src/workflows/blocks/prepare-workspace.ts` i ich testy | opus | tak | tak | nie | testy zielone: gałąź recenzowanego PR-a zostaje `write`, rodzeństwo `read`; brak uprawnień, repo zarchiwizowane i timeout clone degradują do braku rodzeństwa bez wywrócenia `prepare`; czwarte repo pominięte z logiem. Regresja `post-pr-review` zielona. Startuje po bramce 2 |
+| 6 | Sekcja rodzeństwa w kontekście recenzenta, konsumpcja konwencji ścieżek z etapu 5 | `assembleReviewContext` | `apps/worker/src/sandbox/context.ts`, `apps/worker/src/sandbox/context.test.ts` | opus | tak | tak | nie | test zielony z nowym przypadkiem `assembleReviewContext` plus rodzeństwo (ścieżka, URL, SHA) i z przypadkiem bez rodzeństwa dającym dzisiejszy prompt. Jeśli instrukcja siedzi w `DEFAULT_AGENT_PROMPTS`: migracja resync plus `pnpm --filter worker exec tsx src/prompt-library/builtin-prompt-drift-gate.ts` bez dryfu. Startuje po bramkach 1 i 5 |
+| 7 | Bramka pushowania w `fix_agent` plus odfiltrowanie findingów cross-repo z zadania | `fix_agent` | `apps/worker/src/workflows/blocks/fix-agent.ts` i jego test | opus | tak | tak | nie | test zielony: odmowa dla PR-a bez wpisu w `prs`, odmowa przy stanie `unknown` akcesora, zgoda dla PR-a z wpisem; findingi cross-repo nie trafiają do zadania. Startuje po bramkach 1 i 2 |
+| 8 | Domknięcie check-runu na aktualnym head po pętli | check-run | blok `complete_pr_check` i jego test | sonnet | nie | tak | nie | test zielony: head rozwiązany ponownie po pętli, status zamknięty na SHA po pushu fixa, a przy braku pushu na SHA triggera |
+| 9 | Szablon `post-pr-autofix`, scenariusze na wysyłanej wersji, obserwowalność | harness scenariuszowy | `apps/worker/src/workflow-definition/templates.ts`, rejestr szablonów, `templates.test.ts`, `scenarios/post-pr-autofix-template.scenario.test.ts` | opus | tak | nie | nie | scenariusz ładujący szablon przez `loadTemplateGraph("post-pr-autofix")` zielony na approve i na exhausted, plus przypadek "run umiera w rundzie 2". Test dowodzi równości grafu szablonu ze snapshotem z etapu 0 (inaczej snapshot się osieroci). Każdy run wykonuje dokładnie jeden z `post-review-approved`/`post-review-exhausted`. `pnpm --filter worker test src/workflow-definition` zielony. Startuje po bramkach 3, 4, 5, 6, 7, 8 |
+
+Równolegle po bramce 0: etapy 1, 2, 3, 8 (rozłączne pliki, brak zależności kontraktowych). Potem 4 i 7 po bramkach 1 i 2, etap 5 po bramce 2, etap 6 po bramkach 1 i 5. Etap 9 zamyka.
+
+## Weryfikacja produkcyjna (poza tabelą, właściciel: człowiek)
+
+Plan jest skończony dopiero, gdy istnieje przebieg z liczbami, nie zielone testy. Minimalny dowód:
+
+1. Ticket dotykający dwóch repozytoriów, PR-y w obu.
+2. Review na jednym PR-ze cytujące plik z drugiego, z poprawną atrybucją repo i SHA, i bez kotwicy inline w obcym pliku.
+3. Jedna runda fix pushnięta na gałąź PR-a, z komentarzami opublikowanymi raz.
+4. Check zielony na commicie po poprawce, nie na commicie z triggera.
+5. Brak drugiego runu z `synchronize` po tym pushu.
+6. Log runu pokazujący stan akcesora i liczbę repozytoriów rodzeństwa.
+
+Przed testem QA trzeba świadomie zdecydować, który szablon trzyma binding triggera PR-a, bo autofix odbiera go `post-pr-review`.

--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -1125,7 +1125,7 @@
           ],
           statuses: ["ok"],
         }),
-        complete_pr_check: runtimeContract(["conclusion", "details"], {
+        complete_pr_check: runtimeContract(["conclusion", "details", "refreshHead"], {
           requiredInputs: typedPaths("object", "check"),
           optionalInputs: typedPaths("string", "details"),
           requiredOutputs: [


### PR DESCRIPTION
## Summary

- make the existing post-PR review load sibling PRs from the same implementation run as read-only context
- attach repository identity to findings and publish cross-repository evidence as linked summary context without blocking the reviewed PR
- add a separate bounded post-PR autofix workflow with workflow-owned branch guards, two fix attempts, head refresh, and webhook recursion suppression
- document the design, safety boundaries, and rollout stages

## User impact

PR reviews can explain a change using related frontend/backend PRs from the same task, and teams can opt into a separate workflow that fixes blocking findings on workflow-owned PR branches.

## Required action

Deploy or create the new `post-pr-autofix` starter workflow only where autofix is desired. Existing `post-pr-review` definitions remain review-only.

## Release note

PR reviews can now use related repositories for context, with an optional separate workflow for bounded automatic fixes.

## Testing

- `pnpm run typecheck`
- `pnpm run test` — dashboard 723/723, worker 4700/4700
- focused changed-file suite — 639/639
- loop/catalog/autofix regression suite — 96/96
- `pnpm run test:release-notes` — 43/43
- `pnpm run build`
- Workflow SDK assertions completed 9/9 locally; the macOS process retained an external Workflow SDK handle, so GitHub CI is the authoritative process-exit check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a post-PR review with autofix workflow that retries fixes and reports success or failure.
  * Reviews can include up to three related pull requests as read-only context.
  * Findings now identify their repository and reviewed commit when applicable.
  * Checks can refresh to the latest pull request commit after fixes.

* **Bug Fixes**
  * Prevented workflow-generated updates from triggering duplicate reviews.
  * Improved loop handling and preserved values across iterations.
  * Cross-repository findings are excluded from inline comments and automated fix decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->