### PR TITLE
AIW-266: Refresh active workflow runs

### DIFF
--- a/apps/dashboard/app/(cockpit)/cockpit-shell.tsx
+++ b/apps/dashboard/app/(cockpit)/cockpit-shell.tsx
@@ -1,7 +1,7 @@
 // apps/dashboard/app/(cockpit)/cockpit-shell.tsx
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
 import { useTweaks } from "@/lib/use-tweaks";
@@ -77,6 +77,8 @@ export function CockpitShell({
     !!t.activityDrawerOpen,
   );
   const [moreOpen, setMoreOpen] = useState(false);
+  const activeRunRefreshKeys = useRef(new Set<string>());
+  const [runRefreshActive, setRunRefreshActive] = useState(false);
   const moreScreens = cockpitNavItems({ canManageUsers })
     .filter((item) => isMobileMoreNavItem(item.id))
     .map((item) => item.id);
@@ -89,6 +91,21 @@ export function CockpitShell({
     router.push(runHref(r));
   };
 
+  const registerRunRefresh = useCallback((key: string, active: boolean) => {
+    if (active) activeRunRefreshKeys.current.add(key);
+    else activeRunRefreshKeys.current.delete(key);
+    setRunRefreshActive(activeRunRefreshKeys.current.size > 0);
+    return () => {
+      activeRunRefreshKeys.current.delete(key);
+      setRunRefreshActive(activeRunRefreshKeys.current.size > 0);
+    };
+  }, []);
+  const isActiveRunPoll = useCallback(
+    () => activeRunRefreshKeys.current.size > 0,
+    [],
+  );
+  const isRunScreen = screen === "runs" || screen === "ticket";
+
   // Timestamp of the next scheduled refresh, surfaced via context so the
   // live-poll control can render a countdown ring in sync with the actual
   // refreshes (which are driven here, once, for the whole cockpit).
@@ -98,8 +115,12 @@ export function CockpitShell({
   }, [t.livePolling]);
 
   useLivePoll({
-    enabled: !!t.livePolling,
+    // Run surfaces refresh only while they report non-terminal work. Other
+    // cockpit screens retain the existing opt-in global live mode.
+    enabled: isRunScreen ? runRefreshActive : !!t.livePolling,
     intervalMs: LIVE_POLL_MS,
+    maxTicks: isRunScreen ? 60 : undefined,
+    isActive: isRunScreen ? isActiveRunPoll : undefined,
     onTick: () => {
       router.refresh();
       setNextRefreshAt(Date.now() + LIVE_POLL_MS);
@@ -118,6 +139,7 @@ export function CockpitShell({
         livePolling: !!t.livePolling,
         toggleLive: () => setTweak("livePolling", !t.livePolling),
         nextRefreshAt,
+        registerRunRefresh,
       }}
     >
       <div className="h-dvh w-screen flex flex-col lg:flex-row overflow-hidden bg-app-bg relative">

--- a/apps/dashboard/app/ticket-data.tsx
+++ b/apps/dashboard/app/ticket-data.tsx
@@ -59,5 +59,12 @@ export async function RunDetailData({
     getRunDetail(runId),
     getRunReplay(runId),
   ]);
-  return <TraceDetail runId={runId} data={detail} replay={replay} />;
+  return (
+    <TraceDetail
+      runId={runId}
+      data={detail}
+      replay={replay}
+      enableRunRefresh
+    />
+  );
 }

--- a/apps/dashboard/components/cockpit/context.tsx
+++ b/apps/dashboard/components/cockpit/context.tsx
@@ -46,6 +46,8 @@ export interface CockpitCtxValue {
   toggleLive: () => void;
   /** Epoch ms of the next scheduled refresh while live; null when off. */
   nextRefreshAt: number | null;
+  /** Register whether a mounted run surface currently has non-terminal work. */
+  registerRunRefresh: (key: string, active: boolean) => () => void;
 }
 
 export const CockpitCtx = createContext<CockpitCtxValue>({
@@ -58,6 +60,7 @@ export const CockpitCtx = createContext<CockpitCtxValue>({
   livePolling: false,
   toggleLive: () => {},
   nextRefreshAt: null,
+  registerRunRefresh: () => () => {},
 });
 
 /** Convenience hook for nested screens to read cockpit context without prop drilling. */

--- a/apps/dashboard/components/cockpit/mobile/screens/runs-mobile.tsx
+++ b/apps/dashboard/components/cockpit/mobile/screens/runs-mobile.tsx
@@ -1,13 +1,15 @@
 // apps/dashboard/components/cockpit/mobile/screens/runs-mobile.tsx
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CkStatusPill, CkChip, TicketLink, PRLinks } from "@/components/ui";
 import { useCockpit } from "@/components/cockpit/context";
 import { WindowSelector } from "@/components/cockpit/controls";
 import { windowPhrase, type TimeWindow } from "@/lib/window";
 import { cancelRun } from "@/lib/api/cancel-run";
+import { hasActiveRun, useRunRefresh } from "@/lib/use-run-refresh";
+import { RunRefreshControl } from "@/components/cockpit/run-refresh-control";
 import type { RunsResponse } from "@shared/contracts";
 
 const FILTERS = [
@@ -43,11 +45,23 @@ export function RunsMobileScreen({
 }) {
   const { openRun } = useCockpit();
   const router = useRouter();
+  const [lastGoodData, setLastGoodData] = useState<RunsResponse | null>(
+    () => (data.available ? data : null),
+  );
+  useEffect(() => {
+    if (data.available) setLastGoodData(data);
+  }, [data]);
+  const stale = !data.available && lastGoodData !== null;
+  const shownData = stale ? lastGoodData : data;
+  const { isRefreshing, refresh } = useRunRefresh({
+    key: "runs-mobile",
+    active: shownData.rows.some((run) => hasActiveRun(run.status)),
+  });
   const [filter, setFilter] = useState("all");
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Record<string, CancelFeedback>>({});
-  const rows = filter === "all" ? data.rows : data.rows.filter((r) => r.status === filter);
+  const rows = filter === "all" ? shownData.rows : shownData.rows.filter((r) => r.status === filter);
 
   async function handleCancel(runId: string) {
     setBusyId(runId);
@@ -96,9 +110,16 @@ export function RunsMobileScreen({
       <div className="flex items-start justify-between gap-3">
         <div>
           <div className="font-mono text-[10px] uppercase tracking-[0.06em] text-neutral-500">Workflow runs</div>
-          <h2 className="font-display text-xl font-medium text-neutral-900 m-0">{data.total} runs · {windowPhrase(window)}</h2>
+          <h2 className="font-display text-xl font-medium text-neutral-900 m-0">{shownData.total} runs · {windowPhrase(window)}</h2>
         </div>
-        <WindowSelector value={window} size="sm" />
+        <div className="flex flex-col items-end gap-2">
+          <WindowSelector value={window} size="sm" />
+          <RunRefreshControl
+            isRefreshing={isRefreshing}
+            error={stale ? "Refresh failed; showing last good data." : null}
+            onRefresh={refresh}
+          />
+        </div>
       </div>
 
       {/* Horizontally scrollable filter chips */}

--- a/apps/dashboard/components/cockpit/mobile/screens/ticket-mobile.tsx
+++ b/apps/dashboard/components/cockpit/mobile/screens/ticket-mobile.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CkChip, CkStatusPill, PRLinks } from "@/components/ui";
 import { useCockpit } from "@/components/cockpit/context";
 import type { TicketRunsResponse } from "@shared/contracts";
+import { hasActiveRun, useRunRefresh } from "@/lib/use-run-refresh";
+import { RunRefreshControl } from "@/components/cockpit/run-refresh-control";
 
 function fmtCost(n: number): string {
   return `$${n.toFixed(2)}`;
@@ -34,7 +37,19 @@ export function TicketMobileScreen({
   data: TicketRunsResponse;
 }) {
   const { openRun } = useCockpit();
-  const { ticket, runs, totals } = data;
+  const [lastGoodData, setLastGoodData] = useState<TicketRunsResponse | null>(
+    () => (data.available ? data : null),
+  );
+  useEffect(() => {
+    if (data.available) setLastGoodData(data);
+  }, [data]);
+  const stale = !data.available && lastGoodData !== null;
+  const shownData = stale ? lastGoodData : data;
+  const { ticket, runs, totals } = shownData;
+  const { isRefreshing, refresh } = useRunRefresh({
+    key: "ticket-mobile",
+    active: runs.some((run) => hasActiveRun(run.status)),
+  });
 
   return (
     <div className="flex flex-col gap-3 px-4 pt-4 pb-6">
@@ -49,6 +64,11 @@ export function TicketMobileScreen({
           <span className="text-neutral-300">·</span>
           <span>{totals.runCount} {totals.runCount === 1 ? "run" : "runs"}</span>
         </div>
+        <RunRefreshControl
+          isRefreshing={isRefreshing}
+          error={stale ? "Refresh failed; showing last good data." : null}
+          onRefresh={refresh}
+        />
       </div>
 
       <div className="flex flex-col gap-2.5">

--- a/apps/dashboard/components/cockpit/run-refresh-control.tsx
+++ b/apps/dashboard/components/cockpit/run-refresh-control.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+export function RunRefreshControl({
+  isRefreshing,
+  error,
+  onRefresh,
+}: {
+  isRefreshing: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={isRefreshing}
+        className="appearance-none rounded-[3px] border border-neutral-200 bg-panel px-3 py-1.5 font-mono text-[10px] font-medium uppercase tracking-[0.04em] text-neutral-900 cursor-pointer disabled:cursor-default disabled:opacity-50"
+      >
+        {isRefreshing ? "Refreshing…" : "Refresh"}
+      </button>
+      {error && (
+        <span role="status" className="font-mono text-[10px] text-[#7A5A00]">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+

--- a/apps/dashboard/components/cockpit/screens/runs.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/runs.test.tsx
@@ -151,7 +151,7 @@ test("the model column names the attributed model, and unknown when there is non
   const { root } = renderDesktop(t, {
     data: makeData([
       makeRun({ id: "run_attributed", status: "failed", model: "gpt-5.6-sol" }),
-      makeRun({ id: "run_unknown", status: "failed", model: null }),
+      makeRun({ id: "run_unknown", status: "failed", model: undefined }),
     ]),
   });
   const text = screenText(root);
@@ -166,6 +166,16 @@ test("Cancel is absent for a row that is not running", (t) => {
     canCancel: true,
   });
   assert.equal(buttons(root, "Cancel").length, 0);
+});
+
+test("manual refresh is available on the runs list", (t) => {
+  const { root, refreshes } = renderDesktop(t, {
+    data: makeData([makeRun({ id: "run_1", status: "success" })]),
+  });
+  act(() => {
+    button(root, "Refresh").props.onClick();
+  });
+  assert.deepEqual(refreshes, ["refresh"]);
 });
 
 test("Cancel is absent from a running row without the dispatch role", (t) => {

--- a/apps/dashboard/components/cockpit/screens/runs.tsx
+++ b/apps/dashboard/components/cockpit/screens/runs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CkCard, CkChip, CkStatusPill, CkTabs, CkPagination, TicketLink, PRLinks } from "@/components/ui";
 import { useCockpit } from "@/components/cockpit/context";
@@ -9,6 +9,8 @@ import { SpotlightTrigger } from "@/components/cockpit/spotlight-search";
 import { windowPhrase, type TimeWindow } from "@/lib/window";
 import { cancelRun } from "@/lib/api/cancel-run";
 import { runModelLabel } from "@/lib/run-model";
+import { hasActiveRun, useRunRefresh } from "@/lib/use-run-refresh";
+import { RunRefreshControl } from "@/components/cockpit/run-refresh-control";
 import type { RunsResponse } from "@shared/contracts";
 
 const PAGE_SIZE = 25;
@@ -37,12 +39,24 @@ export function RunsScreen({
 }) {
   const { openRun } = useCockpit();
   const router = useRouter();
+  const [lastGoodData, setLastGoodData] = useState<RunsResponse | null>(
+    () => (data.available ? data : null),
+  );
+  useEffect(() => {
+    if (data.available) setLastGoodData(data);
+  }, [data]);
+  const stale = !data.available && lastGoodData !== null;
+  const shownData = stale ? lastGoodData : data;
+  const { isRefreshing, refresh } = useRunRefresh({
+    key: "runs-desktop",
+    active: shownData.rows.some((run) => hasActiveRun(run.status)),
+  });
   const [filter, setFilter] = useState("all");
   const [page, setPage] = useState(0);
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Record<string, CancelFeedback>>({});
-  const filtered = filter === "all" ? data.rows : data.rows.filter((r) => r.status === filter);
+  const filtered = filter === "all" ? shownData.rows : shownData.rows.filter((r) => r.status === filter);
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const start = page * PAGE_SIZE;
   const paged = filtered.slice(start, start + PAGE_SIZE);
@@ -101,7 +115,7 @@ export function RunsScreen({
       <div className="flex flex-col gap-1">
         <div className="font-mono text-[10px] uppercase tracking-[0.06em] text-neutral-500">Workflow runs</div>
         <h2 className="font-display text-2xl font-medium leading-[1.2] text-neutral-900 m-0">
-          {data.total} runs · {windowPhrase(window)}
+          {shownData.total} runs · {windowPhrase(window)}
           {q && <span className="text-neutral-500"> · matching “{q}”</span>}
         </h2>
       </div>
@@ -114,6 +128,11 @@ export function RunsScreen({
           { id: "failed", label: "Failed" },
           { id: "blocked", label: "Blocked" }]
         } />
+        <RunRefreshControl
+          isRefreshing={isRefreshing}
+          error={stale ? "Refresh failed; showing last good data." : null}
+          onRefresh={refresh}
+        />
       </div>
 
       <CkCard pad={0}>

--- a/apps/dashboard/components/cockpit/screens/ticket.tsx
+++ b/apps/dashboard/components/cockpit/screens/ticket.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { CkChip, CkStatusPill } from "@/components/ui";
 import { useTicketSelection } from "@/components/cockpit/screens/ticket-selection";
 import { runModelLabel } from "@/lib/run-model";
 import type { TicketRunsResponse } from "@shared/contracts";
+import { hasActiveRun, useRunRefresh } from "@/lib/use-run-refresh";
+import { RunRefreshControl } from "@/components/cockpit/run-refresh-control";
 
 function fmtCost(n: number): string {
   return `$${n.toFixed(2)}`;
@@ -34,7 +37,19 @@ export function TicketScreen({
   ticketKey: string;
   data: TicketRunsResponse;
 }) {
-  const { ticket, runs, totals } = data;
+  const [lastGoodData, setLastGoodData] = useState<TicketRunsResponse | null>(
+    () => (data.available ? data : null),
+  );
+  useEffect(() => {
+    if (data.available) setLastGoodData(data);
+  }, [data]);
+  const stale = !data.available && lastGoodData !== null;
+  const shownData = stale ? lastGoodData : data;
+  const { ticket, runs, totals } = shownData;
+  const { isRefreshing, refresh } = useRunRefresh({
+    key: "ticket-desktop",
+    active: runs.some((run) => hasActiveRun(run.status)),
+  });
   const title = ticket?.title || ticketKey;
 
   const { select, pendingRun, urlRun } = useTicketSelection();
@@ -68,9 +83,16 @@ export function TicketScreen({
             </a>
           )}
         </div>
-        <h2 className="font-display text-2xl font-medium leading-[1.2] text-neutral-900 m-0">
-          {title}
-        </h2>
+        <div className="flex items-start justify-between gap-3">
+          <h2 className="font-display text-2xl font-medium leading-[1.2] text-neutral-900 m-0">
+            {title}
+          </h2>
+          <RunRefreshControl
+            isRefreshing={isRefreshing}
+            error={stale ? "Refresh failed; showing last good data." : null}
+            onRefresh={refresh}
+          />
+        </div>
         <div className="flex items-center gap-2 flex-wrap font-mono text-[11px] text-neutral-700">
           <CkChip tone="coal">{fmtCost(totals.cost)}</CkChip>
           <span>{fmtTokens(totals.tokens)} tok</span>

--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -15,6 +15,8 @@ import { readErrorMessage } from "@/lib/api/error-message";
 import { runHref } from "@/lib/run-href";
 import { runModelLabel } from "@/lib/run-model";
 import { runPullRequests } from "@/lib/run-prs";
+import { hasActiveRun, useRunRefresh } from "@/lib/use-run-refresh";
+import { RunRefreshControl } from "@/components/cockpit/run-refresh-control";
 import { SPAN_KIND_COLOR } from "@/lib/theme";
 import { pullRequestRef, pullRequestRepoLabels } from "@shared/contracts";
 import type { Span, SpanKind, SpanStatus } from "@/lib/types";
@@ -167,16 +169,57 @@ export function replayForRunLifecycle(
     : { ...candidate, mayAdvance };
 }
 
+/** Keep router-dependent refresh hooks out of the historical trace path. */
+function RunRefreshActions({
+  runId,
+  active,
+  stale,
+}: {
+  runId: string;
+  active: boolean;
+  stale: boolean;
+}) {
+  const { isRefreshing, refresh } = useRunRefresh({
+    key: `run-detail:${runId}`,
+    active,
+  });
+  return (
+    <RunRefreshControl
+      isRefreshing={isRefreshing}
+      error={stale ? "Refresh failed; showing last good data." : null}
+      onRefresh={refresh}
+    />
+  );
+}
+
 export function TraceDetail({
   runId,
   data,
   replay,
+  enableRunRefresh = false,
 }: {
   runId: string;
   data: RunDetailResponse;
   replay: WorkflowRunReplayResponse;
+  enableRunRefresh?: boolean;
 }) {
-  const { run, steps } = data;
+  const [lastGoodData, setLastGoodData] = React.useState<RunDetailResponse | null>(
+    () => (data.available ? data : null),
+  );
+  const [lastGoodReplay, setLastGoodReplay] =
+    React.useState<WorkflowRunReplayResponse | null>(() =>
+      data.available ? replay : null,
+    );
+  React.useEffect(() => {
+    if (data.available) {
+      setLastGoodData(data);
+      setLastGoodReplay(replay);
+    }
+  }, [data, replay]);
+  const stale = !data.available && lastGoodData !== null;
+  const shownData = stale ? lastGoodData : data;
+  const shownReplay = stale ? lastGoodReplay ?? replay : replay;
+  const { run, steps } = shownData;
   const runMayAdvance =
     !!run &&
     !["success", "failed", "blocked"].includes(run.status);
@@ -186,11 +229,11 @@ export function TraceDetail({
     [runMayAdvance],
   );
   const [currentReplay, setCurrentReplay] = React.useState(() =>
-    normalizeReplay(replay),
+    normalizeReplay(shownReplay),
   );
   React.useEffect(() => {
-    setCurrentReplay(normalizeReplay(replay));
-  }, [normalizeReplay, replay, runId]);
+    setCurrentReplay(normalizeReplay(shownReplay));
+  }, [normalizeReplay, shownReplay, runId]);
   const handleReplayResponse = React.useCallback(
     (candidate: WorkflowRunReplayResponse) => {
       setCurrentReplay(normalizeReplay(candidate));
@@ -198,20 +241,17 @@ export function TraceDetail({
     [normalizeReplay],
   );
 
-  // Whether the run is still in flight — drives the "Running" indicator only. The
-  // auto-refresh is owned globally by CockpitShell's live-poll control (the
-  // topbar Live toggle), which calls router.refresh() for the active screen;
-  // this screen no longer polls on its own.
+  // Whether the run is still in flight — drives the "Running" indicator and
+  // keeps the ticket detail's bounded refresh active.
   const isRunning =
     !run ||
     (run.status !== "success" &&
       run.status !== "failed" &&
       run.status !== "blocked" &&
       run.status !== "awaiting");
-
   // Wall-clock offset of "now" from run start — sizes bars for running steps.
   const runStartMs = run ? Date.parse(run.startedAt ?? run.createdAt) : 0;
-  const nowOffsetMs = Math.max(0, Date.parse(data.generatedAt) - runStartMs);
+  const nowOffsetMs = Math.max(0, Date.parse(shownData.generatedAt) - runStartMs);
   const barMs = React.useCallback(
     (s: RunStep): number =>
       s.durationMs ?? Math.max(0, nowOffsetMs - s.startOffsetMs),
@@ -291,7 +331,7 @@ export function TraceDetail({
     setSelectedId(id);
   };
 
-  if (!data.available || !run) {
+  if (!shownData.available || !run) {
     return (
       <CkCard eyebrow="Run trace" title="Run unavailable">
         <div className="py-6 text-center text-neutral-500 font-body text-[13px]">
@@ -340,8 +380,15 @@ export function TraceDetail({
             {run.ticketTitle || run.id}
           </h2>
         </div>
-        {(run.ticketUrl || runPrs.length > 0) && (
+        {(enableRunRefresh || run.ticketUrl || runPrs.length > 0) && (
           <div className="flex items-center gap-2 self-start lg:self-auto flex-wrap">
+            {enableRunRefresh && (
+              <RunRefreshActions
+                runId={runId}
+                active={hasActiveRun(run.status)}
+                stale={stale}
+              />
+            )}
             {run.ticketUrl && (
               <a
                 href={run.ticketUrl}
@@ -425,9 +472,9 @@ export function TraceDetail({
         </CkCard>
       )}
 
-      {data.clarification && (
+      {shownData.clarification && (
         <AnswerPanel
-          clarification={data.clarification}
+          clarification={shownData.clarification}
           ticket={run.ticket}
           runStatus={run.status}
         />

--- a/apps/dashboard/lib/live-poll.test.ts
+++ b/apps/dashboard/lib/live-poll.test.ts
@@ -96,3 +96,59 @@ test("after stop(), a later visibility change does not tick (unsubscribed)", () 
   mock.timers.tick(5000);
   assert.equal(ticks(), 0);
 });
+
+test("a list poll settles as soon as its only run becomes terminal", () => {
+  const vis = makeVisibility(false);
+  let status: "running" | "success" = "running";
+  let ticks = 0;
+  const poll = createLivePoll({
+    intervalMs: 5000,
+    onTick: () => {
+      ticks++;
+      status = "success";
+    },
+    isActive: () => status === "running",
+    isHidden: vis.isHidden,
+    subscribeVisibility: vis.subscribe,
+  });
+  poll.start();
+  mock.timers.tick(5000);
+  mock.timers.tick(5000);
+  assert.equal(ticks, 1);
+});
+
+test("a detail poll settles for an awaiting run after the terminal response", () => {
+  const vis = makeVisibility(false);
+  let status: "awaiting" | "failed" = "awaiting";
+  let ticks = 0;
+  const poll = createLivePoll({
+    intervalMs: 5000,
+    onTick: () => {
+      ticks++;
+      status = "failed";
+    },
+    isActive: () => status === "awaiting",
+    isHidden: vis.isHidden,
+    subscribeVisibility: vis.subscribe,
+  });
+  poll.start();
+  mock.timers.tick(5000);
+  mock.timers.tick(5000);
+  assert.equal(ticks, 1);
+});
+
+test("automatic refresh has a finite tick budget", () => {
+  let count = 0;
+  const finite = createLivePoll({
+    intervalMs: 5000,
+    maxTicks: 2,
+    onTick: () => { count++; },
+    isHidden: () => false,
+    subscribeVisibility: () => () => {},
+  });
+  finite.start();
+  mock.timers.tick(5000);
+  mock.timers.tick(5000);
+  mock.timers.tick(5000);
+  assert.equal(count, 2);
+});

--- a/apps/dashboard/lib/live-poll.ts
+++ b/apps/dashboard/lib/live-poll.ts
@@ -6,6 +6,10 @@
 export interface LivePollDeps {
   intervalMs: number;
   onTick: () => void;
+  /** Optional upper bound for automatic ticks; manual refresh remains available. */
+  maxTicks?: number;
+  /** Optional dynamic gate; a false value stops polling at the next tick. */
+  isActive?: () => boolean;
   /** True when the tab is hidden; while hidden the interval is paused. */
   isHidden: () => boolean;
   /** Subscribe to visibility changes; returns an unsubscribe fn. */
@@ -18,14 +22,38 @@ export interface LivePoll {
 }
 
 export function createLivePoll(deps: LivePollDeps): LivePoll {
-  const { intervalMs, onTick, isHidden, subscribeVisibility } = deps;
+  const {
+    intervalMs,
+    onTick,
+    maxTicks,
+    isActive = () => true,
+    isHidden,
+    subscribeVisibility,
+  } = deps;
 
   let timer: ReturnType<typeof setInterval> | null = null;
   let unsubscribe: (() => void) | null = null;
   let started = false;
+  let tickCount = 0;
+
+  const tick = () => {
+    if (!isActive()) {
+      stopInterval();
+      return;
+    }
+    onTick();
+    tickCount += 1;
+    if (maxTicks !== undefined && tickCount >= maxTicks) stopInterval();
+  };
 
   const startInterval = () => {
-    if (timer === null) timer = setInterval(onTick, intervalMs);
+    if (
+      timer === null &&
+      isActive() &&
+      (maxTicks === undefined || tickCount < maxTicks)
+    ) {
+      timer = setInterval(tick, intervalMs);
+    }
   };
   const stopInterval = () => {
     if (timer !== null) {
@@ -40,7 +68,7 @@ export function createLivePoll(deps: LivePollDeps): LivePoll {
       stopInterval();
     } else if (timer === null) {
       // Became visible while paused: refresh once now, then resume.
-      onTick();
+      tick();
       startInterval();
     }
   };
@@ -49,6 +77,7 @@ export function createLivePoll(deps: LivePollDeps): LivePoll {
     start() {
       if (started) return;
       started = true;
+      tickCount = 0;
       unsubscribe = subscribeVisibility(onVisibilityChange);
       if (!isHidden()) startInterval();
     },

--- a/apps/dashboard/lib/use-live-poll.ts
+++ b/apps/dashboard/lib/use-live-poll.ts
@@ -16,10 +16,14 @@ export function useLivePoll({
   enabled,
   intervalMs,
   onTick,
+  maxTicks,
+  isActive,
 }: {
   enabled: boolean;
   intervalMs: number;
   onTick: () => void;
+  maxTicks?: number;
+  isActive?: () => boolean;
 }): void {
   // Keep the latest onTick without restarting the interval on its identity change.
   const onTickRef = useRef(onTick);
@@ -32,6 +36,8 @@ export function useLivePoll({
 
     const poll = createLivePoll({
       intervalMs,
+      maxTicks,
+      isActive,
       onTick: () => onTickRef.current(),
       isHidden: () => document.visibilityState === "hidden",
       subscribeVisibility: (cb) => {
@@ -41,5 +47,5 @@ export function useLivePoll({
     });
     poll.start();
     return () => poll.stop();
-  }, [enabled, intervalMs]);
+  }, [enabled, intervalMs, maxTicks, isActive]);
 }

--- a/apps/dashboard/lib/use-run-refresh.ts
+++ b/apps/dashboard/lib/use-run-refresh.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback, useEffect, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import { useCockpit } from "@/components/cockpit/context";
+
+/** A run is live until it reaches one of these durable outcomes. */
+export function hasActiveRun(status: string): boolean {
+  return status === "running" || status === "awaiting";
+}
+
+export function useRunRefresh({
+  key,
+  active,
+}: {
+  key: string;
+  active: boolean;
+}): { isRefreshing: boolean; refresh: () => void } {
+  const router = useRouter();
+  const { registerRunRefresh } = useCockpit();
+  const [isRefreshing, startTransition] = useTransition();
+
+  useEffect(
+    () => registerRunRefresh(key, active),
+    [active, key, registerRunRefresh],
+  );
+
+  const refresh = useCallback(() => {
+    startTransition(() => router.refresh());
+  }, [router]);
+
+  return { isRefreshing, refresh };
+}
+


### PR DESCRIPTION
## What changed

- adds bounded automatic refresh while list or detail views contain non-terminal runs
- pauses polling for hidden pages and stops once work is terminal or the tick budget is exhausted
- adds manual refresh controls to Workflow Runs and ticket/run detail surfaces
- preserves the last good payload and shows non-destructive stale-data feedback after refresh failures

## Why

Workflow run status did not update without navigating away or refreshing the whole page manually.

## Impact

Users see current run state while work is active, with a manual fallback and without unbounded background polling.

## Validation

- focused dashboard tests: 27/27 passing
- `git diff --check`
- typecheck reached an existing local workspace-resolution limitation for `@shared/conditions`; task-local TypeScript error found during review was corrected

Jira: https://blazity.atlassian.net/browse/AIW-266