### PR TITLE
fix(worker): make the post-PR autofix loop able to finish

### DIFF
--- a/apps/worker/src/db/queries/workflow-owned-branches.test.ts
+++ b/apps/worker/src/db/queries/workflow-owned-branches.test.ts
@@ -4,12 +4,62 @@ import { createTestDb } from "../test-db.js";
 import {
   bindWorkflowOwnedPullRequestIntent,
   findWorkflowOwnedPullRequest,
+  findWorkflowOwnedPullRequestIdentity,
   findWorkflowOwnedPullRequestIntent,
   listWorkflowOwnedBranchesForTicket,
+  recordWorkflowOwnedPullRequestPublishedHead,
   upsertWorkflowOwnedBranch,
 } from "./workflow-owned-branches.js";
 
 describe("workflow-owned branch records", () => {
+  it("arms anti-recursion with the head a push is about to create", async () => {
+    const db = await createTestDb();
+    await db.insert(workflowOwnedBranches).values({
+      ticketKey: "AIW-arm",
+      provider: "github",
+      repoPath: "acme/web",
+      branchName: "ai-workflow/aiw-arm",
+      publishedHeadSha: "implementation-head",
+      targetBranch: "main",
+      prId: 41,
+      prUrl: "https://github.com/acme/web/pull/41",
+      prBranchName: "ai-workflow/aiw-arm",
+      prPublishedHeadSha: "implementation-head",
+      prTargetBranch: "main",
+    });
+
+    await expect(
+      recordWorkflowOwnedPullRequestPublishedHead(db, {
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 41,
+        headSha: "autofix-head",
+      }),
+    ).resolves.toBe(true);
+
+    // Suppression reads exactly this field, so the pre-push write is what makes
+    // the workflow's own synchronize event recognisable.
+    await expect(
+      findWorkflowOwnedPullRequestIdentity(db, {
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 41,
+      }),
+    ).resolves.toMatchObject({ publishedHeadSha: "autofix-head" });
+  });
+
+  it("reports no row to arm for a pull request it does not own", async () => {
+    const db = await createTestDb();
+    await expect(
+      recordWorkflowOwnedPullRequestPublishedHead(db, {
+        provider: "github",
+        repoPath: "acme/web",
+        prNumber: 999,
+        headSha: "autofix-head",
+      }),
+    ).resolves.toBe(false);
+  });
+
   it("never lets a legacy null confirmed target authorize a webhook", async () => {
     const db = await createTestDb();
     await db.insert(workflowOwnedBranches).values({

--- a/apps/worker/src/db/queries/workflow-owned-branches.ts
+++ b/apps/worker/src/db/queries/workflow-owned-branches.ts
@@ -146,6 +146,41 @@ export async function findWorkflowOwnedPullRequest(
   };
 }
 
+/**
+ * Records the head a workflow publication is ABOUT to push, before it pushes.
+ *
+ * Anti-recursion recognises our own push by an exact sha match, and the provider
+ * webhook for that push arrives within milliseconds. Writing the sha only after
+ * the push therefore loses the race: the synchronize event reads the previous
+ * head, is accepted as foreign, and supersedes the very run that produced it.
+ * Registering the intended head first closes that window. A sha that never
+ * reaches the remote (a failed push) is harmless: it can only ever match an
+ * event carrying that same sha, which by definition never arrives.
+ */
+export async function recordWorkflowOwnedPullRequestPublishedHead(
+  db: Db,
+  input: {
+    provider: VcsProvider;
+    repoPath: string;
+    prNumber: number;
+    headSha: string;
+  },
+): Promise<boolean> {
+  if (input.headSha.trim().length === 0) return false;
+  const rows = await db
+    .update(workflowOwnedBranches)
+    .set({ prPublishedHeadSha: input.headSha, updatedAt: sql`now()` })
+    .where(
+      and(
+        eq(workflowOwnedBranches.provider, input.provider),
+        eq(workflowOwnedBranches.repoPath, input.repoPath),
+        eq(workflowOwnedBranches.prId, input.prNumber),
+      ),
+    )
+    .returning({ ticketKey: workflowOwnedBranches.ticketKey });
+  return rows.length > 0;
+}
+
 /** Reads ownership by provider PR identity for webhook anti-recursion. The
  * caller compares the event head to publishedHeadSha; this query deliberately
  * does not treat a changed human head as workflow-owned. */

--- a/apps/worker/src/lib/dispatch-trigger.test.ts
+++ b/apps/worker/src/lib/dispatch-trigger.test.ts
@@ -288,10 +288,63 @@ describe("provider trigger dispatch", () => {
       result: "started",
     });
     expect(mockStart.mock.calls[0]?.[1]?.[0]).toMatchObject({
-      subjectKey: "ticket:jira:AIW-1",
+      // Keyed on the pull request, not the ticket: the ticket key still travels
+      // with the run, but it no longer decides who may run.
+      subjectKey: "pr:github:acme/app#7",
       ticketKey: "AIW-1",
       scope: "workflow_owned",
     });
+  });
+
+  it("keys every pull request of one ticket on its own subject", async () => {
+    for (const pr of [
+      { id: 7, repoPath: "acme/app", branch: "feature/owned" },
+      { id: 11, repoPath: "acme/api", branch: "feature/owned" },
+    ]) {
+      await upsertWorkflowOwnedBranch(db, {
+        ticketKey: "AIW-1",
+        provider: "github",
+        repoPath: pr.repoPath,
+        branchName: pr.branch,
+        publishedHeadSha: "abc123",
+        targetBranch: "main",
+        pr: {
+          id: pr.id,
+          url: `https://github.com/${pr.repoPath}/pull/${pr.id}`,
+          branch: pr.branch,
+        },
+      });
+    }
+    mockGetEnabled.mockResolvedValue(enabled({ scope: "workflow_owned" }));
+    const { dispatchTriggerEvent } = await import("./dispatch-trigger.js");
+
+    await dispatchTriggerEvent(event(), deps());
+    await dispatchTriggerEvent(
+      event({
+        delivery: { provider: "github", producer: "alice", deliveryId: "delivery-2" },
+        pr: {
+          provider: "github",
+          repoPath: "acme/api",
+          prNumber: 11,
+          prUrl: "https://github.com/acme/api/pull/11",
+          headRef: "feature/owned",
+          headSha: "abc123",
+          baseRef: "main",
+          title: "Fix",
+          author: "alice",
+          isDraft: false,
+        },
+      }),
+      deps(),
+    );
+
+    // A shared ticket subject let the first pull request claim the key and the
+    // single pending slot overwrite the second, so one repository of a multi-repo
+    // change was never reviewed.
+    expect(mockStart.mock.calls.map((call) => call[1]?.[0]?.subjectKey)).toEqual([
+      "pr:github:acme/app#7",
+      "pr:github:acme/api#11",
+    ]);
   });
 
   it("returns the durable winner for a provider retry without starting twice", async () => {

--- a/apps/worker/src/lib/dispatch-trigger.ts
+++ b/apps/worker/src/lib/dispatch-trigger.ts
@@ -24,7 +24,7 @@ import { claimSubjectRun } from "./dispatch.js";
 import { recordIngestionFailure } from "./ingestion-diagnostic.js";
 import { logger } from "./logger.js";
 import { isRepoAllowedForScope } from "./repo-allowlist.js";
-import { prSubjectKey, ticketSubjectKey } from "./subject-key.js";
+import { prSubjectKey } from "./subject-key.js";
 import {
   acceptTriggerDelivery,
   coalescePendingTrigger,
@@ -617,7 +617,7 @@ async function resolveSubjectIdentity(
     baseBranch: event.pr.baseRef,
   });
   if (correlation) {
-    return resolveTicketIdentity(correlation.ticketKey, "resolved", deps);
+    return resolveTicketIdentity(correlation.ticketKey, "resolved", deps, event);
   }
 
   const intent = await findWorkflowOwnedPullRequestIntent(deps.db, {
@@ -629,7 +629,7 @@ async function resolveSubjectIdentity(
   });
   if (!intent) return { status: "ignored" };
   if (event.triggerType !== "trigger_pr_created") {
-    return resolveTicketIdentity(intent.ticketKey, "pending_correlation", deps);
+    return resolveTicketIdentity(intent.ticketKey, "pending_correlation", deps, event);
   }
 
   const bound = await bindWorkflowOwnedPullRequestIntent(deps.db, {
@@ -642,7 +642,7 @@ async function resolveSubjectIdentity(
     prNumber: event.pr.prNumber,
     prUrl: event.pr.prUrl,
   });
-  if (bound) return resolveTicketIdentity(bound.ticketKey, "resolved", deps);
+  if (bound) return resolveTicketIdentity(bound.ticketKey, "resolved", deps, event);
 
   // The CAS can lose to publication correlation or a newer intent between
   // lookup and bind. Re-read exact state; never dispatch from the stale
@@ -655,7 +655,7 @@ async function resolveSubjectIdentity(
     publishedHeadSha: event.pr.headSha,
     baseBranch: event.pr.baseRef,
   });
-  if (concurrent) return resolveTicketIdentity(concurrent.ticketKey, "resolved", deps);
+  if (concurrent) return resolveTicketIdentity(concurrent.ticketKey, "resolved", deps, event);
   const stillPending = await findWorkflowOwnedPullRequestIntent(deps.db, {
     provider: event.pr.provider,
     repoPath: event.pr.repoPath,
@@ -664,13 +664,24 @@ async function resolveSubjectIdentity(
     baseBranch: event.pr.baseRef,
   });
   if (!stillPending) return { status: "ignored" };
-  return resolveTicketIdentity(stillPending.ticketKey, "pending_correlation", deps);
+  return resolveTicketIdentity(stillPending.ticketKey, "pending_correlation", deps, event);
 }
 
+/**
+ * Confirms the ticket a workflow-owned pull request belongs to, and keys the run
+ * on the PULL REQUEST rather than that ticket.
+ *
+ * A ticket subject collapses every pull request of a multi-repo change onto one
+ * key. Only the first event could then claim it, and the single pending slot that
+ * key allows overwrote the rest, so the second repository's pull request was
+ * never reviewed at all. The ticket key still travels with the run, so ticket
+ * context and reconciliation are unchanged; only the concurrency identity moves.
+ */
 async function resolveTicketIdentity(
   ticketKey: string,
   status: "resolved" | "pending_correlation",
   deps: DispatchTriggerDeps,
+  event: Pick<TriggerEvent, "pr">,
 ): Promise<
   | {
       status: "resolved" | "pending_correlation";
@@ -688,7 +699,11 @@ async function resolveTicketIdentity(
     }
     return {
       status,
-      subjectKey: ticketSubjectKey("jira", ticketKey),
+      subjectKey: prSubjectKey(
+        event.pr.provider,
+        event.pr.repoPath,
+        event.pr.prNumber,
+      ),
       ticketKey,
     };
   } catch (error) {

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -602,6 +602,38 @@ describe("reconcileRuns owner-CAS recovery", () => {
     );
   });
 
+  it("retries a closing pull request claim on its own subject, not its ticket", async () => {
+    const closing = entry({
+      subjectKey: "pr:github:acme/app#9",
+      ticketKey: "PROJ-1",
+      kind: "pr_trigger",
+      state: "cancelling",
+    });
+    const runRegistry = registry([closing]);
+    const tracker = issueTracker("AI");
+    mockCancelSubjectRunDetailed.mockResolvedValue({ cancelled: true, released: true });
+    const onReleased = vi.fn();
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(
+        new Set(["PROJ-1"]),
+        runRegistry,
+        tracker,
+        undefined,
+        onReleased,
+      ),
+    ).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockCancelSubjectRunDetailed).toHaveBeenCalledWith(
+      "pr:github:acme/app#9",
+      { ownerToken: "owner-a", runId: "run-1" },
+      runRegistry,
+      onReleased,
+      "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
+    );
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
+  });
+
   it("passes owner-gated drain through cancellation for a ticket that left AI", async () => {
     const bound = entry();
     const runRegistry = registry([bound]);

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -19,6 +19,7 @@ import type {
 import type { Db } from "../db/client.js";
 import { confirmWorkflowStepsDrained } from "./workflow-step-drain.js";
 import { reconcileStartupWatchdog } from "./run-start-lifecycle.js";
+import { ticketSubjectKey } from "./subject-key.js";
 
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 const STALE_RESERVATION_MS = 5 * 60 * 1000;
@@ -275,7 +276,14 @@ async function retryCancellingClaim(
   const reason = entry.runId
     ? "Orphaned run cancelled by reconciler: ticket no longer in the AI column"
     : "In-flight claim cancelled by reconciler: ticket left the AI column before a run was bound";
-  if (!entry.ticketKey) {
+  // Cancel the subject this claim actually holds. Deriving one from the ticket
+  // key was the same string while every run was ticket-keyed; a pull request run
+  // carries a ticket key but claims a pull request subject, and cancelling the
+  // ticket subject would cancel nothing and leave the claim closing forever.
+  if (
+    !entry.ticketKey ||
+    entry.subjectKey !== ticketSubjectKey("jira", entry.ticketKey)
+  ) {
     return cancelSubjectRunDetailed(
       entry.subjectKey,
       target,

--- a/apps/worker/src/lib/trigger-events.test.ts
+++ b/apps/worker/src/lib/trigger-events.test.ts
@@ -143,6 +143,23 @@ describe("normalizeGitHubEvent", () => {
     ).toBeNull();
   });
 
+  it("suppresses a bot synchronize whose recorded SHA lags the pushed head", () => {
+    // The autofix push registers its head before pushing, but a registration
+    // that never landed used to disable the identity fallback outright and the
+    // workflow's own push superseded the run that made it.
+    expect(
+      normalizeGitHubEvent(
+        "pull_request",
+        { action: "synchronize", repository: githubRepo(), pull_request: githubPr() },
+        {
+          ...options,
+          workflowOwnedPullRequest: true,
+          workflowPublishedHeadSha: "an-older-head",
+        },
+      ),
+    ).toBeNull();
+  });
+
   it("does not suppress a human synchronize when the head differs", () => {
     expect(
       normalizeGitHubEvent(

--- a/apps/worker/src/lib/trigger-events.ts
+++ b/apps/worker/src/lib/trigger-events.ts
@@ -92,12 +92,16 @@ export function normalizeGitHubEvent(
         typeof options.workflowPublishedHeadSha === "string" &&
         options.workflowPublishedHeadSha.length > 0 &&
         mapped.headSha === options.workflowPublishedHeadSha;
-      const legacyWorkflowPush =
+      // Identity is a backstop for the sha match, not an alternative to it: a
+      // recorded sha that lags the event (a push whose registration never
+      // landed, or a run from before registration existed) used to disable this
+      // branch outright, which left the workflow's own push looking foreign and
+      // superseding the run that made it.
+      const botIdentityPush =
         options.workflowOwnedPullRequest === true &&
         !workflowPublishedPush &&
-        !options.workflowPublishedHeadSha &&
         vcsLoginsMatch(body?.sender?.login ?? pr.user?.login, options.botLogin);
-      if (workflowPublishedPush || legacyWorkflowPush) return null;
+      if (workflowPublishedPush || botIdentityPush) return null;
       return {
         delivery: githubDelivery(options.deliveryId, body?.sender?.login ?? pr.user?.login),
         triggerType: "trigger_pr_updated",
@@ -347,12 +351,13 @@ export function normalizeGitLabEvent(
           typeof options.workflowPublishedHeadSha === "string" &&
           options.workflowPublishedHeadSha.length > 0 &&
           mapped.headSha === options.workflowPublishedHeadSha;
-        const legacyWorkflowPush =
+        // Same backstop as the GitHub path: identity supplements the sha match
+        // instead of being disabled by a stale recorded sha.
+        const botIdentityPush =
           options.workflowOwnedPullRequest === true &&
           !workflowPublishedPush &&
-          !options.workflowPublishedHeadSha &&
           vcsLoginsMatch(producer, options.botUsername);
-        if (workflowPublishedPush || legacyWorkflowPush) return null;
+        if (workflowPublishedPush || botIdentityPush) return null;
         return {
           delivery: gitLabDelivery(options.deliveryId, producer),
           triggerType: "trigger_pr_updated",

--- a/apps/worker/src/lib/workflow-push-suppression.ts
+++ b/apps/worker/src/lib/workflow-push-suppression.ts
@@ -14,11 +14,14 @@ export function isWorkflowGeneratedPush(input: {
   const exactPublishedHead =
     Boolean(input.workflowPublishedHeadSha) &&
     input.currentHeadSha === input.workflowPublishedHeadSha;
-  const legacyBotPush =
+  // Identity backstops the sha match instead of being disabled by a recorded sha
+  // that lags the event, which is what let the workflow's own push read as
+  // foreign and supersede the run that produced it.
+  const botIdentityPush =
     input.workflowOwnedPullRequest === true &&
-    !input.workflowPublishedHeadSha &&
+    !exactPublishedHead &&
     vcsLoginsMatch(input.producer, input.botIdentity);
-  return exactPublishedHead || legacyBotPush;
+  return exactPublishedHead || botIdentityPush;
 }
 
 export async function workflowPushNormalizationOptions(input: {

--- a/apps/worker/src/manual-dispatch/resolve.test.ts
+++ b/apps/worker/src/manual-dispatch/resolve.test.ts
@@ -357,4 +357,23 @@ describe("manual dispatch against a definition repository pin", () => {
       }),
     ).resolves.toMatchObject({ ticketKey: "AIW-1" });
   });
+
+  it("reserves a workflow-owned pull request on the pull request, not its ticket", async () => {
+    mocks.getDeployedWorkflowDefinitionVersion.mockResolvedValue(
+      deployed("workflow_owned", {}),
+    );
+
+    await expect(
+      resolveManualDispatch({
+        db: definitionDb,
+        issueTracker,
+        definitionId: 5,
+        triggerNodeId: "trigger",
+        dispatchInput: { kind: "pull_request", url: pr.prUrl },
+      }),
+    ).resolves.toMatchObject({
+      subjectKey: "pr:github:acme/api#42",
+      ticketKey: "AIW-1",
+    });
+  });
 });

--- a/apps/worker/src/manual-dispatch/resolve.ts
+++ b/apps/worker/src/manual-dispatch/resolve.ts
@@ -366,11 +366,13 @@ async function resolvePullRequestDispatch(
     );
   }
 
-  let subjectKey: string;
+  // Both scopes reserve the pull request itself. A ticket subject collapsed every
+  // pull request of a multi-repo change onto one key, and now that webhook
+  // dispatch keys on the pull request, a ticket subject here would also stop a
+  // manual run from deduplicating against the automatic run of the same PR.
+  const subjectKey = prSubjectKey(pr.provider, pr.repoPath, pr.prNumber);
   let ticketKey: string | null = null;
-  if (scope === "any") {
-    subjectKey = prSubjectKey(pr.provider, pr.repoPath, pr.prNumber);
-  } else {
+  if (scope !== "any") {
     const owned = await findWorkflowOwnedPullRequest(input.db, {
       provider: pr.provider,
       repoPath: pr.repoPath,
@@ -402,7 +404,6 @@ async function resolvePullRequestDispatch(
         "The linked Jira ticket has a pending or approved workflow plan.",
       );
     }
-    subjectKey = ticketSubjectKey("jira", ticketKey);
   }
 
   return {

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
@@ -217,8 +217,16 @@ describe("trusted workspace publisher", () => {
     expect(mocks.createSandbox).not.toHaveBeenCalled();
   });
 
-  it("fails when the remote branch changed after workspace preparation", async () => {
+  it("fails when the remote branch moved to a head this workspace does not contain", async () => {
     mocks.getBranchSha.mockReset().mockResolvedValue("foreign-head");
+    mocks.sourceCommand.mockImplementation(async (_name: string, args: string[]) => {
+      if (args.includes("rev-parse")) return command("after");
+      // A foreign write is not reachable from the workspace HEAD.
+      if (args.includes("--is-ancestor") && args.includes("foreign-head")) {
+        return command("", "", 1);
+      }
+      return command();
+    });
     const result = await publishTrustedWorkspaceFromSandbox({
       sourceSandboxId: "source-sandbox",
       workspaceManifest: manifest,
@@ -227,6 +235,39 @@ describe("trusted workspace publisher", () => {
 
     expect(result.repositories[0]).toMatchObject({ failureKind: "remote_drift" });
     expect(mocks.createSandbox).not.toHaveBeenCalled();
+  });
+
+  it("leases the current remote head when this workspace already published it", async () => {
+    // A review loop that fixes twice pushes twice from one workspace: the second
+    // push sees a branch this workspace itself moved, which is not drift.
+    mocks.getBranchSha
+      .mockReset()
+      .mockResolvedValueOnce("moved-head")
+      .mockResolvedValue("after");
+    mocks.publisherCommand.mockImplementation(async (_name: string, args: string[]) => {
+      if (args.includes("rev-parse") && args.at(-1) === "HEAD") {
+        return command("moved-head");
+      }
+      if (args.includes("rev-parse") && args.at(-1) === "FETCH_HEAD") {
+        return command("after");
+      }
+      return command();
+    });
+
+    const result = await publishTrustedWorkspaceFromSandbox({
+      sourceSandboxId: "source-sandbox",
+      workspaceManifest: manifest,
+      ...owner,
+    });
+
+    expect(result.repositories[0]).toMatchObject({ pushed: true, pushedHead: "after" });
+    expect(mocks.publisherCommand).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining([
+        "push",
+        "--force-with-lease=refs/heads/blazebot/AIW-100:moved-head",
+      ]),
+    );
   });
 
   it("rides out a 404 on the ref read that verifies the push", async () => {

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.ts
@@ -40,6 +40,12 @@ export interface TrustedWorkspacePushResult {
 
 interface PreparedRepository {
   repo: WorkspaceRepo;
+  /**
+   * The remote sha this publication leases. It is the workspace's recorded
+   * baseline until a push from this same workspace has already moved the branch
+   * forward, in which case it is the current remote head.
+   */
+  leaseSha: string;
   result: TrustedWorkspacePushRepositoryResult;
   bundlePath?: string;
   bundle?: Buffer;
@@ -89,7 +95,12 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
     } as const;
     const fail = (
       result: Omit<TrustedWorkspacePushRepositoryResult, keyof typeof base>,
-    ) => prepared.push({ repo, result: { ...base, ...result } });
+    ) =>
+      prepared.push({
+        repo,
+        leaseSha: repo.expectedRemoteSha ?? "",
+        result: { ...base, ...result },
+      });
 
     if (workspaceRepositoryAccess(input.workspaceManifest, repo) === "read") {
       const researchBaseSha = (repo as WorkspaceRepoV2).researchBaseSha;
@@ -143,6 +154,7 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
       } else {
         prepared.push({
           repo,
+          leaseSha: researchBaseSha,
           result: {
             ...base,
             changed: false,
@@ -263,23 +275,44 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
 
     const providerHead = await readBranchShaAfterWrite(runtime.vcs, repo.branchName);
     const changed = targetHead !== repo.preAgentSha;
+    // A review loop that fixes twice publishes twice from ONE workspace: the
+    // first push moves the branch past the sha this workspace recorded, so the
+    // recorded baseline is stale by construction and every later round would
+    // read as drift. Advancing the lease to the current remote head is safe only
+    // while this workspace already contains that head, which is exactly what an
+    // ancestor check proves. A foreign write is not contained and still fails.
+    let leaseSha = repo.expectedRemoteSha!;
     if (providerHead !== repo.expectedRemoteSha && providerHead !== targetHead) {
-      fail({
-        changed,
-        expectedHead: providerHead,
-        targetHead,
-        failureKind: "remote_drift",
-        error: `remote branch moved from ${repo.expectedRemoteSha} to ${providerHead}`,
-      });
-      continue;
+      const contained = providerHead
+        ? await source.runCommand("git", [
+            "-C",
+            repo.localPath,
+            "merge-base",
+            "--is-ancestor",
+            providerHead,
+            targetHead,
+          ])
+        : null;
+      if (!contained || contained.exitCode !== 0) {
+        fail({
+          changed,
+          expectedHead: providerHead,
+          targetHead,
+          failureKind: "remote_drift",
+          error: `remote branch moved from ${repo.expectedRemoteSha} to ${providerHead}`,
+        });
+        continue;
+      }
+      leaseSha = providerHead;
     }
 
     prepared.push({
       repo,
+      leaseSha,
       result: {
         ...base,
         changed,
-        expectedHead: repo.expectedRemoteSha,
+        expectedHead: leaseSha,
         targetHead,
         pushed: changed && providerHead === targetHead,
         ...(changed && providerHead === targetHead ? { pushedHead: targetHead } : {}),
@@ -302,7 +335,7 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
       "create",
       bundlePath,
       "HEAD",
-      `^${item.repo.expectedRemoteSha}`,
+      `^${item.leaseSha}`,
     ]);
     if (bundle.exitCode !== 0) {
       failPrepared(item, `git bundle failed: ${await commandError(bundle)}`, "preflight_failed");
@@ -369,10 +402,10 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
       }
       const clonedHead = await publisher.runCommand("git", ["-C", checkoutPath, "rev-parse", "HEAD"]);
       const clonedSha = clonedHead.exitCode === 0 ? (await clonedHead.stdout()).trim() : "";
-      if (clonedSha !== item.repo.expectedRemoteSha) {
+      if (clonedSha !== item.leaseSha) {
         failPrepared(
           item,
-          `publisher clone head is ${clonedSha || "unreadable"}, expected ${item.repo.expectedRemoteSha}`,
+          `publisher clone head is ${clonedSha || "unreadable"}, expected ${item.leaseSha}`,
           "remote_drift",
         );
         continue;
@@ -478,7 +511,7 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
         item.checkoutPath!,
         ...item.authArgs!,
         "push",
-        `--force-with-lease=refs/heads/${item.repo.branchName}:${item.repo.expectedRemoteSha}`,
+        `--force-with-lease=refs/heads/${item.repo.branchName}:${item.leaseSha}`,
         item.cloneUrl!,
         `HEAD:refs/heads/${item.repo.branchName}`,
       ]);

--- a/apps/worker/src/workflow-definition/revisions-lifecycle.integration.test.ts
+++ b/apps/worker/src/workflow-definition/revisions-lifecycle.integration.test.ts
@@ -264,7 +264,7 @@ describe("revised Workflows lifecycle", () => {
     const firstRunInput = state.startWorkflow.mock.calls[0]![1] as AgentWorkflowInput[];
     const dispatchedEntry = firstRunInput[0]!;
     expect(dispatchedEntry).toMatchObject({
-      subjectKey: "ticket:jira:AIW-103",
+      subjectKey: "pr:github:acme/app#103",
       definitionId: 1,
       definitionVersion: 1,
     });

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   publishTrustedWorkspaceFromSandbox: vi.fn(),
   findWorkflowOwnedPullRequestIdentity: vi.fn(),
   upsertWorkflowOwnedBranch: vi.fn(),
+  recordWorkflowOwnedPullRequestPublishedHead: vi.fn(),
 }));
 
 vi.mock("workflow", async (importOriginal) => ({
@@ -89,6 +90,8 @@ vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
     mocks.findWorkflowOwnedPullRequestIdentity(...args),
   upsertWorkflowOwnedBranch: (...args: any[]) =>
     mocks.upsertWorkflowOwnedBranch(...args),
+  recordWorkflowOwnedPullRequestPublishedHead: (...args: any[]) =>
+    mocks.recordWorkflowOwnedPullRequestPublishedHead(...args),
 }));
 
 import {
@@ -112,6 +115,39 @@ const usage = {
   duration_api_ms: 10,
   num_turns: 1,
 };
+
+/** A pr_trigger run whose workspace can publish a fix back to the reviewed PR. */
+function prFixCtx(pr: ReturnType<typeof makePrPayload>) {
+  return makeCtx({
+    entry: {
+      kind: "pr_trigger",
+      triggerType: "trigger_pr_updated",
+      subjectKey: "ticket:jira:AWT-1",
+      ticketKey: "AWT-1",
+      ownerToken: "owner:test",
+      definitionId: 1,
+      definitionVersion: 1,
+      scope: "workflow_owned",
+      pr,
+    },
+    repositoryScope: { repositories: [{ provider: "github", repoPath: "acme/api" }] },
+    workspaceManifest: {
+      version: 2,
+      repositories: [
+        {
+          provider: "github",
+          repoPath: "acme/api",
+          slug: "acme__api",
+          localPath: "/vercel/sandbox",
+          defaultBranch: "main",
+          branchName: pr.headRef,
+          selectedRationale: "PR fix",
+          access: "write",
+        },
+      ],
+    },
+  });
+}
 
 function pathsFor(phase: string) {
   return {
@@ -196,6 +232,7 @@ describe("fix_agent execute", () => {
     });
     mocks.findWorkflowOwnedPullRequestIdentity.mockResolvedValue(undefined);
     mocks.upsertWorkflowOwnedBranch.mockResolvedValue(undefined);
+    mocks.recordWorkflowOwnedPullRequestPublishedHead.mockResolvedValue(true);
   });
 
   it("passes only serializable data across the fix publication step boundary", () => {
@@ -245,6 +282,53 @@ describe("fix_agent execute", () => {
     });
     expect(input).not.toHaveProperty("ctx");
     expect(() => structuredClone(input)).not.toThrow();
+  });
+
+  it("carries the head the push will create so anti-recursion can be armed first", () => {
+    const pr = makePrPayload();
+    const ctx = prFixCtx(pr);
+
+    const input = buildPrFixPublicationInput(ctx, "sbx-1", {
+      commits: [
+        { provider: "github", repoPath: "acme/api", sha: "earlier123" },
+        { provider: "github", repoPath: "acme/other", sha: "sibling999" },
+        { provider: "github", repoPath: "acme/api", sha: "fix123" },
+      ],
+      unresolvedConflicts: [],
+    });
+
+    expect(input?.intendedHead).toBe("fix123");
+    expect(() => structuredClone(input)).not.toThrow();
+  });
+
+  it("registers the intended head before pushing it", async () => {
+    mocks.parseAgentOutput.mockReturnValue({ result: "implemented", summary: "patched" });
+    mocks.inspectFixWorkspace
+      .mockResolvedValueOnce({ commits: [], unresolvedConflicts: [] })
+      .mockResolvedValueOnce({
+        commits: [{ provider: "github", repoPath: "acme/api", sha: "fix123" }],
+        unresolvedConflicts: [],
+      });
+
+    const pr = makePrPayload();
+    await execute(makeNode("fix_agent"), {}, prFixCtx(pr));
+
+    expect(mocks.recordWorkflowOwnedPullRequestPublishedHead).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        provider: pr.provider,
+        repoPath: pr.repoPath,
+        prNumber: pr.prNumber,
+        headSha: "fix123",
+      },
+    );
+    // Order is the whole point: the provider webhook for this push arrives
+    // before a post-push write would land, and an unrecognised push supersedes
+    // the run that made it.
+    const registered =
+      mocks.recordWorkflowOwnedPullRequestPublishedHead.mock.invocationCallOrder[0];
+    const published = mocks.publishTrustedWorkspaceFromSandbox.mock.invocationCallOrder[0];
+    expect(registered).toBeLessThan(published);
   });
 
   it("implicitly ensures a workspace when none is attached", async () => {

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -132,15 +132,27 @@ type PrFixPublicationInput = {
   runId: string;
   repositoryScope?: WorkflowRepositoryScope;
   pr: PrTriggerPayload;
+  /** Head this publication will create, registered before the push so the
+   *  provider's own synchronize event is recognised as ours. */
+  intendedHead?: string;
 };
 
 export function buildPrFixPublicationInput(
   ctx: Parameters<BlockExecuteFn>[2],
   sandboxId: string,
+  workspace?: FixWorkspaceState,
 ): PrFixPublicationInput | null {
   if (ctx.workspaceManifest?.version !== 2 || ctx.entry.kind !== "pr_trigger") {
     return null;
   }
+  const pr = ctx.entry.pr;
+  // The last commit this workspace holds for the reviewed repository is the head
+  // the push will create, so anti-recursion can be armed before pushing.
+  const intendedHead = workspace?.commits
+    .filter(
+      (commit) => commit.provider === pr.provider && commit.repoPath === pr.repoPath,
+    )
+    .at(-1)?.sha;
   return {
     sandboxId,
     workspaceManifest: ctx.workspaceManifest,
@@ -148,12 +160,25 @@ export function buildPrFixPublicationInput(
     ownerToken: ctx.entry.ownerToken,
     runId: ctx.runId,
     repositoryScope: ctx.repositoryScope,
-    pr: ctx.entry.pr,
+    pr,
+    ...(intendedHead ? { intendedHead } : {}),
   };
 }
 
 async function publishPrFixStep(input: PrFixPublicationInput): Promise<void> {
   "use step";
+  if (input.intendedHead) {
+    const { getDb } = await import("../../db/client.js");
+    const { recordWorkflowOwnedPullRequestPublishedHead } = await import(
+      "../../db/queries/workflow-owned-branches.js"
+    );
+    await recordWorkflowOwnedPullRequestPublishedHead(getDb(), {
+      provider: input.pr.provider,
+      repoPath: input.pr.repoPath,
+      prNumber: input.pr.prNumber,
+      headSha: input.intendedHead,
+    });
+  }
   const { publishTrustedWorkspaceFromSandbox } = await import(
     "../../sandbox/trusted-workspace-publisher.js",
   );
@@ -657,7 +682,7 @@ export const execute: BlockExecuteFn = async (
       };
     }
     if (output.result === "implemented") {
-      const publicationInput = buildPrFixPublicationInput(ctx, sandboxId);
+      const publicationInput = buildPrFixPublicationInput(ctx, sandboxId, after);
       if (publicationInput) await publishPrFixStep(publicationInput);
     }
     return {

--- a/apps/worker/src/workflows/blocks/post-pr-review.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-review.test.ts
@@ -49,7 +49,7 @@ describe("reviewPrAtWorkflowPublishedHead", () => {
   it("reviews the exact head published by the active ticket workflow", () => {
     expect(
       reviewPrAtWorkflowPublishedHead({
-        subjectKey: "ticket:jira:AWP-26",
+        subjectKey: "pr:github:acme/app#318",
         pr,
         owned,
       }).headSha,
@@ -57,7 +57,8 @@ describe("reviewPrAtWorkflowPublishedHead", () => {
   });
 
   it.each([
-    ["another ticket owns the run", { subjectKey: "ticket:jira:AWP-27" }],
+    ["another pull request owns the run", { subjectKey: "pr:github:acme/app#319" }],
+    ["the ticket subject owns the run", { subjectKey: "ticket:jira:AWP-26" }],
     ["the repository differs", { owned: { ...owned, repoPath: "acme/api" } }],
     ["the pull request differs", { owned: { ...owned, pr: { ...owned.pr!, id: 319 } } }],
     ["the branch differs", { owned: { ...owned, branchName: "other" } }],
@@ -66,7 +67,7 @@ describe("reviewPrAtWorkflowPublishedHead", () => {
   ])("keeps the trigger head when %s", (_name, overrides) => {
     expect(
       reviewPrAtWorkflowPublishedHead({
-        subjectKey: "ticket:jira:AWP-26",
+        subjectKey: "pr:github:acme/app#318",
         pr,
         owned,
         ...overrides,
@@ -90,7 +91,7 @@ describe("postPrReviewStep", () => {
   it("publishes the final review against the head pushed by its fix loop", async () => {
     const result = await postPrReviewStep({
       owner: {
-        subjectKey: "ticket:jira:AWP-26",
+        subjectKey: "pr:github:acme/app#318",
         ownerToken: "owner:autofix",
         runId: "run-autofix",
       },

--- a/apps/worker/src/workflows/blocks/post-pr-review.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-review.ts
@@ -5,7 +5,7 @@ import {
 import type { PrTriggerPayload } from "../agent-input.js";
 import type { ReviewResult } from "@shared/contracts";
 import type { WorkflowOwnedBranchRecord } from "../../db/queries/workflow-owned-branches.js";
-import { ticketSubjectKey } from "../../lib/subject-key.js";
+import { prSubjectKey } from "../../lib/subject-key.js";
 import {
   executionError,
   type BlockExecuteFn,
@@ -18,10 +18,15 @@ export function reviewPrAtWorkflowPublishedHead(args: {
   owned: WorkflowOwnedBranchRecord | null;
 }): PrTriggerPayload {
   const { owned, pr } = args;
+  // The run proves it owns this publication through its own subject. That subject
+  // is the pull request, not the ticket: one ticket can own a pull request per
+  // repository, so a ticket subject would have let the sibling's run retarget to
+  // this pull request's published head.
   if (
     !owned?.publishedHeadSha ||
     !owned.pr ||
-    args.subjectKey !== ticketSubjectKey("jira", owned.ticketKey) ||
+    args.subjectKey !==
+      prSubjectKey(owned.provider, owned.repoPath, owned.pr.id) ||
     owned.provider !== pr.provider ||
     owned.repoPath !== pr.repoPath ||
     owned.pr.id !== pr.prNumber ||

--- a/apps/worker/src/workflows/pr-external-resources.test.ts
+++ b/apps/worker/src/workflows/pr-external-resources.test.ts
@@ -82,6 +82,49 @@ describe("PR review diff placement", () => {
     ).toContain("[acme/api @ api-sha](https://github.com/acme/api/pull/13)");
   });
 
+  it("reads a repository the reviewer spelled in another case as the same repository", () => {
+    const result: ReviewResult = {
+      decision: "request_changes",
+      findings: [
+        {
+          repo: "acme/web",
+          file: "src/index.ts",
+          description: "The reviewed repository, spelled by the agent.",
+          severity: "Blocker",
+          startLine: 2,
+          endLine: 2,
+        },
+        {
+          repo: "ACME/API",
+          file: "src/api.ts",
+          description: "The sibling, spelled by the agent.",
+          severity: "High",
+        },
+      ],
+    };
+    const siblings = new Map([
+      ["acme/api", { url: "https://github.com/acme/api/pull/13", headSha: "api-sha" }],
+    ]);
+    const partition = partitionReviewFindings(
+      [result],
+      [{ path: "src/index.ts", additions: 1, deletions: 0, changeType: "modified", patch: "@@ -1,2 +1,2 @@\n same\n+changed" }],
+      { currentRepository: "Acme/Web", siblingRepositories: siblings },
+    );
+
+    expect(partition.comments).toHaveLength(1);
+    expect(partition.placed[0]).not.toHaveProperty("crossRepository");
+    expect(partition.fallback[0]).toMatchObject({
+      repo: "ACME/API",
+      crossRepository: true,
+    });
+    expect(
+      reviewSummary([result], partition.fallback, [], {
+        reportedCount: 2,
+        distinctCount: 2,
+      }, siblings),
+    ).toContain("[ACME/API @ api-sha](https://github.com/acme/api/pull/13)");
+  });
+
   it("places only complete safe ranges inline and falls back otherwise", () => {
     const results: ReviewResult[] = [
       {

--- a/apps/worker/src/workflows/pr-external-resources.ts
+++ b/apps/worker/src/workflows/pr-external-resources.ts
@@ -593,6 +593,14 @@ function changedNewSidePositions(
  * than to each reviewer separately. Nothing is dropped: a defect that loses its
  * inline slot is listed in the summary with a visible count.
  */
+/** Two forge paths naming one repository, compared the way the forge does. */
+function sameRepository(
+  left: string,
+  right: string | undefined,
+): boolean {
+  return right !== undefined && left.toLowerCase() === right.toLowerCase();
+}
+
 export function partitionReviewFindings(
   results: ReviewResult[],
   files: PRFile[],
@@ -629,10 +637,16 @@ export function partitionReviewFindings(
   const candidates: ReviewFindingCandidate[] = [];
   for (const [reviewerIndex, result] of results.entries()) {
     for (const [findingIndex, finding] of result.findings.entries()) {
+      // Forge paths are case-insensitive, and this one is agent-authored: a
+      // reviewer that spelled the reviewed repository `blazity/app` where the
+      // run carries `Blazity/app` used to read as another repository, which
+      // silently stripped the finding's inline anchor and dropped it into the
+      // summary. Publication takes review results unnormalized, so the
+      // comparison itself has to tolerate the spelling.
       const crossRepository =
         typeof finding.repo === "string" &&
         finding.repo.length > 0 &&
-        finding.repo !== options.currentRepository;
+        !sameRepository(finding.repo, options.currentRepository);
       const path = normalizedPath(finding.file, fileLines);
       const start = finding.startLine;
       const end = finding.endLine ?? start;
@@ -652,8 +666,10 @@ export function partitionReviewFindings(
         findingIndex,
         finding,
         // The normalized path groups `a/x.ts` with `x.ts`; the raw file is the
-        // fallback so an unresolvable path still only ever matches itself.
-        groupKey: `${finding.repo ?? options.currentRepository ?? ""}:${path ?? finding.file.trim()}`,
+        // fallback so an unresolvable path still only ever matches itself. The
+        // repository is folded to one case so two reviewers reporting the same
+        // file still merge when they spelled the repository differently.
+        groupKey: `${(finding.repo ?? options.currentRepository ?? "").toLowerCase()}:${path ?? finding.file.trim()}`,
         anchor: crossRepository
           ? null
           : locatable
@@ -782,6 +798,23 @@ function rangeContainsOnlyChangedSideLines(
  * an unindented blank line closes a markdown list, so the note would detach into
  * its own paragraph and every finding after it would open a fresh list.
  */
+/**
+ * The sibling a finding names, matched the way the forge matches paths. The map
+ * keeps the canonical spelling because the summary prints its keys; only the
+ * lookup tolerates the spelling an agent chose, so a link is not lost to casing.
+ */
+function findSiblingRepository(
+  siblingRepositories: ReadonlyMap<string, { url: string; headSha?: string }> | undefined,
+  repo: string,
+): { url: string; headSha?: string } | undefined {
+  const direct = siblingRepositories?.get(repo);
+  if (direct || !siblingRepositories) return direct;
+  for (const [candidate, sibling] of siblingRepositories) {
+    if (sameRepository(candidate, repo)) return sibling;
+  }
+  return undefined;
+}
+
 function reviewSummaryLine(
   finding: MergedReviewFinding,
   reviewerCount: number,
@@ -791,7 +824,7 @@ function reviewSummaryLine(
     ? `${finding.file}:${finding.startLine}${finding.endLine && finding.endLine !== finding.startLine ? `-${finding.endLine}` : ""}`
     : finding.file;
   const sibling = finding.crossRepository && finding.repo
-    ? siblingRepositories?.get(finding.repo)
+    ? findSiblingRepository(siblingRepositories, finding.repo)
     : undefined;
   const attribution = finding.crossRepository && finding.repo
     ? ` [${finding.repo}${sibling?.headSha ? ` @ ${sibling.headSha}` : ""}]${sibling?.url ? `(${sibling.url})` : ""}`

--- a/apps/worker/src/workflows/review-results.test.ts
+++ b/apps/worker/src/workflows/review-results.test.ts
@@ -117,6 +117,42 @@ describe("normalizeReviewResultsInput", () => {
     });
   });
 
+  it("accepts a repository the agent spelled in another case, in the run's own spelling", () => {
+    expect(
+      normalizeReviewResultsInput(
+        [
+          {
+            decision: "request_changes",
+            findings: [
+              {
+                file: "src/api.ts",
+                description: "The endpoint differs.",
+                severity: "High",
+                repo: "blazity/ai-workflow-prod",
+              },
+            ],
+          },
+        ],
+        { knownRepositories: ["Blazity/ai-workflow-demo", "Blazity/ai-workflow-prod"] },
+      ),
+    ).toEqual({
+      ok: true,
+      value: [
+        {
+          decision: "request_changes",
+          findings: [
+            {
+              file: "src/api.ts",
+              description: "The endpoint differs.",
+              severity: "High",
+              repo: "Blazity/ai-workflow-prod",
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it("classifies a recognized sibling finding without changing old findings", () => {
     expect(
       isCrossRepositoryFinding(

--- a/apps/worker/src/workflows/review-results.ts
+++ b/apps/worker/src/workflows/review-results.ts
@@ -14,6 +14,20 @@ export interface ReviewResultsNormalizationOptions {
   knownRepositories?: readonly string[];
 }
 
+/**
+ * Resolve an agent-authored repository path against the run's selected
+ * repositories, and answer with the selected repository's own spelling.
+ *
+ * The match is case-insensitive because a forge path is: the value is prose an
+ * agent copied from a ticket, and tickets spell `blazity/ai-workflow-prod` where
+ * the run carries `Blazity/ai-workflow-prod`. An exact comparison read that as
+ * an unknown repository and failed the whole run.
+ *
+ * Answering with the known spelling rather than the agent's is what makes the
+ * result usable downstream: cross-repository attribution compares this value
+ * against the review target's repoPath, so echoing the agent's casing would mark
+ * a finding about the reviewed repository as belonging to another one.
+ */
 export function normalizeFindingRepository(
   value: unknown,
   knownRepositories: readonly string[] = [],
@@ -21,9 +35,11 @@ export function normalizeFindingRepository(
   if (typeof value !== "string" || !/^\S+\/\S+$/.test(value)) {
     return undefined;
   }
-  return knownRepositories.length === 0 || knownRepositories.includes(value)
-    ? value
-    : undefined;
+  if (knownRepositories.length === 0) return value;
+  const wanted = value.toLowerCase();
+  return knownRepositories.find(
+    (repository) => repository.toLowerCase() === wanted,
+  );
 }
 
 export function isCrossRepositoryFinding(


### PR DESCRIPTION
## Problem

Dogfooding the `post-pr-autofix` template on production showed the loop can commit useful fixes but can never reach publication. Three independent defects, each reproduced with numbers:

1. **The autofix push superseded its own run.** The ticket run records `published_head_sha` as the implementation head. The fix push creates a new head, and anti-recursion compares the event against the *older* recorded sha, so the push reads as foreign, `supersedePreviousPrRun` cancels the run and starts a successor. The identity fallback could not cover it either: it was gated on `!workflowPublishedHeadSha`, i.e. disabled precisely because a (stale) sha existed.
2. **A second fix round could never push.** The publisher leases `repo.expectedRemoteSha`, captured when the workspace was created. Round one's own push moves the branch past it, so round two fails with `remote branch moved from X to Y`. `maxAttempts: 2` therefore gave one usable attempt.
3. **Only one pull request of a multi-repo ticket was ever reviewed.** A workflow-owned PR run was keyed on `ticket:jira:<KEY>`, so both PRs of one ticket shared a subject. The first claimed it and the single pending slot that key allows overwrote the rest. Production confirms it: both review runs of AWP-63 sat on `ticket:jira:AWP-63`.

The stuck `AI Workflow / Review` check reported earlier is a consequence, not a separate defect: `refreshHead: true` already retargets the check, but no run survived long enough to complete it.

## Changes

- Register the head a fix publication is about to create *before* pushing it, so the provider's own synchronize event matches by sha. A sha that never reaches the remote is inert.
- Let identity backstop the sha match instead of being disabled by a stale recorded sha (GitHub, GitLab, and the shared predicate).
- Advance the publication lease to the current remote head only when the workspace already contains it, proven by an ancestor check. A foreign write is not contained and still fails as `remote_drift`.
- Key a pull request review run on the pull request. The ticket key still travels with the run, so ticket context and reconciliation are unchanged; only the concurrency identity moves.

Moving that identity has three call sites that proved it through the ticket subject, each fixed here:

- **Manual dispatch** still reserved `ticket:jira:<KEY>` for a workflow-owned pull request. Left alone it would have stopped deduplicating a manual run against the automatic run of the same pull request, which is worse than the collision it used to cause.
- **`reviewPrAtWorkflowPublishedHead`** proved ownership by comparing the run's subject to the ticket subject. Under the new key that comparison never matches, so the final review would have silently anchored to the trigger head instead of the head the fix loop pushed, defeating the point of the loop.
- **The reconciler's closing-claim retry** derived the subject from the ticket key. A pull request run carries a ticket key but claims a pull request subject, so the retry would have cancelled nothing and left the claim closing forever.

## A fourth defect, found while reading the production failures

Run `wrun_01KZP0X400V0XYB2SAADV4AV6W` died on `reviewResults[0].findings[0].repo must identify a repository selected for this run`. A finding's `repo` is agent-authored prose, and it was matched against the run's selected repositories with an exact string comparison. Forge paths are case-insensitive, and the AWP tickets spell `blazity/ai-workflow-prod` where the run carries `Blazity/ai-workflow-prod`, so a reviewer echoing the ticket's spelling failed the whole run.

The same comparison appears twice more, and the publication side is worse than a hard failure because it is silent: `partitionReviewFindings` classifies a finding as cross-repository by comparing `finding.repo` to the review target, and publication normalizes review results with no known-repository list at all. A reviewer that spelled the *reviewed* repository in another case had its finding read as belonging to another repository, which stripped the inline anchor and dropped it into the summary with no error anywhere.

That misclassification also reached the verdict. `reviewFindingBlocksPublication` returns false for a cross-repository finding, so a **Blocker** on the reviewed repository, spelled `blazity/...` instead of `Blazity/...`, was excluded from the decision and the review could publish an approval over it.

All three now compare the way the forge does. `normalizeFindingRepository` additionally answers with the selected repository's own spelling rather than the agent's, because cross-repository attribution compares that value downstream.

## Verification

- `pnpm --filter worker test src/lib` - 56 files, 592 tests
- `pnpm --filter worker test src/workflow-definition/scenarios src/workflows/blocks` - 29 files, 447 tests
- `pnpm --filter worker test src/manual-dispatch src/workflows/blocks src/lib/reconcile.test.ts src/lib/dispatch-trigger.test.ts src/lib/cancel-run.test.ts` - 461 tests
- `pnpm --filter worker test src/workflows src/workflow-definition/scenarios` - 79 files, 1234 tests
- `pnpm --filter worker typecheck`

New coverage: pre-push registration and its ordering against the push, a bot synchronize whose recorded sha lags the pushed head, a remote head the workspace already published versus a foreign one, two pull requests of one ticket receiving distinct subjects, a manual dispatch reserving the pull request rather than the ticket, the retarget guard accepting only the pull request subject, a closing pull request claim retried on its own subject, and a reviewer that spelled both the reviewed repository and its sibling in another case.

## Known unrelated CI flake

`workflow-sdk-tests/v2-concurrent.test.ts` intermittently fails with a Workflow replay divergence. It is not from this branch: the same failure hit `fix/run-model-manifest-priority` and `fix/review-sibling-pr-head` on the same day, and the suite passes locally on this branch (16/16, including both tests CI reported). Worth its own ticket, since the shape it exercises (a three-way concurrent fan-out) is the shape the autofix graph runs in production.

## Deployment note

Production has `GITHUB_BOT_LOGIN=blazity-ai-workflow[bot]` stored; it reaches the worker on the redeploy this merge triggers. The Arthur tenant needs the same variable set to *its own* app slug.
