### PR TITLE
AIW-251/248: fix the replay divergence at its cause and run CI on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 on:
   pull_request:
     branches: [main, dev]
+  # Without this, nothing ever ran on main: every recorded run came from a
+  # pull request, so the branch the releases are cut from had no signal of its
+  # own and a merge could land red without anything turning red afterwards.
+  # Pull-request runs test the merge commit against the base at open time, not
+  # what main actually became, so they are not a substitute.
+  push:
+    branches: [main]
   merge_group:
   # The e2e suites below are gated on the merge queue, and no merge queue is
   # configured, so they had never run: 11 of 11 recorded runs skipped all three.
@@ -18,7 +25,11 @@ concurrency:
   # take hours, impossible to finish by hand. Pushes still supersede each other
   # within their own event, which is the behaviour this cancellation is for.
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  # Never on main. Superseding is right for a branch nobody reads the history
+  # of, but a cancelled main run leaves that commit with no verdict at all,
+  # which is the hole this workflow's push trigger exists to close: two merges
+  # in quick succession would otherwise cancel the first and hide its result.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   ci:

--- a/apps/worker/src/run-observability/runtime-hooks.test.ts
+++ b/apps/worker/src/run-observability/runtime-hooks.test.ts
@@ -473,18 +473,23 @@ describe("v2 run observation hooks", () => {
     expect(target.markUnavailable).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps scheduler boundary timing when attempt persistence is delayed", async () => {
-    let resolveAgentStart!: (attemptId: number | null) => void;
-    const agentStart = new Promise<number | null>((resolve) => {
-      resolveAgentStart = resolve;
-    });
+  // Reversed by AIW-251, deliberately. This row used to hold the agent's start
+  // write open for the whole run and assert the scheduler sailed past it:
+  // capture was off the critical path by design. It cannot be, and stay replay
+  // safe: a write the scheduler does not wait for lands at a position the
+  // replay does not reproduce, which is a divergence and kills the run. So the
+  // scheduler now waits, and what this row still guards is the part that was
+  // always the point: the timestamps written are the scheduler's boundary
+  // times, never the wall clock of whenever persistence got around to running.
+  it("records scheduler boundary times when attempt persistence is delayed", async () => {
     const target = sink();
-    target.start.mockImplementation(
-      (identity: V2InvocationIdentity) =>
-        identity.nodeId === "agent"
-          ? agentStart
-          : Promise.resolve(1),
-    );
+    target.start.mockImplementation(async (identity: V2InvocationIdentity) => {
+      if (identity.nodeId !== "agent") return 1;
+      // A slow write, not a hung one: a real capture step always settles, and
+      // the delay has to outlast several scheduler turns to be worth anything.
+      for (let turn = 0; turn < 50; turn += 1) await Promise.resolve();
+      return 42;
+    });
     const definition = workflowDefinition(
       [
         workflowNode("trigger", "trigger_ticket_ai"),
@@ -518,12 +523,10 @@ describe("v2 run observation hooks", () => {
         (identity as V2InvocationIdentity).nodeId === "agent",
     );
     expect(agentStartCall?.[1]).toEqual(STARTED_AT);
-    expect(
-      target.finish.mock.calls.some(([attemptId]) => attemptId === 42),
-    ).toBe(false);
 
+    // Moving the clock after the run proves the recorded times came from the
+    // boundaries, not from when the writes were flushed.
     boundaryAt = new Date("2026-07-23T11:00:00.000Z");
-    resolveAgentStart(42);
     await hooks.finalize("test_finished");
 
     expect(target.finish).toHaveBeenCalledWith(
@@ -799,5 +802,128 @@ describe("v2 run observation hooks", () => {
       },
     });
     expect(capture.attempts.every((attempt) => attempt.finish)).toBe(true);
+  });
+});
+
+// AIW-251. These hooks run inside a "use workflow" function, so every sink call
+// is a durable step and the order the steps are CREATED in is what the event log
+// records. A replay re-runs the same code and must create them in the same
+// order, or the runtime reports a replay divergence and the run dies with
+// CORRUPTED_EVENT_LOG. The one thing a replay cannot reproduce is how long the
+// run's own awaited steps took: the original waits on real I/O, the replay
+// serves the recorded result almost immediately. So a capture write whose
+// position depends on that latency is exactly the defect, and these rows pin
+// the two properties that keep it out: order independent of latency, and a
+// failing write that still cannot take the run down with it.
+describe("v2 run observation hooks are replay-safe", () => {
+  const IDENTITY = { nodeId: "review", attempt: 1, activationScopeId: "root" };
+
+  /** A promise that settles after exactly `turns` microtask turns. */
+  async function hops(turns: number): Promise<void> {
+    for (let turn = 0; turn < turns; turn += 1) await Promise.resolve();
+  }
+
+  /**
+   * Drives the hook sequence agent.ts drives, recording every durable write in
+   * creation order. `stepTurns` stands in for how long the run's OWN steps take
+   * to settle: 0 is a replay serving recorded results, a high count is the
+   * original run waiting on real I/O.
+   */
+  async function writeSequence(stepTurns: number): Promise<string[]> {
+    const log: string[] = [];
+    const hooks = createV2RunObservationHooks({
+      nodeTypes: new Map([["review", "generic_agent" as WorkflowBlockType]]),
+      sink: {
+        async start() {
+          log.push("capture:start");
+          await hops(1);
+          return 1;
+        },
+        async observe() {
+          log.push("capture:observe");
+          await hops(1);
+        },
+        async updateWaiting() {},
+        async finish() {
+          log.push("capture:finish");
+          await hops(1);
+        },
+        async markUnavailable() {
+          log.push("capture:unavailable");
+        },
+      },
+    });
+    // A step of the run's own, recorded when it is created, settling later.
+    const step = async (name: string): Promise<void> => {
+      log.push(`step:${name}`);
+      await hops(stepTurns);
+    };
+
+    await hooks.onNodeStart?.({ ...IDENTITY, startedAt: STARTED_AT });
+    // agent.ts's onNodeFinish exactly: the capture hook, then the run's own
+    // durable write. That write is the gap the detached capture chain used to
+    // race through, and how many turns it lasts is what a replay changes.
+    await hooks.onNodeFinish?.({
+      ...IDENTITY,
+      completedAt: COMPLETED_AT,
+      state: { status: "ok", attempt: 1 },
+      runtimeState: "completed",
+      selectedTransition: null,
+    });
+    await step("blockStatuses");
+    await step("readClock");
+    await hooks.finalize("workflow_finished");
+    return log;
+  }
+
+  it("creates capture writes in the same order however long the run's own steps take", async () => {
+    const replayLike = await writeSequence(0);
+    const originalLike = await writeSequence(20);
+    // The recorded divergence was exactly this pair swapping: the event log had
+    // the attempt-finish write where the replay wanted the run's own next step.
+    expect(replayLike).toEqual(originalLike);
+  });
+
+  it("keeps every capture write ahead of the run's own next step", async () => {
+    const sequence = await writeSequence(0);
+    expect(sequence.indexOf("capture:finish")).toBeLessThan(
+      sequence.indexOf("step:readClock"),
+    );
+  });
+
+  it("completes the run when a capture write throws, and leaves the trace", async () => {
+    const failing = sink();
+    failing.finish.mockRejectedValue(new Error("replay capture is down"));
+    const hooks = createV2RunObservationHooks({
+      nodeTypes: new Map([["review", "generic_agent" as WorkflowBlockType]]),
+      sink: failing,
+    });
+
+    await hooks.onNodeStart?.({ ...IDENTITY, startedAt: STARTED_AT });
+    // The hook has to be awaitable for the scheduler to order against it, and
+    // awaiting it is exactly what would otherwise couple the run's fate to a
+    // telemetry write. So it must absorb the failure itself: a broken capture
+    // write is not a broken run.
+    const settled = hooks.onNodeFinish?.({
+      ...IDENTITY,
+      completedAt: COMPLETED_AT,
+      state: { status: "ok", attempt: 1 },
+      runtimeState: "completed",
+      selectedTransition: null,
+    });
+    expect(settled).toBeInstanceOf(Promise);
+    await expect(settled).resolves.toBeUndefined();
+    // The scheduler keeps going afterwards, and the run reaches its end.
+    await expect(
+      hooks.onNodeSkipped?.({
+        ...IDENTITY,
+        nodeId: "later",
+        startedAt: STARTED_AT,
+        completedAt: COMPLETED_AT,
+      }),
+    ).resolves.toBeUndefined();
+    await expect(hooks.finalize("workflow_finished")).resolves.toBeUndefined();
+    // The trace: capture is marked unavailable rather than failing silently.
+    expect(failing.markUnavailable).toHaveBeenCalled();
   });
 });

--- a/apps/worker/src/run-observability/runtime-hooks.ts
+++ b/apps/worker/src/run-observability/runtime-hooks.ts
@@ -107,10 +107,23 @@ interface PendingAttemptCapture {
 
 /**
  * Bridges scheduler lifecycle events to durable replay capture. Every sink call
- * is isolated so observation failures can never change workflow behavior.
- * Attempt starts and writes run concurrently with authored work, while a
+ * is isolated so observation failures can never change workflow behavior, and a
  * per-run circuit breaker bounds every captured invocation, including skipped
- * nodes. Only finalize drains persistence after scheduler work has stopped.
+ * nodes.
+ *
+ * These hooks run inside the agent's "use workflow" function, so every sink call
+ * is a durable step and the order the steps are created in is what the event log
+ * records. A replay re-runs this code and has to create them in the same order.
+ * That is why each hook awaits its own writes instead of detaching them: a
+ * detached chain lands wherever the event loop allows, and the original run and
+ * its replay do not agree on that, because the original waits on real I/O where
+ * the replay is served from the log. The mismatch surfaces as a replay
+ * divergence and kills the run with CORRUPTED_EVENT_LOG (AIW-251).
+ *
+ * Awaiting buys ordering, not coupling: the chain persist() returns is already
+ * caught, so it never rejects and a failed capture write can never fail the run.
+ * It trips the circuit breaker and the run carries on. finalize still drains
+ * whatever is outstanding once scheduler work has stopped.
  */
 export function createV2RunObservationHooks(input: {
   nodeTypes: ReadonlyMap<string, WorkflowBlockType>;
@@ -205,11 +218,14 @@ export function createV2RunObservationHooks(input: {
     capture.observations.push(structuredClone(observation));
   };
 
+  // Returns the chain so callers can await it. The chain is caught below, so it
+  // never rejects: awaiting it buys a deterministic position in the event log
+  // without ever letting a capture write decide whether the run survives.
   const persist = (
     capture: PendingAttemptCapture,
     write: (attemptId: number) => Promise<void>,
-  ): void => {
-    if (captureDisabled) return;
+  ): Promise<void> => {
+    if (captureDisabled) return Promise.resolve();
     const observations = capture.observations.splice(0);
     const task = capture.persistenceTail
       .then(async () => {
@@ -227,6 +243,7 @@ export function createV2RunObservationHooks(input: {
       });
     capture.persistenceTail = task;
     track(task);
+    return task;
   };
 
   const finish = (
@@ -234,19 +251,20 @@ export function createV2RunObservationHooks(input: {
     capture: PendingAttemptCapture,
     terminal: RunObservationAttemptFinish,
     completedAt: Date,
-  ): void => {
-    persist(capture, (attemptId) =>
+  ): Promise<void> => {
+    const task = persist(capture, (attemptId) =>
       input.sink.finish(attemptId, terminal, completedAt),
     );
     attempts.delete(identityKey(identity));
+    return task;
   };
 
   return {
-    onTriggerActivated(event) {
+    async onTriggerActivated(event) {
       const capture = start(event, event.startedAt);
       if (!capture) return;
       observe(capture, { kind: "output", value: event.output });
-      finish(
+      await finish(
         event,
         capture,
         {
@@ -264,21 +282,21 @@ export function createV2RunObservationHooks(input: {
     onNodeStart(event) {
       start(event, event.startedAt);
     },
-    onNodeWaiting(event) {
+    async onNodeWaiting(event) {
       const capture = attempts.get(identityKey(event));
       if (!capture) return;
-      persist(capture, (attemptId) =>
+      await persist(capture, (attemptId) =>
         input.sink.updateWaiting(
           attemptId,
           event.selectedTransition,
         ),
       );
     },
-    onNodeFinish(event) {
+    async onNodeFinish(event) {
       const key = identityKey(event);
       const capture = attempts.get(key);
       if (!capture) return;
-      finish(
+      await finish(
         event,
         capture,
         {
@@ -295,10 +313,10 @@ export function createV2RunObservationHooks(input: {
         event.completedAt,
       );
     },
-    onNodeSkipped(event) {
+    async onNodeSkipped(event) {
       const capture = start(event, event.startedAt);
       if (!capture) return;
-      finish(
+      await finish(
         event,
         capture,
         {

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -5562,23 +5562,28 @@ async function agentWorkflowBody(
         return result;
       };
 
+      // Awaited, not detached. These hooks write durable steps, so letting them
+      // land whenever the event loop allows put them at a different position on
+      // replay than in the original run, which is a replay divergence and takes
+      // the whole run down (AIW-251). The hooks swallow their own write
+      // failures, so awaiting them costs ordering only, never the run.
       const v2Hooks: V2SchedulerHooks = {
-        onTriggerActivated(event) {
-          void v2RunObservation?.onTriggerActivated?.(event);
+        async onTriggerActivated(event) {
+          await v2RunObservation?.onTriggerActivated?.(event);
         },
         async onNodeStart(event) {
           await hooks.onBlockStart(event.nodeId, event.attempt);
-          void v2RunObservation?.onNodeStart?.(event);
+          await v2RunObservation?.onNodeStart?.(event);
         },
-        onNodeWaiting(event) {
-          void v2RunObservation?.onNodeWaiting?.(event);
+        async onNodeWaiting(event) {
+          await v2RunObservation?.onNodeWaiting?.(event);
         },
         async onNodeFinish(event) {
-          void v2RunObservation?.onNodeFinish?.(event);
+          await v2RunObservation?.onNodeFinish?.(event);
           await hooks.onBlockFinish(event.nodeId, event.state);
         },
         async onNodeSkipped(event) {
-          void v2RunObservation?.onNodeSkipped?.(event);
+          await v2RunObservation?.onNodeSkipped?.(event);
           blockStatuses[event.nodeId] = {
             status: "ok",
             attempt: event.attempt,

--- a/apps/worker/workflow-test-fixtures/v2-concurrent/workflow.ts
+++ b/apps/worker/workflow-test-fixtures/v2-concurrent/workflow.ts
@@ -25,8 +25,10 @@ import {
 //   - each agent block is a multi-step start/poll/finish chain whose steps take
 //     different real time, so completion order differs from admission order
 //   - scheduler hooks write closure state and then await a step
-//   - replay capture is a fire-and-forget promise chain of steps, exactly like
-//     createV2RunObservationHooks
+//   - replay capture is a promise chain of steps whose failures are swallowed
+//     and whose writes the hooks await, exactly like createV2RunObservationHooks.
+//     It was fire-and-forget on both sides until AIW-251: a write the scheduler
+//     does not wait for lands at a position replay cannot reproduce.
 
 async function sleep(ms: number): Promise<void> {
   if (ms <= 0) return;
@@ -217,10 +219,17 @@ export async function probeV2ConcurrentFanOut(input: ProbeConcurrentInput) {
       tail: Promise.resolve(),
     });
   };
-  const flushCapture = (identity: V2InvocationIdentity, state: string): void => {
+  // Returns the chain so the hooks can await it, mirroring runtime-hooks.ts's
+  // persist: the writes are steps, so the scheduler has to wait for them to be
+  // made or their position in the event log stops being replay-stable. The
+  // chain is caught, so awaiting it still cannot fail the run.
+  const flushCapture = (
+    identity: V2InvocationIdentity,
+    state: string,
+  ): Promise<void> => {
     const key = captureKey(identity);
     const capture = captures.get(key);
-    if (!capture) return;
+    if (!capture) return Promise.resolve();
     captures.delete(key);
     const observations = capture.observations.splice(0);
     const task = capture.tail
@@ -238,6 +247,7 @@ export async function probeV2ConcurrentFanOut(input: ProbeConcurrentInput) {
       .catch(() => {});
     capture.tail = task;
     track(task);
+    return task;
   };
 
   const timingFor = (nodeId: string) =>
@@ -375,9 +385,9 @@ export async function probeV2ConcurrentFanOut(input: ProbeConcurrentInput) {
   };
 
   const hooks: V2SchedulerHooks = {
-    onTriggerActivated(event) {
+    async onTriggerActivated(event) {
       beginCapture(event);
-      flushCapture(event, "completed");
+      await flushCapture(event, "completed");
     },
     async onNodeStart(event) {
       // agent.ts's onBlockStart: a budget step, then closure writes, then a
@@ -394,7 +404,7 @@ export async function probeV2ConcurrentFanOut(input: ProbeConcurrentInput) {
       beginCapture(event);
     },
     async onNodeFinish(event) {
-      flushCapture(event, event.runtimeState);
+      await flushCapture(event, event.runtimeState);
       blockStatuses[event.nodeId] = event.state;
       finishOrder.push(event.nodeId);
       await writeBlockStatuses();


### PR DESCRIPTION
## AIW-251: the replay divergence, and its cause

`workflow-sdk-tests/v2-concurrent.test.ts` was not a flaky test. It was a faithful probe reporting a real defect in our own code.

The full message from CI (run 31600115158, on a **docs-only** branch, so nothing else could have caused it):

```
step_created for step_... belongs to ".../persistProbeAttemptFinishStep",
but the current step consumer is ".../readProbeClockStep"
```

Those two steps meet in one place, `onNodeFinish`:

- `apps/worker/src/run-observability/runtime-hooks.ts:208` — `persist()` detached a promise chain that creates **durable steps**.
- `apps/worker/src/workflows/agent.ts:5577` — `void v2RunObservation?.onNodeFinish?.(event)`, immediately followed by `await hooks.onBlockFinish(...)`.

These hooks run inside a `"use workflow"` function, so every sink call is a step, and the order steps are *created* in is what the event log records. A replay reproduces control flow but not time: in the original run `onBlockFinish` waits on real I/O and the detached chain slips its step in first, while on replay the same step is served from the log instantly and the chain does not make it. The position moves, the runtime reports a replay divergence, and the run dies with `CORRUPTED_EVENT_LOG`.

This was never only a test problem. The probe mirrors production deliberately, and production carried the identical hazard.

## The fix

Each capture hook now awaits its own writes instead of detaching them, so their position is decided by control flow.

**Awaiting buys ordering, not coupling.** The chain `persist()` returns is already `.catch()`ed, so it never rejects: a failed capture write trips the circuit breaker, leaves its trace via `markUnavailable`, and the run carries on. There is a test for exactly that.

## One reversal, called out explicitly

`runtime-hooks.test.ts` held a row asserting that delayed capture persistence does **not** delay the scheduler: observability was off the critical path by design. That property and replay safety cannot both hold, so it is reversed here. The row now guards what was always its real point, that recorded timestamps are scheduler boundary times rather than the wall clock of whenever persistence ran.

Costs, measured: the `v2-concurrent` probe went 145s to 244s. Block boundaries now wait for their observability writes.

If that latency proves unacceptable, the way to get both properties is to key capture writes by invocation identity instead of the DB-generated `attemptId`, which would let the writes be created synchronously in the hook and left unawaited. That is a real refactor of the observability write path and is deliberately not in this PR.

## AIW-248: does CI run on main?

**It did not.** `ci.yml` had only `pull_request`, `merge_group` and `workflow_dispatch`. Added `push: branches: [main]`, plus `cancel-in-progress: ${{ github.event_name != 'push' }}` so two quick merges cannot cancel each other's verdict, which is the exact hole this trigger exists to close.

**The ticket's premise is wrong, and that matters more.** "Fails on a different test every time" reads as a capricious gate. It is not. Of four failures:

| Test | Verdict |
| --- | --- |
| `v2-concurrent.test.ts` | the only real flakiness, fixed here |
| `execution-error-invariant.test.ts` | **real** failure of the MCP branch: `src/mcp/run-diagnosis.ts` duplicates error sentences that belong in one table |
| `models.test.ts` | **real** failure of the rate-limit branch: hardcoded `toHaveLength(37)` against 38 blocks |

The gate was not flaking. It was honestly reporting different genuine bugs and we read that as noise.

Both real failures were checked against main and **main is clean**: `models.test.ts` now asserts 38 (12 passed), `execution-error-invariant.test.ts` (99 passed). Neither survived its merge, so there was nothing to fix. The MCP one is left to that stream, untouched, as `src/mcp/**` belongs to a parallel lane.

## Needs a human

`gh api repos/.../branches/main/protection` returns **404**: there is no branch protection on main, so the "required gate" is a convention, not something enforced. That is how a release got merged over a red gate, and no code change here can close it.

## Verification

- `runtime-hooks.test.ts` 15 passed, including 3 new rows that **fail before this fix** (order flips with step latency; capture write lands after the run's next step; the hook is not awaitable).
- `src/run-observability/` 77 passed.
- `test:workflow-sdk` all 4 files, 27 passed, including the divergence probe.
- `pnpm --filter worker typecheck` clean.
