### PR TITLE
fix: prevent MCP pre-auth crash in Vercel bundle

### DIFF
--- a/apps/worker/nitro.config.ts
+++ b/apps/worker/nitro.config.ts
@@ -26,6 +26,10 @@ async function findFuncDirs(root: string): Promise<string[]> {
 
 export default defineNitroConfig({
   preset: "vercel",
+  // The MCP catalog intentionally uses Zod 3 while Better Auth brings Zod 4.
+  // Vercel's dependency tracer otherwise preserves the `zod/v3` subpath import
+  // but installs only the top-level Zod 4 package, crashing /mcp before auth.
+  externals: { inline: ["zod/v3"] },
   modules: [
     "workflow/nitro",
     // Ship YAML configs into every Vercel function bundle so runtime code can


### PR DESCRIPTION
## What changed

- force Nitro to inline the MCP catalog's `zod/v3` import into every Vercel function bundle
- keep Better Auth's external Zod 4 dependency unchanged

## Root cause

The Vercel preset preserved `zod/v3` as a runtime import but traced only top-level `zod@4.3.6`. The generated function therefore crashed with `ERR_MODULE_NOT_FOUND` before the MCP authentication layer.

## Validation

- reproduced the failure by importing the generated Vercel `/mcp` route chunk before the fix
- rebuilt with the Vercel Nitro preset; generated functions contain no bare `zod/v3` imports
- generated `/mcp` route chunk imports successfully with a valid synthetic environment
- focused MCP suite: 81 passed
- worker typecheck: passed
- MCP contract check: 22 tools, 11 error codes, unchanged hash `881de2fae17a183a44645d8d6c6c8c8089e604fcc2197d98d4f27acb66ec2f7b`
- `git diff --check`: passed

Jira: AIW-276


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vercel deployment compatibility for MCP runtime environments using mixed Zod versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->