### PR TITLE
AIW-253: show the model attributed to each run

### DIFF
--- a/apps/dashboard/components/cockpit/screens/overview.tsx
+++ b/apps/dashboard/components/cockpit/screens/overview.tsx
@@ -13,6 +13,7 @@ import {
   CkPagination,
 } from "@/components/ui";
 import { Spark, Donut } from "@/components/charts";
+import { runModelLabel } from "@/lib/run-model";
 import { spanColor } from "@/lib/theme";
 import { useCockpit } from "@/components/cockpit/context";
 import { WindowSelector } from "@/components/cockpit/controls";
@@ -198,7 +199,7 @@ function NowRunningPanel({
                         {r.currentSpan}
                       </span>
                       <span className="ml-auto text-neutral-500 whitespace-nowrap">
-                        {r.model}
+                        {runModelLabel(r.model)}
                       </span>
                     </div>
                   </>
@@ -550,7 +551,7 @@ export function OverviewScreen({
                       </CkChip>
                     </td>
                     <td className="px-4 py-3 font-mono text-[11px] text-neutral-700">
-                      {r.model}
+                      {runModelLabel(r.model)}
                     </td>
                     <td className="px-4 py-3 text-right font-mono text-[11px] text-neutral-500">
                       {r.startedAtMin}m ago

--- a/apps/dashboard/components/cockpit/screens/runs.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/runs.test.tsx
@@ -145,6 +145,20 @@ function renderMobile(
 
 // ── Desktop (RunsScreen) ────────────────────────────────────────────────────
 
+test("the model column names the attributed model, and unknown when there is none", (t) => {
+  // A run the API could not attribute a model to must read as explicitly
+  // unknown; it must never be labelled with the organization default (AIW-253).
+  const { root } = renderDesktop(t, {
+    data: makeData([
+      makeRun({ id: "run_attributed", status: "failed", model: "gpt-5.6-sol" }),
+      makeRun({ id: "run_unknown", status: "failed", model: null }),
+    ]),
+  });
+  const text = screenText(root);
+  assert.match(text, /gpt-5\.6-sol/);
+  assert.match(text, /model unknown/);
+});
+
 test("Cancel is absent for a row that is not running", (t) => {
   const row = makeRun({ id: "run_1", status: "success" });
   const { root } = renderDesktop(t, {

--- a/apps/dashboard/components/cockpit/screens/runs.tsx
+++ b/apps/dashboard/components/cockpit/screens/runs.tsx
@@ -8,6 +8,7 @@ import { WindowSelector } from "@/components/cockpit/controls";
 import { SpotlightTrigger } from "@/components/cockpit/spotlight-search";
 import { windowPhrase, type TimeWindow } from "@/lib/window";
 import { cancelRun } from "@/lib/api/cancel-run";
+import { runModelLabel } from "@/lib/run-model";
 import type { RunsResponse } from "@shared/contracts";
 
 const PAGE_SIZE = 25;
@@ -170,7 +171,7 @@ export function RunsScreen({
                 <td className="px-3 py-2.5">
                   <CkChip>{r.workflowName}</CkChip>
                 </td>
-                <td className="px-3 py-2.5 font-mono text-[11px] text-neutral-700">{r.model}</td>
+                <td className="px-3 py-2.5 font-mono text-[11px] text-neutral-700">{runModelLabel(r.model)}</td>
                 <td className="px-3 py-2.5 text-right font-mono text-[11px] text-neutral-500">{r.startedAtMin}m ago</td>
                 <td className="px-3 py-2.5 text-right font-mono font-medium">{r.duration === null ? "—" : `${r.duration}s`}</td>
                 <td className="px-3 py-2.5 text-right font-mono text-neutral-700">{r.tokens === null ? "—" : `${(r.tokens / 1000).toFixed(1)}k`}</td>

--- a/apps/dashboard/components/cockpit/screens/ticket.tsx
+++ b/apps/dashboard/components/cockpit/screens/ticket.tsx
@@ -2,6 +2,7 @@
 
 import { CkChip, CkStatusPill } from "@/components/ui";
 import { useTicketSelection } from "@/components/cockpit/screens/ticket-selection";
+import { runModelLabel } from "@/lib/run-model";
 import type { TicketRunsResponse } from "@shared/contracts";
 
 function fmtCost(n: number): string {
@@ -123,7 +124,7 @@ export function TicketScreen({
                   </div>
                 )}
                 <div className="flex items-center justify-between gap-2 font-mono text-[11px] text-neutral-700">
-                  <span className="truncate">{r.model}</span>
+                  <span className="truncate">{runModelLabel(r.model)}</span>
                   <span className="shrink-0">{r.cost === null ? "—" : fmtCost(r.cost)}</span>
                 </div>
                 <div className="flex items-center gap-2 font-mono text-[10px] text-neutral-500">

--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -13,6 +13,7 @@ import {
 import { answerPanelMode } from "@/lib/answer-panel-mode";
 import { readErrorMessage } from "@/lib/api/error-message";
 import { runHref } from "@/lib/run-href";
+import { runModelLabel } from "@/lib/run-model";
 import { runPullRequests } from "@/lib/run-prs";
 import { SPAN_KIND_COLOR } from "@/lib/theme";
 import { pullRequestRef, pullRequestRepoLabels } from "@shared/contracts";
@@ -323,7 +324,7 @@ export function TraceDetail({
             <CkStatusPill status={run.status} />
             <CkChip tone="mariner">{run.workflowName}</CkChip>
             <span className="font-mono text-[11px] text-neutral-700">
-              {[run.ticket, run.model].filter(Boolean).join(" · ")}
+              {[run.ticket, runModelLabel(run.model)].filter(Boolean).join(" · ")}
             </span>
             {isRunning && (
               <span className="inline-flex items-center gap-1.5 font-mono text-[10px] text-mariner tracking-[0.04em] uppercase">

--- a/apps/dashboard/lib/run-model.test.ts
+++ b/apps/dashboard/lib/run-model.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runModelLabel, UNKNOWN_MODEL_LABEL } from "./run-model";
+
+test("runModelLabel passes an attributed model through unchanged", () => {
+  assert.equal(runModelLabel("gpt-5.6-sol"), "gpt-5.6-sol");
+});
+
+test("runModelLabel renders an explicit unknown when nothing is attributed", () => {
+  assert.equal(runModelLabel(null), UNKNOWN_MODEL_LABEL);
+  assert.equal(runModelLabel(undefined), UNKNOWN_MODEL_LABEL);
+});

--- a/apps/dashboard/lib/run-model.ts
+++ b/apps/dashboard/lib/run-model.ts
@@ -1,0 +1,15 @@
+/** Rendered when a run has no attributable model (`Run.model === null`). */
+export const UNKNOWN_MODEL_LABEL = "model unknown";
+
+/**
+ * The model label for a run row or header. A run whose model could not be
+ * attributed from its own record (no persisted model, no harness manifest) reads
+ * as an explicit unknown: the API deliberately no longer substitutes the
+ * organization default there, because that constant is not an observation of the
+ * run and made failed runs look like they had executed on a model they never
+ * touched (AIW-253). Every model surface goes through this, so the run list, the
+ * ticket runs screen and the run detail header cannot disagree.
+ */
+export function runModelLabel(model: string | null | undefined): string {
+  return model ?? UNKNOWN_MODEL_LABEL;
+}

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -95,7 +95,10 @@ export interface Run {
   statusReason?: string | null;
   ticket: string;
   actor: string;
-  model: string;
+  /** The model this run can be shown to have used. `null` means nothing
+   * attributes one (no recorded model, no harness manifest): renderers must
+   * show an explicit unknown state and never substitute the org default. */
+  model: string | null;
   startedAtMin: number;
   duration: number | null;
   // Aggregate/graded metrics — `null` means "not tracked yet", distinct from a
@@ -195,7 +198,8 @@ export interface RunDetail {
   prUrl: string | null;
   /** See {@link Run.prs}. */
   prs: RunPullRequest[] | null;
-  model: string;
+  /** See {@link Run.model}. */
+  model: string | null;
   createdAt: string;
   startedAt: string | null;
   completedAt: string | null;

--- a/apps/worker/src/db/queries/run-detail-read.test.ts
+++ b/apps/worker/src/db/queries/run-detail-read.test.ts
@@ -5,7 +5,7 @@ import { workflowRuns } from "../schema.js";
 import type { HarnessRunManifestRecord } from "@shared/contracts";
 import { fetchRunDetailFromDb, fetchRunRefs } from "./run-detail-read.js";
 
-/** Minimal fixture: deriveLiveModel only reads `.manifest.model.id`. */
+/** Minimal fixture: attributeRunModel only reads `.nodeId` / `.manifest.model.id`. */
 function harnessManifest(nodeId: string, modelId: string): HarnessRunManifestRecord {
   return {
     nodeId,
@@ -19,7 +19,7 @@ beforeEach(async () => {
   db = await createTestDb();
 });
 
-const base = { jiraBaseUrl: JIRA, modelFallback: "claude-fallback" };
+const base = { jiraBaseUrl: JIRA };
 
 describe("fetchRunDetailFromDb", () => {
   it("returns null for an unknown run id", async () => {
@@ -46,7 +46,7 @@ describe("fetchRunDetailFromDb", () => {
     expect(res?.run.durationSec).toBe(300);
   });
 
-  it("prefers the live per-block model over the org fallback while a run is still in flight", async () => {
+  it("prefers the live per-block model while a run is still in flight", async () => {
     await db.insert(workflowRuns).values({
       runId: "r1",
       status: "running",
@@ -58,39 +58,66 @@ describe("fetchRunDetailFromDb", () => {
     expect(res?.run.model).toBe("gpt-5.6-sol");
   });
 
-  it("falls back to the org default when no block has resolved a harness yet", async () => {
+  it("attributes the failing first phase's harness model, not the org default", async () => {
     await db.insert(workflowRuns).values({
       runId: "r1",
-      status: "running",
-      model: null,
+      status: "failed",
+      // The org default the run never used: recordRunUsage persisted it from
+      // activeModel's prepare_workspace seeding.
+      model: "claude-opus-4-8",
+      harnessManifests: [
+        harnessManifest("planning-1", "gpt-5.6-sol"),
+        harnessManifest("review-1", "claude-opus-4-8"),
+      ],
+      blockStatuses: {
+        "planning-1": { status: "fail" },
+        "review-1": { status: "pending" },
+      },
       startedAt: new Date(),
     });
     const res = await fetchRunDetailFromDb({ db, runId: "r1", ...base });
-    expect(res?.run.model).toBe("claude-fallback");
+    expect(res?.run.model).toBe("gpt-5.6-sol");
   });
 
-  it("prefers the manifest-derived model over the persisted terminal model when both exist", async () => {
+  it("keeps the persisted terminal model of a completed mixed-profile run", async () => {
     await db.insert(workflowRuns).values({
       runId: "r1",
       status: "success",
-      model: "gpt-5.6-sol",
-      harnessManifests: [harnessManifest("implementation", "gpt-5.6-luna")],
+      model: "gpt-5.6-luna",
+      harnessManifests: [
+        harnessManifest("planning-1", "gpt-5.6-sol"),
+        harnessManifest("implementation-1", "gpt-5.6-luna"),
+      ],
+      blockStatuses: {
+        "planning-1": { status: "ok" },
+        "implementation-1": { status: "ok" },
+      },
       startedAt: new Date(),
     });
     const res = await fetchRunDetailFromDb({ db, runId: "r1", ...base });
     expect(res?.run.model).toBe("gpt-5.6-luna");
   });
 
-  it("shows the block that actually ran, not the org default, for a run parked mid-planning", async () => {
+  it("keeps the persisted terminal model when a finished run has no manifest", async () => {
     await db.insert(workflowRuns).values({
       runId: "r1",
-      status: "awaiting",
-      model: "claude-fallback",
-      harnessManifests: [harnessManifest("planning", "gpt-5.6-sol")],
+      status: "success",
+      model: "gpt-5.6-luna",
       startedAt: new Date(),
     });
     const res = await fetchRunDetailFromDb({ db, runId: "r1", ...base });
-    expect(res?.run.model).toBe("gpt-5.6-sol");
+    expect(res?.run.model).toBe("gpt-5.6-luna");
+  });
+
+  it("reports no model when the run has neither a persisted one nor a manifest", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "r1",
+      status: "failed",
+      model: null,
+      startedAt: new Date(),
+    });
+    const res = await fetchRunDetailFromDb({ db, runId: "r1", ...base });
+    expect(res?.run.model).toBeNull();
   });
 
   it("surfaces the persisted PR ref", async () => {

--- a/apps/worker/src/db/queries/run-detail-read.ts
+++ b/apps/worker/src/db/queries/run-detail-read.ts
@@ -2,7 +2,8 @@ import { eq } from "drizzle-orm";
 import type { RunDetail, RunPullRequest, RunStep } from "@shared/contracts";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
-import { coerceStatus, deriveLiveModel } from "./runs-read.js";
+import { coerceStatus } from "./runs-read.js";
+import { attributeRunModel } from "../../lib/overview/attribute-run-model.js";
 import { sanitizeRunSteps } from "../../lib/overview/sanitize-run-detail.js";
 
 /**
@@ -86,13 +87,12 @@ export interface FetchRunDetailFromDbOptions {
   db: Db;
   runId: string;
   jiraBaseUrl: string;
-  modelFallback: string;
 }
 
 export async function fetchRunDetailFromDb(
   opts: FetchRunDetailFromDbOptions,
 ): Promise<{ run: RunDetail; steps: RunStep[]; hasRealSteps: boolean } | null> {
-  const { db, runId, jiraBaseUrl, modelFallback } = opts;
+  const { db, runId, jiraBaseUrl } = opts;
   const tenantOrigin = jiraBaseUrl.replace(/\/+$/, "");
 
   const [row] = await db
@@ -117,7 +117,7 @@ export async function fetchRunDetailFromDb(
     prNumber: row.prNumber,
     prUrl: row.prUrl,
     prs: row.prs,
-    model: deriveLiveModel(row.harnessManifests) ?? row.model ?? modelFallback,
+    model: attributeRunModel(row),
     createdAt: (row.createdAt ?? row.firstSeenAt).toISOString(),
     startedAt: row.startedAt?.toISOString() ?? null,
     completedAt: row.completedAt?.toISOString() ?? null,

--- a/apps/worker/src/db/queries/runs-read.test.ts
+++ b/apps/worker/src/db/queries/runs-read.test.ts
@@ -3,6 +3,7 @@ import { createTestDb } from "../test-db.js";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
 import type {
+  BlockRunState,
   HarnessRunManifestRecord,
   RunPullRequest,
   WorkflowMeta,
@@ -16,10 +17,10 @@ import {
   costAgg,
   listRunsForTicket,
   isRunRecordedFailed,
-  deriveLiveModel,
+  fetchRunModels,
 } from "./runs-read.js";
 
-/** Minimal fixture: deriveLiveModel only reads `.manifest.model.id`. */
+/** Minimal fixture: attributeRunModel only reads `.nodeId` / `.manifest.model.id`. */
 function harnessManifest(nodeId: string, modelId: string): HarnessRunManifestRecord {
   return {
     nodeId,
@@ -63,6 +64,7 @@ interface SeedRun {
   prUrl?: string | null;
   prs?: RunPullRequest[] | null;
   harnessManifests?: HarnessRunManifestRecord[] | null;
+  blockStatuses?: Record<string, Omit<BlockRunState, "output">> | null;
 }
 
 async function seed(over: SeedRun = {}): Promise<void> {
@@ -87,6 +89,7 @@ async function seed(over: SeedRun = {}): Promise<void> {
     prUrl: over.prUrl ?? null,
     prs: over.prs ?? null,
     harnessManifests: over.harnessManifests ?? null,
+    blockStatuses: over.blockStatuses ?? null,
   });
 }
 
@@ -120,26 +123,10 @@ describe("parseSearch", () => {
   });
 });
 
-describe("deriveLiveModel", () => {
-  it("returns null for no manifests", () => {
-    expect(deriveLiveModel(null)).toBeNull();
-    expect(deriveLiveModel(undefined)).toBeNull();
-    expect(deriveLiveModel([])).toBeNull();
-  });
-
-  it("returns the most-recently-appended block's model", () => {
-    const manifests = [
-      harnessManifest("planning", "gpt-5.6-sol"),
-      harnessManifest("implementation", "gpt-5.6-luna"),
-    ];
-    expect(deriveLiveModel(manifests)).toBe("gpt-5.6-luna");
-  });
-});
-
 describe("listRuns", () => {
-  const base = { jiraBaseUrl: JIRA, modelFallback: "claude-fallback", now: NOW };
+  const base = { jiraBaseUrl: JIRA, now: NOW };
 
-  it("prefers the live per-block model over the org fallback while a run is still in flight", async () => {
+  it("prefers the live per-block model while a run is still in flight", async () => {
     await seed({
       runId: "r-running",
       model: null,
@@ -149,17 +136,45 @@ describe("listRuns", () => {
     expect(rows.find((r) => r.id === "r-running")!.model).toBe("gpt-5.6-sol");
   });
 
-  it("falls back to the org default when no block has resolved a harness yet", async () => {
+  it("reports no model when a just-started run has resolved nothing yet", async () => {
     await seed({ runId: "r-just-started", model: null, harnessManifests: null });
     const { rows } = await listRuns({ db, window: "all", q: null, ...base });
-    expect(rows.find((r) => r.id === "r-just-started")!.model).toBe("claude-fallback");
+    expect(rows.find((r) => r.id === "r-just-started")!.model).toBeNull();
   });
 
-  it("prefers the manifest-derived model over the persisted terminal model when both exist", async () => {
+  it("attributes the failing first phase's harness model, not the org default", async () => {
+    // The AIW-253 case: a run that dies in Planning never reaches the terminal
+    // telemetry step, so `model` is whatever activeModel was seeded with (the
+    // org default) while the manifests hold what the sandbox really launched.
+    await seed({
+      runId: "r-first-phase-failed",
+      status: "failed",
+      model: "claude-opus-4-8",
+      harnessManifests: [
+        harnessManifest("planning-1", "gpt-5.6-sol"),
+        harnessManifest("review-1", "claude-opus-4-8"),
+      ],
+      blockStatuses: {
+        "planning-1": { status: "fail" },
+        "review-1": { status: "pending" },
+      },
+    });
+    const { rows } = await listRuns({ db, window: "all", q: null, ...base });
+    expect(rows.find((r) => r.id === "r-first-phase-failed")!.model).toBe("gpt-5.6-sol");
+  });
+
+  it("keeps the persisted terminal model of a completed mixed-profile run", async () => {
     await seed({
       runId: "r-done",
-      model: "gpt-5.6-sol",
-      harnessManifests: [harnessManifest("implementation", "gpt-5.6-luna")],
+      model: "gpt-5.6-luna",
+      harnessManifests: [
+        harnessManifest("planning-1", "gpt-5.6-sol"),
+        harnessManifest("implementation-1", "gpt-5.6-luna"),
+      ],
+      blockStatuses: {
+        "planning-1": { status: "ok" },
+        "implementation-1": { status: "ok" },
+      },
     });
     const { rows } = await listRuns({ db, window: "all", q: null, ...base });
     expect(rows.find((r) => r.id === "r-done")!.model).toBe("gpt-5.6-luna");
@@ -378,7 +393,7 @@ describe("costAgg", () => {
 });
 
 describe("listRunsForTicket", () => {
-  const base = { db: undefined as unknown as Db, now: NOW, jiraBaseUrl: JIRA, modelFallback: "claude-opus-4-8" };
+  const base = { db: undefined as unknown as Db, now: NOW, jiraBaseUrl: JIRA };
 
   it("returns only exact ticket_key matches, newest first", async () => {
     await seed({ runId: "r_old", ticketKey: "AWT-738", startedAt: new Date(NOW.getTime() - 2 * HOUR) });
@@ -423,6 +438,79 @@ describe("listRunsForTicket", () => {
     expect(res.runs).toEqual([]);
     expect(res.totals.runCount).toBe(0);
     expect(res.ticket).toBeNull();
+  });
+
+  it("attributes models exactly like the run list, per run", async () => {
+    await seed({
+      runId: "r_failed_first_phase",
+      ticketKey: "AWT-253",
+      status: "failed",
+      model: "claude-opus-4-8",
+      harnessManifests: [
+        harnessManifest("planning-1", "gpt-5.6-sol"),
+        harnessManifest("review-1", "claude-opus-4-8"),
+      ],
+      blockStatuses: {
+        "planning-1": { status: "fail" },
+        "review-1": { status: "pending" },
+      },
+      startedAt: new Date(NOW.getTime() - HOUR),
+    });
+    await seed({
+      runId: "r_no_evidence",
+      ticketKey: "AWT-253",
+      status: "failed",
+      model: null,
+      startedAt: new Date(NOW.getTime() - 2 * HOUR),
+    });
+
+    const ticketRuns = await listRunsForTicket({ ...base, db, ticketKey: "AWT-253" });
+    const { rows } = await listRuns({
+      db,
+      window: "all",
+      q: null,
+      now: NOW,
+      jiraBaseUrl: JIRA,
+    });
+
+    const byId = (runs: { id: string; model: string | null }[], id: string) =>
+      runs.find((r) => r.id === id)!.model;
+    expect(byId(ticketRuns.runs, "r_failed_first_phase")).toBe("gpt-5.6-sol");
+    expect(byId(ticketRuns.runs, "r_no_evidence")).toBeNull();
+    // The two read paths must never disagree for the same run.
+    expect(byId(ticketRuns.runs, "r_failed_first_phase")).toBe(
+      byId(rows, "r_failed_first_phase"),
+    );
+    expect(byId(ticketRuns.runs, "r_no_evidence")).toBe(byId(rows, "r_no_evidence"));
+  });
+});
+
+describe("fetchRunModels", () => {
+  it("returns nothing for an empty id list, without touching the db", async () => {
+    const models = await fetchRunModels(undefined as unknown as Db, []);
+    expect(models.size).toBe(0);
+  });
+
+  it("attributes the ran block's model and omits runs with no evidence", async () => {
+    await seed({
+      runId: "r_live",
+      status: "running",
+      model: null,
+      harnessManifests: [
+        harnessManifest("planning-1", "gpt-5.6-sol"),
+        harnessManifest("implementation-1", "gpt-5.6-luna"),
+      ],
+      blockStatuses: {
+        "planning-1": { status: "ok" },
+        "implementation-1": { status: "running" },
+      },
+    });
+    await seed({ runId: "r_bare", status: "running", model: null });
+
+    const models = await fetchRunModels(db, ["r_live", "r_bare", "r_missing"]);
+    expect(models.get("r_live")).toBe("gpt-5.6-luna");
+    expect(models.has("r_bare")).toBe(false);
+    expect(models.has("r_missing")).toBe(false);
   });
 });
 

--- a/apps/worker/src/db/queries/runs-read.ts
+++ b/apps/worker/src/db/queries/runs-read.ts
@@ -1,5 +1,6 @@
-import { and, count, eq, sql, type SQL } from "drizzle-orm";
+import { and, count, eq, inArray, sql, type SQL } from "drizzle-orm";
 import type {
+  BlockRunState,
   CostResponse,
   HarnessRunManifestRecord,
   KpisResponse,
@@ -11,6 +12,7 @@ import type {
 } from "@shared/contracts";
 import type { Db } from "../client.js";
 import { activeRuns, workflowRuns } from "../schema.js";
+import { attributeRunModel } from "../../lib/overview/attribute-run-model.js";
 
 /**
  * Postgres read path for the dashboard. Replaces the Vercel Workflow `world.runs`
@@ -253,6 +255,7 @@ const runColumns = {
   prUrl: workflowRuns.prUrl,
   prs: workflowRuns.prs,
   harnessManifests: workflowRuns.harnessManifests,
+  blockStatuses: workflowRuns.blockStatuses,
 } as const;
 
 type RunRow = {
@@ -275,27 +278,10 @@ type RunRow = {
   prUrl: string | null;
   prs: RunPullRequest[] | null;
   harnessManifests: HarnessRunManifestRecord[] | null;
+  blockStatuses: Record<string, Omit<BlockRunState, "output">> | null;
 };
 
-/**
- * The block-status writer streams `harnessManifests` as each block resolves
- * its harness, so its last entry is the most-recently-started block's actual
- * model — for a normal ticket run that's Implementation, the same block
- * `recordRunUsage` uses for its own terminal `model` column. It diverges only
- * when a run never reaches a block that overwrites the terminal column (e.g.
- * failed or parked on a clarification during Planning): there, the persisted
- * `model` is just the org-wide default `activeModel` was seeded with, while
- * this still reflects the block that actually ran. Preferred over the
- * persisted column everywhere a manifest exists, not only while running.
- */
-export function deriveLiveModel(
-  manifests: HarnessRunManifestRecord[] | null | undefined,
-): string | null {
-  if (!Array.isArray(manifests) || manifests.length === 0) return null;
-  return manifests[manifests.length - 1]?.manifest.model.id ?? null;
-}
-
-function mapRun(r: RunRow, now: Date, tenantOrigin: string, modelFallback: string): Run {
+function mapRun(r: RunRow, now: Date, tenantOrigin: string): Run {
   const eff = r.startedAt ?? r.firstSeenAt;
   const tokens =
     r.tokensInput != null || r.tokensOutput != null
@@ -309,7 +295,7 @@ function mapRun(r: RunRow, now: Date, tenantOrigin: string, modelFallback: strin
     statusReason: r.statusReason,
     ticket: r.ticketKey ?? "",
     actor: "ai-bot",
-    model: deriveLiveModel(r.harnessManifests) ?? r.model ?? modelFallback,
+    model: attributeRunModel(r),
     startedAtMin: Math.max(0, Math.round((now.getTime() - eff.getTime()) / 60000)),
     duration: r.durationSec,
     tokens,
@@ -333,8 +319,6 @@ export interface ListRunsOptions {
   q: string | null;
   now: Date;
   jiraBaseUrl: string;
-  /** Used when a run has no persisted model (e.g. gate runs). */
-  modelFallback: string;
   /** Max rows returned (newest first); counts/total still cover the full match. */
   limit?: number;
 }
@@ -352,7 +336,7 @@ export interface RunsResult {
 }
 
 export async function listRuns(opts: ListRunsOptions): Promise<RunsResult> {
-  const { db, window, q, now, jiraBaseUrl, modelFallback } = opts;
+  const { db, window, q, now, jiraBaseUrl } = opts;
   const limit = opts.limit ?? 500;
   const tenantOrigin = jiraBaseUrl.replace(/\/+$/, "");
   const { cutoff } = windowBounds(window, now);
@@ -382,7 +366,7 @@ export async function listRuns(opts: ListRunsOptions): Promise<RunsResult> {
     total += n;
   }
 
-  const rows = data.map((r) => mapRun(r, now, tenantOrigin, modelFallback));
+  const rows = data.map((r) => mapRun(r, now, tenantOrigin));
 
   return { rows, total, counts };
 }
@@ -656,7 +640,6 @@ export interface ListRunsForTicketOptions {
   ticketKey: string;
   now: Date;
   jiraBaseUrl: string;
-  modelFallback: string;
 }
 
 export interface TicketRunsResult {
@@ -673,7 +656,7 @@ export interface TicketRunsResult {
 export async function listRunsForTicket(
   opts: ListRunsForTicketOptions,
 ): Promise<TicketRunsResult> {
-  const { db, ticketKey, now, jiraBaseUrl, modelFallback } = opts;
+  const { db, ticketKey, now, jiraBaseUrl } = opts;
   const tenantOrigin = jiraBaseUrl.replace(/\/+$/, "");
 
   const data = await db
@@ -682,7 +665,7 @@ export async function listRunsForTicket(
     .where(eq(workflowRuns.ticketKey, ticketKey))
     .orderBy(sql`${effTime()} desc`);
 
-  const runs = data.map((r) => mapRun(r, now, tenantOrigin, modelFallback));
+  const runs = data.map((r) => mapRun(r, now, tenantOrigin));
 
   const counts = { success: 0, running: 0, awaiting: 0, failed: 0, blocked: 0 };
   let cost = 0;
@@ -705,4 +688,38 @@ export async function listRunsForTicket(
     : null;
 
   return { ticket, runs, totals: { cost, tokens, runCount: runs.length, counts } };
+}
+
+// ── Model attribution for rows built outside this module ─────────────────────
+
+/**
+ * Attributed models for the given run ids, from the same evidence the run list
+ * uses. The Overview's live rows are built from the run registry, which knows
+ * nothing about models; they override the store row by id on the runs and ticket
+ * screens (mergeLiveRuns), so without this an in-flight run would show the org
+ * default on exactly the screens the store already labels honestly. Ids with no
+ * row, and runs with no attributable model, are simply absent from the map.
+ */
+export async function fetchRunModels(
+  db: Db,
+  runIds: string[],
+): Promise<Map<string, string>> {
+  const models = new Map<string, string>();
+  if (runIds.length === 0) return models;
+
+  const rows = await db
+    .select({
+      runId: workflowRuns.runId,
+      model: workflowRuns.model,
+      harnessManifests: workflowRuns.harnessManifests,
+      blockStatuses: workflowRuns.blockStatuses,
+    })
+    .from(workflowRuns)
+    .where(inArray(workflowRuns.runId, runIds));
+
+  for (const row of rows) {
+    const model = attributeRunModel(row);
+    if (model) models.set(row.runId, model);
+  }
+  return models;
 }

--- a/apps/worker/src/lib/overview/attribute-run-model.test.ts
+++ b/apps/worker/src/lib/overview/attribute-run-model.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import type { BlockRunState, HarnessRunManifestRecord } from "@shared/contracts";
+import { attributeRunModel } from "./attribute-run-model.js";
+
+/** Minimal fixture: attributeRunModel only reads `.nodeId` / `.manifest.model.id`. */
+function harnessManifest(nodeId: string, modelId: string): HarnessRunManifestRecord {
+  return {
+    nodeId,
+    manifest: { model: { id: modelId } },
+  } as unknown as HarnessRunManifestRecord;
+}
+
+type Statuses = Record<string, Omit<BlockRunState, "output">>;
+
+describe("attributeRunModel", () => {
+  it("returns null when the run carries no evidence at all", () => {
+    expect(
+      attributeRunModel({ model: null, harnessManifests: null, blockStatuses: null }),
+    ).toBeNull();
+    expect(
+      attributeRunModel({ model: null, harnessManifests: [], blockStatuses: {} }),
+    ).toBeNull();
+    expect(
+      attributeRunModel({
+        model: "   ",
+        harnessManifests: undefined,
+        blockStatuses: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it("uses the persisted model when it is the only evidence", () => {
+    expect(
+      attributeRunModel({
+        model: "gpt-5.6-luna",
+        harnessManifests: null,
+        blockStatuses: null,
+      }),
+    ).toBe("gpt-5.6-luna");
+  });
+
+  it("attributes the block that failed in the run's first phase", () => {
+    // The reported bug: `model` holds the org default activeModel was seeded
+    // with, and the alphabetically last manifest belongs to a block that never
+    // ran. Only planning-1 executed, so only its model is attributable.
+    const manifests = [
+      harnessManifest("implementation-1", "claude-opus-4-8"),
+      harnessManifest("planning-1", "gpt-5.6-sol"),
+      harnessManifest("review-1", "claude-haiku-4-5"),
+    ];
+    const blockStatuses: Statuses = {
+      "planning-1": { status: "fail" },
+      "implementation-1": { status: "pending" },
+      "review-1": { status: "pending" },
+    };
+    expect(
+      attributeRunModel({ model: "claude-opus-4-8", harnessManifests: manifests, blockStatuses }),
+    ).toBe("gpt-5.6-sol");
+  });
+
+  it("prefers the block executing right now over blocks that already finished", () => {
+    const manifests = [
+      harnessManifest("planning-1", "gpt-5.6-sol"),
+      harnessManifest("implementation-1", "gpt-5.6-luna"),
+    ];
+    const blockStatuses: Statuses = {
+      "planning-1": { status: "ok" },
+      "implementation-1": { status: "running" },
+    };
+    expect(
+      attributeRunModel({ model: null, harnessManifests: manifests, blockStatuses }),
+    ).toBe("gpt-5.6-luna");
+  });
+
+  it("uses a unanimous manifest set when no block status is recorded yet", () => {
+    const manifests = [
+      harnessManifest("planning-1", "gpt-5.6-sol"),
+      harnessManifest("implementation-1", "gpt-5.6-sol"),
+    ];
+    expect(
+      attributeRunModel({ model: null, harnessManifests: manifests, blockStatuses: null }),
+    ).toBe("gpt-5.6-sol");
+  });
+
+  it("beats the persisted org default with a unanimous manifest set", () => {
+    expect(
+      attributeRunModel({
+        model: "claude-opus-4-8",
+        harnessManifests: [harnessManifest("planning-1", "gpt-5.6-sol")],
+        blockStatuses: null,
+      }),
+    ).toBe("gpt-5.6-sol");
+  });
+
+  it("keeps the persisted terminal model when several blocks ran on different models", () => {
+    // A completed run: every block ran, so block status cannot single one out.
+    // The persisted column is then the run's own recorded headline model.
+    const manifests = [
+      harnessManifest("planning-1", "gpt-5.6-sol"),
+      harnessManifest("implementation-1", "gpt-5.6-luna"),
+    ];
+    const blockStatuses: Statuses = {
+      "planning-1": { status: "ok" },
+      "implementation-1": { status: "ok" },
+    };
+    expect(
+      attributeRunModel({ model: "gpt-5.6-luna", harnessManifests: manifests, blockStatuses }),
+    ).toBe("gpt-5.6-luna");
+  });
+
+  it("returns null when the evidence disagrees and nothing was persisted", () => {
+    const manifests = [
+      harnessManifest("planning-1", "gpt-5.6-sol"),
+      harnessManifest("implementation-1", "gpt-5.6-luna"),
+    ];
+    const blockStatuses: Statuses = {
+      "planning-1": { status: "ok" },
+      "implementation-1": { status: "fail" },
+    };
+    expect(
+      attributeRunModel({ model: null, harnessManifests: manifests, blockStatuses }),
+    ).toBeNull();
+  });
+
+  it("ignores block statuses that name no manifest", () => {
+    // Non-agent blocks (prepare_workspace, open_pr) have statuses but no
+    // manifest; they must not empty the attribution.
+    const manifests = [harnessManifest("planning-1", "gpt-5.6-sol")];
+    const blockStatuses: Statuses = {
+      "prepare-1": { status: "ok" },
+      "planning-1": { status: "pending" },
+    };
+    expect(
+      attributeRunModel({ model: null, harnessManifests: manifests, blockStatuses }),
+    ).toBe("gpt-5.6-sol");
+  });
+});

--- a/apps/worker/src/lib/overview/attribute-run-model.ts
+++ b/apps/worker/src/lib/overview/attribute-run-model.ts
@@ -1,0 +1,89 @@
+import type { BlockRunState, HarnessRunManifestRecord } from "@shared/contracts";
+
+/**
+ * The evidence a run row carries about which model it actually executed on.
+ * `blockStatuses` is keyed by definition node id, exactly like the manifests'
+ * `nodeId`, which is what lets a manifest be matched to a block that ran.
+ */
+export interface RunModelEvidence {
+  /** `workflow_runs.model`, written once by the run's terminal telemetry step. */
+  model: string | null;
+  harnessManifests: HarnessRunManifestRecord[] | null | undefined;
+  blockStatuses: Record<string, Omit<BlockRunState, "output">> | null | undefined;
+}
+
+/** A block that left "pending" has resolved its harness and started executing. */
+function ranNodeIds(
+  blockStatuses: RunModelEvidence["blockStatuses"],
+): { ran: Set<string>; running: Set<string> } {
+  const ran = new Set<string>();
+  const running = new Set<string>();
+  if (!blockStatuses || typeof blockStatuses !== "object") return { ran, running };
+  for (const [nodeId, state] of Object.entries(blockStatuses)) {
+    const status = state?.status;
+    if (!status || status === "pending") continue;
+    ran.add(nodeId);
+    if (status === "running") running.add(nodeId);
+  }
+  return { ran, running };
+}
+
+function soleModel(manifests: HarnessRunManifestRecord[]): string | null {
+  const ids = new Set(
+    manifests
+      .map((m) => m?.manifest?.model?.id)
+      .filter((id): id is string => typeof id === "string" && id.trim().length > 0),
+  );
+  return ids.size === 1 ? [...ids][0]! : null;
+}
+
+/**
+ * The model a run can be *shown* to have used, or null when nothing attributes
+ * one. Never returns the organization-wide default: that constant is not an
+ * observation of this run, and rendering it unmarked made failed runs read as if
+ * they had executed on a model they never touched (AIW-253).
+ *
+ * Evidence, strongest first:
+ *
+ * 1. The harness manifest of a block that actually ran. Manifests are recorded
+ *    once at run start, one per agent node, sorted by node id (agent.ts's
+ *    `harnessManifests`), so the array's order says nothing about execution.
+ *    `blockStatuses` does: a node that left "pending" resolved that manifest and
+ *    started. A "running" node is the block executing right now, so it wins over
+ *    blocks that already finished. Only used when the surviving manifests agree
+ *    on one model id, because a header shows a single model and picking one of
+ *    several would be a guess.
+ * 2. A unanimous manifest set. Covers the common single-profile run and every
+ *    row written before block statuses existed, and it is what fixes the
+ *    reported bug: a run that fails or parks in its first agent phase never
+ *    reaches the terminal telemetry step, so its `model` column is either null
+ *    or the org default `activeModel` was seeded with (agent.ts's
+ *    `activeModel ??= defaultModel`), while its manifests hold the model the
+ *    sandbox really launched.
+ * 3. The persisted `model` column. Ranked below the manifests precisely because
+ *    it can hold that seeded default; where it is a measured terminal value (a
+ *    run that completed through Implementation) the manifests either agree with
+ *    it or disagree among themselves, and this is then the run's own recorded
+ *    headline model.
+ * 4. Nothing: a gate run, or an agent run that died before recording anything.
+ *    Callers render an explicit unknown state.
+ */
+export function attributeRunModel(evidence: RunModelEvidence): string | null {
+  const manifests = Array.isArray(evidence.harnessManifests)
+    ? evidence.harnessManifests
+    : [];
+
+  if (manifests.length > 0) {
+    const { ran, running } = ranNodeIds(evidence.blockStatuses);
+    const scope = running.size > 0 ? running : ran;
+    if (scope.size > 0) {
+      const fromRan = soleModel(manifests.filter((m) => scope.has(m?.nodeId)));
+      if (fromRan) return fromRan;
+    }
+    const unanimous = soleModel(manifests);
+    if (unanimous) return unanimous;
+  }
+
+  const persisted = evidence.model?.trim();
+  return persisted ? persisted : null;
+}

--- a/apps/worker/src/lib/overview/collect-awaiting-store.test.ts
+++ b/apps/worker/src/lib/overview/collect-awaiting-store.test.ts
@@ -4,6 +4,15 @@ import { createTestDb } from "../../db/test-db.js";
 import type { Db } from "../../db/client.js";
 import { approvalRequests, clarificationRequests, workflowRuns } from "../../db/schema.js";
 import { collectAwaitingRuns } from "./collect-awaiting-store.js";
+import type { BlockRunState, HarnessRunManifestRecord } from "@shared/contracts";
+
+/** Minimal fixture: attributeRunModel only reads `.nodeId` / `.manifest.model.id`. */
+function harnessManifest(nodeId: string, modelId: string): HarnessRunManifestRecord {
+  return {
+    nodeId,
+    manifest: { model: { id: modelId } },
+  } as unknown as HarnessRunManifestRecord;
+}
 
 const NOW = new Date("2026-06-16T12:00:00.000Z");
 const HOUR = 3_600_000;
@@ -14,7 +23,7 @@ beforeEach(async () => {
   db = await createTestDb();
 });
 
-const base = { jiraBaseUrl: JIRA, model: "claude-fallback", now: NOW };
+const base = { jiraBaseUrl: JIRA, now: NOW };
 
 async function seedRun(over: {
   runId: string;
@@ -22,6 +31,9 @@ async function seedRun(over: {
   ticketKey?: string | null;
   ticketTitle?: string | null;
   startedAt?: Date | null;
+  model?: string | null;
+  harnessManifests?: HarnessRunManifestRecord[] | null;
+  blockStatuses?: Record<string, Omit<BlockRunState, "output">> | null;
 }): Promise<void> {
   await db.insert(workflowRuns).values({
     runId: over.runId,
@@ -30,7 +42,9 @@ async function seedRun(over: {
     status: over.status ?? "awaiting",
     ticketKey: over.ticketKey === undefined ? "AWT-1" : over.ticketKey,
     ticketTitle: over.ticketTitle === undefined ? "A ticket" : over.ticketTitle,
-    model: "claude-opus-4-8",
+    model: over.model === undefined ? "claude-opus-4-8" : over.model,
+    harnessManifests: over.harnessManifests ?? null,
+    blockStatuses: over.blockStatuses ?? null,
     startedAt: over.startedAt === undefined ? new Date(NOW.getTime() - HOUR) : over.startedAt,
   });
 }
@@ -159,6 +173,36 @@ describe("collectAwaitingRuns (store)", () => {
 
     const rows = await collectAwaitingRuns({ ...base, db });
     expect(rows).toEqual([]);
+  });
+
+  it("attributes the parked block's harness model over the persisted org default", async () => {
+    // A run parked mid-planning persists the org default from activeModel's
+    // prepare_workspace seeding; the manifest holds what actually ran (AIW-253).
+    await seedRun({
+      runId: "run_parked",
+      ticketKey: "AWT-20",
+      model: "claude-opus-4-8",
+      harnessManifests: [
+        harnessManifest("planning-1", "gpt-5.6-sol"),
+        harnessManifest("review-1", "claude-opus-4-8"),
+      ],
+      blockStatuses: {
+        "planning-1": { status: "running" },
+        "review-1": { status: "pending" },
+      },
+    });
+    await seedClarification({ runId: "run_parked", ticketKey: "AWT-20" });
+
+    const rows = await collectAwaitingRuns({ ...base, db });
+    expect(rows[0].model).toBe("gpt-5.6-sol");
+  });
+
+  it("reports no model for a parked run with no attribution evidence", async () => {
+    await seedRun({ runId: "run_bare", ticketKey: "AWT-21", model: null });
+    await seedClarification({ runId: "run_bare", ticketKey: "AWT-21" });
+
+    const rows = await collectAwaitingRuns({ ...base, db });
+    expect(rows[0].model).toBeNull();
   });
 
   it("orders newest ask first", async () => {

--- a/apps/worker/src/lib/overview/collect-awaiting-store.ts
+++ b/apps/worker/src/lib/overview/collect-awaiting-store.ts
@@ -2,12 +2,11 @@ import { and, desc, eq, sql } from "drizzle-orm";
 import type { Run } from "@shared/contracts";
 import type { Db } from "../../db/client.js";
 import { approvalRequests, clarificationRequests, workflowRuns } from "../../db/schema.js";
+import { attributeRunModel } from "./attribute-run-model.js";
 
 export interface CollectAwaitingRunsOptions {
   db: Db;
   jiraBaseUrl: string;
-  /** Used when a run has no persisted model. */
-  model: string;
   now: Date;
 }
 
@@ -34,7 +33,7 @@ export interface CollectAwaitingRunsOptions {
 export async function collectAwaitingRuns(
   opts: CollectAwaitingRunsOptions,
 ): Promise<Run[]> {
-  const { db, jiraBaseUrl, model, now } = opts;
+  const { db, jiraBaseUrl, now } = opts;
   const tenantOrigin = jiraBaseUrl.replace(/\/+$/, "");
 
   const rows = await db
@@ -46,6 +45,8 @@ export async function collectAwaitingRuns(
       ticketTitle: workflowRuns.ticketTitle,
       ticketUrl: workflowRuns.ticketUrl,
       model: workflowRuns.model,
+      harnessManifests: workflowRuns.harnessManifests,
+      blockStatuses: workflowRuns.blockStatuses,
       startedAt: workflowRuns.startedAt,
       firstSeenAt: workflowRuns.firstSeenAt,
       prNumber: workflowRuns.prNumber,
@@ -87,7 +88,7 @@ export async function collectAwaitingRuns(
       status: "awaiting",
       ticket: r.ticketKey ?? "",
       actor: "ai-bot",
-      model: r.model ?? model,
+      model: attributeRunModel(r),
       startedAtMin: Math.max(0, Math.round((now.getTime() - eff.getTime()) / 60000)),
       duration: null,
       tokens: null,

--- a/apps/worker/src/lib/overview/collect-live-runs.test.ts
+++ b/apps/worker/src/lib/overview/collect-live-runs.test.ts
@@ -3,6 +3,13 @@ import { collectLiveRuns } from "./collect-live-runs.js";
 import type { IssueTrackerAdapter } from "../../adapters/issue-tracker/types.js";
 import type { RunRegistryAdapter } from "../../adapters/run-registry/types.js";
 
+/** Pre-attribution shorthand: label every requested run id with one model. */
+function attributeAll(
+  model: string,
+): (runIds: string[]) => Promise<ReadonlyMap<string, string>> {
+  return async (runIds) => new Map(runIds.map((runId) => [runId, model]));
+}
+
 function makeRegistry(
   entries: Array<{
     ticketKey: string;
@@ -79,7 +86,7 @@ describe("collectLiveRuns", () => {
       registry,
       issueTracker: tracker,
       jiraBaseUrl: "https://example.atlassian.net",
-      model: "claude-opus-4-7",
+      resolveModels: attributeAll("claude-opus-4-7"),
     });
 
     expect(rows).toHaveLength(2);
@@ -98,6 +105,30 @@ describe("collectLiveRuns", () => {
     expect(rows[1].ticketTitle).toBe("Second ticket");
   });
 
+  it("carries the attributed model per run, and null for a run with none", async () => {
+    const registry = makeRegistry([
+      { ticketKey: "AWT-1", runId: "run_attributed" },
+      { ticketKey: "AWT-2", runId: "run_unknown" },
+    ]);
+
+    const rows = await collectLiveRuns({
+      registry,
+      issueTracker: makeTracker(),
+      jiraBaseUrl: "https://example.atlassian.net",
+      // Only the first run has attributable evidence; the second must not be
+      // labelled with the org default (AIW-253).
+      resolveModels: async (runIds) => {
+        expect(runIds).toEqual(["run_attributed", "run_unknown"]);
+        return new Map([["run_attributed", "gpt-5.6-sol"]]);
+      },
+    });
+
+    expect(rows.map(({ id, model }) => ({ id, model }))).toEqual([
+      { id: "run_attributed", model: "gpt-5.6-sol" },
+      { id: "run_unknown", model: null },
+    ]);
+  });
+
   it("falls back to the ticket key when issue tracker lookup fails", async () => {
     const registry = makeRegistry([{ ticketKey: "AWT-999", runId: "run_x" }]);
     const tracker = makeTracker({
@@ -108,7 +139,7 @@ describe("collectLiveRuns", () => {
       registry,
       issueTracker: tracker,
       jiraBaseUrl: "https://example.atlassian.net",
-      model: "claude-opus-4-7",
+      resolveModels: attributeAll("claude-opus-4-7"),
     });
 
     expect(rows).toHaveLength(1);
@@ -124,7 +155,7 @@ describe("collectLiveRuns", () => {
       registry: makeRegistry([]),
       issueTracker: makeTracker(),
       jiraBaseUrl: "https://example.atlassian.net",
-      model: "claude-opus-4-7",
+      resolveModels: attributeAll("claude-opus-4-7"),
     });
     expect(rows).toEqual([]);
   });
@@ -137,7 +168,7 @@ describe("collectLiveRuns", () => {
       ]),
       issueTracker: makeTracker(),
       jiraBaseUrl: "https://example.atlassian.net",
-      model: "claude-opus-4-7",
+      resolveModels: attributeAll("claude-opus-4-7"),
     });
 
     expect(rows.map(({ id, status }) => ({ id, status }))).toEqual([
@@ -167,7 +198,7 @@ describe("collectLiveRuns", () => {
       registry,
       issueTracker: tracker,
       jiraBaseUrl: "https://example.atlassian.net/",
-      model: "claude-opus-4-7",
+      resolveModels: attributeAll("claude-opus-4-7"),
     });
 
     expect(rows[0].ticketUrl).toBe("https://example.atlassian.net/browse/AWT-7");

--- a/apps/worker/src/lib/overview/collect-live-runs.ts
+++ b/apps/worker/src/lib/overview/collect-live-runs.ts
@@ -6,7 +6,12 @@ export interface CollectLiveRunsOptions {
   registry: RunRegistryAdapter;
   issueTracker: IssueTrackerAdapter;
   jiraBaseUrl: string;
-  model: string;
+  /** Attributed models for the in-flight run ids (fetchRunModels). The registry
+   * knows nothing about models, and these rows override the store's on the runs
+   * and ticket screens, so they take their model from the same evidence the
+   * store rows do. A run absent from the map has none: its row carries null and
+   * renders as unknown, never as the org default. */
+  resolveModels: (runIds: string[]) => Promise<ReadonlyMap<string, string>>;
 }
 
 /**
@@ -22,7 +27,7 @@ export interface CollectLiveRunsOptions {
 export async function collectLiveRuns(
   opts: CollectLiveRunsOptions,
 ): Promise<Run[]> {
-  const { registry, issueTracker, jiraBaseUrl, model } = opts;
+  const { registry, issueTracker, jiraBaseUrl, resolveModels } = opts;
   const entries = await registry.listAll();
   const tenantOrigin = jiraBaseUrl.replace(/\/+$/, "");
 
@@ -33,6 +38,8 @@ export async function collectLiveRuns(
         entry.state === "parked") &&
       entry.runId !== null,
   );
+
+  const models = await resolveModels(liveEntries.map((entry) => entry.runId));
 
   return Promise.all(
     liveEntries.map(async ({ subjectKey, ticketKey, runId, state }): Promise<Run> => {
@@ -54,7 +61,7 @@ export async function collectLiveRuns(
         status: state === "parked" ? "awaiting" : "running",
         ticket: displayKey,
         actor: "ai-bot",
-        model,
+        model: models.get(runId) ?? null,
         startedAtMin: 0,
         duration: null,
         tokens: null,

--- a/apps/worker/src/lib/overview/collect-run-detail.ts
+++ b/apps/worker/src/lib/overview/collect-run-detail.ts
@@ -115,7 +115,9 @@ export function sanitizeRunStepsForDiagnosticError(
 
 export interface CollectRunDetailOptions {
   world: RunDetailSource;
-  model: string;
+  /** The model attributed to this run by the durable row; null when nothing
+   * attributes one (see attributeRunModel). The world itself has none. */
+  model: string | null;
   runId: string;
 }
 
@@ -218,7 +220,7 @@ export async function captureRunStepsBestEffort(
   runId: string,
 ): Promise<RunStep[] | null> {
   try {
-    const { steps } = await collectRunDetail({ world, model: "", runId });
+    const { steps } = await collectRunDetail({ world, model: null, runId });
     return steps;
   } catch {
     return null;

--- a/apps/worker/src/routes/api/v1/runs.get.ts
+++ b/apps/worker/src/routes/api/v1/runs.get.ts
@@ -27,15 +27,12 @@ export default defineEventHandler(async (event): Promise<RunsResponse> => {
     const query = getQuery(event);
     const window = parseWindow(query.window);
     const q = parseSearch(query.q);
-    const model = env.AGENT_KIND === "codex" ? env.CODEX_MODEL : env.CLAUDE_MODEL;
-
     const { rows, total, counts } = await listRuns({
       db: getDb(),
       window,
       q,
       now: new Date(),
       jiraBaseUrl: env.JIRA_BASE_URL,
-      modelFallback: model,
     });
 
     return { generatedAt, available: true, rows, total, counts };

--- a/apps/worker/src/routes/api/v1/runs/[runId].get.ts
+++ b/apps/worker/src/routes/api/v1/runs/[runId].get.ts
@@ -47,16 +47,12 @@ export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
     .catch(() => null);
 
   try {
-    const model =
-      env.AGENT_KIND === "codex" ? env.CODEX_MODEL : env.CLAUDE_MODEL;
-
     // Read the durable row first: it carries the persisted waterfall (finished
     // runs) plus the ticket/PR refs the world lacks, and is the coarse fallback.
     const dbDetail = await fetchRunDetailFromDb({
       db: getDb(),
       runId,
       jiraBaseUrl: env.JIRA_BASE_URL,
-      modelFallback: model,
     }).catch(() => null);
 
     const result = await resolveRunDetail({
@@ -64,14 +60,14 @@ export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
       // In-flight runs: the world carries the live lifecycle + step waterfall but
       // not the ticket (encrypted input) or PR — merge those from the durable row.
       loadWorld: async () => {
-        // The durable row's model already prefers a live per-block value
-        // (see deriveLiveModel) over the org-wide default; carry that into
-        // the world-sourced header instead of re-flattening to the default.
-        const liveModel = dbDetail?.run.model ?? model;
+        // The world has no model at all, and the durable row is the only thing
+        // that can attribute one (see attributeRunModel), so carry it into the
+        // world-sourced header so the live trace and the run list agree, and
+        // stay null rather than naming the org default when nothing attributes.
         const [{ run, steps }, refs] = await Promise.all([
           collectRunDetail({
             world: getWorld() as unknown as RunDetailSource,
-            model: liveModel,
+            model: dbDetail?.run.model ?? null,
             runId,
           }),
           fetchRunRefs(getDb(), runId, env.JIRA_BASE_URL).catch(() => null),
@@ -116,13 +112,10 @@ export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
     // persisted per-phase breakdown, so old runs still render.
     logger.warn({ err: errorMessage(err), runId }, "run_detail_failed");
     try {
-      const model =
-        env.AGENT_KIND === "codex" ? env.CODEX_MODEL : env.CLAUDE_MODEL;
       const fallback = await fetchRunDetailFromDb({
         db: getDb(),
         runId,
         jiraBaseUrl: env.JIRA_BASE_URL,
-        modelFallback: model,
       });
       if (fallback) {
         const safe = sanitizeRunDetailForResponse(fallback);

--- a/apps/worker/src/routes/api/v1/runs/live.get.ts
+++ b/apps/worker/src/routes/api/v1/runs/live.get.ts
@@ -3,6 +3,7 @@ import { env } from "../../../../../env.js";
 import { getDb } from "../../../../db/client.js";
 import { createAdapters } from "../../../../lib/adapters.js";
 import { requireDashboardActor, toHttpError } from "../../../../lib/auth/request-context.js";
+import { fetchRunModels } from "../../../../db/queries/runs-read.js";
 import { collectLiveRuns } from "../../../../lib/overview/collect-live-runs.js";
 import { collectAwaitingRuns } from "../../../../lib/overview/collect-awaiting-store.js";
 import type { LiveRunsResponse } from "@shared/contracts";
@@ -16,8 +17,6 @@ export default defineEventHandler(
       await requireDashboardActor(event);
 
       const adapters = createAdapters();
-      const model =
-        env.AGENT_KIND === "codex" ? env.CODEX_MODEL : env.CLAUDE_MODEL;
 
       const now = new Date();
       const [running, awaiting] = await Promise.all([
@@ -25,12 +24,11 @@ export default defineEventHandler(
           registry: adapters.runRegistry,
           issueTracker: adapters.issueTracker,
           jiraBaseUrl: env.JIRA_BASE_URL,
-          model,
+          resolveModels: (runIds) => fetchRunModels(getDb(), runIds),
         }),
         collectAwaitingRuns({
           db: getDb(),
           jiraBaseUrl: env.JIRA_BASE_URL,
-          model,
           now,
         }),
       ]);

--- a/apps/worker/src/routes/api/v1/tickets/[ticketKey].get.ts
+++ b/apps/worker/src/routes/api/v1/tickets/[ticketKey].get.ts
@@ -30,14 +30,11 @@ export default defineEventHandler(async (event): Promise<TicketRunsResponse> => 
   if (!ticketKey) return { generatedAt, ...EMPTY };
 
   try {
-    const model =
-      env.AGENT_KIND === "codex" ? env.CODEX_MODEL : env.CLAUDE_MODEL;
     const { ticket, runs, totals } = await listRunsForTicket({
       db: getDb(),
       ticketKey,
       now: new Date(),
       jiraBaseUrl: env.JIRA_BASE_URL,
-      modelFallback: model,
     });
     return { generatedAt, available: true, ticket, runs, totals };
   } catch (err) {


### PR DESCRIPTION
## Summary
- attribute run models only from persisted run data or the recorded harness manifest
- show an explicit unknown state when no run-level evidence exists
- keep run list, ticket, detail, live, and awaiting surfaces consistent

## Verification
- worker focused suite: 87 tests passed
- dashboard focused suite: 14 tests passed
- worker and dashboard typechecks passed

Jira: https://blazity.atlassian.net/browse/AIW-253