### PR TITLE
fix: review sibling pull request heads

### DIFF
--- a/apps/worker/src/sandbox/repo-workspace.test.ts
+++ b/apps/worker/src/sandbox/repo-workspace.test.ts
@@ -102,6 +102,32 @@ describe("repo workspace manifest", () => {
     });
   });
 
+  it("checks out a read-only review sibling at its pull request branch", () => {
+    const manifest = buildWorkspaceManifest({
+      branchName: "blazebot/aiw-45",
+      access: "read",
+      repositories: [
+        {
+          provider: "gitlab",
+          repoPath: "acme/api-contract",
+          defaultBranch: "main",
+          selectedRationale: "read-only sibling PR from the same workflow run",
+          reviewPullRequest: {
+            id: 13,
+            url: "https://gitlab.test/acme/api-contract/-/merge_requests/13",
+            branch: "feature/api-contract",
+            headSha: "current-sibling-sha",
+          },
+        },
+      ],
+    });
+
+    expect(manifest.repositories[0]).toMatchObject({
+      access: "read",
+      branchName: "feature/api-contract",
+    });
+  });
+
   it("rejects duplicate provider/repository selections before provisioning", () => {
     expect(() =>
       buildWorkspaceManifest({

--- a/apps/worker/src/sandbox/repo-workspace.ts
+++ b/apps/worker/src/sandbox/repo-workspace.ts
@@ -142,7 +142,9 @@ export function buildWorkspaceManifest(input: {
         defaultBranch: repo.defaultBranch,
         branchName:
           repo.workflowOwnedBranch?.branchName ??
-          (access === "read" ? repo.defaultBranch : input.branchName),
+          (access === "read"
+            ? (repo.reviewPullRequest?.branch ?? repo.defaultBranch)
+            : input.branchName),
         access,
         ...(repo.mergeBase ? { mergeBase: repo.mergeBase } : {}),
         selectedRationale: repo.selectedRationale,

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
@@ -284,6 +284,61 @@ describe("PR trigger multi-repo review selection", () => {
     expect(repositories[1]?.workflowOwnedBranch).toBeUndefined();
   });
 
+  it("falls back to the default branch for a closed sibling PR", async () => {
+    const pr = makePrPayload();
+    mocks.findRunPrSiblings.mockResolvedValue({
+      status: "siblings",
+      runId: "implementation-run",
+      current: {
+        provider: pr.provider,
+        repoPath: pr.repoPath,
+        id: pr.prNumber,
+        url: pr.prUrl,
+        headSha: pr.headSha,
+      },
+      siblings: [
+        {
+          provider: "gitlab",
+          repoPath: "acme/api-contract",
+          id: 13,
+          url: "https://gitlab.test/acme/api-contract/-/merge_requests/13",
+          headSha: "published-sha",
+        },
+      ],
+    });
+    mocks.listRepositories.mockResolvedValue([
+      {
+        provider: "gitlab",
+        repoPath: "acme/api-contract",
+        name: "api-contract",
+        owner: "acme",
+        defaultBranch: "main",
+        description: "",
+        webUrl: "https://gitlab.test/acme/api-contract",
+        topics: [],
+        archived: false,
+        private: true,
+      },
+    ]);
+    mocks.createRepositoryVCS.mockReturnValue({
+      getPRHead: vi.fn().mockResolvedValue({
+        state: "closed",
+        headRef: "feature/api-contract",
+        headSha: "closed-sibling-sha",
+      }),
+    });
+
+    const repositories = await blockPrTriggerRepositoriesWithSiblingsStep(
+      "review-run",
+      pr,
+    );
+
+    expect(repositories[1]?.reviewPullRequest).toMatchObject({
+      branch: "main",
+      headSha: "closed-sibling-sha",
+    });
+  });
+
   it("does not read a sibling repository outside the agent allowlist", async () => {
     process.env.AGENT_ALLOWED_REPOS = "acme/web";
     const pr = makePrPayload();

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
@@ -260,6 +260,10 @@ describe("PR trigger multi-repo review selection", () => {
         headRef: "feature/api-contract",
         headSha: "current-sibling-sha",
       }),
+      getBranchShaIfExists: vi.fn().mockImplementation(
+        async (branch: string) =>
+          branch === "feature/api-contract" ? "current-sibling-sha" : "default-branch-sha",
+      ),
     });
 
     const repositories = await blockPrTriggerRepositoriesWithSiblingsStep(
@@ -284,7 +288,13 @@ describe("PR trigger multi-repo review selection", () => {
     expect(repositories[1]?.workflowOwnedBranch).toBeUndefined();
   });
 
-  it("falls back to the default branch for a closed sibling PR", async () => {
+  it.each([
+    { label: "closed PR", state: "closed" as const, sourceBranchSha: "closed-sha" },
+    { label: "fork PR", state: "open" as const, sourceBranchSha: null },
+  ])("falls back to the pinned default branch for a $label", async ({
+    state,
+    sourceBranchSha,
+  }) => {
     const pr = makePrPayload();
     mocks.findRunPrSiblings.mockResolvedValue({
       status: "siblings",
@@ -320,12 +330,17 @@ describe("PR trigger multi-repo review selection", () => {
         private: true,
       },
     ]);
+    const getBranchShaIfExists = vi.fn().mockImplementation(
+      async (branch: string) =>
+        branch === "feature/api-contract" ? sourceBranchSha : "default-branch-sha",
+    );
     mocks.createRepositoryVCS.mockReturnValue({
       getPRHead: vi.fn().mockResolvedValue({
-        state: "closed",
+        state,
         headRef: "feature/api-contract",
         headSha: "closed-sibling-sha",
       }),
+      getBranchShaIfExists,
     });
 
     const repositories = await blockPrTriggerRepositoriesWithSiblingsStep(
@@ -335,7 +350,7 @@ describe("PR trigger multi-repo review selection", () => {
 
     expect(repositories[1]?.reviewPullRequest).toMatchObject({
       branch: "main",
-      headSha: "closed-sibling-sha",
+      headSha: "default-branch-sha",
     });
   });
 

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.ts
@@ -92,14 +92,21 @@ export async function blockPrTriggerRepositoriesWithSiblingsStep(
       continue;
     }
     try {
-      const head = await createRepositoryVCS({
+      const vcs = createRepositoryVCS({
         provider: sibling.provider,
         repoPath: sibling.repoPath,
         baseBranch: metadata.defaultBranch,
-      }).getPRHead(sibling.id);
-      const branch = head.state === "open" && head.headRef
-        ? head.headRef
-        : metadata.defaultBranch;
+      });
+      const head = await vcs.getPRHead(sibling.id);
+      const openBranchSha = head.state === "open" && head.headRef
+        ? await vcs.getBranchShaIfExists(head.headRef)
+        : null;
+      const branch = openBranchSha ? head.headRef! : metadata.defaultBranch;
+      const headSha = openBranchSha ??
+        await vcs.getBranchShaIfExists(metadata.defaultBranch);
+      if (!headSha) {
+        throw new Error(`Sibling repository ${sibling.repoPath} has no reviewable branch`);
+      }
       selectedSiblings.push({
         provider: sibling.provider,
         repoPath: sibling.repoPath,
@@ -109,7 +116,7 @@ export async function blockPrTriggerRepositoriesWithSiblingsStep(
           id: sibling.id,
           url: sibling.url,
           branch,
-          headSha: head.headSha,
+          headSha,
         },
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
- check out read-only sibling repositories at the detected pull request branch
- retain the existing default-branch fallback supplied for closed or unavailable PR heads
- keep sibling repositories read-only

## Verification
- pnpm --filter worker test src/sandbox/repo-workspace.test.ts src/workflows/blocks/fetch-pr-context.test.ts src/sandbox/context.test.ts
- pnpm --filter worker typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only repositories now use the review branch when available, ensuring workspaces reflect the correct review context.
  * Closed related pull requests now correctly use the repository’s default branch while preserving the reviewed commit.

* **Tests**
  * Added coverage for review-branch selection and closed related pull request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->