### PR TITLE
fix(worker): derive the running-run model label from live harness manifests

### DIFF
--- a/apps/worker/src/db/queries/run-detail-read.test.ts
+++ b/apps/worker/src/db/queries/run-detail-read.test.ts
@@ -2,7 +2,16 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { createTestDb } from "../test-db.js";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
+import type { HarnessRunManifestRecord } from "@shared/contracts";
 import { fetchRunDetailFromDb, fetchRunRefs } from "./run-detail-read.js";
+
+/** Minimal fixture: deriveLiveModel only reads `.manifest.model.id`. */
+function harnessManifest(nodeId: string, modelId: string): HarnessRunManifestRecord {
+  return {
+    nodeId,
+    manifest: { model: { id: modelId } },
+  } as unknown as HarnessRunManifestRecord;
+}
 
 const JIRA = "https://blazity.atlassian.net";
 let db: Db;
@@ -35,6 +44,29 @@ describe("fetchRunDetailFromDb", () => {
     expect(res?.run.ticketTitle).toBe("Do the thing");
     expect(res?.run.ticketUrl).toBe(`${JIRA}/browse/AWT-5`);
     expect(res?.run.durationSec).toBe(300);
+  });
+
+  it("prefers the live per-block model over the org fallback while a run is still in flight", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "r1",
+      status: "running",
+      model: null,
+      harnessManifests: [harnessManifest("planning", "gpt-5.6-sol")],
+      startedAt: new Date(),
+    });
+    const res = await fetchRunDetailFromDb({ db, runId: "r1", ...base });
+    expect(res?.run.model).toBe("gpt-5.6-sol");
+  });
+
+  it("falls back to the org default when no block has resolved a harness yet", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "r1",
+      status: "running",
+      model: null,
+      startedAt: new Date(),
+    });
+    const res = await fetchRunDetailFromDb({ db, runId: "r1", ...base });
+    expect(res?.run.model).toBe("claude-fallback");
   });
 
   it("surfaces the persisted PR ref", async () => {

--- a/apps/worker/src/db/queries/run-detail-read.ts
+++ b/apps/worker/src/db/queries/run-detail-read.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import type { RunDetail, RunPullRequest, RunStep } from "@shared/contracts";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
-import { coerceStatus } from "./runs-read.js";
+import { coerceStatus, deriveLiveModel } from "./runs-read.js";
 import { sanitizeRunSteps } from "../../lib/overview/sanitize-run-detail.js";
 
 /**
@@ -117,7 +117,7 @@ export async function fetchRunDetailFromDb(
     prNumber: row.prNumber,
     prUrl: row.prUrl,
     prs: row.prs,
-    model: row.model ?? modelFallback,
+    model: row.model ?? deriveLiveModel(row.harnessManifests) ?? modelFallback,
     createdAt: (row.createdAt ?? row.firstSeenAt).toISOString(),
     startedAt: row.startedAt?.toISOString() ?? null,
     completedAt: row.completedAt?.toISOString() ?? null,

--- a/apps/worker/src/db/queries/runs-read.test.ts
+++ b/apps/worker/src/db/queries/runs-read.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { createTestDb } from "../test-db.js";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
-import type { RunPullRequest, WorkflowMeta } from "@shared/contracts";
+import type {
+  HarnessRunManifestRecord,
+  RunPullRequest,
+  WorkflowMeta,
+} from "@shared/contracts";
 import {
   parseWindow,
   parseSearch,
@@ -12,7 +16,16 @@ import {
   costAgg,
   listRunsForTicket,
   isRunRecordedFailed,
+  deriveLiveModel,
 } from "./runs-read.js";
+
+/** Minimal fixture: deriveLiveModel only reads `.manifest.model.id`. */
+function harnessManifest(nodeId: string, modelId: string): HarnessRunManifestRecord {
+  return {
+    nodeId,
+    manifest: { model: { id: modelId } },
+  } as unknown as HarnessRunManifestRecord;
+}
 
 const NOW = new Date("2026-06-16T12:00:00.000Z");
 const HOUR = 3_600_000;
@@ -49,6 +62,7 @@ interface SeedRun {
   prNumber?: number | null;
   prUrl?: string | null;
   prs?: RunPullRequest[] | null;
+  harnessManifests?: HarnessRunManifestRecord[] | null;
 }
 
 async function seed(over: SeedRun = {}): Promise<void> {
@@ -72,6 +86,7 @@ async function seed(over: SeedRun = {}): Promise<void> {
     prNumber: over.prNumber ?? null,
     prUrl: over.prUrl ?? null,
     prs: over.prs ?? null,
+    harnessManifests: over.harnessManifests ?? null,
   });
 }
 
@@ -105,8 +120,50 @@ describe("parseSearch", () => {
   });
 });
 
+describe("deriveLiveModel", () => {
+  it("returns null for no manifests", () => {
+    expect(deriveLiveModel(null)).toBeNull();
+    expect(deriveLiveModel(undefined)).toBeNull();
+    expect(deriveLiveModel([])).toBeNull();
+  });
+
+  it("returns the most-recently-appended block's model", () => {
+    const manifests = [
+      harnessManifest("planning", "gpt-5.6-sol"),
+      harnessManifest("implementation", "gpt-5.6-luna"),
+    ];
+    expect(deriveLiveModel(manifests)).toBe("gpt-5.6-luna");
+  });
+});
+
 describe("listRuns", () => {
   const base = { jiraBaseUrl: JIRA, modelFallback: "claude-fallback", now: NOW };
+
+  it("prefers the live per-block model over the org fallback while a run is still in flight", async () => {
+    await seed({
+      runId: "r-running",
+      model: null,
+      harnessManifests: [harnessManifest("planning", "gpt-5.6-sol")],
+    });
+    const { rows } = await listRuns({ db, window: "all", q: null, ...base });
+    expect(rows.find((r) => r.id === "r-running")!.model).toBe("gpt-5.6-sol");
+  });
+
+  it("falls back to the org default when no block has resolved a harness yet", async () => {
+    await seed({ runId: "r-just-started", model: null, harnessManifests: null });
+    const { rows } = await listRuns({ db, window: "all", q: null, ...base });
+    expect(rows.find((r) => r.id === "r-just-started")!.model).toBe("claude-fallback");
+  });
+
+  it("prefers the persisted terminal model over any harness manifest once the run finishes", async () => {
+    await seed({
+      runId: "r-done",
+      model: "gpt-5.6-luna",
+      harnessManifests: [harnessManifest("planning", "gpt-5.6-sol")],
+    });
+    const { rows } = await listRuns({ db, window: "all", q: null, ...base });
+    expect(rows.find((r) => r.id === "r-done")!.model).toBe("gpt-5.6-luna");
+  });
 
   it("maps persisted cost/tokens (no longer null) and coerces status", async () => {
     await seed({ runId: "r1", status: "success", costUsd: 2.25, tokensInput: 1200, tokensOutput: 800 });

--- a/apps/worker/src/db/queries/runs-read.ts
+++ b/apps/worker/src/db/queries/runs-read.ts
@@ -1,6 +1,7 @@
 import { and, count, eq, sql, type SQL } from "drizzle-orm";
 import type {
   CostResponse,
+  HarnessRunManifestRecord,
   KpisResponse,
   Run,
   RunPullRequest,
@@ -251,6 +252,7 @@ const runColumns = {
   prNumber: workflowRuns.prNumber,
   prUrl: workflowRuns.prUrl,
   prs: workflowRuns.prs,
+  harnessManifests: workflowRuns.harnessManifests,
 } as const;
 
 type RunRow = {
@@ -272,7 +274,22 @@ type RunRow = {
   prNumber: number | null;
   prUrl: string | null;
   prs: RunPullRequest[] | null;
+  harnessManifests: HarnessRunManifestRecord[] | null;
 };
+
+/**
+ * `workflow_runs.model` stays null for a run's entire in-flight window (only
+ * `recordRunUsage` sets it, on completion) and the block-status writer streams
+ * `harnessManifests` as each block resolves its harness — so its last entry is
+ * the most-recently-started block's actual model, a far better RUNNING-state
+ * value than the org-wide fallback.
+ */
+export function deriveLiveModel(
+  manifests: HarnessRunManifestRecord[] | null | undefined,
+): string | null {
+  if (!Array.isArray(manifests) || manifests.length === 0) return null;
+  return manifests[manifests.length - 1]?.manifest.model.id ?? null;
+}
 
 function mapRun(r: RunRow, now: Date, tenantOrigin: string, modelFallback: string): Run {
   const eff = r.startedAt ?? r.firstSeenAt;
@@ -288,7 +305,7 @@ function mapRun(r: RunRow, now: Date, tenantOrigin: string, modelFallback: strin
     statusReason: r.statusReason,
     ticket: r.ticketKey ?? "",
     actor: "ai-bot",
-    model: r.model ?? modelFallback,
+    model: r.model ?? deriveLiveModel(r.harnessManifests) ?? modelFallback,
     startedAtMin: Math.max(0, Math.round((now.getTime() - eff.getTime()) / 60000)),
     duration: r.durationSec,
     tokens,

--- a/apps/worker/src/routes/api/v1/runs/[runId].get.ts
+++ b/apps/worker/src/routes/api/v1/runs/[runId].get.ts
@@ -64,10 +64,14 @@ export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
       // In-flight runs: the world carries the live lifecycle + step waterfall but
       // not the ticket (encrypted input) or PR — merge those from the durable row.
       loadWorld: async () => {
+        // The durable row's model already prefers a live per-block value
+        // (see deriveLiveModel) over the org-wide default; carry that into
+        // the world-sourced header instead of re-flattening to the default.
+        const liveModel = dbDetail?.run.model ?? model;
         const [{ run, steps }, refs] = await Promise.all([
           collectRunDetail({
             world: getWorld() as unknown as RunDetailSource,
-            model,
+            model: liveModel,
             runId,
           }),
           fetchRunRefs(getDb(), runId, env.JIRA_BASE_URL).catch(() => null),


### PR DESCRIPTION
## Summary
- The MODEL column on `/runs` and the model badge on `/trace/[id]` showed a static org-wide default (`CLAUDE_MODEL`/`CODEX_MODEL`) for the entire RUNNING window of a run, unrelated to which model any block actually resolved via its harness profile.
- `workflow_runs.harness_manifests` is already streamed mid-run by `recordBlockStatuses` as each block resolves its harness — this reads that (last entry = most-recently-started block) instead of the static fallback, only when the terminal `model` column isn't set yet.
- Terminal-run behavior (model = the Implementation block's model, an intentional existing choice) is unchanged.

## Test plan
- [x] `pnpm typecheck` (apps/worker)
- [x] `pnpm vitest run src/db/queries/runs-read.test.ts src/db/queries/run-detail-read.test.ts` — 57/57 passing, including new cases for `deriveLiveModel` and the running/just-started/terminal precedence
- [ ] Spot-check `/runs` and a run trace page while a multi-model run (Codex Planning + Codex Execution profiles) is in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)