### PR TITLE
fix(worker): verify the run row before trusting a bound claim on start commit (AIW-249)

### DIFF
--- a/apps/worker/src/lib/run-start-lifecycle.test.ts
+++ b/apps/worker/src/lib/run-start-lifecycle.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   cancelHosted: vi.fn(),
   hostedStatus: "running",
   confirmDrained: vi.fn(),
+  warn: vi.fn(),
 }));
 const state = vi.hoisted(() => ({
   db: undefined as Db | undefined,
@@ -17,6 +18,14 @@ const state = vi.hoisted(() => ({
 
 vi.mock("./cancel-run.js", () => ({
   cancelSubjectRun: (...args: unknown[]) => mocks.cancelOwned(...args),
+}));
+vi.mock("./logger.js", () => ({
+  logger: {
+    warn: mocks.warn,
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
 }));
 vi.mock("../../env.js", () => ({ env: {} }));
 vi.mock("../db/client.js", () => ({
@@ -57,8 +66,13 @@ beforeEach(async () => {
     mocks.hostedStatus = "cancelled";
   });
   mocks.confirmDrained.mockReset().mockResolvedValue(true);
+  mocks.warn.mockReset();
   mocks.hostedStatus = "running";
 });
+
+function warnedMessages(): string[] {
+  return mocks.warn.mock.calls.map((call) => call[1] as string);
+}
 
 const started = {
   subjectKey: "ticket:jira:PROJ-1",
@@ -68,24 +82,109 @@ const started = {
   runId: "run-started",
 };
 
+function boundOwner(overrides: Record<string, unknown> = {}) {
+  return {
+    subjectKey: started.subjectKey,
+    ticketKey: started.ticketKey,
+    ownerToken: started.ownerToken,
+    kind: started.kind,
+    runId: started.runId,
+    state: "bound",
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function throwingCommitRegistry(owner: unknown): RunRegistryAdapter {
+  return {
+    commitStartedRun: vi.fn().mockRejectedValue(new Error("connection lost")),
+    get: vi.fn().mockResolvedValue(owner),
+  } as unknown as RunRegistryAdapter;
+}
+
+async function insertStartedRunRow(): Promise<void> {
+  await db.insert(workflowRuns).values({
+    runId: started.runId,
+    status: "running",
+    subjectKey: started.subjectKey,
+    ticketKey: started.ticketKey,
+  });
+}
+
 describe("hosted start commit", () => {
   it("accepts an exact owner/run after an ambiguous commit exception", async () => {
-    const runRegistry = {
-      commitStartedRun: vi.fn().mockRejectedValue(new Error("connection lost")),
-      get: vi.fn().mockResolvedValue({
-        subjectKey: started.subjectKey,
-        ticketKey: started.ticketKey,
-        ownerToken: started.ownerToken,
-        kind: started.kind,
-        runId: started.runId,
-        state: "bound",
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-      }),
-    } as unknown as RunRegistryAdapter;
+    await insertStartedRunRow();
+    const runRegistry = throwingCommitRegistry(boundOwner());
 
     await expect(commitHostedStart(runRegistry, started)).resolves.toBe(true);
     expect(mocks.cancelHosted).not.toHaveBeenCalled();
+    expect(warnedMessages()).not.toContain(
+      "dispatch_start_bound_without_run_row",
+    );
+  });
+
+  it("treats a bound claim with no run row as an orphan instead of a start", async () => {
+    const runRegistry = throwingCommitRegistry(boundOwner());
+
+    await expect(commitHostedStart(runRegistry, started)).resolves.toBe(false);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subjectKey: started.subjectKey,
+        runId: started.runId,
+        ownerToken: started.ownerToken,
+        claimState: "bound",
+      }),
+      "dispatch_start_bound_without_run_row",
+    );
+    expect(mocks.cancelHosted).toHaveBeenCalledOnce();
+    const [row] = await db
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, started.runId));
+    expect(row).toMatchObject({
+      status: "failed",
+      statusReason: "Hosted workflow start lost dispatch ownership.",
+    });
+  });
+
+  it("keeps the run alive when the run row lookup itself fails", async () => {
+    state.db = {
+      select: () => {
+        throw new Error("read failed");
+      },
+    } as unknown as Db;
+    const runRegistry = throwingCommitRegistry(boundOwner());
+
+    await expect(commitHostedStart(runRegistry, started)).resolves.toBe(true);
+    expect(warnedMessages()).toContain(
+      "dispatch_start_run_row_check_unconfirmed",
+    );
+    expect(mocks.cancelHosted).not.toHaveBeenCalled();
+  });
+
+  it("never reads the run row when the commit itself succeeds", async () => {
+    state.db = undefined;
+    const runRegistry = {
+      commitStartedRun: vi.fn().mockResolvedValue(true),
+      get: vi.fn(),
+    } as unknown as RunRegistryAdapter;
+
+    await expect(commitHostedStart(runRegistry, started)).resolves.toBe(true);
+    expect(mocks.warn).not.toHaveBeenCalled();
+    expect(mocks.cancelHosted).not.toHaveBeenCalled();
+  });
+
+  it("records an orphan when an ambiguous commit left the claim with another owner", async () => {
+    const runRegistry = throwingCommitRegistry(
+      boundOwner({ ownerToken: "owner-b" }),
+    );
+
+    await expect(commitHostedStart(runRegistry, started)).resolves.toBe(false);
+    expect(mocks.cancelHosted).toHaveBeenCalledOnce();
+    expect(warnedMessages()).not.toContain(
+      "dispatch_start_bound_without_run_row",
+    );
   });
 
   it("does not cancel when an ambiguous commit cannot be rechecked", async () => {

--- a/apps/worker/src/lib/run-start-lifecycle.ts
+++ b/apps/worker/src/lib/run-start-lifecycle.ts
@@ -53,7 +53,46 @@ export async function commitHostedStart(
       owner.runId === started.runId &&
       owner.state === "bound"
     ) {
-      return true;
+      // This is the only place in the start flow that infers the workflow_runs
+      // row from the claim state instead of observing it. Production produced a
+      // phantom run twice on 2026-08-10: the claim was bound to this run id, the
+      // occurrence ledger recorded a start, and no workflow_runs row ever
+      // existed, so the run was invisible in the runs list. Observe the row.
+      let outcome: { status: string | null } | null;
+      try {
+        const { findRunOutcomeByRunId } = await import(
+          "../db/queries/runs-read.js"
+        );
+        outcome = await findRunOutcomeByRunId(getDb(), started.runId);
+      } catch (checkError) {
+        logger.warn(
+          {
+            subjectKey: started.subjectKey,
+            runId: started.runId,
+            ownerToken: started.ownerToken,
+            claimState: owner.state,
+            error:
+              checkError instanceof Error
+                ? checkError.message
+                : String(checkError),
+          },
+          "dispatch_start_run_row_check_unconfirmed",
+        );
+        // Deliberate: falling through cancels the hosted run, so an unreadable
+        // database must never kill a healthy start. Only a confirmed absence of
+        // the row justifies the orphan path.
+        return true;
+      }
+      if (outcome) return true;
+      logger.warn(
+        {
+          subjectKey: started.subjectKey,
+          runId: started.runId,
+          ownerToken: started.ownerToken,
+          claimState: owner.state,
+        },
+        "dispatch_start_bound_without_run_row",
+      );
     }
   }
   await recordAndCancelOrphanStartedRun(started);


### PR DESCRIPTION
## AIW-249: stop trusting a bound claim as proof the run row landed

Twice on production a scheduled dispatch produced a **phantom run**: the occurrence ledger published `started` with a run id, a live claim in `active_runs` carried that run id (proven, since cancel-by-id found the claim and succeeded), but there was **no `workflow_runs` row for it at all** and the runtime had no trace of it. Both happened on the first schedule dispatch shortly after a production deployment.

### Why this spot

A full static audit could not explain the state. `recordStartedRun` inserts the `workflow_runs` row and binds the claim in a **single statement** (`exact_owner` -> `started_run` insert -> `bound_owner` update, cross joined against the insert's RETURNING), so no insert means no bind. `bindRun` is dead code, `beginCancellation` never sets `run_id`, the handoff and park-restore writers are unreachable for a fresh dispatch, no raw SQL writes `active_runs` outside the adapter, and nothing anywhere deletes `workflow_runs` rows.

That leaves exactly one place in the whole start flow that infers "the row landed" from "the claim is bound" instead of observing the row: the catch branch of `commitHostedStart`. When `commitStartedRun` throws, it re-read the claim and returned success if the claim was bound to this owner and run id. If the row is in fact missing there, the dispatcher reports a successful start, the occurrence records the run id, and the result is exactly the phantom.

### The change

In that catch branch, verify the row before trusting the claim:

1. **row present** -> return true, unchanged behavior;
2. **row positively absent** -> warn `dispatch_start_bound_without_run_row` (with `subjectKey`, `runId`, `ownerToken`, `claimState`) and fall through to the existing orphan path, which records a diagnostic row and cancels the orphaned hosted run;
3. **the lookup itself throws** -> warn `dispatch_start_run_row_check_unconfirmed` and return true.

Case 3 is deliberate and commented in the code: falling through cancels the hosted run, so a transient database read error must never be allowed to kill a healthy run. Only a confirmed absence justifies that.

### Honest scope: this is a detector, not a full remediation

If the branch fires, the run is cancelled and recorded, but the `active_runs` claim is **not** released here, and for the exact production shape (a run id with no runtime trace) `cancelUnownedHostedRun` cannot confirm terminality, so the startup failure is not marked and the inserted row stays `running` with an immediate startup deadline. That is not worse than today (the claim was stuck anyway, with the run invisible), but it means the next occurrence of this bug will be **loud and attributable** rather than fixed automatically. Remediation for a runtime-less run id stays open on AIW-249.

The root cause is still unknown: the code as written cannot produce the state, and the production logs for the two incidents are unreachable (the Vercel MCP log and error tools return 403 for this project, and the CLI only tails live). This change exists so the next occurrence self-reports.

### Safety review

An adversarial review checked five vectors and found no bug in the changed lines:

- the original test that pinned the old behavior landed together with the catch branch itself, and its missing row was a fixture shortcut rather than a deliberate "trust the claim, the row may lag" contract;
- the fall-through cannot kill a healthy run: before commit, `get()` cannot observe `bound` under READ COMMITTED, so the branch is not entered, and the only other production bind path goes through the same statement;
- no read-your-writes risk: the client is a single lazy singleton over one `DATABASE_URL`, so the registry write, the claim read and the row read all hit the same endpoint;
- blast radius across all dispatch paths (ticket, PR, webhook, schedule, approvals, manual) is a cancelled run plus a retry, never a lost trigger.

### Verification

TDD, red first. Two tests failed before the change with the exact production shape (`expected true to be false` for the absent-row case, and the missing `dispatch_start_run_row_check_unconfirmed` signal for the lookup-failure case). The absent-row test drives the real `findRunOutcomeByRunId` against pglite rather than a mock, and the success-path test poisons `getDb()` so any stray lookup would fail the test rather than be swallowed.

`vitest run src/lib/run-start-lifecycle.test.ts src/lib/dispatch.test.ts` -> 35 passed. `pnpm typecheck` -> exit 0. Full suite runs in CI here.
