### PR TITLE
fix(dashboard): keep run surfaces refreshing and make the live badge honest (AIW-266)

### DIFF
--- a/apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
+++ b/apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
@@ -18,7 +18,7 @@ import {
 
 import { CockpitShell } from "./cockpit-shell";
 import { RunsScreen } from "@/components/cockpit/screens/runs";
-import { TraceDetail } from "@/components/cockpit/screens/trace";
+import { TraceDetail, TraceScreen } from "@/components/cockpit/screens/trace";
 import {
   TicketSelectionProvider,
   DetailArea,
@@ -166,7 +166,11 @@ function mountShell(
   t: TestContext,
   pathname: string,
   child: React.ReactNode,
-): { refreshes: string[]; root: ReactTestInstance } {
+): {
+  refreshes: string[];
+  root: ReactTestInstance;
+  rerender: (next: React.ReactNode) => void;
+} {
   const refreshes: string[] = [];
   const router = {
     refresh: () => refreshes.push("refresh"),
@@ -185,20 +189,27 @@ function mountShell(
     canEditWorkflows: true,
     canDispatchWorkflows: true,
   };
+  const tree = (inner: React.ReactNode) => (
+    <AppRouterContext.Provider value={router as never}>
+      <PathnameContext.Provider value={pathname}>
+        <SearchParamsContext.Provider value={new URLSearchParams() as never}>
+          <CockpitShell session={session as never}>{inner}</CockpitShell>
+        </SearchParamsContext.Provider>
+      </PathnameContext.Provider>
+    </AppRouterContext.Provider>
+  );
   let renderer!: ReactTestRenderer;
   act(() => {
-    renderer = create(
-      <AppRouterContext.Provider value={router as never}>
-        <PathnameContext.Provider value={pathname}>
-          <SearchParamsContext.Provider value={new URLSearchParams() as never}>
-            <CockpitShell session={session as never}>{child}</CockpitShell>
-          </SearchParamsContext.Provider>
-        </PathnameContext.Provider>
-      </AppRouterContext.Provider>,
-    );
+    renderer = create(tree(child));
   });
   t.after(() => act(() => renderer.unmount()));
-  return { refreshes, root: renderer.root };
+  return {
+    refreshes,
+    root: renderer.root,
+    // Stands in for what a refresh delivers: the server component re-renders and
+    // the screen receives new data.
+    rerender: (next) => act(() => renderer.update(tree(next))),
+  };
 }
 
 function runsList(t: TestContext, rows: Run[], tweaks?: Record<string, unknown>) {
@@ -282,6 +293,18 @@ test("the runs list still polls when every visible run has finished, so new runs
   );
 });
 
+test("a list holding only a parked run polls at the live cadence, not the idle one", (t) => {
+  // Parking must never be filed under "nothing in flight". Someone is watching
+  // that screen waiting for their answer to land, so 30s is far too slow exactly
+  // where it hurts most.
+  const { refreshes } = runsList(t, [makeRun("run_1", "awaiting")]);
+  advance(60_000);
+  assert.ok(
+    refreshes.length >= 10,
+    `a parked run was put on the slow cadence: ${refreshes.length} refreshes in a minute`,
+  );
+});
+
 // ── Single run view ─────────────────────────────────────────────────────────
 
 test("a run parked on human input keeps refreshing", (t) => {
@@ -323,6 +346,47 @@ test("a finished run's view does not poll", (t) => {
   const { refreshes } = runDetail(t, "success");
   advance(2 * 60_000);
   assert.equal(refreshes.length, 0, "a terminal run's trace is immutable");
+});
+
+test("the standalone trace page refreshes itself too", (t) => {
+  // /trace/<id> is the screen an audience watches while a run moves, so it must
+  // not be the one surface left frozen.
+  beginTest(t);
+  const { refreshes } = mountShell(
+    t,
+    "/trace/run_1",
+    <TraceScreen runId="run_1" data={makeDetail("running")} replay={REPLAY} />,
+  );
+  advance(60_000);
+  assert.ok(refreshes.length >= 10, `expected a 5s cadence, got ${refreshes.length}`);
+});
+
+test("the loop is bounded by the run finishing, not by a tick count", (t) => {
+  // Replaces #253's tick budget: ticking still has to end, but the thing that
+  // ends it is the run reaching a durable outcome, which a counter cannot know.
+  const { refreshes, rerender } = runDetail(t, "running");
+  advance(30_000);
+  const whileRunning = refreshes.length;
+  assert.ok(whileRunning > 0, "expected the loop to be running");
+
+  rerender(
+    <TicketSelectionProvider ticketKey="AIW-1">
+      <DetailArea>
+        <TraceDetail
+          runId="run_1"
+          data={makeDetail("success")}
+          replay={REPLAY}
+          enableRunRefresh
+        />
+      </DetailArea>
+    </TicketSelectionProvider>,
+  );
+  advance(5 * 60_000);
+  assert.equal(
+    refreshes.length,
+    whileRunning,
+    "the loop kept ticking after the run reached a terminal status",
+  );
 });
 
 // ── Visibility: pause is intended, the resume must restore the whole cycle ───

--- a/apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
+++ b/apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
@@ -106,10 +106,10 @@ function makeRun(id: string, status: Run["status"]): Run {
     guardrailHits: null,
     ticketTitle: "Do the thing",
     prNumber: null,
-    ticketUrl: null,
+    ticketUrl: "",
     prUrl: null,
     prs: null,
-  } as Run;
+  };
 }
 
 function makeRunsData(rows: Run[]): RunsResponse {
@@ -290,6 +290,22 @@ test("a run parked on human input keeps refreshing", (t) => {
   const { refreshes } = runDetail(t, "awaiting");
   advance(60_000);
   assert.ok(refreshes.length >= 10, `expected a 5s cadence, got ${refreshes.length} in a minute`);
+});
+
+test("a parked run is still refreshing by the time the human answers", (t) => {
+  // Parking is the longest-lived state there is, because it waits on a person.
+  // The loop has to outlive however long they take to type an answer, and this
+  // is the exact case production froze on: the trace stuck at
+  // "waiting_for_clarification" while the answer had already restarted the run.
+  const { refreshes } = runDetail(t, "awaiting");
+  advance(5 * 60_000);
+  const atFiveMinutes = refreshes.length;
+  advance(5 * 60_000);
+  assert.ok(
+    refreshes.length > atFiveMinutes + 50,
+    `the loop stalled after ${atFiveMinutes} refreshes, so a parked run stops updating ` +
+      `while the user waits; at 10 minutes it had ${refreshes.length}`,
+  );
 });
 
 test("the single run view keeps refreshing for longer than a run actually takes", (t) => {

--- a/apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
+++ b/apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
@@ -1,0 +1,358 @@
+// apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
+//
+// Integration cover for the automatic run refresh (AIW-266). The unit tests
+// around `createLivePoll` and the screen tests both passed while production was
+// frozen, because neither wired a run screen to the shell that actually owns the
+// `router.refresh()` loop: the screens render without a CockpitCtx provider, so
+// their `registerRunRefresh` was the context default (a no-op). These tests
+// mount the real shell around a real screen and count refreshes over time.
+import assert from "node:assert/strict";
+import test, { mock, type TestContext } from "node:test";
+import React from "react";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import {
+  PathnameContext,
+  SearchParamsContext,
+} from "next/dist/shared/lib/hooks-client-context.shared-runtime";
+
+import { CockpitShell } from "./cockpit-shell";
+import { RunsScreen } from "@/components/cockpit/screens/runs";
+import { TraceDetail } from "@/components/cockpit/screens/trace";
+import {
+  TicketSelectionProvider,
+  DetailArea,
+} from "@/components/cockpit/screens/ticket-selection";
+import type {
+  Run,
+  RunsResponse,
+  RunDetailResponse,
+  WorkflowRunReplayResponse,
+} from "@shared/contracts";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ── Environment: the shell is a browser component, so stub just enough DOM ───
+
+const visibilityListeners = new Set<() => void>();
+const focusListeners = new Set<() => void>();
+let storedTweaks: string | null = null;
+
+const doc = {
+  visibilityState: "visible" as "visible" | "hidden",
+  addEventListener: (_: string, cb: () => void) => visibilityListeners.add(cb),
+  removeEventListener: (_: string, cb: () => void) => visibilityListeners.delete(cb),
+  getElementById: () => null,
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  body: { style: {}, appendChild: () => {}, removeChild: () => {} },
+  documentElement: { style: {} },
+  createElement: () => ({ style: {}, setAttribute: () => {}, appendChild: () => {} }),
+};
+(globalThis as unknown as { document: typeof doc }).document = doc;
+(globalThis as unknown as { window: unknown }).window = {
+  localStorage: {
+    getItem: () => storedTweaks,
+    setItem: () => {},
+  },
+  addEventListener: (event: string, cb: () => void) => {
+    if (event === "focus") focusListeners.add(cb);
+  },
+  removeEventListener: (event: string, cb: () => void) => {
+    if (event === "focus") focusListeners.delete(cb);
+  },
+  dispatchEvent: () => true,
+};
+
+/** Hide or show the tab the way Chrome does: flip the flag, then notify. */
+function setVisibility(state: "visible" | "hidden"): void {
+  doc.visibilityState = state;
+  act(() => {
+    for (const cb of [...visibilityListeners]) cb();
+  });
+}
+
+function beginTest(t: TestContext, tweaks: Record<string, unknown> | null = null): void {
+  storedTweaks = tweaks ? JSON.stringify(tweaks) : null;
+  doc.visibilityState = "visible";
+  (globalThis as { fetch: unknown }).fetch = async () =>
+    new Response("{}", { status: 500 });
+  mock.timers.enable({ apis: ["setInterval", "setTimeout", "Date"] });
+  t.after(() => {
+    mock.timers.reset();
+    storedTweaks = null;
+    doc.visibilityState = "visible";
+  });
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeRun(id: string, status: Run["status"]): Run {
+  return {
+    id,
+    status,
+    workflow: "wf_ticket",
+    workflowName: "Ticket workflow",
+    ticket: "AIW-1",
+    actor: "ai-bot",
+    model: "gpt-5.6",
+    startedAtMin: 3,
+    duration: null,
+    tokens: null,
+    cost: null,
+    spans: null,
+    evalScore: null,
+    guardrailHits: null,
+    ticketTitle: "Do the thing",
+    prNumber: null,
+    ticketUrl: null,
+    prUrl: null,
+    prs: null,
+  } as Run;
+}
+
+function makeRunsData(rows: Run[]): RunsResponse {
+  const counts = { success: 0, running: 0, awaiting: 0, failed: 0, blocked: 0 };
+  for (const r of rows) counts[r.status]++;
+  return {
+    generatedAt: "2026-08-10T00:00:00.000Z",
+    available: true,
+    rows,
+    total: rows.length,
+    counts,
+  };
+}
+
+function makeDetail(status: Run["status"]): RunDetailResponse {
+  return {
+    generatedAt: "2026-08-10T00:00:00.000Z",
+    available: true,
+    run: {
+      id: "run_1",
+      workflow: "wf_ticket",
+      workflowName: "Ticket workflow",
+      status,
+      ticket: "AIW-1",
+      ticketTitle: "Do the thing",
+      ticketUrl: "",
+      prNumber: null,
+      prUrl: null,
+      prs: null,
+      model: "gpt-5.6",
+      createdAt: "2026-08-10T00:00:00.000Z",
+      startedAt: "2026-08-10T00:00:00.000Z",
+      completedAt: null,
+      durationSec: null,
+      error: null,
+      deploymentId: null,
+    },
+    steps: [],
+    clarification: null,
+  };
+}
+
+const REPLAY: WorkflowRunReplayResponse = {
+  availability: "not_captured",
+  mayAdvance: true,
+  snapshot: null,
+  attempts: [],
+  nextCursor: null,
+};
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+function mountShell(
+  t: TestContext,
+  pathname: string,
+  child: React.ReactNode,
+): { refreshes: string[]; root: ReactTestInstance } {
+  const refreshes: string[] = [];
+  const router = {
+    refresh: () => refreshes.push("refresh"),
+    push: () => {},
+    replace: () => {},
+    back: () => {},
+    forward: () => {},
+    prefetch: () => {},
+  };
+  const session = {
+    organizationName: "Org",
+    actorLabel: "me",
+    role: "owner",
+    canManageUsers: true,
+    canEditChecks: true,
+    canEditWorkflows: true,
+    canDispatchWorkflows: true,
+  };
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(
+      <AppRouterContext.Provider value={router as never}>
+        <PathnameContext.Provider value={pathname}>
+          <SearchParamsContext.Provider value={new URLSearchParams() as never}>
+            <CockpitShell session={session as never}>{child}</CockpitShell>
+          </SearchParamsContext.Provider>
+        </PathnameContext.Provider>
+      </AppRouterContext.Provider>,
+    );
+  });
+  t.after(() => act(() => renderer.unmount()));
+  return { refreshes, root: renderer.root };
+}
+
+function runsList(t: TestContext, rows: Run[], tweaks?: Record<string, unknown>) {
+  beginTest(t, tweaks ?? null);
+  return mountShell(
+    t,
+    "/runs",
+    <RunsScreen data={makeRunsData(rows)} window="24h" q="" />,
+  );
+}
+
+function runDetail(t: TestContext, status: Run["status"]) {
+  beginTest(t);
+  return mountShell(
+    t,
+    "/ticket/AIW-1",
+    <TicketSelectionProvider ticketKey="AIW-1">
+      <DetailArea>
+        <TraceDetail
+          runId="run_1"
+          data={makeDetail(status)}
+          replay={REPLAY}
+          enableRunRefresh
+        />
+      </DetailArea>
+    </TicketSelectionProvider>,
+  );
+}
+
+function advance(ms: number): void {
+  act(() => {
+    mock.timers.tick(ms);
+  });
+}
+
+/** The live-poll badge text, deduped: the control renders in both the desktop
+ *  topbar and the mobile header, and both must say the same thing. */
+function liveBadge(root: ReactTestInstance): string {
+  const labels = root
+    .findAll(
+      (node) =>
+        typeof node.type === "string" &&
+        node.props.className?.includes?.("uppercase") &&
+        typeof node.children[0] === "string" &&
+        /^(Live|Live off|Paused|Watching)$/.test(node.children[0]),
+    )
+    .map((node) => node.children[0] as string);
+  assert.ok(labels.length > 0, "expected the live-poll control to render a label");
+  assert.equal(
+    new Set(labels).size,
+    1,
+    `desktop and mobile live badges disagree: ${labels.join(", ")}`,
+  );
+  return labels[0];
+}
+
+// ── Runs list ───────────────────────────────────────────────────────────────
+
+test("the runs list keeps refreshing for longer than a run actually takes", (t) => {
+  // Real runs measured on production last 400-730s, so a refresh loop that dies
+  // after five minutes abandons the user mid-run with no signal.
+  const { refreshes } = runsList(t, [makeRun("run_1", "running")]);
+  advance(5 * 60_000);
+  const atFiveMinutes = refreshes.length;
+  advance(7 * 60_000);
+  assert.ok(
+    refreshes.length > atFiveMinutes + 60,
+    `the loop stalled after ${atFiveMinutes} refreshes; at 12 minutes it had ${refreshes.length}`,
+  );
+});
+
+test("the runs list still polls when every visible run has finished, so new runs appear", (t) => {
+  // The row set itself is what a live list is watching. Gating the loop on the
+  // rows already rendered is a closed loop: a list of finished runs can never
+  // learn that a new run started.
+  const { refreshes } = runsList(t, [makeRun("run_1", "success")]);
+  advance(2 * 60_000);
+  assert.ok(
+    refreshes.length >= 2,
+    `a settled list never refreshed (${refreshes.length} in 2 minutes), so a new run could never show up`,
+  );
+});
+
+// ── Single run view ─────────────────────────────────────────────────────────
+
+test("a run parked on human input keeps refreshing", (t) => {
+  // "awaiting" is the state where the user most needs to see movement: the
+  // question arriving, and their answer restarting the run.
+  const { refreshes } = runDetail(t, "awaiting");
+  advance(60_000);
+  assert.ok(refreshes.length >= 10, `expected a 5s cadence, got ${refreshes.length} in a minute`);
+});
+
+test("the single run view keeps refreshing for longer than a run actually takes", (t) => {
+  const { refreshes } = runDetail(t, "running");
+  advance(5 * 60_000);
+  const atFiveMinutes = refreshes.length;
+  advance(7 * 60_000);
+  assert.ok(
+    refreshes.length > atFiveMinutes + 60,
+    `the loop stalled after ${atFiveMinutes} refreshes; at 12 minutes it had ${refreshes.length}`,
+  );
+});
+
+test("a finished run's view does not poll", (t) => {
+  const { refreshes } = runDetail(t, "success");
+  advance(2 * 60_000);
+  assert.equal(refreshes.length, 0, "a terminal run's trace is immutable");
+});
+
+// ── Visibility: pause is intended, the resume must restore the whole cycle ───
+
+test("returning to the tab restores the refresh cycle, not a single refresh", (t) => {
+  // Pausing a hidden tab is deliberate. What must not happen is coming back to
+  // a tab that refreshes once and then goes quiet again.
+  const { refreshes } = runDetail(t, "running");
+  advance(6 * 60_000);
+  setVisibility("hidden");
+  const whileHidden = refreshes.length;
+  advance(60_000);
+  assert.equal(refreshes.length, whileHidden, "a hidden tab must not poll");
+
+  setVisibility("visible");
+  const onReturn = refreshes.length;
+  assert.ok(onReturn > whileHidden, "coming back must refresh immediately");
+  advance(30_000);
+  assert.ok(
+    refreshes.length >= onReturn + 5,
+    `the cycle did not resume: ${refreshes.length - onReturn} refreshes in the 30s after returning`,
+  );
+});
+
+// ── The LIVE badge ──────────────────────────────────────────────────────────
+
+test("the badge does not claim live data while the tab is hidden and nothing polls", (t) => {
+  // The worst failure mode: a frozen screen that also tells the user it is
+  // current, removing their only cue to reload.
+  const { refreshes, root } = runsList(t, [makeRun("run_1", "running")], {
+    livePolling: true,
+  });
+  setVisibility("hidden");
+  const whileHidden = refreshes.length;
+  advance(60_000);
+  assert.equal(refreshes.length, whileHidden, "a hidden tab must not poll");
+  assert.notEqual(
+    liveBadge(root),
+    "Live",
+    "the badge promised live data while the loop was paused",
+  );
+});
+
+test("the badge reports live data while the loop really is running", (t) => {
+  const { refreshes, root } = runsList(t, [makeRun("run_1", "running")]);
+  advance(30_000);
+  assert.ok(refreshes.length > 0, "expected the loop to be running");
+  assert.equal(liveBadge(root), "Live");
+});

--- a/apps/dashboard/app/(cockpit)/cockpit-shell.tsx
+++ b/apps/dashboard/app/(cockpit)/cockpit-shell.tsx
@@ -1,18 +1,19 @@
 // apps/dashboard/app/(cockpit)/cockpit-shell.tsx
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
 import { useTweaks } from "@/lib/use-tweaks";
 import { runHref } from "@/lib/run-href";
-import { useLivePoll, LIVE_POLL_MS } from "@/lib/use-live-poll";
+import { useLivePoll, LIVE_POLL_MS, IDLE_POLL_MS } from "@/lib/use-live-poll";
 import type { Run } from "@/lib/types";
 import type { DashboardSession } from "@/lib/auth/session";
 
 import {
   CockpitCtx,
   TWEAK_DEFAULTS,
+  type RunRefreshCadence,
   type Tweaks,
 } from "@/components/cockpit/context";
 import {
@@ -34,6 +35,17 @@ const screenForPath = (path: string) => {
   const seg = path.replace(/^\/+/, "").split("/")[0];
   return seg === "" ? "overview" : seg;
 };
+
+/** Drop one key, returning the same object when there is nothing to drop. */
+function withoutKey(
+  current: Readonly<Record<string, RunRefreshCadence>>,
+  key: string,
+): Readonly<Record<string, RunRefreshCadence>> {
+  if (!(key in current)) return current;
+  const next = { ...current };
+  delete next[key];
+  return next;
+}
 
 const TITLE_FOR_SCREEN: Record<string, string> = {
   overview: "Overview",
@@ -77,8 +89,9 @@ export function CockpitShell({
     !!t.activityDrawerOpen,
   );
   const [moreOpen, setMoreOpen] = useState(false);
-  const activeRunRefreshKeys = useRef(new Set<string>());
-  const [runRefreshActive, setRunRefreshActive] = useState(false);
+  const [runRefreshKeys, setRunRefreshKeys] = useState<
+    Readonly<Record<string, RunRefreshCadence>>
+  >({});
   const moreScreens = cockpitNavItems({ canManageUsers })
     .filter((item) => isMobileMoreNavItem(item.id))
     .map((item) => item.id);
@@ -91,41 +104,56 @@ export function CockpitShell({
     router.push(runHref(r));
   };
 
-  const registerRunRefresh = useCallback((key: string, active: boolean) => {
-    if (active) activeRunRefreshKeys.current.add(key);
-    else activeRunRefreshKeys.current.delete(key);
-    setRunRefreshActive(activeRunRefreshKeys.current.size > 0);
-    return () => {
-      activeRunRefreshKeys.current.delete(key);
-      setRunRefreshActive(activeRunRefreshKeys.current.size > 0);
-    };
-  }, []);
-  const isActiveRunPoll = useCallback(
-    () => activeRunRefreshKeys.current.size > 0,
+  // Mounted run surfaces declare their own cadence here; the loop below is the
+  // only thing that calls router.refresh(), once for the whole cockpit. Plain
+  // state (no ref mirror) so `enabled` can never disagree with the registry.
+  const registerRunRefresh = useCallback(
+    (key: string, cadence: RunRefreshCadence) => {
+      setRunRefreshKeys((current) =>
+        cadence === "off"
+          ? withoutKey(current, key)
+          : current[key] === cadence
+            ? current
+            : { ...current, [key]: cadence },
+      );
+      return () => setRunRefreshKeys((current) => withoutKey(current, key));
+    },
     [],
   );
-  const isRunScreen = screen === "runs" || screen === "ticket";
+
+  const cadences = Object.values(runRefreshKeys);
+  const runRefreshCadence: RunRefreshCadence = cadences.includes("live")
+    ? "live"
+    : cadences.length > 0
+      ? "idle"
+      : "off";
+  // A surface with work in flight and the global Live toggle both mean the fast
+  // cadence. A surface with nothing in flight still watches for new work, just
+  // slowly — that is the AIW-266 criterion "polling stops or slows when no
+  // active runs are present", and it is what lets a new run appear in the list.
+  const livePollFast = runRefreshCadence === "live" || !!t.livePolling;
+  const livePollEnabled = livePollFast || runRefreshCadence === "idle";
+  const liveCycleMs = livePollFast ? LIVE_POLL_MS : IDLE_POLL_MS;
 
   // Timestamp of the next scheduled refresh, surfaced via context so the
   // live-poll control can render a countdown ring in sync with the actual
-  // refreshes (which are driven here, once, for the whole cockpit).
+  // refreshes.
   const [nextRefreshAt, setNextRefreshAt] = useState<number | null>(null);
-  useEffect(() => {
-    setNextRefreshAt(t.livePolling ? Date.now() + LIVE_POLL_MS : null);
-  }, [t.livePolling]);
 
-  useLivePoll({
-    // Run surfaces refresh only while they report non-terminal work. Other
-    // cockpit screens retain the existing opt-in global live mode.
-    enabled: isRunScreen ? runRefreshActive : !!t.livePolling,
-    intervalMs: LIVE_POLL_MS,
-    maxTicks: isRunScreen ? 60 : undefined,
-    isActive: isRunScreen ? isActiveRunPoll : undefined,
+  const liveRunning = useLivePoll({
+    enabled: livePollEnabled,
+    intervalMs: liveCycleMs,
     onTick: () => {
       router.refresh();
-      setNextRefreshAt(Date.now() + LIVE_POLL_MS);
+      setNextRefreshAt(Date.now() + liveCycleMs);
     },
   });
+
+  // Keyed off the loop's real state, not off the intent: while the tab is hidden
+  // the loop is paused and there is no next refresh to count down to.
+  useEffect(() => {
+    setNextRefreshAt(liveRunning ? Date.now() + liveCycleMs : null);
+  }, [liveRunning, liveCycleMs]);
 
   return (
     <CockpitCtx.Provider
@@ -139,6 +167,9 @@ export function CockpitShell({
         livePolling: !!t.livePolling,
         toggleLive: () => setTweak("livePolling", !t.livePolling),
         nextRefreshAt,
+        liveRunning,
+        liveCycleMs,
+        runRefreshCadence,
         registerRunRefresh,
       }}
     >

--- a/apps/dashboard/components/cockpit/context.tsx
+++ b/apps/dashboard/components/cockpit/context.tsx
@@ -2,8 +2,18 @@
 
 import { createContext, useContext } from "react";
 import type { Run } from "@/lib/types";
+import { LIVE_POLL_MS } from "@/lib/use-live-poll";
 
 export type Density = "compact" | "comfy";
+
+/**
+ * How often a mounted run surface needs the cockpit to refresh it.
+ * - `live`: something is in flight, refresh at the live cadence.
+ * - `idle`: nothing in flight, but the surface still has to notice new work
+ *   arriving (a runs list), so keep watching at a slower cadence.
+ * - `off`: nothing here can change any more (a terminal run's trace).
+ */
+export type RunRefreshCadence = "off" | "idle" | "live";
 
 export type Tweaks = {
   density: Density;
@@ -46,8 +56,14 @@ export interface CockpitCtxValue {
   toggleLive: () => void;
   /** Epoch ms of the next scheduled refresh while live; null when off. */
   nextRefreshAt: number | null;
-  /** Register whether a mounted run surface currently has non-terminal work. */
-  registerRunRefresh: (key: string, active: boolean) => () => void;
+  /** True while the cockpit's refresh loop is actually running (not paused). */
+  liveRunning: boolean;
+  /** Length of one refresh cycle in ms, so a countdown can match it. */
+  liveCycleMs: number;
+  /** The strongest cadence the mounted run surfaces are asking for. */
+  runRefreshCadence: RunRefreshCadence;
+  /** Register how often a mounted run surface needs to be refreshed. */
+  registerRunRefresh: (key: string, cadence: RunRefreshCadence) => () => void;
 }
 
 export const CockpitCtx = createContext<CockpitCtxValue>({
@@ -60,6 +76,9 @@ export const CockpitCtx = createContext<CockpitCtxValue>({
   livePolling: false,
   toggleLive: () => {},
   nextRefreshAt: null,
+  liveRunning: false,
+  liveCycleMs: LIVE_POLL_MS,
+  runRefreshCadence: "off",
   registerRunRefresh: () => () => {},
 });
 

--- a/apps/dashboard/components/cockpit/controls.tsx
+++ b/apps/dashboard/components/cockpit/controls.tsx
@@ -68,36 +68,84 @@ export function WindowSelector({
 }
 
 /**
- * Live-polling control — sits beside the WindowSelector. Toggles the global
- * `livePolling` state (read from cockpit context, persisted via tweaks); while
- * on, a ring drains over each refresh cycle. The actual `router.refresh()` loop
- * runs once in CockpitShell — this only reflects it.
+ * Live-poll indicator — sits beside the WindowSelector. It reports the refresh
+ * loop's *actual* state (`liveRunning`, owned by CockpitShell), never the
+ * intent: a badge reading "Live" over a stopped loop is worse than no badge,
+ * because it takes away the user's only cue to reload (AIW-266).
+ *
+ * On a screen whose refreshing is driven by its own content (a runs list, a run
+ * in flight) the badge is a read-only status, because the global toggle does not
+ * govern it and a pressable control would imply otherwise. Everywhere else it
+ * stays the toggle it always was.
  */
 export function LivePollControl({ size = "md" }: { size?: "md" | "sm" }) {
-  const { livePolling, toggleLive, nextRefreshAt } = useCockpit();
+  const {
+    livePolling,
+    toggleLive,
+    nextRefreshAt,
+    liveRunning,
+    liveCycleMs,
+    runRefreshCadence,
+  } = useCockpit();
+  const auto = runRefreshCadence !== "off";
+  const watching = liveRunning && runRefreshCadence === "idle" && !livePolling;
+  const label = liveRunning
+    ? watching
+      ? "Watching"
+      : "Live"
+    : auto || livePolling
+      ? "Paused"
+      : "Live off";
+  const seconds = Math.round(liveCycleMs / 1000);
+  const title = liveRunning
+    ? watching
+      ? `No run in flight — checking for new runs every ${seconds}s.`
+      : `Refreshing every ${seconds}s.`
+    : auto || livePolling
+      ? "Paused while this tab is in the background. It resumes the moment you come back."
+      : "Live updates off — click to enable";
+  const pad = size === "sm" ? "py-1 px-2" : "py-1.5 px-2.5";
+  const tone = liveRunning
+    ? "border-emerald-300 bg-emerald-50 text-emerald-700"
+    : "border-neutral-200 bg-app-bg text-neutral-700";
+  const body = (
+    <>
+      <LiveRing
+        on={liveRunning}
+        nextRefreshAt={nextRefreshAt}
+        cycleMs={liveCycleMs}
+        dim={size === "sm" ? 12 : 13}
+      />
+      <span className="font-mono font-medium text-[11px] uppercase tracking-[-0.01em]">
+        {label}
+      </span>
+    </>
+  );
+
+  if (auto) {
+    return (
+      <span
+        role="status"
+        title={title}
+        className={`inline-flex items-center gap-1.5 rounded-sm border ${pad} ${tone}`}
+      >
+        {body}
+      </span>
+    );
+  }
+
   return (
     <button
       type="button"
       onClick={toggleLive}
       aria-pressed={livePolling}
       aria-label="Toggle live updates"
-      title={
-        livePolling
-          ? "Live updates on — refreshing every 5s. Click to pause."
-          : "Live updates off — click to enable"
-      }
-      className={`appearance-none cursor-pointer inline-flex items-center gap-1.5 rounded-sm border transition-colors duration-[180ms] ease-[cubic-bezier(.2,0,0,1)] ${
-        size === "sm" ? "py-1 px-2" : "py-1.5 px-2.5"
-      } ${
-        livePolling
-          ? "border-emerald-300 bg-emerald-50 text-emerald-700"
-          : "border-neutral-200 bg-app-bg text-neutral-700 hover:text-neutral-900"
+      title={title}
+      className={`appearance-none cursor-pointer inline-flex items-center gap-1.5 rounded-sm border transition-colors duration-[180ms] ease-[cubic-bezier(.2,0,0,1)] ${pad} ${tone} ${
+        liveRunning ? "" : "hover:text-neutral-900"
       }`}
     >
-      <LiveRing on={livePolling} nextRefreshAt={nextRefreshAt} dim={size === "sm" ? 12 : 13} />
-      <span className="font-mono font-medium text-[11px] uppercase tracking-[-0.01em]">
-        {livePolling ? "Live" : "Live off"}
-      </span>
+      {body}
     </button>
   );
 }
@@ -110,10 +158,12 @@ export function LivePollControl({ size = "md" }: { size?: "md" | "sm" }) {
 function LiveRing({
   on,
   nextRefreshAt,
+  cycleMs,
   dim,
 }: {
   on: boolean;
   nextRefreshAt: number | null;
+  cycleMs: number;
   dim: number;
 }) {
   const sw = 1.5;
@@ -147,7 +197,7 @@ function LiveRing({
         style={
           {
             "--ck-dash": `${circumference}`,
-            animation: `ck-drain ${LIVE_POLL_MS}ms linear forwards`,
+            animation: `ck-drain ${cycleMs}ms linear forwards`,
           } as CSSProperties
         }
       />

--- a/apps/dashboard/components/cockpit/mobile/screens/runs-mobile.tsx
+++ b/apps/dashboard/components/cockpit/mobile/screens/runs-mobile.tsx
@@ -53,9 +53,12 @@ export function RunsMobileScreen({
   }, [data]);
   const stale = !data.available && lastGoodData !== null;
   const shownData = stale ? lastGoodData : data;
+  // Never "off" — see the desktop list: new runs have to be able to show up.
   const { isRefreshing, refresh } = useRunRefresh({
     key: "runs-mobile",
-    active: shownData.rows.some((run) => hasActiveRun(run.status)),
+    cadence: shownData.rows.some((run) => hasActiveRun(run.status))
+      ? "live"
+      : "idle",
   });
   const [filter, setFilter] = useState("all");
   const [confirmId, setConfirmId] = useState<string | null>(null);

--- a/apps/dashboard/components/cockpit/mobile/screens/ticket-mobile.tsx
+++ b/apps/dashboard/components/cockpit/mobile/screens/ticket-mobile.tsx
@@ -46,9 +46,10 @@ export function TicketMobileScreen({
   const stale = !data.available && lastGoodData !== null;
   const shownData = stale ? lastGoodData : data;
   const { ticket, runs, totals } = shownData;
+  // A ticket's run list, so never "off": a retry creates a new run to show.
   const { isRefreshing, refresh } = useRunRefresh({
     key: "ticket-mobile",
-    active: runs.some((run) => hasActiveRun(run.status)),
+    cadence: runs.some((run) => hasActiveRun(run.status)) ? "live" : "idle",
   });
 
   return (

--- a/apps/dashboard/components/cockpit/screens/runs.tsx
+++ b/apps/dashboard/components/cockpit/screens/runs.tsx
@@ -47,9 +47,13 @@ export function RunsScreen({
   }, [data]);
   const stale = !data.available && lastGoodData !== null;
   const shownData = stale ? lastGoodData : data;
+  // Never "off": the row set itself is what this screen watches, so a list whose
+  // visible runs have all finished still has to notice the next run starting.
   const { isRefreshing, refresh } = useRunRefresh({
     key: "runs-desktop",
-    active: shownData.rows.some((run) => hasActiveRun(run.status)),
+    cadence: shownData.rows.some((run) => hasActiveRun(run.status))
+      ? "live"
+      : "idle",
   });
   const [filter, setFilter] = useState("all");
   const [page, setPage] = useState(0);

--- a/apps/dashboard/components/cockpit/screens/ticket.tsx
+++ b/apps/dashboard/components/cockpit/screens/ticket.tsx
@@ -46,9 +46,10 @@ export function TicketScreen({
   const stale = !data.available && lastGoodData !== null;
   const shownData = stale ? lastGoodData : data;
   const { ticket, runs, totals } = shownData;
+  // A ticket's run list, so never "off": a retry creates a new run to show.
   const { isRefreshing, refresh } = useRunRefresh({
     key: "ticket-desktop",
-    active: runs.some((run) => hasActiveRun(run.status)),
+    cadence: runs.some((run) => hasActiveRun(run.status)) ? "live" : "idle",
   });
   const title = ticket?.title || ticketKey;
 

--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -179,9 +179,10 @@ function RunRefreshActions({
   active: boolean;
   stale: boolean;
 }) {
+  // A terminal run's trace is immutable, so this surface really can go quiet.
   const { isRefreshing, refresh } = useRunRefresh({
     key: `run-detail:${runId}`,
-    active,
+    cadence: active ? "live" : "off",
   });
   return (
     <RunRefreshControl

--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -153,7 +153,9 @@ export function TraceScreen({
         onBack={onBack}
         onTicket={onTicket}
       />
-      <TraceDetail runId={runId} data={data} replay={replay} />
+      {/* The standalone trace is what an audience watches while a run moves, so
+          it refreshes itself on the same terms as the ticket view. */}
+      <TraceDetail runId={runId} data={data} replay={replay} enableRunRefresh />
     </div>
   );
 }
@@ -169,7 +171,7 @@ export function replayForRunLifecycle(
     : { ...candidate, mayAdvance };
 }
 
-/** Keep router-dependent refresh hooks out of the historical trace path. */
+/** Isolates the router-dependent refresh hooks into their own subtree. */
 function RunRefreshActions({
   runId,
   active,

--- a/apps/dashboard/lib/live-poll.test.ts
+++ b/apps/dashboard/lib/live-poll.test.ts
@@ -97,58 +97,46 @@ test("after stop(), a later visibility change does not tick (unsubscribed)", () 
   assert.equal(ticks(), 0);
 });
 
-test("a list poll settles as soon as its only run becomes terminal", () => {
+// The three cases below replace #253's `maxTicks` / `isActive` cases. Those two
+// mechanisms are gone: a tick counter cannot know how long a run takes, and once
+// its budget was spent `startInterval` refused to run again, so the visibility
+// handler could only buy a single refresh per return. What a caller wants
+// instead is expressed by disabling the poll (see AIW-266).
+
+test("a long-lived run keeps ticking well past any five minute budget", () => {
+  const { poll, ticks } = setup(false);
+  poll.start();
+  mock.timers.tick(12 * 60_000);
+  assert.equal(ticks(), 144);
+});
+
+test("returning to the tab after a long session resumes the cycle, not one tick", () => {
+  const { vis, poll, ticks } = setup(false);
+  poll.start();
+  mock.timers.tick(6 * 60_000);
+  const beforeHide = ticks();
+  vis.set(true);
+  mock.timers.tick(60_000);
+  assert.equal(ticks(), beforeHide, "a hidden tab must not tick");
+  vis.set(false);
+  assert.equal(ticks(), beforeHide + 1, "coming back refreshes immediately");
+  mock.timers.tick(30_000);
+  assert.equal(ticks(), beforeHide + 7, "and the interval is running again");
+});
+
+test("reports when the interval starts and stops so the UI can say so", () => {
   const vis = makeVisibility(false);
-  let status: "running" | "success" = "running";
-  let ticks = 0;
+  const states: boolean[] = [];
   const poll = createLivePoll({
     intervalMs: 5000,
-    onTick: () => {
-      ticks++;
-      status = "success";
-    },
-    isActive: () => status === "running",
+    onTick: () => {},
+    onRunningChange: (running) => states.push(running),
     isHidden: vis.isHidden,
     subscribeVisibility: vis.subscribe,
   });
   poll.start();
-  mock.timers.tick(5000);
-  mock.timers.tick(5000);
-  assert.equal(ticks, 1);
-});
-
-test("a detail poll settles for an awaiting run after the terminal response", () => {
-  const vis = makeVisibility(false);
-  let status: "awaiting" | "failed" = "awaiting";
-  let ticks = 0;
-  const poll = createLivePoll({
-    intervalMs: 5000,
-    onTick: () => {
-      ticks++;
-      status = "failed";
-    },
-    isActive: () => status === "awaiting",
-    isHidden: vis.isHidden,
-    subscribeVisibility: vis.subscribe,
-  });
-  poll.start();
-  mock.timers.tick(5000);
-  mock.timers.tick(5000);
-  assert.equal(ticks, 1);
-});
-
-test("automatic refresh has a finite tick budget", () => {
-  let count = 0;
-  const finite = createLivePoll({
-    intervalMs: 5000,
-    maxTicks: 2,
-    onTick: () => { count++; },
-    isHidden: () => false,
-    subscribeVisibility: () => () => {},
-  });
-  finite.start();
-  mock.timers.tick(5000);
-  mock.timers.tick(5000);
-  mock.timers.tick(5000);
-  assert.equal(count, 2);
+  vis.set(true);
+  vis.set(false);
+  poll.stop();
+  assert.deepEqual(states, [true, false, true, false]);
 });

--- a/apps/dashboard/lib/live-poll.ts
+++ b/apps/dashboard/lib/live-poll.ts
@@ -6,14 +6,17 @@
 export interface LivePollDeps {
   intervalMs: number;
   onTick: () => void;
-  /** Optional upper bound for automatic ticks; manual refresh remains available. */
-  maxTicks?: number;
-  /** Optional dynamic gate; a false value stops polling at the next tick. */
-  isActive?: () => boolean;
   /** True when the tab is hidden; while hidden the interval is paused. */
   isHidden: () => boolean;
   /** Subscribe to visibility changes; returns an unsubscribe fn. */
   subscribeVisibility: (cb: () => void) => () => void;
+  /**
+   * Called whenever the interval starts or stops, so the UI can report whether
+   * it is really refreshing rather than guess (AIW-266: a "Live" badge over a
+   * stopped loop is worse than no badge, because it removes the user's only cue
+   * to reload).
+   */
+  onRunningChange?: (running: boolean) => void;
 }
 
 export interface LivePoll {
@@ -21,45 +24,33 @@ export interface LivePoll {
   stop: () => void;
 }
 
+/**
+ * There is deliberately no tick budget. A counter cannot know how long the work
+ * being watched takes — production runs last 400-730s, so a five minute budget
+ * expired mid-run and froze the screen with no signal. Worse, once the budget
+ * was spent the visibility handler could no longer restart the interval, so
+ * returning to the tab bought a single refresh and then silence. The only thing
+ * that ends a loop here is the caller disabling it (the run reached a terminal
+ * status) or the tab going away.
+ */
 export function createLivePoll(deps: LivePollDeps): LivePoll {
-  const {
-    intervalMs,
-    onTick,
-    maxTicks,
-    isActive = () => true,
-    isHidden,
-    subscribeVisibility,
-  } = deps;
+  const { intervalMs, onTick, isHidden, subscribeVisibility, onRunningChange } =
+    deps;
 
   let timer: ReturnType<typeof setInterval> | null = null;
   let unsubscribe: (() => void) | null = null;
   let started = false;
-  let tickCount = 0;
-
-  const tick = () => {
-    if (!isActive()) {
-      stopInterval();
-      return;
-    }
-    onTick();
-    tickCount += 1;
-    if (maxTicks !== undefined && tickCount >= maxTicks) stopInterval();
-  };
 
   const startInterval = () => {
-    if (
-      timer === null &&
-      isActive() &&
-      (maxTicks === undefined || tickCount < maxTicks)
-    ) {
-      timer = setInterval(tick, intervalMs);
-    }
+    if (timer !== null) return;
+    timer = setInterval(onTick, intervalMs);
+    onRunningChange?.(true);
   };
   const stopInterval = () => {
-    if (timer !== null) {
-      clearInterval(timer);
-      timer = null;
-    }
+    if (timer === null) return;
+    clearInterval(timer);
+    timer = null;
+    onRunningChange?.(false);
   };
 
   const onVisibilityChange = () => {
@@ -67,8 +58,8 @@ export function createLivePoll(deps: LivePollDeps): LivePoll {
     if (isHidden()) {
       stopInterval();
     } else if (timer === null) {
-      // Became visible while paused: refresh once now, then resume.
-      tick();
+      // Became visible while paused: refresh once now, then resume the cycle.
+      onTick();
       startInterval();
     }
   };
@@ -77,7 +68,6 @@ export function createLivePoll(deps: LivePollDeps): LivePoll {
     start() {
       if (started) return;
       started = true;
-      tickCount = 0;
       unsubscribe = subscribeVisibility(onVisibilityChange);
       if (!isHidden()) startInterval();
     },

--- a/apps/dashboard/lib/use-live-poll.ts
+++ b/apps/dashboard/lib/use-live-poll.ts
@@ -1,51 +1,72 @@
 // apps/dashboard/lib/use-live-poll.ts
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createLivePoll } from "./live-poll";
 
 /** Live-mode poll cadence (ms). Single source of truth — tune here. */
 export const LIVE_POLL_MS = 5000;
 
 /**
+ * Cadence for a surface that is still worth watching but has nothing in flight —
+ * a runs list whose visible runs have all finished still has to notice the next
+ * run starting. Slower rather than stopped, which is what AIW-266 asks for.
+ */
+export const IDLE_POLL_MS = 30_000;
+
+/**
  * Calls `onTick` every `intervalMs` while `enabled`, pausing when the browser
  * tab is hidden (and firing once immediately when it becomes visible again).
  * Thin DOM/React adapter over the pure `createLivePoll` controller.
+ *
+ * Returns whether the interval is running right now, so the UI can report the
+ * real state instead of the intent.
  */
 export function useLivePoll({
   enabled,
   intervalMs,
   onTick,
-  maxTicks,
-  isActive,
 }: {
   enabled: boolean;
   intervalMs: number;
   onTick: () => void;
-  maxTicks?: number;
-  isActive?: () => boolean;
-}): void {
+}): boolean {
   // Keep the latest onTick without restarting the interval on its identity change.
   const onTickRef = useRef(onTick);
   useEffect(() => {
     onTickRef.current = onTick;
   }, [onTick]);
+  const [running, setRunning] = useState(false);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      setRunning(false);
+      return;
+    }
 
     const poll = createLivePoll({
       intervalMs,
-      maxTicks,
-      isActive,
       onTick: () => onTickRef.current(),
+      onRunningChange: setRunning,
       isHidden: () => document.visibilityState === "hidden",
       subscribeVisibility: (cb) => {
         document.addEventListener("visibilitychange", cb);
-        return () => document.removeEventListener("visibilitychange", cb);
+        // Not every way back into a tab delivers `visibilitychange` (window
+        // managers, extension-driven focus). Regained window focus is a second,
+        // harmless chance to resume: the handler no-ops when already running.
+        window.addEventListener("focus", cb);
+        return () => {
+          document.removeEventListener("visibilitychange", cb);
+          window.removeEventListener("focus", cb);
+        };
       },
     });
     poll.start();
-    return () => poll.stop();
-  }, [enabled, intervalMs, maxTicks, isActive]);
+    return () => {
+      poll.stop();
+      setRunning(false);
+    };
+  }, [enabled, intervalMs]);
+
+  return running;
 }

--- a/apps/dashboard/lib/use-run-refresh.ts
+++ b/apps/dashboard/lib/use-run-refresh.ts
@@ -3,27 +3,38 @@
 import { useCallback, useEffect, useTransition } from "react";
 import { useRouter } from "next/navigation";
 
-import { useCockpit } from "@/components/cockpit/context";
+import {
+  useCockpit,
+  type RunRefreshCadence,
+} from "@/components/cockpit/context";
 
-/** A run is live until it reaches one of these durable outcomes. */
+/**
+ * A run is live until it reaches one of these durable outcomes. `awaiting` counts
+ * as live on purpose: a run parked on a question to a human is exactly when
+ * someone is watching the screen, waiting to see their answer restart it.
+ */
 export function hasActiveRun(status: string): boolean {
   return status === "running" || status === "awaiting";
 }
 
+/**
+ * Declares how often this surface needs refreshing and hands back the manual
+ * refresh affordance. The automatic loop itself lives once in CockpitShell.
+ */
 export function useRunRefresh({
   key,
-  active,
+  cadence,
 }: {
   key: string;
-  active: boolean;
+  cadence: RunRefreshCadence;
 }): { isRefreshing: boolean; refresh: () => void } {
   const router = useRouter();
   const { registerRunRefresh } = useCockpit();
   const [isRefreshing, startTransition] = useTransition();
 
   useEffect(
-    () => registerRunRefresh(key, active),
-    [active, key, registerRunRefresh],
+    () => registerRunRefresh(key, cadence),
+    [cadence, key, registerRunRefresh],
   );
 
   const refresh = useCallback(() => {
@@ -32,4 +43,3 @@ export function useRunRefresh({
 
   return { isRefreshing, refresh };
 }
-


### PR DESCRIPTION
#253 shipped the refresh loop but production stayed frozen. Two defects, both proven at the integration level.

## Cause 1, both surfaces: the tick budget

`cockpit-shell.tsx` passed `maxTicks: isRunScreen ? 60 : undefined` at a 5s cadence, so automatic refresh stopped after exactly 5 minutes. Runs measured on production last 400 to 730 seconds, and a run parked on a question to a human lasts as long as the human takes, so real work outlives its own refresh budget.

It was worse than a stop. `startInterval()` refused to run once `tickCount >= maxTicks`, and `tickCount` was reset only inside `start()`, which never runs again while a run stays active. `tick()` did not check the budget before calling `onTick`. So after the budget was spent, returning to the tab bought exactly one refresh and then silence, forever. That is the "one request, then nothing" signature seen on production.

Measured before the fix: 60 refreshes at 5 minutes, still 60 at 12 minutes; hide then show gave 61 and no cycle.

## Cause 2, the runs list only: a closed enabling condition

`runs.tsx` gated the loop on `rows.some(hasActiveRun)`, i.e. on the rows already rendered. A list whose visible runs have all finished never polls, so it can never learn that a new run started. Measured before the fix: 0 refreshes in 2 minutes.

## What did not turn out to be a cause

`hasActiveRun` already counted `awaiting`, and `isActiveRunPoll` never looked at run status at all (it counted registered surfaces). `isRunning` in `trace.tsx` excludes `awaiting` but only drives a visual indicator. So a parked run was not excluded by any predicate; it froze because parking is the longest-lived state and it outlived the tick budget. There is now an explicit test for it.

## Fix

- The tick budget is gone. A counter cannot know how long the watched work takes; the loop now ends when the caller disables it, which is exactly the run reaching a terminal status. The `isActive` escape hatch is gone too: it was a second silent-stop path that could disagree with `enabled`.
- Cadence is a tri-state per surface: `live` (5s, work in flight), `idle` (30s, nothing in flight but new work must still be noticed), `off` (a terminal run's trace is immutable). This keeps the acceptance criterion "polling stops or slows when no active runs are present" while letting new runs appear.
- The visibility pause is untouched, deliberately. Resume is strengthened: `window.focus` is subscribed alongside `visibilitychange`, since not every way back into a tab delivers a visibility change.
- The registry is plain state instead of a ref mirrored into state, so `enabled` cannot disagree with it.

## The LIVE badge

It read purely from the `livePolling` tweak, which after #253 no longer drove run screens at all, so it lied in both directions: "Live" over a dead loop, and "Live off" while polling. It now reports the loop's real state, which `useLivePoll` returns: `Live` while refreshing, `Watching` on the slow cadence, `Paused` while the tab is in the background. On screens whose refreshing is driven by their own content it is a read-only status rather than a toggle, because the toggle does not govern them and a pressable control would imply it does.

## Tests

New `app/(cockpit)/cockpit-shell.test.tsx` mounts the real shell around a real screen and counts refreshes over time. That seam was missing: the existing screen tests render without a `CockpitCtx` provider, so their `registerRunRefresh` was the context default no-op, which is why this shipped green.

7 of its 9 cases fail against the pre-fix code, including the parked-run case. Three `live-poll.test.ts` cases from #253 that asserted `maxTicks` and `isActive` are replaced by cases for the behaviour that has to hold instead.

Ran: `cockpit-shell.test.tsx`, `live-poll.test.ts`, `runs.test.tsx` (31 pass), `trace-replay.test.tsx`, `workflow-replay.test.tsx` (24 pass), `tsc --noEmit` clean. No migrations, no worker changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic refresh behavior with live and idle polling cadences.
  * Run lists continue refreshing to detect newly started runs, including when displayed runs are complete.
  * Refresh pauses when the page is hidden and resumes with an immediate update when visible or focused.
  * Live status indicators now accurately reflect active, paused, and background polling states.
  * Polling continues for long-running operations without an arbitrary time limit.

* **Bug Fixes**
  * Prevented unnecessary polling for completed run traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->