### PR TITLE
AIW-239: production MCP dogfood harness

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,6 +16,7 @@
     "capture:agent-protocol-fixtures": "tsx scripts/capture-agent-protocol-fixtures.ts",
     "cleanup:startup-orphans": "tsx scripts/cleanup-startup-orphans.ts",
     "mcp:smoke": "tsx scripts/mcp-smoke.ts",
+    "mcp:dogfood": "tsx scripts/mcp-dogfood.ts",
     "mcp:contract:generate": "tsx scripts/generate-mcp-contract.ts",
     "mcp:contract:check": "tsx scripts/generate-mcp-contract.ts --check",
     "check:prompt-drift": "tsx src/prompt-library/builtin-prompt-drift-gate.ts",

--- a/apps/worker/scripts/mcp-dogfood.ts
+++ b/apps/worker/scripts/mcp-dogfood.ts
@@ -57,7 +57,7 @@ if (!baseUrl) {
       "  --run <id>           real run id, so runs.* hit real data",
       "  --definition <id>    real workflow definition id",
       "  --trigger <nodeId>   trigger node id for the workflows.* probes",
-      "  --allow-dispatch     really call the mutating tools (off by default)",
+      "  --allow-dispatch     really call workflows.dispatch only (off by default)",
       "  --json               emit the raw report instead of the readable one",
       "",
       "Environment: MCP_DOGFOOD_BASE_URL, MCP_DOGFOOD_TOKEN (preferred over argv).",

--- a/apps/worker/scripts/mcp-dogfood.ts
+++ b/apps/worker/scripts/mcp-dogfood.ts
@@ -1,0 +1,84 @@
+// Operator CLI for the MCP dogfood harness. Thin on purpose, exactly like
+// mcp-smoke.ts: everything worth testing lives under src/mcp-dogfood/, because
+// a test file under scripts/ would never run (vitest.config.ts only includes
+// src/**/*.test.ts and *.test.ts).
+//
+// Separate from `pnpm mcp:smoke` rather than folded into it. The smoke check
+// answers one question, "is this deployment up and enforcing auth", in a couple
+// of seconds, and deploy steps gate on its exit code. This walks the whole tool
+// surface with two probes per tool and is the slower, broader check an operator
+// runs deliberately. Merging them would make a routine deploy gate fail on a
+// coverage gap, and make the fast check slow.
+import { loadContract } from "../src/mcp-dogfood/plan.js";
+import { renderReport } from "../src/mcp-dogfood/report.js";
+import { dogfoodExitCode, runDogfood } from "../src/mcp-dogfood/run.js";
+
+const VALUED_FLAGS = new Set(["ticket", "run", "definition", "trigger"]);
+const values = new Map<string, string>();
+const switches = new Set<string>();
+const bare: string[] = [];
+
+const argv = process.argv.slice(2);
+for (let index = 0; index < argv.length; index += 1) {
+  const argument = argv[index]!;
+  if (!argument.startsWith("--")) {
+    bare.push(argument);
+    continue;
+  }
+  const name = argument.slice(2);
+  if (VALUED_FLAGS.has(name)) {
+    values.set(name, argv[index + 1] ?? "");
+    index += 1;
+  } else {
+    switches.add(name);
+  }
+}
+
+const flag = (name: string): string | undefined => values.get(name) || undefined;
+
+const baseUrl = bare[0] ?? process.env.MCP_DOGFOOD_BASE_URL;
+// Read from the environment by preference: an argv token is visible in `ps`.
+const token = process.env.MCP_DOGFOOD_TOKEN ?? bare[1];
+
+if (!baseUrl) {
+  console.error(
+    [
+      "Usage: pnpm mcp:dogfood <base-url> [token] [options]",
+      "",
+      "  Walks every tool in the frozen MCP contract against a deployment and",
+      "  reports, per tool, whether it works, refuses correctly, or FAILS.",
+      "",
+      "  Without a token every call is refused by auth and that is reported as a",
+      "  PASS: it proves the deployment enforces auth. Nothing behind the gate is",
+      "  checked, which the report says in as many words.",
+      "",
+      "Options:",
+      "  --ticket <key>       real ticket key, so tickets.* hit real data",
+      "  --run <id>           real run id, so runs.* hit real data",
+      "  --definition <id>    real workflow definition id",
+      "  --trigger <nodeId>   trigger node id for the workflows.* probes",
+      "  --allow-dispatch     really call the mutating tools (off by default)",
+      "  --json               emit the raw report instead of the readable one",
+      "",
+      "Environment: MCP_DOGFOOD_BASE_URL, MCP_DOGFOOD_TOKEN (preferred over argv).",
+    ].join("\n"),
+  );
+  process.exit(1);
+}
+
+const definition = flag("definition");
+const report = await runDogfood({
+  baseUrl,
+  token,
+  contract: loadContract(),
+  fixtures: {
+    ...(flag("ticket") ? { ticketKey: flag("ticket")! } : {}),
+    ...(flag("run") ? { runId: flag("run")! } : {}),
+    ...(definition ? { definitionId: Number(definition) } : {}),
+    ...(flag("trigger") ? { triggerNodeId: flag("trigger")! } : {}),
+  },
+  allowDispatch: switches.has("allow-dispatch"),
+});
+
+console.log(switches.has("json") ? JSON.stringify(report, null, 2) : renderReport(report));
+process.exit(dogfoodExitCode(report));

--- a/apps/worker/src/mcp-dogfood/dogfood.test.ts
+++ b/apps/worker/src/mcp-dogfood/dogfood.test.ts
@@ -224,6 +224,25 @@ describe("the operator report", () => {
     expect(text).toContain("Withheld on purpose");
   });
 
+  it("reports a tool whose happy path the contract cannot express as lost coverage", () => {
+    // #256 adds prompts.get, which takes promptId OR slug with neither marked
+    // required. Arguments built from that schema are refused however healthy
+    // the tool is, so the verdict stays honest and Coverage carries the gap.
+    const text = renderReport({
+      ...base,
+      outcome: "ok",
+      notExercised: [],
+      results: [
+        result({ tool: "prompts.get", status: "refused", errorCode: "VALIDATION_FAILED" }),
+        result({ tool: "prompts.get", kind: "invented_argument", status: "refused", errorCode: "VALIDATION_FAILED" }),
+      ],
+    });
+
+    expect(text).toContain("Happy path NOT reached");
+    expect(text).toContain("prompts.get");
+    expect(text).not.toContain("FAILS");
+  });
+
   it("never prints the token, only its length", () => {
     const text = renderReport({ ...base, tokenLength: 64 });
 

--- a/apps/worker/src/mcp-dogfood/dogfood.test.ts
+++ b/apps/worker/src/mcp-dogfood/dogfood.test.ts
@@ -7,6 +7,7 @@ import { renderReport, verdictFor } from "./report.js";
 import {
   classify,
   compareSurface,
+  dogfoodExitCode,
   readErrorCode,
   type DogfoodReport,
   type ProbeResult,
@@ -231,6 +232,14 @@ describe("the operator report", () => {
     expect(text).toContain("AUTH_REJECTED");
     expect(text).toContain("not a defect");
     expect(text).toContain("NOT CALLED AT ALL");
+  });
+
+  it("fails when a supplied token is rejected, but accepts the anonymous auth probe", () => {
+    expect(dogfoodExitCode(base)).toBe(0);
+
+    const authenticated = { ...base, tokenLength: 64 };
+    expect(dogfoodExitCode(authenticated)).toBe(1);
+    expect(renderReport(authenticated)).toContain("supplied token was rejected");
   });
 
   it("names every uncalled tool rather than reporting a clean sweep", () => {

--- a/apps/worker/src/mcp-dogfood/dogfood.test.ts
+++ b/apps/worker/src/mcp-dogfood/dogfood.test.ts
@@ -51,7 +51,7 @@ describe("the probe plan comes from the contract", () => {
     );
     for (const entry of probes.filter((candidate) => candidate.kind === "invented_argument")) {
       expect(entry.args).toHaveProperty(INVENTED_ARGUMENT);
-      expect(entry.acceptedErrorCodes).toEqual(["VALIDATION_FAILED"]);
+      expect(entry.acceptedErrorCodes).toContain("VALIDATION_FAILED");
     }
   });
 
@@ -95,6 +95,17 @@ describe("the probe plan comes from the contract", () => {
     expect(
       guarded.find((entry) => entry.tool === "workflows.dispatch" && entry.kind === "invented_argument")!.args,
     ).toBeDefined();
+  });
+
+  it("accepts policy refusal only for gated tools", () => {
+    const probes = planProbes(CONTRACT, {}, { allowDispatch: false });
+    const accepted = (tool: string) =>
+      probes.find((entry) => entry.tool === tool && entry.kind === "invented_argument")!
+        .acceptedErrorCodes;
+
+    expect(accepted("tickets.get")).not.toContain("FORBIDDEN");
+    expect(accepted("workflows.dispatch_preflight")).toContain("FORBIDDEN");
+    expect(accepted("workflows.dispatch")).toContain("INSUFFICIENT_SCOPE");
   });
 });
 

--- a/apps/worker/src/mcp-dogfood/dogfood.test.ts
+++ b/apps/worker/src/mcp-dogfood/dogfood.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+
+import { McpPublicError } from "../mcp/contracts.js";
+import { mcpToolErrorResult } from "../mcp/tool-catalog.js";
+import { loadContract, planProbes, sampleArguments, INVENTED_ARGUMENT } from "./plan.js";
+import { renderReport, verdictFor } from "./report.js";
+import { classify, readErrorCode, type DogfoodReport, type ProbeResult } from "./run.js";
+
+const CONTRACT = loadContract();
+const CODES = CONTRACT.errorCodes;
+
+function probe(overrides: Partial<Parameters<typeof classify>[0]> = {}) {
+  return {
+    tool: "tickets.get",
+    kind: "valid" as const,
+    args: { ticketKey: "AIW-1" },
+    acceptedErrorCodes: ["NOT_FOUND"],
+    placeholders: [],
+    ...overrides,
+  };
+}
+
+function errorResult(code: string) {
+  return {
+    isError: true,
+    content: [{ type: "text", text: JSON.stringify({ error: { code, message: "no", retryable: false } }) }],
+  };
+}
+
+function okResult() {
+  return { structuredContent: { data: {}, meta: { contractHash: CONTRACT.contractHash } } };
+}
+
+describe("the probe plan comes from the contract", () => {
+  it("plans a real call and an invented argument for every tool in the contract", () => {
+    const probes = planProbes(CONTRACT, {}, { allowDispatch: false });
+
+    // Two probes per tool, so a tool added to the contract is covered by both
+    // without anyone editing the harness. That is the property that keeps a
+    // coverage claim honest as the surface grows.
+    expect(probes).toHaveLength(CONTRACT.tools.length * 2);
+    expect(new Set(probes.map((entry) => entry.tool))).toEqual(
+      new Set(CONTRACT.tools.map((tool) => tool.name)),
+    );
+    for (const entry of probes.filter((candidate) => candidate.kind === "invented_argument")) {
+      expect(entry.args).toHaveProperty(INVENTED_ARGUMENT);
+      expect(entry.acceptedErrorCodes).toEqual(["VALIDATION_FAILED"]);
+    }
+  });
+
+  it("builds arguments that satisfy each tool's own schema", () => {
+    const dispatch = CONTRACT.tools.find((tool) => tool.name === "workflows.dispatch");
+    expect(dispatch).toBeDefined();
+
+    const { args } = sampleArguments(dispatch!, {});
+
+    // Patterned and formatted fields have to be generated to match, or the
+    // probe is refused by validation and proves nothing about the tool.
+    expect(args.preflightDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(args.idempotencyKey).toMatch(/^[0-9a-f-]{36}$/);
+    expect(args.input).toMatchObject({ kind: "ticket" });
+    expect(typeof args.definitionId).toBe("number");
+  });
+
+  it("prefers a supplied fixture over a placeholder and says which were guessed", () => {
+    const tool = CONTRACT.tools.find((candidate) => candidate.name === "tickets.get")!;
+
+    const withFixture = sampleArguments(tool, { ticketKey: "AIW-251" });
+    const without = sampleArguments(tool, {});
+
+    expect(withFixture.args.ticketKey).toBe("AIW-251");
+    expect(withFixture.placeholders).toEqual([]);
+    expect(without.placeholders).toContain("ticketKey");
+  });
+
+  it("withholds a mutating tool's real call unless it is asked for", () => {
+    const guarded = planProbes(CONTRACT, {}, { allowDispatch: false });
+    const allowed = planProbes(CONTRACT, {}, { allowDispatch: true });
+    const find = (probes: typeof guarded) =>
+      probes.find((entry) => entry.tool === "workflows.dispatch" && entry.kind === "valid")!;
+
+    // Withheld, never dropped: it still has to appear so the report can admit
+    // the gap instead of reading as a clean sweep.
+    expect(find(guarded).skipped).toBeDefined();
+    expect(find(guarded).args).toBeUndefined();
+    expect(find(allowed).args).toBeDefined();
+    // The negative probe is safe either way: validation runs before any effect.
+    expect(
+      guarded.find((entry) => entry.tool === "workflows.dispatch" && entry.kind === "invented_argument")!.args,
+    ).toBeDefined();
+  });
+});
+
+describe("classifying what a tool answered", () => {
+  it("reads the contract error code out of the text content", () => {
+    expect(readErrorCode(errorResult("NOT_FOUND"))).toBe("NOT_FOUND");
+    expect(readErrorCode({ isError: true, content: [{ type: "text", text: "Invalid arguments" }] })).toBeNull();
+  });
+
+  it("counts an expected refusal as refusing correctly, not as a failure", () => {
+    expect(classify(probe(), errorResult("NOT_FOUND"), CODES)).toMatchObject({
+      status: "refused",
+      errorCode: "NOT_FOUND",
+    });
+  });
+
+  it("fails a refusal that arrives without a contract error code", () => {
+    // The regression the negative probes exist for: the SDK's own error path
+    // forwards the message and drops the code, so a caller cannot tell whether
+    // to retry, wait, or give up. isError alone must never read as a pass.
+    const bare = { isError: true, content: [{ type: "text", text: "Invalid arguments for tool tickets.get" }] };
+
+    expect(classify(probe(), bare, CODES)).toMatchObject({
+      status: "failed",
+      detail: "refused without a contract error code, so a caller cannot tell why",
+    });
+  });
+
+  it("fails a refusal whose code is not the one this probe expects", () => {
+    expect(classify(probe(), errorResult("INTERNAL_ERROR"), CODES)).toMatchObject({
+      status: "failed",
+      errorCode: "INTERNAL_ERROR",
+    });
+  });
+
+  it("fails a code the contract never declared", () => {
+    expect(classify(probe(), errorResult("TEAPOT"), CODES)).toMatchObject({
+      status: "failed",
+      detail: "error code is not in the contract",
+    });
+  });
+
+  it("fails a success that arrived without the contract envelope", () => {
+    expect(classify(probe(), { structuredContent: undefined }, CODES)).toMatchObject({
+      status: "failed",
+      detail: "answered without the contract envelope",
+    });
+  });
+
+  it("fails an invented argument that was accepted instead of refused", () => {
+    const negative = probe({ kind: "invented_argument", acceptedErrorCodes: ["VALIDATION_FAILED"] });
+
+    expect(classify(negative, okResult(), CODES)).toMatchObject({
+      status: "failed",
+      detail: "accepted an argument the contract does not declare",
+    });
+  });
+
+  it("passes a real call that answered with the envelope", () => {
+    expect(classify(probe(), okResult(), CODES)).toMatchObject({ status: "ok" });
+  });
+
+  // The one place this harness is coupled to the server's internals: it parses
+  // the error body the server actually builds. Feeding the real production
+  // builder in means a change to that shape breaks here, in CI, rather than
+  // silently turning every negative probe into a false FAILS during a release.
+  it("parses the error body the server really builds", () => {
+    const real = mcpToolErrorResult(
+      new McpPublicError("VALIDATION_FAILED", "tickets.get: unrecognized key(s) 'x'", false),
+    );
+
+    expect(readErrorCode(real)).toBe("VALIDATION_FAILED");
+    expect(
+      classify(probe({ kind: "invented_argument", acceptedErrorCodes: ["VALIDATION_FAILED"] }), real, CODES),
+    ).toMatchObject({ status: "refused", errorCode: "VALIDATION_FAILED" });
+  });
+
+  it("fails a bare SDK-shaped refusal, which is what a lost code looks like", () => {
+    // Not the server's builder: an error that escaped the wrapper carries only
+    // prose, and the harness has to call that a defect rather than a refusal.
+    const unwrapped = { isError: true, content: [{ type: "text", text: "MCP error -32602: Invalid arguments" }] };
+
+    expect(classify(probe({ kind: "invented_argument" }), unwrapped, CODES)).toMatchObject({ status: "failed" });
+  });
+});
+
+describe("the operator report", () => {
+  const result = (overrides: Partial<ProbeResult>): ProbeResult => ({
+    tool: "tickets.get",
+    kind: "valid",
+    status: "ok",
+    placeholders: [],
+    ...overrides,
+  });
+
+  it("reduces a tool's probes to one verdict, worst first", () => {
+    expect(verdictFor([result({ status: "ok" }), result({ status: "failed" })])).toBe("FAILS");
+    expect(verdictFor([result({ status: "ok" }), result({ status: "refused" })])).toBe("works");
+    expect(verdictFor([result({ status: "refused" }), result({ status: "refused" })])).toBe("refuses correctly");
+    expect(verdictFor([result({ status: "withheld" })])).toBe("not exercised");
+    expect(verdictFor([])).toBe("not exercised");
+  });
+
+  const base: DogfoodReport = {
+    baseUrl: "https://example.invalid/mcp",
+    tokenLength: null,
+    outcome: "auth_rejected",
+    contractHash: CONTRACT.contractHash,
+    contractTools: CONTRACT.tools.map((tool) => tool.name),
+    missingFromServer: [],
+    undeclaredOnServer: [],
+    notExercised: CONTRACT.tools.map((tool) => tool.name),
+    results: [],
+    rejection: { status: 401, wwwAuthenticate: 'Bearer realm="mcp"' },
+  };
+
+  it("says plainly that an auth-rejected run checked nothing behind the gate", () => {
+    const text = renderReport(base);
+
+    expect(text).toContain("AUTH_REJECTED");
+    expect(text).toContain("not a defect");
+    expect(text).toContain("NOT CALLED AT ALL");
+  });
+
+  it("names every uncalled tool rather than reporting a clean sweep", () => {
+    const text = renderReport({
+      ...base,
+      outcome: "ok",
+      notExercised: ["workflows.dispatch"],
+      results: [result({ status: "withheld", detail: "mutating tool, needs --allow-dispatch", tool: "workflows.dispatch" })],
+    });
+
+    expect(text).toContain("NOT CALLED AT ALL (1): workflows.dispatch");
+    expect(text).toContain("Withheld on purpose");
+  });
+
+  it("never prints the token, only its length", () => {
+    const text = renderReport({ ...base, tokenLength: 64 });
+
+    expect(text).toContain("supplied, 64 chars");
+    expect(text).not.toMatch(/Bearer [A-Za-z0-9._-]{10,}/);
+  });
+});

--- a/apps/worker/src/mcp-dogfood/dogfood.test.ts
+++ b/apps/worker/src/mcp-dogfood/dogfood.test.ts
@@ -4,7 +4,13 @@ import { McpPublicError } from "../mcp/contracts.js";
 import { mcpToolErrorResult } from "../mcp/tool-catalog.js";
 import { loadContract, planProbes, sampleArguments, INVENTED_ARGUMENT } from "./plan.js";
 import { renderReport, verdictFor } from "./report.js";
-import { classify, readErrorCode, type DogfoodReport, type ProbeResult } from "./run.js";
+import {
+  classify,
+  compareSurface,
+  readErrorCode,
+  type DogfoodReport,
+  type ProbeResult,
+} from "./run.js";
 
 const CONTRACT = loadContract();
 const CODES = CONTRACT.errorCodes;
@@ -92,6 +98,21 @@ describe("the probe plan comes from the contract", () => {
 });
 
 describe("classifying what a tool answered", () => {
+  it("fails the surface gate for a missing hash or any tool drift", () => {
+    expect(
+      compareSurface({
+        contractHash: "expected",
+        serverContractHash: undefined,
+        contractTools: ["tickets.get"],
+        serverTools: ["tickets.get", "runs.get"],
+      }),
+    ).toEqual({
+      matches: false,
+      missingFromServer: [],
+      undeclaredOnServer: ["runs.get"],
+    });
+  });
+
   it("reads the contract error code out of the text content", () => {
     expect(readErrorCode(errorResult("NOT_FOUND"))).toBe("NOT_FOUND");
     expect(readErrorCode({ isError: true, content: [{ type: "text", text: "Invalid arguments" }] })).toBeNull();

--- a/apps/worker/src/mcp-dogfood/plan.ts
+++ b/apps/worker/src/mcp-dogfood/plan.ts
@@ -182,6 +182,8 @@ export function planProbes(
     // operator asks. Skipping it silently would be the worse failure, so the
     // probe is still planned and reports itself as withheld.
     const mutating = tool.annotations?.readOnlyHint !== true;
+    const policyGated = mutating || tool.name === "workflows.dispatch_preflight";
+    const policyRefusals = policyGated ? ["FORBIDDEN", "INSUFFICIENT_SCOPE"] : [];
     const allowedMutation = tool.name === "workflows.dispatch" && options.allowDispatch;
     const withhold = mutating && !allowedMutation;
     probes.push({
@@ -200,14 +202,14 @@ export function planProbes(
       // built from the contract are refused however correct the tool is.
       // Calling that a failure would cry wolf; hiding it would claim a happy
       // path nobody walked. The report names it under Coverage instead.
-      acceptedErrorCodes: ["NOT_FOUND", "VALIDATION_FAILED"],
+      acceptedErrorCodes: ["NOT_FOUND", "VALIDATION_FAILED", ...policyRefusals],
       placeholders,
     });
     probes.push({
       tool: tool.name,
       kind: "invented_argument",
       args: { ...args, [INVENTED_ARGUMENT]: 1 },
-      acceptedErrorCodes: ["VALIDATION_FAILED"],
+      acceptedErrorCodes: ["VALIDATION_FAILED", ...policyRefusals],
       placeholders,
     });
   }

--- a/apps/worker/src/mcp-dogfood/plan.ts
+++ b/apps/worker/src/mcp-dogfood/plan.ts
@@ -1,0 +1,205 @@
+// Turns the frozen MCP contract into a probe plan.
+//
+// Lives outside src/mcp on purpose. That directory is the server's own code and
+// a parallel stream is actively changing it; this is an operator tool that reads
+// the contract and talks to a deployment over the network, so it has no business
+// sharing a folder with the thing it is checking.
+//
+// Everything here is derived from the contract artifact rather than written out
+// by hand, which is the point: when a tool is added to the contract it gets both
+// of its probes with nobody editing this file. A hand-kept list would drift, and
+// a drifting list reports full coverage of a surface it never touched.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export type JsonSchema = {
+  type?: string;
+  const?: unknown;
+  enum?: unknown[];
+  format?: string;
+  pattern?: string;
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  minLength?: number;
+  maxLength?: number;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema;
+  anyOf?: JsonSchema[];
+  oneOf?: JsonSchema[];
+};
+
+export type ContractTool = {
+  name: string;
+  description?: string;
+  inputSchema: JsonSchema;
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+};
+
+export type Contract = {
+  contractHash: string;
+  errorCodes: string[];
+  tools: ContractTool[];
+};
+
+/** Real identifiers an operator can supply so the happy path is really exercised. */
+export type DogfoodFixtures = {
+  ticketKey?: string;
+  runId?: string;
+  definitionId?: number;
+  triggerNodeId?: string;
+};
+
+export type ProbeKind = "valid" | "invented_argument";
+
+export type Probe = {
+  tool: string;
+  kind: ProbeKind;
+  /** Undefined means the probe is planned but deliberately not sent. */
+  args?: Record<string, unknown>;
+  /** Error codes that mean the tool refused correctly rather than broke. */
+  acceptedErrorCodes: string[];
+  /** Set when the probe is planned but withheld, and why, so it can be reported. */
+  skipped?: string;
+  /** Argument names filled with a placeholder because no fixture was given. */
+  placeholders: string[];
+};
+
+const DEFAULT_CONTRACT_PATH = fileURLToPath(
+  new URL("../mcp/contracts/mcp-contract.json", import.meta.url),
+);
+
+export function loadContract(path: string = DEFAULT_CONTRACT_PATH): Contract {
+  const contract = JSON.parse(readFileSync(path, "utf8")) as Contract;
+  if (!Array.isArray(contract.tools) || contract.tools.length === 0) {
+    throw new Error(`contract at ${path} declares no tools`);
+  }
+  return contract;
+}
+
+/**
+ * A string that satisfies the schema it is given. Pattern and format come first
+ * because a value that fails the schema would be refused by validation, and a
+ * probe refused for the wrong reason proves nothing about the tool behind it.
+ */
+function sampleString(schema: JsonSchema): string {
+  if (typeof schema.const === "string") return schema.const;
+  if (schema.pattern) {
+    // The only patterns the contract uses are anchored literal-plus-hex, so a
+    // matching sample is built rather than solved. An unrecognised pattern is
+    // surfaced instead of guessed, because a guess would read as a tool defect.
+    const sha256 = /^\^sha256:\[0-9a-f\]\{64\}\$$/.exec(schema.pattern);
+    if (sha256) return `sha256:${"0".repeat(64)}`;
+    throw new Error(`no sample for pattern ${schema.pattern}`);
+  }
+  if (schema.format === "uuid") return "00000000-0000-4000-8000-000000000000";
+  if (schema.format === "uri") return "https://example.invalid/pull/1";
+  return "dogfood-placeholder";
+}
+
+function sampleValue(schema: JsonSchema, name: string, fixtures: DogfoodFixtures, placeholders: string[]): unknown {
+  // A named fixture always wins: it is the only way the valid probe reaches
+  // real data instead of bouncing off NOT_FOUND.
+  if (name === "ticketKey" && fixtures.ticketKey) return fixtures.ticketKey;
+  if (name === "runId" && fixtures.runId) return fixtures.runId;
+  if (name === "definitionId" && fixtures.definitionId !== undefined) return fixtures.definitionId;
+  if (name === "triggerNodeId" && fixtures.triggerNodeId) return fixtures.triggerNodeId;
+
+  if (schema.const !== undefined) return schema.const;
+  if (schema.enum?.length) return schema.enum[0];
+
+  const branches = schema.anyOf ?? schema.oneOf;
+  // First branch, deterministically: the plan has to be the same on every run
+  // or two reports of the same deployment stop being comparable.
+  if (branches?.length) return sampleValue(branches[0]!, name, fixtures, placeholders);
+
+  switch (schema.type) {
+    case "object": {
+      const value: Record<string, unknown> = {};
+      for (const key of schema.required ?? []) {
+        const property = schema.properties?.[key];
+        if (property) value[key] = sampleValue(property, key, fixtures, placeholders);
+      }
+      return value;
+    }
+    case "array":
+      return schema.items ? [sampleValue(schema.items, name, fixtures, placeholders)] : [];
+    case "integer":
+    case "number": {
+      const floor = schema.exclusiveMinimum !== undefined ? schema.exclusiveMinimum + 1 : schema.minimum ?? 1;
+      placeholders.push(name);
+      return floor;
+    }
+    case "boolean":
+      return true;
+    default: {
+      const value = sampleString(schema);
+      if (value === "dogfood-placeholder") placeholders.push(name);
+      return value;
+    }
+  }
+}
+
+/** Required arguments only: an optional argument the tool never sees cannot break it. */
+export function sampleArguments(
+  tool: ContractTool,
+  fixtures: DogfoodFixtures,
+): { args: Record<string, unknown>; placeholders: string[] } {
+  const placeholders: string[] = [];
+  const args = sampleValue(tool.inputSchema, tool.name, fixtures, placeholders) as Record<string, unknown>;
+  return { args, placeholders };
+}
+
+/**
+ * The invented argument every tool is probed with. The contract closes every
+ * object with additionalProperties: false, so this is refused by the tool's own
+ * validation on every tool including the ones that take no arguments at all,
+ * which is what makes one universal negative probe possible. It also never
+ * reaches an effect: validation runs before the tool body, so it is safe to
+ * send at a mutating tool.
+ *
+ * The name is deliberately dull. An argument name shaped like an instruction is
+ * a separate concern the server already tests, and smuggling one in here would
+ * put it in the operator's report.
+ */
+export const INVENTED_ARGUMENT = "dogfoodNotAnArgument";
+
+export function planProbes(
+  contract: Contract,
+  fixtures: DogfoodFixtures,
+  options: { allowDispatch: boolean },
+): Probe[] {
+  const probes: Probe[] = [];
+  for (const tool of contract.tools) {
+    const { args, placeholders } = sampleArguments(tool, fixtures);
+    // A tool that can change something is not called for real unless the
+    // operator asks. Skipping it silently would be the worse failure, so the
+    // probe is still planned and reports itself as withheld.
+    const mutating = tool.annotations?.readOnlyHint !== true;
+    const withhold = mutating && !options.allowDispatch;
+    probes.push({
+      tool: tool.name,
+      kind: "valid",
+      ...(withhold ? { skipped: "mutating tool, needs --allow-dispatch" } : { args }),
+      // Placeholder identifiers cannot match real rows, so NOT_FOUND is the
+      // tool working, not failing. With fixtures it still counts: the operator
+      // may have handed over an identifier this deployment does not hold.
+      acceptedErrorCodes: ["NOT_FOUND"],
+      placeholders,
+    });
+    probes.push({
+      tool: tool.name,
+      kind: "invented_argument",
+      args: { ...args, [INVENTED_ARGUMENT]: 1 },
+      acceptedErrorCodes: ["VALIDATION_FAILED"],
+      placeholders,
+    });
+  }
+  return probes;
+}

--- a/apps/worker/src/mcp-dogfood/plan.ts
+++ b/apps/worker/src/mcp-dogfood/plan.ts
@@ -190,7 +190,14 @@ export function planProbes(
       // Placeholder identifiers cannot match real rows, so NOT_FOUND is the
       // tool working, not failing. With fixtures it still counts: the operator
       // may have handed over an identifier this deployment does not hold.
-      acceptedErrorCodes: ["NOT_FOUND"],
+      //
+      // VALIDATION_FAILED is accepted too, and reported as a coverage gap
+      // rather than a defect. A tool can require "one of these two optional
+      // fields", which JSON Schema here does not express, so the arguments
+      // built from the contract are refused however correct the tool is.
+      // Calling that a failure would cry wolf; hiding it would claim a happy
+      // path nobody walked. The report names it under Coverage instead.
+      acceptedErrorCodes: ["NOT_FOUND", "VALIDATION_FAILED"],
       placeholders,
     });
     probes.push({

--- a/apps/worker/src/mcp-dogfood/plan.ts
+++ b/apps/worker/src/mcp-dogfood/plan.ts
@@ -182,11 +182,14 @@ export function planProbes(
     // operator asks. Skipping it silently would be the worse failure, so the
     // probe is still planned and reports itself as withheld.
     const mutating = tool.annotations?.readOnlyHint !== true;
-    const withhold = mutating && !options.allowDispatch;
+    const allowedMutation = tool.name === "workflows.dispatch" && options.allowDispatch;
+    const withhold = mutating && !allowedMutation;
     probes.push({
       tool: tool.name,
       kind: "valid",
-      ...(withhold ? { skipped: "mutating tool, needs --allow-dispatch" } : { args }),
+      ...(withhold
+        ? { skipped: "mutating tool withheld; only workflows.dispatch has an explicit opt-in" }
+        : { args }),
       // Placeholder identifiers cannot match real rows, so NOT_FOUND is the
       // tool working, not failing. With fixtures it still counts: the operator
       // may have handed over an identifier this deployment does not hold.

--- a/apps/worker/src/mcp-dogfood/report.ts
+++ b/apps/worker/src/mcp-dogfood/report.ts
@@ -1,0 +1,118 @@
+// Renders the run as something an operator can act on without knowing how any
+// of this works. Kept apart from run.ts because the verdict wording is the
+// deliverable here, not a detail of the transport.
+import type { DogfoodReport, ProbeResult } from "./run.js";
+
+export type ToolVerdict = "works" | "refuses correctly" | "FAILS" | "auth rejected" | "not exercised";
+
+export function verdictFor(results: ProbeResult[]): ToolVerdict {
+  if (results.length === 0) return "not exercised";
+  if (results.some((result) => result.status === "failed")) return "FAILS";
+  if (results.some((result) => result.status === "auth_rejected")) return "auth rejected";
+  const sent = results.filter((result) => result.status !== "withheld");
+  if (sent.length === 0) return "not exercised";
+  // Every tool is probed with a real call and an invented argument. Working
+  // means the real call answered; refusing correctly means it declined for a
+  // reason the contract names, which is what a placeholder identifier earns.
+  return sent.some((result) => result.status === "ok") ? "works" : "refuses correctly";
+}
+
+function line(label: string, value: string | number | undefined): string | null {
+  return value === undefined || value === "" ? null : `  ${label.padEnd(18)} ${value}`;
+}
+
+export function renderReport(report: DogfoodReport): string {
+  const out: string[] = [];
+  const byTool = new Map<string, ProbeResult[]>();
+  for (const name of report.contractTools) byTool.set(name, []);
+  for (const result of report.results) {
+    byTool.set(result.tool, [...(byTool.get(result.tool) ?? []), result]);
+  }
+
+  out.push("MCP dogfood report");
+  out.push(
+    ...[
+      line("endpoint", report.baseUrl),
+      line("outcome", report.outcome.toUpperCase()),
+      line("token", report.tokenLength === null ? "none supplied" : `supplied, ${report.tokenLength} chars`),
+      line("contract tools", report.contractTools.length),
+      line("contract hash", report.contractHash.slice(0, 12)),
+      line("server hash", report.serverContractHash?.slice(0, 12)),
+      line("server version", report.serverVersion),
+      line("protocol", report.protocolVersion),
+    ].filter((entry): entry is string => entry !== null),
+  );
+
+  if (report.outcome === "auth_rejected") {
+    out.push("");
+    out.push("  Every call was refused by auth. That is the deployment behaving correctly,");
+    out.push("  not a defect. Nothing behind the auth gate was reached, so no tool below");
+    out.push("  has been checked. Re-run with a token to exercise the surface.");
+    if (report.rejection) {
+      out.push(`  HTTP ${report.rejection.status}, WWW-Authenticate: ${report.rejection.wwwAuthenticate ?? "absent"}`);
+    }
+  }
+  if (report.error) {
+    out.push("");
+    out.push(`  Could not complete: ${report.error}`);
+  }
+  if (report.serverContractHash && report.serverContractHash !== report.contractHash) {
+    out.push("");
+    out.push("  The deployment answers with a different contract hash than the one in this");
+    out.push("  checkout. The surface below was planned from the checkout, so treat any");
+    out.push("  mismatch as this harness being out of date rather than the server.");
+  }
+
+  out.push("");
+  out.push("Per tool");
+  for (const [tool, results] of byTool) {
+    const verdict = verdictFor(results);
+    out.push(`  ${verdict.padEnd(17)} ${tool}`);
+    for (const result of results) {
+      if (result.status === "failed") {
+        const code = result.errorCode ? ` (${result.errorCode})` : "";
+        out.push(`      ${result.kind}: ${result.detail ?? "failed"}${code}`);
+      }
+      if (result.status === "withheld") {
+        out.push(`      ${result.kind}: not sent, ${result.detail}`);
+      }
+    }
+  }
+
+  // A silent coverage hole reads as a clean sweep, so it gets its own section
+  // even when it is empty.
+  out.push("");
+  out.push("Coverage");
+  const notExercised = report.notExercised;
+  out.push(
+    notExercised.length === 0
+      ? "  Every tool in the contract was called."
+      : `  NOT CALLED AT ALL (${notExercised.length}): ${notExercised.join(", ")}`,
+  );
+  const withheld = report.results.filter((result) => result.status === "withheld");
+  if (withheld.length > 0) {
+    out.push(`  Withheld on purpose: ${withheld.map((result) => `${result.tool} (${result.kind})`).join(", ")}`);
+  }
+  if (report.missingFromServer.length > 0) {
+    out.push(`  In the contract, not advertised by the deployment: ${report.missingFromServer.join(", ")}`);
+  }
+  if (report.undeclaredOnServer.length > 0) {
+    out.push(`  Advertised by the deployment, not in the contract: ${report.undeclaredOnServer.join(", ")}`);
+  }
+  // Only probes that actually reached a tool. A run stopped at the auth gate
+  // called nothing, and saying it called anything would be the same lie the
+  // coverage section exists to prevent.
+  const reached = new Set(["ok", "refused", "failed"]);
+  const placeholders = report.results.filter(
+    (result) => reached.has(result.status) && result.placeholders.length > 0,
+  );
+  if (placeholders.length > 0) {
+    const tools = [...new Set(placeholders.map((result) => result.tool))];
+    out.push(
+      `  Called with placeholder identifiers, so a refusal proves reachability only: ${tools.join(", ")}`,
+    );
+    out.push("  Pass --ticket / --run / --definition / --trigger to exercise the real path.");
+  }
+
+  return out.join("\n");
+}

--- a/apps/worker/src/mcp-dogfood/report.ts
+++ b/apps/worker/src/mcp-dogfood/report.ts
@@ -45,9 +45,14 @@ export function renderReport(report: DogfoodReport): string {
 
   if (report.outcome === "auth_rejected") {
     out.push("");
-    out.push("  Every call was refused by auth. That is the deployment behaving correctly,");
-    out.push("  not a defect. Nothing behind the auth gate was reached, so no tool below");
-    out.push("  has been checked. Re-run with a token to exercise the surface.");
+    if (report.tokenLength === null) {
+      out.push("  Every call was refused by auth. That is the deployment behaving correctly,");
+      out.push("  not a defect. Nothing behind the auth gate was reached, so no tool below");
+      out.push("  has been checked. Re-run with a token to exercise the surface.");
+    } else {
+      out.push("  The supplied token was rejected. Authenticated MCP was not exercised and");
+      out.push("  this run fails even though the unauthenticated boundary remained closed.");
+    }
     if (report.rejection) {
       out.push(`  HTTP ${report.rejection.status}, WWW-Authenticate: ${report.rejection.wwwAuthenticate ?? "absent"}`);
     }

--- a/apps/worker/src/mcp-dogfood/report.ts
+++ b/apps/worker/src/mcp-dogfood/report.ts
@@ -56,7 +56,7 @@ export function renderReport(report: DogfoodReport): string {
     out.push("");
     out.push(`  Could not complete: ${report.error}`);
   }
-  if (report.serverContractHash && report.serverContractHash !== report.contractHash) {
+  if (report.outcome !== "auth_rejected" && report.serverContractHash !== report.contractHash) {
     out.push("");
     out.push("  The deployment answers with a different contract hash than the one in this");
     out.push("  checkout. The surface below was planned from the checkout, so treat any");

--- a/apps/worker/src/mcp-dogfood/report.ts
+++ b/apps/worker/src/mcp-dogfood/report.ts
@@ -93,6 +93,18 @@ export function renderReport(report: DogfoodReport): string {
   if (withheld.length > 0) {
     out.push(`  Withheld on purpose: ${withheld.map((result) => `${result.tool} (${result.kind})`).join(", ")}`);
   }
+  // A tool that refused the arguments built from its own schema was reached but
+  // never actually exercised. It counts as coverage lost, not as a defect.
+  const unconstructible = report.results.filter(
+    (result) => result.kind === "valid" && result.status === "refused" && result.errorCode === "VALIDATION_FAILED",
+  );
+  if (unconstructible.length > 0) {
+    out.push(
+      `  Happy path NOT reached, the contract alone does not describe a valid call: ${unconstructible
+        .map((result) => result.tool)
+        .join(", ")}`,
+    );
+  }
   if (report.missingFromServer.length > 0) {
     out.push(`  In the contract, not advertised by the deployment: ${report.missingFromServer.join(", ")}`);
   }

--- a/apps/worker/src/mcp-dogfood/run.ts
+++ b/apps/worker/src/mcp-dogfood/run.ts
@@ -46,6 +46,24 @@ type ToolCallResult = {
   structuredContent?: unknown;
 };
 
+export function compareSurface(input: {
+  contractHash: string;
+  serverContractHash: string | undefined;
+  contractTools: readonly string[];
+  serverTools: readonly string[];
+}): { matches: boolean; missingFromServer: string[]; undeclaredOnServer: string[] } {
+  const missingFromServer = input.contractTools.filter((name) => !input.serverTools.includes(name));
+  const undeclaredOnServer = input.serverTools.filter((name) => !input.contractTools.includes(name));
+  return {
+    matches:
+      input.serverContractHash === input.contractHash &&
+      missingFromServer.length === 0 &&
+      undeclaredOnServer.length === 0,
+    missingFromServer,
+    undeclaredOnServer,
+  };
+}
+
 /** Same trick mcp-smoke.ts uses: the SDK transport keeps the status and drops the header. */
 function fetchCapturingRejection(rejection: { current: DogfoodReport["rejection"] | null }): FetchLike {
   return async (input, init) => {
@@ -248,7 +266,13 @@ export async function runDogfood(input: {
       results.filter((result) => result.status !== "withheld").map((result) => result.tool),
     );
     const authRejected = results.some((result) => result.status === "auth_rejected");
-    const failed = results.some((result) => result.status === "failed");
+    const surface = compareSurface({
+      contractHash: input.contract.contractHash,
+      serverContractHash,
+      contractTools,
+      serverTools,
+    });
+    const failed = results.some((result) => result.status === "failed") || !surface.matches;
 
     return {
       ...skeleton,
@@ -257,8 +281,8 @@ export async function runDogfood(input: {
       ...(serverVersion === undefined ? {} : { serverVersion }),
       protocolVersion: transport.protocolVersion,
       serverTools,
-      missingFromServer: contractTools.filter((name) => !serverTools.includes(name)),
-      undeclaredOnServer: serverTools.filter((name) => !contractTools.includes(name)),
+      missingFromServer: surface.missingFromServer,
+      undeclaredOnServer: surface.undeclaredOnServer,
       notExercised: contractTools.filter((name) => !reached.has(name)),
       results,
     };

--- a/apps/worker/src/mcp-dogfood/run.ts
+++ b/apps/worker/src/mcp-dogfood/run.ts
@@ -297,5 +297,7 @@ export async function runDogfood(input: {
 }
 
 export function dogfoodExitCode(report: DogfoodReport): 0 | 1 {
-  return report.outcome === "failure" ? 1 : 0;
+  if (report.outcome === "failure") return 1;
+  if (report.outcome === "auth_rejected" && report.tokenLength !== null) return 1;
+  return 0;
 }

--- a/apps/worker/src/mcp-dogfood/run.ts
+++ b/apps/worker/src/mcp-dogfood/run.ts
@@ -1,0 +1,277 @@
+// Runs the probe plan against a deployed /mcp endpoint and classifies what came
+// back. Talks to the real network through the MCP SDK client, never through
+// src/mcp/server.ts, for the same reason mcp-smoke.ts does not: importing the
+// server would produce a check that stays green while the deployment is down.
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+import { resolveMcpEndpoint } from "../mcp/smoke-client.js";
+import { type Contract, type DogfoodFixtures, planProbes, type Probe, type ProbeKind } from "./plan.js";
+
+export type ProbeStatus = "ok" | "refused" | "failed" | "withheld" | "auth_rejected";
+
+export type ProbeResult = {
+  tool: string;
+  kind: ProbeKind;
+  status: ProbeStatus;
+  errorCode?: string;
+  /** Always safe to print: never carries a token and never carries a raw body. */
+  detail?: string;
+  placeholders: string[];
+};
+
+export type DogfoodReport = {
+  baseUrl: string;
+  /** The token itself is never stored, printed, or returned. */
+  tokenLength: number | null;
+  outcome: "ok" | "auth_rejected" | "failure";
+  contractHash: string;
+  serverContractHash?: string;
+  serverVersion?: string;
+  protocolVersion?: string;
+  contractTools: string[];
+  serverTools?: string[];
+  missingFromServer: string[];
+  undeclaredOnServer: string[];
+  notExercised: string[];
+  results: ProbeResult[];
+  rejection?: { status: number; wwwAuthenticate: string | null };
+  error?: string;
+};
+
+type ToolCallResult = {
+  isError?: boolean;
+  content?: unknown;
+  structuredContent?: unknown;
+};
+
+/** Same trick mcp-smoke.ts uses: the SDK transport keeps the status and drops the header. */
+function fetchCapturingRejection(rejection: { current: DogfoodReport["rejection"] | null }): FetchLike {
+  return async (input, init) => {
+    const response = await fetch(input, init);
+    if (response.status === 401) {
+      rejection.current = {
+        status: response.status,
+        wwwAuthenticate: response.headers.get("WWW-Authenticate"),
+      };
+    }
+    return response;
+  };
+}
+
+function safeMessage(error: unknown, token: string | undefined): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const withoutToken = token ? message.split(token).join("[redacted]") : message;
+  // Bounded because this lands in an operator's report, and an adapter failure
+  // can carry a whole response body.
+  return withoutToken.length > 300 ? `${withoutToken.slice(0, 300)}...` : withoutToken;
+}
+
+/**
+ * The contract's error shape, pulled out of the text content. Errors carry no
+ * structuredContent: the code travels in the JSON body of the first text block
+ * because the SDK's own tool-error path forwards only `error.message`. Reading
+ * it back here is the whole point of the negative probes, since a server that
+ * regressed to bare prose still answers isError and would otherwise look fine.
+ */
+export function readErrorCode(result: ToolCallResult): string | null {
+  const content = Array.isArray(result.content) ? result.content : [];
+  const first = content[0] as { type?: string; text?: string } | undefined;
+  if (typeof first?.text !== "string") return null;
+  try {
+    const parsed = JSON.parse(first.text) as { error?: { code?: unknown } };
+    return typeof parsed.error?.code === "string" ? parsed.error.code : null;
+  } catch {
+    return null;
+  }
+}
+
+export function classify(
+  probe: Probe,
+  result: ToolCallResult,
+  contractErrorCodes: readonly string[],
+): ProbeResult {
+  const base = { tool: probe.tool, kind: probe.kind, placeholders: probe.placeholders };
+
+  if (result.isError) {
+    const code = readErrorCode(result);
+    if (code === null) {
+      return {
+        ...base,
+        status: "failed",
+        detail: "refused without a contract error code, so a caller cannot tell why",
+      };
+    }
+    if (!contractErrorCodes.includes(code)) {
+      return { ...base, status: "failed", errorCode: code, detail: "error code is not in the contract" };
+    }
+    if (probe.acceptedErrorCodes.includes(code)) {
+      return { ...base, status: "refused", errorCode: code };
+    }
+    return {
+      ...base,
+      status: "failed",
+      errorCode: code,
+      detail: `expected ${probe.acceptedErrorCodes.join(" or ")}`,
+    };
+  }
+
+  // A negative probe that succeeded is a hole in validation, not a pass.
+  if (probe.kind === "invented_argument") {
+    return { ...base, status: "failed", detail: "accepted an argument the contract does not declare" };
+  }
+
+  const envelope = result.structuredContent as { data?: unknown; meta?: { contractHash?: string } } | undefined;
+  if (!envelope?.meta) {
+    return { ...base, status: "failed", detail: "answered without the contract envelope" };
+  }
+  return { ...base, status: "ok" };
+}
+
+export async function runDogfood(input: {
+  baseUrl: string;
+  token: string | undefined;
+  contract: Contract;
+  fixtures: DogfoodFixtures;
+  allowDispatch: boolean;
+}): Promise<DogfoodReport> {
+  const tokenLength = input.token ? input.token.length : null;
+  const contractTools = input.contract.tools.map((tool) => tool.name);
+  const probes = planProbes(input.contract, input.fixtures, { allowDispatch: input.allowDispatch });
+  const rejection: { current: DogfoodReport["rejection"] | null } = { current: null };
+
+  const skeleton: DogfoodReport = {
+    baseUrl: input.baseUrl,
+    tokenLength,
+    outcome: "failure",
+    contractHash: input.contract.contractHash,
+    contractTools,
+    missingFromServer: [],
+    undeclaredOnServer: [],
+    notExercised: contractTools,
+    results: [],
+  };
+
+  const transport = new StreamableHTTPClientTransport(resolveMcpEndpoint(input.baseUrl), {
+    requestInit: input.token ? { headers: { Authorization: `Bearer ${input.token}` } } : undefined,
+    fetch: fetchCapturingRejection(rejection),
+  });
+  const client = new Client({ name: "ai-workflow-mcp-dogfood", version: "0.1.0" });
+
+  try {
+    await client.connect(transport);
+  } catch (error) {
+    // A refusal here is the deployment enforcing auth, which is a pass. Every
+    // tool is reported as unreached rather than silently dropped.
+    if (rejection.current) {
+      return {
+        ...skeleton,
+        outcome: "auth_rejected",
+        rejection: rejection.current,
+        results: probes.map((probe) => ({
+          tool: probe.tool,
+          kind: probe.kind,
+          status: "auth_rejected" as const,
+          placeholders: probe.placeholders,
+        })),
+      };
+    }
+    return { ...skeleton, error: safeMessage(error, input.token) };
+  }
+
+  try {
+    const listed = await client.listTools();
+    const serverTools = listed.tools.map((tool) => tool.name);
+    const results: ProbeResult[] = [];
+    let serverContractHash: string | undefined;
+    let serverVersion: string | undefined;
+
+    for (const probe of probes) {
+      if (probe.skipped) {
+        results.push({
+          tool: probe.tool,
+          kind: probe.kind,
+          status: "withheld",
+          detail: probe.skipped,
+          placeholders: probe.placeholders,
+        });
+        continue;
+      }
+      // A tool in the contract the deployment never advertised cannot be
+      // called; saying so beats a transport error the reader has to decode.
+      if (!serverTools.includes(probe.tool)) {
+        results.push({
+          tool: probe.tool,
+          kind: probe.kind,
+          status: "failed",
+          detail: "the deployment does not advertise this tool",
+          placeholders: probe.placeholders,
+        });
+        continue;
+      }
+      try {
+        const result = (await client.callTool({
+          name: probe.tool,
+          arguments: probe.args,
+        })) as ToolCallResult;
+        const envelope = result.structuredContent as
+          | { meta?: { contractHash?: string; serverVersion?: string } }
+          | undefined;
+        serverContractHash ??= envelope?.meta?.contractHash;
+        serverVersion ??= envelope?.meta?.serverVersion;
+        results.push(classify(probe, result, input.contract.errorCodes));
+      } catch (error) {
+        if (rejection.current) {
+          results.push({
+            tool: probe.tool,
+            kind: probe.kind,
+            status: "auth_rejected",
+            placeholders: probe.placeholders,
+          });
+          continue;
+        }
+        // The SDK throwing instead of answering means the contract's error
+        // shape never reached the caller, which is the exact regression the
+        // negative probes exist to catch.
+        results.push({
+          tool: probe.tool,
+          kind: probe.kind,
+          status: "failed",
+          detail: `threw instead of answering: ${safeMessage(error, input.token)}`,
+          placeholders: probe.placeholders,
+        });
+      }
+    }
+
+    const reached = new Set(
+      results.filter((result) => result.status !== "withheld").map((result) => result.tool),
+    );
+    const authRejected = results.some((result) => result.status === "auth_rejected");
+    const failed = results.some((result) => result.status === "failed");
+
+    return {
+      ...skeleton,
+      outcome: authRejected ? "auth_rejected" : failed ? "failure" : "ok",
+      ...(serverContractHash === undefined ? {} : { serverContractHash }),
+      ...(serverVersion === undefined ? {} : { serverVersion }),
+      protocolVersion: transport.protocolVersion,
+      serverTools,
+      missingFromServer: contractTools.filter((name) => !serverTools.includes(name)),
+      undeclaredOnServer: serverTools.filter((name) => !contractTools.includes(name)),
+      notExercised: contractTools.filter((name) => !reached.has(name)),
+      results,
+    };
+  } catch (error) {
+    if (rejection.current) {
+      return { ...skeleton, outcome: "auth_rejected", rejection: rejection.current };
+    }
+    return { ...skeleton, error: safeMessage(error, input.token) };
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+export function dogfoodExitCode(report: DogfoodReport): 0 | 1 {
+  return report.outcome === "failure" ? 1 : 0;
+}


### PR DESCRIPTION
Adds the contract-driven MCP dogfood harness and hardens its release gate. It now fails on contract/tool drift or a rejected supplied token, keeps mutations withheld by default, and only allows workflows.dispatch through an explicit opt-in.\n\nStacked on #263 until the MCP tool surface lands. Verified against the final 22-tool / 11-error contract: 30 focused tests and worker typecheck pass.