### PR TITLE
fix(worker): refuse to publish a scheduled start for a run with no run row (AIW-249)

### DIFF
--- a/apps/worker/src/schedule-trigger/occurrence-store.test.ts
+++ b/apps/worker/src/schedule-trigger/occurrence-store.test.ts
@@ -6,6 +6,7 @@ import {
   scheduleOccurrences,
   workflowDefinitions,
   workflowDefinitionVersions,
+  workflowRuns,
   workflowSchedules,
 } from "../db/schema.js";
 import { createTestDb } from "../db/test-db.js";
@@ -99,11 +100,21 @@ async function settle(
     .where(eq(scheduleOccurrences.occurrenceAt, occurrenceAt));
 }
 
+/**
+ * A claim plus the run rows the registry writes in the very statement that binds
+ * it. recordOccurrenceStarted requires the run row, so a caller that owns the
+ * subject but has no run cannot publish a start (AIW-249).
+ */
 async function reserve(
   ownerToken: string,
   subjectKey = "schedule:sch_test",
+  runIds: string[] = ["run-1"],
 ): Promise<void> {
   await db.insert(activeRuns).values({ subjectKey, ownerToken });
+  await db
+    .insert(workflowRuns)
+    .values(runIds.map((runId) => ({ runId, status: "running", subjectKey })))
+    .onConflictDoNothing({ target: workflowRuns.runId });
 }
 
 function causeMessage(error: unknown): string {
@@ -322,6 +333,25 @@ describe("recordOccurrenceStarted", () => {
     });
   });
 
+  it("refuses to publish a start for a run that has no run row", async () => {
+    await acceptOccurrence(db, admitted(AT_10));
+    // The claim on its own, with no run row: exactly the state a dispatcher
+    // holds BEFORE the registry writes workflow_runs. Publishing from it is
+    // AIW-249's phantom, an occurrence that says a run started while the runs
+    // list has nothing and the runtime has no trace of it.
+    await db
+      .insert(activeRuns)
+      .values({ subjectKey: "schedule:sch_test", ownerToken: "owner-1" });
+    expect(
+      await recordOccurrenceStarted(db, SCHEDULE_ID, AT_10, "owner-1", "run-1"),
+    ).toBe(false);
+    const stored = await getOccurrence(db, SCHEDULE_ID, AT_10);
+    expect({ pending: stored?.pending, outcome: stored?.outcome }).toEqual({
+      pending: true,
+      outcome: null,
+    });
+  });
+
   it("publishes the start, releases the slot, and records the firing on the schedule", async () => {
     await acceptOccurrence(db, admitted(AT_10));
     await reserve("owner-1");
@@ -349,7 +379,7 @@ describe("recordOccurrenceStarted", () => {
 
   it("keeps the last started occurrence monotonic", async () => {
     await acceptOccurrence(db, admitted(AT_11));
-    await reserve("owner-1");
+    await reserve("owner-1", "schedule:sch_test", ["run-newer", "run-older"]);
     await recordOccurrenceStarted(db, SCHEDULE_ID, AT_11, "owner-1", "run-newer");
     // A late publication for an older occurrence must not rewind what a UI shows.
     await acceptOccurrence(db, admitted(AT_09));
@@ -416,7 +446,7 @@ describe("recordOccurrenceStarted", () => {
     await acceptOccurrence(db, admitted(AT_10));
     await reserve("owner-1");
     await recordOccurrenceStarted(db, SCHEDULE_ID, AT_10, "owner-1", "run-1");
-    await reserve("owner-2", "schedule:sch_test:2");
+    await reserve("owner-2", "schedule:sch_test:2", ["run-2"]);
     expect(
       await recordOccurrenceStarted(db, SCHEDULE_ID, AT_10, "owner-2", "run-2"),
     ).toBe(false);
@@ -479,7 +509,7 @@ describe("settleScheduleOccurrenceOnCancel", () => {
   it("leaves rows whose run_id differs or whose outcome is not started", async () => {
     // A started occurrence owned by a different run: guarded by the run_id filter.
     await acceptOccurrence(db, admitted(AT_10));
-    await reserve("owner-1");
+    await reserve("owner-1", "schedule:sch_test", ["run-other"]);
     await recordOccurrenceStarted(db, SCHEDULE_ID, AT_10, "owner-1", "run-other");
 
     // A settled non-started occurrence that happens to carry the target run id:

--- a/apps/worker/src/schedule-trigger/occurrence-store.ts
+++ b/apps/worker/src/schedule-trigger/occurrence-store.ts
@@ -1,6 +1,11 @@
 import { and, asc, desc, eq, getTableColumns, isNull, lt, sql } from "drizzle-orm";
 import type { Db } from "../db/client.js";
-import { activeRuns, scheduleOccurrences, workflowSchedules } from "../db/schema.js";
+import {
+  activeRuns,
+  scheduleOccurrences,
+  workflowRuns,
+  workflowSchedules,
+} from "../db/schema.js";
 
 /**
  * Durable occurrence ledger for schedule triggers.
@@ -340,6 +345,21 @@ export async function supersedePendingThenAccept(
  * it. That is the same boundary assertActiveRunOwner defends before an
  * irreversible provider call (lib/active-run-owner.ts:13-18).
  *
+ * The run row is the second half of that fence, and it is what AIW-249 is about.
+ * A claim proves ownership, NOT that the run exists: the pre-start reservation
+ * branch above is true for a whole dispatch before the registry writes anything
+ * to workflow_runs, so on that branch alone this statement will happily publish
+ * "started" naming a run that has no row and no runtime trace. That is the
+ * phantom an operator then reads as a run that fired and vanished. Requiring the
+ * row makes the publication self-certifying instead of inferred, in the same
+ * statement, which is the only atomicity available here: neon-http has no
+ * transactions, so the writes cannot be wrapped, only ordered and checked. The
+ * row is never the slow half of this: recordStartedRun writes it and binds the
+ * claim in ONE statement (adapters/run-registry/postgres.ts:53-124), so every
+ * caller that legitimately reaches this point already has both. A refusal
+ * therefore means the run genuinely is not there, and the caller's existing
+ * orphaned-start path cleans it up rather than the ledger recording a fiction.
+ *
  * The schedule-row write is what a UI should render as "last run". It is kept
  * monotonic so a late publication for an older occurrence cannot rewind it, and
  * it outlives the ledger's retention window, which is the only reason a schedule
@@ -380,6 +400,10 @@ export async function recordOccurrenceStarted(
               (${activeRuns.state} = 'reserved' AND ${activeRuns.runId} IS NULL)
               OR (${activeRuns.state} = 'bound' AND ${activeRuns.runId} = ${runId})
             )
+        )
+        AND EXISTS (
+          SELECT 1 FROM ${workflowRuns}
+          WHERE ${workflowRuns.runId} = ${runId}
         )
       RETURNING ${scheduleOccurrences.scheduleId}, ${scheduleOccurrences.occurrenceAt}
     ), fired AS (

--- a/apps/worker/src/schedule-trigger/phantom-scheduled-run.test.ts
+++ b/apps/worker/src/schedule-trigger/phantom-scheduled-run.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { eq, sql } from "drizzle-orm";
+import type { Db } from "../db/client.js";
+import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
+import {
+  activeRuns,
+  scheduleOccurrences,
+  workflowDefinitions,
+  workflowDefinitionVersions,
+  workflowRuns,
+  workflowSchedules,
+} from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+
+/**
+ * AIW-249: an occurrence that says a run started must name a run that exists.
+ *
+ * The dispatcher's own suite runs on a fake ledger and a fake registry, which
+ * model the intent rather than the SQL, so the phantom this file is about is
+ * invisible there by construction. Everything below runs the REAL occurrence
+ * store, the REAL PostgresRunRegistry and the REAL dispatcher against the
+ * committed migrations, and asserts the one property an operator relies on:
+ * schedule_occurrences.outcome = 'started' implies a workflow_runs row for its
+ * run id.
+ *
+ * The failure modes injected here are the ones a production deployment swap
+ * actually produces: a commit whose response is lost after the statement
+ * applied (the neon-http shape), a commit that never reaches the database, a
+ * reservation that ages past its bind grace, and a poll invocation killed
+ * between start() and the commit so the hosted run publishes its own start.
+ */
+
+const { testEnv } = vi.hoisted(() => ({
+  testEnv: { MAX_CONCURRENT_AGENTS: 3 } as Record<string, unknown>,
+}));
+vi.mock("../../env.js", () => ({ env: testEnv }));
+
+const { startMock, getRunMock } = vi.hoisted(() => ({
+  startMock: vi.fn(),
+  getRunMock: vi.fn(),
+}));
+vi.mock("workflow/api", () => ({ start: startMock, getRun: getRunMock }));
+vi.mock("../workflows/agent.js", () => ({ agentWorkflow: "agentWorkflow_sentinel" }));
+vi.mock("../lib/workflow-step-drain.js", () => ({
+  confirmWorkflowStepsDrained: vi.fn(async () => true),
+}));
+
+const { dbRef } = vi.hoisted(() => ({ dbRef: { current: null as unknown as Db } }));
+vi.mock("../db/client.js", () => ({ getDb: () => dbRef.current }));
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("../lib/logger.js", () => ({ logger: loggerMock }));
+
+const { PostgresRunRegistry } = await import("../adapters/run-registry/postgres.js");
+const { recordOccurrenceStarted } = await import("./occurrence-store.js");
+const { createScheduleDispatchDeps, dispatchScheduleOccurrence } = await import(
+  "./dispatch-schedule-trigger.js"
+);
+type DispatchParams = Parameters<typeof dispatchScheduleOccurrence>[0];
+
+const SCHEDULE_ID = "sch_phantom";
+const NODE_ID = "trigger_schedule_1";
+const OCCURRENCE_AT = new Date("2026-08-10T17:00:00.000Z");
+const RUN_ID = "wrun_01KZPA62DVJSBJRM1AOVKDY2HS";
+
+let db: Db;
+
+beforeEach(async () => {
+  db = await createTestDb();
+  dbRef.current = db;
+  startMock.mockReset();
+  getRunMock.mockReset();
+  getRunMock.mockReturnValue({ cancel: async () => {}, status: "cancelled" });
+  await db.insert(workflowDefinitions).values({
+    id: 7,
+    name: "Nightly report",
+    createdById: "test",
+    createdByLabel: "Test",
+  });
+  await db.insert(workflowDefinitionVersions).values({
+    definitionId: 7,
+    version: 2,
+    definition: {},
+    createdById: "test",
+    createdByLabel: "Test",
+  });
+  await db.insert(workflowSchedules).values({
+    id: SCHEDULE_ID,
+    definitionId: 7,
+    nodeId: NODE_ID,
+    cron: "0 * * * *",
+  });
+});
+
+const occurrence: DispatchParams = {
+  scheduleId: SCHEDULE_ID,
+  occurrenceAt: OCCURRENCE_AT,
+  definitionId: 7,
+  definitionVersion: 2,
+  nodeId: NODE_ID,
+  overlapPolicy: "skip",
+  taskTitle: "Nightly report",
+  taskDescription: "Produce the nightly report",
+  previousOccurrenceAt: null,
+  previousRunPullRequests: [],
+  droppedOlder: 0,
+  droppedOlderAtLeast: false,
+};
+
+/** The real registry with one method swapped for a failure injector. */
+function withCommit(
+  registry: RunRegistryAdapter,
+  impl: RunRegistryAdapter["commitStartedRun"],
+): RunRegistryAdapter {
+  return new Proxy(registry, {
+    get(target, prop, receiver) {
+      if (prop === "commitStartedRun") return impl;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as RunRegistryAdapter;
+}
+
+/** The symptom, read from the two tables an operator actually looks at. */
+async function expectNoPhantom(): Promise<void> {
+  const [occ] = await db
+    .select({ outcome: scheduleOccurrences.outcome, runId: scheduleOccurrences.runId })
+    .from(scheduleOccurrences)
+    .where(eq(scheduleOccurrences.scheduleId, SCHEDULE_ID));
+  if (occ?.outcome !== "started") return;
+  const [row] = await db
+    .select({ runId: workflowRuns.runId })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, occ.runId!));
+  expect(
+    row,
+    `phantom: occurrence says started with run ${occ.runId} and no workflow_runs row exists`,
+  ).toBeTruthy();
+}
+
+describe("AIW-249: a started occurrence names a run that exists", () => {
+  it("publishes a start whose run row is present", async () => {
+    startMock.mockResolvedValue({ runId: RUN_ID });
+    const result = await dispatchScheduleOccurrence(
+      occurrence,
+      createScheduleDispatchDeps(db, new PostgresRunRegistry(db), 3),
+    );
+    expect(result).toEqual({ result: "started", runId: RUN_ID });
+    await expectNoPhantom();
+  });
+
+  it("keeps the run row when the commit response is lost after it applied", async () => {
+    startMock.mockResolvedValue({ runId: RUN_ID });
+    const real = new PostgresRunRegistry(db);
+    const registry = withCommit(real, async (started) => {
+      await real.commitStartedRun(started);
+      throw new Error("fetch failed");
+    });
+    const result = await dispatchScheduleOccurrence(
+      occurrence,
+      createScheduleDispatchDeps(db, registry, 3),
+    );
+    expect(result).toEqual({ result: "started", runId: RUN_ID });
+    await expectNoPhantom();
+  });
+
+  it("publishes nothing when the commit never reaches the database", async () => {
+    startMock.mockResolvedValue({ runId: RUN_ID });
+    const real = new PostgresRunRegistry(db);
+    const registry = withCommit(real, async () => {
+      throw new Error("fetch failed");
+    });
+    const result = await dispatchScheduleOccurrence(
+      occurrence,
+      createScheduleDispatchDeps(db, registry, 3),
+    );
+    expect(result.result).toBe("error");
+    await expectNoPhantom();
+  });
+
+  it("publishes nothing when the reservation aged past its bind grace", async () => {
+    startMock.mockImplementation(async () => {
+      await db.execute(
+        sql`update active_runs set updated_at = now() - interval '10 minutes'`,
+      );
+      return { runId: RUN_ID };
+    });
+    const result = await dispatchScheduleOccurrence(
+      occurrence,
+      createScheduleDispatchDeps(db, new PostgresRunRegistry(db), 3),
+    );
+    expect(result.result).toBe("error");
+    await expectNoPhantom();
+  });
+
+  it("keeps the invariant when the hosted run publishes its own start", async () => {
+    // The poll invocation is killed between start() and the commit, which is
+    // what a deployment swap does. The hosted run then binds the reservation
+    // itself (bindWorkflowCandidateStep) and publishes the occurrence
+    // (acknowledgeScheduleDispatchStep). Both writers are exercised here in
+    // that order, against the real registry.
+    const registry = new PostgresRunRegistry(db);
+    const ownerToken = "owner:deployment-swap";
+    const subject = { subjectKey: `schedule:${SCHEDULE_ID}`, ticketKey: null, kind: "schedule" as const };
+    await db.insert(scheduleOccurrences).values({
+      scheduleId: SCHEDULE_ID,
+      occurrenceAt: OCCURRENCE_AT,
+      definitionId: 7,
+      definitionVersion: 2,
+      pending: true,
+    });
+    expect(await registry.reserve({ ...subject, ownerToken })).toBe(true);
+
+    expect(
+      await registry.markRunEntryStarted({ ...subject, ownerToken, runId: RUN_ID }),
+    ).toBe(true);
+    expect(
+      await recordOccurrenceStarted(db, SCHEDULE_ID, OCCURRENCE_AT, ownerToken, RUN_ID),
+    ).toBe(true);
+
+    const [claim] = await db.select().from(activeRuns);
+    expect(claim).toMatchObject({ state: "bound", runId: RUN_ID });
+    await expectNoPhantom();
+  });
+});


### PR DESCRIPTION
## AIW-249: phantom scheduled runs

A scheduled occurrence could be published as `started` naming a run that has no `workflow_runs` row and no runtime trace. This closes the one write path that can produce that state, and adds the reproduction harness the existing suite could not provide.

### Cause

`recordOccurrenceStarted` authorized a publication purely from the run claim (`apps/worker/src/schedule-trigger/occurrence-store.ts`), and the claim predicate admits a pre-start reservation:

```sql
(state = 'reserved' AND run_id IS NULL) OR (state = 'bound' AND run_id = <runId>)
```

The first branch is true for the whole dispatch before the registry writes anything to `workflow_runs`, so on that branch alone the statement publishes `started` for a run that does not exist. A claim proves ownership, not existence.

### Fix

The statement now also requires the run row, in the same statement (neon-http has no transactions, so the writes can only be ordered and checked, never wrapped). `recordStartedRun` writes the run row and binds the claim in ONE statement (`adapters/run-registry/postgres.ts`), so every caller that legitimately reaches publication already has both: the happy path is unchanged. A refusal now means the run genuinely is not there, and the dispatcher's existing orphaned-start path cleans it up instead of the ledger recording a fiction.

No migration. No `db.transaction()`.

### Evidence

Regression test `refuses to publish a start for a run that has no run row` fails before the fix:

```
AssertionError: expected true to be false
 ❯ src/schedule-trigger/occurrence-store.test.ts:336:7
```

The new `phantom-scheduled-run.test.ts` drives the REAL occurrence store, the REAL `PostgresRunRegistry` and the REAL dispatcher against the committed migrations (the dispatcher's own suite runs on fakes, so the phantom is invisible there by construction). It asserts `outcome = 'started'` implies a `workflow_runs` row, across four production failure shapes: a commit response lost after the statement applied, a commit that never reaches the database, a reservation aged past its bind grace, and a poll invocation killed between `start()` and the commit so the hosted run publishes its own start.

### Verification run locally

```
npx vitest run src/schedule-trigger/occurrence-store.test.ts            # 55 passed
npx vitest run src/schedule-trigger/phantom-scheduled-run.test.ts \
              src/schedule-trigger/dispatch-schedule-trigger.test.ts    # 47 passed
npx vitest run src/workflows/run-ownership-steps.test.ts \
              src/routes/.../schedule/schedule-routes.test.ts \
              src/schedule-trigger/schedule-store.test.ts \
              src/schedule-trigger/occurrence.test.ts                   # 152 passed
npx tsc --noEmit                                                        # clean
```

### Known limit

The exact production trigger on 2026-08-10 stays unproven: no code path in main creates `bound claim + missing run row`, and the runtime logs for those invocations are unreadable (Vercel MCP returns 403 for this project). What this PR proves is that the ledger itself could write the phantom, and now cannot.

### AIW-223

The two commits on `feat/schedule-cron-trigger` (`9dda9dea`, `fb55629b`) are already in main, folded into `4f5a7c2e feat(worker): add the schedule trigger (AIW-223) (#225)`. `git diff 9dda9dea HEAD -- apps/worker/src/workflows/workspace-gate.ts` and `git diff fb55629b HEAD -- apps/worker/src/workflows/workspace-gate.test.ts` are both empty, so nothing was cherry-picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
