### PR TITLE
fix(worker): sync Jira when a dashboard clarification answer resumes a run (AIW-265, AIW-267)

### DIFF
--- a/apps/worker/src/clarifications/answer-core.ts
+++ b/apps/worker/src/clarifications/answer-core.ts
@@ -1,12 +1,18 @@
 // Static import so route tests can vi.mock("workflow/api"): a dynamic import
 // would bypass the module mock and hit the real Workflow runtime.
 import { getHookByToken, resumeHook } from "workflow/api";
+import { and, eq } from "drizzle-orm";
+import { env } from "../../env.js";
 import type { Db } from "../db/client.js";
+import { activeRuns } from "../db/schema.js";
 import {
   IssueTrackerNotFoundError,
   type IssueTrackerAdapter,
 } from "../adapters/issue-tracker/types.js";
+import { logger } from "../lib/logger.js";
+import { aiColumnMoveTarget } from "../lib/move-targets.js";
 import { markRunBlockedOnCancel, markRunResumed } from "../lib/telemetry/run-telemetry.js";
+import { moveTicketForRun } from "../lib/ticket-transition.js";
 import { answerHookClarification, type HookClarificationRow } from "./hook-store.js";
 import { supersedeClarification, supersedePendingForTicket } from "./store.js";
 
@@ -17,7 +23,53 @@ export type AnswerClarificationOutcome =
   | { kind: "invalid_answer" }
   | { kind: "conflict" }
   | { kind: "ticket_gone" }
+  | { kind: "ticket_transition_failed"; error: unknown }
   | { kind: "resume_failed_retryable"; error: unknown };
+
+/**
+ * Bring a parked ticket back to the configured AI column so its status matches
+ * the run that is about to wake up. Rides the asking run's own subject claim:
+ * the run still holds it while suspended on the hook, so the same owner fence
+ * that guards every other run-driven move guards this one. A missing bound
+ * claim means no run can work this ticket, so it must not be moved either;
+ * that is logged, not raised, because the answer itself is still legitimate.
+ */
+async function moveTicketToAiColumn(input: {
+  db: Db;
+  issueTracker: Pick<IssueTrackerAdapter, "fetchTicket" | "moveTicket">;
+  ticketKey: string;
+  row: HookClarificationRow;
+}): Promise<void> {
+  const [owner] = await input.db
+    .select({ ownerToken: activeRuns.ownerToken })
+    .from(activeRuns)
+    .where(
+      and(
+        eq(activeRuns.subjectKey, input.row.subjectKey),
+        eq(activeRuns.runId, input.row.runId),
+        eq(activeRuns.state, "bound"),
+      ),
+    )
+    .limit(1);
+  if (!owner) {
+    logger.warn(
+      { ticketKey: input.ticketKey, runId: input.row.runId },
+      "clarification_answer_transition_skipped_no_bound_owner",
+    );
+    return;
+  }
+  await moveTicketForRun({
+    db: input.db,
+    issueTracker: input.issueTracker,
+    ticketKey: input.ticketKey,
+    target: aiColumnMoveTarget(env),
+    owner: {
+      subjectKey: input.row.subjectKey,
+      ownerToken: owner.ownerToken,
+      runId: input.row.runId,
+    },
+  });
+}
 
 /**
  * Answer a pending clarification and resume its asking run, with the CAS and
@@ -25,14 +77,19 @@ export type AnswerClarificationOutcome =
  * Returns a tagged outcome instead of throwing HTTP errors so the transport
  * layer owns status-code mapping; the ticket fetch is injected so this module
  * stays free of adapter-construction and HTTP concerns.
+ *
+ * `skipTicketMove` is for callers that already proved the ticket is live in the
+ * AI column (the Jira comment path only ever commits from there), so they do
+ * not pay a second provider read for a move that could only be a no-op.
  */
 export async function answerClarificationAndResume(input: {
   db: Db;
   row: HookClarificationRow;
   rawAnswer: string;
   actor: { id: string; label: string };
-  issueTracker: Pick<IssueTrackerAdapter, "fetchTicket">;
+  issueTracker: Pick<IssueTrackerAdapter, "fetchTicket" | "moveTicket">;
   skipTicketFetch?: boolean;
+  skipTicketMove?: boolean;
 }): Promise<AnswerClarificationOutcome> {
   const { db, row, rawAnswer, actor, issueTracker } = input;
 
@@ -59,6 +116,25 @@ export async function answerClarificationAndResume(input: {
       if (!(err instanceof IssueTrackerNotFoundError)) throw err;
       await retireClarificationForGoneTicket(db, row);
       return { kind: "ticket_gone" };
+    }
+  }
+
+  // The ticket parked itself in the backlog when the question was asked, so put
+  // it back in the AI column BEFORE the run wakes up: a resumed run must never
+  // work a ticket Jira still shows as AI Backlog. Ordered ahead of the answer
+  // CAS so a failed transition leaves the question answerable again instead of
+  // stranding a live run behind a stale column, and surfaced as its own outcome
+  // so the caller can retry it rather than swallow it.
+  if (row.ticketKey && !input.skipTicketMove) {
+    try {
+      await moveTicketToAiColumn({
+        db,
+        issueTracker,
+        ticketKey: row.ticketKey,
+        row,
+      });
+    } catch (error) {
+      return { kind: "ticket_transition_failed", error };
     }
   }
 

--- a/apps/worker/src/clarifications/answer-core.ts
+++ b/apps/worker/src/clarifications/answer-core.ts
@@ -13,6 +13,7 @@ import { logger } from "../lib/logger.js";
 import { aiColumnMoveTarget } from "../lib/move-targets.js";
 import { markRunBlockedOnCancel, markRunResumed } from "../lib/telemetry/run-telemetry.js";
 import { moveTicketForRun } from "../lib/ticket-transition.js";
+import { formatClarificationAnswerComment } from "./comment-format.js";
 import { answerHookClarification, type HookClarificationRow } from "./hook-store.js";
 import { supersedeClarification, supersedePendingForTicket } from "./store.js";
 
@@ -81,15 +82,18 @@ async function moveTicketToAiColumn(input: {
  * `skipTicketMove` is for callers that already proved the ticket is live in the
  * AI column (the Jira comment path only ever commits from there), so they do
  * not pay a second provider read for a move that could only be a no-op.
+ * `skipAnswerComment` is for callers whose answer already exists as a ticket
+ * comment, so mirroring it back would duplicate what a human just wrote.
  */
 export async function answerClarificationAndResume(input: {
   db: Db;
   row: HookClarificationRow;
   rawAnswer: string;
   actor: { id: string; label: string };
-  issueTracker: Pick<IssueTrackerAdapter, "fetchTicket" | "moveTicket">;
+  issueTracker: Pick<IssueTrackerAdapter, "fetchTicket" | "moveTicket" | "postComment">;
   skipTicketFetch?: boolean;
   skipTicketMove?: boolean;
+  skipAnswerComment?: boolean;
 }): Promise<AnswerClarificationOutcome> {
   const { db, row, rawAnswer, actor, issueTracker } = input;
 
@@ -143,6 +147,30 @@ export async function answerClarificationAndResume(input: {
     : await answerHookClarification(db, row.id, answer, answerer);
   if (!answered) {
     return { kind: "conflict" };
+  }
+
+  // Mirror the answer into the ticket. The question was posted there publicly,
+  // so the answer that unblocked the run belongs there too; without this the
+  // ticket shows a question, a status change, and nothing in between. Posted
+  // only on the branch that actually recorded the answer, which makes it
+  // exactly-once without any new state: an identical retry re-drives the resume,
+  // not the trace. Best-effort in the strongest sense, because a comment must
+  // never fail an answer that is already committed. Safe against the comment
+  // path reading it back: that path skips comments authored by the bot account.
+  if (row.ticketKey && !input.skipAnswerComment && !isResumeRetry) {
+    const ticketKey = row.ticketKey;
+    await issueTracker
+      .postComment(
+        ticketKey,
+        formatClarificationAnswerComment({ answeredByLabel: answerer.label, answer }),
+      )
+      .catch((error: unknown) => {
+        logger.warn(
+          { ticketKey, runId: row.runId, error: (error as Error).message },
+          "clarification_answer_comment_failed",
+        );
+        return null;
+      });
   }
 
   try {

--- a/apps/worker/src/clarifications/comment-format.ts
+++ b/apps/worker/src/clarifications/comment-format.ts
@@ -89,6 +89,29 @@ export function formatClarificationNudgeComment(input: {
   ].join("\n");
 }
 
+/**
+ * Trace posted to the ticket when a clarification is answered somewhere other
+ * than the ticket itself, which today means the dashboard. Without it the public
+ * questions comment ends in silence: the ticket shows a question, then a status
+ * change, and nothing that explains what unblocked the run. The Jira comment
+ * path needs no trace, because the human's own comment already is one and this
+ * would echo it back at them.
+ *
+ * The answer is human-authored, not agent-authored, and goes back into the
+ * ticket that same human is invited to comment on, so it is published verbatim:
+ * scrubbing here would edit a person's own words. Its length is already bounded
+ * by MAX_ANSWER_LENGTH where the answer enters.
+ */
+export function formatClarificationAnswerComment(input: {
+  answeredByLabel: string;
+  answer: string;
+}): string {
+  return [
+    `${input.answeredByLabel} answered the clarification in the dashboard; the run is resuming.`,
+    ["Answer:", input.answer.trim()].join("\n"),
+  ].join("\n\n");
+}
+
 /** One-liner acknowledging that a clarification was answered and the run resumes. */
 export function formatAlreadyAnsweredComment(input: { answeredByLabel: string }): string {
   return `This clarification was already answered by ${input.answeredByLabel}; the run is resuming.`;

--- a/apps/worker/src/clarifications/resume-from-comments.test.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.test.ts
@@ -98,10 +98,12 @@ function makeTracker(opts: {
   trackerStatus?: string;
   botId?: () => Promise<string>;
   fetchTicket?: () => Promise<TicketContent>;
+  moveTicket?: () => Promise<void>;
 } = {}) {
   const ticket = ticketWith(opts.comments ?? [], opts.trackerStatus ?? "AI");
   return {
     fetchTicket: vi.fn(opts.fetchTicket ?? (async () => ticket)),
+    moveTicket: vi.fn(opts.moveTicket ?? (async () => undefined)),
     postComment: vi.fn(async (_id: string, _comment: string) => null as string | null),
     getCurrentUserAccountId: vi.fn(opts.botId ?? (async () => BOT)),
   };
@@ -352,6 +354,36 @@ describe("resumeClarificationFromComments", () => {
       row.hookToken,
       expect.objectContaining({ answer: "Stored answer", answeredById: "user_1" }),
     );
+  });
+
+  it("never moves the ticket for a comment-composed answer", async () => {
+    await seedPending();
+    const tracker = makeTracker({
+      comments: [
+        { author: "Jane", accountId: "human-1", body: "Use Next.js", createdAt: AFTER },
+      ],
+    });
+
+    expect(await run(tracker)).toEqual({ status: "resumed", runId: RUN });
+    // The human's own column move was the commit gesture here.
+    expect(tracker.moveTicket).not.toHaveBeenCalled();
+  });
+
+  it("releases the claim when the answered retry cannot re-sync the column", async () => {
+    const row = await seedPending();
+    await answerHookClarification(db, row.id, "Stored answer", { id: "user_1", label: "Ada" });
+    const tracker = makeTracker({
+      trackerStatus: "AI Backlog",
+      moveTicket: async () => {
+        throw new Error("Jira 502");
+      },
+    });
+
+    expect(await run(tracker)).toEqual({ status: "resume_retry_pending", runId: RUN });
+    expect(mocks.resumeHook).not.toHaveBeenCalled();
+    expect(
+      (await db.select().from(workflowRuns).where(eq(workflowRuns.runId, RUN)))[0]?.status,
+    ).toBe("awaiting");
   });
 
   it("allows only one concurrent delivery to invoke resumeHook", async () => {

--- a/apps/worker/src/clarifications/resume-from-comments.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.ts
@@ -93,8 +93,11 @@ export type CommentResumeStatus =
  * Jira ticket and moving it back into the AI column. Comments alone never
  * resume; the move is the commit gesture, so this only ever commits while the
  * ticket is live in the AI column. Composes the human comments into the answer
- * and rides answer-core's CAS + retry semantics; it never moves tickets,
- * mutates labels, or touches active_runs (the resumed run owns all of that).
+ * and rides answer-core's CAS + retry semantics; it never mutates labels or
+ * touches active_runs (the resumed run owns that). The human already performed
+ * the column move on this path, so the comment-composed answer opts out of
+ * answer-core's own transition; the answered-retry branch keeps it, which is
+ * what re-syncs a dashboard answer whose column move never landed.
  */
 export async function resumeClarificationFromComments(input: {
   db: Db;
@@ -162,6 +165,16 @@ export async function resumeClarificationFromComments(input: {
       case "ticket_gone": {
         await finishAnsweredResumeClaim(db, row.runId, "blocked");
         return { status: "ticket_gone" };
+      }
+      case "ticket_transition_failed": {
+        // Nothing was committed, so release the claim and let the next delivery
+        // (or the cron) retry the whole resume, transition included.
+        await finishAnsweredResumeClaim(db, row.runId, "awaiting");
+        logger.warn(
+          { ticketKey, runId: row.runId },
+          "clarification_resume_transition_retry_pending",
+        );
+        return { status: "resume_retry_pending", runId: row.runId };
       }
       case "conflict": {
         await finishAnsweredResumeClaim(db, row.runId, "awaiting");
@@ -295,6 +308,9 @@ export async function resumeClarificationFromComments(input: {
     actor: { id: answeredById, label: answeredByLabel },
     issueTracker,
     skipTicketFetch: true,
+    // The guard above already proved the ticket is live in the AI column, so the
+    // core's transition could only be a no-op costing one more provider read.
+    skipTicketMove: true,
   });
   switch (outcome.kind) {
     case "answered":
@@ -330,6 +346,13 @@ export async function resumeClarificationFromComments(input: {
     }
     case "ticket_gone":
       return { status: "ticket_gone" };
+    case "ticket_transition_failed":
+      // Unreachable: this path skips the transition entirely. Defensive only.
+      logger.warn(
+        { ticketKey, runId: row.runId },
+        "clarification_resume_transition_retry_pending",
+      );
+      return { status: "resume_retry_pending", runId: row.runId };
     case "invalid_answer":
       // Unreachable after the empty-compose guard above; defensive only.
       logger.warn(

--- a/apps/worker/src/clarifications/resume-from-comments.ts
+++ b/apps/worker/src/clarifications/resume-from-comments.ts
@@ -308,6 +308,9 @@ export async function resumeClarificationFromComments(input: {
     actor: { id: answeredById, label: answeredByLabel },
     issueTracker,
     skipTicketFetch: true,
+    // The answer is literally a comment on this ticket already, so mirroring it
+    // back would echo the human's own words at them.
+    skipAnswerComment: true,
     // The guard above already proved the ticket is live in the AI column, so the
     // core's transition could only be a no-op costing one more provider read.
     skipTicketMove: true,

--- a/apps/worker/src/lib/ticket-transition.ts
+++ b/apps/worker/src/lib/ticket-transition.ts
@@ -18,7 +18,7 @@ export type TicketTransitionOwner = ActiveRunOwner;
  */
 export async function moveTicketForRun(input: {
   db: Db;
-  issueTracker: IssueTrackerAdapter;
+  issueTracker: Pick<IssueTrackerAdapter, "fetchTicket" | "moveTicket">;
   ticketKey: string;
   target: IssueTrackerMoveTarget;
   owner: TicketTransitionOwner;

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
@@ -250,6 +250,52 @@ describe("selectRepositoriesFromMetadata", () => {
     expect(selected.status).toBe("discovery_needed");
   });
 
+  it("names the unavailable repository from the answer instead of asking again", () => {
+    // The production "asks twice" loop: the answer named a repository that is
+    // not in the catalog, discovery could not honour it, so the model asked the
+    // same question again in its own words and the human never learned why.
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "acme/ai-workflow-prod only",
+    });
+
+    expect(selected.status).toBe("clarification_needed");
+    if (selected.status !== "clarification_needed") {
+      throw new Error("expected clarification_needed");
+    }
+    expect(selected.questions[0]).toContain("acme/ai-workflow-prod");
+  });
+
+  it("keeps a provider-scoped path in the question it cannot satisfy", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "use github:acme/missing please",
+    });
+
+    expect(selected.status).toBe("clarification_needed");
+    if (selected.status !== "clarification_needed") {
+      throw new Error("expected clarification_needed");
+    }
+    expect(selected.questions[0]).toContain("github:acme/missing");
+  });
+
+  it("still falls to discovery when the answer names no repository path", () => {
+    // Prose is not an explicit choice, so the model still gets its turn rather
+    // than the human being sent a second deterministic question.
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Update data warehouse model",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "the prod one",
+    });
+
+    expect(selected.status).toBe("discovery_needed");
+  });
+
   it("resolves a transposed-letter typo once the name is long enough to fuzzy-match safely", () => {
     // "webyb" is "webby" with the last two letters swapped — a one-edit
     // transposition once the name clears the 4-char fuzzy-match floor.

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.ts
@@ -20,6 +20,9 @@ import {
   buildRepositoryCatalogEntries,
   type RepositoryCatalogEntry,
 } from "../../repository-discovery/catalog.js";
+// Pure token parser, no adapters behind it: runner.js imports only types plus
+// catalog.js, which this module already pulls in.
+import { parseRepositoryExpansionAnswer } from "../../repository-discovery/runner.js";
 import { filterRepositoriesForScope } from "../../lib/repo-allowlist.js";
 // Type only, so importing this file never pulls the routing module in with it.
 //
@@ -826,6 +829,33 @@ export function selectRepositoriesFromMetadata(input: {
   // and pull request already exist.
   if (incompleteCatalogProviders.length > 0) {
     return incompleteCatalog(incompleteCatalogProviders);
+  }
+
+  // A human answer that names repository paths none of which exist here gets the
+  // same treatment as an unsatisfiable pin above: surfaced by name. Reaching this
+  // line already proves none of them matched, because a named path present in the
+  // catalog is matched by the ticket-text scan and the answer scan before it.
+  //
+  // The alternative is what production showed: the answer falls through to model
+  // discovery, which cannot honour a repository that is not in the catalog it was
+  // handed, so it asks the same question again in its own words. The human sees a
+  // reworded repeat of a question they just answered and never learns that what
+  // they named is not available, which is the "asks twice" loop. Only paths count
+  // here: a bare short name is not evidence of an explicit choice, and the scans
+  // above already resolve the ones that do match.
+  if (input.directAnswer) {
+    const named = parseRepositoryExpansionAnswer(input.directAnswer).map((identity) =>
+      identity.provider ? `${identity.provider}:${identity.repoPath}` : identity.repoPath,
+    );
+    if (named.length > 0) {
+      return {
+        status: "clarification_needed",
+        questions: [
+          `None of the repositories named in the previous answer are available to this workflow: ${named.join(", ")}. ` +
+            `Name a repository from the accessible catalog as "owner/repo", or as "github:owner/repo" to pin the provider.`,
+        ],
+      };
+    }
   }
 
   if (scopedRepositories.length === 1) {

--- a/apps/worker/src/routes/api/v1/clarifications.test.ts
+++ b/apps/worker/src/routes/api/v1/clarifications.test.ts
@@ -2,7 +2,7 @@ import { createApp, createRouter, toWebHandler } from "h3";
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Db } from "../../../db/client.js";
-import { member, organization, user, workflowRuns } from "../../../db/schema.js";
+import { activeRuns, member, organization, user, workflowRuns } from "../../../db/schema.js";
 import { createTestDb } from "../../../db/test-db.js";
 import {
   getHookClarification,
@@ -14,11 +14,12 @@ import { IssueTrackerNotFoundError } from "../../../adapters/issue-tracker/types
 const state = vi.hoisted(() => ({
   db: undefined as unknown,
   session: { user: { id: "user_admin" }, session: { id: "session_test" } } as unknown,
-  env: { DASHBOARD_ORG_SLUG: "ai-workflow" },
+  env: { DASHBOARD_ORG_SLUG: "ai-workflow", COLUMN_AI: "AI" },
 }));
 
 const mocks = vi.hoisted(() => ({
   fetchTicket: vi.fn(),
+  moveTicket: vi.fn(),
   resumeHook: vi.fn(),
   getHookByToken: vi.fn(),
 }));
@@ -29,7 +30,9 @@ vi.mock("../../../auth-instance.js", () => ({
   auth: { api: { getSession: vi.fn(async () => state.session) } },
 }));
 vi.mock("../../../lib/adapters.js", () => ({
-  createAdapters: () => ({ issueTracker: { fetchTicket: mocks.fetchTicket } }),
+  createAdapters: () => ({
+    issueTracker: { fetchTicket: mocks.fetchTicket, moveTicket: mocks.moveTicket },
+  }),
 }));
 vi.mock("workflow/api", () => ({
   resumeHook: (...args: unknown[]) => mocks.resumeHook(...args),
@@ -57,14 +60,25 @@ const answer = (id: string, value = "Use Next.js") =>
   );
 
 async function seedPending(ticketKey: string | null = "AWT-1") {
+  const subjectKey = ticketKey ? `ticket:jira:${ticketKey}` : "pr:github:acme/api:42";
   const row = await prepareHookClarification(db, {
     ticketKey,
-    subjectKey: ticketKey ? `ticket:jira:${ticketKey}` : "pr:github:acme/api:42",
+    subjectKey,
     runId: "run-asked",
     blockId: "question",
     definitionId: 1,
     definitionVersion: 4,
     questions: ["What framework?"],
+  });
+  // A run suspended on a clarification hook still holds its bound subject claim;
+  // the answer's column move rides that exact owner.
+  await db.insert(activeRuns).values({
+    subjectKey,
+    ticketKey,
+    ownerToken: "owner-1",
+    runId: "run-asked",
+    state: "bound",
+    runKind: "ticket",
   });
   return publishHookClarification(db, row.id);
 }
@@ -88,7 +102,10 @@ const runStatus = (runId: string) =>
 beforeEach(async () => {
   vi.clearAllMocks();
   state.session = { user: { id: "user_admin" }, session: { id: "session_test" } };
-  mocks.fetchTicket.mockResolvedValue({ identifier: "AWT-1" });
+  // The question parked the ticket in the backlog, which is where every answer
+  // starts from.
+  mocks.fetchTicket.mockResolvedValue({ identifier: "AWT-1", trackerStatus: "AI Backlog" });
+  mocks.moveTicket.mockResolvedValue(undefined);
   mocks.resumeHook.mockResolvedValue({ runId: "run-asked" });
   mocks.getHookByToken.mockRejectedValue(new Error("hook consumed"));
   db = await createTestDb();
@@ -168,6 +185,64 @@ describe("POST /api/v1/clarifications/:id/answer", () => {
 
     expect((await answer(row.id)).status).toBe(200);
     expect(await runStatus("run-asked")).toBe("running");
+  });
+
+  it("moves the ticket back to the AI column before the run wakes up", async () => {
+    const row = await seedPending();
+    await parkedRun();
+
+    expect((await answer(row.id)).status).toBe(200);
+
+    expect(mocks.moveTicket).toHaveBeenCalledWith("AWT-1", "AI");
+    // Ordering is the point: Jira must never show AI Backlog for a run that is
+    // already working again.
+    expect(mocks.moveTicket.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.resumeHook.mock.invocationCallOrder[0]!,
+    );
+    expect(await runStatus("run-asked")).toBe("running");
+  });
+
+  it("keeps the answer retryable when the column transition fails", async () => {
+    const row = await seedPending();
+    await parkedRun();
+    mocks.moveTicket.mockRejectedValueOnce(new Error("Jira 502"));
+
+    expect((await answer(row.id)).status).toBe(503);
+
+    // Nothing committed: the question is still answerable and the run still
+    // parked, so the same answer can simply be submitted again.
+    expect((await getHookClarification(db, row.id))?.status).toBe("pending");
+    expect(mocks.resumeHook).not.toHaveBeenCalled();
+    expect(await runStatus("run-asked")).toBe("awaiting");
+  });
+
+  it("does not repeat the transition on an identical retry", async () => {
+    const row = await seedPending();
+    await parkedRun();
+    mocks.resumeHook.mockRejectedValueOnce(new Error("transport failed"));
+    mocks.getHookByToken.mockResolvedValueOnce({ runId: "run-asked" });
+    expect((await answer(row.id)).status).toBe(503);
+    expect(mocks.moveTicket).toHaveBeenCalledTimes(1);
+
+    // The first attempt already landed the ticket in the AI column.
+    mocks.fetchTicket.mockResolvedValue({ identifier: "AWT-1", trackerStatus: "AI" });
+
+    const retry = await answer(row.id);
+
+    expect(retry.status).toBe(200);
+    expect(mocks.moveTicket).toHaveBeenCalledTimes(1);
+    expect(await runStatus("run-asked")).toBe("running");
+  });
+
+  it("skips the transition when the asking run no longer holds its claim", async () => {
+    const row = await seedPending();
+    await parkedRun();
+    await db.delete(activeRuns);
+
+    // A run without a bound claim can never work the ticket, so moving it would
+    // be wrong. The answer itself still stands.
+    expect((await answer(row.id)).status).toBe(200);
+    expect(mocks.moveTicket).not.toHaveBeenCalled();
   });
 
   it("leaves the park marker in place when the resume can still be retried", async () => {

--- a/apps/worker/src/routes/api/v1/clarifications.test.ts
+++ b/apps/worker/src/routes/api/v1/clarifications.test.ts
@@ -20,6 +20,7 @@ const state = vi.hoisted(() => ({
 const mocks = vi.hoisted(() => ({
   fetchTicket: vi.fn(),
   moveTicket: vi.fn(),
+  postComment: vi.fn(),
   resumeHook: vi.fn(),
   getHookByToken: vi.fn(),
 }));
@@ -31,7 +32,11 @@ vi.mock("../../../auth-instance.js", () => ({
 }));
 vi.mock("../../../lib/adapters.js", () => ({
   createAdapters: () => ({
-    issueTracker: { fetchTicket: mocks.fetchTicket, moveTicket: mocks.moveTicket },
+    issueTracker: {
+      fetchTicket: mocks.fetchTicket,
+      moveTicket: mocks.moveTicket,
+      postComment: mocks.postComment,
+    },
   }),
 }));
 vi.mock("workflow/api", () => ({
@@ -106,6 +111,7 @@ beforeEach(async () => {
   // starts from.
   mocks.fetchTicket.mockResolvedValue({ identifier: "AWT-1", trackerStatus: "AI Backlog" });
   mocks.moveTicket.mockResolvedValue(undefined);
+  mocks.postComment.mockResolvedValue(null);
   mocks.resumeHook.mockResolvedValue({ runId: "run-asked" });
   mocks.getHookByToken.mockRejectedValue(new Error("hook consumed"));
   db = await createTestDb();
@@ -151,6 +157,8 @@ describe("POST /api/v1/clarifications/:id/answer", () => {
     const row = await seedPending(null);
     expect((await answer(row.id)).status).toBe(200);
     expect(mocks.fetchTicket).not.toHaveBeenCalled();
+    expect(mocks.moveTicket).not.toHaveBeenCalled();
+    expect(mocks.postComment).not.toHaveBeenCalled();
   });
 
   it("accepts an identical retry after the hook was already consumed", async () => {
@@ -216,13 +224,14 @@ describe("POST /api/v1/clarifications/:id/answer", () => {
     expect(await runStatus("run-asked")).toBe("awaiting");
   });
 
-  it("does not repeat the transition on an identical retry", async () => {
+  it("does not repeat the transition or the answer comment on an identical retry", async () => {
     const row = await seedPending();
     await parkedRun();
     mocks.resumeHook.mockRejectedValueOnce(new Error("transport failed"));
     mocks.getHookByToken.mockResolvedValueOnce({ runId: "run-asked" });
     expect((await answer(row.id)).status).toBe(503);
     expect(mocks.moveTicket).toHaveBeenCalledTimes(1);
+    expect(mocks.postComment).toHaveBeenCalledTimes(1);
 
     // The first attempt already landed the ticket in the AI column.
     mocks.fetchTicket.mockResolvedValue({ identifier: "AWT-1", trackerStatus: "AI" });
@@ -231,6 +240,36 @@ describe("POST /api/v1/clarifications/:id/answer", () => {
 
     expect(retry.status).toBe(200);
     expect(mocks.moveTicket).toHaveBeenCalledTimes(1);
+    // The retry re-drives the resume, not the ticket trace: a second identical
+    // comment would just be noise in the customer's ticket.
+    expect(mocks.postComment).toHaveBeenCalledTimes(1);
+    expect(await runStatus("run-asked")).toBe("running");
+  });
+
+  it("mirrors the answer into the ticket so the question thread does not end in silence", async () => {
+    const row = await seedPending();
+    await parkedRun();
+    state.session = { user: { id: "user_member" }, session: { id: "session_test" } };
+
+    expect((await answer(row.id)).status).toBe(200);
+
+    expect(mocks.postComment).toHaveBeenCalledTimes(1);
+    const [ticketKey, body] = mocks.postComment.mock.calls[0] as [string, string];
+    expect(ticketKey).toBe("AWT-1");
+    expect(body).toContain("Use Next.js");
+    expect(body).toContain("Member");
+  });
+
+  it("delivers the answer even when the ticket trace comment fails", async () => {
+    const row = await seedPending();
+    await parkedRun();
+    mocks.postComment.mockRejectedValueOnce(new Error("Jira 500"));
+
+    // A missing comment is a cosmetic loss; refusing the answer over it would
+    // park a run that a human already unblocked.
+    expect((await answer(row.id)).status).toBe(200);
+    expect(mocks.resumeHook).toHaveBeenCalledTimes(1);
+    expect((await getHookClarification(db, row.id))?.status).toBe("answered");
     expect(await runStatus("run-asked")).toBe("running");
   });
 

--- a/apps/worker/src/routes/api/v1/clarifications/[id]/answer.post.ts
+++ b/apps/worker/src/routes/api/v1/clarifications/[id]/answer.post.ts
@@ -70,6 +70,14 @@ export default defineEventHandler(async (event): Promise<ClarificationAnswerResp
         throw createError({ statusCode: 409, statusMessage: "already_answered" });
       case "ticket_gone":
         throw createError({ statusCode: 410, statusMessage: "ticket_gone" });
+      case "ticket_transition_failed":
+        // Nothing was committed: the question is still pending, so the same
+        // answer can simply be submitted again once Jira recovers.
+        throw createError({
+          statusCode: 503,
+          statusMessage: "clarification_transition_failed",
+          cause: outcome.error,
+        });
       case "resume_failed_retryable":
         throw createError({
           statusCode: 503,


### PR DESCRIPTION
## AIW-265: a dashboard answer left Jira untouched

Measured on prod (AWP-69): the ticket parked, the answer was given in the dashboard, the dashboard confirmed the resume, and Jira kept the backlog status with **no new comment**. The run then worked to completion and the status jumped straight to the post-PR column, skipping the AI column entirely. So this was not one lost transition: the dashboard resume path performed **no Jira write at all**, and the ticket only caught up at the end of the run.

Both halves now happen in `answerClarificationAndResume`, the core the dashboard route and the Jira comment path already share, so neither channel can drift from the other.

**1. The column move** (`apps/worker/src/clarifications/answer-core.ts`)

- New private `moveTicketToAiColumn` reads the asking run's `bound` claim from `active_runs` and calls the existing `moveTicketForRun` with `aiColumnMoveTarget(env)`. It rides the asking run's own owner fence, which still holds the subject while the run is suspended on the hook, so a cancelled or superseded run cannot move a ticket. A missing bound claim logs `clarification_answer_transition_skipped_no_bound_owner` and skips: a run with no claim can never work the ticket, so moving it would be wrong, while the answer itself is still legitimate.
- Ordered **before** the answer CAS on purpose. A failed move leaves the row `pending` and the run parked, so the same answer can simply be submitted again; the reverse order would leave a live run behind a stale column, which is the defect itself.
- New outcome `ticket_transition_failed`, mapped to `503 clarification_transition_failed` in `routes/api/v1/clarifications/[id]/answer.post.ts`. Visible and retryable, never swallowed.
- `moveTicketForRun` now takes `Pick<IssueTrackerAdapter, "fetchTicket" | "moveTicket">` so the core can pass its narrow adapter without a cast.

**2. The Jira trace** (`apps/worker/src/clarifications/comment-format.ts`)

- New `formatClarificationAnswerComment` posts the answer back to the ticket, so the public questions comment no longer ends in silence. Posted best-effort after the answer is committed: a comment must never fail an answer a human already gave.
- Exactly-once without new state: it only posts on the branch that actually recorded the answer, so an identical retry re-drives the resume, not the trace.
- Safe against feedback: the comment resume path skips comments authored by the bot account (`resume-from-comments.ts:236-246`), so our own trace can never be read back as an answer.

The Jira comment path opts out of both (`skipTicketMove`, `skipAnswerComment`): the human already moved the column and their comment already is the trace. Its answered-retry branch keeps the move and releases the AIW-264 claim on failure, which is what re-syncs a dashboard answer whose move never landed.

## AIW-267 as filed: not reproduced

Two tickets with identical title and description, moved to the AI column together, **both** asked for clarification, 0.7 s apart, both about the repository. The decision was consistent; only the question wording differed. No fix, no prompt change.

## The real defect found next to it: the agent asks twice

Observed on AWP-70/AWP-71: after an unambiguous repository answer, a reworded version of the same question arrives minutes later. **This is a separate source from AIW-265.** The answer does reach the run durably: hook payload to `execution.clarificationAnswer` to a re-execution of the asking block (`workflow-definition/interpreter.ts:806-819`), injected as a synthetic `Human clarification` comment (`workflows/blocks/prepare-workspace.ts:664-669`) that the selection scan reads (`repo-selection.ts:884-892`).

The source is that the `discovery_needed` branch hands the model only `catalog` and `mandatoryRepositories` (`repo-selection.ts:141-165`). The human's answer is never given to discovery, so whenever the deterministic ladder cannot match it, the model sees the same catalog with no sign that a human already answered, and asks again in its own words.

Fixed here for the case where the answer names repository paths that are not in the catalog: the selection now returns a clarification naming them, exactly as the unsatisfiable-pin branch above already does, instead of letting discovery silently replace an explicit human choice. Reaching that line already proves none of the named paths matched, because a path present in the catalog is resolved by the ticket-text scan and the answer scan before it.

**Known remaining gap, deliberately not fixed here:** a prose answer with no repository path ("the prod one") still falls through to discovery blind. Closing it means threading the answer into the discovery input (`repository-discovery/protocol.ts`, `runner.ts` and the step), which is its own change.

## Tests

Narrow files only, no full suite:

- `src/routes/api/v1/clarifications.test.ts` 15/15 (new: transition before resume with call-order assertion, transition failure keeps the answer retryable, no repeated transition or comment on an identical retry, missing bound claim skips the move, answer mirrored into the ticket, trace failure still delivers the answer)
- `src/clarifications/resume-from-comments.test.ts` 21/21 (new: never moves the ticket for a comment-composed answer, releases the claim when the answered retry cannot re-sync the column)
- `src/pre-sandbox/steps/repo-selection.test.ts` 105/105 (new: names the unavailable repository, keeps a provider-scoped path in the question, prose still falls to discovery)
- `src/lib/ticket-transition.test.ts` 4/4
- `npx tsc --noEmit` clean

No migration needed. No `db.transaction()` anywhere in these paths.
