### PR TITLE
AIW-264: Resume Jira clarification exactly once

### DIFF
--- a/apps/worker/src/clarifications/resume-from-comments.test.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.test.ts
@@ -354,6 +354,54 @@ describe("resumeClarificationFromComments", () => {
     );
   });
 
+  it("allows only one concurrent delivery to invoke resumeHook", async () => {
+    const row = await seedPending();
+    await answerHookClarification(db, row.id, "Stored answer", { id: "user_1", label: "Ada" });
+    const tracker = makeTracker();
+    let releaseResume!: () => void;
+    let resumeStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resumeStarted = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      releaseResume = resolve;
+    });
+    mocks.resumeHook.mockImplementationOnce(async () => {
+      resumeStarted();
+      await released;
+      return { runId: RUN };
+    });
+
+    const first = run(tracker);
+    await started;
+    const second = await run(tracker);
+
+    expect(second).toEqual({ status: "resume_retry_pending", runId: RUN });
+    expect(mocks.resumeHook).toHaveBeenCalledTimes(1);
+    releaseResume();
+    expect(await first).toEqual({ status: "resumed", runId: RUN });
+    expect(mocks.resumeHook).toHaveBeenCalledTimes(1);
+    expect(
+      (await db.select().from(workflowRuns).where(eq(workflowRuns.runId, RUN)))[0]?.status,
+    ).toBe("running");
+  });
+
+  it("restores retry eligibility when the claimed resume fails", async () => {
+    const row = await seedPending();
+    await answerHookClarification(db, row.id, "Stored answer", { id: "user_1", label: "Ada" });
+    const tracker = makeTracker();
+    mocks.resumeHook.mockRejectedValueOnce(new Error("transport failed"));
+    mocks.getHookByToken.mockResolvedValueOnce({ token: row.hookToken });
+
+    expect(await run(tracker)).toEqual({ status: "resume_retry_pending", runId: RUN });
+    expect(
+      (await db.select().from(workflowRuns).where(eq(workflowRuns.runId, RUN)))[0]?.status,
+    ).toBe("awaiting");
+
+    expect(await run(tracker)).toEqual({ status: "resumed", runId: RUN });
+    expect(mocks.resumeHook).toHaveBeenCalledTimes(2);
+  });
+
   it("treats a consumed hook on an answered row as won", async () => {
     const row = await seedPending();
     await answerHookClarification(db, row.id, "Stored answer", { id: "user_1", label: "Ada" });

--- a/apps/worker/src/clarifications/resume-from-comments.test.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.test.ts
@@ -7,7 +7,7 @@ import {
   type TicketComment,
   type TicketContent,
 } from "../adapters/issue-tracker/types.js";
-import { activeRuns, clarificationRequests } from "../db/schema.js";
+import { activeRuns, clarificationRequests, workflowRuns } from "../db/schema.js";
 import { createTestDb } from "../db/test-db.js";
 import { CLARIFICATION_NUDGE_MARKER } from "./comment-format.js";
 import {
@@ -65,16 +65,26 @@ async function seedPending() {
     state: "bound",
     runKind: "ticket",
   });
+  await db.insert(workflowRuns).values({
+    runId: RUN,
+    subjectKey: SUBJECT,
+    ticketKey: TICKET,
+    status: "awaiting",
+  });
   return published;
 }
 
-function ticketWith(comments: TicketComment[], trackerStatus = "AI"): TicketContent {
+function ticketWith(
+  comments: TicketComment[],
+  trackerStatus = "AI",
+  description = "Description",
+): TicketContent {
   return {
     id: "1",
     identifier: TICKET,
     projectKey: "AWT",
     title: "Title",
-    description: "Description",
+    description,
     acceptanceCriteria: "",
     comments,
     labels: [],
@@ -143,6 +153,36 @@ describe("resumeClarificationFromComments", () => {
       answeredById: "jira:human-1",
       answeredByLabel: "Jane (via Jira)",
     });
+  });
+
+  it("resumes an empty-description ticket once across comment and move deliveries", async () => {
+    const row = await seedPending();
+    expect(
+      (await db.select().from(workflowRuns).where(eq(workflowRuns.runId, RUN)))[0]?.status,
+    ).toBe("awaiting");
+    let trackerStatus = "Backlog";
+    const comments = [
+      { author: "Jane", accountId: "human-1", body: "Use Next.js", createdAt: AFTER },
+    ];
+    const tracker = makeTracker({
+      fetchTicket: async () => ticketWith(comments, trackerStatus, ""),
+    });
+
+    // The comment arrives while the ticket is still parked; comments alone do
+    // not commit the answer.
+    expect(await run(tracker)).toEqual({ status: "not_in_ai_column" });
+    trackerStatus = "AI";
+    expect(await run(tracker)).toEqual({ status: "resumed", runId: RUN });
+    // Jira may deliver the comment and the move-to-AI as separate webhook
+    // deliveries. The second delivery observes the answered row, but must not
+    // resume the same Workflow a second time after the first hook was consumed.
+    expect(await run(tracker)).toEqual({ status: "resumed", runId: RUN });
+
+    expect(mocks.resumeHook).toHaveBeenCalledTimes(1);
+    expect((await getHookClarification(db, row.id))?.status).toBe("answered");
+    expect(
+      (await db.select().from(workflowRuns).where(eq(workflowRuns.runId, RUN)))[0]?.status,
+    ).toBe("running");
   });
 
   it("joins multiple commenters and attributes the last one", async () => {

--- a/apps/worker/src/clarifications/resume-from-comments.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.ts
@@ -1,5 +1,5 @@
 import { env } from "../../env.js";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 import {
   IssueTrackerNotFoundError,
   type IssueTrackerAdapter,
@@ -19,6 +19,65 @@ import {
   formatClarificationNudgeComment,
 } from "./comment-format.js";
 import { getHookClarification, getResumableClarificationForTicket } from "./hook-store.js";
+
+const RESUME_CLAIM_TTL_MS = 60_000;
+
+async function claimAnsweredResume(
+  db: Db,
+  row: { runId: string; subjectKey: string | null; ticketKey: string | null },
+): Promise<"claimed" | "in_progress" | "resumed" | "settled"> {
+  const claimable = or(
+    isNull(workflowRuns.status),
+    eq(workflowRuns.status, "awaiting"),
+    and(
+      eq(workflowRuns.status, "resuming"),
+      or(
+        isNull(workflowRuns.updatedAt),
+        sql`${workflowRuns.updatedAt} < now() - (${RESUME_CLAIM_TTL_MS} * interval '1 millisecond')`,
+      ),
+    ),
+  );
+  const [updated] = await db
+    .update(workflowRuns)
+    .set({ status: "resuming", updatedAt: sql`now()` })
+    .where(and(eq(workflowRuns.runId, row.runId), claimable))
+    .returning({ runId: workflowRuns.runId });
+  if (updated) return "claimed";
+
+  // The run row should already exist, but claiming an older status-less run is
+  // still safe. ON CONFLICT makes this the same one-winner CAS as the update.
+  const [inserted] = await db
+    .insert(workflowRuns)
+    .values({
+      runId: row.runId,
+      subjectKey: row.subjectKey,
+      ticketKey: row.ticketKey,
+      status: "resuming",
+    })
+    .onConflictDoNothing()
+    .returning({ runId: workflowRuns.runId });
+  if (inserted) return "claimed";
+
+  const [current] = await db
+    .select({ status: workflowRuns.status })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, row.runId))
+    .limit(1);
+  if (current?.status === "running") return "resumed";
+  if (current?.status === "resuming") return "in_progress";
+  return "settled";
+}
+
+async function finishAnsweredResumeClaim(
+  db: Db,
+  runId: string,
+  status: "awaiting" | "running" | "blocked",
+): Promise<void> {
+  await db
+    .update(workflowRuns)
+    .set({ status, updatedAt: sql`now()` })
+    .where(and(eq(workflowRuns.runId, runId), eq(workflowRuns.status, "resuming")));
+}
 
 export type CommentResumeStatus =
   | "no_clarification" // caller proceeds to dispatchTicket as today
@@ -59,40 +118,57 @@ export async function resumeClarificationFromComments(input: {
     // resume. Keep the dashboard's retry behavior in answer-core unchanged by
     // using the Jira run marker only on this provider-specific path. A row that
     // is still awaiting input means the earlier resume needs a retry.
-    const [run] = await db
-      .select({ status: workflowRuns.status })
-      .from(workflowRuns)
-      .where(eq(workflowRuns.runId, row.runId))
-      .limit(1);
-    if (run?.status === "running") {
+    const claim = await claimAnsweredResume(db, row);
+    if (claim === "resumed") {
       return { status: "resumed", runId: row.runId };
     }
+    if (claim === "in_progress") {
+      return { status: "resume_retry_pending", runId: row.runId };
+    }
+    if (claim === "settled") {
+      return { status: "already_answered", runId: row.runId };
+    }
 
-    const outcome = await answerClarificationAndResume({
-      db,
-      row,
-      rawAnswer: row.answer ?? "",
-      actor: {
-        id: row.answeredById ?? "system",
-        label: row.answeredByLabel ?? "system",
-      },
-      issueTracker,
-      skipTicketFetch: false,
-    });
+    let outcome;
+    try {
+      outcome = await answerClarificationAndResume({
+        db,
+        row,
+        rawAnswer: row.answer ?? "",
+        actor: {
+          id: row.answeredById ?? "system",
+          label: row.answeredByLabel ?? "system",
+        },
+        issueTracker,
+        skipTicketFetch: false,
+      });
+    } catch (error) {
+      await finishAnsweredResumeClaim(db, row.runId, "awaiting");
+      throw error;
+    }
     switch (outcome.kind) {
-      case "answered":
+      case "answered": {
+        await finishAnsweredResumeClaim(db, row.runId, "running");
         return { status: "resumed", runId: row.runId };
-      case "resume_failed_retryable":
+      }
+      case "resume_failed_retryable": {
+        await finishAnsweredResumeClaim(db, row.runId, "awaiting");
         logger.warn(
           { ticketKey, runId: row.runId },
           "clarification_resume_retry_pending",
         );
         return { status: "resume_retry_pending", runId: row.runId };
-      case "ticket_gone":
+      }
+      case "ticket_gone": {
+        await finishAnsweredResumeClaim(db, row.runId, "blocked");
         return { status: "ticket_gone" };
-      case "conflict":
+      }
+      case "conflict": {
+        await finishAnsweredResumeClaim(db, row.runId, "awaiting");
         return { status: "already_answered" };
-      case "invalid_answer":
+      }
+      case "invalid_answer": {
+        await finishAnsweredResumeClaim(db, row.runId, "awaiting");
         // Defensive: an answered row with an empty answer cannot resume. Do not
         // throw; the run stays parked and expiry eventually reclaims it.
         logger.warn(
@@ -100,6 +176,7 @@ export async function resumeClarificationFromComments(input: {
           "clarification_resume_answered_row_empty_answer",
         );
         return { status: "already_answered" };
+      }
     }
   }
 

--- a/apps/worker/src/clarifications/resume-from-comments.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.ts
@@ -1,9 +1,11 @@
 import { env } from "../../env.js";
+import { eq } from "drizzle-orm";
 import {
   IssueTrackerNotFoundError,
   type IssueTrackerAdapter,
 } from "../adapters/issue-tracker/types.js";
 import type { Db } from "../db/client.js";
+import { workflowRuns } from "../db/schema.js";
 import { ticketPageUrl } from "../lib/dashboard-links.js";
 import { logger } from "../lib/logger.js";
 import {
@@ -51,6 +53,21 @@ export async function resumeClarificationFromComments(input: {
   // isResumeRetry path (a consumed hook is treated as won, idempotent). Never
   // compose from comments here so identical retries stay convergent.
   if (row.status === "answered") {
+    // Jira can deliver the comment and the status move as separate webhooks.
+    // Once the first delivery has cleared the live park marker, the second
+    // must not call resumeHook again: it is a duplicate delivery, not a lost
+    // resume. Keep the dashboard's retry behavior in answer-core unchanged by
+    // using the Jira run marker only on this provider-specific path. A row that
+    // is still awaiting input means the earlier resume needs a retry.
+    const [run] = await db
+      .select({ status: workflowRuns.status })
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, row.runId))
+      .limit(1);
+    if (run?.status === "running") {
+      return { status: "resumed", runId: row.runId };
+    }
+
     const outcome = await answerClarificationAndResume({
       db,
       row,

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -148,7 +148,7 @@ export async function upsertRunSnapshots(
         // endpoint owns that transition. Only advance a row that hasn't reached
         // a frozen state.
         status: sql`case
-          when ${workflowRuns.status} in ('success', 'failed', 'blocked', 'awaiting') then ${workflowRuns.status}
+          when ${workflowRuns.status} in ('success', 'failed', 'blocked', 'awaiting', 'resuming') then ${workflowRuns.status}
           else excluded.status
         end`,
         ticketKey: keepIfNull(workflowRuns.ticketKey, workflowRuns.ticketKey),


### PR DESCRIPTION
## What changed

- claims an answered Jira clarification resume with a durable compare-and-set lease before invoking the Workflow hook
- prevents concurrent comment/status webhook deliveries from invoking the same resume hook twice
- restores the awaiting state after a retryable or unexpected hook failure, with stale-claim recovery
- keeps dashboard clarification behavior unchanged
- adds regressions for an empty-description ticket, concurrent deliveries, and failed-resume retry

## Why

Jira can deliver the comment and status transition separately or concurrently. Without an atomic claim, both deliveries could observe the parked run and attempt to consume the same Workflow hook.

## Impact

The existing run keeps the same run ID and resumes exactly once. Failed attempts remain retryable instead of leaving a permanent claim.

## Validation

- focused clarification suite: 19/19 passing
- worker typecheck: passing
- `git diff --check`
- rebased on `main` after #253

Jira: https://blazity.atlassian.net/browse/AIW-264