### PR TITLE
fix(worker): verify MCP tokens against mounted JWKS

### DIFF
--- a/apps/worker/src/mcp/request-context.test.ts
+++ b/apps/worker/src/mcp/request-context.test.ts
@@ -76,6 +76,7 @@ describe("requireMcpActor", () => {
       audience: "https://worker.example.com/mcp",
     });
     expect(state.verifyAccessToken).toHaveBeenCalledWith("access-token", {
+      jwksUrl: "https://worker.example.com/api/auth/jwks",
       verifyOptions: {
         issuer: "https://worker.example.com/api/auth",
         audience: "https://worker.example.com/mcp",

--- a/apps/worker/src/mcp/request-context.ts
+++ b/apps/worker/src/mcp/request-context.ts
@@ -26,6 +26,10 @@ export async function requireMcpActor(request: Request): Promise<McpActorContext
     claims = (await oauthProviderResourceClient(auth)
       .getActions()
       .verifyAccessToken(token, {
+        // The resource client reads auth.options.basePath before Better Auth
+        // applies its default, so without this it probes /jwks instead of the
+        // mounted /api/auth/jwks endpoint and rejects every valid token.
+        jwksUrl: `${issuer}/jwks`,
         verifyOptions: { issuer, audience },
       })) as Record<string, unknown>;
   } catch {


### PR DESCRIPTION
Production PKCE completes and issues a correctly signed token with the expected issuer, audience, scopes, actor and organization claims, but every authenticated MCP request returns 401.

Root cause: `oauthProviderResourceClient(auth)` reads `auth.options.basePath` before Better Auth applies its default. It therefore probes `/jwks`, which does not exist, instead of the mounted `/api/auth/jwks` route.

This patch passes the canonical JWKS URL explicitly and locks it with a request-context regression assertion.

Verification:
- 31 OAuth/request-context tests passed
- 34 transport tests passed
- worker typecheck passed
- live JWT signature + issuer + audience validation passed against production JWKS

No deployment or Arthur release is included.