### PR TITLE
fix(worker): publish autofix review on fixed head

### DIFF
--- a/apps/worker/src/workflows/blocks/post-pr-review.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-review.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkflowDefinitionNode } from "@shared/contracts";
 
 const mocks = vi.hoisted(() => ({
   findWorkflowOwnedPullRequestIdentity: vi.fn(),
@@ -16,7 +17,7 @@ vi.mock("../pr-external-resources.js", async (importOriginal) => ({
     mocks.publishRunOwnedPrReview(...args),
 }));
 import type { WorkflowOwnedBranchRecord } from "../../db/queries/workflow-owned-branches.js";
-import { makeCtx, makeNode, makePrPayload } from "./test-support.js";
+import { makeCtx, makePrPayload } from "./test-support.js";
 import { execute, reviewPrAtWorkflowPublishedHead } from "./post-pr-review.js";
 
 const owned: WorkflowOwnedBranchRecord = {
@@ -86,20 +87,30 @@ describe("post_pr_review execute", () => {
 
   it("publishes the final review against the head pushed by its fix loop", async () => {
     const result = await execute(
-      makeNode("post_pr_review", {}, "post-review-approved"),
+      {
+        id: "post-review-approved",
+        type: "post_pr_review",
+        x: 0,
+        y: 0,
+        params: {},
+        inputs: {},
+      } as unknown as WorkflowDefinitionNode,
       {},
       makeCtx({
         runId: "run-autofix",
         entry: {
           kind: "pr_trigger",
+          triggerType: "trigger_pr_updated",
           subjectKey: "ticket:jira:AWP-26",
           ticketKey: "AWP-26",
           ownerToken: "owner:autofix",
+          definitionId: 23,
+          definitionVersion: 1,
+          scope: "workflow_owned",
           pr,
         },
       }),
       { reviewResults: [{ decision: "approve", findings: [] }] },
-      { attempt: 1, activationScopeId: "retry:1", observations: [] },
     );
 
     expect(result.kind).toBe("next");

--- a/apps/worker/src/workflows/blocks/post-pr-review.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-review.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findWorkflowOwnedPullRequestIdentity: vi.fn(),
+  publishRunOwnedPrReview: vi.fn(),
+}));
+
+vi.mock("../../db/client.js", () => ({ getDb: () => ({ kind: "db" }) }));
+vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
+  findWorkflowOwnedPullRequestIdentity: (...args: unknown[]) =>
+    mocks.findWorkflowOwnedPullRequestIdentity(...args),
+}));
+vi.mock("../pr-external-resources.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../pr-external-resources.js")>()),
+  publishRunOwnedPrReview: (...args: unknown[]) =>
+    mocks.publishRunOwnedPrReview(...args),
+}));
+import type { WorkflowOwnedBranchRecord } from "../../db/queries/workflow-owned-branches.js";
+import { makeCtx, makeNode, makePrPayload } from "./test-support.js";
+import { execute, reviewPrAtWorkflowPublishedHead } from "./post-pr-review.js";
+
+const owned: WorkflowOwnedBranchRecord = {
+  ticketKey: "AWP-26",
+  provider: "github",
+  repoPath: "acme/app",
+  branchName: "ai-workflow/awp-26",
+  publishedHeadSha: "fixed-head",
+  targetBranch: "main",
+  pr: {
+    id: 318,
+    url: "https://github.com/acme/app/pull/318",
+    branch: "ai-workflow/awp-26",
+  },
+};
+
+const pr = makePrPayload({
+  repoPath: "acme/app",
+  prNumber: 318,
+  prUrl: "https://github.com/acme/app/pull/318",
+  headRef: "ai-workflow/awp-26",
+  headSha: "trigger-head",
+  baseRef: "main",
+});
+
+describe("reviewPrAtWorkflowPublishedHead", () => {
+  it("reviews the exact head published by the active ticket workflow", () => {
+    expect(
+      reviewPrAtWorkflowPublishedHead({
+        subjectKey: "ticket:jira:AWP-26",
+        pr,
+        owned,
+      }).headSha,
+    ).toBe("fixed-head");
+  });
+
+  it.each([
+    ["another ticket owns the run", { subjectKey: "ticket:jira:AWP-27" }],
+    ["the repository differs", { owned: { ...owned, repoPath: "acme/api" } }],
+    ["the pull request differs", { owned: { ...owned, pr: { ...owned.pr!, id: 319 } } }],
+    ["the branch differs", { owned: { ...owned, branchName: "other" } }],
+    ["the target differs", { owned: { ...owned, targetBranch: "release" } }],
+    ["there is no published head", { owned: { ...owned, publishedHeadSha: undefined } }],
+  ])("keeps the trigger head when %s", (_name, overrides) => {
+    expect(
+      reviewPrAtWorkflowPublishedHead({
+        subjectKey: "ticket:jira:AWP-26",
+        pr,
+        owned,
+        ...overrides,
+      }).headSha,
+    ).toBe("trigger-head");
+  });
+});
+
+describe("post_pr_review execute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValue(owned);
+    mocks.publishRunOwnedPrReview.mockResolvedValue({
+      decision: "approve",
+      summary: "Approved",
+      inlineCommentCount: 0,
+      summaryFallbackCount: 0,
+    });
+  });
+
+  it("publishes the final review against the head pushed by its fix loop", async () => {
+    const result = await execute(
+      makeNode("post_pr_review", {}, "post-review-approved"),
+      {},
+      makeCtx({
+        runId: "run-autofix",
+        entry: {
+          kind: "pr_trigger",
+          subjectKey: "ticket:jira:AWP-26",
+          ticketKey: "AWP-26",
+          ownerToken: "owner:autofix",
+          pr,
+        },
+      }),
+      { reviewResults: [{ decision: "approve", findings: [] }] },
+      { attempt: 1, activationScopeId: "retry:1", observations: [] },
+    );
+
+    expect(result.kind).toBe("next");
+    expect(mocks.publishRunOwnedPrReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ headSha: "fixed-head" }),
+      }),
+    );
+  });
+});

--- a/apps/worker/src/workflows/blocks/post-pr-review.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-review.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { WorkflowDefinitionNode } from "@shared/contracts";
 
 const mocks = vi.hoisted(() => ({
   findWorkflowOwnedPullRequestIdentity: vi.fn(),
@@ -17,8 +16,11 @@ vi.mock("../pr-external-resources.js", async (importOriginal) => ({
     mocks.publishRunOwnedPrReview(...args),
 }));
 import type { WorkflowOwnedBranchRecord } from "../../db/queries/workflow-owned-branches.js";
-import { makeCtx, makePrPayload } from "./test-support.js";
-import { execute, reviewPrAtWorkflowPublishedHead } from "./post-pr-review.js";
+import { makePrPayload } from "./test-support.js";
+import {
+  postPrReviewStep,
+  reviewPrAtWorkflowPublishedHead,
+} from "./post-pr-review.js";
 
 const owned: WorkflowOwnedBranchRecord = {
   ticketKey: "AWP-26",
@@ -73,7 +75,7 @@ describe("reviewPrAtWorkflowPublishedHead", () => {
   });
 });
 
-describe("post_pr_review execute", () => {
+describe("postPrReviewStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValue(owned);
@@ -86,34 +88,20 @@ describe("post_pr_review execute", () => {
   });
 
   it("publishes the final review against the head pushed by its fix loop", async () => {
-    const result = await execute(
-      {
-        id: "post-review-approved",
-        type: "post_pr_review",
-        x: 0,
-        y: 0,
-        params: {},
-        inputs: {},
-      } as unknown as WorkflowDefinitionNode,
-      {},
-      makeCtx({
+    const result = await postPrReviewStep({
+      owner: {
+        subjectKey: "ticket:jira:AWP-26",
+        ownerToken: "owner:autofix",
         runId: "run-autofix",
-        entry: {
-          kind: "pr_trigger",
-          triggerType: "trigger_pr_updated",
-          subjectKey: "ticket:jira:AWP-26",
-          ticketKey: "AWP-26",
-          ownerToken: "owner:autofix",
-          definitionId: 23,
-          definitionVersion: 1,
-          scope: "workflow_owned",
-          pr,
-        },
-      }),
-      { reviewResults: [{ decision: "approve", findings: [] }] },
-    );
+      },
+      pr,
+      nodeId: "post-review-approved",
+      attempt: 1,
+      activationScope: "retry:1",
+      reviewResults: [{ decision: "approve", findings: [] }],
+    });
 
-    expect(result.kind).toBe("next");
+    expect(result.decision).toBe("approve");
     expect(mocks.publishRunOwnedPrReview).toHaveBeenCalledWith(
       expect.objectContaining({
         target: expect.objectContaining({ headSha: "fixed-head" }),

--- a/apps/worker/src/workflows/blocks/post-pr-review.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-review.ts
@@ -34,7 +34,7 @@ export function reviewPrAtWorkflowPublishedHead(args: {
   return { ...pr, headSha: owned.publishedHeadSha };
 }
 
-async function postPrReviewStep(
+export async function postPrReviewStep(
   args: {
     owner: { subjectKey: string; ownerToken: string; runId: string };
     pr: PrTriggerPayload;

--- a/apps/worker/src/workflows/blocks/post-pr-review.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-review.ts
@@ -4,11 +4,35 @@ import {
 } from "../review-results.js";
 import type { PrTriggerPayload } from "../agent-input.js";
 import type { ReviewResult } from "@shared/contracts";
+import type { WorkflowOwnedBranchRecord } from "../../db/queries/workflow-owned-branches.js";
+import { ticketSubjectKey } from "../../lib/subject-key.js";
 import {
   executionError,
   type BlockExecuteFn,
   type BlockExecutionResult,
 } from "./types.js";
+
+export function reviewPrAtWorkflowPublishedHead(args: {
+  subjectKey: string;
+  pr: PrTriggerPayload;
+  owned: WorkflowOwnedBranchRecord | null;
+}): PrTriggerPayload {
+  const { owned, pr } = args;
+  if (
+    !owned?.publishedHeadSha ||
+    !owned.pr ||
+    args.subjectKey !== ticketSubjectKey("jira", owned.ticketKey) ||
+    owned.provider !== pr.provider ||
+    owned.repoPath !== pr.repoPath ||
+    owned.pr.id !== pr.prNumber ||
+    owned.branchName !== pr.headRef ||
+    owned.pr.branch !== pr.headRef ||
+    owned.targetBranch !== pr.baseRef
+  ) {
+    return pr;
+  }
+  return { ...pr, headSha: owned.publishedHeadSha };
+}
 
 async function postPrReviewStep(
   args: {
@@ -22,14 +46,28 @@ async function postPrReviewStep(
 ) {
   "use step";
   const { getDb } = await import("../../db/client.js");
+  const { findWorkflowOwnedPullRequestIdentity } = await import(
+    "../../db/queries/workflow-owned-branches.js"
+  );
   const {
     prRunTarget,
     publishRunOwnedPrReview,
   } = await import("../pr-external-resources.js");
+  const db = getDb();
+  const owned = await findWorkflowOwnedPullRequestIdentity(db, {
+    provider: args.pr.provider,
+    repoPath: args.pr.repoPath,
+    prNumber: args.pr.prNumber,
+  });
+  const pr = reviewPrAtWorkflowPublishedHead({
+    subjectKey: args.owner.subjectKey,
+    pr: args.pr,
+    owned,
+  });
   return publishRunOwnedPrReview({
-    db: getDb(),
+    db,
     owner: args.owner,
-    target: prRunTarget(args.owner.subjectKey, args.pr),
+    target: prRunTarget(args.owner.subjectKey, pr),
     nodeId: args.nodeId,
     attempt: args.attempt,
     activationScope: args.activationScope,


### PR DESCRIPTION
## Summary
- rebind final post-PR review to the exact head published by the active ticket workflow
- keep fail-closed behavior unless ticket, provider, repo, PR, branch, and target all match
- cover the production autofix regression and mismatch guardrails

## Production evidence
Dogfood run `wrun_01KZPADBZQF6F0FEAHS5SQVR1W` pushed fix commit `5e1d2659d4bb9f81c1623da714f0cb0f0df4d8e2`, then failed final review publication because it still expected trigger head `49d45cb20ac7e398c62f3f00d949ed7220115f21`. GitLab sibling MR7 remained unchanged and read-only.

## Verification
- `pnpm --filter worker typecheck`
- focused regression suites: 80 tests passed
- full worker suite: 310 files, 4824 tests passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request reviews now target the exact workflow-published commit when ownership and branch details match.
  * Reviews safely retain the original trigger commit when metadata is missing or inconsistent.
  * Review publication now uses the final commit produced by the workflow’s fix process.

* **Tests**
  * Added coverage for matching, mismatched, and incomplete workflow metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->