### PR TITLE
fix(worker): do not read file modes a deployment bundle does not carry (AIW-246)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -568,7 +568,7 @@ A copyable example lives in [`docs/example-skill/SKILL.md`](./docs/example-skill
 | Rule | Limit |
 | --- | --- |
 | Nesting | exactly one level; a `SKILL.md` one level deeper is reported, not found |
-| `SKILL.md` | a regular file, not a symlink, and not executable |
+| `SKILL.md` | a regular file, not a symlink |
 | `name` | lowercase letters, digits and hyphens, 1 to 64 characters, starting and ending alphanumeric, unique across the directory |
 | `description` | 1 to 1024 characters, no leading or trailing whitespace |
 | Files per skill | 500 |
@@ -576,7 +576,7 @@ A copyable example lives in [`docs/example-skill/SKILL.md`](./docs/example-skill
 | Bytes per skill | 5 MiB |
 | Bytes across `skills/` | 25 MiB, because the directory is copied into every function bundle |
 | Symlinks | rejected anywhere inside a skill |
-| File modes | only the executable bit survives, as in a Git checkout |
+| File modes | not carried: the function bundle does not preserve them, so every file is imported as a plain file and a deployment skill cannot ship an executable |
 
 **Using them.** In the dashboard, open a harness profile, go to Skills and choose **Add skills → This deployment**. An imported skill is stored as an immutable artifact and the profile pins it by content hash, so a later deployment changes nothing on its own: after a redeploy that edits a skill, use **Refresh** on that skill and publish the profile again. The dashboard says whether the refresh moved the pin or found the same contents.
 

--- a/apps/worker/src/harness-profiles/local-skills.test.ts
+++ b/apps/worker/src/harness-profiles/local-skills.test.ts
@@ -67,6 +67,9 @@ describe("deployment-local skills", () => {
       "SKILL.md": skillDocument(),
       "scripts/check.sh": "#!/bin/sh\necho review\n",
     });
+    // Executable on disk, and still reported as 0644: the deployment bundle
+    // does not preserve the repository's mode, so reading it would make the
+    // artifact's identity depend on whoever repacked the function.
     chmodSync(join(directory, "scripts/check.sh"), 0o755);
 
     const { skills, skipped, directoryPresent } = await readLocalSkills(root);
@@ -83,7 +86,7 @@ describe("deployment-local skills", () => {
         contentSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       },
       files: [
-        { path: "scripts/check.sh", mode: 0o755 },
+        { path: "scripts/check.sh", mode: 0o644 },
         { path: "SKILL.md", mode: 0o644 },
       ],
     });
@@ -91,6 +94,26 @@ describe("deployment-local skills", () => {
       Buffer.from(skill!.files[1]!.contentBase64, "base64").toString("utf8"),
     ).toBe(skillDocument());
     expect(hashHarnessSkillArtifact(skill!)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("offers a skill whose files all arrived executable, as a bundle delivers them", async () => {
+    // The condition this pins was found on production, not in a test: git stores
+    // SKILL.md as 0644 and the build-time check accepted it from the source
+    // tree, but every file inside the repacked function bundle arrives
+    // executable, so a mode check refused the only skill the deployment shipped.
+    const root = skillsRoot();
+    const directory = writeSkill(root, "review-rules", {
+      "SKILL.md": skillDocument(),
+      "reference.md": "Reference notes.\n",
+    });
+    chmodSync(join(directory, "SKILL.md"), 0o755);
+    chmodSync(join(directory, "reference.md"), 0o755);
+
+    const { skills, skipped } = await readLocalSkills(root);
+
+    expect(skipped).toEqual([]);
+    expect(skills.map((skill) => skill.name)).toEqual(["review-rules"]);
+    expect(skills[0]!.files.map((file) => file.mode)).toEqual([0o644, 0o644]);
   });
 
   it("separates a missing directory from a directory holding nothing usable", async () => {
@@ -263,17 +286,6 @@ describe("deployment-local skills", () => {
         return directory;
       },
       /not a regular file/,
-    ],
-    [
-      "an executable SKILL.md",
-      (root: string) => {
-        const directory = writeSkill(root, "broken", {
-          "SKILL.md": skillDocument("broken"),
-        });
-        chmodSync(join(directory, "SKILL.md"), 0o755);
-        return directory;
-      },
-      /must not be executable/,
     ],
   ])(
     "skips %s without costing the healthy skills beside it",

--- a/apps/worker/src/harness-profiles/local-skills.ts
+++ b/apps/worker/src/harness-profiles/local-skills.ts
@@ -242,14 +242,13 @@ async function readSkill(
       reason: `${SKILL_DOCUMENT} is not a regular file`,
     };
   }
-  // Artifact verification requires a mode 0644 SKILL.md, the same shape the
-  // GitHub importer demands of the blob it reads metadata from.
-  if ((document.mode & 0o111) !== 0) {
-    return {
-      skipped: true,
-      reason: `${SKILL_DOCUMENT} must not be executable`,
-    };
-  }
+  // No mode check here, deliberately. A GitHub blob carries its mode as data,
+  // so the importer can trust it; a file inside a deployed function bundle does
+  // not. The bundle is repacked on the way to the runtime and every file arrives
+  // executable, whatever the repository recorded, which rejected a skill that
+  // git stores as 0644 and that the build-time check had already accepted from
+  // the source tree. Mode is therefore not observable on this path (see
+  // `readSkillFiles`), so it cannot be a reason to refuse a skill either.
 
   const files = await readSkillFiles(root, path, budget);
   const metadata = parseSkillMetadata(
@@ -557,8 +556,14 @@ async function readSkillFiles(
       const content = await readFile(absolute);
       files.push({
         path: relativePath,
-        // Git tracks only the executable bit, so this round-trips a checkout.
-        mode: (stats.mode & 0o111) === 0 ? 0o644 : 0o755,
+        // Fixed, not read from disk. The deployment bundle does not carry the
+        // mode the repository recorded: everything arrives executable once the
+        // function has been repacked, so reading it here would make an artifact
+        // whose identity depends on the packer rather than on the skill, and
+        // would differ from the same bytes imported from GitHub for no reason a
+        // reader could see. The cost is that a deployment skill cannot ship an
+        // executable file; a skill that needs one belongs in a GitHub source.
+        mode: 0o644,
         sizeBytes: content.byteLength,
         sha256: createHash("sha256").update(content).digest("hex"),
         contentBase64: content.toString("base64"),


### PR DESCRIPTION
Found by dogfooding #231 on production, which is the only place it could have been found.

The deployment shipped exactly one skill, `skills/ai-workflow-review`, and the dashboard refused it:

> The skills/ directory is present, but none of its entries can be offered.
> Skipped 1 directory: `skills/ai-workflow-review` — SKILL.md must not be executable

Git stores that file as `100644`. It is `-rw-r--r--` in a checkout. The build-time gate read the source tree and passed, logging `Validated 1 deployment skill(s) at /vercel/path0/skills`. Yet at runtime the same file reports as executable, because the function bundle is repacked on its way to the runtime and does not carry the mode the repository recorded.

The reader was treating mode as data, the way the GitHub importer legitimately can: a blob carries its mode, so the importer can both trust it and refuse on it. A file inside a deployed bundle carries whatever the packer decided.

Two changes, both narrow:

- The reader no longer refuses a skill because `SKILL.md` looks executable. That check could only ever fire on a false signal.
- File modes are fixed at `0644` rather than read from disk. Reading them would make the artifact hash depend on the packer instead of on the skill, and would give the same bytes a different identity depending on whether they arrived from GitHub or from the bundle.

The cost is stated rather than hidden, in the code comment and in `SETUP.md`: a deployment skill cannot ship an executable file, and a skill that needs one belongs in a GitHub source.

A test pins the production condition directly, with every file in the skill chmodded executable before the read, so this cannot regress quietly. The case that asserted the old refusal is gone, because it asserted a behaviour that was wrong.

`vitest run src/harness-profiles/` 92/92, worker typecheck clean.
