### PR TITLE
Fix post-PR capture safety and preserve main CI verdicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ concurrency:
   # any push kills a dispatch already running. That makes the e2e suites, which
   # take hours, impossible to finish by hand. Pushes still supersede each other
   # within their own event, which is the behaviour this cancellation is for.
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
-  # Never on main. Superseding is right for a branch nobody reads the history
-  # of, but a cancelled main run leaves that commit with no verdict at all,
-  # which is the hole this workflow's push trigger exists to close: two merges
-  # in quick succession would otherwise cancel the first and hide its result.
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  # Main pushes add their SHA to the key below, so this remains true without
+  # allowing one merged commit to cancel the verdict for its predecessor.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}-${{ github.event_name == 'push' && github.sha || 'shared' }}
+  # Main pushes have unique groups; pull-request and manual runs keep the
+  # existing superseding behavior.
+  cancel-in-progress: true
 
 jobs:
   ci:
@@ -55,6 +55,7 @@ jobs:
       - run: pnpm run typecheck
       - run: pnpm run test
       - run: pnpm run test:release-notes
+      - run: pnpm run test:ci
       # Durable-workflow tests. They need their own Workflow SDK builder config,
       # so vitest.config.ts cannot pick them up alongside the rest of the suite.
       - run: pnpm run test:workflow-sdk

--- a/apps/worker/src/run-observability/runtime-hooks.test.ts
+++ b/apps/worker/src/run-observability/runtime-hooks.test.ts
@@ -926,4 +926,45 @@ describe("v2 run observation hooks are replay-safe", () => {
     // The trace: capture is marked unavailable rather than failing silently.
     expect(failing.markUnavailable).toHaveBeenCalled();
   });
+
+  it("waits for the unavailable marker before releasing the lifecycle hook", async () => {
+    const failing = sink();
+    let releaseMarker!: () => void;
+    let markStarted!: () => void;
+    const markerStarted = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const marker = new Promise<void>((resolve) => {
+      releaseMarker = resolve;
+    });
+    failing.start.mockResolvedValue(null);
+    failing.markUnavailable.mockImplementation(() => {
+      markStarted();
+      return marker;
+    });
+    const hooks = createV2RunObservationHooks({
+      nodeTypes: new Map([["review", "generic_agent" as WorkflowBlockType]]),
+      sink: failing,
+    });
+
+    await hooks.onNodeStart?.({ ...IDENTITY, startedAt: STARTED_AT });
+    let finished = false;
+    const lifecycle = hooks.onNodeFinish?.({
+      ...IDENTITY,
+      completedAt: COMPLETED_AT,
+      state: { status: "ok", attempt: 1 },
+      runtimeState: "completed",
+      selectedTransition: null,
+    });
+    void lifecycle?.then(() => {
+      finished = true;
+    });
+
+    await markerStarted;
+    await Promise.resolve();
+    expect(finished).toBe(false);
+
+    releaseMarker();
+    await expect(lifecycle).resolves.toBeUndefined();
+  });
 });

--- a/apps/worker/src/run-observability/runtime-hooks.ts
+++ b/apps/worker/src/run-observability/runtime-hooks.ts
@@ -138,14 +138,15 @@ export function createV2RunObservationHooks(input: {
   const now = input.clock ?? (() => new Date());
   let capturedAttemptStarts = 0;
   let captureDisabled = false;
+  let captureUnavailable: Promise<void> | null = null;
 
   const track = (task: Promise<void>): void => {
     persistenceTasks.add(task);
     void task.finally(() => persistenceTasks.delete(task));
   };
 
-  const tripCapture = (): void => {
-    if (captureDisabled) return;
+  const tripCapture = (): Promise<void> => {
+    if (captureUnavailable) return captureUnavailable;
     captureDisabled = true;
     attempts.clear();
     let marker: Promise<void>;
@@ -154,7 +155,13 @@ export function createV2RunObservationHooks(input: {
     } catch {
       marker = Promise.resolve();
     }
-    track(marker.catch(() => {}));
+    captureUnavailable = marker.catch(() => {});
+    track(captureUnavailable);
+    return captureUnavailable;
+  };
+
+  const awaitCaptureUnavailable = async (): Promise<void> => {
+    await captureUnavailable;
   };
 
   const start = (
@@ -182,18 +189,17 @@ export function createV2RunObservationHooks(input: {
           startedAt,
         )
         .then(
-          (id) => {
-            if (id === null) tripCapture();
+          async (id) => {
+            if (id === null) await tripCapture();
             return id;
           },
-          () => {
-            tripCapture();
+          async () => {
+            await tripCapture();
             return null;
           },
         );
     } catch {
-      tripCapture();
-      attemptId = Promise.resolve(null);
+      attemptId = tripCapture().then(() => null);
     }
     const nodeType = input.nodeTypes.get(identity.nodeId);
     const capture: PendingAttemptCapture = {
@@ -238,8 +244,8 @@ export function createV2RunObservationHooks(input: {
         if (captureDisabled) return;
         await write(attemptId);
       })
-      .catch(() => {
-        tripCapture();
+      .catch(async () => {
+        await tripCapture();
       });
     capture.persistenceTail = task;
     track(task);
@@ -262,7 +268,10 @@ export function createV2RunObservationHooks(input: {
   return {
     async onTriggerActivated(event) {
       const capture = start(event, event.startedAt);
-      if (!capture) return;
+      if (!capture) {
+        await awaitCaptureUnavailable();
+        return;
+      }
       observe(capture, { kind: "output", value: event.output });
       await finish(
         event,
@@ -279,12 +288,16 @@ export function createV2RunObservationHooks(input: {
         event.completedAt,
       );
     },
-    onNodeStart(event) {
+    async onNodeStart(event) {
       start(event, event.startedAt);
+      await awaitCaptureUnavailable();
     },
     async onNodeWaiting(event) {
       const capture = attempts.get(identityKey(event));
-      if (!capture) return;
+      if (!capture) {
+        await awaitCaptureUnavailable();
+        return;
+      }
       await persist(capture, (attemptId) =>
         input.sink.updateWaiting(
           attemptId,
@@ -295,7 +308,10 @@ export function createV2RunObservationHooks(input: {
     async onNodeFinish(event) {
       const key = identityKey(event);
       const capture = attempts.get(key);
-      if (!capture) return;
+      if (!capture) {
+        await awaitCaptureUnavailable();
+        return;
+      }
       await finish(
         event,
         capture,
@@ -315,7 +331,10 @@ export function createV2RunObservationHooks(input: {
     },
     async onNodeSkipped(event) {
       const capture = start(event, event.startedAt);
-      if (!capture) return;
+      if (!capture) {
+        await awaitCaptureUnavailable();
+        return;
+      }
       await finish(
         event,
         capture,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:e2e:agent": "pnpm --filter worker test:e2e:agent",
     "test:e2e:orchestration": "pnpm --filter worker test:e2e:orchestration",
     "test:e2e:capacity": "pnpm --filter worker test:e2e:capacity",
+    "test:ci": "node --import tsx --test \"scripts/ci/*.test.ts\"",
     "test:e2e:harness-profiles": "pnpm --filter worker test:e2e:harness-profiles",
     "test:e2e:harness-profiles:dry": "pnpm --filter worker test:e2e:harness-profiles:dry",
     "test:e2e:replay": "pnpm --filter worker test:e2e:replay",

--- a/scripts/ci/ci-workflow.test.ts
+++ b/scripts/ci/ci-workflow.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { parse } from "yaml";
+
+test("main pushes run CI in a non-canceling concurrency group", async () => {
+  const source = await readFile(".github/workflows/ci.yml", "utf8");
+  const workflow = parse(source) as {
+    on: { push: { branches: string[] } };
+    concurrency: { group: string; "cancel-in-progress": boolean };
+  };
+
+  assert.deepEqual(workflow.on.push.branches, ["main"]);
+  assert.equal(workflow.concurrency["cancel-in-progress"], true);
+  assert.match(
+    workflow.concurrency.group,
+    /github\.event_name == 'push' && github\.sha/,
+  );
+});


### PR DESCRIPTION
## Summary

- await the replay-capture unavailable marker before releasing lifecycle hooks, while still swallowing capture failures
- give each main push a SHA-specific CI concurrency group so successive merges cannot cancel an older main verdict
- add deterministic regression tests for the marker barrier and CI workflow configuration

## Evidence

- clean origin/main reproduced the detached marker race: the lifecycle hook resolved while markUnavailable remained unresolved
- clean origin/main passed 16/16 WDK concurrency probe tests and 28/28 run-budget tests; those paths are unchanged
- focused runtime-hook tests pass 16/16, CI configuration test passes, and worker typecheck passes

## Scope

No merge or deployment performed.