### PR TITLE
fix(worker): prefer the live harness manifest for the model label everywhere

### DIFF
--- a/apps/worker/src/db/queries/run-detail-read.test.ts
+++ b/apps/worker/src/db/queries/run-detail-read.test.ts
@@ -69,6 +69,30 @@ describe("fetchRunDetailFromDb", () => {
     expect(res?.run.model).toBe("claude-fallback");
   });
 
+  it("prefers the manifest-derived model over the persisted terminal model when both exist", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "r1",
+      status: "success",
+      model: "gpt-5.6-sol",
+      harnessManifests: [harnessManifest("implementation", "gpt-5.6-luna")],
+      startedAt: new Date(),
+    });
+    const res = await fetchRunDetailFromDb({ db, runId: "r1", ...base });
+    expect(res?.run.model).toBe("gpt-5.6-luna");
+  });
+
+  it("shows the block that actually ran, not the org default, for a run parked mid-planning", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "r1",
+      status: "awaiting",
+      model: "claude-fallback",
+      harnessManifests: [harnessManifest("planning", "gpt-5.6-sol")],
+      startedAt: new Date(),
+    });
+    const res = await fetchRunDetailFromDb({ db, runId: "r1", ...base });
+    expect(res?.run.model).toBe("gpt-5.6-sol");
+  });
+
   it("surfaces the persisted PR ref", async () => {
     await db.insert(workflowRuns).values({
       runId: "r1",

--- a/apps/worker/src/db/queries/run-detail-read.ts
+++ b/apps/worker/src/db/queries/run-detail-read.ts
@@ -117,7 +117,7 @@ export async function fetchRunDetailFromDb(
     prNumber: row.prNumber,
     prUrl: row.prUrl,
     prs: row.prs,
-    model: row.model ?? deriveLiveModel(row.harnessManifests) ?? modelFallback,
+    model: deriveLiveModel(row.harnessManifests) ?? row.model ?? modelFallback,
     createdAt: (row.createdAt ?? row.firstSeenAt).toISOString(),
     startedAt: row.startedAt?.toISOString() ?? null,
     completedAt: row.completedAt?.toISOString() ?? null,

--- a/apps/worker/src/db/queries/runs-read.test.ts
+++ b/apps/worker/src/db/queries/runs-read.test.ts
@@ -155,14 +155,34 @@ describe("listRuns", () => {
     expect(rows.find((r) => r.id === "r-just-started")!.model).toBe("claude-fallback");
   });
 
-  it("prefers the persisted terminal model over any harness manifest once the run finishes", async () => {
+  it("prefers the manifest-derived model over the persisted terminal model when both exist", async () => {
     await seed({
       runId: "r-done",
-      model: "gpt-5.6-luna",
-      harnessManifests: [harnessManifest("planning", "gpt-5.6-sol")],
+      model: "gpt-5.6-sol",
+      harnessManifests: [harnessManifest("implementation", "gpt-5.6-luna")],
     });
     const { rows } = await listRuns({ db, window: "all", q: null, ...base });
     expect(rows.find((r) => r.id === "r-done")!.model).toBe("gpt-5.6-luna");
+  });
+
+  it("falls back to the persisted terminal model when a finished run never resolved a block harness", async () => {
+    await seed({ runId: "r-no-manifest", model: "gpt-5.6-luna", harnessManifests: null });
+    const { rows } = await listRuns({ db, window: "all", q: null, ...base });
+    expect(rows.find((r) => r.id === "r-no-manifest")!.model).toBe("gpt-5.6-luna");
+  });
+
+  it("shows the block that actually ran, not the org default, for a run parked mid-planning", async () => {
+    // Mirrors recordRunUsage seeding `model` from activeModel's org-default
+    // fallback when a run parks on a clarification before Implementation ever
+    // assigns a real value.
+    await seed({
+      runId: "r-awaiting",
+      status: "awaiting",
+      model: "claude-fallback",
+      harnessManifests: [harnessManifest("planning", "gpt-5.6-sol")],
+    });
+    const { rows } = await listRuns({ db, window: "all", q: null, ...base });
+    expect(rows.find((r) => r.id === "r-awaiting")!.model).toBe("gpt-5.6-sol");
   });
 
   it("maps persisted cost/tokens (no longer null) and coerces status", async () => {

--- a/apps/worker/src/db/queries/runs-read.ts
+++ b/apps/worker/src/db/queries/runs-read.ts
@@ -278,11 +278,15 @@ type RunRow = {
 };
 
 /**
- * `workflow_runs.model` stays null for a run's entire in-flight window (only
- * `recordRunUsage` sets it, on completion) and the block-status writer streams
- * `harnessManifests` as each block resolves its harness — so its last entry is
- * the most-recently-started block's actual model, a far better RUNNING-state
- * value than the org-wide fallback.
+ * The block-status writer streams `harnessManifests` as each block resolves
+ * its harness, so its last entry is the most-recently-started block's actual
+ * model — for a normal ticket run that's Implementation, the same block
+ * `recordRunUsage` uses for its own terminal `model` column. It diverges only
+ * when a run never reaches a block that overwrites the terminal column (e.g.
+ * failed or parked on a clarification during Planning): there, the persisted
+ * `model` is just the org-wide default `activeModel` was seeded with, while
+ * this still reflects the block that actually ran. Preferred over the
+ * persisted column everywhere a manifest exists, not only while running.
  */
 export function deriveLiveModel(
   manifests: HarnessRunManifestRecord[] | null | undefined,
@@ -305,7 +309,7 @@ function mapRun(r: RunRow, now: Date, tenantOrigin: string, modelFallback: strin
     statusReason: r.statusReason,
     ticket: r.ticketKey ?? "",
     actor: "ai-bot",
-    model: r.model ?? deriveLiveModel(r.harnessManifests) ?? modelFallback,
+    model: deriveLiveModel(r.harnessManifests) ?? r.model ?? modelFallback,
     startedAtMin: Math.max(0, Math.round((now.getTime() - eff.getTime()) / 60000)),
     duration: r.durationSec,
     tokens,


### PR DESCRIPTION
## Summary
- Follow-up to #240. The terminal `model` column (set by `recordRunUsage`) still only reflects the Implementation block's model (existing, intentional design) — but for a run that fails, gets blocked, or parks on a clarification *before* Implementation ever runs, that column just holds the org-wide default `activeModel` was seeded with, not anything real.
- `harnessManifests` already carries the real per-block data for every state. Flips the priority so `deriveLiveModel(harnessManifests)` wins over the persisted `model` whenever a manifest exists (RUNNING and terminal alike), falling back to the persisted column only when no manifest was ever recorded.
- No behavior change for the common path (a run that reaches Implementation): the manifest's last entry there already equals the persisted terminal model.

## Test plan
- [x] `pnpm typecheck` (apps/worker)
- [x] `pnpm vitest run src/db/queries/runs-read.test.ts src/db/queries/run-detail-read.test.ts` — 61/61 passing, including new cases for the manifest-over-persisted-model priority and a run parked mid-planning

🤖 Generated with [Claude Code](https://claude.com/claude-code)