### PR TITLE
feat: read agent skills from the deployment's own repository (AIW-246)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -395,7 +395,7 @@ If you followed [`docs/GITHUB-APP-SETUP.md`](./docs/GITHUB-APP-SETUP.md) in step
    - Subscribe to events → **Pull request**, **Check run**, **Pull request review** (all checked). See [`docs/GITHUB-APP-SETUP.md` §5](./docs/GITHUB-APP-SETUP.md#5-subscribe-to-events). Without **Check run** and **Pull request review**, the `trigger_pr_checks_failed` and `trigger_pr_review` workflow triggers never fire.
 3. **Re-accept on every installed repo** if you changed permissions or events after the initial install. A repo admin opens `https://github.com/organizations/<ORG>/settings/installations/<INSTALLATION_ID>` and clicks "Review request" → "Accept". Until accepted, the new permissions and events are inert and the gate webhook stays silent.
 4. **Confirm `GITHUB_WEBHOOK_SECRET`** is set in Vercel (step 5) and matches the value pasted into the App's webhook config. A mismatch returns 401 on every delivery — visible in the App's **Advanced → Recent Deliveries** tab.
-5. **Tune `post-pr-gate.yaml`** at `apps/worker/post-pr-gate.yaml` if the defaults don't fit (the build copies it from `nitro.options.rootDir`, which is `apps/worker/`, not the monorepo root; a file placed at the monorepo root is silently ignored and the built-in default keeps applying). The default config runs on `blazebot/*` branches only, skips drafts, and runs a single `code-hygiene` step as advisory (`onFailure: continue`). Steps are defined in `apps/worker/src/post-pr-gate/steps/`.
+5. **Tune `post-pr-gate.yaml`** at `apps/worker/post-pr-gate.yaml` if the defaults don't fit (the build copies it from `nitro.options.rootDir`, which is `apps/worker/`, not the monorepo root; a file placed at the monorepo root is silently ignored and the built-in default keeps applying). The default config runs on `blazebot/*` branches only, skips drafts, and runs a single `code-hygiene` step as advisory (`onFailure: continue`). Steps are defined in `apps/worker/src/post-pr-gate/steps/`. (The deployment skills directory ships by a twin mechanism but follows the opposite location rule: see [§12 Agent skills shipped with this deployment](#agent-skills-shipped-with-this-deployment).)
 
 For GitLab.com, configure the project webhook instead: see [`docs/GITLAB-SETUP.md`](./docs/GITLAB-SETUP.md). The webhook URL is `https://<your-vercel-domain>/webhooks/gitlab`, the **Secret token** field must match `GITLAB_WEBHOOK_SECRET`, and **Merge request events**, **Pipeline events** (the **Pipeline Hook**), and **Comments** (the **Note Hook**) are required. Pipeline events drive `trigger_pr_checks_failed`; Comments can drive only the `commented` variant of `trigger_pr_review`. GitLab Request Changes, with or without a summary, is unsupported until GitLab emits a reliable event that distinguishes that transition. Do not use GitLab's newer **Signing token** flow until the worker implements signing-token verification.
 
@@ -531,6 +531,56 @@ to the Artur repository. See the
    ```
 
 The dashboard holds no worker secret. Human login is handled by the worker (Better Auth); the dashboard stores the worker-issued session token in a first-party `httpOnly` cookie and replays it server-side. Set `DASHBOARD_ORIGIN` on the **worker** to this dashboard's URL so Better Auth trusts it. Password-only mode needs no SSO vars; sign in at `/login` with `DASHBOARD_AUTH_EMAIL` / `DASHBOARD_AUTH_PASSWORD`. Optional SSO, Resend, and fixed organization vars belong on the worker project, not the dashboard project.
+
+### Agent skills shipped with this deployment
+
+Skills are the repository-specific knowledge an agent loads on top of its prompt. Besides importing them from GitHub, a deployment can carry its own: put a `skills/` directory at the **root of the repository this deployment is built from**, and every tenant gets its skills without any cross-organization GitHub App access, GitLab-only tenants included.
+
+**Location, and how it differs from the YAML rule.** `post-pr-gate.yaml` is copied from `nitro.options.rootDir`, which is `apps/worker/`, and a copy at the monorepo root is ignored ([§8 step 5](#8-register-the-vcs-webhook-post-pr-gate)). The skills directory is the opposite: it is copied from the **monorepo root**, because it belongs to the repository a tenant deploys, not to the worker app. In local development the worker runs with `apps/worker` as its working directory, so the runtime looks there first and then falls back to the repository root; a `skills/` directory at the root therefore works under `nitro dev` as well as in a deployment.
+
+**Layout.** One level of nesting, one directory per skill, each holding a `SKILL.md`:
+
+```
+skills/
+  review-checklist/
+    SKILL.md
+    references/api.md
+  release-notes/
+    SKILL.md
+```
+
+`SKILL.md` opens with YAML front matter, and the rest of the file is the Markdown the agent reads:
+
+```markdown
+---
+name: review-checklist
+description: House rules the reviewer applies to every pull request.
+---
+
+# Review checklist
+...
+```
+
+A copyable example lives in [`docs/example-skill/SKILL.md`](./docs/example-skill/SKILL.md). It sits under `docs/` deliberately: a copy under `skills/` would be discovered as a real skill of this deployment.
+
+**Contract.** A directory that breaks any of these is skipped, with the reason shown in the dashboard and, since the same reader runs during the build, printed by the build:
+
+| Rule | Limit |
+| --- | --- |
+| Nesting | exactly one level; a `SKILL.md` one level deeper is reported, not found |
+| `SKILL.md` | a regular file, not a symlink, and not executable |
+| `name` | lowercase letters, digits and hyphens, 1 to 64 characters, starting and ending alphanumeric, unique across the directory |
+| `description` | 1 to 1024 characters, no leading or trailing whitespace |
+| Files per skill | 500 |
+| Bytes per file | 1 MiB |
+| Bytes per skill | 5 MiB |
+| Bytes across `skills/` | 25 MiB, because the directory is copied into every function bundle |
+| Symlinks | rejected anywhere inside a skill |
+| File modes | only the executable bit survives, as in a Git checkout |
+
+**Using them.** In the dashboard, open a harness profile, go to Skills and choose **Add skills → This deployment**. An imported skill is stored as an immutable artifact and the profile pins it by content hash, so a later deployment changes nothing on its own: after a redeploy that edits a skill, use **Refresh** on that skill and publish the profile again. The dashboard says whether the refresh moved the pin or found the same contents.
+
+**Build behaviour.** `pnpm build` in `apps/worker` validates the directory before anything else runs and fails the build when any entry cannot ship, listing each path and reason. A deployment with no `skills/` directory is fine and says so in one line.
 
 ### Arthur AI Engine (tracing + prompt-injection check)
 

--- a/apps/dashboard/app/api/harness-profiles/handler.test.ts
+++ b/apps/dashboard/app/api/harness-profiles/handler.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  handleHarnessLocalSkillDiscovery,
   handleHarnessProfileAction,
   handleHarnessProfileGet,
   handleHarnessProfilePatch,
@@ -151,6 +152,43 @@ test("profile mutations and skill operations forward to the exact action routes"
       commitSha: "abc123",
     },
     paths: ["skills/docs"],
+  });
+});
+
+test("deployment skills are discovered by GET and imported by POST on one route", async () => {
+  const calls: Array<{ path: string; method: string | undefined; body: unknown }> =
+    [];
+  const proxy = async (path: string, init?: RequestInit) => {
+    calls.push({
+      path,
+      method: init?.method,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    return Response.json({ ok: true });
+  };
+
+  await handleHarnessLocalSkillDiscovery(proxy);
+  await handleHarnessSkillAction(
+    new Request("https://dashboard.test/api/harness-skills/local", {
+      method: "POST",
+      body: JSON.stringify({
+        skills: [{ path: "review", artifactHash: "a".repeat(64) }],
+      }),
+    }),
+    "local",
+    proxy,
+  );
+
+  assert.deepEqual(
+    calls.map(({ path, method }) => [path, method]),
+    [
+      ["/api/v1/harness-skills/local", "GET"],
+      ["/api/v1/harness-skills/local", "POST"],
+    ],
+  );
+  assert.deepEqual(calls[0]?.body, null);
+  assert.deepEqual(calls[1]?.body, {
+    skills: [{ path: "review", artifactHash: "a".repeat(64) }],
   });
 });
 

--- a/apps/dashboard/app/api/harness-profiles/handler.ts
+++ b/apps/dashboard/app/api/harness-profiles/handler.ts
@@ -147,7 +147,7 @@ export async function handleHarnessProfileAction(
 
 export function handleHarnessSkillAction(
   request: Request,
-  action: "discover" | "import",
+  action: "discover" | "import" | "local",
   workerProxy: WorkerProxy,
 ) {
   return jsonMutation(
@@ -155,4 +155,14 @@ export function handleHarnessSkillAction(
     `/api/v1/harness-skills/${action}`,
     workerProxy,
   );
+}
+
+/**
+ * Deployment-local discovery takes no repository coordinate, so it is a GET
+ * with nothing to forward but the method.
+ */
+export function handleHarnessLocalSkillDiscovery(workerProxy: WorkerProxy) {
+  return forward(workerProxy, "/api/v1/harness-skills/local", {
+    method: "GET",
+  });
 }

--- a/apps/dashboard/app/api/harness-skills/local/route.ts
+++ b/apps/dashboard/app/api/harness-skills/local/route.ts
@@ -1,0 +1,13 @@
+import { proxyWorker } from "@/lib/api/proxy";
+import {
+  handleHarnessLocalSkillDiscovery,
+  handleHarnessSkillAction,
+} from "../../harness-profiles/handler";
+
+export function GET() {
+  return handleHarnessLocalSkillDiscovery(proxyWorker);
+}
+
+export function POST(request: Request) {
+  return handleHarnessSkillAction(request, "local", proxyWorker);
+}

--- a/apps/dashboard/components/cockpit/flow-editor/agent-harness-profile.test.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/agent-harness-profile.test.tsx
@@ -101,6 +101,7 @@ function detail(
     canManageProfile: true,
     canDeleteProfile: false,
     usage: [],
+    skillSources: [],
   };
 }
 

--- a/apps/dashboard/components/cockpit/harness-profiles/profile-editor.test.tsx
+++ b/apps/dashboard/components/cockpit/harness-profiles/profile-editor.test.tsx
@@ -3,10 +3,17 @@ import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { ProfileEditor, parseHomeFiles } from "./profile-editor";
+import {
+  LocalSkillPinNotice,
+  ProfileEditor,
+  parseHomeFiles,
+  pinsDeploymentSkill,
+} from "./profile-editor";
 import type {
+  HarnessLocalSkillDiscoveryResponse,
   HarnessProfileDetailResponse,
   HarnessProfileDto,
+  HarnessSkillSource,
 } from "@shared/contracts";
 import {
   BUILTIN_HARNESS_PROFILE_IDS,
@@ -52,6 +59,8 @@ function render(
   profileValue: HarnessProfileDto,
   canManageProfile: boolean,
   initialMode: "overview" | "edit" | "review" = "overview",
+  skillSources: HarnessProfileDetailResponse["skillSources"] = [],
+  refreshNotice: { artifactHash: string; changed: boolean } | null = null,
 ) {
   const detail: HarnessProfileDetailResponse = {
     profile: profileValue,
@@ -60,6 +69,7 @@ function render(
     canManageProfile,
     canDeleteProfile: canManageProfile,
     usage: [],
+    skillSources,
   };
   return renderToStaticMarkup(
     <ProfileEditor
@@ -75,6 +85,7 @@ function render(
       onDelete={async () => undefined}
       onRestore={async () => undefined}
       onRefreshSkill={async () => undefined}
+      refreshNotice={refreshNotice}
       onDirtyChange={() => undefined}
       initialMode={initialMode}
     />,
@@ -90,7 +101,7 @@ function inputByLabel(html: string, label: string): string {
   return match[0];
 }
 
-test("editable profiles expose the complete manifest and GitHub skill authoring", () => {
+test("editable profiles expose the complete manifest and skill authoring", () => {
   const html = render(profile(), true, "edit");
   assert.match(html, /Identity and harness/);
   assert.match(html, />Context</);
@@ -98,7 +109,7 @@ test("editable profiles expose the complete manifest and GitHub skill authoring"
   assert.match(html, /Limits and workspace/);
   assert.match(html, /Declared capabilities/);
   assert.match(html, /Safe home files/);
-  assert.match(html, /Add from GitHub/);
+  assert.match(html, /Add skills/);
   assert.match(html, /Provider default/);
   assert.match(html, /gpt-5\.4 · unavailable/);
   assert.match(
@@ -204,6 +215,197 @@ test("home-file parsing accepts only the provider-owned runtime file", () => {
       "codex",
     ),
     null,
+  );
+});
+
+test("a pinned skill names the source it came from", () => {
+  const base = profile();
+  const draft = structuredClone(base.draft);
+  draft.skills = [
+    { artifactHash: "a".repeat(64), name: "from-github" },
+    { artifactHash: "b".repeat(64), name: "from-deployment" },
+  ];
+  const html = render({ ...base, draft }, true, "overview", [
+    {
+      artifactHash: "a".repeat(64),
+      source: {
+        owner: "blazity",
+        repository: "ai-workflow",
+        path: "skills/review",
+        commitSha: "c".repeat(40),
+      },
+    },
+    {
+      artifactHash: "b".repeat(64),
+      source: { path: "review-checklist", contentSha256: "d".repeat(64) },
+    },
+  ]);
+
+  assert.match(html, /blazity\/ai-workflow @ cccccccccccc/);
+  assert.match(html, /This deployment · skills\/review-checklist @ dddddddddddd/);
+});
+
+test("refreshing tells a moved pin apart from a deployment carrying the same bytes", () => {
+  const base = profile();
+  const draft = structuredClone(base.draft);
+  draft.skills = [{ artifactHash: "b".repeat(64), name: "from-deployment" }];
+  const sources = [
+    {
+      artifactHash: "b".repeat(64),
+      source: { path: "review-checklist", contentSha256: "d".repeat(64) },
+    },
+  ];
+
+  const updated = render({ ...base, draft }, true, "edit", sources, {
+    artifactHash: "b".repeat(64),
+    changed: true,
+  });
+  const unchanged = render({ ...base, draft }, true, "edit", sources, {
+    artifactHash: "b".repeat(64),
+    changed: false,
+  });
+
+  assert.notEqual(updated, unchanged);
+  assert.match(updated, /Refreshed: updated to new contents/);
+  assert.doesNotMatch(updated, /carries the same contents/);
+  assert.match(
+    unchanged,
+    /Refreshed: this deployment carries the same contents, so the pin is unchanged/,
+  );
+  assert.doesNotMatch(unchanged, /updated to new contents/);
+});
+
+test("a pinned deployment skill reads differently once the deployment moves", () => {
+  const localSource: HarnessSkillSource = {
+    path: "review-checklist",
+    contentSha256: "d".repeat(64),
+  };
+  const notice = (discovery: HarnessLocalSkillDiscoveryResponse | null) =>
+    renderToStaticMarkup(
+      <LocalSkillPinNotice
+        artifactHash={"b".repeat(64)}
+        source={localSource}
+        discovery={discovery}
+      />,
+    );
+
+  const aligned = notice({
+    directoryPresent: true,
+    skills: [
+      {
+        name: "review-checklist",
+        path: "review-checklist",
+        description: null,
+        artifactHash: "b".repeat(64),
+      },
+    ],
+    skipped: [],
+  });
+  const moved = notice({
+    directoryPresent: true,
+    skills: [
+      {
+        name: "review-checklist",
+        path: "review-checklist",
+        description: null,
+        artifactHash: "e".repeat(64),
+      },
+    ],
+    skipped: [],
+  });
+  const gone = notice({
+    directoryPresent: true,
+    skills: [
+      {
+        name: "release-notes",
+        path: "release-notes",
+        description: null,
+        artifactHash: "e".repeat(64),
+      },
+    ],
+    skipped: [],
+  });
+
+  assert.equal(new Set([aligned, moved, gone]).size, 3);
+  assert.match(aligned, /Matches skills\/review-checklist in this deployment/);
+  assert.match(
+    moved,
+    /ships different contents at skills\/review-checklist\. Use Refresh to move the pin/,
+  );
+  assert.doesNotMatch(moved, /Restore the directory/);
+  assert.match(
+    gone,
+    /no longer ships skills\/review-checklist\. Restore the directory in the repository, or remove this skill/,
+  );
+  assert.doesNotMatch(gone, /Use Refresh/);
+});
+
+test("an unreadable deployment listing is unknown, never drifted", () => {
+  const unread = renderToStaticMarkup(
+    <LocalSkillPinNotice
+      artifactHash={"b".repeat(64)}
+      source={{ path: "review-checklist", contentSha256: "d".repeat(64) }}
+      discovery={null}
+    />,
+  );
+  const github = renderToStaticMarkup(
+    <LocalSkillPinNotice
+      artifactHash={"a".repeat(64)}
+      source={{
+        owner: "blazity",
+        repository: "ai-workflow",
+        path: "skills/review",
+        commitSha: "c".repeat(40),
+      }}
+      discovery={{ directoryPresent: true, skills: [], skipped: [] }}
+    />,
+  );
+
+  assert.equal(unread, "");
+  assert.equal(github, "");
+});
+
+test("only a profile pinning a deployment skill has the deployment to ask", () => {
+  const github: HarnessSkillSource = {
+    owner: "blazity",
+    repository: "ai-workflow",
+    path: "skills/review",
+    commitSha: "c".repeat(40),
+  };
+  const local: HarnessSkillSource = {
+    path: "review-checklist",
+    contentSha256: "d".repeat(64),
+  };
+  const sources = new Map<string, HarnessSkillSource>([
+    ["a".repeat(64), github],
+    ["b".repeat(64), local],
+  ]);
+  const lookup = (artifactHash: string) => sources.get(artifactHash);
+
+  assert.equal(pinsDeploymentSkill([], lookup), false);
+  assert.equal(
+    pinsDeploymentSkill(
+      [{ artifactHash: "a".repeat(64), name: "from-github" }],
+      lookup,
+    ),
+    false,
+  );
+  assert.equal(
+    pinsDeploymentSkill(
+      [{ artifactHash: "f".repeat(64), name: "source-unknown" }],
+      lookup,
+    ),
+    false,
+  );
+  assert.equal(
+    pinsDeploymentSkill(
+      [
+        { artifactHash: "a".repeat(64), name: "from-github" },
+        { artifactHash: "b".repeat(64), name: "from-deployment" },
+      ],
+      lookup,
+    ),
+    true,
   );
 });
 

--- a/apps/dashboard/components/cockpit/harness-profiles/profile-editor.tsx
+++ b/apps/dashboard/components/cockpit/harness-profiles/profile-editor.tsx
@@ -16,6 +16,7 @@ import {
 import { readErrorMessage } from "@/lib/api/error-message";
 import type {
   HarnessCapabilitiesResponse,
+  HarnessLocalSkillDiscoveryResponse,
   HarnessProvider,
   HarnessProfileDetailResponse,
   HarnessProfileDraftManifest,
@@ -23,8 +24,13 @@ import type {
   HarnessProfileDto,
   HarnessProfileSkillReference,
   HarnessSkillArtifact,
+  HarnessSkillSource,
 } from "@shared/contracts";
-import { HARNESS_TOOL_IDS, stableJson } from "@shared/contracts";
+import {
+  HARNESS_TOOL_IDS,
+  isHarnessGitHubSkillSource,
+  stableJson,
+} from "@shared/contracts";
 
 const inputClass =
   "h-[30px] w-full rounded-[3px] border border-neutral-200 bg-white px-2 font-mono text-[11px] text-coal outline-none focus:border-mariner disabled:bg-app-bg disabled:opacity-70";
@@ -58,6 +64,8 @@ export interface ProfileEditorProps {
   onDelete: () => Promise<void>;
   onRestore: (version: number) => Promise<void>;
   onRefreshSkill: (artifactHash: string) => Promise<void>;
+  /** Outcome of the last refresh, keyed by the hash the draft now pins. */
+  refreshNotice?: { artifactHash: string; changed: boolean } | null;
   onDirtyChange?: (dirty: boolean) => void;
   initialMode?: "overview" | "edit" | "review";
 }
@@ -156,6 +164,70 @@ function nullableNumber(value: string): number | null {
   return value.trim() === "" ? null : Number(value);
 }
 
+/**
+ * The two variants are told apart by the guard, never by a tag: a tag inside
+ * the source object would enter the artifact hash that profiles pin.
+ *
+ * Both carry a version, because the path alone would read identically before
+ * and after a redeploy: the commit for GitHub, the content digest for the
+ * deployment, which is what a local skill has instead of a commit.
+ */
+function skillSourceLabel(source: HarnessSkillSource): string {
+  return isHarnessGitHubSkillSource(source)
+    ? `${source.owner}/${source.repository} @ ${source.commitSha.slice(0, 12)}`
+    : `This deployment · skills/${source.path} @ ${source.contentSha256.slice(0, 12)}`;
+}
+
+/**
+ * Gate for the deployment read: a profile pinning no deployment skill has
+ * nothing to compare, so it must not spend a request on every editor opening.
+ */
+export function pinsDeploymentSkill(
+  skills: HarnessProfileSkillReference[],
+  source: (artifactHash: string) => HarnessSkillSource | undefined,
+): boolean {
+  return skills.some((skill) => {
+    const pinned = source(skill.artifactHash);
+    return pinned !== undefined && !isHarnessGitHubSkillSource(pinned);
+  });
+}
+
+/**
+ * Checks a pinned deployment skill against what the running deployment ships.
+ * A null discovery is a read that has not landed or has failed, and renders
+ * nothing: not knowing is not the same as having drifted.
+ *
+ * Matching goes by the pinned path, the same coordinate Refresh re-reads, so a
+ * renamed directory reads as gone rather than as a new version of the skill.
+ * The GitHub variant is out of scope: its version is a commit, which the
+ * deployment listing knows nothing about.
+ */
+export function LocalSkillPinNotice({
+  artifactHash,
+  source,
+  discovery,
+}: {
+  artifactHash: string;
+  source: HarnessSkillSource | undefined;
+  discovery: HarnessLocalSkillDiscoveryResponse | null;
+}) {
+  if (!source || isHarnessGitHubSkillSource(source) || !discovery) return null;
+  if (discovery.skills.some((skill) => skill.artifactHash === artifactHash)) {
+    return (
+      <div className="mt-1 font-body text-[10px] text-neutral-600">
+        Matches skills/{source.path} in this deployment.
+      </div>
+    );
+  }
+  return (
+    <div className="mt-1 font-body text-[10px] text-amber-700">
+      {discovery.skills.some((skill) => skill.path === source.path)
+        ? `This deployment ships different contents at skills/${source.path}. Use Refresh to move the pin, then publish the profile.`
+        : `This deployment no longer ships skills/${source.path}. Restore the directory in the repository, or remove this skill from the profile.`}
+    </div>
+  );
+}
+
 function mergeSkills(
   current: HarnessProfileSkillReference[],
   incoming: HarnessProfileSkillReference[],
@@ -185,6 +257,7 @@ export function ProfileEditor({
   onDelete,
   onRestore,
   onRefreshSkill,
+  refreshNotice = null,
   onDirtyChange,
   initialMode = "overview",
 }: ProfileEditorProps) {
@@ -218,6 +291,8 @@ export function ProfileEditor({
   const [importedArtifacts, setImportedArtifacts] = useState<
     Map<string, HarnessSkillArtifact>
   >(new Map());
+  const [deploymentSkills, setDeploymentSkills] =
+    useState<HarnessLocalSkillDiscoveryResponse | null>(null);
   const [capabilities, setCapabilities] =
     useState<HarnessCapabilitiesResponse | null>(null);
   const [capabilityError, setCapabilityError] = useState<string | null>(null);
@@ -236,6 +311,10 @@ export function ProfileEditor({
     setInspectedVersion(null);
     setEditSection("general");
     setImportedArtifacts(new Map());
+    // The deployment listing is deliberately kept: it describes the deployment,
+    // not this profile, so a save, a refresh or a switch to another profile
+    // does not invalidate it. Dropping it here would blank every pin notice
+    // right after Refresh, which is the remedy those notices prescribe.
   }, [profile.id, profile.draftRevision, profile.draft]);
 
   useEffect(() => {
@@ -292,6 +371,36 @@ export function ProfileEditor({
   }, [capabilities, draft, mode]);
 
   const editable = canEditProfile(profile, detail.canManageProfile);
+  // Two complementary windows: the imported map covers skills added to the
+  // unsaved draft, the detail response covers the ones already persisted.
+  const persistedSkillSources = new Map(
+    detail.skillSources.map((entry) => [entry.artifactHash, entry.source]),
+  );
+  const skillSource = (artifactHash: string): HarnessSkillSource | undefined =>
+    importedArtifacts.get(artifactHash)?.source ??
+    persistedSkillSources.get(artifactHash);
+  const comparesDeployment = pinsDeploymentSkill(draft.skills, skillSource);
+
+  // A failed read leaves the listing null on purpose: the pin notices then say
+  // nothing, because an unanswered deployment is unknown, not drifted.
+  useEffect(() => {
+    if (!comparesDeployment) return;
+    const controller = new AbortController();
+    void fetch("/api/harness-skills/local", {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then((response) =>
+        response.ok
+          ? (response.json() as Promise<HarnessLocalSkillDiscoveryResponse>)
+          : null,
+      )
+      .then((listing) => {
+        if (listing && !controller.signal.aborted) setDeploymentSkills(listing);
+      })
+      .catch(() => undefined);
+    return () => controller.abort();
+  }, [comparesDeployment]);
   const hasCompleteRuntimeToolSet =
     draft.tools.length === HARNESS_TOOL_IDS.length &&
     HARNESS_TOOL_IDS.every((tool) => draft.tools.includes(tool));
@@ -767,7 +876,8 @@ export function ProfileEditor({
                     Skills
                   </h2>
                   <p className="mt-1 mb-0 font-body text-[11px] text-neutral-500">
-                    Skills are pinned to exact Git commits for reproducibility.
+                    Skills are pinned to immutable artifacts: an exact GitHub
+                    commit, or the contents this deployment ships.
                   </p>
                 </div>
                 {editable && (
@@ -776,7 +886,7 @@ export function ProfileEditor({
                     onClick={() => setShowSkillImport(true)}
                     className={primaryButtonClass}
                   >
-                    Add from GitHub
+                    Add skills
                   </button>
                 )}
               </div>
@@ -786,24 +896,34 @@ export function ProfileEditor({
                     No skills are attached to this profile.
                   </div>
                 ) : (
-                  draft.skills.map((skill) => (
-                    <div
-                      key={skill.artifactHash}
-                      className="grid gap-2 border-b border-neutral-100 px-4 py-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_180px]"
-                    >
-                      <div>
-                        <div className="font-mono text-[11px] font-semibold text-coal">
-                          {skill.name}
+                  draft.skills.map((skill) => {
+                    const source = skillSource(skill.artifactHash);
+                    return (
+                      <div
+                        key={skill.artifactHash}
+                        className="grid gap-2 border-b border-neutral-100 px-4 py-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_180px]"
+                      >
+                        <div>
+                          <div className="font-mono text-[11px] font-semibold text-coal">
+                            {skill.name}
+                          </div>
+                          <div className="mt-0.5 font-body text-[10px] text-neutral-500">
+                            {source
+                              ? skillSourceLabel(source)
+                              : "Immutable skill artifact"}
+                          </div>
+                          <LocalSkillPinNotice
+                            artifactHash={skill.artifactHash}
+                            source={source}
+                            discovery={deploymentSkills}
+                          />
                         </div>
-                        <div className="mt-0.5 font-body text-[10px] text-neutral-500">
-                          Immutable GitHub skill artifact
+                        <div className="truncate font-mono text-[9px] text-neutral-500">
+                          {skill.artifactHash}
                         </div>
                       </div>
-                      <div className="truncate font-mono text-[9px] text-neutral-500">
-                        {skill.artifactHash}
-                      </div>
-                    </div>
-                  ))
+                    );
+                  })
                 )}
               </div>
             </div>
@@ -1660,6 +1780,9 @@ export function ProfileEditor({
             )}
             {draft.skills.map((skill) => {
               const artifact = importedArtifacts.get(skill.artifactHash);
+              const source = skillSource(skill.artifactHash);
+              const local =
+                source !== undefined && !isHarnessGitHubSkillSource(source);
               return (
                 <div
                   key={skill.artifactHash}
@@ -1673,11 +1796,30 @@ export function ProfileEditor({
                       <div className="truncate font-mono text-[9px] text-neutral-500">
                         {skill.artifactHash}
                       </div>
-                      {artifact && (
+                      {source && (
                         <div className="mt-1 font-mono text-[9px] text-neutral-500">
-                          {artifact.source.owner}/{artifact.source.repository} @{" "}
-                          {artifact.source.commitSha.slice(0, 12)} ·{" "}
-                          {artifact.files.length} files
+                          {skillSourceLabel(source)}
+                          {artifact ? ` · ${artifact.files.length} files` : ""}
+                        </div>
+                      )}
+                      <LocalSkillPinNotice
+                        artifactHash={skill.artifactHash}
+                        source={source}
+                        discovery={deploymentSkills}
+                      />
+                      {refreshNotice?.artifactHash === skill.artifactHash && (
+                        <div
+                          className={`mt-1 font-body text-[10px] ${
+                            refreshNotice.changed
+                              ? "text-green-700"
+                              : "text-neutral-600"
+                          }`}
+                        >
+                          {refreshNotice.changed
+                            ? "Refreshed: updated to new contents."
+                            : local
+                              ? "Refreshed: this deployment carries the same contents, so the pin is unchanged."
+                              : "Refreshed: the default branch carries the same contents, so the pin is unchanged."}
                         </div>
                       )}
                     </div>
@@ -1690,7 +1832,9 @@ export function ProfileEditor({
                           title={
                             dirty
                               ? "Save local profile changes before refreshing a skill"
-                              : "Discover the latest commit and update only this profile draft"
+                              : local
+                                ? "Re-read this skill from the deployment and update only this profile draft"
+                                : "Discover the latest commit and update only this profile draft"
                           }
                           className="appearance-none border-none bg-transparent p-0 font-body text-[11px] text-mariner cursor-pointer disabled:cursor-default disabled:opacity-40"
                         >
@@ -1727,7 +1871,7 @@ export function ProfileEditor({
                 disabled={busy !== null}
                 className={secondaryButtonClass}
               >
-                Add from GitHub
+                Add skills
               </button>
             )}
           </div>
@@ -1928,6 +2072,14 @@ export function ProfileEditor({
       <SkillImport
         open={showSkillImport}
         disabled={!editable || busy !== null}
+        pinned={draft.skills.map((skill) => {
+          const source = skillSource(skill.artifactHash);
+          return {
+            name: skill.name,
+            artifactHash: skill.artifactHash,
+            sourceLabel: source ? skillSourceLabel(source) : null,
+          };
+        })}
         onClose={() => setShowSkillImport(false)}
         onImported={(skills, artifacts) => {
           setDraft((current) => ({

--- a/apps/dashboard/components/cockpit/harness-profiles/skill-import.test.tsx
+++ b/apps/dashboard/components/cockpit/harness-profiles/skill-import.test.tsx
@@ -3,15 +3,33 @@ import test from "node:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { SkillImport } from "./skill-import";
+import {
+  LOCAL_SOURCE_NOTE,
+  LocalSkillDiscovery,
+  SkillImport,
+  SkillReplacementNotice,
+} from "./skill-import";
+import type { HarnessLocalSkillDiscoveryResponse } from "@shared/contracts";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+function localDiscovery(discovery: HarnessLocalSkillDiscoveryResponse) {
+  return renderToStaticMarkup(
+    <LocalSkillDiscovery
+      discovery={discovery}
+      selected={[]}
+      disabled={false}
+      onToggle={() => undefined}
+    />,
+  );
+}
 
 test("GitHub skill import opens as the approved three-step exact-pin drawer", () => {
   const html = renderToStaticMarkup(
     <SkillImport
       open
       disabled={false}
+      pinned={[]}
       onClose={() => undefined}
       onImported={() => undefined}
     />,
@@ -27,11 +45,144 @@ test("GitHub skill import opens as the approved three-step exact-pin drawer", ()
   assert.match(html, /exact commit/);
 });
 
+test("the drawer offers both skill sources", () => {
+  const html = renderToStaticMarkup(
+    <SkillImport
+      open
+      disabled={false}
+      pinned={[]}
+      onClose={() => undefined}
+      onImported={() => undefined}
+    />,
+  );
+  assert.match(html, /role="radiogroup"/);
+  assert.match(html, /GitHub repository/);
+  assert.match(html, /This deployment/);
+});
+
+test("the local source note describes freezing, not a self-updating skill", () => {
+  assert.match(
+    LOCAL_SOURCE_NOTE,
+    /an imported skill is frozen at the contents it had/,
+  );
+  assert.match(
+    LOCAL_SOURCE_NOTE,
+    /use Refresh on the skill and publish the profile again/,
+  );
+  assert.doesNotMatch(LOCAL_SOURCE_NOTE, /change with the next deployment/);
+});
+
+test("a deployment with no directory reads differently from one that skipped everything", () => {
+  const absent = localDiscovery({
+    directoryPresent: false,
+    skills: [],
+    skipped: [],
+  });
+  const allSkipped = localDiscovery({
+    directoryPresent: true,
+    skills: [],
+    skipped: [
+      { path: "review", reason: "SKILL.md is missing" },
+      { path: "triage", reason: "Description is longer than 1024 characters" },
+    ],
+  });
+
+  assert.notEqual(absent, allSkipped);
+  assert.match(absent, /carries no skills\/ directory/);
+  assert.match(absent, /skills\/\n {2}review-checklist\/\n {4}SKILL\.md/);
+  assert.match(absent, /name: review-checklist/);
+  assert.match(absent, /description: House rules/);
+  assert.doesNotMatch(absent, /none of its entries can be offered/);
+  assert.match(allSkipped, /none of its entries can be offered/);
+  assert.doesNotMatch(allSkipped, /carries no skills\/ directory/);
+  assert.match(allSkipped, /Skipped 2 directories/);
+  assert.match(allSkipped, /SKILL\.md is missing/);
+  assert.match(allSkipped, /Description is longer than 1024 characters/);
+});
+
+test("offerable deployment skills are listed with their directory", () => {
+  const html = localDiscovery({
+    directoryPresent: true,
+    skills: [
+      {
+        name: "review-checklist",
+        path: "review-checklist",
+        description: "House review rules",
+        artifactHash: "a".repeat(64),
+      },
+    ],
+    skipped: [{ path: "draft", reason: "SKILL.md is missing" }],
+  });
+
+  assert.match(html, /review-checklist/);
+  assert.match(html, /House review rules/);
+  assert.match(html, /skills\/review-checklist/);
+  assert.match(html, /type="checkbox"/);
+  assert.match(html, /Skipped 1 directory/);
+  assert.doesNotMatch(html, /carries no skills\/ directory/);
+  assert.doesNotMatch(html, /none of its entries can be offered/);
+});
+
+test("a deployment skill taking over a GitHub name says whose pin it takes", () => {
+  const pinned = [
+    {
+      name: "review-checklist",
+      artifactHash: "a".repeat(64),
+      sourceLabel: "blazity/ai-workflow @ cccccccccccc",
+    },
+  ];
+
+  const collides = renderToStaticMarkup(
+    <SkillReplacementNotice
+      incoming={[{ name: "review-checklist", artifactHash: "b".repeat(64) }]}
+      pinned={pinned}
+    />,
+  );
+  const distinct = renderToStaticMarkup(
+    <SkillReplacementNotice
+      incoming={[{ name: "release-notes", artifactHash: "b".repeat(64) }]}
+      pinned={pinned}
+    />,
+  );
+  const identical = renderToStaticMarkup(
+    <SkillReplacementNotice
+      incoming={[{ name: "review-checklist", artifactHash: "a".repeat(64) }]}
+      pinned={pinned}
+    />,
+  );
+
+  assert.match(collides, /Replaces 1 pinned skill/);
+  assert.match(collides, /review-checklist/);
+  assert.match(collides, /takes over the pin held by/);
+  assert.match(collides, /blazity\/ai-workflow @ cccccccccccc/);
+  assert.match(collides, /name in their SKILL\.md/);
+  assert.equal(distinct, "");
+  assert.equal(identical, "");
+});
+
+test("a replaced pin with no source on record still names what happens", () => {
+  const html = renderToStaticMarkup(
+    <SkillReplacementNotice
+      incoming={[{ name: "review-checklist" }]}
+      pinned={[
+        {
+          name: "review-checklist",
+          artifactHash: "a".repeat(64),
+          sourceLabel: null,
+        },
+      ]}
+    />,
+  );
+
+  assert.match(html, /takes over the pin held by a source no longer on record/);
+});
+
 test("closed GitHub skill import renders nothing", () => {
   const html = renderToStaticMarkup(
     <SkillImport
       open={false}
       disabled={false}
+      pinned={[]}
       onClose={() => undefined}
       onImported={() => undefined}
     />,

--- a/apps/dashboard/components/cockpit/harness-profiles/skill-import.tsx
+++ b/apps/dashboard/components/cockpit/harness-profiles/skill-import.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { readErrorMessage } from "@/lib/api/error-message";
 import type {
+  HarnessLocalSkillDiscoveryResponse,
   HarnessProfileSkillReference,
   HarnessSkillArtifact,
   HarnessSkillDiscoveryResponse,
@@ -14,23 +15,204 @@ const primaryButtonClass =
 const secondaryButtonClass =
   "appearance-none rounded-[3px] border border-neutral-300 bg-panel px-4 py-2 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-coal cursor-pointer disabled:cursor-default disabled:opacity-40";
 
+type SkillSourceKind = "github" | "local";
+
+/**
+ * Says what the deployment source does and, as importantly, what it does not:
+ * an imported artifact is content-addressed and the pin is a hash, so a later
+ * deployment cannot change what an agent receives.
+ */
+export const LOCAL_SOURCE_NOTE =
+  "Read from the deployment bundle. No GitHub App installation and no cross-organization access are involved. This list comes from the bundle of the deployment you are using now, while an imported skill is frozen at the contents it had: after a redeploy, use Refresh on the skill and publish the profile again.";
+
+/**
+ * The deployment-local list, split out from the drawer so the three states it
+ * has to tell apart can be rendered without the drawer's fetch: no directory
+ * at all, a directory whose every entry was rejected, and offerable skills.
+ */
+export function LocalSkillDiscovery({
+  discovery,
+  selected,
+  disabled,
+  onToggle,
+}: {
+  discovery: HarnessLocalSkillDiscoveryResponse;
+  selected: string[];
+  disabled: boolean;
+  onToggle: (path: string, checked: boolean) => void;
+}) {
+  return (
+    <div className="mt-6">
+      {!discovery.directoryPresent ? (
+        <div className="rounded-[3px] border border-dashed border-neutral-300 px-3 py-6 font-body text-[11px] text-neutral-500">
+          <p className="m-0">
+            This deployment carries no skills/ directory. Add one at the root of
+            the repository this deployment is built from, then redeploy. Each
+            skill is one directory holding a SKILL.md:
+          </p>
+          <pre className="mt-3 mb-0 overflow-x-auto rounded-[3px] border border-neutral-200 bg-app-bg p-3 font-mono text-[10px] leading-[1.5] text-coal">
+{`skills/
+  review-checklist/
+    SKILL.md
+    references/api.md
+
+# skills/review-checklist/SKILL.md
+---
+name: review-checklist
+description: House rules the reviewer applies to every pull request.
+---
+Markdown the agent reads once the skill is loaded.`}
+          </pre>
+          <p className="mt-3 mb-0">
+            The name is lowercase letters, digits and hyphens; the description
+            is 1 to 1024 characters. SETUP.md carries the full contract.
+          </p>
+        </div>
+      ) : discovery.skills.length === 0 ? (
+        <div className="rounded-[3px] border border-amber-300 bg-amber-50 px-3 py-4 font-body text-[11px] text-amber-800">
+          The skills/ directory is present, but none of its entries can be
+          offered.
+          {discovery.skipped.length > 0
+            ? " Fix the reasons below in the repository, then redeploy."
+            : " It holds no skill directories."}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-[3px] border border-neutral-200">
+          {discovery.skills.map((skill) => {
+            const checked = selected.includes(skill.path);
+            return (
+              <label
+                key={skill.path}
+                className={`flex cursor-pointer items-start gap-3 border-b border-neutral-100 px-3 py-3 last:border-b-0 ${
+                  checked ? "bg-mariner-50" : "bg-panel"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={disabled}
+                  onChange={(event) =>
+                    onToggle(skill.path, event.target.checked)
+                  }
+                  className="mt-0.5 size-3.5 accent-mariner"
+                />
+                <span className="min-w-0">
+                  <span className="block font-mono text-[11px] font-semibold text-coal">
+                    {skill.name}
+                  </span>
+                  {skill.description && (
+                    <span className="mt-0.5 block font-body text-[10px] text-neutral-600">
+                      {skill.description}
+                    </span>
+                  )}
+                  <span className="mt-1 block truncate font-mono text-[9px] text-neutral-500">
+                    skills/{skill.path}
+                  </span>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      )}
+
+      {discovery.skipped.length > 0 && (
+        <div className="mt-4 rounded-[3px] border border-neutral-200 bg-app-bg p-3">
+          <div className="font-body text-[11px] font-semibold text-coal">
+            Skipped {discovery.skipped.length}{" "}
+            {discovery.skipped.length === 1 ? "directory" : "directories"}
+          </div>
+          <div className="mt-2 flex flex-col gap-1">
+            {discovery.skipped.map((skip) => (
+              <div key={skip.path} className="font-body text-[10px]">
+                <span className="font-mono text-neutral-700">
+                  skills/{skip.path}
+                </span>{" "}
+                <span className="text-neutral-600">{skip.reason}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A skill the draft already pins, labelled by the editor that owns labelling. */
+export interface PinnedSkillSummary {
+  name: string;
+  artifactHash: string;
+  sourceLabel: string | null;
+}
+
+/**
+ * Merging into the draft drops every pinned skill sharing the incoming name,
+ * which is how a re-import from a newer commit lands and is the intent there.
+ * With a second source that same rule swaps a GitHub pin for a deployment one,
+ * and the name comes from front matter, so it need not match the directory
+ * holding it. Say so before the import instead of hiding it.
+ */
+export function SkillReplacementNotice({
+  incoming,
+  pinned,
+}: {
+  incoming: Array<{ name: string; artifactHash?: string }>;
+  pinned: PinnedSkillSummary[];
+}) {
+  const replaced = incoming.flatMap((skill) => {
+    const match = pinned.find(
+      (candidate) =>
+        candidate.name === skill.name &&
+        candidate.artifactHash !== skill.artifactHash,
+    );
+    return match ? [{ name: skill.name, previous: match }] : [];
+  });
+  if (replaced.length === 0) return null;
+  return (
+    <div className="mt-3 rounded-[3px] border border-amber-300 bg-amber-50 px-3 py-2 font-body text-[11px] text-amber-800">
+      <div className="font-semibold">
+        Replaces {replaced.length} pinned{" "}
+        {replaced.length === 1 ? "skill" : "skills"}
+      </div>
+      <div className="mt-1 flex flex-col gap-1">
+        {replaced.map((entry) => (
+          <div key={entry.name} className="font-body text-[10px]">
+            <span className="font-mono">{entry.name}</span> takes over the pin
+            held by{" "}
+            {entry.previous.sourceLabel ?? "a source no longer on record"}.
+          </div>
+        ))}
+      </div>
+      <div className="mt-1 font-body text-[10px]">
+        Skills are matched by the name in their SKILL.md, which need not match
+        the directory holding it. The replaced pin leaves the draft as soon as
+        you add this selection.
+      </div>
+    </div>
+  );
+}
+
 export function SkillImport({
   open,
   disabled,
+  pinned,
   onClose,
   onImported,
 }: {
   open: boolean;
   disabled: boolean;
+  pinned: PinnedSkillSummary[];
   onClose: () => void;
   onImported: (
     skills: HarnessProfileSkillReference[],
     artifacts: HarnessSkillArtifact[],
   ) => void;
 }) {
+  const [sourceKind, setSourceKind] = useState<SkillSourceKind>("github");
   const [source, setSource] = useState("");
   const [discovery, setDiscovery] =
     useState<HarnessSkillDiscoveryResponse | null>(null);
+  const [localDiscovery, setLocalDiscovery] =
+    useState<HarnessLocalSkillDiscoveryResponse | null>(null);
   const [selected, setSelected] = useState<string[]>([]);
   const [search, setSearch] = useState("");
   const [step, setStep] = useState<"source" | "discover" | "review">("source");
@@ -46,6 +228,42 @@ export function SkillImport({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [busy, onClose, open]);
 
+  // Re-read on every opening rather than caching: a redeploy between two
+  // openings swaps the bytes on disk, and a stale list would offer hashes the
+  // import then rejects.
+  useEffect(() => {
+    if (!open || sourceKind !== "local") return;
+    let cancelled = false;
+    setBusy("discover");
+    setError(null);
+    setLocalDiscovery(null);
+    setSelected([]);
+    void fetch("/api/harness-skills/local", { cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(await readErrorMessage(response));
+        return (await response.json()) as HarnessLocalSkillDiscoveryResponse;
+      })
+      .then((result) => {
+        if (cancelled) return;
+        setLocalDiscovery(result);
+        setSelected(result.skills.map((skill) => skill.path));
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return;
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : "Unable to read deployment skills",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setBusy(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, sourceKind]);
+
   const visibleSkills = useMemo(() => {
     const query = search.trim().toLowerCase();
     if (!discovery || query === "") return discovery?.skills ?? [];
@@ -56,6 +274,41 @@ export function SkillImport({
         skill.description?.toLowerCase().includes(query),
     );
   }, [discovery, search]);
+
+  function switchSource(next: SkillSourceKind) {
+    if (next === sourceKind) return;
+    setSourceKind(next);
+    setDiscovery(null);
+    setLocalDiscovery(null);
+    setSelected([]);
+    setSearch("");
+    setError(null);
+    setStep(next === "local" ? "discover" : "source");
+  }
+
+  function toggleSelected(path: string, checked: boolean) {
+    setSelected((previous) =>
+      checked
+        ? [...previous, path]
+        : previous.filter((candidate) => candidate !== path),
+    );
+  }
+
+  function applyImported(artifacts: HarnessSkillArtifact[]) {
+    onImported(
+      artifacts.map((artifact) => ({
+        artifactHash: artifact.artifactHash,
+        name: artifact.name,
+      })),
+      artifacts,
+    );
+    setSource("");
+    setDiscovery(null);
+    setLocalDiscovery(null);
+    setSelected([]);
+    setSearch("");
+    setStep(sourceKind === "local" ? "discover" : "source");
+  }
 
   async function discover() {
     setBusy("discover");
@@ -86,17 +339,32 @@ export function SkillImport({
   }
 
   async function importSelected() {
-    if (!discovery || selected.length === 0) return;
+    if (selected.length === 0) return;
+    const request =
+      sourceKind === "local"
+        ? localDiscovery && {
+            url: "/api/harness-skills/local",
+            body: {
+              skills: localDiscovery.skills
+                .filter((skill) => selected.includes(skill.path))
+                .map((skill) => ({
+                  path: skill.path,
+                  artifactHash: skill.artifactHash,
+                })),
+            },
+          }
+        : discovery && {
+            url: "/api/harness-skills/import",
+            body: { source: discovery.source, paths: selected },
+          };
+    if (!request) return;
     setBusy("import");
     setError(null);
     try {
-      const response = await fetch("/api/harness-skills/import", {
+      const response = await fetch(request.url, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          source: discovery.source,
-          paths: selected,
-        }),
+        body: JSON.stringify(request.body),
       });
       if (!response.ok) {
         setError(await readErrorMessage(response));
@@ -105,18 +373,7 @@ export function SkillImport({
       const result = (await response.json()) as {
         artifacts: HarnessSkillArtifact[];
       };
-      onImported(
-        result.artifacts.map((artifact) => ({
-          artifactHash: artifact.artifactHash,
-          name: artifact.name,
-        })),
-        result.artifacts,
-      );
-      setSource("");
-      setDiscovery(null);
-      setSelected([]);
-      setSearch("");
-      setStep("source");
+      applyImported(result.artifacts);
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Unable to import skills");
     } finally {
@@ -125,6 +382,27 @@ export function SkillImport({
   }
 
   if (!open) return null;
+
+  const selectedSkills: Array<{ name: string; artifactHash?: string }> =
+    sourceKind === "local"
+      ? (localDiscovery?.skills ?? []).filter((skill) =>
+          selected.includes(skill.path),
+        )
+      : (discovery?.skills ?? []).filter((skill) =>
+          selected.includes(skill.path),
+        );
+
+  const steps: Array<[string, string]> =
+    sourceKind === "local"
+      ? [
+          ["discover", "1. Discover"],
+          ["review", "2. Review"],
+        ]
+      : [
+          ["source", "1. Source"],
+          ["discover", "2. Discover"],
+          ["review", "3. Review"],
+        ];
 
   return (
     <div className="fixed inset-0 z-[120] bg-coal/20" onMouseDown={onClose}>
@@ -141,16 +419,17 @@ export function SkillImport({
               id="skill-import-title"
               className="m-0 font-display text-[20px] font-semibold text-coal"
             >
-              Add skills from GitHub
+              Add skills
             </h2>
             <p className="mt-1 mb-0 font-body text-[11px] text-neutral-500">
-              Discover skills first, then pin the selected files to one exact
-              commit.
+              {sourceKind === "local"
+                ? "Take skills from the skills/ directory this deployment ships."
+                : "Discover skills first, then pin the selected files to one exact commit."}
             </p>
           </div>
           <button
             type="button"
-            aria-label="Close GitHub skill import"
+            aria-label="Close skill import"
             onClick={onClose}
             disabled={busy !== null}
             className="appearance-none border-none bg-transparent p-2 font-body text-[20px] text-neutral-500 cursor-pointer"
@@ -159,14 +438,44 @@ export function SkillImport({
           </button>
         </header>
 
-        <div className="grid grid-cols-3 border-b border-neutral-200 px-5 py-3">
-          {[
-            ["source", "1. Source"],
-            ["discover", "2. Discover"],
-            ["review", "3. Review"],
-          ].map(([id, label], index) => {
-            const order = ["source", "discover", "review"];
-            const activeIndex = order.indexOf(step);
+        <div
+          role="radiogroup"
+          aria-label="Skill source"
+          className="flex gap-2 border-b border-neutral-200 px-5 py-3"
+        >
+          {(
+            [
+              ["github", "GitHub repository"],
+              ["local", "This deployment"],
+            ] as Array<[SkillSourceKind, string]>
+          ).map(([kind, label]) => (
+            <button
+              key={kind}
+              type="button"
+              role="radio"
+              aria-checked={sourceKind === kind}
+              onClick={() => switchSource(kind)}
+              disabled={busy !== null}
+              className={`appearance-none rounded-[3px] border px-3 py-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] cursor-pointer disabled:cursor-default disabled:opacity-40 ${
+                sourceKind === kind
+                  ? "border-mariner bg-mariner-50 text-mariner"
+                  : "border-neutral-300 bg-panel text-neutral-600"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div
+          className={`grid border-b border-neutral-200 px-5 py-3 ${
+            sourceKind === "local" ? "grid-cols-2" : "grid-cols-3"
+          }`}
+        >
+          {steps.map(([id, label], index) => {
+            const activeIndex = steps.findIndex(
+              ([candidate]) => candidate === step,
+            );
             return (
               <div
                 key={id}
@@ -183,47 +492,53 @@ export function SkillImport({
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto p-5">
-          <div>
-            <label
-              htmlFor="github-skill-source"
-              className="font-body text-[12px] font-semibold text-coal"
-            >
-              Source repository
-            </label>
-            <p className="mt-1 mb-2 font-body text-[10px] text-neutral-500">
-              Enter owner/repository, a full GitHub URL, or a direct path to a
-              skill.
-            </p>
-            <div className="flex gap-2">
-              <input
-                id="github-skill-source"
-                value={source}
-                disabled={disabled || busy !== null}
-                onChange={(event) => {
-                  setSource(event.target.value);
-                  if (step !== "source") {
-                    setDiscovery(null);
-                    setSelected([]);
-                    setStep("source");
-                  }
-                }}
-                placeholder="vercel-labs/agent-skills"
-                className="h-[36px] min-w-0 flex-1 rounded-[3px] border border-neutral-200 bg-white px-3 font-mono text-[11px] text-coal outline-none focus:border-mariner"
-              />
-              <button
-                type="button"
-                onClick={() => void discover()}
-                disabled={disabled || busy !== null || source.trim() === ""}
-                className={secondaryButtonClass}
+          {sourceKind === "local" ? (
+            <div className="rounded-[3px] border border-neutral-200 bg-app-bg px-3 py-2 font-body text-[10px] text-neutral-600">
+              {LOCAL_SOURCE_NOTE}
+            </div>
+          ) : (
+            <div>
+              <label
+                htmlFor="github-skill-source"
+                className="font-body text-[12px] font-semibold text-coal"
               >
-                {busy === "discover" ? "Discovering…" : "Discover"}
-              </button>
+                Source repository
+              </label>
+              <p className="mt-1 mb-2 font-body text-[10px] text-neutral-500">
+                Enter owner/repository, a full GitHub URL, or a direct path to a
+                skill.
+              </p>
+              <div className="flex gap-2">
+                <input
+                  id="github-skill-source"
+                  value={source}
+                  disabled={disabled || busy !== null}
+                  onChange={(event) => {
+                    setSource(event.target.value);
+                    if (step !== "source") {
+                      setDiscovery(null);
+                      setSelected([]);
+                      setStep("source");
+                    }
+                  }}
+                  placeholder="vercel-labs/agent-skills"
+                  className="h-[36px] min-w-0 flex-1 rounded-[3px] border border-neutral-200 bg-white px-3 font-mono text-[11px] text-coal outline-none focus:border-mariner"
+                />
+                <button
+                  type="button"
+                  onClick={() => void discover()}
+                  disabled={disabled || busy !== null || source.trim() === ""}
+                  className={secondaryButtonClass}
+                >
+                  {busy === "discover" ? "Discovering…" : "Discover"}
+                </button>
+              </div>
+              <div className="mt-2 rounded-[3px] border border-neutral-200 bg-app-bg px-3 py-2 font-body text-[10px] text-neutral-600">
+                Uses the organization GitHub App with read-only repository
+                access. Nothing is written back to GitHub.
+              </div>
             </div>
-            <div className="mt-2 rounded-[3px] border border-neutral-200 bg-app-bg px-3 py-2 font-body text-[10px] text-neutral-600">
-              Uses the organization GitHub App with read-only repository
-              access. Nothing is written back to GitHub.
-            </div>
-          </div>
+          )}
 
           {error && (
             <div
@@ -234,7 +549,16 @@ export function SkillImport({
             </div>
           )}
 
-          {discovery && (
+          {sourceKind === "local" && localDiscovery && (
+            <LocalSkillDiscovery
+              discovery={localDiscovery}
+              selected={selected}
+              disabled={disabled || busy !== null}
+              onToggle={toggleSelected}
+            />
+          )}
+
+          {sourceKind === "github" && discovery && (
             <div className="mt-6">
               <div className="grid grid-cols-2 rounded-[3px] border border-neutral-200 bg-app-bg p-3">
                 <div>
@@ -305,11 +629,7 @@ export function SkillImport({
                           checked={checked}
                           disabled={disabled || busy !== null}
                           onChange={(event) =>
-                            setSelected((previous) =>
-                              event.target.checked
-                                ? [...previous, skill.path]
-                                : previous.filter((path) => path !== skill.path),
-                            )
+                            toggleSelected(skill.path, event.target.checked)
                           }
                           className="mt-0.5 size-3.5 accent-mariner"
                         />
@@ -357,18 +677,24 @@ export function SkillImport({
             </div>
           )}
 
-          {step === "review" && discovery && (
-            <div className="mt-5 rounded-[3px] border border-mariner-200 bg-mariner-50 p-3">
-              <div className="font-body text-[12px] font-semibold text-coal">
-                Ready to add {selected.length}{" "}
-                {selected.length === 1 ? "skill" : "skills"} to this draft
+          {step === "review" && (
+            <>
+              <div className="mt-5 rounded-[3px] border border-mariner-200 bg-mariner-50 p-3">
+                <div className="font-body text-[12px] font-semibold text-coal">
+                  Ready to add {selected.length}{" "}
+                  {selected.length === 1 ? "skill" : "skills"} to this draft
+                </div>
+                <p className="mt-1 mb-0 font-body text-[10px] text-neutral-600">
+                  {sourceKind === "local"
+                    ? "The selected directories will be stored as immutable artifacts of their current contents. They take effect only after you save and publish the profile."
+                    : `The selected files will be stored as immutable artifacts at ${discovery?.source.commitSha.slice(0, 12) ?? ""}. They take effect only after you save and publish the profile.`}
+                </p>
               </div>
-              <p className="mt-1 mb-0 font-body text-[10px] text-neutral-600">
-                The selected files will be stored as immutable artifacts at{" "}
-                {discovery.source.commitSha.slice(0, 12)}. They take effect only
-                after you save and publish the profile.
-              </p>
-            </div>
+              <SkillReplacementNotice
+                incoming={selectedSkills}
+                pinned={pinned}
+              />
+            </>
           )}
         </div>
 
@@ -385,7 +711,7 @@ export function SkillImport({
             <button
               type="button"
               onClick={() => setStep("review")}
-              disabled={!discovery || selected.length === 0 || busy !== null}
+              disabled={selected.length === 0 || busy !== null}
               className={primaryButtonClass}
             >
               Review {selected.length || ""}{" "}

--- a/apps/dashboard/components/cockpit/screens/harness-profiles.tsx
+++ b/apps/dashboard/components/cockpit/screens/harness-profiles.tsx
@@ -203,6 +203,12 @@ export function HarnessProfilesScreen({
   const [busy, setBusy] = useState<ProfileAction | "create" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [editorDirty, setEditorDirty] = useState(false);
+  // Keyed by the hash the draft pins after the refresh, which is the previous
+  // one when the deployment carried the same bytes.
+  const [refreshNotice, setRefreshNotice] = useState<{
+    artifactHash: string;
+    changed: boolean;
+  } | null>(null);
   const requestId = useRef(0);
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
@@ -226,6 +232,7 @@ export function HarnessProfilesScreen({
     setEditorDirty(false);
     setActiveId(profileId);
     setError(null);
+    setRefreshNotice(null);
     updateProfileUrl(profileId, mode);
   }
 
@@ -496,7 +503,12 @@ export function HarnessProfilesScreen({
       },
       `refresh-${artifactHash}`,
     );
-    if (result) await reload(result.profile.id);
+    if (!result) return;
+    setRefreshNotice({
+      artifactHash: result.artifact.artifactHash,
+      changed: result.changed,
+    });
+    await reload(result.profile.id);
   }
 
   if (!available) {
@@ -630,6 +642,7 @@ export function HarnessProfilesScreen({
               onDelete={remove}
               onRestore={restore}
               onRefreshSkill={refreshSkill}
+              refreshNotice={refreshNotice}
               onDirtyChange={setEditorDirty}
             />
           ) : (

--- a/apps/shared/contracts/harness-profiles.ts
+++ b/apps/shared/contracts/harness-profiles.ts
@@ -341,6 +341,21 @@ export interface HarnessProfileDetailResponse {
   canManageProfile: boolean;
   canDeleteProfile: boolean;
   usage: HarnessProfileUsageDto[];
+  /**
+   * Where each skill the draft pins came from, looked up at read time. A pin
+   * whose artifact row is gone is simply absent here.
+   */
+  skillSources: HarnessProfileSkillSourceDto[];
+}
+
+/**
+ * Derived, never persisted. A skill reference inside a manifest stays exactly
+ * `{artifactHash, name}` because the manifest is hashed whole, so growing it
+ * would rehash every profile version already stored.
+ */
+export interface HarnessProfileSkillSourceDto {
+  artifactHash: string;
+  source: HarnessSkillSource;
 }
 
 export interface HarnessProfileUsageDto {
@@ -360,11 +375,46 @@ export interface HarnessProfilePublishResponse {
   changed: boolean;
 }
 
-export interface HarnessSkillSource {
+/**
+ * Frozen canonical shape. The source object is serialized whole into the
+ * artifact hash that profiles pin, so adding, renaming or reordering a field
+ * here rehashes every artifact already stored and unpins every profile.
+ */
+export interface HarnessGitHubSkillSource {
   owner: string;
   repository: string;
   path: string;
   commitSha: string;
+}
+
+/**
+ * A skill read from the `skills/` directory of the deployment's own
+ * repository. It has no commit and no repository to point at; its version is
+ * the digest of its contents.
+ */
+export interface HarnessLocalSkillSource {
+  path: string;
+  contentSha256: string;
+}
+
+/**
+ * The variants are told apart by which fields are present, never by a kind
+ * tag inside the object: a tag would enter the hashed payload and break the
+ * freeze above. A persisted kind belongs in a column beside the hash.
+ */
+export type HarnessSkillSource =
+  | HarnessGitHubSkillSource
+  | HarnessLocalSkillSource;
+
+/**
+ * Tells the variants apart by the field only the GitHub one carries. Every
+ * caller that needs the GitHub coordinate goes through this rather than
+ * reading a tag, because there is no tag to read.
+ */
+export function isHarnessGitHubSkillSource(
+  source: HarnessSkillSource,
+): source is HarnessGitHubSkillSource {
+  return "commitSha" in source;
 }
 
 export interface HarnessSkillDiscovery {
@@ -374,7 +424,7 @@ export interface HarnessSkillDiscovery {
 }
 
 export interface HarnessSkillDiscoveryResponse {
-  source: Omit<HarnessSkillSource, "path">;
+  source: Omit<HarnessGitHubSkillSource, "path">;
   skills: HarnessSkillDiscovery[];
 }
 
@@ -383,8 +433,54 @@ export interface HarnessSkillDiscoverRequest {
 }
 
 export interface HarnessSkillImportRequest {
-  source: Omit<HarnessSkillSource, "path">;
+  source: Omit<HarnessGitHubSkillSource, "path">;
   paths: string[];
+}
+
+/**
+ * Discovering deployment-local skills takes no repository coordinate: the
+ * source is the deployment itself. `path` is the skill's directory name under
+ * `skills/`.
+ *
+ * `artifactHash` is the identity the import would mint for the bytes on disk
+ * right now. It travels because nothing else can answer whether a pinned skill
+ * still matches the deployment: the pin is a hash, so without one to compare it
+ * against, a stale pin is undetectable rather than merely unshown.
+ */
+export interface HarnessLocalSkillDiscovery extends HarnessSkillDiscovery {
+  artifactHash: string;
+}
+
+/** A directory under `skills/` that cannot be offered, and why. */
+export interface HarnessLocalSkillSkip {
+  path: string;
+  reason: string;
+}
+
+export interface HarnessLocalSkillDiscoveryResponse {
+  /**
+   * False when the deployment carries no `skills/` directory at all. That is a
+   * different failure from a directory whose entries were all skipped, and the
+   * two are indistinguishable from an empty list alone.
+   */
+  directoryPresent: boolean;
+  skills: HarnessLocalSkillDiscovery[];
+  skipped: HarnessLocalSkillSkip[];
+}
+
+/**
+ * The hash comes back from discovery for the same reason the GitHub import
+ * repeats an exact commit: a deployment promoted between the two calls swaps
+ * the bytes under the selection, and the import must catch that instead of
+ * storing content the operator never saw.
+ */
+export interface HarnessLocalSkillSelection {
+  path: string;
+  artifactHash: string;
+}
+
+export interface HarnessLocalSkillImportRequest {
+  skills: HarnessLocalSkillSelection[];
 }
 
 export interface HarnessSkillArtifactFile {
@@ -399,6 +495,7 @@ export interface HarnessSkillArtifact {
   organizationId: string;
   name: string;
   description: string | null;
+  /** Mirrors the persisted row, whose kind lives in a column beside the hash. */
   source: HarnessSkillSource;
   files: HarnessSkillArtifactFile[];
   createdAt: string;
@@ -422,6 +519,12 @@ export interface HarnessSkillRefreshRequest {
 export interface HarnessSkillRefreshResponse {
   profile: HarnessProfileDto;
   artifact: HarnessSkillArtifact;
+  /**
+   * False when the source still holds the bytes the profile already pinned.
+   * Both outcomes are successes, and without this flag they are the same
+   * response, so "the redeploy did not arrive" would look like "it did".
+   */
+  changed: boolean;
 }
 
 export const HARNESS_SKILL_IMPORT_LIMITS = {

--- a/apps/worker/drizzle/0046_local_skill_source.sql
+++ b/apps/worker/drizzle/0046_local_skill_source.sql
@@ -1,0 +1,66 @@
+-- Widens harness_skill_artifacts so it can also hold a skill read from the
+-- `skills/` directory of the deployment's own repository, next to the
+-- GitHub-imported skills it holds today.
+--
+-- A local skill has no owner, no repository and no commit to point at (its
+-- version is the digest of its contents), so the four GitHub columns stop being
+-- NOT NULL and two local ones join them: "local_path" and
+-- "local_content_sha256", mirroring HarnessLocalSkillSource in
+-- apps/shared/contracts/harness-profiles.ts.
+--
+-- The variant marker lives in "source_kind", a column, and deliberately NOT
+-- inside the source object that the artifact hash covers: that object is
+-- serialized whole into the hash, so a discriminator inside it would rehash
+-- every artifact already stored and unpin every profile that pins one.
+--
+-- Every existing row is a GitHub import (the four columns were NOT NULL until
+-- now), so DEFAULT 'github' both backfills them and keeps the one existing
+-- writer working: the import path in apps/worker/src/harness-profiles/
+-- github-skills.ts inserts through raw SQL that does not name this column yet.
+-- The default cannot mislabel a local artifact, because a row that takes it
+-- while leaving the GitHub columns empty is rejected by the shape check below.
+--
+-- Nullable columns alone would let a half-filled row through, so
+-- "harness_skill_artifacts_source_shape_check" makes one unrepresentable: a
+-- 'github' row must carry all four GitHub columns and neither local one, a
+-- 'local' row exactly the reverse.
+--
+-- "harness_skill_artifacts_source_idx" stays exactly as it is, with no local
+-- counterpart: nothing queries artifacts by source (every read goes through the
+-- org+hash unique index or the primary key), so a second index over the local
+-- columns would add write cost and serve no reader.
+--
+-- Rolling back is safe only while no local artifact exists. Restoring NOT NULL
+-- on the four GitHub columns fails on the first local row, and dropping the
+-- local columns would leave any profile version pinning a local artifact
+-- pointing at a row whose source can no longer be described. Delete the local
+-- rows, and unpin them from profile versions, before reverting.
+ALTER TABLE "harness_skill_artifacts" ALTER COLUMN "source_owner" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "harness_skill_artifacts" ALTER COLUMN "source_repository" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "harness_skill_artifacts" ALTER COLUMN "source_path" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "harness_skill_artifacts" ALTER COLUMN "source_commit_sha" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "harness_skill_artifacts" ADD COLUMN "source_kind" text DEFAULT 'github' NOT NULL;--> statement-breakpoint
+ALTER TABLE "harness_skill_artifacts" ADD COLUMN "local_path" text;--> statement-breakpoint
+ALTER TABLE "harness_skill_artifacts" ADD COLUMN "local_content_sha256" text;--> statement-breakpoint
+ALTER TABLE "harness_skill_artifacts" ADD CONSTRAINT "harness_skill_artifacts_source_kind_check" CHECK ("harness_skill_artifacts"."source_kind" in ('github', 'local'));--> statement-breakpoint
+ALTER TABLE "harness_skill_artifacts" ADD CONSTRAINT "harness_skill_artifacts_source_shape_check" CHECK ((
+        "harness_skill_artifacts"."source_kind" <> 'github'
+        or (
+          "harness_skill_artifacts"."source_owner" is not null
+          and "harness_skill_artifacts"."source_repository" is not null
+          and "harness_skill_artifacts"."source_path" is not null
+          and "harness_skill_artifacts"."source_commit_sha" is not null
+          and "harness_skill_artifacts"."local_path" is null
+          and "harness_skill_artifacts"."local_content_sha256" is null
+        )
+      ) and (
+        "harness_skill_artifacts"."source_kind" <> 'local'
+        or (
+          "harness_skill_artifacts"."local_path" is not null
+          and "harness_skill_artifacts"."local_content_sha256" is not null
+          and "harness_skill_artifacts"."source_owner" is null
+          and "harness_skill_artifacts"."source_repository" is null
+          and "harness_skill_artifacts"."source_path" is null
+          and "harness_skill_artifacts"."source_commit_sha" is null
+        )
+      ));

--- a/apps/worker/drizzle/meta/0046_snapshot.json
+++ b/apps/worker/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,5764 @@
+{
+  "id": "5eb7c4db-91bc-4e8f-a79c-086108c9bed5",
+  "prevId": "f607ab39-0edd-4752-b906-6ab927e5823e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_capability_catalogs": {
+      "name": "harness_capability_catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_hash": {
+          "name": "catalog_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "harness_capability_catalogs_scope_unique": {
+          "name": "harness_capability_catalogs_scope_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_capability_catalogs_organization_id_organization_id_fk": {
+          "name": "harness_capability_catalogs_organization_id_organization_id_fk",
+          "tableFrom": "harness_capability_catalogs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_capability_catalogs_provider_check": {
+          "name": "harness_capability_catalogs_provider_check",
+          "value": "\"harness_capability_catalogs\".\"provider\" in ('claude', 'codex')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_content_sha256": {
+          "name": "local_content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifacts_source_kind_check": {
+          "name": "harness_skill_artifacts_source_kind_check",
+          "value": "\"harness_skill_artifacts\".\"source_kind\" in ('github', 'local')"
+        },
+        "harness_skill_artifacts_source_shape_check": {
+          "name": "harness_skill_artifacts_source_shape_check",
+          "value": "(\n        \"harness_skill_artifacts\".\"source_kind\" <> 'github'\n        or (\n          \"harness_skill_artifacts\".\"source_owner\" is not null\n          and \"harness_skill_artifacts\".\"source_repository\" is not null\n          and \"harness_skill_artifacts\".\"source_path\" is not null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is not null\n          and \"harness_skill_artifacts\".\"local_path\" is null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is null\n        )\n      ) and (\n        \"harness_skill_artifacts\".\"source_kind\" <> 'local'\n        or (\n          \"harness_skill_artifacts\".\"local_path\" is not null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is not null\n          and \"harness_skill_artifacts\".\"source_owner\" is null\n          and \"harness_skill_artifacts\".\"source_repository\" is null\n          and \"harness_skill_artifacts\".\"source_path\" is null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is null\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_occurrences": {
+      "name": "schedule_occurrences",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_at": {
+          "name": "occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_count": {
+          "name": "dropped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dropped_count_capped": {
+          "name": "dropped_count_capped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocking_run_id": {
+          "name": "blocking_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedule_occurrences_one_pending_per_schedule_idx": {
+          "name": "schedule_occurrences_one_pending_per_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedule_occurrences\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_occurrences_run_id_idx": {
+          "name": "schedule_occurrences_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_occurrences_schedule_id_workflow_schedules_id_fk": {
+          "name": "schedule_occurrences_schedule_id_workflow_schedules_id_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_occurrences_definition_version_fk": {
+          "name": "schedule_occurrences_definition_version_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedule_occurrences_schedule_id_occurrence_at_pk": {
+          "name": "schedule_occurrences_schedule_id_occurrence_at_pk",
+          "columns": [
+            "schedule_id",
+            "occurrence_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedule_occurrences_outcome_check": {
+          "name": "schedule_occurrences_outcome_check",
+          "value": "\"schedule_occurrences\".\"outcome\" is null or \"schedule_occurrences\".\"outcome\" in ('started', 'skipped_overlap', 'skipped_stale', 'superseded', 'expired', 'cancelled', 'run_cancelled', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_deliveries": {
+      "name": "webhook_trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "webhook_trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_trigger_deliveries_definition_version_fk": {
+          "name": "webhook_trigger_deliveries_definition_version_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_deliveries_endpoint_id_delivery_id_pk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_delivery_id_pk",
+          "columns": [
+            "endpoint_id",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_endpoints": {
+      "name": "webhook_trigger_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_scheme": {
+          "name": "auth_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hmac_sha256'"
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_timestamp": {
+          "name": "require_timestamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timestamp_header": {
+          "name": "timestamp_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp_tolerance_seconds": {
+          "name": "timestamp_tolerance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_secret_ciphertext": {
+          "name": "previous_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_endpoints_definition_node_idx": {
+          "name": "webhook_trigger_endpoints_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk": {
+          "name": "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "webhook_trigger_endpoints",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhook_trigger_endpoints_auth_scheme_check": {
+          "name": "webhook_trigger_endpoints_auth_scheme_check",
+          "value": "\"webhook_trigger_endpoints\".\"auth_scheme\" in ('hmac_sha256', 'shared_token')"
+        },
+        "webhook_trigger_endpoints_timestamp_tolerance_check": {
+          "name": "webhook_trigger_endpoints_timestamp_tolerance_check",
+          "value": "\"webhook_trigger_endpoints\".\"timestamp_tolerance_seconds\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rate_limits": {
+      "name": "webhook_trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inbox'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_rate_limits",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rejection_counters": {
+      "name": "webhook_trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk": {
+          "name": "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publication_comments": {
+      "name": "workflow_pr_review_publication_comments",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk",
+          "tableFrom": "workflow_pr_review_publication_comments",
+          "tableTo": "workflow_pr_review_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_pr_review_publication_comments_publication_id_content_hash_pk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_content_hash_pk",
+          "columns": [
+            "publication_id",
+            "content_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publication_comments_state_check": {
+          "name": "workflow_pr_review_publication_comments_state_check",
+          "value": "\"workflow_pr_review_publication_comments\".\"state\" in ('pending', 'published')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publications": {
+      "name": "workflow_pr_review_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_comment_count": {
+          "name": "inline_comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summary_fallback_count": {
+          "name": "summary_fallback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_pr_review_publications_content_unique": {
+          "name": "workflow_pr_review_publications_content_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pr_review_publications_run_idx": {
+          "name": "workflow_pr_review_publications_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_pr_review_publications",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publications_state_check": {
+          "name": "workflow_pr_review_publications_state_check",
+          "value": "\"workflow_pr_review_publications\".\"state\" in ('pending', 'published')"
+        },
+        "workflow_pr_review_publications_decision_check": {
+          "name": "workflow_pr_review_publications_decision_check",
+          "value": "\"workflow_pr_review_publications\".\"decision\" in ('approve', 'request_changes')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_external_checks": {
+      "name": "workflow_run_external_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "closure_intent": {
+          "name": "closure_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_external_checks_attempt_unique": {
+          "name": "workflow_run_external_checks_attempt_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_reconcile_idx": {
+          "name": "workflow_run_external_checks_reconcile_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_run_idx": {
+          "name": "workflow_run_external_checks_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_external_checks_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_external_checks_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_external_checks",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_external_checks_state_check": {
+          "name": "workflow_run_external_checks_state_check",
+          "value": "\"workflow_run_external_checks\".\"state\" in ('creating', 'pending', 'closing', 'completed')"
+        },
+        "workflow_run_external_checks_conclusion_check": {
+          "name": "workflow_run_external_checks_conclusion_check",
+          "value": "\"workflow_run_external_checks\".\"conclusion\" is null or \"workflow_run_external_checks\".\"conclusion\" in ('success', 'failure', 'neutral', 'cancelled', 'timed_out', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_started_at": {
+          "name": "entry_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_deadline_at": {
+          "name": "startup_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_startup_watchdog_idx": {
+          "name": "workflow_runs_startup_watchdog_idx",
+          "columns": [
+            {
+              "expression": "startup_deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_runs\".\"entry_started_at\" is null and coalesce(\"workflow_runs\".\"status\", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "overlap_policy": {
+          "name": "overlap_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "catch_up_grace_minutes": {
+          "name": "catch_up_grace_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_watermark_at": {
+          "name": "evaluation_watermark_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_occurrence_at": {
+          "name": "last_started_occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_run_id": {
+          "name": "last_started_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_schedules_definition_node_idx": {
+          "name": "workflow_schedules_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_schedules_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_schedules_overlap_policy_check": {
+          "name": "workflow_schedules_overlap_policy_check",
+          "value": "\"workflow_schedules\".\"overlap_policy\" in ('skip', 'queue', 'allow')"
+        },
+        "workflow_schedules_catch_up_grace_check": {
+          "name": "workflow_schedules_catch_up_grace_check",
+          "value": "\"workflow_schedules\".\"catch_up_grace_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memory_documents": {
+      "name": "agent_memory_documents",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memory_documents_ticket_key_idx": {
+          "name": "agent_memory_documents_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_documents_updated_at_idx": {
+          "name": "agent_memory_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_memory_documents_subject_key_doc_path_pk": {
+          "name": "agent_memory_documents_subject_key_doc_path_pk",
+          "columns": [
+            "subject_key",
+            "doc_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1786369600000,
       "tag": "0045_schedule_occurrence_run_cancelled",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1786374669306,
+      "tag": "0046_local_skill_source",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/e2e/harness-profiles/canary-contract.ts
+++ b/apps/worker/e2e/harness-profiles/canary-contract.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowDefinitionDetailResponse,
   WorkflowDefinitionV2,
 } from "@shared/contracts";
+import { isHarnessGitHubSkillSource } from "@shared/contracts";
 import { z } from "zod";
 
 const positiveInteger = z.coerce.number().int().positive();
@@ -199,6 +200,9 @@ export function assertRunHarnessManifest(
   );
   if (
     !skill ||
+    // The canary pins a GitHub-imported skill; a deployment-local source in
+    // this slot is itself the failure, not a shape to branch on.
+    !isHarnessGitHubSkillSource(skill.source) ||
     skill.source.owner !== expected.skill.owner ||
     skill.source.repository !== expected.skill.repository ||
     skill.source.path !== expected.skill.path ||

--- a/apps/worker/nitro.config.ts
+++ b/apps/worker/nitro.config.ts
@@ -1,4 +1,4 @@
-import { copyFile, readdir, stat } from "node:fs/promises";
+import { copyFile, cp, readdir, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { defineNitroConfig } from "nitropack/config";
 
@@ -57,12 +57,28 @@ export default defineNitroConfig({
             if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
           }
         }
+        // Skills shipped with the deployment ride along for the same reason,
+        // but their directory sits at the repository root rather than inside
+        // this app: they belong to the repository a tenant deploys, not to the
+        // worker. A deployment without local skills has no directory to copy,
+        // which is not a build failure.
+        const skillsDir = resolve(nitro.options.rootDir, "..", "..", "skills");
+        let hasSkills = true;
+        try {
+          await stat(skillsDir);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+          hasSkills = false;
+        }
         await Promise.all(
-          funcDirs.flatMap((dir) =>
-            presentYamlFiles.map((name) =>
+          funcDirs.flatMap((dir) => [
+            ...presentYamlFiles.map((name) =>
               copyFile(resolve(nitro.options.rootDir, name), join(dir, name)),
             ),
-          ),
+            ...(hasSkills
+              ? [cp(skillsDir, join(dir, "skills"), { recursive: true })]
+              : []),
+          ]),
         );
       });
     },

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm build:shared && rm -rf .nitro/workflow && nitro dev",
-    "build": "pnpm build:shared && pnpm validate:pre-sandbox && pnpm db:migrate && pnpm seed:auth-user && rm -rf .nitro/workflow && NODE_OPTIONS=--max-old-space-size=8192 nitro build",
+    "build": "pnpm build:shared && pnpm validate:pre-sandbox && pnpm validate:local-skills && pnpm db:migrate && pnpm seed:auth-user && rm -rf .nitro/workflow && NODE_OPTIONS=--max-old-space-size=8192 nitro build",
     "preview": "nitro preview",
     "test": "pnpm build:shared && vitest run",
     "test:workflow-sdk": "pnpm build:shared && vitest run --config vitest.run-control-workflow.config.ts",
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "typecheck": "pnpm build:shared && tsc --noEmit",
     "validate:pre-sandbox": "tsx scripts/validate-pre-sandbox-config.ts",
+    "validate:local-skills": "tsx scripts/validate-local-skills.ts",
     "capture:agent-protocol-fixtures": "tsx scripts/capture-agent-protocol-fixtures.ts",
     "cleanup:startup-orphans": "tsx scripts/cleanup-startup-orphans.ts",
     "check:prompt-drift": "tsx src/prompt-library/builtin-prompt-drift-gate.ts",

--- a/apps/worker/scripts/validate-local-skills.ts
+++ b/apps/worker/scripts/validate-local-skills.ts
@@ -1,0 +1,15 @@
+import { resolve } from "node:path";
+import { checkLocalSkills } from "../src/harness-profiles/local-skills.js";
+
+// The same expression the Nitro `compiled` hook copies from, spelled out rather
+// than resolved: validating any other directory would pass a build that ships
+// something else.
+const directory = resolve(process.cwd(), "..", "..", "skills");
+const result = await checkLocalSkills(directory);
+
+if (result.ok) {
+  console.log(result.message);
+} else {
+  console.error(result.message);
+  process.exit(1);
+}

--- a/apps/worker/src/db/local-skill-source-migration.test.ts
+++ b/apps/worker/src/db/local-skill-source-migration.test.ts
@@ -1,0 +1,223 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { afterEach, describe, expect, it } from "vitest";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+const openClients: PGlite[] = [];
+
+afterEach(async () => {
+  await Promise.all(openClients.splice(0).map((client) => client.close()));
+});
+
+async function migrateThrough(lastPrefix: string): Promise<PGlite> {
+  const client = new PGlite();
+  openClients.push(client);
+  const files = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith(".sql") && file.slice(0, 4) <= lastPrefix)
+    .sort();
+  for (const file of files) {
+    await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+  }
+  return client;
+}
+
+async function applyLocalSkillSource(client: PGlite): Promise<void> {
+  await client.exec(
+    readFileSync(`${migrationsDir}0046_local_skill_source.sql`, "utf8"),
+  );
+}
+
+const seedOrganization = `
+  INSERT INTO organization (id, name, slug)
+  VALUES ('org-skills', 'Skills organization', 'skills-org')
+`;
+
+const legacyArtifact = `
+  INSERT INTO harness_skill_artifacts (
+    organization_id,
+    artifact_hash,
+    name,
+    description,
+    source_owner,
+    source_repository,
+    source_path,
+    source_commit_sha,
+    created_by_id
+  )
+  VALUES (
+    'org-skills',
+    'artifact-hash-legacy',
+    'legacy-skill',
+    'Imported before local sources existed',
+    'blazity',
+    'ai-workflow',
+    'skills/legacy-skill',
+    'a'||repeat('0', 39),
+    'admin'
+  )
+`;
+
+describe("0046 local skill source migration", () => {
+  it("leaves an existing artifact untouched and marks it as a GitHub source", async () => {
+    const client = await migrateThrough("0043");
+    await client.exec(seedOrganization);
+    await client.exec(legacyArtifact);
+
+    await applyLocalSkillSource(client);
+
+    const rows = await client.query<{
+      source_kind: string;
+      source_owner: string | null;
+      source_repository: string | null;
+      source_path: string | null;
+      source_commit_sha: string | null;
+      local_path: string | null;
+      local_content_sha256: string | null;
+    }>(`
+      SELECT
+        source_kind,
+        source_owner,
+        source_repository,
+        source_path,
+        source_commit_sha,
+        local_path,
+        local_content_sha256
+      FROM harness_skill_artifacts
+      WHERE artifact_hash = 'artifact-hash-legacy'
+    `);
+    expect(rows.rows).toEqual([
+      {
+        source_kind: "github",
+        source_owner: "blazity",
+        source_repository: "ai-workflow",
+        source_path: "skills/legacy-skill",
+        source_commit_sha: `a${"0".repeat(39)}`,
+        local_path: null,
+        local_content_sha256: null,
+      },
+    ]);
+  });
+
+  it("keeps the GitHub import path working without naming the new column", async () => {
+    const client = await migrateThrough("0043");
+    await client.exec(seedOrganization);
+
+    await applyLocalSkillSource(client);
+    // The one production writer inserts through raw SQL that predates
+    // source_kind; the backfill default has to carry it.
+    await client.exec(legacyArtifact);
+
+    const rows = await client.query<{ source_kind: string }>(`
+      SELECT source_kind
+      FROM harness_skill_artifacts
+      WHERE artifact_hash = 'artifact-hash-legacy'
+    `);
+    expect(rows.rows).toEqual([{ source_kind: "github" }]);
+  });
+
+  it("accepts a local artifact that carries only the local columns", async () => {
+    const client = await migrateThrough("0046");
+    await client.exec(seedOrganization);
+
+    await client.exec(`
+      INSERT INTO harness_skill_artifacts (
+        organization_id,
+        artifact_hash,
+        name,
+        source_kind,
+        local_path,
+        local_content_sha256,
+        created_by_id
+      )
+      VALUES (
+        'org-skills',
+        'artifact-hash-local',
+        'local-skill',
+        'local',
+        'skills/local-skill',
+        repeat('b', 64),
+        'admin'
+      )
+    `);
+
+    const rows = await client.query<{
+      source_kind: string;
+      source_owner: string | null;
+      local_path: string | null;
+    }>(`
+      SELECT source_kind, source_owner, local_path
+      FROM harness_skill_artifacts
+      WHERE artifact_hash = 'artifact-hash-local'
+    `);
+    expect(rows.rows).toEqual([
+      {
+        source_kind: "local",
+        source_owner: null,
+        local_path: "skills/local-skill",
+      },
+    ]);
+  });
+
+  it("rejects an unknown source kind", async () => {
+    const client = await migrateThrough("0046");
+    await client.exec(seedOrganization);
+
+    await expect(
+      client.exec(`
+        INSERT INTO harness_skill_artifacts (
+          organization_id, artifact_hash, name, source_kind, created_by_id
+        )
+        VALUES ('org-skills', 'artifact-hash-gitlab', 'x', 'gitlab', 'admin')
+      `),
+    ).rejects.toThrow(/harness_skill_artifacts_source_kind_check/);
+  });
+
+  it.each([
+    [
+      "a GitHub row missing a GitHub column",
+      `
+        (organization_id, artifact_hash, name, source_kind,
+         source_owner, source_repository, source_path, created_by_id)
+        VALUES ('org-skills', 'artifact-hash-mixed-1', 'x', 'github',
+                'blazity', 'ai-workflow', 'skills/x', 'admin')
+      `,
+    ],
+    [
+      "a GitHub row that also carries local columns",
+      `
+        (organization_id, artifact_hash, name, source_kind,
+         source_owner, source_repository, source_path, source_commit_sha,
+         local_path, local_content_sha256, created_by_id)
+        VALUES ('org-skills', 'artifact-hash-mixed-2', 'x', 'github',
+                'blazity', 'ai-workflow', 'skills/x', 'deadbeef',
+                'skills/x', repeat('c', 64), 'admin')
+      `,
+    ],
+    [
+      "a local row missing its content digest",
+      `
+        (organization_id, artifact_hash, name, source_kind,
+         local_path, created_by_id)
+        VALUES ('org-skills', 'artifact-hash-mixed-3', 'x', 'local',
+                'skills/x', 'admin')
+      `,
+    ],
+    [
+      "a local row that also carries GitHub columns",
+      `
+        (organization_id, artifact_hash, name, source_kind,
+         local_path, local_content_sha256, source_owner, created_by_id)
+        VALUES ('org-skills', 'artifact-hash-mixed-4', 'x', 'local',
+                'skills/x', repeat('d', 64), 'blazity', 'admin')
+      `,
+    ],
+  ])("rejects %s", async (_label, values) => {
+    const client = await migrateThrough("0046");
+    await client.exec(seedOrganization);
+
+    await expect(
+      client.exec(`INSERT INTO harness_skill_artifacts ${values}`),
+    ).rejects.toThrow(/harness_skill_artifacts_source_shape_check/);
+  });
+});

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -1260,9 +1260,16 @@ export const harnessCapabilityCatalogs = pgTable(
 );
 
 /**
- * Content-addressed, organization-private snapshots of imported GitHub skills.
- * The artifact hash covers the exact source commit, root path, file paths,
- * modes, hashes, and bytes.
+ * Content-addressed, organization-private snapshots of imported skills. The
+ * artifact hash covers the exact source, root path, file paths, modes, hashes,
+ * and bytes.
+ *
+ * A row carries exactly one source variant: either the four GitHub columns, or
+ * the two local ones describing a directory shipped with the deployment. The
+ * variants are told apart by `sourceKind`, which lives here rather than inside
+ * the hashed source payload: a discriminator inside that payload would rehash
+ * every artifact already stored and unpin every profile pinning it. The shape
+ * check makes a half-filled row unrepresentable.
  */
 export const harnessSkillArtifacts = pgTable(
   "harness_skill_artifacts",
@@ -1274,10 +1281,13 @@ export const harnessSkillArtifacts = pgTable(
     artifactHash: text("artifact_hash").notNull(),
     name: text("name").notNull(),
     description: text("description"),
-    sourceOwner: text("source_owner").notNull(),
-    sourceRepository: text("source_repository").notNull(),
-    sourcePath: text("source_path").notNull(),
-    sourceCommitSha: text("source_commit_sha").notNull(),
+    sourceKind: text("source_kind").notNull().default("github"),
+    sourceOwner: text("source_owner"),
+    sourceRepository: text("source_repository"),
+    sourcePath: text("source_path"),
+    sourceCommitSha: text("source_commit_sha"),
+    localPath: text("local_path"),
+    localContentSha256: text("local_content_sha256"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -1293,6 +1303,34 @@ export const harnessSkillArtifacts = pgTable(
       t.sourceOwner,
       t.sourceRepository,
       t.sourcePath,
+    ),
+    check(
+      "harness_skill_artifacts_source_kind_check",
+      sql`${t.sourceKind} in ('github', 'local')`,
+    ),
+    check(
+      "harness_skill_artifacts_source_shape_check",
+      sql`(
+        ${t.sourceKind} <> 'github'
+        or (
+          ${t.sourceOwner} is not null
+          and ${t.sourceRepository} is not null
+          and ${t.sourcePath} is not null
+          and ${t.sourceCommitSha} is not null
+          and ${t.localPath} is null
+          and ${t.localContentSha256} is null
+        )
+      ) and (
+        ${t.sourceKind} <> 'local'
+        or (
+          ${t.localPath} is not null
+          and ${t.localContentSha256} is not null
+          and ${t.sourceOwner} is null
+          and ${t.sourceRepository} is null
+          and ${t.sourcePath} is null
+          and ${t.sourceCommitSha} is null
+        )
+      )`,
     ),
   ],
 );

--- a/apps/worker/src/harness-profiles/detail.test.ts
+++ b/apps/worker/src/harness-profiles/detail.test.ts
@@ -9,6 +9,7 @@ import type { Db } from "../db/client.js";
 import {
   harnessProfiles,
   harnessProfileVersions,
+  harnessSkillArtifacts,
   organization,
 } from "../db/schema.js";
 import { createTestDb } from "../db/test-db.js";
@@ -97,5 +98,77 @@ describe("Harness Profile detail", () => {
     expect(detail?.versions.some((version) => version.version === 1)).toBe(
       true,
     );
+  });
+
+  it("carries the source of every pinned skill without changing the manifest", async () => {
+    const githubHash = "a".repeat(64);
+    const localHash = "b".repeat(64);
+    const danglingHash = "c".repeat(64);
+    await db.insert(harnessSkillArtifacts).values([
+      {
+        organizationId: "org-detail",
+        artifactHash: githubHash,
+        name: "from-github",
+        sourceKind: "github",
+        sourceOwner: "blazity",
+        sourceRepository: "ai-workflow",
+        sourcePath: "skills/review",
+        sourceCommitSha: "d".repeat(40),
+        createdById: "owner",
+      },
+      {
+        organizationId: "org-detail",
+        artifactHash: localHash,
+        name: "from-deployment",
+        sourceKind: "local",
+        localPath: "review-checklist",
+        localContentSha256: "e".repeat(64),
+        createdById: "owner",
+      },
+    ]);
+
+    const draft = baseDraft();
+    draft.skills = [
+      { artifactHash: githubHash, name: "from-github" },
+      { artifactHash: localHash, name: "from-deployment" },
+      { artifactHash: danglingHash, name: "gone" },
+    ];
+    await db.insert(harnessProfiles).values({
+      id: "profile-skill-sources",
+      organizationId: "org-detail",
+      slug: "skill-sources",
+      draftManifest: draft,
+      draftRevision: 1,
+      publishedVersion: null,
+      createdById: "owner",
+      updatedById: "owner",
+    });
+
+    const detail = await getHarnessProfileDetail(db, {
+      organizationId: "org-detail",
+      profileId: "profile-skill-sources",
+      actorRole: "owner",
+    });
+
+    expect(
+      [...(detail?.skillSources ?? [])].sort((left, right) =>
+        left.artifactHash.localeCompare(right.artifactHash),
+      ),
+    ).toEqual([
+      {
+        artifactHash: githubHash,
+        source: {
+          owner: "blazity",
+          repository: "ai-workflow",
+          path: "skills/review",
+          commitSha: "d".repeat(40),
+        },
+      },
+      {
+        artifactHash: localHash,
+        source: { path: "review-checklist", contentSha256: "e".repeat(64) },
+      },
+    ]);
+    expect(detail?.profile.draft.skills).toEqual(draft.skills);
   });
 });

--- a/apps/worker/src/harness-profiles/github-skills.test.ts
+++ b/apps/worker/src/harness-profiles/github-skills.test.ts
@@ -635,7 +635,41 @@ describe("GitHub skill import", () => {
       artifactHash: original!.artifactHash,
     });
     expect(refreshed.artifactHash).not.toBe(original!.artifactHash);
-    expect(refreshed.source.commitSha).toBe(COMMIT_TWO);
+    expect(refreshed.source).toMatchObject({ commitSha: COMMIT_TWO });
     expect(await db.select().from(harnessSkillArtifacts)).toHaveLength(2);
+  });
+
+  it("refuses a deployment-local artifact before touching the provider", async () => {
+    const artifactHash = "f".repeat(64);
+    await db.insert(harnessSkillArtifacts).values({
+      organizationId: "org-skills",
+      artifactHash,
+      name: "local-skill",
+      sourceKind: "local",
+      localPath: "skills/local-skill",
+      localContentSha256: "a".repeat(64),
+      createdById: "admin",
+    });
+    const repository = new FakeRepository();
+
+    const error = await refreshGitHubSkillArtifact(db, {
+      repository,
+      organizationId: "org-skills",
+      actorId: "admin",
+      artifactHash,
+    }).then(
+      () => null,
+      (reason: unknown) => reason,
+    );
+
+    // Callers route deployment skills to the local refresher; reaching this
+    // function with one is a wiring mistake, and it must stay a mapped client
+    // error rather than an unmapped 500 from the provider call that follows.
+    expect(error).toBeInstanceOf(HarnessSkillImportError);
+    expect(error).toMatchObject({
+      statusCode: 400,
+      message: "Only a GitHub-sourced skill artifact can be refreshed from GitHub",
+    });
+    expect(repository.calls).toEqual([]);
   });
 });

--- a/apps/worker/src/harness-profiles/github-skills.ts
+++ b/apps/worker/src/harness-profiles/github-skills.ts
@@ -4,12 +4,17 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { createGunzip } from "node:zlib";
 import type {
+  HarnessGitHubSkillSource,
   HarnessSkillArtifact,
   HarnessSkillArtifactFile,
   HarnessSkillDiscoveryResponse,
   HarnessSkillImportRequest,
+  HarnessSkillSource,
 } from "@shared/contracts";
-import { HARNESS_SKILL_IMPORT_LIMITS } from "@shared/contracts";
+import {
+  HARNESS_SKILL_IMPORT_LIMITS,
+  isHarnessGitHubSkillSource,
+} from "@shared/contracts";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { extract } from "tar-stream";
 import type { Db } from "../db/client.js";
@@ -24,6 +29,7 @@ import {
   parseHarnessSkillMetadata,
   verifyHarnessSkillArtifact,
 } from "./skill-artifact.js";
+import { readHarnessSkillArtifactSource } from "./store.js";
 
 const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/i;
 const MAX_REPOSITORY_ARCHIVE_BYTES = 50 * 1024 * 1024;
@@ -574,7 +580,7 @@ export async function importGitHubSkills(
     names.add(artifact.name);
     artifacts.push(artifact);
   }
-  return persistArtifacts(db, {
+  return persistHarnessSkillArtifacts(db, {
     organizationId: input.organizationId,
     actorId: input.actorId,
     artifacts,
@@ -603,16 +609,39 @@ export async function refreshGitHubSkillArtifact(
   if (!existing) {
     throw new HarnessSkillImportError(404, "Skill artifact not found");
   }
+  // The route hands this an artifactHash straight from the client, so the
+  // integrity error has to become a status this file's error mapping knows;
+  // unmapped it would surface as a 500.
+  let stored: HarnessSkillSource;
+  try {
+    stored = readHarnessSkillArtifactSource(existing);
+  } catch (error) {
+    if (!(error instanceof HarnessSkillArtifactIntegrityError)) throw error;
+    throw new HarnessSkillImportError(
+      400,
+      "Only a GitHub-sourced skill artifact can be refreshed",
+    );
+  }
+  // Narrowed before the first provider call. Callers reach the right variant
+  // through refreshHarnessSkillArtifact, so this guard catches a miswired
+  // caller rather than an operator: a deployment skill refreshes from disk.
+  if (!isHarnessGitHubSkillSource(stored)) {
+    throw new HarnessSkillImportError(
+      400,
+      "Only a GitHub-sourced skill artifact can be refreshed from GitHub",
+    );
+  }
+  const source = stored;
   const defaultBranch = await readProvider(() =>
     input.repository.getDefaultBranch({
-      owner: existing.sourceOwner,
-      repository: existing.sourceRepository,
+      owner: source.owner,
+      repository: source.repository,
     }),
   );
   const resolved = await readProvider(() =>
     input.repository.resolveCommit({
-      owner: existing.sourceOwner,
-      repository: existing.sourceRepository,
+      owner: source.owner,
+      repository: source.repository,
       ref: defaultBranch,
     }),
   );
@@ -622,26 +651,35 @@ export async function refreshGitHubSkillArtifact(
     actorId: input.actorId,
     request: {
       source: {
-        owner: existing.sourceOwner,
-        repository: existing.sourceRepository,
+        owner: source.owner,
+        repository: source.repository,
         commitSha: resolved.commitSha,
       },
-      paths: [existing.sourcePath],
+      paths: [source.path],
     },
   });
   return artifact!;
 }
 
-interface BuiltArtifact {
+/**
+ * An artifact ready to be written, from either source. The deployment-local
+ * importer builds these too, which is why the write below takes the whole
+ * union rather than the GitHub variant.
+ */
+export interface PersistableSkillArtifact {
   artifactHash: string;
   name: string;
   description: string;
-  source: HarnessSkillArtifact["source"];
+  source: HarnessSkillSource;
   files: Array<HarnessSkillArtifactFile & { contentBase64: string }>;
 }
 
+interface BuiltArtifact extends PersistableSkillArtifact {
+  source: HarnessGitHubSkillSource;
+}
+
 async function buildArtifact(input: {
-  source: HarnessSkillArtifact["source"];
+  source: HarnessGitHubSkillSource;
   entries: GitHubSkillTreeEntry[];
   contents: Map<string, Buffer>;
 }): Promise<BuiltArtifact> {
@@ -750,12 +788,22 @@ async function buildArtifact(input: {
   };
 }
 
-async function persistArtifacts(
+/**
+ * The one write both importers go through. Deduplication by hash, reuse of an
+ * artifact another import already stored, and the file rows hanging off either
+ * outcome are all decided inside the single statement below, so a second copy
+ * of it for the local variant would drift the first time either changes.
+ *
+ * The variant only decides which source columns carry a value and which stay
+ * empty; `source_kind` names the choice, and the shape check from migration
+ * 0046 rejects the row if the two disagree.
+ */
+export async function persistHarnessSkillArtifacts(
   db: Db,
   input: {
     organizationId: string;
     actorId: string;
-    artifacts: BuiltArtifact[];
+    artifacts: PersistableSkillArtifact[];
   },
 ): Promise<HarnessSkillArtifact[]> {
   for (const artifact of input.artifacts) {
@@ -768,18 +816,40 @@ async function persistArtifacts(
     });
   }
 
-  const artifactRows = input.artifacts.map(
-    (artifact) =>
-      sql`(
+  const artifactRows = input.artifacts.map((artifact) => {
+    const source = artifact.source;
+    const columns = isHarnessGitHubSkillSource(source)
+      ? {
+          kind: "github",
+          owner: source.owner,
+          repository: source.repository,
+          path: source.path,
+          commitSha: source.commitSha,
+          localPath: null,
+          localContentSha256: null,
+        }
+      : {
+          kind: "local",
+          owner: null,
+          repository: null,
+          path: null,
+          commitSha: null,
+          localPath: source.path,
+          localContentSha256: source.contentSha256,
+        };
+    return sql`(
         ${artifact.artifactHash}::text,
         ${artifact.name}::text,
         ${artifact.description}::text,
-        ${artifact.source.owner}::text,
-        ${artifact.source.repository}::text,
-        ${artifact.source.path}::text,
-        ${artifact.source.commitSha}::text
-      )`,
-  );
+        ${columns.kind}::text,
+        ${columns.owner}::text,
+        ${columns.repository}::text,
+        ${columns.path}::text,
+        ${columns.commitSha}::text,
+        ${columns.localPath}::text,
+        ${columns.localContentSha256}::text
+      )`;
+  });
   const fileRows = input.artifacts.flatMap((artifact) =>
     artifact.files.map(
       (file) =>
@@ -798,10 +868,13 @@ async function persistArtifacts(
       artifact_hash,
       name,
       description,
+      source_kind,
       source_owner,
       source_repository,
       source_path,
-      source_commit_sha
+      source_commit_sha,
+      local_path,
+      local_content_sha256
     ) AS (
       VALUES ${sql.join(artifactRows, sql`, `)}
     ), inserted_artifact AS (
@@ -810,10 +883,13 @@ async function persistArtifacts(
         artifact_hash,
         name,
         description,
+        source_kind,
         source_owner,
         source_repository,
         source_path,
         source_commit_sha,
+        local_path,
+        local_content_sha256,
         created_by_id
       )
       SELECT
@@ -821,10 +897,13 @@ async function persistArtifacts(
         artifact_hash,
         name,
         description,
+        source_kind,
         source_owner,
         source_repository,
         source_path,
         source_commit_sha,
+        local_path,
+        local_content_sha256,
         ${input.actorId}
       FROM imported_artifact
       ON CONFLICT (organization_id, artifact_hash) DO NOTHING
@@ -921,13 +1000,9 @@ async function persistArtifacts(
       );
     }
     const files = filesByArtifactId.get(stored.id) ?? [];
-    const source = {
-      owner: stored.sourceOwner,
-      repository: stored.sourceRepository,
-      path: stored.sourcePath,
-      commitSha: stored.sourceCommitSha,
-    };
+    let source: HarnessSkillSource;
     try {
+      source = readHarnessSkillArtifactSource(stored);
       verifyHarnessSkillArtifact({
         artifactHash: stored.artifactHash,
         name: stored.name,

--- a/apps/worker/src/harness-profiles/local-skills.test.ts
+++ b/apps/worker/src/harness-profiles/local-skills.test.ts
@@ -1,0 +1,662 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Db } from "../db/client.js";
+import {
+  harnessSkillArtifactFiles,
+  harnessSkillArtifacts,
+  organization,
+} from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+import { HarnessSkillImportError } from "./github-skills.js";
+import {
+  checkLocalSkills,
+  defaultLocalSkillsDirectory,
+  discoverLocalSkills,
+  importLocalSkills,
+  readLocalSkills,
+  refreshLocalSkillArtifact,
+} from "./local-skills.js";
+import { hashHarnessSkillArtifact } from "./skill-artifact.js";
+
+const roots: string[] = [];
+
+function skillsRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "local-skills-"));
+  roots.push(root);
+  return root;
+}
+
+function skillDocument(
+  name = "review-rules",
+  description = "Client-specific review rules.",
+): string {
+  return `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`;
+}
+
+function writeSkill(
+  root: string,
+  path: string,
+  files: Record<string, string> = { "SKILL.md": skillDocument() },
+): string {
+  const directory = join(root, path);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const file = join(directory, relativePath);
+    mkdirSync(join(file, ".."), { recursive: true });
+    writeFileSync(file, content);
+  }
+  return directory;
+}
+
+afterEach(() => {
+  while (roots.length > 0) rmSync(roots.pop()!, { force: true, recursive: true });
+});
+
+describe("deployment-local skills", () => {
+  it("reads a skill directory into an artifact the hasher accepts", async () => {
+    const root = skillsRoot();
+    const directory = writeSkill(root, "review-rules", {
+      "SKILL.md": skillDocument(),
+      "scripts/check.sh": "#!/bin/sh\necho review\n",
+    });
+    chmodSync(join(directory, "scripts/check.sh"), 0o755);
+
+    const { skills, skipped, directoryPresent } = await readLocalSkills(root);
+    const [skill, ...rest] = skills;
+
+    expect(directoryPresent).toBe(true);
+    expect(skipped).toEqual([]);
+    expect(rest).toEqual([]);
+    expect(skill).toMatchObject({
+      name: "review-rules",
+      description: "Client-specific review rules.",
+      source: {
+        path: "review-rules",
+        contentSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+      files: [
+        { path: "scripts/check.sh", mode: 0o755 },
+        { path: "SKILL.md", mode: 0o644 },
+      ],
+    });
+    expect(
+      Buffer.from(skill!.files[1]!.contentBase64, "base64").toString("utf8"),
+    ).toBe(skillDocument());
+    expect(hashHarnessSkillArtifact(skill!)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("separates a missing directory from a directory holding nothing usable", async () => {
+    await expect(
+      readLocalSkills(join(tmpdir(), "local-skills-absent")),
+    ).resolves.toEqual({
+      directoryPresent: false,
+      skills: [],
+      skipped: [],
+    });
+
+    const empty = skillsRoot();
+    await expect(readLocalSkills(empty)).resolves.toEqual({
+      directoryPresent: true,
+      skills: [],
+      skipped: [],
+    });
+  });
+
+  it("finds the directory in both the deployed bundle and the development tree", async () => {
+    // The bundle: the copy sits beside the code the function runs, so the
+    // working directory holds it.
+    const bundle = skillsRoot();
+    mkdirSync(join(bundle, "skills"));
+    expect(defaultLocalSkillsDirectory(bundle)).toBe(join(bundle, "skills"));
+
+    // The development tree: the working directory is apps/worker, while the
+    // directory belongs to the repository two levels up.
+    const repository = skillsRoot();
+    mkdirSync(join(repository, "skills"));
+    const worker = join(repository, "apps", "worker");
+    mkdirSync(worker, { recursive: true });
+    expect(defaultLocalSkillsDirectory(worker)).toBe(join(repository, "skills"));
+
+    // Neither: the deployment ships none, and the path it would have shipped
+    // them in is the one reported.
+    const bare = skillsRoot();
+    expect(defaultLocalSkillsDirectory(bare)).toBe(join(bare, "skills"));
+  });
+
+  it("fails the build for an entry that cannot ship and passes without a directory", async () => {
+    const broken = skillsRoot();
+    writeSkill(broken, "review-rules");
+    writeSkill(broken, "notes", { "README.md": "Not a skill.\n" });
+
+    const rejected = await checkLocalSkills(broken);
+    expect(rejected.ok).toBe(false);
+    expect(rejected.message).toContain("skills/notes");
+    expect(rejected.message).toContain("No SKILL.md");
+
+    const healthy = skillsRoot();
+    writeSkill(healthy, "review-rules");
+    await expect(checkLocalSkills(healthy)).resolves.toEqual({
+      ok: true,
+      message: `Validated 1 deployment skill(s) at ${healthy}.`,
+    });
+
+    const absent = join(tmpdir(), "local-skills-absent-gate");
+    await expect(checkLocalSkills(absent)).resolves.toEqual({
+      ok: true,
+      message: `No deployment skills directory at ${absent}; none will ship.`,
+    });
+  });
+
+  it("reports why a directory is not a skill, including one nested a level too deep", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "notes", { "README.md": "Not a skill.\n" });
+    writeSkill(root, "nested/review-notes", {
+      "SKILL.md": skillDocument("review-notes", "Nested by mistake."),
+    });
+    writeSkill(root, "review-rules");
+    writeFileSync(join(root, "README.md"), "Skills live here.\n");
+
+    const read = await readLocalSkills(root);
+
+    expect(read.skills).toMatchObject([{ name: "review-rules" }]);
+    expect(read.skipped).toEqual([
+      {
+        path: "nested",
+        reason:
+          'No SKILL.md here, but "review-notes/SKILL.md" exists: a skill must sit one level under the skills directory',
+      },
+      { path: "notes", reason: "No SKILL.md" },
+    ]);
+  });
+
+  it.each([
+    [
+      "an invalid skill name",
+      (root: string) =>
+        writeSkill(root, "broken", {
+          "SKILL.md": skillDocument("BAD NAME"),
+        }),
+      /invalid name/,
+    ],
+    [
+      "a description past the length limit",
+      (root: string) =>
+        writeSkill(root, "broken", {
+          "SKILL.md": skillDocument("broken", "d".repeat(1_025)),
+        }),
+      /invalid description/,
+    ],
+    [
+      "a file over the per-file limit",
+      (root: string) =>
+        writeSkill(root, "broken", {
+          "SKILL.md": skillDocument("broken"),
+          "reference.md": "d".repeat(1024 * 1024 + 1),
+        }),
+      /is too large/,
+    ],
+    [
+      "an artifact over the total size limit",
+      (root: string) =>
+        writeSkill(root, "broken", {
+          "SKILL.md": skillDocument("broken"),
+          ...Object.fromEntries(
+            Array.from({ length: 6 }, (_, index) => [
+              `reference-${index}.md`,
+              "d".repeat(1024 * 1024),
+            ]),
+          ),
+        }),
+      /5 MiB size limit/,
+    ],
+    [
+      "more files than the limit allows",
+      (root: string) =>
+        writeSkill(root, "broken", {
+          "SKILL.md": skillDocument("broken"),
+          ...Object.fromEntries(
+            Array.from({ length: 500 }, (_, index) => [
+              `reference-${index}.md`,
+              "reference\n",
+            ]),
+          ),
+        }),
+      /500 files/,
+    ],
+    [
+      // A POSIX file name may contain a backslash, which is a traversal
+      // separator once the path leaves this process. Artifact verification
+      // rejects such a path too; catching it here keeps the read honest.
+      "a file name that traverses out of the skill",
+      (root: string) =>
+        writeSkill(root, "broken", {
+          "SKILL.md": skillDocument("broken"),
+          "..\\..\\escape.md": "escaped\n",
+        }),
+      /unsafe file path/,
+    ],
+    [
+      "a symlink pointing outside the skill",
+      (root: string) => {
+        const directory = writeSkill(root, "broken", {
+          "SKILL.md": skillDocument("broken"),
+        });
+        symlinkSync("/etc/passwd", join(directory, "escape.md"));
+        return directory;
+      },
+      /symlink/,
+    ],
+    [
+      "a SKILL.md that is a symlink rather than a file",
+      (root: string) => {
+        const directory = join(root, "broken");
+        mkdirSync(directory, { recursive: true });
+        symlinkSync("/etc/passwd", join(directory, "SKILL.md"));
+        return directory;
+      },
+      /not a regular file/,
+    ],
+    [
+      "an executable SKILL.md",
+      (root: string) => {
+        const directory = writeSkill(root, "broken", {
+          "SKILL.md": skillDocument("broken"),
+        });
+        chmodSync(join(directory, "SKILL.md"), 0o755);
+        return directory;
+      },
+      /must not be executable/,
+    ],
+  ])(
+    "skips %s without costing the healthy skills beside it",
+    async (_label, prepare, reason) => {
+      const root = skillsRoot();
+      prepare(root);
+      writeSkill(root, "review-rules");
+
+      const read = await readLocalSkills(root);
+
+      expect(read.skills).toMatchObject([{ name: "review-rules" }]);
+      expect(read.skipped).toMatchObject([
+        { path: "broken", reason: expect.stringMatching(reason) },
+      ]);
+    },
+  );
+
+  it("names both directories when two skills claim one name", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "a-copy", { "SKILL.md": skillDocument("review-rules") });
+    writeSkill(root, "b-original", {
+      "SKILL.md": skillDocument("review-rules"),
+    });
+
+    const read = await readLocalSkills(root);
+
+    expect(read.skills).toMatchObject([{ source: { path: "a-copy" } }]);
+    expect(read.skipped).toEqual([
+      {
+        path: "b-original",
+        reason: 'Skill name "review-rules" is already used by "a-copy"',
+      },
+    ]);
+  });
+
+  it("reports the errno when the skills path cannot be read at all", async () => {
+    const root = skillsRoot();
+    const file = join(root, "skills");
+    writeFileSync(file, "not a directory\n");
+
+    const error = await readLocalSkills(file).then(
+      () => null,
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(HarnessSkillImportError);
+    expect(error).toMatchObject({
+      statusCode: 422,
+      message: expect.stringContaining("ENOTDIR"),
+    });
+  });
+
+  it("bounds the whole directory, not just one skill at a time", async () => {
+    // Every per-skill limit passes here: each skill sits at 4 MiB, under the
+    // 5 MiB ceiling, and carries five files, far under 500. Only a budget
+    // spanning the read catches this, and without one the reader would hold
+    // 28 MiB of bytes plus their base64 in a serverless function.
+    const root = skillsRoot();
+    for (let skill = 0; skill < 8; skill += 1) {
+      writeSkill(root, `skill-${skill}`, {
+        "SKILL.md": skillDocument(`skill-${skill}`),
+        ...Object.fromEntries(
+          Array.from({ length: 4 }, (_, index) => [
+            `reference-${index}.md`,
+            "e".repeat(1024 * 1024),
+          ]),
+        ),
+      });
+    }
+
+    const read = await readLocalSkills(root);
+
+    // The budget is spent in directory order, so the skill it lands on is an
+    // accident of ordering: naming it is the only way the operator can tell
+    // which read was cut short from which skill is oversized.
+    expect(read.skills.map((skill) => skill.name)).toEqual([
+      "skill-0",
+      "skill-1",
+      "skill-2",
+      "skill-3",
+      "skill-4",
+      "skill-5",
+    ]);
+    expect(read.skipped).toEqual([
+      {
+        path: "skill-6",
+        reason:
+          'Not read: skill "skill-6" exhausted the 25 MiB deployment skills budget',
+      },
+      {
+        path: "skill-7",
+        reason:
+          'Not read: the deployment skills budget was exhausted at "skill-6"',
+      },
+    ]);
+  });
+
+  it("derives the same content digest from the same bytes and a different one from any edit", async () => {
+    const files = {
+      "SKILL.md": skillDocument(),
+      "reference.md": "Reference notes.\n",
+    };
+    const first = skillsRoot();
+    writeSkill(first, "review-rules", files);
+    const second = skillsRoot();
+    writeSkill(second, "review-rules", files);
+    const edited = skillsRoot();
+    writeSkill(edited, "review-rules", {
+      ...files,
+      "reference.md": "Reference notes,\n",
+    });
+    const renamed = skillsRoot();
+    writeSkill(renamed, "review-rules", {
+      "SKILL.md": files["SKILL.md"],
+      "notes.md": files["reference.md"],
+    });
+
+    const digest = async (root: string) =>
+      (await readLocalSkills(root)).skills[0]!.source.contentSha256;
+
+    expect(await digest(second)).toBe(await digest(first));
+    expect(await digest(edited)).not.toBe(await digest(first));
+    expect(await digest(renamed)).not.toBe(await digest(first));
+  });
+});
+
+describe("deployment-local skill discovery and import", () => {
+  let db: Db;
+
+  /** The selection the dashboard would send: path plus the advertised hash. */
+  async function selection(
+    root: string,
+    path: string,
+  ): Promise<{ path: string; artifactHash: string }> {
+    const discovery = await discoverLocalSkills(root);
+    return {
+      path,
+      artifactHash: discovery.skills.find((skill) => skill.path === path)!
+        .artifactHash,
+    };
+  }
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    await db
+      .insert(organization)
+      .values({ id: "org-skills", name: "Skills", slug: "skills-test" });
+  });
+
+  it("discovers what the deployment ships without any repository coordinate", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "review-rules");
+    writeSkill(root, "release-notes", {
+      "SKILL.md": skillDocument("release-notes", "How releases are written."),
+    });
+
+    // The signature is the argument: there is no repository, no provider and
+    // no credential to pass, so a tenant without a GitHub App reaches this.
+    const discovery = await discoverLocalSkills(root);
+
+    expect(discovery).toEqual({
+      directoryPresent: true,
+      skipped: [],
+      skills: [
+        {
+          name: "release-notes",
+          path: "release-notes",
+          description: "How releases are written.",
+          artifactHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
+        {
+          name: "review-rules",
+          path: "review-rules",
+          description: "Client-specific review rules.",
+          artifactHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
+      ],
+    });
+
+    // The advertised hash is the identity an import mints, which is what makes
+    // a pin comparable against what the deployment currently carries.
+    const [imported] = await importLocalSkills(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      skills: [
+        {
+          path: "review-rules",
+          artifactHash: discovery.skills[1]!.artifactHash,
+        },
+      ],
+      directory: root,
+    });
+    expect(imported?.artifactHash).toBe(discovery.skills[1]!.artifactHash);
+  });
+
+  it("stores a selected skill as a local row the 0046 shape check accepts", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "review-rules", {
+      "SKILL.md": skillDocument(),
+      "reference.md": "Reference notes.\n",
+    });
+
+    const [artifact] = await importLocalSkills(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      skills: [await selection(root, "review-rules")],
+      directory: root,
+    });
+
+    expect(artifact).toMatchObject({
+      organizationId: "org-skills",
+      name: "review-rules",
+      source: {
+        path: "review-rules",
+        contentSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      },
+      files: [{ path: "reference.md" }, { path: "SKILL.md" }],
+    });
+    expect(JSON.stringify(artifact)).not.toContain("contentBase64");
+
+    const [row] = await db.select().from(harnessSkillArtifacts);
+    expect(row).toMatchObject({
+      sourceKind: "local",
+      localPath: "review-rules",
+      localContentSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      sourceOwner: null,
+      sourceRepository: null,
+      sourcePath: null,
+      sourceCommitSha: null,
+    });
+    expect(await db.select().from(harnessSkillArtifactFiles)).toHaveLength(2);
+  });
+
+  it("reuses the stored artifact when the same content is imported again", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "review-rules");
+    const request = {
+      organizationId: "org-skills",
+      actorId: "admin",
+      skills: [await selection(root, "review-rules")],
+      directory: root,
+    };
+
+    const [first] = await importLocalSkills(db, request);
+    const [again] = await importLocalSkills(db, request);
+
+    expect(again?.artifactHash).toBe(first?.artifactHash);
+    expect(await db.select().from(harnessSkillArtifacts)).toHaveLength(1);
+    expect(await db.select().from(harnessSkillArtifactFiles)).toHaveLength(1);
+  });
+
+  it("rejects a selection the deployment does not ship", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "review-rules");
+
+    const error = await importLocalSkills(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      skills: [
+        await selection(root, "review-rules"),
+        { path: "absent", artifactHash: "a".repeat(64) },
+      ],
+      directory: root,
+    }).then(
+      () => null,
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(HarnessSkillImportError);
+    expect(error).toMatchObject({ statusCode: 400 });
+    expect(await db.select().from(harnessSkillArtifacts)).toHaveLength(0);
+  });
+
+  it("refuses a selection whose own directory is unusable and names the reason", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "review-rules");
+    writeSkill(root, "broken", { "SKILL.md": skillDocument("BAD NAME") });
+
+    // The healthy selection alone still imports: only a selected entry's own
+    // failure is fatal.
+    await expect(
+      importLocalSkills(db, {
+        organizationId: "org-skills",
+        actorId: "admin",
+        skills: [await selection(root, "review-rules")],
+        directory: root,
+      }),
+    ).resolves.toHaveLength(1);
+
+    const error = await importLocalSkills(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      skills: [{ path: "broken", artifactHash: "a".repeat(64) }],
+      directory: root,
+    }).then(
+      () => null,
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toMatchObject({
+      statusCode: 400,
+      message: expect.stringContaining("invalid name"),
+    });
+  });
+
+  it("refuses an import whose hash predates a deployment swap", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "review-rules");
+    const stale = await selection(root, "review-rules");
+    // What a promotion between discovery and import looks like to the reader:
+    // the same path, different bytes.
+    writeSkill(root, "review-rules", {
+      "SKILL.md": skillDocument("review-rules", "Rewritten by a redeploy."),
+    });
+
+    const error = await importLocalSkills(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      skills: [stale],
+      directory: root,
+    }).then(
+      () => null,
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(HarnessSkillImportError);
+    expect(error).toMatchObject({
+      statusCode: 409,
+      message: expect.stringContaining("Reload"),
+    });
+    expect(await db.select().from(harnessSkillArtifacts)).toHaveLength(0);
+  });
+
+  it("refreshes a deployment skill into a new artifact after a redeploy changes it", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "review-rules");
+    const [original] = await importLocalSkills(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      skills: [await selection(root, "review-rules")],
+      directory: root,
+    });
+    writeSkill(root, "review-rules", {
+      "SKILL.md": skillDocument("review-rules", "Rules the client rewrote."),
+    });
+
+    const refreshed = await refreshLocalSkillArtifact(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      artifactHash: original!.artifactHash,
+      directory: root,
+    });
+
+    expect(refreshed.artifactHash).not.toBe(original!.artifactHash);
+    expect(refreshed.description).toBe("Rules the client rewrote.");
+    expect(await db.select().from(harnessSkillArtifacts)).toHaveLength(2);
+  });
+
+  it("refuses to refresh a skill the deployment no longer ships", async () => {
+    const root = skillsRoot();
+    writeSkill(root, "review-rules");
+    const [original] = await importLocalSkills(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      skills: [await selection(root, "review-rules")],
+      directory: root,
+    });
+    rmSync(join(root, "review-rules"), { force: true, recursive: true });
+
+    const error = await refreshLocalSkillArtifact(db, {
+      organizationId: "org-skills",
+      actorId: "admin",
+      artifactHash: original!.artifactHash,
+      directory: root,
+    }).then(
+      () => null,
+      (reason: unknown) => reason,
+    );
+
+    expect(error).toBeInstanceOf(HarnessSkillImportError);
+    expect(error).toMatchObject({
+      statusCode: 404,
+      message: expect.stringContaining("no longer part of this deployment"),
+    });
+  });
+});

--- a/apps/worker/src/harness-profiles/local-skills.ts
+++ b/apps/worker/src/harness-profiles/local-skills.ts
@@ -1,0 +1,610 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { lstat, readFile, readdir, stat } from "node:fs/promises";
+import { join, posix, relative, resolve } from "node:path";
+import type {
+  HarnessLocalSkillDiscoveryResponse,
+  HarnessLocalSkillSelection,
+  HarnessLocalSkillSource,
+  HarnessSkillArtifact,
+  HarnessSkillArtifactFile,
+} from "@shared/contracts";
+import {
+  HARNESS_SKILL_IMPORT_LIMITS,
+  isHarnessGitHubSkillSource,
+} from "@shared/contracts";
+import { and, eq } from "drizzle-orm";
+import type { Db } from "../db/client.js";
+import { harnessSkillArtifacts } from "../db/schema.js";
+import {
+  HarnessSkillImportError,
+  persistHarnessSkillArtifacts,
+} from "./github-skills.js";
+import {
+  hashHarnessSkillArtifact,
+  HarnessSkillArtifactIntegrityError,
+  parseHarnessSkillMetadata,
+} from "./skill-artifact.js";
+import { readHarnessSkillArtifactSource } from "./store.js";
+
+/**
+ * Skills shipped by the deployment itself live in `skills/` at the repository
+ * root, the first container the GitHub importer looks in, so one layout stays
+ * legible to both paths. The Nitro `compiled` hook copies that directory into
+ * every function bundle, which is why the runtime resolves it against the
+ * process working directory the same way the YAML configs are resolved.
+ */
+const LOCAL_SKILLS_DIRECTORY = "skills";
+
+const SKILL_DOCUMENT = "SKILL.md";
+
+/**
+ * The per-skill limits bound one skill, not a directory of them, and this reader
+ * holds every skill it finds in memory at once, base64-encoded on top of the raw
+ * bytes. Without a budget spanning the whole read, a deployment carrying twenty
+ * skills at the 5 MiB ceiling would ask a serverless function for well over
+ * 200 MiB before returning anything.
+ *
+ * The ceiling is deliberately far below what a function could survive, because
+ * memory is not the binding constraint: the Nitro hook copies this directory
+ * into every function bundle, so each byte here is paid for several times over
+ * in deployment size.
+ */
+const MAX_LOCAL_SKILLS_BYTES = 25 * 1024 * 1024;
+
+export interface LocalSkillArtifact {
+  name: string;
+  description: string;
+  /** `path` is relative to the skills directory, e.g. `review-rules`. */
+  source: HarnessLocalSkillSource;
+  files: Array<HarnessSkillArtifactFile & { contentBase64: string }>;
+}
+
+export interface LocalSkillsRead {
+  directoryPresent: boolean;
+  skills: LocalSkillArtifact[];
+  skipped: LocalSkillSkip[];
+}
+
+interface LocalSkillSkip {
+  path: string;
+  reason: string;
+}
+
+/**
+ * Thrown when the whole-directory budget runs out. It is separate from the
+ * per-skill rejections because it is the one condition that must also stop the
+ * read: the budget exists to bound memory, so continuing past it would defeat
+ * the check it just failed.
+ */
+class LocalSkillsBudgetError extends Error {}
+
+/**
+ * The two layouts this runs in have different working directories. In a
+ * deployed function the bundle carries its own copy of the directory beside the
+ * code, so the working directory is the right place to look. In the development
+ * tree the working directory is `apps/worker`, while the directory belongs to
+ * the repository the tenant deploys, two levels up. Without the second attempt
+ * the skills are invisible to `nitro dev` no matter where they are put.
+ *
+ * When neither exists the bundled path comes back, so a deployment that ships
+ * no skills reports the location it would have shipped them in.
+ */
+export function defaultLocalSkillsDirectory(cwd: string = process.cwd()): string {
+  const bundled = resolve(cwd, LOCAL_SKILLS_DIRECTORY);
+  if (existsSync(bundled)) return bundled;
+  const repositoryRoot = resolve(cwd, "..", "..", LOCAL_SKILLS_DIRECTORY);
+  return existsSync(repositoryRoot) ? repositoryRoot : bundled;
+}
+
+/**
+ * Reads every skill shipped with the deployment. Each immediate subdirectory
+ * holding a `SKILL.md` is one skill.
+ *
+ * A directory that is not a usable skill is reported, never thrown: one
+ * malformed entry used to cost the operator every other skill in the
+ * deployment, including the healthy ones, and left the only difference between
+ * "nothing is here" and "everything was rejected" invisible. Callers that need
+ * a specific skill check `skipped` for it and fail on that entry alone.
+ *
+ * A deployment without the directory has no local skills; that is not an error,
+ * but it is distinguishable, because a missing directory and a directory whose
+ * entries were all skipped call for opposite fixes.
+ */
+export async function readLocalSkills(
+  directory: string = defaultLocalSkillsDirectory(),
+): Promise<LocalSkillsRead> {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    const failure = error as NodeJS.ErrnoException;
+    if (failure.code === "ENOENT") {
+      return { directoryPresent: false, skills: [], skipped: [] };
+    }
+    // The code separates the two realistic causes, a file where the directory
+    // should be and a permission problem, which are otherwise indistinguishable
+    // from a deployment that simply ships nothing.
+    throw new HarnessSkillImportError(
+      422,
+      `The deployment skills directory "${describeDirectory(directory)}" could not be read (${failure.code ?? "unknown error"})`,
+    );
+  }
+
+  const skills: LocalSkillArtifact[] = [];
+  const skipped: LocalSkillSkip[] = [];
+  const pathByName = new Map<string, string>();
+  const budget = { spent: 0 };
+  const sorted = entries.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+  for (const [index, entry] of sorted.entries()) {
+    // A symlink is the only way an entry on disk can stand for content outside
+    // the directory; the GitHub importer rejects mode 120000 for the same
+    // reason. (Submodules have no equivalent here: the bundle is a plain copy.)
+    if (entry.isSymbolicLink()) {
+      skipped.push({ path: entry.name, reason: "Entry is a symlink" });
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
+    try {
+      const skill = await readSkill(directory, entry.name, budget);
+      if (skill.skipped) {
+        skipped.push({ path: entry.name, reason: skill.reason });
+        continue;
+      }
+      const collision = pathByName.get(skill.artifact.name);
+      if (collision !== undefined) {
+        // The name comes from the front matter, so it need not match either
+        // directory name: without both paths the operator has nowhere to look.
+        skipped.push({
+          path: entry.name,
+          reason: `Skill name "${skill.artifact.name}" is already used by "${collision}"`,
+        });
+        continue;
+      }
+      pathByName.set(skill.artifact.name, entry.name);
+      skills.push(skill.artifact);
+    } catch (error) {
+      if (error instanceof LocalSkillsBudgetError) {
+        skipped.push({ path: entry.name, reason: error.message });
+        for (const remaining of sorted.slice(index + 1)) {
+          if (!remaining.isDirectory() || remaining.isSymbolicLink()) continue;
+          skipped.push({
+            path: remaining.name,
+            reason: `Not read: the deployment skills budget was exhausted at "${entry.name}"`,
+          });
+        }
+        break;
+      }
+      if (!(error instanceof HarnessSkillImportError)) throw error;
+      skipped.push({ path: entry.name, reason: error.message });
+    }
+  }
+  return { directoryPresent: true, skills, skipped };
+}
+
+/**
+ * The build-time gate over the same reader. Without it the first sign of a
+ * mistyped name, an out-of-range description or an oversized file is the import
+ * dialog after a full deployment cycle, and a directory in the wrong place
+ * simply ships nothing without saying so.
+ *
+ * A skipped entry fails the build rather than warning: every skip means the
+ * operator meant to ship a skill and will not get it. A deployment with no
+ * directory at all is not a mistake, so it passes with a line saying so.
+ */
+export async function checkLocalSkills(
+  directory: string,
+): Promise<{ ok: boolean; message: string }> {
+  const read = await readLocalSkills(directory);
+  if (!read.directoryPresent) {
+    return {
+      ok: true,
+      message: `No deployment skills directory at ${directory}; none will ship.`,
+    };
+  }
+  if (read.skipped.length > 0) {
+    const reasons = read.skipped
+      .map((skip) => `  skills/${skip.path}: ${skip.reason}`)
+      .join("\n");
+    return {
+      ok: false,
+      message: `${read.skipped.length} entr${read.skipped.length === 1 ? "y" : "ies"} under ${directory} cannot ship as skills:\n${reasons}`,
+    };
+  }
+  return {
+    ok: true,
+    message: `Validated ${read.skills.length} deployment skill(s) at ${directory}.`,
+  };
+}
+
+type ReadSkillResult =
+  | { skipped: true; reason: string }
+  | { skipped: false; artifact: LocalSkillArtifact };
+
+async function readSkill(
+  directory: string,
+  path: string,
+  budget: { spent: number },
+): Promise<ReadSkillResult> {
+  assertSafePath(path, path);
+  const root = join(directory, path);
+  const document = await lstatOrNull(join(root, SKILL_DOCUMENT));
+  if (document === null) {
+    return { skipped: true, reason: await describeMissingDocument(root) };
+  }
+  // Not a plain file means a symlink standing in for one, which would otherwise
+  // vanish from the listing without a word.
+  if (!document.isFile()) {
+    return {
+      skipped: true,
+      reason: `${SKILL_DOCUMENT} is not a regular file`,
+    };
+  }
+  // Artifact verification requires a mode 0644 SKILL.md, the same shape the
+  // GitHub importer demands of the blob it reads metadata from.
+  if ((document.mode & 0o111) !== 0) {
+    return {
+      skipped: true,
+      reason: `${SKILL_DOCUMENT} must not be executable`,
+    };
+  }
+
+  const files = await readSkillFiles(root, path, budget);
+  const metadata = parseSkillMetadata(
+    Buffer.from(
+      files.find((file) => file.path === SKILL_DOCUMENT)!.contentBase64,
+      "base64",
+    ),
+    path,
+  );
+  return {
+    skipped: false,
+    artifact: {
+      name: metadata.name,
+      description: metadata.description,
+      source: { path, contentSha256: hashSkillContent(files) },
+      files,
+    },
+  };
+}
+
+/**
+ * A skill one level too deep is the mistake this distinguishes: the directory
+ * looks empty to the reader while the operator can plainly see a SKILL.md
+ * inside it.
+ */
+async function describeMissingDocument(root: string): Promise<string> {
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return `No ${SKILL_DOCUMENT}`;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const nested = await lstatOrNull(join(root, entry.name, SKILL_DOCUMENT));
+    if (nested !== null) {
+      return `No ${SKILL_DOCUMENT} here, but "${entry.name}/${SKILL_DOCUMENT}" exists: a skill must sit one level under the skills directory`;
+    }
+  }
+  return `No ${SKILL_DOCUMENT}`;
+}
+
+function describeDirectory(directory: string): string {
+  const relativePath = relative(process.cwd(), directory);
+  return relativePath === "" || relativePath.startsWith("..")
+    ? directory
+    : relativePath;
+}
+
+/**
+ * Discovery for the local variant takes no coordinate to point at: the source
+ * is this deployment. Each entry carries the identity an import of it would
+ * mint, so a caller holding a pinned hash can tell whether the deployment has
+ * moved underneath it.
+ */
+export async function discoverLocalSkills(
+  directory?: string,
+): Promise<HarnessLocalSkillDiscoveryResponse> {
+  const read = await readLocalSkills(directory);
+  return {
+    directoryPresent: read.directoryPresent,
+    skills: read.skills.map((skill) => ({
+      name: skill.name,
+      path: skill.source.path,
+      description: skill.description,
+      artifactHash: hashHarnessSkillArtifact(skill),
+    })),
+    skipped: read.skipped,
+  };
+}
+
+/**
+ * Imports the selected deployment skills into the same artifact table the
+ * GitHub importer writes to, through the same write.
+ *
+ * The selection repeats the hash discovery reported, which is this variant's
+ * answer to the exact-commit check on the GitHub side. The bundle is fixed for
+ * the life of one deployment, but a promotion between the two requests is
+ * ordinary, and without the check it would import bytes the operator never saw.
+ */
+export async function importLocalSkills(
+  db: Db,
+  input: {
+    organizationId: string;
+    actorId: string;
+    skills: HarnessLocalSkillSelection[];
+    directory?: string;
+  },
+): Promise<HarnessSkillArtifact[]> {
+  const selections = validateSelections(input.skills);
+  const read = await readLocalSkills(input.directory);
+  const available = new Map(
+    read.skills.map((skill) => [skill.source.path, skill]),
+  );
+  const skipped = new Map(read.skipped.map((skip) => [skip.path, skip.reason]));
+  const artifacts = selections.map((selection) => {
+    const skill = available.get(selection.path);
+    if (!skill) {
+      // Only the selected entry's own failure is fatal here; the rest of the
+      // directory being unusable is discovery's problem to report, not this
+      // import's problem to refuse over.
+      const reason = skipped.get(selection.path);
+      throw new HarnessSkillImportError(
+        400,
+        reason === undefined
+          ? `Selected path "${selection.path}" is not a deployment skill`
+          : `Skill "${selection.path}" cannot be imported: ${reason}`,
+      );
+    }
+    const artifactHash = hashHarnessSkillArtifact(skill);
+    if (artifactHash !== selection.artifactHash) {
+      throw new HarnessSkillImportError(
+        409,
+        `Skill "${selection.path}" changed since the list was loaded, which means the deployment was replaced. Reload the deployment skills and select again.`,
+      );
+    }
+    return { ...skill, artifactHash };
+  });
+  return persistHarnessSkillArtifacts(db, {
+    organizationId: input.organizationId,
+    actorId: input.actorId,
+    artifacts,
+  });
+}
+
+/**
+ * Refreshes a deployment skill from the directory the running deployment
+ * carries. Pinning is by hash, so a redeploy on its own changes nothing a
+ * profile can see: this is the step that turns new bytes into a new artifact,
+ * and the caller then repoints the pin at it.
+ */
+export async function refreshLocalSkillArtifact(
+  db: Db,
+  input: {
+    organizationId: string;
+    actorId: string;
+    artifactHash: string;
+    directory?: string;
+  },
+): Promise<HarnessSkillArtifact> {
+  const [existing] = await db
+    .select()
+    .from(harnessSkillArtifacts)
+    .where(
+      and(
+        eq(harnessSkillArtifacts.organizationId, input.organizationId),
+        eq(harnessSkillArtifacts.artifactHash, input.artifactHash),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new HarnessSkillImportError(404, "Skill artifact not found");
+  }
+  let source;
+  try {
+    source = readHarnessSkillArtifactSource(existing);
+  } catch (error) {
+    if (!(error instanceof HarnessSkillArtifactIntegrityError)) throw error;
+    throw new HarnessSkillImportError(400, "Skill artifact source is unreadable");
+  }
+  if (isHarnessGitHubSkillSource(source)) {
+    throw new HarnessSkillImportError(
+      400,
+      "Only a deployment skill can be refreshed from the deployment",
+    );
+  }
+
+  const read = await readLocalSkills(input.directory);
+  const skill = read.skills.find(
+    (candidate) => candidate.source.path === source.path,
+  );
+  if (!skill) {
+    const reason = read.skipped.find((skip) => skip.path === source.path);
+    throw new HarnessSkillImportError(
+      404,
+      reason === undefined
+        ? `Skill "${source.path}" is no longer part of this deployment. Restore it under skills/ and redeploy, or replace the pin with a skill this deployment ships.`
+        : `Skill "${source.path}" cannot be read from this deployment: ${reason.reason}`,
+    );
+  }
+  const [artifact] = await persistHarnessSkillArtifacts(db, {
+    organizationId: input.organizationId,
+    actorId: input.actorId,
+    artifacts: [{ ...skill, artifactHash: hashHarnessSkillArtifact(skill) }],
+  });
+  return artifact!;
+}
+
+function validateSelections(
+  selections: HarnessLocalSkillSelection[],
+): HarnessLocalSkillSelection[] {
+  if (
+    !Array.isArray(selections) ||
+    selections.length < 1 ||
+    selections.length > 100
+  ) {
+    throw new HarnessSkillImportError(
+      400,
+      "Select between one and 100 skills",
+    );
+  }
+  for (const selection of selections) {
+    if (
+      selection === null ||
+      typeof selection !== "object" ||
+      typeof selection.path !== "string" ||
+      typeof selection.artifactHash !== "string"
+    ) {
+      throw new HarnessSkillImportError(
+        400,
+        "Each selected skill needs the path and artifactHash reported by discovery",
+      );
+    }
+  }
+  const paths = selections.map((selection) => selection.path);
+  if (new Set(paths).size !== paths.length) {
+    throw new HarnessSkillImportError(400, "Selected skill path is duplicated");
+  }
+  // Nothing normalizes these: they are matched against the directory names the
+  // reader found on disk, so anything else simply misses and answers 400.
+  return selections;
+}
+
+/**
+ * The local variant has no commit to name a version after, so the version is
+ * the content: for every file, sorted by path, the path and the SHA-256 of its
+ * bytes, joined line by line and hashed once more. Location and deployment
+ * identity stay out of it, so two deployments carrying byte-identical skills
+ * mint the same artifact identity, and renaming or editing any file changes it.
+ */
+function hashSkillContent(files: LocalSkillArtifact["files"]): string {
+  const digest = createHash("sha256");
+  for (const file of [...files].sort((left, right) =>
+    left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
+  )) {
+    digest.update(`${file.path} ${file.sha256}\n`);
+  }
+  return digest.digest("hex");
+}
+
+async function readSkillFiles(
+  root: string,
+  skillPath: string,
+  budget: { spent: number },
+): Promise<LocalSkillArtifact["files"]> {
+  const files: LocalSkillArtifact["files"] = [];
+  let totalBytes = 0;
+
+  async function walk(directory: string, prefix: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const relativePath = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+      assertSafePath(relativePath, skillPath);
+      const absolute = join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        throw new HarnessSkillImportError(
+          400,
+          `Skill "${skillPath}" contains a symlink`,
+        );
+      }
+      if (entry.isDirectory()) {
+        await walk(absolute, relativePath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        throw new HarnessSkillImportError(
+          400,
+          `Skill "${skillPath}" contains an unsupported file`,
+        );
+      }
+      if (files.length + 1 > HARNESS_SKILL_IMPORT_LIMITS.maxFiles) {
+        throw new HarnessSkillImportError(
+          413,
+          `Skill exceeds ${HARNESS_SKILL_IMPORT_LIMITS.maxFiles} files`,
+        );
+      }
+      const stats = await stat(absolute);
+      // Checked before the read so an oversized file never reaches memory.
+      if (
+        !Number.isSafeInteger(stats.size) ||
+        stats.size > HARNESS_SKILL_IMPORT_LIMITS.maxFileBytes
+      ) {
+        throw new HarnessSkillImportError(
+          413,
+          `File "${relativePath}" is too large`,
+        );
+      }
+      totalBytes += stats.size;
+      if (totalBytes > HARNESS_SKILL_IMPORT_LIMITS.maxSkillBytes) {
+        throw new HarnessSkillImportError(
+          413,
+          "Skill exceeds the 5 MiB size limit",
+        );
+      }
+      // Spent before the read, like the per-file check above, so the budget
+      // bounds what reaches memory rather than recording what already did.
+      budget.spent += stats.size;
+      if (budget.spent > MAX_LOCAL_SKILLS_BYTES) {
+        // Names the skill the budget ran out on, because the budget is spent in
+        // directory order: the skill that trips it is the one that happened to
+        // come later, not the one that is oversized.
+        throw new LocalSkillsBudgetError(
+          `Not read: skill "${skillPath}" exhausted the 25 MiB deployment skills budget`,
+        );
+      }
+      const content = await readFile(absolute);
+      files.push({
+        path: relativePath,
+        // Git tracks only the executable bit, so this round-trips a checkout.
+        mode: (stats.mode & 0o111) === 0 ? 0o644 : 0o755,
+        sizeBytes: content.byteLength,
+        sha256: createHash("sha256").update(content).digest("hex"),
+        contentBase64: content.toString("base64"),
+      });
+    }
+  }
+
+  await walk(root, "");
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function lstatOrNull(path: string) {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function assertSafePath(path: string, skillPath: string): void {
+  if (
+    path.startsWith("/") ||
+    path.includes("\\") ||
+    path.includes("\0") ||
+    posix.normalize(path) !== path ||
+    path.split("/").some((segment) => segment === "." || segment === "..")
+  ) {
+    throw new HarnessSkillImportError(
+      400,
+      `Skill "${skillPath}" contains an unsafe file path`,
+    );
+  }
+}
+
+function parseSkillMetadata(
+  content: Buffer,
+  skillPath: string,
+): { name: string; description: string } {
+  try {
+    return parseHarnessSkillMetadata(content);
+  } catch (error) {
+    if (!(error instanceof HarnessSkillArtifactIntegrityError)) throw error;
+    throw new HarnessSkillImportError(
+      400,
+      `Skill "${skillPath}": ${error.message.replace(/\.$/, "")}`,
+    );
+  }
+}

--- a/apps/worker/src/harness-profiles/skill-artifact.test.ts
+++ b/apps/worker/src/harness-profiles/skill-artifact.test.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { HarnessSkillArtifactHashInput } from "./skill-artifact.js";
+import { hashHarnessSkillArtifact } from "./skill-artifact.js";
+
+const SKILL_DOCUMENT = `---
+name: review-rules
+description: Client-specific review rules.
+---
+
+Review rules body.
+`;
+
+const REFERENCE_DOCUMENT = "Reference notes.\n";
+
+function artifactFile(
+  path: string,
+  content: string,
+): HarnessSkillArtifactHashInput["files"][number] {
+  const buffer = Buffer.from(content, "utf8");
+  return {
+    path,
+    mode: 0o644,
+    sizeBytes: buffer.byteLength,
+    sha256: createHash("sha256").update(buffer).digest("hex"),
+    contentBase64: buffer.toString("base64"),
+  };
+}
+
+function artifactFiles(): HarnessSkillArtifactHashInput["files"] {
+  return [
+    artifactFile("reference.md", REFERENCE_DOCUMENT),
+    artifactFile("SKILL.md", SKILL_DOCUMENT),
+  ];
+}
+
+function githubArtifact(): HarnessSkillArtifactHashInput {
+  return {
+    name: "review-rules",
+    description: "Client-specific review rules.",
+    source: {
+      owner: "blazity",
+      repository: "ai-workflow",
+      path: "skills/review-rules",
+      commitSha: "0123456789abcdef0123456789abcdef01234567",
+    },
+    files: artifactFiles(),
+  };
+}
+
+describe("harness skill artifact hashing", () => {
+  it("keeps the canonical hash of a GitHub-sourced artifact frozen", () => {
+    expect(hashHarnessSkillArtifact(githubArtifact())).toBe(
+      // Recorded from the GitHub-only contract that shipped before local
+      // skills existed. Profiles pin skills by this hash, so a change here
+      // unpins every artifact already stored in production.
+      "f3c0c900c158fae7e8950cd63dbb6ce693917a4fed2b40fe014a814df2f7c691",
+    );
+  });
+
+  it("gives a deployment-local artifact an identity of its own", () => {
+    const local: HarnessSkillArtifactHashInput = {
+      name: "review-rules",
+      description: "Client-specific review rules.",
+      source: {
+        path: "review-rules",
+        contentSha256:
+          "89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab",
+      },
+      files: artifactFiles(),
+    };
+
+    // Compared against a hash computed here rather than against the frozen
+    // literal above: the same files under a different source must hash apart,
+    // and pinning that to a literal would let this stop proving it the day the
+    // fixture changes.
+    expect(hashHarnessSkillArtifact(local)).toMatch(/^[a-f0-9]{64}$/);
+    expect(hashHarnessSkillArtifact(local)).not.toBe(
+      hashHarnessSkillArtifact(githubArtifact()),
+    );
+  });
+
+  it("hashes two deployment-local artifacts with the same path and content alike", () => {
+    const source = {
+      path: "review-rules",
+      contentSha256:
+        "89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab89ab",
+    };
+    const base: HarnessSkillArtifactHashInput = {
+      name: "review-rules",
+      description: "Client-specific review rules.",
+      source,
+      files: artifactFiles(),
+    };
+
+    expect(hashHarnessSkillArtifact(base)).toBe(
+      hashHarnessSkillArtifact({ ...base, source: { ...source } }),
+    );
+  });
+});

--- a/apps/worker/src/harness-profiles/skill-artifact.ts
+++ b/apps/worker/src/harness-profiles/skill-artifact.ts
@@ -197,6 +197,12 @@ export function parseHarnessSkillMetadata(content: Buffer): {
   return { name: record.name, description: record.description };
 }
 
+/**
+ * `source` is serialized whole, so the set of fields a variant carries is part
+ * of the artifact's identity. Never add a variant tag to it: that would rehash
+ * every artifact imported under the GitHub-only contract and unpin the
+ * profiles referencing them.
+ */
 function canonicalHashPayload(artifact: HarnessSkillArtifactHashInput) {
   return {
     source: artifact.source,

--- a/apps/worker/src/harness-profiles/skill-refresh.ts
+++ b/apps/worker/src/harness-profiles/skill-refresh.ts
@@ -1,0 +1,56 @@
+import type { HarnessSkillArtifact } from "@shared/contracts";
+import { and, eq } from "drizzle-orm";
+import type { Db } from "../db/client.js";
+import { harnessSkillArtifacts } from "../db/schema.js";
+import {
+  HarnessSkillImportError,
+  refreshGitHubSkillArtifact,
+  type GitHubSkillRepository,
+} from "./github-skills.js";
+import { refreshLocalSkillArtifact } from "./local-skills.js";
+
+/**
+ * Refreshing a pinned skill, whichever source it came from. Both variants mint
+ * a new artifact from the current bytes and leave the caller to repoint the
+ * pin, so the operator sees one button with one meaning.
+ *
+ * The GitHub client is built lazily, and that is the point: a deployment with
+ * no GitHub App configured can still refresh its own skills, while building the
+ * client up front would answer 503 to every refresh it makes.
+ */
+export async function refreshHarnessSkillArtifact(
+  db: Db,
+  input: {
+    organizationId: string;
+    actorId: string;
+    artifactHash: string;
+    githubRepository: () => GitHubSkillRepository;
+  },
+): Promise<HarnessSkillArtifact> {
+  const [existing] = await db
+    .select({ sourceKind: harnessSkillArtifacts.sourceKind })
+    .from(harnessSkillArtifacts)
+    .where(
+      and(
+        eq(harnessSkillArtifacts.organizationId, input.organizationId),
+        eq(harnessSkillArtifacts.artifactHash, input.artifactHash),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new HarnessSkillImportError(404, "Skill artifact not found");
+  }
+  if (existing.sourceKind === "local") {
+    return refreshLocalSkillArtifact(db, {
+      organizationId: input.organizationId,
+      actorId: input.actorId,
+      artifactHash: input.artifactHash,
+    });
+  }
+  return refreshGitHubSkillArtifact(db, {
+    repository: input.githubRepository(),
+    organizationId: input.organizationId,
+    actorId: input.actorId,
+    artifactHash: input.artifactHash,
+  });
+}

--- a/apps/worker/src/harness-profiles/store.ts
+++ b/apps/worker/src/harness-profiles/store.ts
@@ -23,9 +23,11 @@ import type {
   HarnessProfileManifestV1,
   HarnessProfileReference,
   HarnessProfileResolvedVersion,
+  HarnessProfileSkillSourceDto,
   HarnessProfileUsageDto,
   HarnessProfileVersionDto,
   HarnessResolvedSkillArtifact,
+  HarnessSkillSource,
 } from "@shared/contracts";
 import { BUILTIN_HARNESS_PROFILE_MANIFESTS } from "@shared/contracts";
 import {
@@ -90,6 +92,64 @@ export class HarnessProfileStoreError extends Error {
 
 type ProfileSelect = typeof harnessProfiles.$inferSelect;
 type VersionSelect = typeof harnessProfileVersions.$inferSelect;
+type SkillArtifactSelect = typeof harnessSkillArtifacts.$inferSelect;
+
+/**
+ * The single place where a stored skill artifact row becomes a source object
+ * from the contract.
+ *
+ * Every source column is nullable in the schema because each variant fills
+ * only its own. On a row of either kind the matching columns are nonetheless
+ * guaranteed to be filled, and not by convention: the
+ * `harness_skill_artifacts_source_shape_check` constraint added in migration
+ * 0046 rejects any row that claims a kind without the complete set. The checks
+ * below restate that constraint rather than assuming it, so if the constraint
+ * is ever dropped the failure surfaces here instead of as a `null` silently
+ * reaching the artifact hash.
+ *
+ * A row of a kind this function does not know throws rather than returning
+ * null: every caller needs a source it can hand straight to the contract, so a
+ * nullable return would make each of them invent its own error for a case none
+ * of them can act on.
+ */
+export function readHarnessSkillArtifactSource(
+  artifact: SkillArtifactSelect,
+): HarnessSkillSource {
+  if (artifact.sourceKind === "local") {
+    const { localPath, localContentSha256 } = artifact;
+    if (localPath === null || localContentSha256 === null) {
+      throw new HarnessSkillArtifactIntegrityError(
+        "Skill artifact claims the local source kind but is missing columns " +
+          "that harness_skill_artifacts_source_shape_check should have required.",
+      );
+    }
+    return { path: localPath, contentSha256: localContentSha256 };
+  }
+  if (artifact.sourceKind !== "github") {
+    throw new HarnessSkillArtifactIntegrityError(
+      `Skill artifact source kind '${artifact.sourceKind}' is unknown.`,
+    );
+  }
+  const { sourceOwner, sourceRepository, sourcePath, sourceCommitSha } =
+    artifact;
+  if (
+    sourceOwner === null ||
+    sourceRepository === null ||
+    sourcePath === null ||
+    sourceCommitSha === null
+  ) {
+    throw new HarnessSkillArtifactIntegrityError(
+      "Skill artifact claims the GitHub source kind but is missing columns " +
+        "that harness_skill_artifacts_source_shape_check should have required.",
+    );
+  }
+  return {
+    owner: sourceOwner,
+    repository: sourceRepository,
+    path: sourcePath,
+    commitSha: sourceCommitSha,
+  };
+}
 
 function requireManageRole(role: DashboardRole): void {
   if (!canManageHarnessProfiles(role)) {
@@ -584,6 +644,45 @@ export async function getHarnessProfileVersion(
   return row ? mapVersion(row) : null;
 }
 
+/**
+ * Reads the source of every skill the draft pins. The manifest carries only a
+ * hash and a name, so this is the only way the dashboard can tell a skill
+ * shipped by the deployment from one fetched out of GitHub.
+ *
+ * Selecting the artifact rows directly rather than through
+ * `getHarnessSkillArtifactsByHashes` is deliberate: that path loads and
+ * verifies every file blob, which a detail view has no use for and which would
+ * make one corrupt artifact break the whole page. File contents live in a
+ * separate table, so these rows are metadata only.
+ *
+ * A hash with no matching row is dropped rather than raised: a draft is not
+ * foreign-keyed to the artifact table, and a dangling pin must not take the
+ * detail view down with it.
+ */
+async function readDraftSkillSources(
+  db: Db,
+  input: {
+    organizationId: string;
+    draft: HarnessProfileDraftManifest;
+  },
+): Promise<HarnessProfileSkillSourceDto[]> {
+  const artifactHashes = input.draft.skills.map((skill) => skill.artifactHash);
+  if (artifactHashes.length === 0) return [];
+  const rows = await db
+    .select()
+    .from(harnessSkillArtifacts)
+    .where(
+      and(
+        eq(harnessSkillArtifacts.organizationId, input.organizationId),
+        inArray(harnessSkillArtifacts.artifactHash, artifactHashes),
+      ),
+    );
+  return rows.map((row) => ({
+    artifactHash: row.artifactHash,
+    source: readHarnessSkillArtifactSource(row),
+  }));
+}
+
 export async function getHarnessProfileDetail(
   db: Db,
   input: {
@@ -613,6 +712,10 @@ export async function getHarnessProfileDetail(
     !profile.readOnly && canManageHarnessProfiles(input.actorRole);
   return {
     profile: mapProfile(profile),
+    skillSources: await readDraftSkillSources(db, {
+      organizationId: input.organizationId,
+      draft: profile.draftManifest,
+    }),
     published:
       versions.find((version) => version.version === profile.publishedVersion) ??
       null,
@@ -1359,12 +1462,7 @@ async function loadAndVerifyHarnessSkillArtifacts(
       organizationId: artifact.organizationId,
       name: artifact.name,
       description: artifact.description,
-      source: {
-        owner: artifact.sourceOwner,
-        repository: artifact.sourceRepository,
-        path: artifact.sourcePath,
-        commitSha: artifact.sourceCommitSha,
-      },
+      source: readHarnessSkillArtifactSource(artifact),
       files: (filesByArtifact.get(artifact.id) ?? []).map((file) => ({
         path: file.path,
         mode: file.mode,

--- a/apps/worker/src/routes/api/v1/harness-profiles.test.ts
+++ b/apps/worker/src/routes/api/v1/harness-profiles.test.ts
@@ -419,5 +419,8 @@ describe("Harness Skill API", () => {
     const refreshed = await response.json();
     expect(refreshed.profile.draftRevision).toBe(1);
     expect(refreshed.artifact.artifactHash).toBe(artifactHash);
+    // The source still holds the pinned bytes, and saying so is the only thing
+    // separating this from a refresh that moved the pin.
+    expect(refreshed.changed).toBe(false);
   });
 });

--- a/apps/worker/src/routes/api/v1/harness-profiles/[id]/skills/refresh.post.ts
+++ b/apps/worker/src/routes/api/v1/harness-profiles/[id]/skills/refresh.post.ts
@@ -4,9 +4,7 @@ import type {
   HarnessSkillRefreshResponse,
 } from "@shared/contracts";
 import { getDb } from "../../../../../../db/client.js";
-import {
-  refreshGitHubSkillArtifact,
-} from "../../../../../../harness-profiles/github-skills.js";
+import { refreshHarnessSkillArtifact } from "../../../../../../harness-profiles/skill-refresh.js";
 import { createConfiguredGitHubSkillRepository } from "../../../../../../harness-profiles/configured-github-skills.js";
 import {
   HarnessProfileStoreError,
@@ -44,8 +42,10 @@ export default defineEventHandler(
         });
       }
       const db = getDb();
-      const artifact = await refreshGitHubSkillArtifact(db, {
-        repository: createConfiguredGitHubSkillRepository(),
+      const artifact = await refreshHarnessSkillArtifact(db, {
+        // Passed unbuilt: a deployment-local refresh must not need a GitHub
+        // installation the tenant may not have.
+        githubRepository: createConfiguredGitHubSkillRepository,
         organizationId: actor.organizationId,
         actorId: actor.userId,
         artifactHash: body.artifactHash,
@@ -63,6 +63,9 @@ export default defineEventHandler(
           },
         }),
         artifact,
+        // The same predicate the draft update returns early on: a refresh that
+        // found identical bytes mints the identical hash.
+        changed: artifact.artifactHash !== body.artifactHash,
       };
     } catch (error) {
       if (error instanceof HarnessProfileStoreError) {

--- a/apps/worker/src/routes/api/v1/harness-skills-local.test.ts
+++ b/apps/worker/src/routes/api/v1/harness-skills-local.test.ts
@@ -1,0 +1,259 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp, createRouter, toWebHandler } from "h3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HarnessProfileDraftManifestV1 } from "@shared/contracts";
+import {
+  BUILTIN_HARNESS_PROFILE_IDS,
+  BUILTIN_HARNESS_PROFILE_MANIFESTS,
+} from "@shared/contracts";
+import type { Db } from "../../../db/client.js";
+import {
+  harnessSkillArtifacts,
+  member,
+  organization,
+  user,
+} from "../../../db/schema.js";
+import { createTestDb } from "../../../db/test-db.js";
+
+const state = vi.hoisted(() => ({
+  db: undefined as unknown,
+  sessionUserId: "user_admin" as string | null,
+  env: { DASHBOARD_ORG_SLUG: "ai-workflow" },
+}));
+
+/**
+ * A deployment with no GitHub App: asking for the provider config throws, which
+ * is the exact condition the local routes exist to survive. Nothing here is
+ * stubbed for the local path, so whatever it reaches for, it reaches for real.
+ */
+vi.mock("../../../../env.js", () => ({
+  env: state.env,
+  getVcsProviderConfig: () => {
+    throw new Error("No VCS provider is configured");
+  },
+}));
+vi.mock("../../../db/client.js", () => ({ getDb: () => state.db }));
+vi.mock("../../../auth-instance.js", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(async () =>
+        state.sessionUserId
+          ? {
+              user: { id: state.sessionUserId },
+              session: { id: "session_test" },
+            }
+          : null,
+      ),
+    },
+  },
+}));
+
+const localGet = (await import("./harness-skills/local.get.js")).default;
+const localPost = (await import("./harness-skills/local.post.js")).default;
+const githubDiscoverPost = (await import("./harness-skills/discover.post.js"))
+  .default;
+const createPost = (await import("./harness-profiles.post.js")).default;
+const refreshPost = (
+  await import("./harness-profiles/[id]/skills/refresh.post.js")
+).default;
+
+let db: Db;
+let workingDirectory: string;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handlerFor(route: any) {
+  const app = createApp();
+  app.use("/", route);
+  return toWebHandler(app);
+}
+
+function jsonRequest(method: string, body: unknown, path = "/"): Request {
+  return new Request(`http://worker.test${path}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function paramHandler(
+  pattern: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  route: any,
+) {
+  const app = createApp();
+  const router = createRouter();
+  router.post(pattern, route);
+  app.use(router);
+  return toWebHandler(app);
+}
+
+function draft(): HarnessProfileDraftManifestV1 {
+  const {
+    profileId: _profileId,
+    version: _version,
+    slug: _slug,
+    system: _system,
+    ...value
+  } = structuredClone(
+    BUILTIN_HARNESS_PROFILE_MANIFESTS[BUILTIN_HARNESS_PROFILE_IDS.codex],
+  );
+  return value;
+}
+
+function writeSkill(name: string, description: string): void {
+  const directory = join(workingDirectory, "skills", name);
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    join(directory, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`,
+  );
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  state.sessionUserId = "user_admin";
+  db = await createTestDb();
+  state.db = db;
+  await db
+    .insert(organization)
+    .values({ id: "org_aiw", name: "AI Workflow", slug: "ai-workflow" });
+  await db.insert(user).values([
+    {
+      id: "user_admin",
+      name: "Admin",
+      email: "admin@example.com",
+      emailVerified: true,
+    },
+    {
+      id: "user_member",
+      name: "Member",
+      email: "member@example.com",
+      emailVerified: true,
+    },
+  ]);
+  await db.insert(member).values([
+    {
+      id: "member_admin",
+      organizationId: "org_aiw",
+      userId: "user_admin",
+      role: "admin",
+    },
+    {
+      id: "member_member",
+      organizationId: "org_aiw",
+      userId: "user_member",
+      role: "member",
+    },
+  ]);
+  // The reader resolves `skills/` against the process working directory, the
+  // same way it finds the copy the build hook drops beside each function.
+  workingDirectory = mkdtempSync(join(tmpdir(), "local-skills-api-"));
+  vi.spyOn(process, "cwd").mockReturnValue(workingDirectory);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(workingDirectory, { force: true, recursive: true });
+});
+
+describe("deployment-local skill API", () => {
+  it("discovers and imports deployment skills while GitHub is unconfigured", async () => {
+    writeSkill("review-rules", "Client-specific review rules.");
+
+    const unconfigured = await handlerFor(githubDiscoverPost)(
+      jsonRequest("POST", { source: "acme/skills" }),
+    );
+    expect(unconfigured.status).toBe(503);
+
+    const discovery = await handlerFor(localGet)(
+      new Request("http://worker.test/"),
+    );
+    expect(discovery.status).toBe(200);
+    expect(discovery.headers.get("cache-control")).toBe("private, no-store");
+    const listed = await discovery.json();
+    expect(listed).toEqual({
+      directoryPresent: true,
+      skipped: [],
+      skills: [
+        {
+          name: "review-rules",
+          path: "review-rules",
+          description: "Client-specific review rules.",
+          artifactHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        },
+      ],
+    });
+
+    const imported = await handlerFor(localPost)(
+      jsonRequest("POST", { skills: [listed.skills[0]] }),
+    );
+    expect(imported.status).toBe(200);
+    expect((await imported.json()).artifacts).toMatchObject([
+      { name: "review-rules", source: { path: "review-rules" } },
+    ]);
+    expect(await db.select().from(harnessSkillArtifacts)).toMatchObject([
+      { sourceKind: "local", localPath: "review-rules", sourceOwner: null },
+    ]);
+  });
+
+  it("repoints a pinned deployment skill at the redeployed content", async () => {
+    writeSkill("review-rules", "Client-specific review rules.");
+    const listed = await (
+      await handlerFor(localGet)(new Request("http://worker.test/"))
+    ).json();
+    const imported = await (
+      await handlerFor(localPost)(
+        jsonRequest("POST", { skills: [listed.skills[0]] }),
+      )
+    ).json();
+    const artifactHash = imported.artifacts[0].artifactHash as string;
+    const withSkill = draft();
+    withSkill.skills = [{ artifactHash, name: "review-rules" }];
+    const created = await (
+      await handlerFor(createPost)(
+        jsonRequest("POST", { slug: "local-refresh", draft: withSkill }),
+      )
+    ).json();
+
+    // The redeploy: same path, new bytes, and a pin that still points at the
+    // old artifact until refresh mints a new one.
+    writeSkill("review-rules", "Rules the client rewrote.");
+    const response = await paramHandler(
+      "/profiles/:id/skills/refresh",
+      refreshPost,
+    )(
+      jsonRequest(
+        "POST",
+        { expectedRevision: 1, artifactHash },
+        `/profiles/${created.profile.id}/skills/refresh`,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const refreshed = await response.json();
+    expect(refreshed.artifact.artifactHash).not.toBe(artifactHash);
+    expect(refreshed.artifact.description).toBe("Rules the client rewrote.");
+    expect(refreshed.profile.draft.skills).toEqual([
+      { artifactHash: refreshed.artifact.artifactHash, name: "review-rules" },
+    ]);
+  });
+
+  it("reserves both routes for the roles that manage profiles", async () => {
+    state.sessionUserId = "user_member";
+
+    expect(
+      (await handlerFor(localGet)(new Request("http://worker.test/"))).status,
+    ).toBe(403);
+    expect(
+      (
+        await handlerFor(localPost)(
+          jsonRequest("POST", {
+            skills: [{ path: "review-rules", artifactHash: "a".repeat(64) }],
+          }),
+        )
+      ).status,
+    ).toBe(403);
+  });
+});

--- a/apps/worker/src/routes/api/v1/harness-skills/local.get.ts
+++ b/apps/worker/src/routes/api/v1/harness-skills/local.get.ts
@@ -1,0 +1,29 @@
+import { defineEventHandler } from "h3";
+import type { HarnessLocalSkillDiscoveryResponse } from "@shared/contracts";
+import { discoverLocalSkills } from "../../../../harness-profiles/local-skills.js";
+import { requireDashboardActor } from "../../../../lib/auth/request-context.js";
+import { canManageHarnessProfiles } from "../../../../lib/auth/roles.js";
+import { DashboardAuthError } from "../../../../lib/auth/users-read.js";
+import { setHarnessApiNoStore } from "../harness-profiles.get.js";
+import { toHarnessSkillHttpError } from "./discover.post.js";
+
+/**
+ * Discovering the skills this deployment ships. Unlike the GitHub sibling there
+ * is nothing to submit, and nothing to configure: the source is the bundle this
+ * function runs from, so a tenant with no GitHub App installation reaches its
+ * skills through here.
+ */
+export default defineEventHandler(
+  async (event): Promise<HarnessLocalSkillDiscoveryResponse | undefined> => {
+    try {
+      setHarnessApiNoStore(event);
+      const actor = await requireDashboardActor(event);
+      if (!canManageHarnessProfiles(actor.role)) {
+        throw new DashboardAuthError(403, "Forbidden");
+      }
+      return discoverLocalSkills();
+    } catch (error) {
+      toHarnessSkillHttpError(error);
+    }
+  },
+);

--- a/apps/worker/src/routes/api/v1/harness-skills/local.post.ts
+++ b/apps/worker/src/routes/api/v1/harness-skills/local.post.ts
@@ -1,0 +1,48 @@
+import { createError, defineEventHandler, readBody } from "h3";
+import type {
+  HarnessLocalSkillImportRequest,
+  HarnessSkillImportResponse,
+} from "@shared/contracts";
+import { getDb } from "../../../../db/client.js";
+import { importLocalSkills } from "../../../../harness-profiles/local-skills.js";
+import { requireDashboardActor } from "../../../../lib/auth/request-context.js";
+import { canManageHarnessProfiles } from "../../../../lib/auth/roles.js";
+import { DashboardAuthError } from "../../../../lib/auth/users-read.js";
+import { setHarnessApiNoStore } from "../harness-profiles.get.js";
+import { toHarnessSkillHttpError } from "./discover.post.js";
+
+/**
+ * Importing deployment skills. The selection carries the hash discovery
+ * reported, which is what the GitHub sibling's exact commit does for it: a
+ * deployment promoted between the two calls is caught, not imported silently.
+ */
+export default defineEventHandler(
+  async (event): Promise<HarnessSkillImportResponse | undefined> => {
+    try {
+      setHarnessApiNoStore(event);
+      const actor = await requireDashboardActor(event);
+      if (!canManageHarnessProfiles(actor.role)) {
+        throw new DashboardAuthError(403, "Forbidden");
+      }
+      const body =
+        (await readBody<Partial<HarnessLocalSkillImportRequest>>(event).catch(
+          () => null,
+        )) ?? {};
+      if (!Array.isArray(body.skills)) {
+        throw createError({
+          statusCode: 400,
+          statusMessage: "Selected skills are required",
+        });
+      }
+      return {
+        artifacts: await importLocalSkills(getDb(), {
+          organizationId: actor.organizationId,
+          actorId: actor.userId,
+          skills: body.skills,
+        }),
+      };
+    } catch (error) {
+      toHarnessSkillHttpError(error);
+    }
+  },
+);

--- a/docs/example-skill/SKILL.md
+++ b/docs/example-skill/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: review-checklist
+description: House rules the reviewer applies to every pull request. Copy this directory into skills/ at the repository root and rewrite it for your own conventions.
+---
+
+# Review checklist
+
+Everything below the front matter is ordinary Markdown, loaded into the agent
+when a profile pins this skill.
+
+## What to check
+
+- Every changed line traces back to the ticket.
+- No new dependency without a note explaining why the standard library is not
+  enough.
+- Tests cover the failure the change fixes, not only the happy path.
+
+## Extra files
+
+A skill may ship further files beside `SKILL.md`, in subdirectories if that
+helps. They travel with the artifact and land next to it in the sandbox, so
+refer to them by their path relative to this file, for example
+`references/api.md`.
+
+> This directory lives under `docs/` on purpose. A copy under `skills/` would be
+> discovered as a real skill of this deployment and offered for import, which
+> would blur the difference between "this deployment ships no skills" and "it
+> ships one example".

--- a/docs/plans/2026-08-10-local-skill-source.md
+++ b/docs/plans/2026-08-10-local-skill-source.md
@@ -1,0 +1,189 @@
+# Skille z własnego deploymentu
+
+Plan wykonawczy. Wejście dla `/opus-orchestration`.
+
+## Problem
+
+Skille można dziś wziąć wyłącznie z GitHuba, przez jedną organizacyjną instalację GitHub App
+na deployment. To ma dwie konsekwencje, obie bolą przy klonach dla klientów.
+
+Tenant, którego instalacja stoi w organizacji klienta, nie przeczyta katalogu skilli
+leżącego w repozytorium naszej organizacji, nawet jeśli to repozytorium jest źródłem
+jego własnego deploymentu. Tenant obsługiwany wyłącznie przez GitLaba nie przeczyta
+żadnego katalogu skilli, bo GitLab nie jest wspierany jako źródło w ogóle.
+
+Efekt jest taki, że wiedza specyficzna dla klienta, czyli jedyna rzecz odróżniająca ten
+produkt od gotowych narzędzi SaaS do recenzji, nie ma jak do niego dojechać.
+
+## Rozwiązanie
+
+Z perspektywy operatora tenanta: katalog `skills/` w repozytorium, z którego zbudowany jest
+jego deployment, jest źródłem skilli. Nic nie jest pobierane z zewnątrz, nic nie wymaga
+autoryzacji między organizacjami, a wersją skilla jest wersja deploymentu. Każdy klon niesie
+swoje skille, a zmiana skilla to zwykła zmiana w repozytorium i redeploy.
+
+Ścieżka GitHubowa zostaje bez zmian: jest nadal poprawnym sposobem współdzielenia skilli
+między organizacjami.
+
+## User stories
+
+1. Jako operator tenantu chcę trzymać skille w repozytorium swojego deploymentu, żeby nie
+   zależeć od dostępu naszej instalacji GitHub App do cudzej organizacji.
+2. Jako operator tenantu na GitLabie chcę w ogóle móc używać skilli.
+3. Jako operator chcę widzieć w dashboardzie, które skille pochodzą z deploymentu, a które
+   z GitHuba, żeby wiedzieć, co zmieni redeploy, a co odświeżenie.
+4. Jako właściciel produktu chcę, żeby wdrożenie tej zmiany nie unieważniło ani jednego
+   przypiętego profilu.
+
+## Decyzje implementacyjne
+
+**Skille lokalne przechodzą tą samą drogą, co GitHubowe.** Są importowane do tej samej
+tabeli artefaktów, dostają ten sam `artifactHash` liczony z tej samej zawartości, i są
+przypinane w profilu tak samo. Różni je wyłącznie to, skąd bierze się treść. Dzięki temu
+materializacja w sandboxie, weryfikacja integralności i przypinanie wersji pozostają
+nietknięte.
+
+**Kanoniczna postać źródła GitHubowego jest zamrożona.** `artifactHash` liczy się po
+`stableJson`, w którym `source` uczestniczy w całości, więc dopisanie do niego pola
+dyskryminującego zmieniłoby hash każdego istniejącego artefaktu i rozpięło każdy profil,
+który go przypina. Wariant GitHubowy zachowuje dokładnie cztery dotychczasowe pola w tej
+samej kolejności semantycznej. Rozróżnienie wariantów odbywa się po zbiorze obecnych pól,
+a nie po znaczniku wewnątrz hashowanej struktury. Znacznik rodzaju żyje w kolumnie bazy,
+poza hashem.
+
+**Źródłem lokalnym jest katalog `skills/` w korzeniu repozytorium.** Ta nazwa nie jest
+dowolna: to pierwszy z siedmiu katalogów, których szuka dziś importer GitHubowy, więc ten
+sam układ pozostaje czytelny dla obu ścieżek. Wariant lokalny opisuje ścieżka wewnątrz
+katalogu oraz skrót zawartości; nie ma w nim commita, bo nie ma repozytorium do wskazania.
+
+**Pliki muszą trafić do bundla funkcji.** Nitro pakuje wyłącznie JavaScript, a warstwa
+workflow emituje osobne funkcje kroku, przepływu i webhooka obok fallbacku, z których każda
+dostaje własny katalog roboczy. Katalog skilli kopiuje się więc do każdej z nich tym samym
+hookiem kompilacji, który dziś rozwozi pliki konfiguracyjne YAML. Runtime czyta je względem
+katalogu roboczego procesu.
+
+**Odświeżenie znaczy co innego dla obu wariantów.** Skill GitHubowy odświeża się przez
+ponowne pobranie z domyślnej gałęzi. Skill lokalny zmienia się wyłącznie przez redeploy, więc
+próba odświeżenia go musi to powiedzieć wprost, zamiast udawać, że coś zrobiła.
+
+## Seamy i decyzje testowe
+
+| Seam | Obserwowane zachowanie | Prior art |
+|---|---|---|
+| kanoniczny ładunek hasha | dla niezmienionego źródła GitHubowego hash jest identyczny co do bajtu przed i po zmianie | `apps/worker/src/harness-profiles/skill-artifact.ts:200-217` |
+| czytnik katalogu skilli | dla katalogu na dysku zwraca te same artefakty, które importer GitHubowy zwróciłby dla tej samej treści | `apps/worker/src/harness-profiles/github-skills.ts` i jego test obok |
+| hook kompilacji | po budowie każdy katalog funkcji niesie katalog skilli | hook YAML w `apps/worker/nitro.config.ts` |
+
+## Domknięte po red teamie
+
+Oba punkty poniżej były przez chwilę odłożone jako "wykrywanie, nie działanie", po czym
+zostały zrobione w tym samym branchu. Opis zostaje, bo tłumaczy, po co te dwa mechanizmy
+istnieją.
+
+Rozjazd przypięcia jest widoczny bez klikania: edytor profilu odpytuje listę skilli
+deploymentu, ale wyłącznie wtedy, gdy draft przypina choć jeden skill lokalny, i rozróżnia
+trzy stany. Przypięcie zgodne z deploymentem. Przypięcie do skilla, który w deploymencie ma
+inną treść, gdzie lekarstwem jest odświeżenie i publikacja. Przypięcie do skilla, którego
+deployment już nie wozi, gdzie lekarstwem jest przywrócenie katalogu albo zdjęcie przypięcia.
+Nieudane pobranie listy nie rysuje ostrzeżenia, bo brak odpowiedzi znaczy "nie wiem", a nie
+"rozjazd".
+
+Podmiana źródła jest powiedziana wprost: krok przeglądu importu nazywa każde przypięcie,
+które wybrany skill zastąpi, razem z jego dotychczasowym źródłem, i przypomina, że skille
+dopasowywane są po nazwie z `SKILL.md`, która nie musi odpowiadać nazwie katalogu. Operacja
+nie jest blokowana, przestaje być tylko ukryta.
+
+**Rozjazd przypięcia nie jest widoczny bez kliknięcia odświeżania.** Odkrywanie zwraca skrót
+artefaktu, jaki wyprodukowałby import, ale jedynym miejscem, które o to pyta, jest okno
+dodawania skilla. Edytor profilu nigdy nie porównuje przypiętych skrótów z tym, co niesie
+bieżący deployment, więc po cofnięciu wdrożenia profil wygląda zdrowo i dalej wysyła agentowi
+treść z wycofanej wersji. Dane do wykrycia tego istnieją, brakuje wyłącznie porównania.
+
+**Import lokalnego skilla po cichu zdejmuje przypięty skill GitHubowy o tej samej nazwie.**
+Scalanie usuwa z draftu wpis o zbieżnej nazwie albo skrócie, co dotąd trafiało wyłącznie
+w ponowny import tego samego skilla i było zgodne z intencją. Po dodaniu drugiego źródła ta
+sama reguła podmienia źródło skilla bez słowa, a nazwa pochodzi z front mattera, więc nie
+musi odpowiadać nazwie katalogu.
+
+## Pułapki czekające na etap 4b, znalezione na bramce 4a
+
+**Proxy dashboardu nie przepuści odkrywania lokalnego bez nowego handlera.** Przepuszcza dziś
+tylko odkrywanie i import GitHubowy, a jego jedyny pomocnik mutacji jest wyłącznie POST-owy,
+więc dopisanie akcji do unii nie wystarczy. Odkrywanie lokalne nie ma czego przyjąć w ciele,
+więc albo dostaje własny handler odczytu, albo trasa lokalna przyjmuje POST bez ciała wbrew
+swojej naturze. To decyzja do podjęcia na starcie 4b, nie w trakcie.
+
+**Historia użytkownika o widocznym źródle przypiętego skilla nie ma dziś ścieżki danych.**
+Obiekt wersji profilu niesie manifest, a odwołanie do skilla w manifeście to wyłącznie hash
+artefaktu i nazwa. Źródło widać dopiero w zapisie manifestu runu, czyli po fakcie. Pokazanie
+w edytorze profilu, który skill pochodzi z deploymentu, wymaga poszerzenia kontraktu wersji
+profilu, a nie tylko zmiany komponentu. Etap 4b musi to policzyć w swój zakres.
+
+## Wycofane: rzekoma kolizja nazw skilli
+
+Wcześniejsza wersja tego planu twierdziła, że profil przypinający dwa skille o tej samej
+nazwie materializuje je pod jedną ścieżką w sandboxie i drugi nadpisuje pierwszy bez śladu.
+To nieprawda i zapisałem to bez sprawdzenia. Walidacja manifestu odrzuca zarówno duplikat
+nazwy, jak i duplikat hasha artefaktu, przy każdym parsowaniu draftu, czyli na każdej ścieżce
+zapisu profilu. Kolizja nie dociera do sandboxa, więc nie ma czego zgłaszać ani czym
+podpierać dodatkowej walidacji w czytniku. Osobny ticket.
+
+## Out of scope
+
+- Autorstwo skilli w dashboardzie. Dashboard nadal tylko dołącza, nie tworzy treści.
+- Import z GitLaba jako zdalnego źródła. Wariant lokalny odblokowuje tenantów GitLabowych
+  bez niego.
+- Migracja istniejących skilli GitHubowych na lokalne. Obie ścieżki żyją równolegle.
+
+## Założenia
+
+1. **Katalog skilli jest mały wobec limitu bundla.** Trzy skille klienta to około 140 KB,
+   a kopiowane są do każdej funkcji. Przy kilkudziesięciu skillach warto to zmierzyć ponownie.
+2. **Skrót zawartości wystarcza za wersję.** Skill lokalny nie ma commita, więc dwa różne
+   deploymenty z identyczną treścią dają ten sam artefakt. To jest pożądane, bo artefakty są
+   adresowane treścią, ale znaczy też, że rollback deploymentu nie zmienia przypięcia.
+3. **Żaden istniejący wiersz artefaktu nie ma pustego źródła GitHubowego**, więc migracja
+   może domyślnie oznaczyć wszystkie istniejące wiersze jako GitHubowe.
+
+## Etapy
+
+| # | Etap | Seam | Zakres plików | Tier | Sceptyk | TDD | Delegacja | DoD |
+|---|------|------|---------------|------|---------|-----|-----------|-----|
+| 1 | Kontrakt źródła: wariant lokalny obok GitHubowego, z zamrożoną postacią kanoniczną | kanoniczny ładunek hasha | `apps/shared/contracts/harness-profiles.ts`, `apps/worker/src/harness-profiles/skill-artifact.ts` (+testy obok) | opus | tak | tak | nie | test pinujący dowodzi, że dla niezmienionego wejścia GitHubowego `artifactHash` równa się zapisanemu w teście literałowi; drugi test dowodzi, że artefakt lokalny o tej samej treści plików ma hash INNY niż GitHubowy, bo źródło jest częścią tożsamości; `pnpm --filter worker test harness-profiles` zielone |
+| 2 | Trwałość: rodzaj źródła w bazie, kolumny GitHubowe dopuszczają brak, migracja | brak (schemat) | `apps/worker/src/db/schema.ts`, nowa migracja w `apps/worker/drizzle/` | opus | nie | nie | nie | migracja stosuje się na czystej bazie i na bazie z istniejącymi wierszami; wszystkie istniejące wiersze wychodzą oznaczone jako GitHubowe z nienaruszonymi kolumnami; numer migracji nie koliduje z `origin/main` |
+| 3 | Czytnik katalogu z deploymentu plus rozwiezienie plików do funkcji | czytnik katalogu skilli | `apps/worker/src/harness-profiles/local-skills.ts` (nowy, +test), `apps/worker/nitro.config.ts` | opus | tak | tak | nie | test dowodzi, że czytnik odrzuca to samo, co odrzuca importer GitHubowy: zły wzorzec nazwy, opis poza zakresem długości, plik ponad limit, przekroczony rozmiar artefaktu; test dowodzi, że katalog bez `SKILL.md` jest pomijany, a nie wywala importu; hook kompilacji ma test albo jawnie udokumentowaną weryfikację ręczną z wynikiem |
+| 4 | Wystawienie: odkrywanie i import lokalnych, rozróżnienie w dashboardzie, odświeżanie mówi prawdę | brak (API i UI) | `apps/worker/src/routes/api/v1/harness-skills/`, `apps/worker/src/routes/api/v1/harness-profiles/[id]/skills/refresh.post.ts`, dashboard: edytor profilu | sonnet | tak | nie | tak | odkrywanie zwraca skille z deploymentu bez konfiguracji GitHuba; próba odświeżenia skilla lokalnego zwraca czytelny komunikat, że zmienia go redeploy, zamiast błędu providera; dashboard pokazuje, z którego źródła pochodzi każdy przypięty skill |
+
+Etapy są sekwencyjne. Pierwotnie zakładałem, że 2 i 3 pobiegną równolegle, ale etap 1 pokazał
+sprzężenie, którego plan nie widział: obiekty przenoszące artefakt na zewnątrz są przypięte do
+wariantu GitHubowego, a czytają je miejsca spoza zakresu etapu 1. Poszerzenie ich pociąga
+zawężenie w miejscu zapisu artefaktu, czyli dokładnie tam, gdzie etap 3 zapisuje rodzaj źródła
+wprowadzony przez etap 2. Przy budżecie dwóch godzin dziennie równoległość nie jest tu wartością,
+a kolizja na tym samym pliku jest realna.
+
+**Decyzja advisora do QUESTION z etapu 1.** Obiekty wyjściowe artefaktu zostają przypięte do
+wariantu GitHubowego do końca etapu 1 i poszerza je etap 3, razem z zawężeniem w miejscu zapisu
+i w kontrakcie kanarka. Odrzucone: poszerzanie ich już w etapie 1, bo zostawiłoby w drzewie
+obsługę wariantu, którego nic jeszcze nie produkuje, oraz nadanie wariantowi lokalnemu pól
+fantomowych, bo to ucisza kompilator dokładnie tam, gdzie ma on wskazać miejsca wymagające
+obsługi.
+
+**Korekta granicy etapów 2 i 3, po znalezisku z etapu 2.** Pierwotny podział zakładał, że
+zmiana schematu jest sprawdzalna w izolacji. Nie jest: rozluźnienie nullowalności kolumny
+natychmiast rozjeżdża typy w każdym miejscu, które czyta z niej źródło, a te miejsca leżały
+poza zakresem etapu 2. Zapisany DoD tego etapu wymagał zielonego typechecku, więc plan był
+wewnętrznie sprzeczny.
+
+Rozstrzygnięcie: etap 2 dokłada jedno miejsce, w którym gwarancja bazy przekracza granicę
+systemu typów, czyli funkcję odwzorowującą wiersz artefaktu na źródło z kontraktu. Wywołania
+w miejscach odczytu używają jej zamiast czytać kolumny wprost. Wariant lokalny nie jest tam
+jeszcze produkowany, bo nic go nie zapisuje: dokłada go etap 3 razem z czytnikiem katalogu.
+Odrzucone: rozsypanie kilkunastu zawężeń po dwóch plikach, bo zaklepywałoby decyzję należącą
+do etapu 3, oraz przepuszczenie czerwonego drzewa przez granicę commita, bo na tym branchu
+pracują równolegle inne osoby.
+
+**Decyzja advisora: źródło pozostaje częścią tożsamości artefaktu.** Ten sam zestaw plików
+wzięty z GitHuba i z deploymentu daje dwa różne hashe, więc przeniesienie skilla między
+źródłami wymaga ponownego przypięcia w profilu. To nie jest wybór, tylko konsekwencja: `source`
+zawsze uczestniczył w hashu, a wyjęcie go stamtąd samo w sobie przeliczyłoby wszystkie
+istniejące artefakty.


### PR DESCRIPTION
Closes AIW-246.

## Why

Skill import authenticates through a single organization-wide GitHub App installation, one per deployment. A tenant whose installation lives in the customer's organization cannot read a skills directory in a repository of ours, even when that repository is the source of the tenant's own deployment. A tenant served only by GitLab cannot read any skills directory at all.

Skills carry the knowledge of a customer's repositories, which is the one thing that distinguishes this product from a managed code-review service, so today that knowledge cannot reach the deployments that need it most.

This adds a second source: a `skills/` directory in the repository a deployment is built from. GitHub stays exactly as it was.

## The constraint that shaped the design

`artifactHash` is a SHA-256 over `stableJson({source, name, description, files})`, and profiles pin skills by that hash. Adding a `kind` discriminator inside `source` would rehash every artifact already stored and unpin every profile that pins one. The same holds for the skill reference inside a profile manifest, which is hashed too.

So the variants are told apart by which fields are present, never by a tag inside the hashed object, the persisted kind lives in a column beside the hash, and the source reaches the dashboard as a field derived at read time. A pinning test records the pre-change hash as a literal; it is green and its literal is untouched.

## How the files reach the function

Nitro bundles JavaScript only, and the workflow layer emits separate step, flow and webhook functions beside the fallback, each with its own working directory. The existing `compiled` hook that ships the YAML configs now also copies the skills directory into every function bundle. Verified against a real build: the copy lands in all four function directories.

## What an operator gets

Discovery and import that need no GitHub configuration. An import bound to exact contents, so a deployment swapped between listing and importing is refused rather than silently importing something else. Refresh that re-reads the directory, moves the pin, and says whether anything actually changed. A profile that shows when the deployment carries different contents for a pinned skill, and when it no longer carries it at all. One malformed entry costs its own skill only, and names the reason. A build that fails on a malformed skill instead of shipping a deployment whose skills quietly do not load. An empty result that distinguishes "ships no skills" from "nothing here could be used".

## Migration

`0045_local_skill_source` widens the artifact table: a source kind column defaulting to `github`, the four GitHub columns become nullable, two local columns join them, and two check constraints make a half-filled row unrepresentable. Every existing row comes out marked `github` with its columns untouched. The default is load-bearing: the only production writer is a raw SQL statement that does not name the new column and is invisible to typecheck.

## Verification

Worker: 115 tests across 11 files, typecheck clean. Dashboard: 28 tests, typecheck clean. `drizzle-kit check` clean with no drift. The migration was generated fresh against this branch's base rather than carried over, because main took 0044 in the meantime.

## Deliberately out of scope

GitLab as a remote skill source: the deployment-local variant unblocks GitLab-only tenants without it. Authoring skills in the dashboard: it still attaches rather than writes. Migrating existing GitHub skills to local: both sources live side by side.
