### PR TITLE
docs(releases): add an upgrade preflight for schemas frozen in loop carries

### DIFF
--- a/docs/releases/artur/README.md
+++ b/docs/releases/artur/README.md
@@ -25,6 +25,11 @@ its Vercel production deployment and smoke tests succeed.
 
 The source repository never deploys Artur production directly.
 
+Before step 3, run the check in [`upgrade-preflight.md`](upgrade-preflight.md)
+against the tenant database. It names deployed workflows whose Loop carries a
+frozen copy of a schema the release has since changed, which would otherwise
+break a working configuration the tenant never touched.
+
 ## Ownership and synchronization
 
 The synchronization replaces every tracked application path, including

--- a/docs/releases/artur/README.md
+++ b/docs/releases/artur/README.md
@@ -11,7 +11,10 @@ its Vercel production deployment and smoke tests succeed.
    the source commit Zak last reviewed as `previous_ref` for the first release.
    Keep `dry_run` enabled to inspect the draft without opening a pull request.
 2. Run preparation with `dry_run` disabled. Review the docs-only pull request,
-   edit the non-technical English wording where needed, approve it, and merge.
+   edit the non-technical English wording where needed, and approve it. Before
+   merging, run the tenant-database check in
+   [`upgrade-preflight.md`](upgrade-preflight.md). Merge only after the check
+   identifies no unrepaired deployed workflows.
 3. The merge automatically runs **Sync Approved Artur Release**. It copies the
    complete application tree from the pinned `targetSourceCommit` into a new
    `release/artur-<version>` branch in `Blazity/ai-workflow-arthur`.
@@ -25,10 +28,9 @@ its Vercel production deployment and smoke tests succeed.
 
 The source repository never deploys Artur production directly.
 
-Before step 3, run the check in [`upgrade-preflight.md`](upgrade-preflight.md)
-against the tenant database. It names deployed workflows whose Loop carries a
-frozen copy of a schema the release has since changed, which would otherwise
-break a working configuration the tenant never touched.
+The pre-merge check names deployed workflows whose Loop carries a frozen copy
+of a schema the release has since changed, which would otherwise break a
+working configuration the tenant never touched.
 
 ## Ownership and synchronization
 

--- a/docs/releases/artur/upgrade-preflight.md
+++ b/docs/releases/artur/upgrade-preflight.md
@@ -1,0 +1,72 @@
+# Upgrade preflight: carried schemas frozen at authoring time
+
+Run this against the tenant database **before** synchronising a release that
+changes a block's output schema. It takes seconds and needs no downtime.
+
+## What it catches
+
+A Loop's carried value stores the source block's JSON Schema **by value**, at the
+moment the author picked the source. Nothing revisits that copy afterwards. When
+a later release changes the shipped schema, every deployed definition keeps the
+old copy, and the two disagree at validation time.
+
+The failure mode is the reason this check exists: the tenant changes nothing,
+upgrades, and their working workflow stops validating. The editor reports the
+carried value as invalid against a schema they never chose and cannot see.
+
+Known instance: the review finding severity enum moved from
+`["critical", "suggestion"]` to `["Blocker", "High", "Medium", "Nit"]`. Tracked
+as AIW-245; this document is the operational half, not the engine fix.
+
+## The query
+
+```sql
+select
+  d.id,
+  d.name,
+  d.enabled,
+  d.deployed_version,
+  c->>'name'                 as carried_value,
+  c->'binding'->>'reference' as source,
+  c->'schema'#>>'{properties,findings,items,properties,severity,enum}' as frozen_severity
+from workflow_definitions d
+join workflow_definition_versions v
+  on v.definition_id = d.id and v.version = d.deployed_version
+cross join lateral jsonb_array_elements(v.definition->'nodes') n
+cross join lateral jsonb_array_elements(coalesce(n->'configuration'->'carry', '[]'::jsonb)) c
+where d.archived_at is null
+  and n->>'type' = 'loop'
+  and c->'schema'#>>'{properties,findings,items,properties,severity,enum}' is not null
+  and c->'schema'#>>'{properties,findings,items,properties,severity,enum}'
+      <> '["Blocker", "High", "Medium", "Nit"]'
+order by d.enabled desc, d.id;
+```
+
+Zero rows means no deployed definition carries a stale severity enum. Rows are
+listed enabled-first, because an enabled definition breaks on its next run while
+a disabled one breaks whenever somebody enables it.
+
+The query reads the **deployed** version, not the draft. A draft repaired but
+not redeployed still fails, which is the point.
+
+## The repair
+
+Per row, in the editor:
+
+1. Open the definition, select the Loop node.
+2. Open the carried value named in `carried_value`.
+3. Reselect the same source output named in `source`. Reselecting is what
+   replaces the frozen copy; editing anything else does not.
+4. Deploy.
+
+Verified on production on 2026-08-10 against a definition carrying the stale
+enum in three places: after transplanting the current schema and redeploying,
+deployment returned 200 with no validation issues, and the query above returned
+zero rows.
+
+## Scope note
+
+The severity enum is the only instance measured so far. Any future schema change
+to a block that can feed a Loop carry has the same shape, so widen the two
+`#>>` paths to whichever field moved rather than assuming this file already
+covers it.

--- a/docs/releases/artur/upgrade-preflight.md
+++ b/docs/releases/artur/upgrade-preflight.md
@@ -21,25 +21,33 @@ as AIW-245; this document is the operational half, not the engine fix.
 ## The query
 
 ```sql
+with expected_schema_fields(schema_path, expected_value) as (
+  values (
+    array['properties', 'findings', 'items', 'properties', 'severity', 'enum']::text[],
+    '["Blocker", "High", "Medium", "Nit"]'::jsonb
+  )
+)
 select
   d.id,
   d.name,
   d.enabled,
+  d.archived_at,
   d.deployed_version,
   c->>'name'                 as carried_value,
   c->'binding'->>'reference' as source,
-  c->'schema'#>>'{properties,findings,items,properties,severity,enum}' as frozen_severity
+  array_to_string(e.schema_path, '.') as schema_field,
+  c->'schema' #> e.schema_path        as frozen_value,
+  e.expected_value
 from workflow_definitions d
 join workflow_definition_versions v
   on v.definition_id = d.id and v.version = d.deployed_version
 cross join lateral jsonb_array_elements(v.definition->'nodes') n
 cross join lateral jsonb_array_elements(coalesce(n->'configuration'->'carry', '[]'::jsonb)) c
-where d.archived_at is null
-  and n->>'type' = 'loop'
-  and c->'schema'#>>'{properties,findings,items,properties,severity,enum}' is not null
-  and c->'schema'#>>'{properties,findings,items,properties,severity,enum}'
-      <> '["Blocker", "High", "Medium", "Nit"]'
-order by d.enabled desc, d.id;
+cross join expected_schema_fields e
+where n->>'type' = 'loop'
+  and c->'schema' #> e.schema_path is not null
+  and c->'schema' #> e.schema_path <> e.expected_value
+order by d.archived_at nulls first, d.enabled desc, d.id;
 ```
 
 Zero rows means no deployed definition carries a stale severity enum. Rows are
@@ -66,7 +74,9 @@ zero rows.
 
 ## Scope note
 
-The severity enum is the only instance measured so far. Any future schema change
-to a block that can feed a Loop carry has the same shape, so widen the two
-`#>>` paths to whichever field moved rather than assuming this file already
-covers it.
+The severity enum is the only instance measured so far. Any future schema
+change to a block that can feed a Loop carry has the same shape. Add one row to
+`expected_schema_fields` for each changed field, pairing its exact `schema_path`
+with that field's expected deployed JSON value. Changing a path without its
+matching expected value would compare unrelated fields and produce incorrect
+results.


### PR DESCRIPTION
A Loop's carried value stores the source block's JSON Schema by value, at authoring time, and nothing revisits that copy. When a release changes the shipped schema, a deployed definition keeps the old copy and the two disagree at validation time. The tenant changes nothing, upgrades, and a working workflow stops validating against a schema they never chose.

This adds the operational half: a query that names the affected deployed definitions before the synchronisation runs, plus the repair (reselect the same source output on the carried value, redeploy). The engine fix is AIW-245 and is not in this PR.

Measured on production on 2026-08-10: of 3 deployed definitions carrying a value, exactly 1 held the stale severity enum. After transplanting the current schema into its three carry entries and redeploying, deployment returned 200 with zero validation issues and the query returned zero rows.

Docs only. Linked from the release README at the step where it has to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a pre-release database check for deployed workflows with frozen schemas that may conflict with release changes.
  * Added an operational preflight guide for detecting and repairing stale review-severity schema values.
  * Documented result interpretation, editor-based remediation, production verification, and guidance for future schema updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->