### PR TITLE
fix(worker): canonicalize review repository paths

### DIFF
--- a/apps/worker/src/workflows/agent-block-outputs.test.ts
+++ b/apps/worker/src/workflows/agent-block-outputs.test.ts
@@ -103,6 +103,63 @@ describe("specialized workflow block outputs", () => {
     ).toEqual([]);
   });
 
+  it("canonicalizes reviewer workspace paths to repository identities", () => {
+    const output = buildReviewAgentSuccessOutput(
+      {
+        feedback: "Cross-repository mismatch.",
+        issues: [
+          {
+            file: "src/app.ts",
+            description: "The local implementation is inconsistent.",
+            severity: "High",
+            repo: "/vercel/sandbox",
+          },
+          {
+            file: "src/contracts.ts",
+            description: "The sibling contract is stale.",
+            severity: "High",
+            repo: "/vercel/sandbox/repos/gitlab__acme__contracts",
+          },
+        ],
+      },
+      {
+        version: 2,
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/app",
+            slug: "acme__app",
+            localPath: "/vercel/sandbox",
+            defaultBranch: "main",
+            branchName: "ai-workflow/AIW-1",
+            selectedRationale: "current PR",
+            access: "write",
+          },
+          {
+            provider: "gitlab",
+            repoPath: "acme/contracts",
+            slug: "gitlab__acme__contracts",
+            localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+            defaultBranch: "main",
+            branchName: "ai-workflow/AIW-1",
+            selectedRationale: "sibling PR",
+            access: "read",
+          },
+        ],
+      },
+    );
+
+    expect(output.findings).toEqual([
+      expect.objectContaining({ repo: "acme/app" }),
+      expect.objectContaining({ repo: "acme/contracts" }),
+    ]);
+    expect(
+      normalizeReviewResultsInput([output], {
+        knownRepositories: ["acme/app", "acme/contracts"],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
   it("publishes integer line numbers so a finding can be placed inline", () => {
     const output = buildReviewAgentSuccessOutput({
       feedback: "",

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -439,8 +439,15 @@ export function buildImplementationAgentSuccessOutput(input: {
 
 export function buildReviewAgentSuccessOutput(
   review: Pick<ReviewOutput, "feedback" | "issues">,
+  workspaceManifest?: WorkspaceManifest,
 ): BlockOutput {
   const feedback = review.feedback.trim();
+  const repositoryByLocalPath = new Map(
+    workspaceManifest?.repositories.map((repository) => [
+      repository.localPath,
+      repository.repoPath,
+    ]) ?? [],
+  );
   // Strict-mode providers must emit every key, so a missing line arrives as
   // null. The Review Result contract accepts positive integers only, so those
   // nulls are dropped here instead of failing validation downstream.
@@ -465,7 +472,12 @@ export function buildReviewAgentSuccessOutput(
         severity: finding.severity,
         ...(startLine === undefined ? {} : { startLine }),
         ...(endLine === undefined ? {} : { endLine }),
-        ...(typeof finding.repo === "string" ? { repo: finding.repo } : {}),
+        ...(typeof finding.repo === "string"
+          ? {
+              repo:
+                repositoryByLocalPath.get(finding.repo) ?? finding.repo,
+            }
+          : {}),
       };
     }),
     decision: review.issues.some(
@@ -480,6 +492,7 @@ export function buildReviewAgentSuccessOutput(
 export function reviewAgentExecutionResult(
   schemaVersion: 1 | 2,
   review: ReviewOutput,
+  workspaceManifest?: WorkspaceManifest,
 ): BlockExecutionResult {
   if (schemaVersion === 1 && review.result === "failed") {
     return executionError(review.error ?? "unknown", {
@@ -489,7 +502,7 @@ export function reviewAgentExecutionResult(
   }
   return {
     kind: "next",
-    output: buildReviewAgentSuccessOutput(review),
+    output: buildReviewAgentSuccessOutput(review, workspaceManifest),
   };
 }
 
@@ -4907,7 +4920,11 @@ async function agentWorkflowBody(
                 });
               }
 
-              return reviewAgentExecutionResult(ctx.schemaVersion, reviewOutput);
+              return reviewAgentExecutionResult(
+                ctx.schemaVersion,
+                reviewOutput,
+                ctx.workspaceManifest,
+              );
             } finally {
               await teardownSandboxes([sandboxId]);
             }


### PR DESCRIPTION
## Summary
- map trusted reviewer workspace paths back to canonical repository identities
- pass the verified workspace manifest through review result construction
- add a regression test matching the production multi-repo autofix failure

## Verification
- `pnpm --filter worker typecheck`
- `pnpm --filter worker test` (303 files, 4706 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review findings now correctly associate local workspace paths with their corresponding repository paths, including reviews spanning multiple repositories.
  - Findings retain their original repository value when no matching workspace mapping is available.
  - Review result validation now supports normalized repository references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->