### PR TITLE
test(worker): fail US-06 on a missing commenter token instead of skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
       JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
+      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
       COLUMN_AI: ${{ secrets.COLUMN_AI }}
       COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
       COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}
@@ -113,6 +114,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
       JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
+      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
       COLUMN_AI: ${{ secrets.COLUMN_AI }}
       COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
       COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}
@@ -166,6 +168,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
       JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
+      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
       COLUMN_AI: ${{ secrets.COLUMN_AI }}
       COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
       COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}

--- a/apps/worker/e2e/env.ts
+++ b/apps/worker/e2e/env.ts
@@ -12,10 +12,20 @@ const schema = z.object({
    * answer as a NON-bot user. The comment-driven resume path excludes the bot's
    * own comments by accountId (see src/clarifications/resume-from-comments.ts),
    * so an answer posted with the bot's JIRA_API_TOKEN is ignored and can never
-   * wake the suspended run. When this is absent, US-06 is skipped. Bearer token
-   * for a user distinct from the one JIRA_API_TOKEN authenticates.
+   * wake the suspended run. When this is absent, US-06 fails with an explicit
+   * message. Bearer token for a user distinct from the one JIRA_API_TOKEN
+   * authenticates.
+   *
+   * Empty is treated as absent: the workflow passes this through as
+   * `${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}`, and Actions renders an
+   * unconfigured secret as "" rather than omitting the variable. Without the
+   * preprocess, `min(1)` would reject "" and take down the whole env parse,
+   * failing every suite instead of the one story that needs the token.
    */
-  JIRA_E2E_COMMENTER_TOKEN: z.string().min(1).optional(),
+  JIRA_E2E_COMMENTER_TOKEN: z.preprocess(
+    (value) => (value === "" ? undefined : value),
+    z.string().min(1).optional(),
+  ),
 
   COLUMN_AI: z.string().min(1),
   COLUMN_AI_REVIEW: z.string().min(1),

--- a/apps/worker/e2e/tier2/us06-clarification-answered.test.ts
+++ b/apps/worker/e2e/tier2/us06-clarification-answered.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterAll } from "vitest";
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
 import {
   createTestTicket,
   moveTicketToColumn,
@@ -34,9 +34,8 @@ import { e2eEnv } from "../env.js";
 // US-06 answers the clarification from a NON-bot Jira identity. The resume path
 // filters the bot's own comments by accountId (resume-from-comments.ts), so
 // answering with the bot token (JIRA_API_TOKEN) can never wake the run. The
-// test is meaningless without a distinct commenter. Skip the whole suite when
-// JIRA_E2E_COMMENTER_TOKEN is absent.
-describe.skipIf(!e2eEnv.JIRA_E2E_COMMENTER_TOKEN)(
+// test is meaningless without a distinct commenter.
+describe(
   "US-06: Clarification answered → ticket completes",
   () => {
   // Unique value so the PR content check can't pass on pre-existing files
@@ -44,6 +43,17 @@ describe.skipIf(!e2eEnv.JIRA_E2E_COMMENTER_TOKEN)(
   let ticketKey: string;
   let branchName: string;
   let prNumber: number | undefined;
+
+  // Skipping used to be silent, so a run missing this secret reported the same
+  // green as a run that exercised the resume path. Fail like US-12 does: a
+  // missing prerequisite is a red job, not an invisible pass.
+  beforeAll(() => {
+    if (!e2eEnv.JIRA_E2E_COMMENTER_TOKEN) {
+      throw new Error(
+        "US-06 requires JIRA_E2E_COMMENTER_TOKEN: a Jira token for a user distinct from JIRA_API_TOKEN.",
+      );
+    }
+  });
 
   afterAll(async () => {
     if (ticketKey) await stopSandboxesForTicket(ticketKey).catch(() => {});


### PR DESCRIPTION
US-06 covers the only path where a clarification answer can wake a suspended run: the answer must come from a Jira identity that is not the bot, because the resume path filters the bot's own comments by accountId. The suite guarded that with `describe.skipIf(...)`, and `JIRA_E2E_COMMENTER_TOKEN` has never been configured in the `e2e` environment. So the story has never executed, and a run that never exercised the resume path reported the same green as one that did.

US-12 already handles the same situation the honest way: a `beforeAll` that throws and names the missing secret. This makes US-06 match it. A missing prerequisite becomes a red job with an instructive message rather than an invisible pass.

## Empty is treated as absent, deliberately

The workflow now passes the token through to all three e2e jobs. Actions renders an unconfigured secret as `""` rather than omitting the variable, and `z.string().min(1)` rejects `""`, so wiring it up alone would have failed the whole env parse and taken down every suite instead of the one story that needs the token. `JIRA_E2E_COMMENTER_TOKEN` therefore preprocesses `""` to `undefined`.

Measured, not assumed:

```
z.string().min(1).optional().safeParse("").success      -> false
preprocessed.parse("")                                  -> undefined
```

and the full schema parses with the variable present-but-empty, yielding `undefined`.

`JIRA_WEBHOOK_SECRET` has the same latent shape but its secret is configured, so it is dormant; left untouched.

## What this does not fix

Two things gate the e2e suite and only a human can do them:

1. Create a Jira token for a user distinct from `JIRA_API_TOKEN` and add it to the `e2e` environment as `JIRA_E2E_COMMENTER_TOKEN`. Until then US-06 fails loudly, which is the point of this change.
2. Replace `DATABASE_URL` in the `e2e` environment. The current value is dated 2026-06-15 and preflight fails with `password authentication failed for user "neondb_owner"`, so dispatching CI proves nothing regardless of this change.

Context: the three e2e jobs were gated on `merge_group` with no merge queue enabled, so they were skipped in 11 of 11 runs inspected. `workflow_dispatch` was added earlier so they can be run manually.
