### PR TITLE
feat(release): let a tenant own the skills its deployment ships (AIW-246)

### DIFF
--- a/.github/workflows/sync-artur-release.yml
+++ b/.github/workflows/sync-artur-release.yml
@@ -156,7 +156,7 @@ jobs:
             echo "- Source SHA: \`$SOURCE_SHA\`"
             echo "- Destination base: \`$(jq -r '.destinationBaseCommit' .release-notes/artur-sync.json)\`"
             echo "- Generation run: $GENERATION_RUN"
-            echo "- Preserved destination paths: \`.github/\`, \`renovate.json\`"
+            echo "- Preserved destination paths: \`.github/\`, \`renovate.json\`, \`skills/\`"
             echo
             echo "## Change summary"
             echo

--- a/scripts/release-notes/sync.test.ts
+++ b/scripts/release-notes/sync.test.ts
@@ -173,6 +173,14 @@ test("destination drift ignores repository config and patch-equivalent backports
   await mkdir(path.join(destinationDir, ".github"), { recursive: true });
   await writeFile(path.join(destinationDir, ".github", "release.yml"), "destination config\n");
   await commitAll(destinationDir, "destination config");
+  await mkdir(path.join(destinationDir, "skills", "arthur-review"), { recursive: true });
+  await writeFile(
+    path.join(destinationDir, "skills", "arthur-review", "SKILL.md"),
+    "arthur skill\n",
+  );
+  // The tenant adding its own skills is not an application change waiting to be
+  // backported, so it must not hold up a release the way a real hotfix would.
+  await commitAll(destinationDir, "tenant skills");
   await writeFile(path.join(destinationDir, "apps", "unique.txt"), "not backported\n");
   const uniqueCommit = await commitAll(destinationDir, "unbackported Artur hotfix");
 

--- a/scripts/release-notes/sync.test.ts
+++ b/scripts/release-notes/sync.test.ts
@@ -47,6 +47,8 @@ test("Artur snapshot replaces all source-owned files and preserves destination-o
   await symlink("app.txt", path.join(sourceSnapshotDir, "apps", "app-link"));
   await writeFile(path.join(sourceSnapshotDir, ".github", "workflows", "ci.yml"), "source-ci\n");
   await writeFile(path.join(sourceSnapshotDir, "renovate.json"), "{\"source\":true}\n");
+  await mkdir(path.join(sourceSnapshotDir, "skills", "source-review"), { recursive: true });
+  await writeFile(path.join(sourceSnapshotDir, "skills", "source-review", "SKILL.md"), "source skill\n");
   const sourceCommit = await commitAll(sourceSnapshotDir, "source snapshot");
 
   await initRepository(sourceMainDir);
@@ -62,6 +64,8 @@ test("Artur snapshot replaces all source-owned files and preserves destination-o
   await writeFile(path.join(destinationDir, "apps", "obsolete.txt"), "remove me\n");
   await writeFile(path.join(destinationDir, ".github", "workflows", "ci.yml"), "arthur-ci\n");
   await writeFile(path.join(destinationDir, "renovate.json"), "{\"arthur\":true}\n");
+  await mkdir(path.join(destinationDir, "skills", "arthur-review"), { recursive: true });
+  await writeFile(path.join(destinationDir, "skills", "arthur-review", "SKILL.md"), "arthur skill\n");
   const destinationBaseCommit = await commitAll(destinationDir, "destination base");
   await writeFile(path.join(destinationDir, "untracked.txt"), "leave untracked\n");
 
@@ -88,10 +92,22 @@ test("Artur snapshot replaces all source-owned files and preserves destination-o
   assert.deepEqual(await readFile(path.join(destinationDir, "apps", "binary.bin")), Buffer.from([0, 1, 2, 255]));
   assert.equal(await readFile(path.join(destinationDir, ".github", "workflows", "ci.yml"), "utf8"), "arthur-ci\n");
   assert.equal(await readFile(path.join(destinationDir, "renovate.json"), "utf8"), "{\"arthur\":true}\n");
+  // The tenant owns its skills: its own survives the snapshot untouched, and
+  // the source repository's skill never reaches it, because a skill carries the
+  // review knowledge of whoever ships it.
+  assert.equal(
+    await readFile(path.join(destinationDir, "skills", "arthur-review", "SKILL.md"), "utf8"),
+    "arthur skill\n",
+  );
+  await assert.rejects(readFile(path.join(destinationDir, "skills", "source-review", "SKILL.md")));
   assert.equal(await readFile(path.join(destinationDir, notesPath), "utf8"), "approved release notes\n");
   assert.equal(await readFile(path.join(destinationDir, "untracked.txt"), "utf8"), "leave untracked\n");
   await assert.rejects(readFile(path.join(destinationDir, "apps", "obsolete.txt")));
-  assert.deepEqual(result.preserved, [".github/workflows/ci.yml", "renovate.json"]);
+  assert.deepEqual(result.preserved, [
+    ".github/workflows/ci.yml",
+    "renovate.json",
+    "skills/arthur-review/SKILL.md",
+  ]);
   assert.ok(result.added.includes("apps/binary.bin"));
   assert.ok(result.added.includes(notesPath));
   assert.ok(result.modified.includes("apps/app.txt"));

--- a/scripts/release-notes/sync.ts
+++ b/scripts/release-notes/sync.ts
@@ -9,10 +9,30 @@ import type { SyncInput, SyncResult } from "./types.js";
 
 const execFileAsync = promisify(execFile);
 
-export const DESTINATION_OWNED_PATHS = [".github/", "renovate.json"] as const;
+/**
+ * Paths the destination owns, which a snapshot therefore never overwrites or
+ * deletes.
+ *
+ * `skills/` is here because agent skills are the tenant's own content: they
+ * carry the review knowledge of the tenant's repositories, which is exactly
+ * what must not live in this open-source repository. The deployment reads them
+ * from its own bundle, so without this entry a release would ship a complete
+ * snapshot that silently removed the only skills that deployment had.
+ */
+export const DESTINATION_OWNED_PATHS = [
+  ".github/",
+  "renovate.json",
+  "skills/",
+] as const;
 
 function isDestinationOwned(file: string): boolean {
-  return file === "renovate.json" || file === ".github" || file.startsWith(".github/");
+  return (
+    file === "renovate.json" ||
+    file === ".github" ||
+    file.startsWith(".github/") ||
+    file === "skills" ||
+    file.startsWith("skills/")
+  );
 }
 
 async function git(dir: string, args: string[]): Promise<string> {


### PR DESCRIPTION
Prerequisite for putting Arthur's review skills into their tenant. Without it, the next release would delete them.

## What the release sync does today

`sync-artur-release` copies a complete application snapshot from this repository into the tenant repository, and preserves exactly two destination paths: `.github/` and `renovate.json` (`scripts/release-notes/sync.ts:12`). Everything else in the destination that the snapshot does not contain is deleted.

A `skills/` directory committed to `Blazity/ai-workflow-arthur` would therefore survive until the next release and then vanish, silently, in a pull request titled "complete application snapshot". The tenant would lose the only skills its deployment had, and the failure would look like the deployment simply stopped carrying them.

## Why `skills/` belongs to the destination

A skill carries the review knowledge of the repositories the tenant owns. That is precisely the content this repository must not hold: it is open source, and the guidance is the client's. The deployment reads skills from its own bundle, so the tenant repository is where they have to live, and the sync has to treat them the way it already treats the tenant's CI configuration.

The reverse also follows and is intended: this repository's own `skills/ai-workflow-review` never reaches the tenant. It reviews this codebase, not theirs.

## Change

`skills/` joins `DESTINATION_OWNED_PATHS`, with the same treatment `.github/` gets, and the synchronization pull-request body names it among the preserved paths.

The test now ships a skill on both sides: the source snapshot carries `skills/source-review`, the destination carries `skills/arthur-review`. After a sync, the destination still has its own and never receives the source's. Mutation-checked: reverting the one-line predicate makes it fail.

`tsx --test scripts/release-notes/*.test.ts` 43/43.
