### PR TITLE
Update MCP surface expectations

### DIFF
--- a/apps/worker/src/auth.test.ts
+++ b/apps/worker/src/auth.test.ts
@@ -12,6 +12,7 @@ import {
   type AuthOptions,
 } from "./auth.js";
 import { account, member, organization, ssoProvider, user, verification } from "./db/schema.js";
+import { MCP_SCOPES } from "./mcp/contracts.js";
 
 const OPTS = {
   secret: "x".repeat(32),
@@ -310,7 +311,7 @@ describe("MCP OAuth provider", () => {
 
     await expect(auth.api.getOAuthServerConfig()).resolves.toMatchObject({
       issuer: "http://localhost:3000/api/auth",
-      scopes_supported: ["mcp:read", "runs:dispatch", "prompts:write", "workflows:write"],
+      scopes_supported: [...MCP_SCOPES],
       registration_endpoint: "http://localhost:3000/api/auth/oauth2/register",
       code_challenge_methods_supported: expect.arrayContaining(["S256"]),
       grant_types_supported: expect.arrayContaining([

--- a/apps/worker/src/routes/api/v1/system/mcp-readiness.test.ts
+++ b/apps/worker/src/routes/api/v1/system/mcp-readiness.test.ts
@@ -4,6 +4,7 @@ import { createApp, toWebHandler } from "h3";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { member, organization, user } from "../../../../db/schema.js";
 import { createTestDb } from "../../../../db/test-db.js";
+import { FIRST_SLICE_TOOLS } from "../../../../mcp/contracts.js";
 
 // The secret-shaped values are here so the "no secrets" assertion has something
 // real to fail on: an env this route can reach, holding values that must never
@@ -126,25 +127,8 @@ describe("GET /api/v1/system/mcp-readiness", () => {
       serverVersion: "0.1.0",
       protocolVersion: "2025-11-25",
       contractHash: committed.contractHash,
-      toolCount: 16,
-      tools: [
-        "system.capabilities",
-        "tickets.get",
-        "tickets.list_runs",
-        "runs.get",
-        "runs.trace",
-        "runs.result",
-        "runs.diagnose",
-        "workflows.dispatch_preflight",
-        "workflows.dispatch",
-        "workflows.list",
-        "prompts.list",
-        "prompts.get",
-        "prompts.update",
-        "workflows.create",
-        "workflows.save_draft",
-        "workflows.publish",
-      ],
+      toolCount: FIRST_SLICE_TOOLS.length,
+      tools: [...FIRST_SLICE_TOOLS],
       enabledDomains: ["system", "tickets", "runs", "workflows", "prompts"],
     });
   });


### PR DESCRIPTION
## Summary

- derive OAuth metadata scope expectations from `MCP_SCOPES`, including `tickets:write`
- derive readiness tool count and names from `FIRST_SLICE_TOOLS`, reflecting the current 22-tool surface

## Why

The main CI run exposed stale full-suite expectations after the MCP surface expanded. Production values are already correct; this keeps the tests exact while preventing future drift from duplicated literals.

## Validation

- `pnpm --filter worker exec vitest run src/auth.test.ts src/routes/api/v1/system/mcp-readiness.test.ts`
- `pnpm --filter worker exec vitest run src/mcp/contracts.test.ts src/mcp/contract-artifact.test.ts`
- `pnpm --filter worker typecheck`
- `git diff --check`