### PR TITLE
fix(worker): only name repositories from an answer that really did not resolve

### DIFF
--- a/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.test.ts
@@ -283,6 +283,48 @@ describe("selectRepositoriesFromMetadata", () => {
     expect(selected.questions[0]).toContain("github:acme/missing");
   });
 
+  it("selects a repository whose path is embedded in a sentence rather than calling it unavailable", () => {
+    // The whole-answer scan above compares the entire reply to one path or short
+    // name, so it cannot see a path sitting inside a sentence. The unavailable-
+    // repository fallback is token-based and can, so it used to declare a
+    // repository that exists right here to be unavailable — a confident, wrong
+    // statement to a human, which is worse than the "asks twice" loop the
+    // fallback was added to end.
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "use acme/web please",
+    });
+
+    expect(selected).toEqual({
+      status: "selected",
+      repositories: [
+        expect.objectContaining({
+          repoPath: "acme/web",
+          selectedRationale: "human clarification answer",
+        }),
+      ],
+    });
+  });
+
+  it("names only the repositories that really did not resolve", () => {
+    const selected = selectRepositoriesFromMetadata({
+      ticketText: "Fix billing webhook retry behavior",
+      repositories: repos,
+      workflowOwnedBranches: [],
+      directAnswer: "use acme/web and acme/gone",
+    });
+
+    expect(selected.status).toBe("clarification_needed");
+    if (selected.status !== "clarification_needed") {
+      throw new Error("expected clarification_needed");
+    }
+    expect(selected.questions[0]).toContain("acme/gone");
+    // Naming acme/web here would be the false claim: it is in the catalog.
+    expect(selected.questions[0]).not.toContain("acme/web");
+  });
+
   it("still falls to discovery when the answer names no repository path", () => {
     // Prose is not an explicit choice, so the model still gets its turn rather
     // than the human being sent a second deterministic question.

--- a/apps/worker/src/pre-sandbox/steps/repo-selection.ts
+++ b/apps/worker/src/pre-sandbox/steps/repo-selection.ts
@@ -22,7 +22,10 @@ import {
 } from "../../repository-discovery/catalog.js";
 // Pure token parser, no adapters behind it: runner.js imports only types plus
 // catalog.js, which this module already pulls in.
-import { parseRepositoryExpansionAnswer } from "../../repository-discovery/runner.js";
+import {
+  parseRepositoryExpansionAnswer,
+  type ParsedRepositoryIdentity,
+} from "../../repository-discovery/runner.js";
 import { filterRepositoriesForScope } from "../../lib/repo-allowlist.js";
 // Type only, so importing this file never pulls the routing module in with it.
 //
@@ -832,9 +835,7 @@ export function selectRepositoriesFromMetadata(input: {
   }
 
   // A human answer that names repository paths none of which exist here gets the
-  // same treatment as an unsatisfiable pin above: surfaced by name. Reaching this
-  // line already proves none of them matched, because a named path present in the
-  // catalog is matched by the ticket-text scan and the answer scan before it.
+  // same treatment as an unsatisfiable pin above: surfaced by name.
   //
   // The alternative is what production showed: the answer falls through to model
   // discovery, which cannot honour a repository that is not in the catalog it was
@@ -843,18 +844,47 @@ export function selectRepositoriesFromMetadata(input: {
   // they named is not available, which is the "asks twice" loop. Only paths count
   // here: a bare short name is not evidence of an explicit choice, and the scans
   // above already resolve the ones that do match.
+  //
+  // Reaching this line does NOT prove that none of them matched, which is what an
+  // earlier version of this block assumed. The answer scan above compares the
+  // whole reply to one path or short name, so it cannot see a path sitting inside
+  // a sentence ("use acme/web please"); the parser here is token-based and only
+  // needs a slash, so it reads paths that scan never could. Every named identity
+  // is therefore resolved against the catalog first, and only the ones that
+  // genuinely do not resolve are named. Announcing that a repository sitting in
+  // the catalog is unavailable is a confident, wrong statement to a human — worse
+  // than the loop this fallback exists to end.
   if (input.directAnswer) {
-    const named = parseRepositoryExpansionAnswer(input.directAnswer).map((identity) =>
-      identity.provider ? `${identity.provider}:${identity.repoPath}` : identity.repoPath,
-    );
-    if (named.length > 0) {
+    const unresolved: string[] = [];
+    const resolved = new Map<string, RepositoryMetadata>();
+    for (const identity of parseRepositoryExpansionAnswer(input.directAnswer)) {
+      const matches = resolveNamedRepository(identity, scopedRepositories);
+      if (matches.length === 0) {
+        unresolved.push(describeNamedRepository(identity));
+        continue;
+      }
+      for (const repo of matches) resolved.set(repositoryKey(repo), repo);
+    }
+    if (unresolved.length > 0) {
       return {
         status: "clarification_needed",
         questions: [
-          `None of the repositories named in the previous answer are available to this workflow: ${named.join(", ")}. ` +
+          `These repositories named in the previous answer are not available to this workflow: ${unresolved.join(", ")}. ` +
             `Name a repository from the accessible catalog as "owner/repo", or as "github:owner/repo" to pin the provider.`,
         ],
       };
+    }
+    // Everything named resolved, and to a single repository: an explicit choice
+    // the whole-reply scan could not read. Honour it rather than asking again.
+    // Several distinct repositories is the same ambiguity the answer scan above
+    // declines to guess at, so that still falls through to discovery.
+    if (resolved.size === 1) {
+      const repo = [...resolved.values()][0]!;
+      selected.set(
+        repositoryKey(repo),
+        selectedRepository(repo, "human clarification answer"),
+      );
+      return { status: "selected", repositories: [...selected.values()] };
     }
   }
 
@@ -919,6 +949,35 @@ function latestClarificationAnswer(
     if (comments[i]!.author === "Human clarification") return comments[i]!.body;
   }
   return null;
+}
+
+/**
+ * Repositories one identity parsed out of a human answer resolves to. Matched
+ * leniently on path or short name, the same two keys the whole-reply scan uses,
+ * but per identity so a path embedded in prose still resolves. A provider-scoped
+ * identity ("github:owner/repo") only ever matches that provider.
+ *
+ * Deliberately resolved against the *scoped* catalog: a repository a provider or
+ * repository pin excludes really is not available to this workflow, so keeping it
+ * out here is what makes the resulting message true.
+ */
+function resolveNamedRepository(
+  identity: ParsedRepositoryIdentity,
+  repositories: RepositoryMetadata[],
+): RepositoryMetadata[] {
+  const named = normalizeRepoAnswer(identity.repoPath);
+  return repositories.filter(
+    (repo) =>
+      (identity.provider === undefined || repo.provider === identity.provider) &&
+      (normalizeRepoAnswer(repo.repoPath) === named ||
+        normalizeRepoAnswer(repoShortName(repo)) === named),
+  );
+}
+
+function describeNamedRepository(identity: ParsedRepositoryIdentity): string {
+  return identity.provider
+    ? `${identity.provider}:${identity.repoPath}`
+    : identity.repoPath;
 }
 
 function repoShortName(repo: Pick<RepositoryMetadata, "name" | "repoPath">): string {


### PR DESCRIPTION
Follow-up to the MAJOR finding on #258, reviewed after that PR was already merged and deployed.

## The defect

`repo-selection.ts`'s "name the unavailable repository" fallback claimed a repository was unavailable even when it sits in the catalog, as long as the human wrote its path inside a sentence rather than on its own.

Catalog holds `acme/web` and `acme/api`, `directAnswer = "use acme/web please"`, and the run answered:

> None of the repositories named in the previous answer are available to this workflow: acme/web.

That is false. `acme/web` is right there and usable. It is a confident, specific, wrong statement aimed at a human, which is worse than the "asks twice" loop the fallback was added to end, and clarification is one of the demo paths.

## Cause

Two different readers of the same answer disagree about what it names.

The lenient answer scan matches on the **whole** reply: `normalizeRepoAnswer(input.directAnswer)` is compared for equality against one path or short name, and `fuzzyRepoMatches` runs its edit distance over that same whole string. `"use acme/web please"` never equals `"acme/web"`, and it is far outside any typo tolerance, so that scan cannot resolve it.

`parseRepositoryExpansionAnswer` is a **token** parser: it splits on whitespace and commas and accepts any token containing a slash. It happily extracts `acme/web` from the sentence.

The fallback's comment asserted that "reaching this line already proves none of them matched". That assumption only holds for readers with equal reach, and these two do not have it, so the stronger reader was used to produce a claim the weaker reader had licensed.

## Fix

Resolve every identity the parser returns against the catalog before asserting anything, matching on path or short name (the same two keys the whole-reply scan uses, applied per identity), with a provider-scoped identity restricted to that provider.

- Only identities that genuinely do not resolve are named. The message wording changed from "None of the repositories named ... are available" to "These repositories named ... are not available", because with a partial list the old phrasing was itself a false claim.
- If everything named resolves and it resolves to exactly one repository, that repository is selected with the existing `human clarification answer` rationale instead of asking again.
- Several distinct repositories resolving is the same ambiguity the answer scan above already declines to guess at, so it still falls through to discovery. Discovery now gets a catalog that does contain what the human named, so it can honour the answer.

Resolution runs against `scopedRepositories`, not the unscoped usable list. A repository a provider or repository pin excludes really is not available to this workflow, so keeping it out of the resolved set is what keeps the message true rather than hiding a real exclusion.

## Tests

Started from the reviewer's exact sentence, red first (`9923a523`):

- `selects a repository whose path is embedded in a sentence rather than calling it unavailable` — the reproduction, asserts selection rather than clarification.
- `names only the repositories that really did not resolve` — mixed answer `"use acme/web and acme/gone"`, asserts the message contains `acme/gone` and does **not** contain `acme/web`. Before the fix it read `acme/web, acme/gone`.

Both fail against the pre-fix code. Both halves of the fix are load-bearing, checked by mutation: neutering the resolver fails both tests, and disabling the single-resolved selection fails the first.

The pre-existing fallback tests still pass unchanged, including the two that name paths genuinely absent from the catalog (`acme/ai-workflow-prod`, `github:acme/missing`), which is the behaviour #258 added and this keeps.

Ran: `repo-selection.test.ts` 107 pass, `repository-discovery/runner.test.ts` 20 pass, `tsc --noEmit` clean. One file plus its test, no migrations.

Out of scope by request: the two MINOR findings from the same review (silent skip of the ticket move with no bound owner, and the missing move-succeeds-then-CAS-conflicts interleaving test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)