### PR TITLE
feat: AIW-261 Zendesk and Sentry support investigation

### DIFF
--- a/apps/dashboard/components/cockpit/flow-editor/config-fields.tsx
+++ b/apps/dashboard/components/cockpit/flow-editor/config-fields.tsx
@@ -975,10 +975,22 @@ const WEBHOOK_REJECTION_CAUSES: Record<string, string> = {
 };
 
 const WEBHOOK_MAPPING_FIELDS: readonly {
-  key: "mapSubject" | "mapDescription" | "mapRequester" | "mapPriority";
+  key:
+    | "provider"
+    | "sourceIdPath"
+    | "sourceUrlPath"
+    | "customerContextPath"
+    | "mapSubject"
+    | "mapDescription"
+    | "mapRequester"
+    | "mapPriority";
   label: string;
   placeholder: string;
 }[] = [
+  { key: "provider", label: "Support provider (optional)", placeholder: "zendesk or sentry" },
+  { key: "sourceIdPath", label: "Source ID mapping", placeholder: "ticket.id" },
+  { key: "sourceUrlPath", label: "Source URL mapping", placeholder: "ticket.url" },
+  { key: "customerContextPath", label: "Customer context mapping", placeholder: "ticket.requester" },
   { key: "mapSubject", label: "Subject mapping", placeholder: "subject" },
   { key: "mapDescription", label: "Description mapping", placeholder: "description" },
   { key: "mapRequester", label: "Requester mapping", placeholder: "requester" },

--- a/apps/shared/contracts/workflow-graph.ts
+++ b/apps/shared/contracts/workflow-graph.ts
@@ -167,6 +167,10 @@ export const BLOCK_PARAM_KEYS: Record<WorkflowBlockType, readonly string[]> = {
   trigger_pr_review: ["providers", "scope", "on", "rateLimitMax", "rateLimitWindow"],
   trigger_pr_merged: ["providers", "scope", "rateLimitMax", "rateLimitWindow"],
   trigger_webhook: [
+    "provider",
+    "sourceIdPath",
+    "sourceUrlPath",
+    "customerContextPath",
     "authScheme",
     "headerName",
     "requireTimestamp",

--- a/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
+++ b/apps/worker/src/routes/api/v1/workflow-definitions.test.ts
@@ -367,6 +367,7 @@ describe("GET /api/v1/workflow-definitions", () => {
       "Post-PR review with autofix",
       "Fully modular",
       "Ticket triage (webhook)",
+      "Support investigation (Zendesk + Sentry)",
     ]);
     expect(
       body.templates.every(

--- a/apps/worker/src/routes/webhooks/custom/[endpointId].post.ts
+++ b/apps/worker/src/routes/webhooks/custom/[endpointId].post.ts
@@ -248,7 +248,7 @@ export default defineEventHandler(async (event) => {
     getHeader(event, DELIVERY_ID_HEADER)?.trim().slice(0, MAX_DELIVERY_ID_LENGTH) ||
     fallbackWebhookDeliveryId(rawBody);
 
-  const mapped = mapWebhookPayload(target.configuration, body);
+  const mapped = mapWebhookPayload(target.configuration, body, endpointId);
   const result = await dispatchWebhookDelivery(
     {
       endpointId,

--- a/apps/worker/src/webhook-trigger/payload-mapping.test.ts
+++ b/apps/worker/src/webhook-trigger/payload-mapping.test.ts
@@ -10,6 +10,90 @@ const registryDefaults = {
 };
 
 describe("webhook payload mapping", () => {
+  it("normalizes a Zendesk-shaped delivery into the support-case contract", () => {
+    const mapped = mapWebhookPayload(
+      {
+        provider: "zendesk",
+        sourceIdPath: "ticket.id",
+        sourceUrlPath: "ticket.url",
+        mapSubject: "ticket.subject",
+        mapDescription: "ticket.description",
+        mapRequester: "ticket.requester.email",
+        customerContextPath: "ticket.requester",
+        mapPriority: "ticket.priority",
+      },
+      {
+        ticket: {
+          id: 35436,
+          subject: "The printer is on fire",
+          description: "Smoke started after the firmware update.",
+          priority: "urgent",
+          url: "https://support.example.test/agent/tickets/35436",
+          requester: { email: "customer@example.test", name: "Ada" },
+        },
+      },
+      "wh_zendesk",
+    );
+
+    expect(mapped.entry.supportCase).toEqual({
+      provider: "zendesk",
+      endpoint: "wh_zendesk",
+      sourceId: "35436",
+      sourceUrl: "https://support.example.test/agent/tickets/35436",
+      title: "The printer is on fire",
+      description: "Smoke started after the firmware update.",
+      severity: "urgent",
+      priority: "urgent",
+      reporter: "customer@example.test",
+      customerContext: { email: "customer@example.test", name: "Ada" },
+      metadata: {
+        ticket: {
+          id: 35436,
+          subject: "The printer is on fire",
+          description: "Smoke started after the firmware update.",
+          priority: "urgent",
+          url: "https://support.example.test/agent/tickets/35436",
+          requester: { email: "customer@example.test", name: "Ada" },
+        },
+      },
+    });
+  });
+
+  it("normalizes a Sentry-shaped delivery and remains total for missing fields", () => {
+    const mapped = mapWebhookPayload(
+      {
+        provider: "sentry",
+        sourceIdPath: "data.issue.id",
+        sourceUrlPath: "data.issue.permalink",
+        mapSubject: "data.issue.title",
+        mapDescription: "data.issue.metadata.value",
+        mapRequester: "actor.email",
+        mapPriority: "data.issue.level",
+      },
+      {
+        action: "created",
+        data: { issue: { id: "123", title: "TypeError", level: "error", metadata: {} } },
+      },
+      "wh_sentry",
+    );
+
+    expect(mapped.entry.supportCase).toMatchObject({
+      provider: "sentry",
+      endpoint: "wh_sentry",
+      sourceId: "123",
+      sourceUrl: "",
+      title: "TypeError",
+      description: "",
+      severity: "error",
+      priority: "error",
+      reporter: "",
+    });
+    expect(mapped.entry.supportCase?.metadata).toEqual({
+      action: "created",
+      data: { issue: { id: "123", title: "TypeError", level: "error", metadata: {} } },
+    });
+  });
+
   it("maps the registry default field names off a flat body", () => {
     const body = {
       subject: "Printer is on fire",

--- a/apps/worker/src/webhook-trigger/payload-mapping.ts
+++ b/apps/worker/src/webhook-trigger/payload-mapping.ts
@@ -11,15 +11,40 @@ export interface WebhookTriggerEntry {
   description: string;
   requester: string;
   priority: string;
+  /** Optional provider-normalized support case. Generic webhooks omit this
+   * field, preserving the original trigger contract. */
+  supportCase?: SupportCase;
   /** The delivered body, unchanged, so a workflow can read anything the
    *  configured mappings did not name. JSON-shaped because it is persisted as
    *  jsonb and carried through a Workflow input, both of which must serialize. */
   payload: JsonValue;
 }
 
-/** The five payload-shaped node-config keys. The endpoint row owns the two auth
- *  keys, which have no meaning for mapping. */
+/** Explicit contract shared by provider-specific support webhook endpoints.
+ * The raw payload remains available alongside this bounded, normalized view. */
+export interface SupportCase {
+  [key: string]: JsonValue;
+  provider: "zendesk" | "sentry";
+  endpoint: string;
+  sourceId: string;
+  sourceUrl: string;
+  title: string;
+  description: string;
+  severity: string;
+  priority: string;
+  reporter: string;
+  customerContext: JsonValue;
+  metadata: JsonValue;
+}
+
+/** Payload-shaped node-config keys. The endpoint row owns the auth keys, which
+ * have no meaning for mapping. */
 export interface WebhookMappingConfig {
+  /** Set only for a provider-specific support endpoint. */
+  provider?: "zendesk" | "sentry" | null;
+  sourceIdPath?: string | null;
+  sourceUrlPath?: string | null;
+  customerContextPath?: string | null;
   subjectPath?: string | null;
   mapSubject?: string | null;
   mapDescription?: string | null;
@@ -54,6 +79,7 @@ const DEFAULT_MAPPINGS = {
 export function mapWebhookPayload(
   config: WebhookMappingConfig,
   body: JsonValue,
+  endpointId = "",
 ): MappedWebhookPayload {
   const entry: WebhookTriggerEntry = {
     subject: mappedString(body, config.mapSubject ?? DEFAULT_MAPPINGS.mapSubject),
@@ -68,6 +94,26 @@ export function mapWebhookPayload(
     priority: mappedString(body, config.mapPriority ?? DEFAULT_MAPPINGS.mapPriority),
     payload: body,
   };
+  if (config.provider) {
+    const customerContext = resolvePayloadPath(
+      body,
+      config.customerContextPath ?? config.mapRequester ?? "",
+    );
+    entry.supportCase = {
+      provider: config.provider,
+      endpoint: endpointId,
+      sourceId: mappedString(body, config.sourceIdPath),
+      sourceUrl: mappedString(body, config.sourceUrlPath),
+      title: entry.subject,
+      description: entry.description,
+      severity: entry.priority,
+      priority: entry.priority,
+      reporter: entry.requester,
+      customerContext:
+        customerContext === undefined ? entry.requester : (customerContext as JsonValue),
+      metadata: body,
+    };
+  }
   return { entry, subjectId: resolveSubjectId(body, config.subjectPath) };
 }
 

--- a/apps/worker/src/workflow-definition/block-registry.test.ts
+++ b/apps/worker/src/workflow-definition/block-registry.test.ts
@@ -169,6 +169,7 @@ describe("workflow block registry", () => {
     expect(Object.keys(registry.human_question.inputs)).toEqual([
       "questions",
       "suggestedAnswers",
+      "context",
     ]);
     expect(registry.trigger_ticket_ai.output.bindingSchema).toMatchObject({
       required: expect.arrayContaining(["ticket", "comments", "priorAnswers"]),

--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -192,6 +192,35 @@ const retrievalGapType = objectType({
   scope: stringType(),
 });
 
+const supportCaseType = objectType(
+  {
+    provider: enumStringType(["zendesk", "sentry"]),
+    endpoint: stringType(),
+    sourceId: stringType(),
+    sourceUrl: stringType(),
+    title: stringType(),
+    description: stringType(),
+    severity: stringType(),
+    priority: stringType(),
+    reporter: stringType(),
+    customerContext: unknownType(),
+    metadata: unknownType(),
+  },
+  [
+    "provider",
+    "endpoint",
+    "sourceId",
+    "sourceUrl",
+    "title",
+    "description",
+    "severity",
+    "priority",
+    "reporter",
+    "customerContext",
+    "metadata",
+  ],
+);
+
 const ticketContextType = objectType({
   identifier: stringType(),
   title: stringType(),
@@ -550,6 +579,7 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
         requester: stringType(),
         priority: stringType(),
         payload: unknownType(),
+        supportCase: supportCaseType,
       },
       ["subject", "description", "requester", "priority", "payload"],
     ),
@@ -1035,12 +1065,14 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
     inputs: {
       questions: input(arrayType(stringType())),
       suggestedAnswers: input(arrayType(stringType()), false),
+      context: input(stringType(), false),
     },
     output: statusOutput({
       questions: arrayType(stringType()),
       suggestedAnswers: arrayType(stringType()),
       answer: stringType(),
     }),
+    normalOutputRequired: ["answer"],
     statusVariants: ["needs_human_input", "answered"],
   },
   arthur_injection_check: {

--- a/apps/worker/src/workflow-definition/default-v2.test.ts
+++ b/apps/worker/src/workflow-definition/default-v2.test.ts
@@ -222,7 +222,7 @@ describe("v2 built-in authoring definitions", () => {
         provider,
       });
 
-      expect(templates).toHaveLength(8);
+      expect(templates).toHaveLength(9);
       for (const template of templates) {
         expect(template.definition.schemaVersion).toBe(2);
         if (template.definition.schemaVersion !== 2) continue;

--- a/apps/worker/src/workflow-definition/scenarios/support-investigation.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/support-investigation.scenario.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import type { BlockOutput, JsonValue } from "@shared/contracts";
+import type { AgentWorkflowInput } from "../../workflows/agent-input.js";
+import {
+  executorRunsOf,
+  expectNeverInvoked,
+  portsOf,
+} from "./assertions.js";
+import { createScenario, type Scenario } from "./harness.js";
+
+const TEMPLATE = {
+  id: "support-investigation",
+  options: { includeReview: false, provider: "claude" as const },
+};
+
+const ZENDESK_PAYLOAD = {
+  ticket: {
+    id: 35436,
+    subject: "The login button does nothing on Safari",
+    description: "Three customers report the same failure after the release.",
+    priority: "urgent",
+    url: "https://support.example.test/agent/tickets/35436",
+    requester: { email: "customer@example.test", name: "Ada" },
+  },
+};
+
+const SENTRY_PAYLOAD = {
+  action: "created",
+  data: {
+    issue: {
+      id: "12345",
+      title: "TypeError in session cookie handler",
+      level: "error",
+      permalink: "https://sentry.example.test/issues/12345",
+      metadata: { value: "Cannot read properties of undefined (reading 'token')" },
+    },
+  },
+  actor: { email: "sentry@example.test", name: "Sentry" },
+};
+
+function supportCase(input: {
+  provider: "zendesk" | "sentry";
+  endpoint: string;
+  sourceId: string;
+  sourceUrl: string;
+  title: string;
+  description: string;
+  priority: string;
+  customerContext: JsonValue;
+  metadata: JsonValue;
+}) {
+  return {
+    ...input,
+    severity: input.priority,
+    reporter:
+      input.provider === "zendesk" ? "customer@example.test" : "sentry@example.test",
+  };
+}
+
+const ZENDESK_CASE = supportCase({
+  provider: "zendesk",
+  endpoint: "wh_zendesk",
+  sourceId: "35436",
+  sourceUrl: "https://support.example.test/agent/tickets/35436",
+  title: ZENDESK_PAYLOAD.ticket.subject,
+  description: ZENDESK_PAYLOAD.ticket.description,
+  priority: "urgent",
+  customerContext: ZENDESK_PAYLOAD.ticket.requester,
+  metadata: ZENDESK_PAYLOAD,
+});
+
+const SENTRY_CASE = supportCase({
+  provider: "sentry",
+  endpoint: "wh_sentry",
+  sourceId: "12345",
+  sourceUrl: SENTRY_PAYLOAD.data.issue.permalink,
+  title: SENTRY_PAYLOAD.data.issue.title,
+  description: SENTRY_PAYLOAD.data.issue.metadata.value,
+  priority: "error",
+  customerContext: SENTRY_PAYLOAD.actor,
+  metadata: SENTRY_PAYLOAD,
+});
+
+function entry(
+  provider: "zendesk" | "sentry",
+  support: typeof ZENDESK_CASE,
+): AgentWorkflowInput {
+  return {
+    kind: "webhook_trigger",
+    endpointId: support.endpoint,
+    definitionId: 42,
+    definitionVersion: 7,
+    nodeId: provider,
+    deliveryId: `${provider}-delivery-1`,
+    subjectKey: `webhook:${support.endpoint}:${support.sourceId}`,
+    ownerToken: "owner-1",
+    entry: {
+      subject: support.title,
+      description: support.description,
+      requester: support.reporter,
+      priority: support.priority,
+      payload: provider === "zendesk" ? ZENDESK_PAYLOAD : SENTRY_PAYLOAD,
+      supportCase: support,
+    },
+  };
+}
+
+function investigationOutput(
+  classification: string,
+  theory: string,
+  options: { evidence?: JsonValue[]; partial?: string[]; partialReasons?: JsonValue[] } = {},
+): BlockOutput {
+  return {
+    status: "ok",
+    classification,
+    theory,
+    evidence: options.evidence ?? [],
+    partial: options.partial ?? [],
+    partialReasons: options.partialReasons ?? [],
+  };
+}
+
+function classifierOutput(classification: string, rationale: string): BlockOutput {
+  return { status: "completed", classification, rationale, data: { classification, rationale } };
+}
+
+function baseScenario(
+  provider: "zendesk" | "sentry",
+  support: typeof ZENDESK_CASE,
+): Scenario {
+  return createScenario({
+    template: TEMPLATE,
+    entry: entry(provider, support),
+    entryTriggerId: provider,
+  });
+}
+
+function scriptInvestigation(
+  scenario: Scenario,
+  classification: string,
+  theory: string,
+  options: { evidence?: JsonValue[]; partial?: string[]; partialReasons?: JsonValue[] } = {},
+): void {
+  scenario.script({ nodeId: "investigate" }, {
+    kind: "next",
+    output: investigationOutput(classification, theory, options),
+  });
+}
+
+describe("support investigation workflow", () => {
+  it("answers a Zendesk question with a bounded response and never prepares a workspace", async () => {
+    const scenario = baseScenario("zendesk", ZENDESK_CASE);
+    scriptInvestigation(scenario, "question", "The evidence explains the expected Safari behaviour.");
+    scenario.script({ nodeId: "classify" }, {
+      kind: "next",
+      output: classifierOutput("question", "The requester asks for an explanation, not a code change."),
+    });
+    scenario.script({ nodeId: "notify-non-code" }, { kind: "next", output: { status: "ok" } });
+
+    const outcome = await scenario.execute();
+    expect(outcome.result.outcome).toBe("completed");
+    expect(portsOf(outcome, "code-route")).toEqual(["false"]);
+    expectNeverInvoked(outcome, ["prepare", "implementation", "checks", "finalize", "open-pr"]);
+  });
+
+  it("routes a known false positive from Sentry to the non-code summary", async () => {
+    const scenario = baseScenario("sentry", SENTRY_CASE);
+    scriptInvestigation(scenario, "false_positive", "The alert was emitted by a resolved test event.");
+    scenario.script({ nodeId: "classify" }, {
+      kind: "next",
+      output: classifierOutput("false_positive", "The issue is noise and does not require a product change."),
+    });
+    scenario.script({ nodeId: "notify-non-code" }, { kind: "next", output: { status: "ok" } });
+
+    const outcome = await scenario.execute();
+    expect(outcome.result.outcome).toBe("completed");
+    expectNeverInvoked(outcome, ["prepare", "implementation", "open-pr"]);
+  });
+
+  it("keeps missing context and provider gaps in the internal summary", async () => {
+    const scenario = baseScenario("zendesk", {
+      ...ZENDESK_CASE,
+      title: "",
+      description: "",
+    });
+    scriptInvestigation(scenario, "insufficient_data", "No usable context was available.", {
+      partial: ["jira", "slack"],
+      partialReasons: [
+        { provider: "jira", reason: "unavailable", scope: "" },
+        { provider: "slack", reason: "permission", scope: "" },
+      ],
+    });
+    scenario.script({ nodeId: "classify" }, {
+      kind: "next",
+      output: classifierOutput("question", "Missing context requires a human response."),
+    });
+    scenario.script({ nodeId: "notify-non-code" }, { kind: "next", output: { status: "ok" } });
+
+    const outcome = await scenario.execute();
+    expect(outcome.result.outcome).toBe("completed");
+    expectNeverInvoked(outcome, ["prepare", "implementation", "open-pr"]);
+  });
+
+  it("requires approval before a Zendesk code issue reaches implementation", async () => {
+    const scenario = baseScenario("zendesk", ZENDESK_CASE);
+    scriptInvestigation(scenario, "real_bug", "The same regression is present in Jira and Slack.", {
+      evidence: [{ ref: "jira:AIW-9", source: "jira", title: "Safari regression", excerpt: "Same failure", author: "Ada", origin: "AIW", timestamp: "2026-08-12T09:00:00Z", link: "https://jira.example.test/browse/AIW-9" }],
+    });
+    scenario.script({ nodeId: "classify" }, {
+      kind: "next",
+      output: classifierOutput("code_issue", "The evidence supports a repository fix."),
+    });
+    scenario.script({ nodeId: "approval" }, {
+      kind: "next",
+      output: { status: "answered", questions: ["Approve"], answer: "approve" },
+    });
+    scenario.script({ nodeId: "prepare" }, { kind: "next", output: { status: "ok", sandboxId: "sbx", repositories: [], workspace: { id: "sbx", repositories: [] } } });
+    scenario.script({ nodeId: "implementation" }, { kind: "next", output: { status: "implemented", workspaceId: "sbx", branches: [], commits: [], summary: "Fixed cookie handling." } });
+    scenario.script({ nodeId: "checks" }, { kind: "next", output: { status: "ok", ok: true, outcome: "passed", fixCycles: 0, summary: "All focused checks passed." } });
+    scenario.script({ nodeId: "finalize" }, { kind: "next", output: { status: "finalized", repositories: [] } });
+    scenario.script({ nodeId: "open-pr" }, { kind: "next", output: { status: "ok", prs: [], prUrl: "", prNumber: 0 } });
+    scenario.script({ nodeId: "notify-code" }, { kind: "next", output: { status: "ok" } });
+
+    const outcome = await scenario.execute();
+    expect(outcome.result.outcome).toBe("completed");
+    expect(portsOf(outcome, "approval-route")).toEqual(["true"]);
+    expect(executorRunsOf(outcome, "prepare")).toHaveLength(1);
+  });
+
+  it("rejects a Sentry code issue without workspace, implementation, or PR", async () => {
+    const scenario = baseScenario("sentry", SENTRY_CASE);
+    scriptInvestigation(scenario, "real_bug", "The stack trace points to a product defect.");
+    scenario.script({ nodeId: "classify" }, {
+      kind: "next",
+      output: classifierOutput("code_issue", "A code change is proposed but needs approval."),
+    });
+    scenario.script({ nodeId: "approval" }, {
+      kind: "next",
+      output: { status: "answered", questions: ["Approve"], answer: "reject" },
+    });
+
+    const outcome = await scenario.execute();
+    expect(outcome.result.outcome).toBe("completed");
+    expect(portsOf(outcome, "approval-route")).toEqual(["false"]);
+    expectNeverInvoked(outcome, ["prepare", "implementation", "checks", "finalize", "open-pr"]);
+  });
+});

--- a/apps/worker/src/workflow-definition/schema.test.ts
+++ b/apps/worker/src/workflow-definition/schema.test.ts
@@ -1122,7 +1122,7 @@ describe("workflowDefinitionSchema block-executor node types", () => {
 });
 
 describe("validateWorkflowGraph fixtures", () => {
-  it("ships eight deployable starter templates with the production ticket workflow first", () => {
+  it("ships deployable starter templates with the production ticket workflow first", () => {
     const templates = workflowDefinitionTemplates({ includeReview: true });
     expect(templates.map((template) => template.name)).toEqual([
       "Ticket workflow",
@@ -1133,6 +1133,7 @@ describe("validateWorkflowGraph fixtures", () => {
       "Post-PR review with autofix",
       "Fully modular",
       "Ticket triage (webhook)",
+      "Support investigation (Zendesk + Sentry)",
     ]);
     expect(templates[0].definition.nodes.some((node) => node.type === "review_agent")).toBe(true);
     for (const template of templates) {

--- a/apps/worker/src/workflow-definition/schema.ts
+++ b/apps/worker/src/workflow-definition/schema.ts
@@ -670,6 +670,10 @@ const webhookPayloadPath = z
  * deploy (like any other block parameter). */
 const v2TriggerWebhookConfiguration = z
   .object({
+    provider: z.enum(["zendesk", "sentry"]).optional(),
+    sourceIdPath: webhookPayloadPath.optional(),
+    sourceUrlPath: webhookPayloadPath.optional(),
+    customerContextPath: webhookPayloadPath.optional(),
     authScheme: z.enum(WEBHOOK_AUTH_SCHEMES).optional(),
     headerName: z
       .string()

--- a/apps/worker/src/workflow-definition/store.test.ts
+++ b/apps/worker/src/workflow-definition/store.test.ts
@@ -191,7 +191,7 @@ describe("migration seed", () => {
 });
 
 describe("starter template seed", () => {
-  it("adds the seven disabled starter workflows exactly once", async () => {
+  it("adds the eight disabled starter workflows exactly once", async () => {
     await seedWorkflowDefinitionTemplates(db, { includeReview: true });
     await seedWorkflowDefinitionTemplates(db, { includeReview: true });
 
@@ -205,9 +205,11 @@ describe("starter template seed", () => {
       "Post-PR review with autofix",
       "Fully modular",
       "Ticket triage (webhook)",
+      "Support investigation (Zendesk + Sentry)",
     ]);
     expect(defs.map((definition) => definition.enabled)).toEqual([
       true,
+      false,
       false,
       false,
       false,
@@ -224,8 +226,10 @@ describe("starter template seed", () => {
       1,
       1,
       1,
+      1,
     ]);
     expect(defs.slice(1).map((definition) => definition.deployedVersion)).toEqual([
+      1,
       1,
       1,
       1,
@@ -242,6 +246,7 @@ describe("starter template seed", () => {
       ["trigger_pr_ready", "trigger_pr_updated"],
       ["trigger_ticket_ai"],
       ["trigger_webhook"],
+      ["trigger_webhook", "trigger_webhook"],
     ]);
   });
 });

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -558,6 +558,245 @@ function webhookTicketTriageDefinition(
   ]);
 }
 
+/** Provider-shaped support ingress that keeps both receivers on one definition
+ * while selecting the exact trigger node for each endpoint. The provider-aware
+ * normalization happens at webhook ingress; Investigate remains the existing
+ * Jira/Slack evidence block from AIW-257. */
+function supportInvestigationDefinition(
+  provider: HarnessProvider,
+  profileReference?: HarnessProfileReference,
+): WorkflowDefinitionV2 {
+  const profile = () =>
+    builtinHarnessProfileConfiguration(provider, profileReference);
+  const classificationOutput = JSON.stringify({
+    type: "object",
+    properties: {
+      classification: {
+        type: "string",
+        enum: ["question", "known_issue", "false_positive", "product_issue", "code_issue"],
+      },
+      rationale: { type: "string" },
+    },
+    required: ["classification", "rationale"],
+    additionalProperties: false,
+  });
+  const specs: V2BlockSpec[] = [
+    {
+      id: "zendesk",
+      type: "trigger_webhook",
+      name: "Zendesk support ticket",
+      column: 0,
+      configuration: {
+        provider: "zendesk",
+        subjectPath: "ticket.id",
+        mapSubject: "ticket.subject",
+        mapDescription: "ticket.description",
+        mapRequester: "ticket.requester.email",
+        mapPriority: "ticket.priority",
+        sourceIdPath: "ticket.id",
+        sourceUrlPath: "ticket.url",
+        customerContextPath: "ticket.requester",
+      },
+    },
+    {
+      id: "sentry",
+      type: "trigger_webhook",
+      name: "Sentry issue",
+      column: 0,
+      row: 1,
+      configuration: {
+        provider: "sentry",
+        subjectPath: "data.issue.id",
+        mapSubject: "data.issue.title",
+        mapDescription: "data.issue.metadata.value",
+        mapRequester: "actor.email",
+        mapPriority: "data.issue.level",
+        sourceIdPath: "data.issue.id",
+        sourceUrlPath: "data.issue.permalink",
+        customerContextPath: "data.issue.project",
+      },
+    },
+    {
+      id: "investigate",
+      type: "investigate",
+      name: "Gather Jira and Slack evidence",
+      column: 1,
+      configuration: {
+        providers: ["jira", "slack"],
+        slackChannels: ["C_SUPPORT"],
+        slackLookbackDays: 30,
+        maxResults: 10,
+      },
+    },
+    {
+      id: "classify",
+      type: "generic_agent",
+      name: "Classify support case",
+      column: 2,
+      configuration: {
+        ...profile(),
+        prompt:
+          "Map the existing investigation result to exactly one support category. Do not add evidence or change the investigation's facts. " +
+          "Use question for requests for explanation, known_issue for an existing tracked issue, false_positive for noise or misunderstanding, " +
+          "product_issue for a genuine product request or non-code operational problem, and code_issue only for a defect requiring a repository change.\n\n" +
+          "Normalized support case:\n{{data:steps.entry.output.supportCase}}\n\n" +
+          "Investigation classification: {{data:steps.investigate.output.classification}}\n" +
+          "Investigation theory:\n{{data:steps.investigate.output.theory}}",
+        outputSchema: classificationOutput,
+        outputSchemaDialect: "https://json-schema.org/draft/2020-12/schema",
+        workspaceMode: "none",
+      },
+    },
+    {
+      id: "code-route",
+      type: "branch",
+      name: "Code issue?",
+      column: 3,
+      configuration: {
+        combinator: "all",
+        conditions: [{
+          reference: "steps.classify.output.classification",
+          operator: "equals",
+          value: "code_issue",
+        }],
+      },
+    },
+    {
+      id: "approval-plan",
+      type: "transform",
+      name: "Prepare approval brief",
+      column: 4,
+      row: -1,
+      configuration: {
+        operation: "format_text",
+        template:
+          "Support case approval brief\n\nNormalized case:\n{{data:steps.entry.output.supportCase}}\n\nClassification: {{data:steps.classify.output.classification}}\nClassification rationale: {{data:steps.classify.output.rationale}}\n\nInvestigation theory:\n{{data:steps.investigate.output.theory}}\n\nEvidence:\n{{data:steps.investigate.output.evidence}}\n\nProposed code action: inspect the repository context, implement the smallest safe fix supported by the evidence, run focused checks, and open a pull request.",
+      },
+    },
+    {
+      id: "approval",
+      type: "human_question",
+      name: "Approve proposed code action",
+      column: 5,
+      row: -1,
+      configuration: { questions: ["Approve the proposed code action?"], suggestedAnswers: ["approve", "reject"] },
+      inputs: {
+        context: { kind: "reference", reference: "steps.approval-plan.output.output" },
+      },
+    },
+    {
+      id: "approval-route",
+      type: "branch",
+      name: "Approved?",
+      column: 6,
+      row: -1,
+      configuration: {
+        combinator: "all",
+        conditions: [{
+          reference: "steps.approval.output.answer",
+          operator: "equals",
+          value: "approve",
+        }],
+      },
+    },
+    {
+      id: "prepare",
+      type: "prepare_workspace",
+      name: "Prepare workspace",
+      column: 7,
+      row: -1,
+    },
+    {
+      id: "implementation",
+      type: "implementation_agent",
+      name: "Implement approved fix",
+      column: 8,
+      row: -1,
+      configuration: { ...profile(), prompt: "{{prompt:implement@1}}" },
+      inputs: {
+        plan: { kind: "reference", reference: "steps.approval-plan.output.output" },
+      },
+    },
+    {
+      id: "checks",
+      type: "run_pre_pr_checks",
+      name: "Run focused checks",
+      column: 9,
+      row: -1,
+    },
+    {
+      id: "finalize",
+      type: "finalize_workspace",
+      name: "Finalize workspace",
+      column: 10,
+      row: -1,
+    },
+    {
+      id: "open-pr",
+      type: "open_pr",
+      name: "Open fix PR",
+      column: 11,
+      row: -1,
+      inputs: { repositories: { kind: "reference", reference: "steps.finalize.output.repositories" } },
+    },
+    {
+      id: "notify-code",
+      type: "send_slack_message",
+      name: "Notify approved fix",
+      column: 12,
+      row: -1,
+      configuration: { message: "An approved support-case fix PR is ready.", sendOn: "always" },
+    },
+    {
+      id: "non-code-summary",
+      type: "transform",
+      name: "Draft non-code response",
+      column: 4,
+      row: 1,
+      configuration: {
+        operation: "format_text",
+        template:
+          "Support investigation summary\n\nCase:\n{{data:steps.entry.output.supportCase}}\n\nClassification: {{data:steps.classify.output.classification}}\nRationale: {{data:steps.classify.output.rationale}}\n\nResponse draft:\n{{data:steps.investigate.output.theory}}\n\nEvidence:\n{{data:steps.investigate.output.evidence}}",
+      },
+    },
+    {
+      id: "notify-non-code",
+      type: "send_slack_message",
+      name: "Share non-code summary",
+      column: 5,
+      row: 1,
+      configuration: { message: "", sendOn: "always" },
+      inputs: { message: { kind: "reference", reference: "steps.non-code-summary.output.output" } },
+    },
+    {
+      id: "reject",
+      type: "terminate",
+      name: "Stop after rejection",
+      column: 7,
+      row: 1,
+      configuration: { terminalStatus: "skipped", postComment: "Human rejected the proposed code action." },
+    },
+  ];
+  return buildBuiltinV2Definition("support-investigation", specs, [
+    { from: "zendesk", to: "investigate" },
+    { from: "sentry", to: "investigate" },
+    { from: "investigate", to: "classify" },
+    { from: "classify", to: "code-route" },
+    { from: "code-route", fromPort: "true", to: "approval-plan" },
+    { from: "approval-plan", to: "approval" },
+    { from: "approval", to: "approval-route" },
+    { from: "approval-route", fromPort: "true", to: "prepare" },
+    { from: "prepare", to: "implementation" },
+    { from: "implementation", to: "checks" },
+    { from: "checks", to: "finalize" },
+    { from: "finalize", to: "open-pr" },
+    { from: "open-pr", to: "notify-code" },
+    { from: "approval-route", fromPort: "false", to: "reject" },
+    { from: "code-route", fromPort: "false", to: "non-code-summary" },
+    { from: "non-code-summary", to: "notify-non-code" },
+  ]);
+}
+
 const REVIEW_TASKS = {
   security:
     "Review the implementation for security vulnerabilities, unsafe trust boundaries, credential exposure, and abuse cases. Do not modify files. Report concrete findings only.",
@@ -1298,6 +1537,13 @@ export function workflowDefinitionTemplates({
       description:
         "Triages a support ticket delivered by a signed webhook and opens a fix PR only when the issue is in code. Warning: external ticket input reaches an automatically opened PR with no human gate, so add an approval step before open_pr or point it only at a trusted sender.",
       definition: webhookTicketTriageDefinition(provider, profileReference),
+    },
+    {
+      id: "support-investigation",
+      name: "Support investigation (Zendesk + Sentry)",
+      description:
+        "Normalizes Zendesk and Sentry webhooks, gathers Jira and Slack evidence, routes non-code cases to a response summary, and gates approved code fixes before workspace preparation.",
+      definition: supportInvestigationDefinition(provider, profileReference),
     },
   ];
 }

--- a/apps/worker/src/workflows/agent-input.ts
+++ b/apps/worker/src/workflows/agent-input.ts
@@ -6,6 +6,7 @@
 import type { ApprovedRepositoryScope, JsonValue } from "@shared/contracts";
 import type { RunKind } from "../adapters/run-registry/types.js";
 import type { PrTriggerType } from "../lib/trigger-events.js";
+import type { SupportCase } from "../webhook-trigger/payload-mapping.js";
 
 export interface PrTriggerPayload {
   provider: "github" | "gitlab";
@@ -47,6 +48,7 @@ export interface WebhookTriggerEntryPayload {
   priority: string;
   /** The authenticated request body, already parsed. */
   payload: JsonValue;
+  supportCase?: SupportCase;
 }
 
 /** Immutable identity for the built-in fresh-install graph, which has no

--- a/apps/worker/src/workflows/agent-trigger-output.test.ts
+++ b/apps/worker/src/workflows/agent-trigger-output.test.ts
@@ -177,6 +177,29 @@ describe("webhook trigger input", () => {
     expect(output).not.toHaveProperty("comments");
     expect(output).not.toHaveProperty("priorAnswers");
   });
+
+  it("retains normalized provider context when supplied by ingress", () => {
+    const output = triggerOutputWithTicketContext({
+      ...webhookEntry,
+      entry: {
+        ...webhookEntry.entry,
+        supportCase: {
+          provider: "zendesk",
+          endpoint: webhookEntry.endpointId,
+          sourceId: "77",
+          sourceUrl: "https://support.example.test/tickets/77",
+          title: webhookEntry.entry.subject,
+          description: webhookEntry.entry.description,
+          severity: "urgent",
+          priority: "urgent",
+          reporter: webhookEntry.entry.requester,
+          customerContext: { email: webhookEntry.entry.requester },
+          metadata: webhookEntry.entry.payload,
+        },
+      },
+    });
+    expect(output.supportCase).toMatchObject({ provider: "zendesk", sourceId: "77" });
+  });
 });
 
 describe("entry trigger node selection", () => {

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -1228,6 +1228,9 @@ export function triggerOutputWithTicketContext(
       requester: entry.entry.requester,
       priority: entry.entry.priority,
       payload: entry.entry.payload,
+      ...(entry.entry.supportCase === undefined
+        ? {}
+        : { supportCase: entry.entry.supportCase }),
     };
   }
   if (entry.kind === "schedule") {

--- a/apps/worker/src/workflows/blocks/human-question.test.ts
+++ b/apps/worker/src/workflows/blocks/human-question.test.ts
@@ -87,6 +87,37 @@ describe("human_question execute", () => {
     });
   });
 
+  it("returns a normal answered output when a parked question resumes", async () => {
+    const result = await execute(
+      makeNode("human_question", { questions: ["Approve?"] }),
+      {},
+      makeCtx(),
+      {},
+      { clarificationAnswer: "approve" },
+    );
+    expect(result).toEqual({
+      kind: "next",
+      output: {
+        status: "answered",
+        questions: ["Approve?"],
+        answer: "approve",
+      },
+    });
+  });
+
+  it("places a normalized approval brief in the human decision", async () => {
+    const result = await execute(
+      makeNode("human_question", { questions: ["Approve?"] }),
+      {},
+      makeCtx(),
+      { context: "Provider: zendesk\nEvidence: jira:AIW-1" },
+    );
+    expect(result).toMatchObject({
+      kind: "needs_human_input",
+      questions: [expect.stringContaining("jira:AIW-1")],
+    });
+  });
+
   it("picks up upstream suggestedAnswers when questions fall back and params provide none", async () => {
     const steps: StepsRecord = {
       upstream: {

--- a/apps/worker/src/workflows/blocks/human-question.ts
+++ b/apps/worker/src/workflows/blocks/human-question.ts
@@ -20,6 +20,7 @@ export const execute: BlockExecuteFn = async (
   steps,
   _ctx,
   resolvedInputs = {},
+  execution,
 ): Promise<BlockExecutionResult> => {
   const configuredQuestions = Array.isArray(resolvedInputs.questions)
     ? resolvedInputs.questions
@@ -29,6 +30,13 @@ export const execute: BlockExecuteFn = async (
         (q): q is string => typeof q === "string" && q.trim().length > 0,
       )
     : [];
+  const context =
+    typeof resolvedInputs.context === "string" ? resolvedInputs.context.trim() : "";
+  if (context !== "") {
+    questions = [
+      `Review this support investigation before deciding:\n\n${context}\n\nApprove the proposed code action?`,
+    ];
+  }
 
   // Params-provided suggestions win. Upstream suggestions only fill in when the
   // questions themselves fall back to upstream and the params carried none,
@@ -71,6 +79,22 @@ export const execute: BlockExecuteFn = async (
       "human_question has no questions: set the questions param or place it after a block that produces questions",
       { category: "binding" },
     );
+  }
+
+  // A resumed clarification carries its answer in the invocation context.
+  // Returning it as a normal block output lets a v2 graph branch on approve vs
+  // reject, which is useful for webhook-originated cases that have no Jira
+  // ticket to park or mutate.
+  if (execution?.clarificationAnswer !== undefined) {
+    return {
+      kind: "next",
+      output: {
+        status: "answered",
+        questions,
+        ...(suggestedAnswers.length > 0 ? { suggestedAnswers } : {}),
+        answer: execution.clarificationAnswer,
+      },
+    };
   }
 
   return {

--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -892,6 +892,10 @@
           ],
         ),
         trigger_webhook: runtimeContract([
+          "provider",
+          "sourceIdPath",
+          "sourceUrlPath",
+          "customerContextPath",
           "authScheme",
           "headerName",
           "requireTimestamp",
@@ -909,6 +913,26 @@
             ...STATUS_OUTPUT,
             ...typedPaths("string", "subject", "description", "requester", "priority"),
             ...typedPaths("unknown", "payload"),
+          ],
+          optionalOutputs: [
+            ...typedPaths("object", "supportCase"),
+            ...typedPaths(
+              "string",
+              "supportCase.provider",
+              "supportCase.endpoint",
+              "supportCase.sourceId",
+              "supportCase.sourceUrl",
+              "supportCase.title",
+              "supportCase.description",
+              "supportCase.severity",
+              "supportCase.priority",
+              "supportCase.reporter",
+            ),
+            ...typedPaths(
+              "unknown",
+              "supportCase.customerContext",
+              "supportCase.metadata",
+            ),
           ],
           statuses: FIRED,
         }),
@@ -1182,12 +1206,12 @@
           statuses: ["awaiting_approval"],
         }),
         human_question: runtimeContract(["questions", "suggestedAnswers"], {
-          optionalInputs: typedPaths("string[]", "questions", "suggestedAnswers"),
-          requiredOutputs: STATUS_OUTPUT,
-          optionalOutputs: [
+          optionalInputs: [
             ...typedPaths("string[]", "questions", "suggestedAnswers"),
-            ...typedPaths("string", "answer"),
+            ...typedPaths("string", "context"),
           ],
+          requiredOutputs: [...STATUS_OUTPUT, ...typedPaths("string", "answer")],
+          optionalOutputs: typedPaths("string[]", "questions", "suggestedAnswers"),
           statuses: ["needs_human_input", "answered"],
         }),
         arthur_injection_check: runtimeContract([], {


### PR DESCRIPTION
## Summary
- add provider-aware Zendesk and Sentry webhook normalization while preserving generic webhook behavior
- compose both isolated endpoints with the existing Jira/Slack investigate block, bounded classification, non-code response path, and approval-gated code path
- add realistic fixtures and contract, schema, branching, approval, rejection, and isolation coverage

## Verification
- 459 focused worker tests (including support scenario, catalog, template seed, and workflow API suites)
- 94 affected worker tests
- 777 dashboard tests
- worker and dashboard typechecks
- git diff --check

## Notes
- provider configuration remains editable through existing investigate contracts; the starter template defaults to Jira + Slack.
- approval uses the existing durable human-input surface because send-plan-approval is Jira-ticket-specific; rejection terminates before workspace preparation.
- no deployment or release performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Support Investigation workflow for Zendesk and Sentry cases.
  * Webhook triggers can now map provider, source, customer context, and normalized support-case details.
  * Added Jira and Slack evidence gathering, case classification, human approval, and code-fix routing.
  * Human-review steps now support contextual approval prompts and clarification answers.
* **Documentation**
  * Updated workflow contracts for webhook mappings, support-case outputs, and human-question inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->