### PR TITLE
fix(worker): settle AIW-271 hanging runs

### DIFF
--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -3,7 +3,12 @@ import { eq } from "drizzle-orm";
 import { createTestDb } from "../../db/test-db.js";
 import type { Db } from "../../db/client.js";
 import type { ResolvedPromptReference } from "@shared/contracts";
-import { approvalRequests, clarificationRequests, workflowRuns } from "../../db/schema.js";
+import {
+  activeRuns,
+  approvalRequests,
+  clarificationRequests,
+  workflowRuns,
+} from "../../db/schema.js";
 import {
   upsertRunSnapshots,
   recordRunUsage,
@@ -18,6 +23,7 @@ import {
   markRunResumed,
   markRunSucceededOnSelfMove,
   sweepOrphanedAwaitingRuns,
+  sweepOrphanedRunningRuns,
   type RunSnapshot,
   type RunUsage,
   type RunBlockStatusWrite,
@@ -912,5 +918,53 @@ describe("sweepOrphanedAwaitingRuns", () => {
     expect(await sweepOrphanedAwaitingRuns(db)).toBe(1);
     expect(await sweepOrphanedAwaitingRuns(db)).toBe(0);
     expect((await row("wrun_orphan")).status).toBe("blocked");
+  });
+});
+
+describe("sweepOrphanedRunningRuns", () => {
+  it("settles a running row whose active claim disappeared", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_lost_claim",
+      subjectKey: "ticket:jira:PROJ-1",
+      ticketKey: "PROJ-1",
+      status: "running",
+    });
+
+    expect(await sweepOrphanedRunningRuns(db)).toBe(1);
+    expect((await row("wrun_lost_claim")).status).toBe("blocked");
+    expect((await row("wrun_lost_claim")).statusReason).toBe(
+      "Run lost its active claim before reaching a terminal status.",
+    );
+  });
+
+  it("leaves a running row alone while its exact claim remains active", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_claimed",
+      subjectKey: "ticket:jira:PROJ-1",
+      ticketKey: "PROJ-1",
+      status: "running",
+    });
+    await db.insert(activeRuns).values({
+      subjectKey: "ticket:jira:PROJ-1",
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-1",
+      runId: "wrun_claimed",
+      state: "bound",
+      runKind: "ticket",
+    });
+
+    expect(await sweepOrphanedRunningRuns(db)).toBe(0);
+    expect((await row("wrun_claimed")).status).toBe("running");
+  });
+
+  it("does not treat unclaimed post-PR gate rows as agent orphans", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_gate",
+      workflowId: "wf_post_pr_gate",
+      status: "running",
+    });
+
+    expect(await sweepOrphanedRunningRuns(db)).toBe(0);
+    expect((await row("wrun_gate")).status).toBe("running");
   });
 });

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -1,6 +1,21 @@
-import { and, eq, inArray, isNull, ne, notInArray, or, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  ne,
+  notInArray,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { Db } from "../../db/client.js";
-import { approvalRequests, clarificationRequests, workflowRuns } from "../../db/schema.js";
+import {
+  activeRuns,
+  approvalRequests,
+  clarificationRequests,
+  workflowRuns,
+} from "../../db/schema.js";
 import type {
   BlockRunState,
   HarnessRunManifestRecord,
@@ -594,6 +609,35 @@ export async function sweepOrphanedAwaitingRuns(db: Db): Promise<number> {
           select 1 from ${approvalRequests}
           where ${approvalRequests.runId} = ${workflowRuns.runId}
             and ${approvalRequests.status} = 'pending'
+        )`,
+      ),
+    )
+    .returning({ runId: workflowRuns.runId });
+  return rows.length;
+}
+
+/**
+ * Cron backstop for a run whose active owner disappeared before the workflow
+ * recorded a terminal outcome. Agent runs are the only workflow rows with a
+ * subject key; post-PR gate rows are intentionally unclaimed and must not be
+ * treated as orphans. A terminal blocked row is the same settled outcome used
+ * for an awaiting run with no continuation.
+ */
+export async function sweepOrphanedRunningRuns(db: Db): Promise<number> {
+  const rows = await db
+    .update(workflowRuns)
+    .set({
+      status: "blocked",
+      statusReason: "Run lost its active claim before reaching a terminal status.",
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(workflowRuns.status, "running"),
+        isNotNull(workflowRuns.subjectKey),
+        sql`not exists (
+          select 1 from ${activeRuns}
+          where ${activeRuns.runId} = ${workflowRuns.runId}
         )`,
       ),
     )

--- a/apps/worker/src/lib/trigger-delivery-store.test.ts
+++ b/apps/worker/src/lib/trigger-delivery-store.test.ts
@@ -4,6 +4,7 @@ import {
   activeRuns,
   workflowDefinitions,
   workflowDefinitionVersions,
+  workflowRuns,
 } from "../db/schema.js";
 import { createTestDb } from "../db/test-db.js";
 import {
@@ -188,10 +189,27 @@ describe("provider event inbox", () => {
     ).resolves.toBe(false);
     await expect(
       recordCandidateStartedTriggerDelivery(db, accepted, "owner-1", "run-1"),
+    ).resolves.toBe(false);
+    await db.insert(workflowRuns).values({
+      runId: "run-1",
+      subjectKey: accepted.subjectKey,
+      status: "running",
+    });
+    await expect(
+      recordCandidateStartedTriggerDelivery(db, accepted, "owner-1", "run-1"),
     ).resolves.toBe(true);
     await expect(
       acknowledgeStartedTriggerDelivery(db, accepted, "other-run"),
     ).resolves.toBe(false);
+    await db.delete(workflowRuns);
+    await expect(
+      acknowledgeStartedTriggerDelivery(db, accepted, "run-1"),
+    ).resolves.toBe(false);
+    await db.insert(workflowRuns).values({
+      runId: "run-1",
+      subjectKey: accepted.subjectKey,
+      status: "running",
+    });
     await expect(
       acknowledgeStartedTriggerDelivery(db, accepted, "run-1"),
     ).resolves.toBe(true);

--- a/apps/worker/src/lib/trigger-delivery-store.ts
+++ b/apps/worker/src/lib/trigger-delivery-store.ts
@@ -1,6 +1,6 @@
 import { and, asc, eq, sql } from "drizzle-orm";
 import type { Db } from "../db/client.js";
-import { activeRuns, triggerDeliveries } from "../db/schema.js";
+import { activeRuns, triggerDeliveries, workflowRuns } from "../db/schema.js";
 import { isUniqueViolation } from "./unique-violation.js";
 import type { PrTriggerType, TriggerEvent } from "./trigger-events.js";
 
@@ -298,6 +298,10 @@ export async function recordCandidateStartedTriggerDelivery(
             OR (${activeRuns.state} = 'bound' AND ${activeRuns.runId} = ${runId})
           )
       )
+      AND EXISTS (
+        SELECT 1 FROM ${workflowRuns}
+        WHERE ${workflowRuns.runId} = ${runId}
+      )
     RETURNING inbox.delivery_id
   `);
   return rawRows(updated).length === 1;
@@ -326,6 +330,10 @@ export async function acknowledgeStartedTriggerDelivery(
         WHERE ${activeRuns.subjectKey} = ${accepted.subjectKey}
           AND ${activeRuns.runId} = ${runId}
           AND ${activeRuns.state} = 'bound'
+      )
+      AND EXISTS (
+        SELECT 1 FROM ${workflowRuns}
+        WHERE ${workflowRuns.runId} = ${runId}
       )
       AND (
         inbox.result IS NULL

--- a/apps/worker/src/routes/cron/poll.get.test.ts
+++ b/apps/worker/src/routes/cron/poll.get.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   recoverManualDispatches: vi.fn(),
   listRecoverableManualDispatches: vi.fn(),
   sweepOrphanedAwaitingRuns: vi.fn(),
+  sweepOrphanedRunningRuns: vi.fn(),
   redispatchPendingWebhookDeliveries: vi.fn(),
   sweepWebhookRateLimits: vi.fn(),
   pruneMcpAudits: vi.fn(),
@@ -170,6 +171,8 @@ vi.mock("../../lib/telemetry/run-telemetry.js", () => ({
   upsertRunSnapshots: vi.fn().mockResolvedValue(undefined),
   sweepOrphanedAwaitingRuns: (...args: unknown[]) =>
     mocks.sweepOrphanedAwaitingRuns(...args),
+  sweepOrphanedRunningRuns: (...args: unknown[]) =>
+    mocks.sweepOrphanedRunningRuns(...args),
 }));
 
 const poll = (await import("./poll.get.js")).default;
@@ -237,6 +240,7 @@ describe("cron clarification recovery ordering", () => {
     });
     mocks.listRecoverableManualDispatches.mockResolvedValue([]);
     mocks.sweepOrphanedAwaitingRuns.mockResolvedValue(0);
+    mocks.sweepOrphanedRunningRuns.mockResolvedValue(0);
     mocks.redispatchPendingWebhookDeliveries.mockResolvedValue([]);
     mocks.sweepWebhookRateLimits.mockResolvedValue(undefined);
     mocks.pruneMcpAudits.mockResolvedValue({ deleted: 0 });
@@ -268,6 +272,7 @@ describe("cron clarification recovery ordering", () => {
   it("sweeps orphaned awaiting runs alongside the telemetry snapshot", async () => {
     expect((await request()).status).toBe(200);
     expect(mocks.sweepOrphanedAwaitingRuns).toHaveBeenCalledWith({ db: true });
+    expect(mocks.sweepOrphanedRunningRuns).toHaveBeenCalledWith({ db: true });
   });
 
   it("keeps polling when the awaiting sweep fails", async () => {

--- a/apps/worker/src/routes/cron/poll.get.ts
+++ b/apps/worker/src/routes/cron/poll.get.ts
@@ -10,6 +10,7 @@ import { getDb } from "../../db/client.js";
 import { collectSnapshots } from "../../lib/telemetry/collect-snapshots.js";
 import {
   sweepOrphanedAwaitingRuns,
+  sweepOrphanedRunningRuns,
   upsertRunSnapshots,
 } from "../../lib/telemetry/run-telemetry.js";
 import type { RunsLister } from "../../lib/overview/collect-runs.js";
@@ -242,6 +243,7 @@ export default defineEventHandler(async (event) => {
     // marker left behind by a best-effort writer that failed is invisible to it.
     // This settles those orphans.
     await sweepOrphanedAwaitingRuns(db);
+    await sweepOrphanedRunningRuns(db);
   } catch (err) {
     logger.warn({ err: (err as Error).message }, "poll_snapshot_failed");
   }

--- a/apps/worker/src/webhook-trigger/delivery-store.test.ts
+++ b/apps/worker/src/webhook-trigger/delivery-store.test.ts
@@ -7,6 +7,7 @@ import {
   webhookTriggerEndpoints,
   workflowDefinitions,
   workflowDefinitionVersions,
+  workflowRuns,
 } from "../db/schema.js";
 import { createTestDb } from "../db/test-db.js";
 import {
@@ -237,6 +238,14 @@ describe("webhook delivery inbox", () => {
     ).resolves.toBe(false);
     await expect(
       recordWebhookDeliveryStarted(db, accepted, "owner-1", "run-1"),
+    ).resolves.toBe(false);
+    await db.insert(workflowRuns).values({
+      runId: "run-1",
+      subjectKey: accepted.subjectKey,
+      status: "running",
+    });
+    await expect(
+      recordWebhookDeliveryStarted(db, accepted, "owner-1", "run-1"),
     ).resolves.toBe(true);
     await expect(getWebhookDelivery(db, ENDPOINT_ID, "d-1")).resolves.toMatchObject({
       pending: false,
@@ -255,6 +264,11 @@ describe("webhook delivery inbox", () => {
       runId: "run-1",
       state: "bound",
       runKind: "webhook_trigger",
+    });
+    await db.insert(workflowRuns).values({
+      runId: "run-1",
+      subjectKey: accepted.subjectKey,
+      status: "running",
     });
     await recordWebhookDeliveryStarted(db, accepted, "owner-1", "run-1");
 

--- a/apps/worker/src/webhook-trigger/delivery-store.ts
+++ b/apps/worker/src/webhook-trigger/delivery-store.ts
@@ -1,7 +1,11 @@
 import { and, asc, desc, eq, isNotNull, lt, sql } from "drizzle-orm";
 import type { WebhookDeliveryOutcome } from "@shared/contracts";
 import type { Db } from "../db/client.js";
-import { activeRuns, webhookTriggerDeliveries } from "../db/schema.js";
+import {
+  activeRuns,
+  webhookTriggerDeliveries,
+  workflowRuns,
+} from "../db/schema.js";
 import { isUniqueViolation } from "../lib/unique-violation.js";
 import type { WebhookTriggerEntry } from "./payload-mapping.js";
 import type { WebhookVerifiedWith } from "./verify.js";
@@ -290,6 +294,10 @@ export async function recordWebhookDeliveryStarted(
             (${activeRuns.state} = 'reserved' AND ${activeRuns.runId} IS NULL)
             OR (${activeRuns.state} = 'bound' AND ${activeRuns.runId} = ${runId})
           )
+      )
+      AND EXISTS (
+        SELECT 1 FROM ${workflowRuns}
+        WHERE ${workflowRuns.runId} = ${runId}
       )
     RETURNING inbox.delivery_id
   `);


### PR DESCRIPTION
## Summary

- Add a cron backstop for subject-bound running rows whose active claim disappeared, settling them as blocked while leaving unclaimed post-PR gate rows alone.
- Require the workflow_runs row when publishing or acknowledging PR and webhook start deliveries, matching the existing schedule guard from AIW-249.
- Add regression coverage for lost claims, active claims, gate rows, and phantom delivery starts.

## Validation

- pnpm --filter worker typecheck
- pnpm --filter worker exec vitest run src/lib/telemetry/run-telemetry.test.ts src/lib/trigger-delivery-store.test.ts src/webhook-trigger/delivery-store.test.ts src/routes/cron/poll.get.test.ts
- pnpm --filter worker exec vitest run src/lib/dispatch-trigger.test.ts src/webhook-trigger/dispatch-webhook-trigger.test.ts src/schedule-trigger/occurrence-store.test.ts
- git diff --check

AIW-271 was reproducible on origin/main: the running-row backstop only swept awaiting rows, and the PR/webhook stores trusted activeRuns without requiring the workflow_runs row. No merge or deploy performed. Production cleanup and verification of the Jira-reported stuck rows still need an operator follow-up.