### PR TITLE
fix(worker): serialize autofix publication input

### DIFF
--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -85,7 +85,11 @@ vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
     mocks.upsertWorkflowOwnedBranch(...args),
 }));
 
-import { execute, paramsSchema } from "./fix-agent.js";
+import {
+  buildPrFixPublicationInput,
+  execute,
+  paramsSchema,
+} from "./fix-agent.js";
 import {
   expectOutputConformsToRegistry,
   makeCtx,
@@ -184,6 +188,55 @@ describe("fix_agent execute", () => {
     });
     mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValue(undefined);
     mocks.upsertWorkflowOwnedBranch.mockResolvedValue(undefined);
+  });
+
+  it("passes only serializable data across the fix publication step boundary", () => {
+    const pr = makePrPayload();
+    const ctx = makeCtx({
+      entry: {
+        kind: "pr_trigger",
+        triggerType: "trigger_pr_updated",
+        subjectKey: "ticket:jira:AWT-1",
+        ticketKey: "AWT-1",
+        ownerToken: "owner:test",
+        definitionId: 1,
+        definitionVersion: 1,
+        scope: "workflow_owned",
+        pr,
+      },
+      repositoryScope: {
+        repositories: [{ provider: "github", repoPath: "acme/api" }],
+      },
+      workspaceManifest: {
+        version: 2,
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/api",
+            slug: "acme__api",
+            localPath: "/vercel/sandbox",
+            defaultBranch: "main",
+            branchName: pr.headRef,
+            selectedRationale: "PR fix",
+            access: "write",
+          },
+        ],
+      },
+    });
+
+    const input = buildPrFixPublicationInput(ctx, "sbx-1");
+
+    expect(input).toEqual({
+      sandboxId: "sbx-1",
+      workspaceManifest: ctx.workspaceManifest,
+      subjectKey: "ticket:jira:AWT-1",
+      ownerToken: "owner:test",
+      runId: ctx.runId,
+      repositoryScope: ctx.repositoryScope,
+      pr,
+    });
+    expect(input).not.toHaveProperty("ctx");
+    expect(() => structuredClone(input)).not.toThrow();
   });
 
   it("implicitly ensures a workspace when none is attached", async () => {

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import type { WorkflowDefinitionNode } from "@shared/contracts";
+import type {
+  WorkflowDefinitionNode,
+  WorkflowRepositoryScope,
+} from "@shared/contracts";
 import type { AgentKind } from "../../sandbox/agents/index.js";
 import type {
   AgentOutput,
@@ -9,6 +12,7 @@ import type {
   PhaseUsage,
 } from "../../sandbox/agents/types.js";
 import type { CheckRunResult, PRComment } from "../../adapters/vcs/types.js";
+import type { WorkspaceManifestV2 } from "../../sandbox/repo-workspace.js";
 import type { PrTriggerPayload } from "../agent-input.js";
 import { resolveBlockAgent } from "../../workflow-definition/resolve-agent.js";
 import type { ResolvedHarnessRuntime } from "../../sandbox/harness-runtime.js";
@@ -90,24 +94,46 @@ async function assertFixPrOwnershipStep(pr: PrTriggerPayload, runId: string): Pr
   void runId;
 }
 
-async function publishPrFixStep(input: {
-  ctx: Parameters<BlockExecuteFn>[2];
+type PrFixPublicationInput = {
   sandboxId: string;
-}): Promise<void> {
-  "use step";
-  if (input.ctx.workspaceManifest?.version !== 2 || input.ctx.entry.kind !== "pr_trigger") {
-    return;
+  workspaceManifest: WorkspaceManifestV2;
+  subjectKey: string;
+  ownerToken: string;
+  runId: string;
+  repositoryScope?: WorkflowRepositoryScope;
+  pr: PrTriggerPayload;
+};
+
+export function buildPrFixPublicationInput(
+  ctx: Parameters<BlockExecuteFn>[2],
+  sandboxId: string,
+): PrFixPublicationInput | null {
+  if (ctx.workspaceManifest?.version !== 2 || ctx.entry.kind !== "pr_trigger") {
+    return null;
   }
+  return {
+    sandboxId,
+    workspaceManifest: ctx.workspaceManifest,
+    subjectKey: ctx.entry.subjectKey,
+    ownerToken: ctx.entry.ownerToken,
+    runId: ctx.runId,
+    repositoryScope: ctx.repositoryScope,
+    pr: ctx.entry.pr,
+  };
+}
+
+async function publishPrFixStep(input: PrFixPublicationInput): Promise<void> {
+  "use step";
   const { publishTrustedWorkspaceFromSandbox } = await import(
     "../../sandbox/trusted-workspace-publisher.js",
   );
   const result = await publishTrustedWorkspaceFromSandbox({
     sourceSandboxId: input.sandboxId,
-    workspaceManifest: input.ctx.workspaceManifest,
-    subjectKey: input.ctx.entry.subjectKey,
-    ownerToken: input.ctx.entry.ownerToken,
-    runId: input.ctx.runId,
-    repositoryScope: input.ctx.repositoryScope,
+    workspaceManifest: input.workspaceManifest,
+    subjectKey: input.subjectKey,
+    ownerToken: input.ownerToken,
+    runId: input.runId,
+    repositoryScope: input.repositoryScope,
   });
   if (result.error) throw new Error(`Fix push failed: ${result.error}`);
   const failedRepository = result.repositories.find(
@@ -126,8 +152,8 @@ async function publishPrFixStep(input: {
   } = await import("../../db/queries/workflow-owned-branches.js");
   for (const repository of result.repositories) {
     if (
-      repository.provider !== input.ctx.entry.pr.provider ||
-      repository.repoPath !== input.ctx.entry.pr.repoPath
+      repository.provider !== input.pr.provider ||
+      repository.repoPath !== input.pr.repoPath
     ) {
       continue;
     }
@@ -135,7 +161,7 @@ async function publishPrFixStep(input: {
     const owned = await findWorkflowOwnedPullRequestIdentity(getDb(), {
       provider: repository.provider,
       repoPath: repository.repoPath,
-      prNumber: input.ctx.entry.pr.prNumber,
+      prNumber: input.pr.prNumber,
     });
     if (!owned?.pr) continue;
     await upsertWorkflowOwnedBranch(getDb(), {
@@ -584,7 +610,8 @@ export const execute: BlockExecuteFn = async (
       };
     }
     if (output.result === "implemented") {
-      await publishPrFixStep({ ctx, sandboxId });
+      const publicationInput = buildPrFixPublicationInput(ctx, sandboxId);
+      if (publicationInput) await publishPrFixStep(publicationInput);
     }
     return {
       kind: "next",


### PR DESCRIPTION
## Summary
- pass only plain, serializable data into the durable fix publication step
- preserve the existing PR ownership and repository-scope guardrails
- add a regression test proving the step input contains no engine context/functions

## Production dogfood evidence
A real `Post-PR review with autofix` run reached the fix publication boundary and Vercel Workflow rejected `ctx.observeBudget` as a non-serializable function. The run was cancelled before push, autofix was disabled, and normal post-PR review was restored.

## Verification
- focused fix-agent suite: 28/28 passed
- worker typecheck: passed
- full worker suite: running locally
