### PR TITLE
fix: report a torn-down run as cancelled instead of unconfirmed (AIW-247)

### DIFF
--- a/apps/worker/src/lib/cancel-run.test.ts
+++ b/apps/worker/src/lib/cancel-run.test.ts
@@ -150,7 +150,12 @@ describe("cancelRun", () => {
       "PROJ-1",
       { ownerToken: "owner-a", runId: "run-1" },
       runRegistry,
-    )).resolves.toEqual({ cancelled: true, released: true, alreadyTerminal: true });
+    )).resolves.toEqual({
+      cancelled: true,
+      released: true,
+      alreadyTerminal: true,
+      tornDown: true,
+    });
     expect(runRegistry.releaseCancellation).toHaveBeenCalledWith(
       "ticket:jira:PROJ-1",
       "owner-a",
@@ -346,6 +351,59 @@ describe("cancelRunById", () => {
     expect(runRegistry.releaseCancellation).toHaveBeenCalled();
   });
 
+  // Observed on prod: the Workflow run was cancelled mid-step, so the step drain
+  // never confirms. The run is dead, so "try again" is a lie and the schedule
+  // ledger (settled by the route on outcome "cancelled") would never flip.
+  it("reports cancelled when the run is torn down but the step drain cannot be confirmed", async () => {
+    state.listSteps.mockResolvedValue({
+      data: [{ status: "running" }],
+      cursor: null,
+      hasMore: false,
+    });
+    state.findLiveClaim.mockResolvedValue({
+      subjectKey: "sched:demo:hourly",
+      ownerToken: "owner-a",
+    });
+    const runRegistry = registry(scheduleClaim());
+
+    await expect(
+      cancelRunById(outerDb, "run-1", {
+        actorLabel: "operator kate",
+        runRegistry,
+      }),
+    ).resolves.toEqual({ outcome: "cancelled", subjectKey: "sched:demo:hourly" });
+
+    expect(state.markBlockedByOperator).toHaveBeenCalledWith(
+      outerDb,
+      "run-1",
+      "cancelled by operator kate",
+    );
+    // This path deliberately leaves the claim in "cancelling" for reconcileRuns
+    // to converge on the poll cron (retryCancellingClaim); nothing here
+    // force-releases it.
+    expect(runRegistry.releaseCancellation).not.toHaveBeenCalled();
+  });
+
+  // Same shape one step earlier: the sandbox cleanup throws after the Workflow
+  // run is already gone. The teardown is still irreversible.
+  it("reports cancelled when sandbox cleanup fails after the run is torn down", async () => {
+    state.stopSandboxes.mockRejectedValue(new Error("sandbox api down"));
+    state.findLiveClaim.mockResolvedValue({
+      subjectKey: "sched:demo:hourly",
+      ownerToken: "owner-a",
+    });
+    const runRegistry = registry(scheduleClaim());
+
+    await expect(
+      cancelRunById(outerDb, "run-1", {
+        actorLabel: "operator kate",
+        runRegistry,
+      }),
+    ).resolves.toEqual({ outcome: "cancelled", subjectKey: "sched:demo:hourly" });
+
+    expect(state.markBlockedByOperator).toHaveBeenCalled();
+  });
+
   it("reports already_terminal without writing status when the run had already finished", async () => {
     state.getRun.mockReturnValue({
       cancel: vi.fn().mockRejectedValue(new Error("run already terminal")),
@@ -389,6 +447,27 @@ describe("cancelRunById", () => {
     await expect(
       cancelRunById(outerDb, "run-1", {
         actorLabel: "operator",
+        runRegistry,
+      }),
+    ).resolves.toEqual({ outcome: "unconfirmed", subjectKey: "sched:demo:hourly" });
+
+    expect(state.markBlockedByOperator).not.toHaveBeenCalled();
+    expect(runRegistry.releaseCancellation).not.toHaveBeenCalled();
+  });
+
+  // The other side of the discriminator: cancellation never began, so Workflow
+  // was never touched and the claim is untouched. Retrying is the correct advice.
+  it("reports unconfirmed and writes no status when the cancellation never began", async () => {
+    state.findLiveClaim.mockResolvedValue({
+      subjectKey: "sched:demo:hourly",
+      ownerToken: "owner-a",
+    });
+    const runRegistry = registry(scheduleClaim());
+    (runRegistry.beginCancellation as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    await expect(
+      cancelRunById(outerDb, "run-1", {
+        actorLabel: "operator kate",
         runRegistry,
       }),
     ).resolves.toEqual({ outcome: "unconfirmed", subjectKey: "sched:demo:hourly" });

--- a/apps/worker/src/lib/cancel-run.ts
+++ b/apps/worker/src/lib/cancel-run.ts
@@ -32,11 +32,27 @@ export type CancelRunTarget = string | ObservedRunClaim;
  * Slack "canceled" messages) must treat the two differently, since the
  * already-terminal case is a release of bookkeeping for a run that failed or
  * completed on its own, not a fresh cancellation.
+ *
+ * `tornDown` reports the narrower fact that the Workflow run will not advance
+ * any further: `cancel()` resolved, or the status re-read confirmed it was
+ * already terminal. It does NOT mean the run is quiet yet: a step handler that
+ * was already executing keeps running to its end (that is what the step drain
+ * waits for), so a side effect can still land after this is true.
+ * It stays true on the returns that follow, where `cancelled`
+ * is false because a post-teardown bookkeeping step (sandbox cleanup, step
+ * drain, continuation retirement, ticket move, claim release) could not be
+ * confirmed this attempt. The two must be reported differently: `cancelled`
+ * false alone reads as "nothing happened, retry", but a retry cannot un-cancel a
+ * dead run, so telling an operator to try again is a lie, and any caller that
+ * only settles ledgers on a confirmed cancel would silently skip them. Only
+ * meaningful for a claim that carried a run id: a claim with a null runId never
+ * touched Workflow and never sets it.
  */
 export interface CancelRunResult {
   cancelled: boolean;
   released: boolean;
   alreadyTerminal?: boolean;
+  tornDown?: boolean;
 }
 
 /**
@@ -143,15 +159,18 @@ export async function cancelSubjectRunDetailed(
 /**
  * Outcome of an operator cancel-by-id. Distinguishes the four states it can
  * reach so a route (or Slack surface) reports each honestly:
- *   - "cancelled": a live run was found and cancelled, its status settled as
- *     "blocked" with the operator reason, and its subject released so a
- *     schedule/webhook blocked behind it resumes.
+ *   - "cancelled": a live run was found and torn down, and its status settled as
+ *     "blocked" with the operator reason. Usually its subject is released too so
+ *     a schedule/webhook blocked behind it resumes; when only the teardown could
+ *     be confirmed, the dying run's own finally releases the claim instead.
  *   - "already_terminal": the run had already reached a terminal outcome, either
  *     Workflow reported it terminal while the claim still lingered, or the run
  *     had already left active_runs. No status is written; `status` carries the
  *     recorded outcome when known.
- *   - "unconfirmed": a live run was found but cancellation could not be confirmed
- *     this attempt, so the claim is retained for a safe retry.
+ *   - "unconfirmed": a live run was found but cancellation never began, so the
+ *     Workflow run was never touched and the claim is retained. This is the only
+ *     state where a retry is the right advice: once the run is torn down it
+ *     cannot be un-cancelled, and that case reports "cancelled" instead.
  *   - "not_found": neither a live claim nor a workflow_runs row carries the id.
  * `subjectKey` is set whenever a live claim was located.
  */
@@ -216,12 +235,33 @@ export async function cancelRunById(
         status: outcome?.status ?? undefined,
       };
     }
-    if (result.cancelled) {
-      // Runs after cancelSubjectRunDetailed has drained every step, so no body
-      // write can land after this blocked settle. Only-advance guarded inside.
-      // Best-effort like persistCancelReason/settleCancelledPark: the run is
-      // already cancelled and its claim released, so a failed settle must never
-      // turn a confirmed cancel into a thrown 500. The cron backstops the row.
+    if (result.cancelled || result.tornDown) {
+      // tornDown without cancelled is a run whose teardown landed but whose
+      // post-cancel bookkeeping stayed unconfirmed. It reports identically:
+      // "unconfirmed" would tell the operator to retry an irreversible action
+      // and, worse, skip every ledger the caller settles on "cancelled" (the
+      // schedule occurrence would stay "started"), which is the production bug
+      // this branch exists to fix.
+      //
+      // The status write itself is safe ahead of the drain: no writer can put
+      // "running" back over "blocked" (markRunResumed, the only writer of
+      // "running", is guarded on "awaiting"), so a cancelled run cannot read as
+      // in flight. Best-effort like persistCancelReason, because the teardown
+      // already landed and a failed settle must never turn it into a 500.
+      //
+      // Known trade, deliberately taken: cancelling during the run's own
+      // finalization step means recordRunUsage (the one unguarded status
+      // writer) can still overwrite this settle with the run's real outcome,
+      // and the cron will NOT undo that because upsertRunSnapshots freezes on a
+      // terminal status. The row then reads success while the caller already
+      // stamped the occurrence "run_cancelled". That mislabel is audit-only
+      // (nothing dispatches off the occurrence outcome) and it is the price of
+      // not leaving every mid-step cancel unsettled, which is strictly worse.
+      //
+      // The claim is released here only on the confirmed path. A tornDown-only
+      // cancel leaves the claim in "cancelling"; reconcileRuns picks that state
+      // up on the one-minute poll cron and converges it through
+      // retryCancellingClaim, which is what actually releases it.
       const { markRunBlockedByOperator } = await import(
         "./telemetry/run-telemetry.js"
       );
@@ -239,8 +279,8 @@ export async function cancelRunById(
       }
       return { outcome: "cancelled", subjectKey: claim.subjectKey };
     }
-    // A live run whose cancellation could not be confirmed this attempt: the
-    // claim is retained, so report unconfirmed and let the caller retry.
+    // A live run cancellation that never began: Workflow was never touched and
+    // the claim is retained, so report unconfirmed and let the caller retry.
     return { outcome: "unconfirmed", subjectKey: claim.subjectKey };
   }
 
@@ -343,6 +383,7 @@ async function cancelOwnedSubject(
   if (!closed) return { cancelled: false, released: false };
 
   let alreadyTerminal = false;
+  let tornDown = false;
   if (closed.runId) {
     const workflowRun = getRun(closed.runId);
     try {
@@ -376,6 +417,12 @@ async function cancelOwnedSubject(
         "cancel_run_already_terminal",
       );
     }
+    // From here the Workflow run will not advance, by cancellation or by its own
+    // terminal status. A step handler that was already executing still runs to
+    // its end, which is what the drain below waits for. Every return past this
+    // point carries the fact so a caller never mistakes unconfirmed bookkeeping
+    // for an untouched run.
+    tornDown = true;
     await persistCancelReason(subjectKey, closed.runId, reason);
   }
 
@@ -387,7 +434,7 @@ async function cancelOwnedSubject(
       { subjectKey, runId: closed.runId },
       "cancel_run_sandbox_lookup_unconfirmed",
     );
-    return { cancelled: false, released: false };
+    return { cancelled: false, released: false, tornDown };
   }
   try {
     await stopSandboxesByIds(sandboxIds);
@@ -396,18 +443,18 @@ async function cancelOwnedSubject(
       { subjectKey, runId: closed.runId, error: (err as Error).message },
       "cancel_run_sandbox_cleanup_unconfirmed",
     );
-    return { cancelled: false, released: false };
+    return { cancelled: false, released: false, tornDown };
   }
 
   if (closed.runId && !(await confirmWorkflowStepsDrained(subjectKey, closed.runId))) {
-    return { cancelled: false, released: false };
+    return { cancelled: false, released: false, tornDown };
   }
 
   if (
     closed.runId &&
     !(await retirePostDrainContinuations(subjectKey, closed, closed.runId))
   ) {
-    return { cancelled: false, released: false };
+    return { cancelled: false, released: false, tornDown };
   }
 
   if (closed.runId) {
@@ -416,7 +463,7 @@ async function cancelOwnedSubject(
 
   if (beforeRelease) {
     if (!(await confirmBeforeRelease(subjectKey, closed, beforeRelease))) {
-      return { cancelled: false, released: false };
+      return { cancelled: false, released: false, tornDown };
     }
   }
 
@@ -425,10 +472,10 @@ async function cancelOwnedSubject(
     .catch(() => false);
   if (!released) {
     const refreshed = await runRegistry.get(subjectKey).catch(() => undefined);
-    if (refreshed !== null) return { cancelled: false, released: false };
+    if (refreshed !== null) return { cancelled: false, released: false, tornDown };
   }
   await notifyReleased(subjectKey, onReleased);
-  return { cancelled: true, released: true, alreadyTerminal };
+  return { cancelled: true, released: true, alreadyTerminal, tornDown };
 }
 
 /**


### PR DESCRIPTION
## AIW-247: a successful cancel reported itself as unconfirmed

Found while dogfooding AIW-240 on production right after it shipped.

An operator cancels a live run from the dashboard. The run **is** actually torn down: the Workflow run stops mid-step and `workflow_runs` ends up `blocked` with `status_reason = "cancelled by <operator>"`. But the endpoint returned **409 unconfirmed** and the UI said "The cancel could not be confirmed. Try again." Reproduced 2 out of 2 attempts on live scheduled runs.

Prod evidence, run `wrun_01KZPAR3SDRNQAYQCQQWJ1RS1F` on the "AIW-223 schedule smoke" schedule:

- trace: `BLOCKED`, reason "cancelled by <operator>", `Prepare workspace COMPLETED 66s`, `Record occurrence IN PROGRESS`, `Open smoke PR NOT REACHED` (so the cancel did its job and stopped the run before it opened a PR)
- the very same cancel returned 409 unconfirmed
- the occurrence ledger stayed `started` instead of flipping to `run_cancelled`

The second consequence is the serious one: `cancel.post.ts` settles the schedule occurrence only on `outcome === "cancelled"`, so the human-cancel-in-flight distinction AIW-240 added never materialized on this path.

### Root cause

`cancelOwnedSubject` returns `{cancelled: false}` from six places that all run **after** the run is already destroyed (`beginCancellation` succeeded, `cancel()` resolved, `persistCancelReason` wrote the reason): sandbox lookup, sandbox stop, step drain, continuation retirement, before-release hook, release. The prime suspect in prod is the step drain, because the cancelled run had an agent step that had been running for 66 seconds.

So the boolean conflated two different states: "nothing happened, the claim is retained, retrying is correct" and "the run is already dead, only the bookkeeping is unconfirmed". A retry cannot un-cancel a dead run.

### Fix

`CancelRunResult` gains `tornDown`, set once the Workflow run will not advance (`cancel()` resolved, or the status re-read confirmed it terminal) and carried on every later return where `cancelled` is false only because bookkeeping went unconfirmed. `cancelRunById` maps `cancelled || tornDown` to outcome `cancelled`, which restores both the blocked status write and the occurrence settle. `unconfirmed` now means strictly "cancellation never began; the claim is retained; retry".

`cancelled` semantics are deliberately unchanged for every existing caller (`reconcile.ts`, `cancelTrackedRun` in the Jira webhook, and the `cancelRun`/`cancelSubjectRun` boolean wrappers) — the only behavior change in the diff is inside `cancelRunById`.

### Why writing the status before the drain is safe

An adversarial review checked every `workflow_runs.status` writer: none can put `running` back over `blocked` (`markRunResumed`, the only writer of `running`, is guarded on `awaiting`). So a cancelled run cannot read as in flight. In the common case the row now reaches `blocked` immediately instead of waiting for a cron tick.

### Known trade, documented in the code

If the cancel lands while the run is inside its own finalization step, `recordRunUsage` (the one unguarded status writer) can still overwrite the settle with the run's real outcome, and the cron will not undo that because snapshots freeze on a terminal status. The row then reads `success` while the occurrence is stamped `run_cancelled`. That mislabel is audit-only (nothing dispatches off the occurrence outcome) and is the price of not leaving every mid-step cancel unsettled, which is strictly worse. Closing it properly means settling the occurrence from the reconciler's converged retry, which is new plumbing and a separate ticket.

### Verification

TDD, red first: two new tests reproduce the prod shape (teardown succeeded, drain or sandbox cleanup unconfirmed) and failed with `expected 'unconfirmed' to be 'cancelled'` before the fix. Regression tests pin that a cancellation which never began still reports `unconfirmed` and writes no status, and that `already_terminal` still wins and still writes nothing.

`vitest run src/lib/cancel-run.test.ts src/lib/telemetry/run-telemetry.test.ts src/routes/api/v1/runs/cancel.test.ts` → 98 passed. `pnpm typecheck` → exit 0. Full suite runs in CI here.
