### PR TITLE
fix: report dirty review source paths

### DIFF
--- a/apps/worker/src/sandbox/disposable-review-workspace.test.ts
+++ b/apps/worker/src/sandbox/disposable-review-workspace.test.ts
@@ -505,7 +505,9 @@ describe("disposable review workspace", () => {
         model: "gpt-5",
         arthurTaskId: null,
       }),
-    ).rejects.toThrow(/uncommitted changes/i);
+    ).rejects.toThrow(
+      "review source github:acme/api has uncommitted changes: M src/index.ts",
+    );
 
     expect(mocks.sandboxCreate).not.toHaveBeenCalled();
     expect(mocks.registerSandbox).not.toHaveBeenCalled();

--- a/apps/worker/src/sandbox/disposable-review-workspace.ts
+++ b/apps/worker/src/sandbox/disposable-review-workspace.ts
@@ -16,6 +16,18 @@ import { fingerprintWorkspaceState } from "../workflows/workspace-gate-fingerpri
 const PRIMARY_REPOSITORY_EXCLUDES_PATH = "/tmp/aiw-review-primary-git-excludes";
 const PRIMARY_REPOSITORY_EXCLUDES =
   "/aiw-repos.json\n/repos/\n/blazebot/memory/\n/.codex\n/.claude\n";
+const DIRTY_STATUS_ENTRY_LIMIT = 5;
+const DIRTY_STATUS_CHARACTER_LIMIT = 500;
+
+function summarizeDirtyStatus(statusText: string): string {
+  return statusText
+    .split(/\r?\n/u)
+    .slice(0, DIRTY_STATUS_ENTRY_LIMIT)
+    .map((line) => line.replace(/[\u0000-\u001f\u007f]/gu, " ").trim())
+    .filter(Boolean)
+    .join("; ")
+    .slice(0, DIRTY_STATUS_CHARACTER_LIMIT);
+}
 
 export interface DisposableReviewRepository {
   repoPath: string;
@@ -110,8 +122,9 @@ export async function provisionDisposableReviewWorkspaceStep(
       );
     }
     if (statusText) {
+      const statusSummary = summarizeDirtyStatus(statusText);
       throw new Error(
-        `review source ${repo.provider}:${repo.repoPath} has uncommitted changes`,
+        `review source ${repo.provider}:${repo.repoPath} has uncommitted changes: ${statusSummary}`,
       );
     }
 


### PR DESCRIPTION
## Summary
- include a bounded, sanitized git status summary when a disposable reviewer rejects a dirty source workspace
- keep the existing fail-closed behavior before any review sandbox is created

## Verification
- pnpm --filter worker test src/sandbox/disposable-review-workspace.test.ts
- pnpm --filter worker typecheck
- git diff --check