### PR TITLE
fix(worker): reject premature AI Review success (AIW-274)

### DIFF
--- a/apps/worker/src/db/queries/runs-read.test.ts
+++ b/apps/worker/src/db/queries/runs-read.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createTestDb } from "../test-db.js";
 import type { Db } from "../client.js";
-import { workflowRuns } from "../schema.js";
+import { activeRuns, workflowOwnedBranches, workflowRuns } from "../schema.js";
 import type {
   BlockRunState,
   HarnessRunManifestRecord,
@@ -17,6 +17,7 @@ import {
   costAgg,
   listRunsForTicket,
   isRunRecordedFailed,
+  hasDurableRunPublication,
   fetchRunModels,
 } from "./runs-read.js";
 
@@ -61,6 +62,7 @@ interface SeedRun {
   tokensInput?: number | null;
   tokensOutput?: number | null;
   prNumber?: number | null;
+  prRepo?: string | null;
   prUrl?: string | null;
   prs?: RunPullRequest[] | null;
   harnessManifests?: HarnessRunManifestRecord[] | null;
@@ -86,6 +88,7 @@ async function seed(over: SeedRun = {}): Promise<void> {
     tokensInput: over.tokensInput === undefined ? 1000 : over.tokensInput,
     tokensOutput: over.tokensOutput === undefined ? 500 : over.tokensOutput,
     prNumber: over.prNumber ?? null,
+    prRepo: over.prRepo ?? null,
     prUrl: over.prUrl ?? null,
     prs: over.prs ?? null,
     harnessManifests: over.harnessManifests ?? null,
@@ -531,5 +534,126 @@ describe("isRunRecordedFailed", () => {
 
   it("is false for a missing run", async () => {
     expect(await isRunRecordedFailed(db, "wrun_missing")).toBe(false);
+  });
+});
+
+describe("hasDurableRunPublication", () => {
+  it("requires publication evidence on the exact run", async () => {
+    await seed({ runId: "wrun_empty", status: "running" });
+    await seed({
+      runId: "wrun_gate",
+      status: "running",
+      prRepo: "acme/app",
+      prNumber: 42,
+    });
+
+    expect(await hasDurableRunPublication(db, "wrun_empty")).toBe(false);
+    expect(await hasDurableRunPublication(db, "wrun_gate")).toBe(true);
+    expect(await hasDurableRunPublication(db, "wrun_missing")).toBe(false);
+  });
+
+  it("recognizes a valid multi-repository publication and ignores malformed entries", async () => {
+    await seed({
+      runId: "wrun_publication",
+      status: "running",
+      prs: [
+        {
+          provider: "github",
+          repoPath: "acme/app",
+          id: 7,
+          url: "https://github.com/acme/app/pull/7",
+        },
+      ],
+    });
+    await seed({
+      runId: "wrun_malformed",
+      status: "running",
+      prs: [{ provider: "github" } as unknown as RunPullRequest],
+    });
+
+    expect(await hasDurableRunPublication(db, "wrun_publication")).toBe(true);
+    expect(await hasDurableRunPublication(db, "wrun_malformed")).toBe(false);
+  });
+
+  it("recognizes a confirmed mid-run publication correlated to the current active claim", async () => {
+    const claimCreatedAt = new Date("2026-06-16T10:00:00.000Z");
+    await db.insert(activeRuns).values({
+      subjectKey: "ticket:jira:AIW-274",
+      ticketKey: "AIW-274",
+      ownerToken: "owner-current",
+      runId: "wrun_current",
+      state: "bound",
+      createdAt: claimCreatedAt,
+    });
+    await db.insert(workflowOwnedBranches).values({
+      ticketKey: "AIW-274",
+      provider: "github",
+      repoPath: "acme/app",
+      branchName: "blazebot/aiw-274",
+      publishedHeadSha: "abc123",
+      targetBranch: "main",
+      prId: 274,
+      prUrl: "https://github.com/acme/app/pull/274",
+      prBranchName: "blazebot/aiw-274",
+      prPublishedHeadSha: "abc123",
+      prTargetBranch: "main",
+      prCorrelationPending: false,
+      updatedAt: new Date(claimCreatedAt.getTime() + 1_000),
+    });
+
+    expect(await hasDurableRunPublication(db, "wrun_current")).toBe(true);
+  });
+
+  it("rejects confirmed publication metadata left by a prior run of the ticket", async () => {
+    const claimCreatedAt = new Date("2026-06-16T10:00:00.000Z");
+    await db.insert(activeRuns).values({
+      subjectKey: "ticket:jira:AIW-274",
+      ticketKey: "AIW-274",
+      ownerToken: "owner-current",
+      runId: "wrun_current",
+      state: "bound",
+      createdAt: claimCreatedAt,
+    });
+    await db.insert(workflowOwnedBranches).values({
+      ticketKey: "AIW-274",
+      provider: "github",
+      repoPath: "acme/app",
+      branchName: "blazebot/aiw-274",
+      publishedHeadSha: "prior123",
+      targetBranch: "main",
+      prId: 273,
+      prUrl: "https://github.com/acme/app/pull/273",
+      prBranchName: "blazebot/aiw-274",
+      prPublishedHeadSha: "prior123",
+      prTargetBranch: "main",
+      prCorrelationPending: false,
+      updatedAt: new Date(claimCreatedAt.getTime() - 1_000),
+    });
+
+    expect(await hasDurableRunPublication(db, "wrun_current")).toBe(false);
+  });
+
+  it("rejects a current run's unconfirmed publication intent", async () => {
+    const claimCreatedAt = new Date("2026-06-16T10:00:00.000Z");
+    await db.insert(activeRuns).values({
+      subjectKey: "ticket:jira:AIW-274",
+      ticketKey: "AIW-274",
+      ownerToken: "owner-current",
+      runId: "wrun_current",
+      state: "bound",
+      createdAt: claimCreatedAt,
+    });
+    await db.insert(workflowOwnedBranches).values({
+      ticketKey: "AIW-274",
+      provider: "github",
+      repoPath: "acme/app",
+      branchName: "blazebot/aiw-274",
+      publishedHeadSha: "abc123",
+      targetBranch: "main",
+      prCorrelationPending: true,
+      updatedAt: new Date(claimCreatedAt.getTime() + 1_000),
+    });
+
+    expect(await hasDurableRunPublication(db, "wrun_current")).toBe(false);
   });
 });

--- a/apps/worker/src/db/queries/runs-read.ts
+++ b/apps/worker/src/db/queries/runs-read.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, inArray, sql, type SQL } from "drizzle-orm";
+import { and, count, eq, gte, inArray, sql, type SQL } from "drizzle-orm";
 import type {
   BlockRunState,
   CostResponse,
@@ -11,7 +11,7 @@ import type {
   WorkflowRow,
 } from "@shared/contracts";
 import type { Db } from "../client.js";
-import { activeRuns, workflowRuns } from "../schema.js";
+import { activeRuns, workflowOwnedBranches, workflowRuns } from "../schema.js";
 import { attributeRunModel } from "../../lib/overview/attribute-run-model.js";
 
 /**
@@ -119,6 +119,95 @@ export async function isRunRecordedSucceeded(db: Db, runId: string): Promise<boo
     .where(eq(workflowRuns.runId, runId))
     .limit(1);
   return row?.status === "success";
+}
+
+/**
+ * True when this exact run has durable PR/publication evidence. Agent PR
+ * telemetry lands only at terminal completion, so an active run additionally
+ * correlates its current claim to a confirmed workflow-owned publication for
+ * the same ticket. The timestamp boundary rejects a prior run's ticket-scoped
+ * PR row. Exact-run workflow telemetry remains valid for gate and legacy runs.
+ */
+export async function hasDurableRunPublication(db: Db, runId: string): Promise<boolean> {
+  const [row] = await db
+    .select({
+      prRepo: workflowRuns.prRepo,
+      prUrl: workflowRuns.prUrl,
+      prNumber: workflowRuns.prNumber,
+      prs: workflowRuns.prs,
+    })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, runId))
+    .limit(1);
+  if (
+    row &&
+    row.prNumber !== null &&
+    row.prNumber > 0 &&
+    ((typeof row.prUrl === "string" && row.prUrl.trim().length > 0) ||
+      (typeof row.prRepo === "string" && row.prRepo.trim().length > 0))
+  ) {
+    return true;
+  }
+  if (
+    row &&
+    Array.isArray(row.prs) &&
+    row.prs.some(
+      (pr) =>
+        Boolean(
+          pr &&
+            (pr.provider === "github" || pr.provider === "gitlab") &&
+            typeof pr.repoPath === "string" &&
+            pr.repoPath.trim().length > 0 &&
+            typeof pr.id === "number" &&
+            pr.id > 0 &&
+            typeof pr.url === "string" &&
+            pr.url.trim().length > 0,
+        ),
+    )
+  ) {
+    return true;
+  }
+
+  const publications = await db
+    .select({
+      provider: workflowOwnedBranches.provider,
+      repoPath: workflowOwnedBranches.repoPath,
+      branchName: workflowOwnedBranches.branchName,
+      publishedHeadSha: workflowOwnedBranches.publishedHeadSha,
+      targetBranch: workflowOwnedBranches.targetBranch,
+      prId: workflowOwnedBranches.prId,
+      prUrl: workflowOwnedBranches.prUrl,
+      prBranchName: workflowOwnedBranches.prBranchName,
+      prPublishedHeadSha: workflowOwnedBranches.prPublishedHeadSha,
+      prTargetBranch: workflowOwnedBranches.prTargetBranch,
+    })
+    .from(activeRuns)
+    .innerJoin(
+      workflowOwnedBranches,
+      eq(workflowOwnedBranches.ticketKey, activeRuns.ticketKey),
+    )
+    .where(
+      and(
+        eq(activeRuns.runId, runId),
+        eq(workflowOwnedBranches.prCorrelationPending, false),
+        gte(workflowOwnedBranches.updatedAt, activeRuns.createdAt),
+      ),
+    );
+
+  return publications.some(
+    (publication) =>
+      (publication.provider === "github" || publication.provider === "gitlab") &&
+      publication.repoPath.trim().length > 0 &&
+      publication.branchName.trim().length > 0 &&
+      Boolean(publication.publishedHeadSha?.trim()) &&
+      Boolean(publication.targetBranch?.trim()) &&
+      publication.prId !== null &&
+      publication.prId > 0 &&
+      Boolean(publication.prUrl?.trim()) &&
+      Boolean(publication.prBranchName?.trim()) &&
+      Boolean(publication.prPublishedHeadSha?.trim()) &&
+      Boolean(publication.prTargetBranch?.trim()),
+  );
 }
 
 /**

--- a/apps/worker/src/lib/ai-review-transition.ts
+++ b/apps/worker/src/lib/ai-review-transition.ts
@@ -1,0 +1,30 @@
+import type { Db } from "../db/client.js";
+import {
+  hasDurableRunPublication,
+  isRunRecordedFailed,
+  isRunRecordedSucceeded,
+} from "../db/queries/runs-read.js";
+
+export const PREMATURE_AI_REVIEW_CANCELLATION_REASON =
+  "Jira AI Review transition before durable PR publication evidence";
+
+export type AiReviewRunDecision = "retain" | "cancel" | "lookup_failed";
+
+/**
+ * Decide whether an active run can survive an AI Review transition. The
+ * webhook and reconciler use this same durable evidence rule; a failed lookup
+ * is distinct from absent evidence so callers can retry instead of guessing.
+ */
+export async function decideAiReviewRun(
+  db: Db | undefined,
+  runId: string,
+): Promise<AiReviewRunDecision> {
+  if (!db) return "lookup_failed";
+  try {
+    if (await isRunRecordedFailed(db, runId)) return "retain";
+    if (await isRunRecordedSucceeded(db, runId)) return "retain";
+    return (await hasDurableRunPublication(db, runId)) ? "retain" : "cancel";
+  } catch {
+    return "lookup_failed";
+  }
+}

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -5,6 +5,7 @@ import type {
   RunRegistryAdapter,
 } from "../adapters/run-registry/types.js";
 import type { IssueTrackerAdapter } from "../adapters/issue-tracker/types.js";
+import type { Db } from "../db/client.js";
 
 vi.mock("../../env.js", () => ({
   env: {
@@ -19,6 +20,10 @@ vi.mock("../../env.js", () => ({
 const mockGetRun = vi.fn();
 const mockCancelRunDetailed = vi.fn();
 const mockCancelSubjectRunDetailed = vi.fn();
+const mockIsRunRecordedFailed = vi.fn();
+const mockIsRunRecordedSucceeded = vi.fn();
+const mockHasDurableRunPublication = vi.fn();
+const mockDb = {} as Db;
 const mockStopSandboxesByIds = vi.fn();
 const mockListWorkflowSteps = vi.fn();
 vi.mock("workflow/api", () => ({ getRun: (...args: any[]) => mockGetRun(...args) }));
@@ -30,6 +35,11 @@ vi.mock("workflow/runtime", () => ({
 vi.mock("./cancel-run.js", () => ({
   cancelRunDetailed: (...args: any[]) => mockCancelRunDetailed(...args),
   cancelSubjectRunDetailed: (...args: any[]) => mockCancelSubjectRunDetailed(...args),
+}));
+vi.mock("../db/queries/runs-read.js", () => ({
+  isRunRecordedFailed: (...args: any[]) => mockIsRunRecordedFailed(...args),
+  isRunRecordedSucceeded: (...args: any[]) => mockIsRunRecordedSucceeded(...args),
+  hasDurableRunPublication: (...args: any[]) => mockHasDurableRunPublication(...args),
 }));
 vi.mock("./run-start-lifecycle.js", () => ({
   reconcileStartupWatchdog: vi.fn().mockResolvedValue({
@@ -117,6 +127,9 @@ describe("reconcileRuns owner-CAS recovery", () => {
     vi.clearAllMocks();
     (await import("./ai-review-destination.js")).resetAiReviewDestinationCache();
     mockStopSandboxesByIds.mockResolvedValue(2);
+    mockIsRunRecordedFailed.mockResolvedValue(false);
+    mockIsRunRecordedSucceeded.mockResolvedValue(false);
+    mockHasDurableRunPublication.mockResolvedValue(false);
     mockListWorkflowSteps.mockResolvedValue({
       data: [],
       cursor: null,
@@ -688,10 +701,19 @@ describe("reconcileRuns owner-CAS recovery", () => {
     const bound = entry();
     const runRegistry = registry([bound]);
     mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    mockHasDurableRunPublication.mockResolvedValue(true);
     const { reconcileRuns } = await import("./reconcile.js");
 
     expect(
-      await reconcileRuns(new Set(), runRegistry, issueTracker("Review")),
+      await reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Review"),
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
     ).toEqual({ cancelled: 0, cleaned: 0 });
     expect(mockCancelRunDetailed).not.toHaveBeenCalled();
     expect(runRegistry.release).not.toHaveBeenCalled();
@@ -705,6 +727,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
     const bound = entry();
     const runRegistry = registry([bound]);
     mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    mockHasDurableRunPublication.mockResolvedValue(true);
     const { reconcileRuns } = await import("./reconcile.js");
 
     expect(
@@ -715,8 +738,85 @@ describe("reconcileRuns owner-CAS recovery", () => {
           trackerStatusId: "11418",
           reviewDestination: { id: "11418", name: "Weryfikacja" },
         }),
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
       ),
     ).toEqual({ cancelled: 0, cleaned: 0 });
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
+  });
+
+  it("cancels an AI Review transition when the exact run has no durable publication", async () => {
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Review"),
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
+    ).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockHasDurableRunPublication).toHaveBeenCalledWith(expect.anything(), "run-1");
+    expect(mockCancelRunDetailed).toHaveBeenCalledWith(
+      "PROJ-1",
+      "run-1",
+      runRegistry,
+      expect.anything(),
+      undefined,
+      undefined,
+      "Jira AI Review transition before durable PR publication evidence",
+    );
+  });
+
+  it("retains an AI Review transition when the exact run's success is recorded", async () => {
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    mockIsRunRecordedSucceeded.mockResolvedValue(true);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Review"),
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
+    ).resolves.toEqual({ cancelled: 0, cleaned: 0 });
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
+    expect(mockHasDurableRunPublication).not.toHaveBeenCalled();
+  });
+
+  it("retains an AI Review owner when durable evidence lookup fails", async () => {
+    const bound = entry();
+    const runRegistry = registry([bound]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    mockHasDurableRunPublication.mockRejectedValue(new Error("db down"));
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Review"),
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
+    ).resolves.toEqual({ cancelled: 0, cleaned: 0 });
     expect(mockCancelRunDetailed).not.toHaveBeenCalled();
   });
 
@@ -747,11 +847,20 @@ describe("reconcileRuns owner-CAS recovery", () => {
     const bound = entry();
     const runRegistry = registry([bound]);
     mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+    mockHasDurableRunPublication.mockResolvedValue(true);
     mockCancelRunDetailed.mockResolvedValue({ cancelled: true, released: true });
     const { reconcileRuns } = await import("./reconcile.js");
 
     expect(
-      await reconcileRuns(new Set(), runRegistry, issueTracker("Review")),
+      await reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Review"),
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
     ).toEqual({ cancelled: 1, cleaned: 0 });
     expect(mockCancelRunDetailed).toHaveBeenCalledOnce();
   });

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -2,6 +2,10 @@ import { getRun } from "workflow/api";
 import { env } from "../../env.js";
 import { isAiReviewDestination } from "./ai-review-destination.js";
 import {
+  decideAiReviewRun,
+  PREMATURE_AI_REVIEW_CANCELLATION_REASON,
+} from "./ai-review-transition.js";
+import {
   cancelRunDetailed,
   cancelSubjectRunDetailed,
   type CancelRunResult,
@@ -160,13 +164,20 @@ export async function reconcileRuns(
     }
     const departure = await verifyTicketLeftAiColumn(ticketKey, issueTracker);
     if (!departure.left) continue;
+    const reviewDestination =
+      departure.trackerStatus !== null &&
+      (await isAiReviewDestination({
+        issueTracker: issueTracker!,
+        ticketKey,
+        statusName: departure.trackerStatus,
+        statusId: departure.trackerStatusId,
+      }));
     if (
+      reviewDestination &&
       await shouldRetainFinalizingRunInAiReview(
         ticketKey,
         entry.runId,
-        departure.trackerStatus,
-        departure.trackerStatusId,
-        issueTracker,
+        db,
       )
     ) {
       continue;
@@ -179,7 +190,9 @@ export async function reconcileRuns(
       issueTracker,
       undefined,
       onSubjectReleased,
-      "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
+      reviewDestination
+        ? PREMATURE_AI_REVIEW_CANCELLATION_REASON
+        : "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
     );
     if (!cancellationResult.cancelled) {
       logger.warn({ ticketKey, runId: entry.runId }, "reconcile_orphan_cancel_unconfirmed");
@@ -482,33 +495,27 @@ async function verifyTicketLeftAiColumn(
 }
 
 /**
- * A ticket sitting in the AI Review column while its bound run is still
- * executing is the run's own success destination reached early: a Jira
- * automation rule (or an eager human) raced the run's final self-move as soon
- * as the PR appeared, before the run could freeze its "success" status.
- * Cancelling would record that genuine success as "cancelled"/"blocked".
- * Retain the owner until the Workflow world reports a terminal status; the
- * next tick then releases it through this same orphan path (cancelRun's
- * already-terminal branch) exactly as for a normal completion.
+ * A ticket sitting in the AI Review column is retained while its bound run is
+ * still executing only when the exact run has a recorded outcome or durable
+ * PR/publication evidence. That preserves the genuine post-PR finalization
+ * race without treating an eager human move with no evidence as success.
+ * Once the Workflow world is terminal, release it through this same orphan
+ * path (cancelRun's already-terminal branch) exactly as for normal completion.
  */
 async function shouldRetainFinalizingRunInAiReview(
   ticketKey: string,
   runId: string,
-  trackerStatus: string | null,
-  trackerStatusId: string | null,
-  issueTracker?: IssueTrackerAdapter,
+  db?: Db,
 ): Promise<boolean> {
-  if (!issueTracker) return false;
-  if (
-    !(await isAiReviewDestination({
-      issueTracker,
-      ticketKey,
-      statusName: trackerStatus,
-      statusId: trackerStatusId,
-    }))
-  ) {
-    return false;
+  const decision = await decideAiReviewRun(db, runId);
+  if (decision === "lookup_failed") {
+    logger.warn(
+      { ticketKey, runId },
+      "reconcile_ai_review_run_evidence_lookup_failed",
+    );
+    return true;
   }
+  if (decision === "cancel") return false;
   try {
     const status = await getRun(runId).status;
     if (TERMINAL_STATUSES.has(status)) return false;

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -17,6 +17,7 @@ const state = vi.hoisted(() => ({
   resume: vi.fn(),
   isRunRecordedFailed: vi.fn(),
   isRunRecordedSucceeded: vi.fn(),
+  hasDurableRunPublication: vi.fn(),
   classifyProtected: vi.fn(),
   listApprovalParked: vi.fn(),
 }));
@@ -40,6 +41,7 @@ vi.mock("../../approvals/store.js", () => ({
 vi.mock("../../db/queries/runs-read.js", () => ({
   isRunRecordedFailed: state.isRunRecordedFailed,
   isRunRecordedSucceeded: state.isRunRecordedSucceeded,
+  hasDurableRunPublication: state.hasDurableRunPublication,
 }));
 
 const { resetAiReviewDestinationCache } = await import(
@@ -127,6 +129,7 @@ describe("POST /webhooks/jira", () => {
     state.dispatch.mockResolvedValue({ started: false, reason: "not_applicable" });
     state.isRunRecordedFailed.mockResolvedValue(false);
     state.isRunRecordedSucceeded.mockResolvedValue(false);
+    state.hasDurableRunPublication.mockResolvedValue(false);
     state.classifyProtected.mockResolvedValue({ all: [], retained: [], terminal: [] });
     state.listApprovalParked.mockResolvedValue([]);
   });
@@ -326,18 +329,24 @@ describe("POST /webhooks/jira", () => {
     // webhook. The run already recorded 'success', so cancelling would
     // overwrite that with a 'blocked' status even though the PR already opened.
     const connected = adapters();
+    connected.issueTracker.fetchTicket.mockResolvedValue({
+      identifier: "PROJ-42",
+      projectKey: "PROJ",
+      trackerStatus: "Review",
+    });
     state.createAdapters.mockReturnValue(connected);
     state.isRunRecordedSucceeded.mockResolvedValue(true);
 
-    const response = await app()(request({ actor: "human-account" }));
+    const response = await app()(request({ actor: "human-account", status: "Review" }));
 
     await expect(response.json()).resolves.toMatchObject({
       status: "ignored",
-      reason: "run_already_succeeded",
+      reason: "ticket_in_ai_review_column",
       ticketKey: "PROJ-42",
     });
     expect(state.isRunRecordedSucceeded).toHaveBeenCalledWith(expect.anything(), "run-1");
     expect(state.cancel).not.toHaveBeenCalled();
+    expect(state.hasDurableRunPublication).not.toHaveBeenCalled();
   });
 
   it("reports the real outcome (not cancelled) when the run went terminal as the ticket left the AI column", async () => {
@@ -376,6 +385,7 @@ describe("POST /webhooks/jira", () => {
       projectKey: "PROJ",
       trackerStatus: "Review",
     });
+    state.hasDurableRunPublication.mockResolvedValue(true);
     state.createAdapters.mockReturnValue(connected);
 
     const response = await app()(request({ actor: "automation-account", status: "Review" }));
@@ -386,10 +396,34 @@ describe("POST /webhooks/jira", () => {
       ticketKey: "PROJ-42",
     });
     expect(state.cancel).not.toHaveBeenCalled();
-    // The guard sits before the recorded-outcome lookup: a review-column move
-    // must never surface the retryable 503 of a failed lookup either.
-    expect(state.isRunRecordedFailed).not.toHaveBeenCalled();
-    expect(state.isRunRecordedSucceeded).not.toHaveBeenCalled();
+    expect(state.hasDurableRunPublication).toHaveBeenCalledWith(expect.anything(), "run-1");
+  });
+
+  it("cancels a human AI Review move before durable PR publication exists", async () => {
+    const connected = adapters();
+    connected.issueTracker.fetchTicket.mockResolvedValue({
+      identifier: "PROJ-42",
+      projectKey: "PROJ",
+      trackerStatus: "Review",
+    });
+    state.createAdapters.mockReturnValue(connected);
+
+    const response = await app()(request({ actor: "human-account", status: "Review" }));
+
+    await expect(response.json()).resolves.toMatchObject({
+      status: "cancelled",
+      reason: "left_ai_column",
+    });
+    expect(state.hasDurableRunPublication).toHaveBeenCalledWith(expect.anything(), "run-1");
+    expect(state.cancel).toHaveBeenCalledWith(
+      "PROJ-42",
+      { ownerToken: "owner-1", runId: "run-1" },
+      connected.runRegistry,
+      connected.issueTracker,
+      undefined,
+      undefined,
+      "Jira AI Review transition before durable PR publication evidence",
+    );
   });
 
   it("does not cancel a still-finalizing run when COLUMN_AI_REVIEW names the transition and the status name differs", async () => {
@@ -409,6 +443,7 @@ describe("POST /webhooks/jira", () => {
       id: "11418",
       name: "Weryfikacja",
     });
+    state.hasDurableRunPublication.mockResolvedValue(true);
     state.createAdapters.mockReturnValue(connected);
 
     const response = await app()(
@@ -421,7 +456,23 @@ describe("POST /webhooks/jira", () => {
       ticketKey: "PROJ-42",
     });
     expect(state.cancel).not.toHaveBeenCalled();
-    expect(state.isRunRecordedSucceeded).not.toHaveBeenCalled();
+    expect(state.hasDurableRunPublication).toHaveBeenCalledWith(expect.anything(), "run-1");
+  });
+
+  it("fails closed when AI Review publication evidence lookup fails", async () => {
+    const connected = adapters();
+    connected.issueTracker.fetchTicket.mockResolvedValue({
+      identifier: "PROJ-42",
+      projectKey: "PROJ",
+      trackerStatus: "Review",
+    });
+    state.createAdapters.mockReturnValue(connected);
+    state.hasDurableRunPublication.mockRejectedValue(new Error("db down"));
+
+    const response = await app()(request({ actor: "human-account", status: "Review" }));
+
+    expect(response.status).toBe(503);
+    expect(state.cancel).not.toHaveBeenCalled();
   });
 
   it("still cancels a genuine pull-out when the resolved review destination differs", async () => {

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -9,6 +9,10 @@ import { getDb } from "../../db/client.js";
 import { isRunRecordedFailed, isRunRecordedSucceeded } from "../../db/queries/runs-read.js";
 import { createAdapters } from "../../lib/adapters.js";
 import { isAiReviewDestination } from "../../lib/ai-review-destination.js";
+import {
+  decideAiReviewRun,
+  PREMATURE_AI_REVIEW_CANCELLATION_REASON,
+} from "../../lib/ai-review-transition.js";
 import { cancelRunDetailed } from "../../lib/cancel-run.js";
 import { dispatchTicket } from "../../lib/dispatch.js";
 import { logger } from "../../lib/logger.js";
@@ -213,44 +217,13 @@ export default defineEventHandler(async (event) => {
       };
     }
 
-    // The AI Review column is the flow's own success destination: the run's
-    // final update_ticket_status block moves the finished ticket there right
-    // after the PR opens. A Jira automation rule (or an eager human) can race
-    // that same move as soon as the PR link appears, landing the ticket in AI
-    // Review while the run is still finalizing and BEFORE the self-move froze
-    // the "success" status, so the recorded-outcome guard below cannot help.
-    // Entering the review column is a completion gesture, never an abort,
-    // whichever actor performed it: skip cancellation and let the run finish.
-    // Its own later move lands as a no-op (moveTicketForRun's already-at-target
-    // check). A human abort still cancels, because it moves the ticket to a
-    // non-review column.
-    if (
-      await isAiReviewDestination({
-        issueTracker: adapters.issueTracker,
-        ticketKey,
-        statusName: liveTicketState.status,
-        statusId: liveTicketState.statusId,
-      })
-    ) {
-      logger.info(
-        {
-          ticketKey,
-          payloadStatus: ticketStatus,
-          liveStatus: liveTicketState.status,
-        },
-        "webhook_skip_cancel_ticket_in_ai_review_column",
-      );
-      return { status: "ignored", reason: "ticket_in_ai_review_column", ticketKey };
-    }
-
     // The bot's OWN finalization moves this ticket out of the AI column: its
     // failure handling moves a failed run's ticket to the backlog, and its
     // success handling moves a finished run's ticket to AI Review. Both fire
-    // this exact webhook. Refuse to cancel a run whose terminal outcome is
-    // already recorded: cancelling would overwrite a "failed" outcome with a
-    // "cancelled" world status the errors KPI never counts, or a "success"
-    // outcome with a "blocked" status even though the PR already opened. A
-    // human abort still cancels, because a live run records neither outcome.
+    // this exact webhook. AI Review is retained only for a recorded outcome or
+    // exact-run durable publication evidence; an active move with neither is a
+    // premature human transition and falls through to cancellation. Other
+    // columns retain the recorded-outcome guards below.
     const subjectKey = ticketSubjectKey("jira", ticketKey);
     const activeRun = await adapters.runRegistry.get(subjectKey).catch(() => null);
     // Manual PR/MR dispatch can correlate through a workflow-owned Jira ticket
@@ -267,7 +240,48 @@ export default defineEventHandler(async (event) => {
         ticketKey,
       };
     }
-    if (activeRun?.runId) {
+    let prematureAiReviewTransition = false;
+    if (
+      await isAiReviewDestination({
+        issueTracker: adapters.issueTracker,
+        ticketKey,
+        statusName: liveTicketState.status,
+        statusId: liveTicketState.statusId,
+      })
+    ) {
+      if (!activeRun?.runId) {
+        logger.info(
+          { ticketKey, payloadStatus: ticketStatus, liveStatus: liveTicketState.status },
+          "webhook_skip_cancel_ticket_in_ai_review_without_active_run",
+        );
+        return { status: "ignored", reason: "ticket_in_ai_review_column", ticketKey };
+      }
+      const aiReviewDecision = await decideAiReviewRun(getDb(), activeRun.runId);
+      if (aiReviewDecision === "lookup_failed") {
+        logger.warn(
+          { ticketKey, runId: activeRun.runId },
+          "webhook_ai_review_run_evidence_lookup_failed",
+        );
+        throw createError({
+          statusCode: 503,
+          statusMessage: "AI Review run evidence lookup failed",
+        });
+      }
+      if (aiReviewDecision === "retain") {
+        logger.info(
+          {
+            ticketKey,
+            runId: activeRun.runId,
+            payloadStatus: ticketStatus,
+            liveStatus: liveTicketState.status,
+          },
+          "webhook_skip_cancel_ticket_in_ai_review_column",
+        );
+        return { status: "ignored", reason: "ticket_in_ai_review_column", ticketKey };
+      }
+      prematureAiReviewTransition = true;
+    }
+    if (activeRun?.runId && !prematureAiReviewTransition) {
       let recordedFailed: boolean;
       let recordedSucceeded: boolean;
       try {
@@ -368,7 +382,9 @@ export default defineEventHandler(async (event) => {
       adapters.runRegistry,
       adapters.issueTracker,
       undefined,
-      `Ticket left the AI column (${env.COLUMN_AI} → ${ticketStatus}) via Jira webhook`,
+      prematureAiReviewTransition
+        ? PREMATURE_AI_REVIEW_CANCELLATION_REASON
+        : `Ticket left the AI column (${env.COLUMN_AI} → ${ticketStatus}) via Jira webhook`,
     );
     if (cancellation === "unconfirmed") {
       logger.warn(


### PR DESCRIPTION
## Summary

Root cause: the Jira AI Review transition was treated as success for any active run, so a premature transition could race before the run froze its terminal success state and durable PR publication evidence, masking the run as successful.

This change applies one durable, exact-run publication rule in both the Jira webhook and reconciler: retain an active run only when that same run has a recorded terminal outcome or complete workflow-owned PR/publication evidence correlated to the run and created-at boundary.

Fail-closed behavior: absent exact-run evidence cancels the premature AI Review transition with a diagnostic reason; evidence lookup failures do not guess—webhook handling returns 503 and reconciliation retains for retry.

## Verification

- 110 focused tests passed
- Worker typecheck passed
- `git diff origin/main...HEAD --check` passed
- Branch is rebased on `origin/main` including `68e39949`