### PR TITLE
fix(worker): keep sibling findings out of autofix

### DIFF
--- a/apps/worker/src/sandbox/context.test.ts
+++ b/apps/worker/src/sandbox/context.test.ts
@@ -284,6 +284,10 @@ describe("assembleResearchPlanContext", () => {
 
     expect(result).toContain("`github:acme/api` at `/vercel/sandbox/repos/github__acme__api`");
     expect(result).toContain("`github:acme/web` at `/vercel/sandbox/repos/github__acme__web`");
+    expect(result).toContain("`/vercel/sandbox/repos/github__acme__api` (write)");
+    expect(result).toContain("`/vercel/sandbox/repos/github__acme__web` (read-only)");
+    expect(result).toContain("Only repositories marked write may be modified");
+    expect(result).toContain("Read-only repositories are context only");
   });
 
   it("renders legacy root layout paths from the trusted manifest", () => {

--- a/apps/worker/src/sandbox/context.ts
+++ b/apps/worker/src/sandbox/context.ts
@@ -481,9 +481,24 @@ function renderSelectedRepositories(
       throw new Error(`Selected repository path is duplicated for ${repo.repoPath}`);
     }
     seen.add(localPath);
-    return `- \`${repo.provider}:${repo.repoPath}\` at \`${localPath}\` - ${repo.selectedRationale}`;
+    const manifestAccess =
+      manifest?.version === 2
+        ? manifest.repositories.find(
+            (candidate) =>
+              candidate.provider === repo.provider &&
+              candidate.repoPath === repo.repoPath,
+          )?.access
+        : undefined;
+    const access = manifestAccess
+      ? ` (${manifestAccess === "write" ? "write" : "read-only"})`
+      : "";
+    return `- \`${repo.provider}:${repo.repoPath}\` at \`${localPath}\`${access} - ${repo.selectedRationale}`;
   });
-  return `\n## Selected Repositories\n\nEdit only these Run Workspace repositories:\n\n${lines.join("\n")}\n`;
+  const instruction =
+    manifest?.version === 2
+      ? "Only repositories marked write may be modified. Read-only repositories are context only and must not be changed."
+      : "Edit only these Run Workspace repositories:";
+  return `\n## Selected Repositories\n\n${instruction}\n\n${lines.join("\n")}\n`;
 }
 
 /**

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -1130,7 +1130,7 @@ function postPrAutofixDefinition(
       configuration: {
         ...profile(),
         instructions:
-          "Resolve the supplied review findings, verify the changes, and commit the fix.",
+          "Resolve only supplied findings in repositories marked write. Treat read-only sibling findings as context and never modify those repositories. Verify the changes and commit the fix.",
         maxMinutes: 25,
       },
       inputs: {

--- a/apps/worker/src/workflows/agent-block-outputs.test.ts
+++ b/apps/worker/src/workflows/agent-block-outputs.test.ts
@@ -160,6 +160,57 @@ describe("specialized workflow block outputs", () => {
     ).toMatchObject({ ok: true });
   });
 
+  it("keeps read-only sibling findings informational for the autofix decision", () => {
+    const output = buildReviewAgentSuccessOutput(
+      {
+        feedback: "The sibling contract is stale.",
+        issues: [
+          {
+            file: "src/contracts.ts",
+            description: "Update this in the sibling repository.",
+            severity: "Blocker",
+            repo: "/vercel/sandbox/repos/gitlab__acme__contracts",
+          },
+        ],
+      },
+      {
+        version: 2,
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/app",
+            slug: "acme__app",
+            localPath: "/vercel/sandbox",
+            defaultBranch: "main",
+            branchName: "ai-workflow/AIW-1",
+            selectedRationale: "current PR",
+            access: "write",
+          },
+          {
+            provider: "gitlab",
+            repoPath: "acme/contracts",
+            slug: "gitlab__acme__contracts",
+            localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+            defaultBranch: "main",
+            branchName: "main",
+            selectedRationale: "sibling PR",
+            access: "read",
+          },
+        ],
+      },
+    );
+
+    expect(output).toMatchObject({
+      decision: "approve",
+      findings: [
+        expect.objectContaining({
+          repo: "acme/contracts",
+          severity: "Blocker",
+        }),
+      ],
+    });
+  });
+
   it("publishes integer line numbers so a finding can be placed inline", () => {
     const output = buildReviewAgentSuccessOutput({
       feedback: "",

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -453,38 +453,50 @@ export function buildReviewAgentSuccessOutput(
   // nulls are dropped here instead of failing validation downstream.
   const line = (value: number | null | undefined): number | undefined =>
     typeof value === "number" && value >= 1 ? value : undefined;
+  const findings = review.issues.map((finding) => {
+    const startLine = line(finding.startLine);
+    // The Review Result normalizer rejects an endLine without a startLine and
+    // an endLine below its startLine, so neither shape may reach the output.
+    const candidateEnd = line(finding.endLine);
+    const endLine =
+      startLine !== undefined &&
+      candidateEnd !== undefined &&
+      candidateEnd >= startLine
+        ? candidateEnd
+        : undefined;
+    return {
+      file: finding.file,
+      description: finding.description,
+      severity: finding.severity,
+      ...(startLine === undefined ? {} : { startLine }),
+      ...(endLine === undefined ? {} : { endLine }),
+      ...(typeof finding.repo === "string"
+        ? {
+            repo:
+              repositoryByLocalPath.get(finding.repo) ?? finding.repo,
+          }
+        : {}),
+    };
+  });
+  const writableRepositories =
+    workspaceManifest?.version === 2
+      ? new Set(
+          workspaceManifest.repositories
+            .filter((repository) => repository.access === "write")
+            .map((repository) => repository.repoPath),
+        )
+      : undefined;
+  const blocksPublication = findings.some(
+    (finding) =>
+      (finding.severity === "Blocker" || finding.severity === "High") &&
+      (writableRepositories === undefined ||
+        finding.repo === undefined ||
+        writableRepositories.has(finding.repo)),
+  );
   return {
     status: "reviewed",
-    findings: review.issues.map((finding) => {
-      const startLine = line(finding.startLine);
-      // The Review Result normalizer rejects an endLine without a startLine and
-      // an endLine below its startLine, so neither shape may reach the output.
-      const candidateEnd = line(finding.endLine);
-      const endLine =
-        startLine !== undefined &&
-        candidateEnd !== undefined &&
-        candidateEnd >= startLine
-          ? candidateEnd
-          : undefined;
-      return {
-        file: finding.file,
-        description: finding.description,
-        severity: finding.severity,
-        ...(startLine === undefined ? {} : { startLine }),
-        ...(endLine === undefined ? {} : { endLine }),
-        ...(typeof finding.repo === "string"
-          ? {
-              repo:
-                repositoryByLocalPath.get(finding.repo) ?? finding.repo,
-            }
-          : {}),
-      };
-    }),
-    decision: review.issues.some(
-      (finding) => finding.severity === "Blocker" || finding.severity === "High",
-    )
-      ? "request_changes"
-      : "approve",
+    findings,
+    decision: blocksPublication ? "request_changes" : "approve",
     ...(feedback ? { feedback } : {}),
   };
 }

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   ensureWorkspace: vi.fn(),
   maybePromoteTicketWorkspaceWrites: vi.fn().mockResolvedValue(null),
   inspectFixWorkspace: vi.fn(),
+  restoreReadOnlyFixRepositories: vi.fn(),
   prepareHarnessAgentInvocation: vi.fn(),
   pollPhaseUntilDone: vi.fn().mockResolvedValue(true),
   findRunPrSiblings: vi.fn(),
@@ -69,6 +70,7 @@ vi.mock("./agent-sandbox.js", () => ({
 vi.mock("./fix-workspace-state.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./fix-workspace-state.js")>()),
   inspectFixWorkspace: mocks.inspectFixWorkspace,
+  restoreReadOnlyFixRepositories: mocks.restoreReadOnlyFixRepositories,
 }));
 vi.mock("../../db/client.js", () => ({ getDb: () => ({}) }));
 vi.mock("../../db/queries/run-pr-siblings.js", () => ({
@@ -168,6 +170,7 @@ describe("fix_agent execute", () => {
       };
     });
     mocks.inspectFixWorkspace.mockResolvedValue({ commits: [], unresolvedConflicts: [] });
+    mocks.restoreReadOnlyFixRepositories.mockResolvedValue([]);
     mocks.prepareHarnessAgentInvocation.mockResolvedValue({
       ok: true,
       value: undefined,
@@ -561,6 +564,84 @@ describe("fix_agent execute", () => {
         },
       ],
     });
+  });
+
+  it("does not send read-only sibling findings to the fix agent", async () => {
+    const block = makeNode("fix_agent");
+    const pr = makePrPayload({ prNumber: 42 });
+    const workspaceManifest = {
+      version: 2 as const,
+      repositories: [
+        {
+          provider: "github" as const,
+          repoPath: "acme/api",
+          slug: "acme__api",
+          localPath: "/vercel/sandbox",
+          defaultBranch: "main",
+          branchName: pr.headRef,
+          selectedRationale: "current PR",
+          access: "write" as const,
+        },
+        {
+          provider: "gitlab" as const,
+          repoPath: "acme/contracts",
+          slug: "gitlab__acme__contracts",
+          localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+          defaultBranch: "main",
+          branchName: "main",
+          selectedRationale: "sibling PR",
+          access: "read" as const,
+          researchBaseSha: "read-base",
+        },
+      ],
+    };
+    await execute(
+      block,
+      {},
+      makeCtx({
+        schemaVersion: 2,
+        entry: {
+          kind: "pr_trigger",
+          triggerType: "trigger_pr_updated",
+          subjectKey: "pr:github:acme/api#42",
+          ownerToken: "owner:test",
+          definitionId: 1,
+          definitionVersion: 1,
+          scope: "workflow_owned",
+          pr,
+        },
+        selectedRepositories: [
+          { provider: "github", repoPath: "acme/api", defaultBranch: "main", selectedRationale: "current PR" },
+          { provider: "gitlab", repoPath: "acme/contracts", defaultBranch: "main", selectedRationale: "sibling PR" },
+        ],
+        workspaceManifest,
+        harnessRuntimes: { [block.id]: makeHarnessRuntime(block.id, block.type) },
+      }),
+      {
+        reviewResults: [
+          {
+            decision: "request_changes",
+            findings: [
+              { file: "src/api.ts", description: "Fix the API.", severity: "High", repo: "acme/api" },
+              { file: "src/contracts.ts", description: "Fix the sibling.", severity: "Blocker", repo: "acme/contracts" },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(mocks.assembleFixContext.mock.calls[0][0].reviewResults).toEqual([
+      {
+        decision: "request_changes",
+        findings: [
+          { file: "src/api.ts", description: "Fix the API.", severity: "High", repo: "acme/api" },
+        ],
+      },
+    ]);
+    expect(mocks.restoreReadOnlyFixRepositories).toHaveBeenCalledWith(
+      "sbx-1",
+      workspaceManifest,
+    );
   });
 
   it("rejects malformed internal Review Results before invoking the agent", async () => {

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   restoreReadOnlyFixRepositories: vi.fn(),
   prepareHarnessAgentInvocation: vi.fn(),
   pollPhaseUntilDone: vi.fn().mockResolvedValue(true),
+  stopPhaseCommand: vi.fn().mockResolvedValue(undefined),
   findRunPrSiblings: vi.fn(),
   publishTrustedWorkspaceFromSandbox: vi.fn(),
   findWorkflowOwnedPullRequestIdentity: vi.fn(),
@@ -43,7 +44,10 @@ vi.mock("@vercel/sandbox", () => ({
     get: vi.fn(async () => ({ writeFiles: mocks.writeFiles, runCommand: mocks.runCommand })),
   },
 }));
-vi.mock("./poll-phase.js", () => ({ pollPhaseUntilDone: mocks.pollPhaseUntilDone }));
+vi.mock("./poll-phase.js", () => ({
+  pollPhaseUntilDone: mocks.pollPhaseUntilDone,
+  stopPhaseCommand: mocks.stopPhaseCommand,
+}));
 vi.mock("../../sandbox/agents/index.js", () => ({
   createAgentAdapter: vi.fn(() => ({
     cliSpec: {
@@ -185,6 +189,7 @@ describe("fix_agent execute", () => {
         : { cmdId: "cmd-2", exitCode: null },
     );
     mocks.pollPhaseUntilDone.mockResolvedValue(true);
+    mocks.stopPhaseCommand.mockResolvedValue(undefined);
     mocks.publishTrustedWorkspaceFromSandbox.mockResolvedValue({
       pushed: true,
       repositories: [],
@@ -939,10 +944,30 @@ describe("fix_agent execute", () => {
     };
     mocks.inspectFixWorkspace.mockResolvedValueOnce(before).mockResolvedValueOnce(after);
 
+    const block = makeNode("fix_agent");
     const result = await execute(
-      makeNode("fix_agent"),
+      block,
       {},
-      makeCtx(),
+      makeCtx({
+        schemaVersion: 2,
+        workspaceManifest: {
+          version: 2,
+          repositories: [
+            {
+              provider: "gitlab",
+              repoPath: "acme/contracts",
+              slug: "gitlab__acme__contracts",
+              localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+              defaultBranch: "main",
+              branchName: "main",
+              selectedRationale: "sibling PR",
+              access: "read",
+              researchBaseSha: "read-base",
+            },
+          ],
+        },
+        harnessRuntimes: { [block.id]: makeHarnessRuntime(block.id, block.type) },
+      }),
       {},
       { observations: { emit } },
     );
@@ -956,6 +981,8 @@ describe("fix_agent execute", () => {
       },
     });
     expect(mocks.inspectFixWorkspace).toHaveBeenCalledTimes(1);
+    expect(mocks.stopPhaseCommand).toHaveBeenCalledWith("sbx-1", "cmd-2");
+    expect(mocks.restoreReadOnlyFixRepositories).toHaveBeenCalledOnce();
     expect(mocks.collectPhase).toHaveBeenCalledOnce();
     expect(emit).toHaveBeenCalledWith({
       kind: "log",
@@ -970,5 +997,52 @@ describe("fix_agent execute", () => {
         },
       }),
     });
+  });
+
+  it("restores read-only repositories when parsing the agent result fails", async () => {
+    const block = makeNode("fix_agent");
+    mocks.parseAgentOutputProtocol.mockReturnValueOnce({
+      ok: false,
+      category: "parsing",
+      message: "The current agent phase returned an invalid structured response.",
+      diagnostic: {
+        provider: "claude",
+        packageName: "@anthropic-ai/claude-code",
+        cliVersion: "2.1.216",
+        protocol: "claude-json-2.1.216",
+        phase: "fix-blk",
+        failureKind: "invalid_json",
+        exitCode: 0,
+      },
+    });
+
+    const result = await execute(
+      block,
+      {},
+      makeCtx({
+        schemaVersion: 2,
+        workspaceManifest: {
+          version: 2,
+          repositories: [
+            {
+              provider: "gitlab",
+              repoPath: "acme/contracts",
+              slug: "gitlab__acme__contracts",
+              localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+              defaultBranch: "main",
+              branchName: "main",
+              selectedRationale: "sibling PR",
+              access: "read",
+              researchBaseSha: "read-base",
+            },
+          ],
+        },
+        harnessRuntimes: { [block.id]: makeHarnessRuntime(block.id, block.type) },
+      }),
+    );
+
+    expect(result.kind).toBe("execution_error");
+    expect(mocks.stopPhaseCommand).toHaveBeenCalledWith("sbx-1", "cmd-2");
+    expect(mocks.restoreReadOnlyFixRepositories).toHaveBeenCalledOnce();
   });
 });

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -17,7 +17,7 @@ import type { PrTriggerPayload } from "../agent-input.js";
 import { resolveBlockAgent } from "../../workflow-definition/resolve-agent.js";
 import type { ResolvedHarnessRuntime } from "../../sandbox/harness-runtime.js";
 import { isRunControlError } from "../run-control-error.js";
-import { pollPhaseUntilDone } from "./poll-phase.js";
+import { pollPhaseUntilDone, stopPhaseCommand } from "./poll-phase.js";
 import {
   emitAgentInvocationObservations,
   emitTimedOutAgentInvocationObservations,
@@ -464,6 +464,16 @@ export const execute: BlockExecuteFn = async (
   const maxMinutes =
     typeof block.params.maxMinutes === "number" ? block.params.maxMinutes : DEFAULT_MAX_MINUTES;
   const phase = agentArtifactPhase(`fix-${sanitizeBlockId(block.id)}`, execution);
+  let launchedCommandId: string | null = null;
+  let cleanupAttempted = false;
+  const cleanupLaunchedPhase = async (): Promise<void> => {
+    if (cleanupAttempted || launchedCommandId === null) return;
+    cleanupAttempted = true;
+    await stopPhaseCommand(sandboxId, launchedCommandId);
+    if (ctx.workspaceManifest?.version === 2) {
+      await restoreReadOnlyFixRepositories(sandboxId, ctx.workspaceManifest);
+    }
+  };
 
   try {
     const reviewFeedback = resolveReviewFeedbackInput(resolvedInputs, {
@@ -554,6 +564,7 @@ export const execute: BlockExecuteFn = async (
     );
     if (!launch.ok) return agentProtocolExecutionError(launch.failure);
     const commandId = launch.commandId;
+    launchedCommandId = commandId;
     markBlockPhaseLaunched(ctx, usageLabel(block.id), execution);
 
     const done = await pollPhaseUntilDone(
@@ -576,6 +587,7 @@ export const execute: BlockExecuteFn = async (
         collectArtifacts: () =>
           collectPhaseReplayDiagnostics(sandboxId, paths),
       });
+      await cleanupLaunchedPhase();
       return executionError("fix phase timed out", { category: "timeout" });
     }
 
@@ -603,9 +615,7 @@ export const execute: BlockExecuteFn = async (
       model,
       execution,
     );
-    if (ctx.workspaceManifest?.version === 2) {
-      await restoreReadOnlyFixRepositories(sandboxId, ctx.workspaceManifest);
-    }
+    await cleanupLaunchedPhase();
     if (!result.ok) return agentProtocolExecutionError(result);
     const output = result.value;
     const after = await inspectFixWorkspace(sandboxId);
@@ -659,6 +669,15 @@ export const execute: BlockExecuteFn = async (
       },
     };
   } catch (err) {
+    try {
+      await cleanupLaunchedPhase();
+    } catch (cleanupError) {
+      if (isRunControlError(err)) throw err;
+      return executionError(
+        cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+        { category: "provider" },
+      );
+    }
     if (isRunControlError(err)) throw err;
     return executionError(err instanceof Error ? err.message : String(err), {
       category: "provider",

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -30,6 +30,7 @@ import {
 } from "./prepare-workspace.js";
 import {
   inspectFixWorkspace,
+  restoreReadOnlyFixRepositories,
   resolvedFixConflicts,
   type FixWorkspaceState,
 } from "./fix-workspace-state.js";
@@ -66,6 +67,35 @@ export const paramsSchema = z
 
 const DEFAULT_MAX_MINUTES = 25;
 const usageLabel = (blockId: string) => `Fix ${blockId}`;
+
+function actionableReviewResults(
+  reviewResults: Extract<ReviewResultsResolution, { ok: true }>["value"],
+  workspaceManifest: WorkspaceManifestV2 | null,
+): Extract<ReviewResultsResolution, { ok: true }>["value"] {
+  if (!reviewResults || !workspaceManifest) return reviewResults;
+  const writableRepositories = new Set(
+    workspaceManifest.repositories
+      .filter((repository) => repository.access === "write")
+      .map((repository) => repository.repoPath),
+  );
+  return reviewResults.map((result) => {
+    const findings = result.findings.filter(
+      (finding) =>
+        finding.repo === undefined || writableRepositories.has(finding.repo),
+    );
+    const removedReadOnlyFindings = findings.length !== result.findings.length;
+    const requestChanges = findings.some(
+      (finding) => finding.severity === "Blocker" || finding.severity === "High",
+    );
+    return {
+      decision: requestChanges ? "request_changes" : "approve",
+      findings,
+      ...(!removedReadOnlyFindings && result.feedback
+        ? { feedback: result.feedback }
+        : {}),
+    };
+  });
+}
 
 async function assertFixPrOwnershipStep(pr: PrTriggerPayload, runId: string): Promise<void> {
   "use step";
@@ -462,12 +492,16 @@ export const execute: BlockExecuteFn = async (
         message: reviewResults.message,
       });
     }
+    const fixReviewResults = actionableReviewResults(
+      reviewResults.value,
+      ctx.workspaceManifest?.version === 2 ? ctx.workspaceManifest : null,
+    );
     const before = await inspectFixWorkspace(sandboxId);
     const fallbackInput = await buildFixInput(
       block,
       ctx,
       reviewFeedback.value,
-      reviewResults.value,
+      fixReviewResults,
       execution?.compileEffectivePrompt === undefined,
     );
     const resolvedInput = await resolveAgentInput({
@@ -569,6 +603,9 @@ export const execute: BlockExecuteFn = async (
       model,
       execution,
     );
+    if (ctx.workspaceManifest?.version === 2) {
+      await restoreReadOnlyFixRepositories(sandboxId, ctx.workspaceManifest);
+    }
     if (!result.ok) return agentProtocolExecutionError(result);
     const output = result.value;
     const after = await inspectFixWorkspace(sandboxId);

--- a/apps/worker/src/workflows/blocks/fix-workspace-state.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-workspace-state.test.ts
@@ -9,7 +9,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../sandbox/credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
 vi.mock("@vercel/sandbox", () => ({ Sandbox: { get: mocks.sandboxGet } }));
 
-import { inspectFixWorkspace, resolvedFixConflicts } from "./fix-workspace-state.js";
+import {
+  inspectFixWorkspace,
+  resolvedFixConflicts,
+  restoreReadOnlyFixRepositories,
+} from "./fix-workspace-state.js";
 
 const result = (stdout: string, exitCode = 0) => ({
   exitCode,
@@ -76,5 +80,72 @@ describe("Fix workspace state", () => {
         },
       ),
     ).toEqual([{ provider: "github", repoPath: "acme/api", files: ["a.ts"] }]);
+  });
+
+  it("restores tracked changes in read-only repositories to their trusted baselines", async () => {
+    mocks.runCommand.mockImplementation(async (cmd: string, args: string[]) => {
+      if (cmd !== "git") return result("");
+      if (args.includes("reset")) return result("");
+      if (args.includes("rev-parse")) return result("read-base\n");
+      if (args.includes("status")) return result("");
+      return result("");
+    });
+
+    await expect(
+      restoreReadOnlyFixRepositories("sbx-1", {
+        version: 2,
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/api",
+            slug: "acme__api",
+            localPath: "/vercel/sandbox",
+            defaultBranch: "main",
+            branchName: "ai-workflow/AIW-1",
+            selectedRationale: "current PR",
+            access: "write",
+          },
+          {
+            provider: "gitlab",
+            repoPath: "acme/contracts",
+            slug: "gitlab__acme__contracts",
+            localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+            defaultBranch: "main",
+            branchName: "main",
+            selectedRationale: "sibling PR",
+            access: "read",
+            researchBaseSha: "read-base",
+          },
+        ],
+      }),
+    ).resolves.toEqual(["gitlab:acme/contracts"]);
+
+    expect(mocks.runCommand).toHaveBeenCalledWith("git", [
+      "-C",
+      "/vercel/sandbox/repos/gitlab__acme__contracts",
+      "reset",
+      "--hard",
+      "read-base",
+    ]);
+  });
+
+  it("fails closed when a read-only repository has no trusted baseline", async () => {
+    await expect(
+      restoreReadOnlyFixRepositories("sbx-1", {
+        version: 2,
+        repositories: [
+          {
+            provider: "gitlab",
+            repoPath: "acme/contracts",
+            slug: "gitlab__acme__contracts",
+            localPath: "/vercel/sandbox/repos/gitlab__acme__contracts",
+            defaultBranch: "main",
+            branchName: "main",
+            selectedRationale: "sibling PR",
+            access: "read",
+          },
+        ],
+      }),
+    ).rejects.toThrow(/missing its research baseline/i);
   });
 });

--- a/apps/worker/src/workflows/blocks/fix-workspace-state.ts
+++ b/apps/worker/src/workflows/blocks/fix-workspace-state.ts
@@ -1,7 +1,9 @@
 import { getSandboxCredentials } from "../../sandbox/credentials.js";
 import type { JsonValue } from "@shared/contracts";
 import {
+  isValidWorkspaceLocalPath,
   parseWorkspaceManifest,
+  type WorkspaceManifestV2,
   WORKSPACE_MANIFEST_PATH,
 } from "../../sandbox/repo-workspace.js";
 
@@ -69,6 +71,66 @@ export async function inspectFixWorkspace(sandboxId: string): Promise<FixWorkspa
   }
 
   return { commits, unresolvedConflicts };
+}
+
+/** Discard forbidden tracked edits in context-only repositories before any
+ * fix result can be inspected or published. The trusted manifest comes from
+ * the workflow context, not the agent-writable sandbox copy. */
+export async function restoreReadOnlyFixRepositories(
+  sandboxId: string,
+  trustedManifest: WorkspaceManifestV2,
+): Promise<string[]> {
+  "use step";
+  const { Sandbox } = await import("@vercel/sandbox");
+  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+  const restored: string[] = [];
+
+  for (const repo of trustedManifest.repositories) {
+    if (repo.access !== "read") continue;
+    const identity = `${repo.provider}:${repo.repoPath}`;
+    if (!isValidWorkspaceLocalPath(repo)) {
+      throw new Error(`Read-only repository path is invalid for ${identity}`);
+    }
+    if (!repo.researchBaseSha) {
+      throw new Error(`Read-only repository ${identity} is missing its research baseline`);
+    }
+    const reset = await sandbox.runCommand("git", [
+      "-C",
+      repo.localPath,
+      "reset",
+      "--hard",
+      repo.researchBaseSha,
+    ]);
+    if (reset.exitCode !== 0) {
+      throw new Error(`Could not restore read-only repository ${identity}`);
+    }
+    const head = await sandbox.runCommand("git", [
+      "-C",
+      repo.localPath,
+      "rev-parse",
+      "HEAD",
+    ]);
+    const status = await sandbox.runCommand("git", [
+      "-C",
+      repo.localPath,
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=no",
+    ]);
+    const restoredHead = head.exitCode === 0 ? (await head.stdout()).trim() : "";
+    const trackedChanges = status.exitCode === 0 ? (await status.stdout()).trim() : "";
+    if (
+      head.exitCode !== 0 ||
+      status.exitCode !== 0 ||
+      restoredHead !== repo.researchBaseSha ||
+      trackedChanges.length > 0
+    ) {
+      throw new Error(`Could not verify restored read-only repository ${identity}`);
+    }
+    restored.push(identity);
+  }
+
+  return restored;
 }
 
 export function resolvedFixConflicts(

--- a/apps/worker/src/workflows/blocks/poll-phase.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.ts
@@ -31,19 +31,19 @@ export async function pollPhaseUntilDone(
   let phaseElapsedMs = 0;
   while (phaseElapsedMs < phaseLimitMs) {
     if (cancellation?.cancelled) {
-      await killPhaseCommand(sandboxId, commandId);
+      await stopPhaseCommand(sandboxId, commandId);
       throw new V2InvocationCancelledError(cancellation.reason);
     }
     const before = await observeBudget(true);
     if (before.check.status !== "ok") {
-      await killPhaseCommand(sandboxId, commandId);
+      await stopPhaseCommand(sandboxId, commandId);
       throw new RunBudgetError(before.check);
     }
     const sleepMs = Math.min(30_000, phaseLimitMs - phaseElapsedMs, before.remainingDurationMs);
     if (sleepMs <= 0) {
       const limit = before.durationLimitMs ?? before.activeElapsedMs ?? 0;
       const consumed = before.activeElapsedMs ?? limit;
-      await killPhaseCommand(sandboxId, commandId);
+      await stopPhaseCommand(sandboxId, commandId);
       throw new RunBudgetError({
         status: "budget_exceeded",
         metric: "duration",
@@ -64,7 +64,7 @@ export async function pollPhaseUntilDone(
         cancellation.wait().then(() => true),
       ]);
       if (cancelled) {
-        await killPhaseCommand(sandboxId, commandId);
+        await stopPhaseCommand(sandboxId, commandId);
         throw new V2InvocationCancelledError(cancellation.reason);
       }
     } else {
@@ -73,21 +73,21 @@ export async function pollPhaseUntilDone(
     phaseElapsedMs += sleepMs;
 
     if (cancellation?.cancelled) {
-      await killPhaseCommand(sandboxId, commandId);
+      await stopPhaseCommand(sandboxId, commandId);
       throw new V2InvocationCancelledError(cancellation.reason);
     }
     const after = await observeBudget(false);
     const status = await checkPhaseDone(sandboxId, sentinelFile);
     if (status === true) return true;
     if (after.check.status !== "ok") {
-      await killPhaseCommand(sandboxId, commandId);
+      await stopPhaseCommand(sandboxId, commandId);
       throw new RunBudgetError(after.check);
     }
     if (status === "stopped") return false;
     if (after.remainingDurationMs === 0) {
       const limit = after.durationLimitMs ?? after.activeElapsedMs ?? 0;
       const consumed = after.activeElapsedMs ?? limit;
-      await killPhaseCommand(sandboxId, commandId);
+      await stopPhaseCommand(sandboxId, commandId);
       throw new RunBudgetError({
         status: "budget_exceeded",
         metric: "duration",
@@ -97,11 +97,14 @@ export async function pollPhaseUntilDone(
       });
     }
   }
-  await killPhaseCommand(sandboxId, commandId);
+  await stopPhaseCommand(sandboxId, commandId);
   return false;
 }
 
-async function killPhaseCommand(sandboxId: string, commandId: string): Promise<void> {
+export async function stopPhaseCommand(
+  sandboxId: string,
+  commandId: string,
+): Promise<void> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
   const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
@@ -114,4 +117,4 @@ async function killPhaseCommand(sandboxId: string, commandId: string): Promise<v
     // responsible for the sandbox itself; budget handling must stay deterministic.
   }
 }
-killPhaseCommand.maxRetries = 0;
+stopPhaseCommand.maxRetries = 0;


### PR DESCRIPTION
## Summary
- keep read-only sibling findings visible in review but exclude them from autofix decisions
- pass only writable-repository findings to the fix agent and label repository access in its context
- restore read-only repositories to their trusted baseline before inspection or publication

## Verification
- `pnpm typecheck` (worker)
- focused regression suite: 89 passed
- full worker suite: 304 files, 4736 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for distinguishing writable and read-only repositories during review and autofix workflows.
  * Read-only repositories are restored to their trusted baseline after fix operations.
  * Review findings from read-only repositories remain visible as context without blocking publication or triggering fixes.

* **Bug Fixes**
  * Prevented agents from modifying repositories marked read-only.
  * Added validation to detect missing trusted baselines and unsuccessful repository restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->