### PR TITLE
AIW-270: let the MCP consent screen render, so a client can actually get a token

### DIFF
--- a/apps/worker/src/routes/mcp-auth/consent.get.test.ts
+++ b/apps/worker/src/routes/mcp-auth/consent.get.test.ts
@@ -1,0 +1,122 @@
+// Regression cover for the consent screen, which had none: every MCP client
+// (Claude Code, Claude Desktop, an Arthur agent) was refused here with
+// "Invalid OAuth request" while 394 MCP tests stayed green, because the tests
+// all start from an actor and never walk the browser half of the flow.
+import { createApp, eventHandler, toWebHandler } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  prelogin: vi.fn(),
+  env: {
+    BETTER_AUTH_SECRET: "test-secret",
+  },
+}));
+
+vi.mock("../../../env.js", () => ({
+  env: state.env,
+}));
+
+vi.mock("../../auth-instance.js", () => ({
+  auth: {
+    api: {
+      getOAuthClientPublicPrelogin: state.prelogin,
+    },
+  },
+}));
+
+const consentRoute = (await import("./consent.get.js")).default;
+
+const CLIENT_ID = "eiWzIXwrrXzrZboIhhEFKalUtICrwHCe";
+const REDIRECT_URI = "http://127.0.0.1:43110/callback";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The exact shape production returns. /oauth2/public-client-prelogin answers a
+  // caller who is not signed in yet, so it withholds the registered redirect
+  // list: verified against the deployment with the signed query taken from a
+  // real /oauth2/authorize redirect, which answered
+  // {"client_id":"eiWzIX…","client_name":"aiw-dogfood-pkce","redirect_uris":[]}.
+  state.prelogin.mockResolvedValue({
+    client_id: CLIENT_ID,
+    client_name: "aiw-dogfood-pkce",
+    redirect_uris: [],
+  });
+});
+
+function handlerFor(route: Parameters<typeof eventHandler>[0]) {
+  const app = createApp();
+  app.use("/", route);
+  return toWebHandler(app);
+}
+
+function consentUrl(overrides: Record<string, string> = {}): string {
+  const query = new URLSearchParams({
+    response_type: "code",
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    scope: "mcp:read",
+    state: "probe",
+    code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    code_challenge_method: "S256",
+    exp: "1786597132",
+    ba_iat: "1786596532923",
+    sig: "0e6g9sZI2vvfQEnndJjoGGfdPi2kfBu9W21XvBmGbe4=",
+    ...overrides,
+  });
+  return `http://worker.example.com/mcp-auth/consent?${query.toString()}`;
+}
+
+describe("MCP consent screen", () => {
+  it("renders for a public client, whose registered redirects prelogin never returns", async () => {
+    const response = await handlerFor(consentRoute)(new Request(consentUrl()));
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Authorize");
+    expect(body).toContain("aiw-dogfood-pkce");
+    // The host the human decides on has to be the one from the signed query.
+    expect(body).toContain("127.0.0.1");
+    expect(body).toContain('name="accept" value="true"');
+    expect(response.headers.get("set-cookie")).toContain("Path=/");
+  });
+
+  it("still refuses a scope the deployment does not advertise", async () => {
+    const response = await handlerFor(consentRoute)(
+      new Request(consentUrl({ scope: "mcp:read admin:all" })),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("still refuses an unregistered or edited redirect, whose signature prelogin rejects", async () => {
+    // This is the negative case for the check the route no longer performs.
+    // Two independent guards keep it covered, both verified against the
+    // deployment rather than assumed. First, /oauth2/authorize refuses a
+    // redirect_uri outside the client's registered set before it ever redirects
+    // here (@better-auth/oauth-provider@1.6.20, dist/index.mjs:3864-3872), and
+    // answered 400 for http://evil.example/cb on a client registered only for
+    // loopback. Second, redirect_uri is inside the HMAC over the ba_param list:
+    // swapping it in a genuine signed query made prelogin answer
+    // {"error":"invalid_signature"}, which this route turns into the 400 below.
+    // A third guard sits past consent: the token exchange rejects a redirect_uri
+    // that differs from the one stored with the code (dist/index.mjs:581-582).
+    state.prelogin.mockRejectedValue(new Error("invalid_signature"));
+
+    const response = await handlerFor(consentRoute)(new Request(consentUrl()));
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toContain("OAuth request expired");
+  });
+
+  it("still refuses a query missing the client or the redirect", async () => {
+    const withoutClient = new URLSearchParams(new URL(consentUrl()).search);
+    withoutClient.delete("client_id");
+
+    const response = await handlerFor(consentRoute)(
+      new Request(`http://worker.example.com/mcp-auth/consent?${withoutClient.toString()}`),
+    );
+
+    expect(response.status).toBe(400);
+    expect(state.prelogin).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/routes/mcp-auth/consent.get.ts
+++ b/apps/worker/src/routes/mcp-auth/consent.get.ts
@@ -30,10 +30,21 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "OAuth request expired" });
   }
   const allowed = allowedScopes(requestedScopes);
-  if (
-    !client.redirect_uris.includes(redirectUri) ||
-    allowed.length !== new Set(requestedScopes).size
-  ) {
+  // Scopes only. The redirect_uri is deliberately NOT compared against
+  // client.redirect_uris: /oauth2/public-client-prelogin answers a caller who is
+  // not signed in yet, so it withholds the registered redirect list and returns
+  // redirect_uris: [] in production. That comparison therefore refused every
+  // single authorization request, and no MCP client could obtain a token at all
+  // (AIW-270).
+  //
+  // What replaces it is not weaker. /oauth2/authorize answers 400 for a
+  // redirect_uri the client did not register, before it ever redirects here, and
+  // the query it forwards is HMAC-signed over its ba_param list, which includes
+  // both client_id and redirect_uri. Editing either one breaks the signature,
+  // the prelogin call above throws, and the request dies as "OAuth request
+  // expired". So the redirect host rendered below is one the authorization
+  // server already accepted for this exact client.
+  if (allowed.length !== new Set(requestedScopes).size) {
     throw createError({ statusCode: 400, statusMessage: "Invalid OAuth request" });
   }
   const flowId = randomUUID();


### PR DESCRIPTION
Fixes AIW-270. Small and standalone, deliberately not folded into #256, which has CI in flight.

The MCP consent screen refused **every** authorization request with `400 Invalid OAuth request`, so no MCP client could obtain a token: Claude Code, Claude Desktop and an Arthur agent alike. `claude mcp list` showed "Needs authentication" and could never get past it.

## Cause

`consent.get.ts` validated the requested `redirect_uri` against `client.redirect_uris` returned by `/oauth2/public-client-prelogin`. That endpoint answers a caller who is **not signed in yet**, so it withholds the registered redirect list. Production, asked with a signed query lifted from a real `/oauth2/authorize` redirect, answers:

```
{"client_id":"eiWzIX…","client_name":"aiw-dogfood-pkce","redirect_uris":[]}
```

An empty array can never contain the requested URI, so the gate rejected everything. The scope half of the same condition was fine.

## Why removing the check is the fix, rather than repairing the comparison

Three independent guards already cover what that comparison was trying to cover, and each was verified rather than assumed.

1. **The authorization server refuses an unregistered redirect up front.** `@better-auth/oauth-provider@1.6.20`, `dist/index.mjs:3864-3872`: inside the `/oauth2/authorize` handler, `client.redirectUris` must contain the requested URI, either exactly or under the loopback rule from RFC 8252, otherwise it answers `invalid_redirect`. This runs before any redirect to the login or consent page. Confirmed live: the registered test client, asked to redirect to `http://evil.example/cb`, got `400` and never reached consent.
2. **`redirect_uri` is inside the HMAC that prelogin verifies.** The forwarded query carries `sig` over a `ba_param` list that includes `client_id`, `redirect_uri`, `scope`, `code_challenge` and `exp`. Proven by tampering rather than by reading the signer: taking a genuine signed query and swapping only the redirect to `evil.example` makes prelogin answer `{"error":"invalid_signature"}`, and swapping the scope does the same. This route turns that rejection into `400 OAuth request expired`. So the redirect host rendered on the page is one the authorization server already accepted for that exact client, and it cannot be edited afterwards.
3. **The token exchange rejects a redirect that differs from the one bound to the code.** `dist/index.mjs:581-582`, `redirect_uri mismatch`.

`consent.post.ts` needed no change and has no equivalent hole: it reconstructs the request from the **signed flow cookie**, not from the form. The form supplies only `flow_id`, `accept` and `scope`, the scope is re-validated against `MCP_SCOPES` there too, and the POST is same-origin checked.

## Test

The regression test is the point of this PR as much as the one-line condition. That seam had no cover at all, which is how 394 green MCP tests coexisted with a surface no client could authenticate against: every MCP test starts from an actor and none of them walk the browser half of the flow.

`consent.get.test.ts` asserts the page renders for a public client whose `redirect_uris` come back **empty, using the exact shape production returns**, and keeps the negative cases: an unadvertised scope is still refused, a query whose signature prelogin rejects is still refused, and a query missing the client or the redirect is still refused without even calling prelogin.

- `npx vitest run src/routes/mcp-auth/ src/mcp/auth-pages.test.ts` → 18 passed, exit 0. The new case fails with `400` instead of `200` before the fix.
- `npx vitest run src/mcp/ --hookTimeout=90000 --maxWorkers=2` → 293 passed, 21 files, exit 0.
- `pnpm --filter worker typecheck` → exit 0.

No change to scope policy and none to the DCR hardening.

## One more finding, reported and deliberately not fixed here

The redirect from `/oauth2/authorize` to `/mcp-auth/consent` drops the `resource` parameter: it is absent from the forwarded query and from the signed `ba_param` list. That is real, and it is **harmless on this deployment**, which is why it is not in this diff. The provider fills the audience itself from `validAudiences` when the request names no resource, and it collapses a single-element list to a bare string (`dist/index.mjs:305`, `aud: typeof audience === "string" ? audience : audience?.length === 1 ? audience.at(0) : audience`). Our `validAudiences` holds exactly one entry, the canonical `/mcp`, so the minted token carries `aud` as the string `request-context.ts:35` compares against.

The latent trap worth writing down: that strict comparison only survives while `validAudiences` has exactly one entry. Add a second and `aud` becomes an array, and every token starts failing that line even though `jwtVerify`'s own audience option would accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wUPzpKC8cJSKkZ4DWAu7g
