### PR TITLE
fix(worker): keep MCP contract schemas on Zod 3

### DIFF
--- a/apps/worker/src/mcp/tool-catalog.ts
+++ b/apps/worker/src/mcp/tool-catalog.ts
@@ -1,6 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { z } from "zod";
+// Nitro's worker bundle resolves bare `zod` to the workspace's Zod 4 copy,
+// while the MCP contract is generated and validated with Zod 3. The SDK's
+// Zod 4 JSON-schema conversion drops constraints such as maxLength, maximum,
+// format and additionalProperties, so pin the catalog schemas to the same
+// Zod 3 dialect used by the committed contract artifact.
+import { z } from "zod/v3";
 
 import { McpPublicError, type McpToolName } from "./contracts.js";
 import { policyFor, type McpToolPolicy } from "./policy.js";


### PR DESCRIPTION
## Summary
- pin MCP catalog schemas to `zod/v3` so Nitro cannot convert the production tools/list surface through the Zod 4 path
- preserve maxLength, maximum, exclusiveMinimum, format, and additionalProperties in the advertised contract

## Evidence
- production exact PR #268 deployment advertised 22 names/order and matching descriptions/annotations, but omitted schema constraints; wire-derived hash was `0f60c3bf...` instead of committed `881de2fa...`
- `pnpm --filter worker exec vitest run src/mcp/contract-artifact.test.ts src/mcp/tool-catalog.test.ts src/mcp/server.test.ts` — 41 passed
- `pnpm --filter worker mcp:contract:check` — passed at 22 tools / 11 error codes / `881de2fa...`
- `pnpm --filter worker typecheck` — passed

No deployment or merge performed by this PR.