### PR TITLE
fix: reuse dashboard session for MCP authorization

### DIFF
--- a/apps/dashboard/app/api/auth/sso/mcp-session/route.test.ts
+++ b/apps/dashboard/app/api/auth/sso/mcp-session/route.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+
+type ModuleMock = typeof mock & {
+  module: (
+    specifier: string,
+    options: { namedExports: Record<string, unknown> },
+  ) => void;
+};
+
+const state = {
+  sessionToken: undefined as string | undefined,
+  workerBaseUrl: "https://worker.example.com",
+  fetchCalls: [] as Array<{ path: string; init: RequestInit }>,
+  workerResponse: Response.json({ token: "opaque-handoff-token-123456" }),
+};
+
+const moduleMock = (mock as ModuleMock).module?.bind(mock);
+if (!moduleMock) {
+  test("MCP session handoff route requires Node module mocks", { skip: true });
+} else {
+  moduleMock("next/headers", {
+    namedExports: {
+      cookies: async () => ({
+        get: (name: string) =>
+          name === "ba_session" && state.sessionToken
+            ? { value: state.sessionToken }
+            : undefined,
+      }),
+    },
+  });
+  moduleMock("@/lib/auth/worker", {
+    namedExports: {
+      fetchAuthWorker: async (path: string, init: RequestInit) => {
+        state.fetchCalls.push({ path, init });
+        return state.workerResponse;
+      },
+      readWorkerJson: async <T>(response: Response) => (await response.json()) as T,
+    },
+  });
+  moduleMock("@/lib/auth/worker-core", {
+    namedExports: {
+      workerUrl: (base: string | undefined, path: string) => {
+        if (!base) throw new Error("WORKER_BASE_URL is required");
+        return `${base}${path}`;
+      },
+    },
+  });
+
+  const route = import("./route.ts");
+
+  async function get(request: Request) {
+    return (await route).GET(request);
+  }
+
+  function reset() {
+    state.sessionToken = "raw-dashboard-session-token";
+    state.workerBaseUrl = "https://worker.example.com";
+    state.fetchCalls.length = 0;
+    state.workerResponse = Response.json({ token: "opaque-handoff-token-123456" });
+    process.env.WORKER_BASE_URL = state.workerBaseUrl;
+  }
+
+  test("bridges ba_session through a server-side bearer call", async () => {
+    reset();
+
+    const response = await get(
+      new Request("https://dashboard.example.com/api/auth/sso/mcp-session"),
+    );
+
+    assert.equal(response.status, 307);
+    assert.equal(
+      response.headers.get("location"),
+      "https://worker.example.com/mcp-auth/login?handoff=opaque-handoff-token-123456",
+    );
+    assert.equal(response.headers.get("cache-control"), "no-store");
+    assert.equal(state.fetchCalls.length, 1);
+    assert.equal(state.fetchCalls[0]?.path, "/api/dashboard-auth/sso/mcp-session");
+    assert.equal(
+      new Headers(state.fetchCalls[0]?.init.headers).get("authorization"),
+      "Bearer raw-dashboard-session-token",
+    );
+    assert.equal(
+      response.headers.get("location")?.includes("raw-dashboard-session-token"),
+      false,
+    );
+  });
+
+  test("falls back to worker login when ba_session is absent", async () => {
+    reset();
+    state.sessionToken = undefined;
+
+    const response = await get(
+      new Request("https://dashboard.example.com/api/auth/sso/mcp-session"),
+    );
+
+    assert.equal(response.status, 307);
+    assert.equal(
+      response.headers.get("location"),
+      "https://worker.example.com/mcp-auth/login?fallback=1",
+    );
+    assert.equal(state.fetchCalls.length, 0);
+    assert.equal(response.headers.get("cache-control"), "no-store");
+  });
+
+  test("falls back when the worker rejects the session", async () => {
+    reset();
+    state.workerResponse = new Response(null, { status: 401 });
+
+    const response = await get(
+      new Request("https://dashboard.example.com/api/auth/sso/mcp-session"),
+    );
+
+    assert.equal(response.status, 307);
+    assert.equal(
+      response.headers.get("location"),
+      "https://worker.example.com/mcp-auth/login?fallback=1",
+    );
+    assert.equal(response.headers.get("cache-control"), "no-store");
+  });
+
+  test("falls back when the worker returns a non-opaque token", async () => {
+    reset();
+    state.workerResponse = Response.json({ token: "raw.session.token" });
+
+    const response = await get(
+      new Request("https://dashboard.example.com/api/auth/sso/mcp-session"),
+    );
+
+    assert.equal(response.status, 307);
+    assert.equal(
+      response.headers.get("location"),
+      "https://worker.example.com/mcp-auth/login?fallback=1",
+    );
+    assert.equal(response.headers.get("cache-control"), "no-store");
+  });
+
+  test("falls back to the dashboard login when the worker base URL is missing", async () => {
+    reset();
+    process.env.WORKER_BASE_URL = "";
+
+    const response = await get(
+      new Request("https://dashboard.example.com/api/auth/sso/mcp-session"),
+    );
+
+    assert.equal(response.status, 307);
+    assert.equal(response.headers.get("location"), "https://dashboard.example.com/login");
+    assert.equal(state.fetchCalls.length, 0);
+  });
+}

--- a/apps/dashboard/app/api/auth/sso/mcp-session/route.ts
+++ b/apps/dashboard/app/api/auth/sso/mcp-session/route.ts
@@ -1,0 +1,49 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { fetchAuthWorker, readWorkerJson } from "@/lib/auth/worker";
+import { workerUrl } from "@/lib/auth/worker-core";
+
+const OPAQUE_HANDOFF_TOKEN = /^[A-Za-z0-9_-]{20,256}$/;
+
+/**
+ * Turn the dashboard's local session into a worker session for an MCP browser
+ * flow. The session is sent only server-to-server; the browser sees only the
+ * one-time token returned by Better Auth.
+ */
+export async function GET(req: Request) {
+  const workerLogin = workerLoginUrl();
+  if (!workerLogin) return redirectNoStore(new URL("/login", req.url));
+
+  const sessionToken = (await cookies()).get("ba_session")?.value;
+  if (!sessionToken) return redirectNoStore(workerLogin);
+
+  const response = await fetchAuthWorker("/api/dashboard-auth/sso/mcp-session", {
+    headers: { authorization: `Bearer ${sessionToken}` },
+  });
+  if (!response?.ok) return redirectNoStore(workerLogin);
+
+  const body = await readWorkerJson<{ token?: unknown }>(response);
+  if (typeof body.token !== "string" || !OPAQUE_HANDOFF_TOKEN.test(body.token)) {
+    return redirectNoStore(workerLogin);
+  }
+
+  const handoff = new URL(workerLogin);
+  handoff.searchParams.delete("fallback");
+  handoff.searchParams.set("handoff", body.token);
+  return redirectNoStore(handoff);
+}
+
+function redirectNoStore(url: URL): NextResponse {
+  return NextResponse.redirect(url, { headers: { "cache-control": "no-store" } });
+}
+
+function workerLoginUrl(): URL | null {
+  try {
+    const url = new URL("/mcp-auth/login", workerUrl(process.env.WORKER_BASE_URL, "/"));
+    url.searchParams.set("fallback", "1");
+    return url;
+  } catch {
+    return null;
+  }
+}

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "pnpm build:shared && tsc --noEmit",
-    "test": "pnpm build:shared && tsx --test \"**/*.test.ts\" \"**/*.test.tsx\"",
+    "test": "pnpm build:shared && node --experimental-test-module-mocks --import tsx --test \"**/*.test.ts\" \"**/*.test.tsx\"",
     "build:shared": "pnpm --filter @shared/contracts build && pnpm --filter @shared/conditions build"
   },
   "dependencies": {

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -4,7 +4,12 @@ import { waitUntil } from "@vercel/functions";
 import { betterAuth } from "better-auth";
 import { createAuthMiddleware } from "better-auth/api";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { bearer, jwt, organization as organizationPlugin } from "better-auth/plugins";
+import {
+  bearer,
+  jwt,
+  oneTimeToken,
+  organization as organizationPlugin,
+} from "better-auth/plugins";
 import { defaultAc } from "better-auth/plugins/organization/access";
 import { and, eq, isNotNull } from "drizzle-orm";
 import { createError } from "h3";
@@ -123,6 +128,11 @@ export function createAuth(db: Db, options: AuthOptions) {
       : undefined,
     plugins: [
       bearer(),
+      oneTimeToken({
+        disableClientRequest: true,
+        expiresIn: 1,
+        storeToken: "hashed",
+      }),
       organizationPlugin({
         allowUserToCreateOrganization: false,
         creatorRole: "owner",

--- a/apps/worker/src/lib/auth/one-time-token-handoff.test.ts
+++ b/apps/worker/src/lib/auth/one-time-token-handoff.test.ts
@@ -1,0 +1,84 @@
+import { like } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+
+import { createAuth, seedAuthUser } from "../../auth.js";
+import { verification } from "../../db/auth-schema.js";
+import { createTestDb } from "../../db/test-db.js";
+
+const OPTS = {
+  secret: "x".repeat(32),
+  baseURL: "http://localhost:3000",
+  trustedOrigins: ["http://localhost:3001"],
+};
+
+function tokenFrom(res: { headers: Headers; response: unknown }): string {
+  return (
+    res.headers.get("set-auth-token") ??
+    (res.response as { token?: string }).token ??
+    ""
+  );
+}
+
+describe("Better Auth one-time MCP session handoff", () => {
+  it("bridges a bearer session, then rejects the consumed token on replay", async () => {
+    const auth = createAuth(await createTestDb(), OPTS);
+    await seedAuthUser(auth, { email: "owner@example.com", password: "password123" });
+    const signIn = await auth.api.signInEmail({
+      body: { email: "owner@example.com", password: "password123" },
+      returnHeaders: true,
+    });
+    const sessionToken = tokenFrom(signIn);
+
+    const generated = await auth.api.generateOneTimeToken({
+      headers: new Headers({ authorization: `Bearer ${sessionToken}` }),
+    });
+    expect(generated.token).not.toBe(sessionToken);
+    expect(generated.token).toMatch(/^[A-Za-z0-9_-]{20,256}$/);
+
+    const verified = await auth.api.verifyOneTimeToken({
+      body: { token: generated.token },
+      returnHeaders: true,
+    });
+    expect(verified.response.user.email).toBe("owner@example.com");
+    expect(verified.headers.get("set-cookie")).toContain("better-auth.session_token");
+
+    await expect(
+      auth.api.verifyOneTimeToken({ body: { token: generated.token } }),
+    ).rejects.toThrow("Invalid token");
+  });
+
+  it("rejects absent, invalid, and expired handoffs", async () => {
+    const db = await createTestDb();
+    const auth = createAuth(db, OPTS);
+    await seedAuthUser(auth, { email: "owner@example.com", password: "password123" });
+    const signIn = await auth.api.signInEmail({
+      body: { email: "owner@example.com", password: "password123" },
+      returnHeaders: true,
+    });
+    const sessionToken = tokenFrom(signIn);
+
+    await expect(
+      auth.api.generateOneTimeToken({ headers: new Headers() }),
+    ).rejects.toThrow("Unauthorized");
+    await expect(
+      auth.api.verifyOneTimeToken({ body: { token: "missing-token-1234567890" } }),
+    ).rejects.toThrow("Invalid token");
+
+    const generated = await auth.api.generateOneTimeToken({
+      headers: new Headers({ authorization: `Bearer ${sessionToken}` }),
+    });
+    const [stored] = await db
+      .select()
+      .from(verification)
+      .where(like(verification.identifier, "one-time-token:%"));
+    if (!stored) throw new Error("one-time handoff was not stored");
+    await db
+      .update(verification)
+      .set({ expiresAt: new Date(Date.now() - 1_000) })
+      .where(like(verification.identifier, stored.identifier));
+
+    await expect(
+      auth.api.verifyOneTimeToken({ body: { token: generated.token } }),
+    ).rejects.toThrow("Invalid token");
+  });
+});

--- a/apps/worker/src/mcp/auth-pages.test.ts
+++ b/apps/worker/src/mcp/auth-pages.test.ts
@@ -24,6 +24,9 @@ vi.mock("../auth-instance.js", () => ({
 
 import {
   createOAuthFlowCookie,
+  isOAuthAuthorizationQuery,
+  isOpaqueHandoffToken,
+  oauthConsentUrl,
   readOAuthFlowCookie,
   renderMcpConsentPage,
   renderMcpLoginPage,
@@ -58,6 +61,23 @@ function handlerFor(route: Parameters<typeof eventHandler>[0]) {
 }
 
 describe("MCP auth pages", () => {
+  it("recognizes OAuth authorization queries and keeps handoffs opaque", () => {
+    expect(
+      isOAuthAuthorizationQuery(
+        new URLSearchParams({
+          response_type: "code",
+          client_id: "client",
+          redirect_uri: "https://client.example/callback",
+        }),
+      ),
+    ).toBe(true);
+    expect(isOpaqueHandoffToken("opaque-handoff-token-123456")).toBe(true);
+    expect(isOpaqueHandoffToken("raw.session.token")).toBe(false);
+    expect(oauthConsentUrl("client_id=client&redirect_uri=https%3A%2F%2Fclient.example", "https://worker.example.com")).toBe(
+      "https://worker.example.com/mcp-auth/consent?client_id=client&redirect_uri=https%3A%2F%2Fclient.example",
+    );
+  });
+
   it("escapes client-controlled login errors", () => {
     const html = renderMcpLoginPage({ error: '<img src=x onerror="alert(1)">' });
 

--- a/apps/worker/src/mcp/auth-pages.ts
+++ b/apps/worker/src/mcp/auth-pages.ts
@@ -5,6 +5,24 @@ import { MCP_SCOPES, type McpScope } from "./contracts.js";
 const FLOW_COOKIE = "mcp_oauth";
 const FLOW_TTL_SECONDS = 10 * 60;
 
+export function isOAuthAuthorizationQuery(query: URLSearchParams): boolean {
+  return Boolean(
+    query.get("client_id") &&
+      query.get("redirect_uri") &&
+      query.get("response_type"),
+  );
+}
+
+export function isOpaqueHandoffToken(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{20,256}$/.test(value);
+}
+
+export function oauthConsentUrl(oauthQuery: string, workerOrigin: string): string {
+  const url = new URL("/mcp-auth/consent", workerOrigin);
+  url.search = `?${oauthQuery}`;
+  return url.href;
+}
+
 export function safeOAuthReturnPath(value: unknown): string | null {
   if (typeof value !== "string" || !value.startsWith("/api/auth/oauth2/authorize?")) {
     return null;
@@ -130,12 +148,10 @@ function inspectOAuthFlowCookie(
 }
 
 export function renderMcpLoginPage(input: { error?: string | null }): string {
-  const error = input.error
-    ? `<p role="alert">${escapeHtml(input.error)}</p>`
-    : "";
+  const error = input.error ? `<p class="error" role="alert">${escapeHtml(input.error)}</p>` : "";
   return htmlPage(
     "Sign in to AI Workflow",
-    `<main><h1>Sign in to AI Workflow</h1>${error}<form method="post" action="/mcp-auth/login"><label>Email<input name="email" type="email" autocomplete="email" required></label><label>Password<input name="password" type="password" autocomplete="current-password" required></label><button type="submit">Sign in</button></form><p><a href="/api/dashboard-auth/sso/start?oauth=1">Continue with SSO</a></p></main>`,
+    `<main class="card" aria-labelledby="login-title"><p class="eyebrow">AI Workflow</p><h1 id="login-title">Sign in to continue</h1><p class="lede">Sign in to review and authorize this MCP connection.</p>${error}<form method="post" action="/mcp-auth/login"><label for="email">Email</label><input id="email" name="email" type="email" autocomplete="email" required><label for="password">Password</label><input id="password" name="password" type="password" autocomplete="current-password" required><button class="primary" type="submit">Sign in</button></form><div class="divider" role="presentation"><span>or</span></div><a class="secondary" href="/api/dashboard-auth/sso/start?oauth=1">Continue with SSO</a><p class="fine-print">You can return to your agent after signing in.</p></main>`,
   );
 }
 
@@ -147,10 +163,12 @@ export function renderMcpConsentPage(input: {
 }): string {
   const hostname = safeHostname(input.redirectUri);
   const scopes = allowedScopes(input.requestedScopes);
-  const scopeList = scopes.map((scope) => `<li>${escapeHtml(scope)}</li>`).join("");
+  const scopeList = scopes
+    .map((scope) => `<li><code>${escapeHtml(scope)}</code></li>`)
+    .join("");
   return htmlPage(
     "Authorize MCP client",
-    `<main><h1>Authorize ${escapeHtml(input.clientName)}</h1><p>Redirect host: <strong>${escapeHtml(hostname)}</strong></p><ul>${scopeList}</ul><form method="post" action="/mcp-auth/consent"><input type="hidden" name="flow_id" value="${escapeHtml(input.flowId)}"><input type="hidden" name="scope" value="${escapeHtml(scopes.join(" "))}"><button name="accept" value="true" type="submit">Allow</button><button name="accept" value="false" type="submit">Deny</button></form></main>`,
+    `<main class="card" aria-labelledby="consent-title"><p class="eyebrow">MCP authorization</p><h1 id="consent-title">Authorize ${escapeHtml(input.clientName)}</h1><p class="lede">This application is requesting access to your AI Workflow account.</p><dl class="details"><div><dt>Application</dt><dd>${escapeHtml(input.clientName)}</dd></div><div><dt>Redirect host</dt><dd><code>${escapeHtml(hostname)}</code></dd></div></dl><h2>Requested access</h2><ul class="scopes">${scopeList}</ul><form method="post" action="/mcp-auth/consent"><input type="hidden" name="flow_id" value="${escapeHtml(input.flowId)}"><input type="hidden" name="scope" value="${escapeHtml(scopes.join(" "))}"><div class="actions"><button class="secondary" name="accept" value="false" type="submit">Deny</button><button class="primary" name="accept" value="true" type="submit">Allow</button></div></form></main>`,
   );
 }
 
@@ -198,5 +216,5 @@ function escapeHtml(value: string): string {
 }
 
 function htmlPage(title: string, body: string): string {
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(title)}</title></head><body>${body}</body></html>`;
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(title)}</title><style>:root{font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#172033;background:#f5f7fb}*{box-sizing:border-box}body{min-height:100vh;margin:0;display:grid;place-items:center;padding:24px;background:radial-gradient(circle at top,#fff 0,#f5f7fb 55%)}.card{width:min(100%,460px);padding:36px;border:1px solid #dfe5ef;border-radius:18px;background:#fff;box-shadow:0 18px 48px #17203314}.eyebrow{margin:0 0 10px;color:#53627a;font-size:12px;font-weight:700;letter-spacing:.12em;text-transform:uppercase}.lede{margin:0 0 26px;color:#53627a;line-height:1.55}h1{margin:0 0 10px;font-size:30px;letter-spacing:-.03em}h2{margin:28px 0 12px;font-size:15px}form{display:grid;gap:9px}label,dt{color:#344158;font-size:13px;font-weight:650}input{width:100%;margin:0 0 8px;padding:11px 12px;border:1px solid #cbd4e2;border-radius:9px;background:#fff;color:inherit;font:inherit}input:focus{outline:3px solid #b9d7ff;border-color:#377dcc}button,.secondary{display:inline-flex;align-items:center;justify-content:center;min-height:42px;padding:10px 16px;border-radius:9px;font:inherit;font-weight:700;text-decoration:none;cursor:pointer}.primary{border:1px solid #1f5fa8;background:#1f5fa8;color:#fff}.secondary{border:1px solid #b9c5d6;background:#fff;color:#24334d}.divider{display:flex;align-items:center;gap:12px;margin:22px 0;color:#8490a3;font-size:12px}.divider:before,.divider:after{content:"";height:1px;flex:1;background:#e3e8f0}.fine-print{margin:18px 0 0;color:#718097;font-size:12px;line-height:1.5;text-align:center}.error{margin:0 0 18px;padding:10px 12px;border:1px solid #efb9b9;border-radius:9px;background:#fff4f4;color:#a52f2f;font-size:13px}.details{display:grid;gap:12px;margin:24px 0;padding:16px;border-radius:12px;background:#f6f8fb}.details div{display:grid;gap:4px}.details dd{margin:0;color:#53627a;font-size:14px}.scopes{display:grid;gap:9px;margin:0;padding:0;list-style:none}.scopes li{padding:11px 12px;border:1px solid #e1e7f0;border-radius:9px;background:#fbfcfe}.scopes code,dd code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px}.actions{display:flex;justify-content:flex-end;gap:10px;margin-top:28px}</style></head><body>${body}</body></html>`;
 }

--- a/apps/worker/src/routes/api/dashboard-auth/sso/mcp-session.get.test.ts
+++ b/apps/worker/src/routes/api/dashboard-auth/sso/mcp-session.get.test.ts
@@ -1,0 +1,68 @@
+import { createApp, eventHandler, toWebHandler } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  generateOneTimeToken: vi.fn(),
+}));
+
+vi.mock("../../../../auth-instance.js", () => ({
+  auth: { api: { generateOneTimeToken: state.generateOneTimeToken } },
+}));
+
+const bridgeRoute = (await import("./mcp-session.get.js")).default;
+
+function handlerFor(route: Parameters<typeof eventHandler>[0]) {
+  const app = createApp();
+  app.use("/", route);
+  return toWebHandler(app);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.generateOneTimeToken.mockResolvedValue({ token: "opaque-handoff-token-123456" });
+});
+
+describe("dashboard MCP session bridge", () => {
+  it("turns the dashboard bearer session into an opaque one-time token", async () => {
+    const rawSession = "raw-dashboard-session-token";
+    const response = await handlerFor(bridgeRoute)(
+      new Request("https://worker.example.com/api/dashboard-auth/sso/mcp-session", {
+        headers: { authorization: `Bearer ${rawSession}` },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ token: "opaque-handoff-token-123456" });
+    expect(state.generateOneTimeToken).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+    });
+    expect(state.generateOneTimeToken.mock.calls[0]?.[0].headers.get("authorization")).toBe(
+      `Bearer ${rawSession}`,
+    );
+    expect(JSON.stringify(body)).not.toContain(rawSession);
+  });
+
+  it("rejects missing, expired, or invalid dashboard sessions", async () => {
+    state.generateOneTimeToken.mockRejectedValue(new Error("Unauthorized"));
+
+    const response = await handlerFor(bridgeRoute)(
+      new Request("https://worker.example.com/api/dashboard-auth/sso/mcp-session"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(state.generateOneTimeToken).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a malformed token returned by the auth provider", async () => {
+    state.generateOneTimeToken.mockResolvedValue({ token: "raw.session.token" });
+
+    const response = await handlerFor(bridgeRoute)(
+      new Request("https://worker.example.com/api/dashboard-auth/sso/mcp-session", {
+        headers: { authorization: "Bearer valid-session" },
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/apps/worker/src/routes/api/dashboard-auth/sso/mcp-session.get.ts
+++ b/apps/worker/src/routes/api/dashboard-auth/sso/mcp-session.get.ts
@@ -1,0 +1,23 @@
+import { createError, defineEventHandler, toWebRequest } from "h3";
+
+import { auth } from "../../../../auth-instance.js";
+import { isOpaqueHandoffToken } from "../../../../mcp/auth-pages.js";
+
+/**
+ * Server-to-server bridge for a dashboard session. The dashboard sends its
+ * Better Auth bearer session here; the one-time-token plugin stores that
+ * session server-side and returns only an opaque, single-use token.
+ */
+export default defineEventHandler(async (event) => {
+  try {
+    const result = await auth.api.generateOneTimeToken({
+      headers: toWebRequest(event).headers,
+    });
+    if (!isOpaqueHandoffToken(result.token)) {
+      throw new Error("Better Auth returned an invalid handoff token");
+    }
+    return { token: result.token };
+  } catch {
+    throw createError({ statusCode: 401, statusMessage: "Dashboard session required" });
+  }
+});

--- a/apps/worker/src/routes/mcp-auth/login.get.test.ts
+++ b/apps/worker/src/routes/mcp-auth/login.get.test.ts
@@ -1,0 +1,120 @@
+import { createApp, eventHandler, toWebHandler } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  verifyOneTimeToken: vi.fn(),
+  env: {
+    BETTER_AUTH_SECRET: "test-secret",
+    BETTER_AUTH_URL: "https://worker.example.com",
+    DASHBOARD_ORIGIN: "https://dashboard.example.com",
+  },
+}));
+
+vi.mock("../../../env.js", () => ({ env: state.env }));
+vi.mock("../../auth-instance.js", () => ({
+  auth: {
+    api: {
+      getSession: state.getSession,
+      verifyOneTimeToken: state.verifyOneTimeToken,
+    },
+  },
+}));
+
+const loginRoute = (await import("./login.get.js")).default;
+
+function handlerFor(route: Parameters<typeof eventHandler>[0]) {
+  const app = createApp();
+  app.use("/", route);
+  return toWebHandler(app);
+}
+
+function oauthUrl(): string {
+  return "https://worker.example.com/mcp-auth/login?response_type=code&client_id=client_1&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback&scope=mcp%3Aread";
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.getSession.mockResolvedValue(null);
+  state.verifyOneTimeToken.mockResolvedValue({
+    headers: new Headers({ "set-cookie": "__Secure-better-auth.session_token=session-cookie" }),
+    response: { session: {}, user: {} },
+  });
+});
+
+describe("MCP login handoff", () => {
+  it("bypasses login for an existing worker session", async () => {
+    state.getSession.mockResolvedValue({ session: { token: "worker-session" }, user: {} });
+
+    const response = await handlerFor(loginRoute)(new Request(oauthUrl()));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://worker.example.com/mcp-auth/consent?response_type=code&client_id=client_1&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback&scope=mcp%3Aread",
+    );
+    expect(response.headers.get("set-cookie")).toContain("mcp_oauth=");
+  });
+
+  it("bridges a dashboard session without exposing a raw session token", async () => {
+    const response = await handlerFor(loginRoute)(new Request(oauthUrl()));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://dashboard.example.com/api/auth/sso/mcp-session",
+    );
+    expect(response.headers.get("location")).not.toContain("worker-session");
+  });
+
+  it("keeps the email/password and SSO fallback available", async () => {
+    const response = await handlerFor(loginRoute)(
+      new Request("https://worker.example.com/mcp-auth/login?fallback=1"),
+    );
+
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain('action="/mcp-auth/login"');
+    expect(html).toContain("Continue with SSO");
+    expect(state.getSession).toHaveBeenCalledOnce();
+  });
+
+  it("verifies a single-use opaque handoff and resumes the saved OAuth query", async () => {
+    const initial = await handlerFor(loginRoute)(new Request(oauthUrl()));
+    const cookie = initial.headers.get("set-cookie")?.split(";", 1)[0];
+
+    const response = await handlerFor(loginRoute)(
+      new Request("https://worker.example.com/mcp-auth/login?handoff=opaque-handoff-token-123456", {
+        headers: { cookie: cookie ?? "" },
+      }),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "https://worker.example.com/mcp-auth/consent?response_type=code&client_id=client_1&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback&scope=mcp%3Aread",
+    );
+    expect(response.headers.get("location")).not.toContain("worker-session");
+    expect(state.verifyOneTimeToken).toHaveBeenCalledWith({
+      body: { token: "opaque-handoff-token-123456" },
+      returnHeaders: true,
+    });
+    expect(response.headers.get("set-cookie")).toContain("session-cookie");
+  });
+
+  it.each([
+    ["invalid", "not-a-valid-token"],
+    ["expired", "opaque-expired-token-123456"],
+    ["replayed", "opaque-replayed-token-123456"],
+  ])("rejects %s handoffs", async (_label, token) => {
+    state.verifyOneTimeToken.mockRejectedValue(new Error("Invalid token"));
+    const initial = await handlerFor(loginRoute)(new Request(oauthUrl()));
+    const cookie = initial.headers.get("set-cookie")?.split(";", 1)[0];
+
+    const response = await handlerFor(loginRoute)(
+      new Request(`https://worker.example.com/mcp-auth/login?handoff=${token}`, {
+        headers: { cookie: cookie ?? "" },
+      }),
+    );
+
+    expect(response.status).toBe(token === "not-a-valid-token" ? 400 : 401);
+    expect(response.headers.get("location")).toBeNull();
+  });
+});

--- a/apps/worker/src/routes/mcp-auth/login.get.ts
+++ b/apps/worker/src/routes/mcp-auth/login.get.ts
@@ -1,11 +1,35 @@
-import { defineEventHandler, setResponseHeader, toWebRequest } from "h3";
+import {
+  appendResponseHeader,
+  createError,
+  defineEventHandler,
+  getHeader,
+  sendRedirect,
+  setResponseHeader,
+  splitCookiesString,
+  toWebRequest,
+} from "h3";
 
 import { env } from "../../../env.js";
-import { createOAuthFlowCookie, renderMcpLoginPage } from "../../mcp/auth-pages.js";
+import { auth } from "../../auth-instance.js";
+import {
+  createOAuthFlowCookie,
+  isOAuthAuthorizationQuery,
+  isOpaqueHandoffToken,
+  oauthConsentUrl,
+  readOAuthFlowCookie,
+  renderMcpLoginPage,
+} from "../../mcp/auth-pages.js";
 
-export default defineEventHandler((event) => {
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, "cache-control", "no-store");
   const request = toWebRequest(event);
-  const oauthQuery = new URL(request.url).search.slice(1);
+  const url = new URL(request.url);
+  const handoffToken = url.searchParams.get("handoff");
+  const fallback = url.searchParams.get("fallback") === "1";
+  const oauthQuery =
+    !handoffToken && !fallback && isOAuthAuthorizationQuery(url.searchParams)
+      ? url.search.slice(1)
+      : null;
   if (oauthQuery) {
     setResponseHeader(
       event,
@@ -13,6 +37,50 @@ export default defineEventHandler((event) => {
       createOAuthFlowCookie(oauthQuery, env.BETTER_AUTH_SECRET),
     );
   }
+
+  const flowQuery =
+    oauthQuery ??
+    readOAuthFlowCookie(getHeader(event, "cookie") ?? null, env.BETTER_AUTH_SECRET);
+
+  if (handoffToken) {
+    if (!isOpaqueHandoffToken(handoffToken) || !flowQuery) {
+      throw createError({ statusCode: 400, statusMessage: "Invalid login handoff" });
+    }
+
+    let verification: { headers: Headers };
+    try {
+      verification = (await auth.api.verifyOneTimeToken({
+        body: { token: handoffToken },
+        returnHeaders: true,
+      })) as unknown as { headers: Headers };
+    } catch {
+      throw createError({ statusCode: 401, statusMessage: "Invalid login handoff" });
+    }
+    forwardCookies(event, verification.headers);
+    return sendRedirect(event, oauthConsentUrl(flowQuery, env.BETTER_AUTH_URL), 302);
+  }
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (session && flowQuery) {
+    return sendRedirect(event, oauthConsentUrl(flowQuery, env.BETTER_AUTH_URL), 302);
+  }
+
+  if (oauthQuery && !session) {
+    const dashboardBridge = new URL(
+      "/api/auth/sso/mcp-session",
+      env.DASHBOARD_ORIGIN,
+    );
+    return sendRedirect(event, dashboardBridge.href, 302);
+  }
+
   setResponseHeader(event, "content-type", "text/html; charset=utf-8");
   return renderMcpLoginPage({ error: null });
 });
+
+function forwardCookies(
+  event: Parameters<typeof appendResponseHeader>[0],
+  headers: Headers,
+) {
+  const cookies = splitCookiesString(headers.get("set-cookie") ?? "");
+  for (const cookie of cookies) appendResponseHeader(event, "set-cookie", cookie);
+}


### PR DESCRIPTION
## What changed

- bridges an existing dashboard Better Auth session into the worker MCP OAuth flow
- uses a hashed, single-use, one-minute handoff token instead of exposing a session token to the browser
- lets an existing worker session skip the login form and continue directly to consent
- keeps email/password and SSO as fallbacks
- adds focused dashboard, worker route, replay, invalid-token, and expiry coverage

## Why

Dashboard and worker cookies live on separate domains. A user already signed into AI Workflow was therefore shown another login screen during MCP authorization instead of continuing to the consent step.

## User impact

Signed-in users can start MCP authorization and continue to consent without entering credentials again. The raw dashboard session remains server-side.

## Validation

- dashboard test suite: 794 passed
- focused dashboard handoff route: 5 passed
- focused worker MCP auth suite: 27 passed
- dashboard typecheck: passed
- worker typecheck: passed
- `git diff --check`: passed

Jira: AIW-273
