### PR TITLE
AIW-270: complete OAuth consent through the Better Auth handler

### DIFF
--- a/apps/worker/src/routes/mcp-auth/consent.post.test.ts
+++ b/apps/worker/src/routes/mcp-auth/consent.post.test.ts
@@ -4,12 +4,11 @@
 // one message, so this file drives the REAL handoff (GET sets the cookie and
 // renders the flow id, POST sends both back) rather than hand-building a cookie.
 import { createApp, eventHandler, toWebHandler } from "h3";
-import { APIError } from "better-auth/api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
   prelogin: vi.fn(),
-  consent: vi.fn(),
+  authHandler: vi.fn(),
   loggerWarn: vi.fn(),
   env: {
     BETTER_AUTH_SECRET: "test-secret",
@@ -23,9 +22,9 @@ vi.mock("../../../env.js", () => ({
 
 vi.mock("../../auth-instance.js", () => ({
   auth: {
+    handler: state.authHandler,
     api: {
       getOAuthClientPublicPrelogin: state.prelogin,
-      oauth2Consent: state.consent,
     },
   },
 }));
@@ -47,9 +46,9 @@ beforeEach(() => {
     client_name: "aiw-dogfood-pkce",
     redirect_uris: [],
   });
-  state.consent.mockResolvedValue({
-    url: `${REDIRECT_URI}?code=the-code&state=probe`,
-  });
+  state.authHandler.mockResolvedValue(
+    Response.json({ url: `${REDIRECT_URI}?code=the-code&state=probe` }),
+  );
 });
 
 function handlerFor(route: Parameters<typeof eventHandler>[0]) {
@@ -111,10 +110,17 @@ describe("MCP consent POST", () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe(`${REDIRECT_URI}?code=the-code&state=probe`);
-    expect(state.consent).toHaveBeenCalledOnce();
+    expect(state.authHandler).toHaveBeenCalledOnce();
+    const request = state.authHandler.mock.calls[0]?.[0] as Request;
+    expect(request.url).toBe("https://worker.example.com/api/auth/oauth2/consent");
+    expect(request.headers.get("content-type")).toBe("application/json");
+    expect(await request.clone().json()).toMatchObject({
+      accept: true,
+      scope: "mcp:read runs:dispatch",
+    });
     // The redirect_uri reaching the provider comes from the signed cookie, never
     // from the form, which is what keeps the form from being an open redirect.
-    expect(state.consent.mock.calls[0]?.[0]?.body?.oauth_query).toContain(
+    expect((await request.json()).oauth_query).toContain(
       "client_id=eiWzIXwrrXzrZboIhhEFKalUtICrwHCe",
     );
     expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
@@ -124,7 +130,8 @@ describe("MCP consent POST", () => {
     const { response } = await renderThenApprove("false");
 
     expect(response.status).toBe(302);
-    expect(state.consent.mock.calls[0]?.[0]?.body?.accept).toBe(false);
+    const request = state.authHandler.mock.calls[0]?.[0] as Request;
+    await expect(request.json()).resolves.toMatchObject({ accept: false });
   });
 
   it("still refuses a cross-origin post, which the reordered body read must not weaken", async () => {
@@ -140,7 +147,7 @@ describe("MCP consent POST", () => {
     );
 
     expect(response.status).toBe(403);
-    expect(state.consent).not.toHaveBeenCalled();
+    expect(state.authHandler).not.toHaveBeenCalled();
   });
 
   it("names the missing form field instead of blaming expiry", async () => {
@@ -187,9 +194,9 @@ describe("MCP consent POST", () => {
   });
 
   it("names a provider rejection instead of blaming expiry", async () => {
-    const error = new APIError("UNAUTHORIZED", { error: "invalid_signature" });
-    expect(error.message).toBe("");
-    state.consent.mockRejectedValue(error);
+    state.authHandler.mockResolvedValue(
+      Response.json({ error: "invalid_signature" }, { status: 400 }),
+    );
 
     const { response } = await renderThenApprove();
 
@@ -203,7 +210,7 @@ describe("MCP consent POST", () => {
 
   it("normalizes unknown provider errors without logging their details", async () => {
     const secret = "oauth-query-and-secret-details";
-    state.consent.mockRejectedValue(new Error(secret));
+    state.authHandler.mockResolvedValue(Response.json({ error: secret }, { status: 400 }));
 
     const { response } = await renderThenApprove();
 

--- a/apps/worker/src/routes/mcp-auth/consent.post.ts
+++ b/apps/worker/src/routes/mcp-auth/consent.post.ts
@@ -38,9 +38,8 @@ const AUTHORIZATION_FAILURE_CODES = new Set([
   "unsupported_response_type",
 ]);
 
-function normalizedAuthorizationFailureCode(error: unknown): string {
-  if (!isAPIError(error)) return "unknown";
-  const body = error.body;
+function normalizedAuthorizationFailureCode(value: unknown): string {
+  const body = isAPIError(value) ? value.body : value;
   if (!body || typeof body !== "object" || Array.isArray(body)) return "unknown";
   const code = "error" in body && typeof body.error === "string" ? body.error : null;
   return code && AUTHORIZATION_FAILURE_CODES.has(code) ? code : "unknown";
@@ -104,12 +103,20 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Invalid OAuth scope" });
   }
 
-  let result: Awaited<ReturnType<typeof auth.api.oauth2Consent>>;
+  let response: Response;
   try {
-    result = await auth.api.oauth2Consent({
-      body: { accept, scope: scopes.join(" "), oauth_query: oauthQuery },
-      headers: request.headers,
-    });
+    response = await auth.handler(
+      new Request(`${env.BETTER_AUTH_URL.replace(/\/$/, "")}/api/auth/oauth2/consent`, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          cookie: getHeader(event, "cookie") ?? "",
+          origin: new URL(env.BETTER_AUTH_URL).origin,
+        },
+        body: JSON.stringify({ accept, scope: scopes.join(" "), oauth_query: oauthQuery }),
+      }),
+    );
   } catch (error) {
     // Better Auth puts OAuth failures in APIError.body.error and may leave
     // Error.message empty. Only emit the small known code set; never log a raw
@@ -123,6 +130,21 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Authorization server rejected the consent",
     });
   }
+  const location = response.headers.get("location");
+  const result = (await response.json().catch(() => ({}))) as {
+    error?: unknown;
+    url?: unknown;
+  };
+  if ((!response.ok && !location) || (typeof result.url !== "string" && !location)) {
+    logger.warn(
+      { code: normalizedAuthorizationFailureCode(result) },
+      "mcp_consent_post_rejected_by_authorization_server",
+    );
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Authorization server rejected the consent",
+    });
+  }
   setResponseHeader(event, "set-cookie", clearOAuthFlowCookie());
-  return sendRedirect(event, result.url, 302);
+  return sendRedirect(event, location ?? String(result.url), 302);
 });


### PR DESCRIPTION
Production OAuth consent reached POST /mcp-auth/consent but Better Auth rejected it with invalid_request. The route called auth.api.oauth2Consent directly, bypassing the full HTTP endpoint pipeline that restores the signed oauth_query into request-local provider state. This patch sends the already validated consent payload through auth.handler at /api/auth/oauth2/consent, preserving the session cookie, same-origin check, scope filtering, and sanitized diagnostics.\n\nVerification: 43 focused OAuth/consent tests passed; worker typecheck passed. No Arthur deployment.