### PR TITLE
chore(worker): add narrow AIW-271 orphan cleanup command

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -15,6 +15,7 @@
     "validate:local-skills": "tsx scripts/validate-local-skills.ts",
     "capture:agent-protocol-fixtures": "tsx scripts/capture-agent-protocol-fixtures.ts",
     "cleanup:startup-orphans": "tsx scripts/cleanup-startup-orphans.ts",
+    "cleanup:orphaned-running-runs": "tsx scripts/cleanup-orphaned-running-runs.ts",
     "mcp:smoke": "tsx scripts/mcp-smoke.ts",
     "mcp:dogfood": "tsx scripts/mcp-dogfood.ts",
     "mcp:contract:generate": "tsx scripts/generate-mcp-contract.ts",

--- a/apps/worker/scripts/cleanup-orphaned-running-runs.ts
+++ b/apps/worker/scripts/cleanup-orphaned-running-runs.ts
@@ -1,0 +1,144 @@
+import { fileURLToPath } from "node:url";
+import { asc, and, eq, isNotNull, sql } from "drizzle-orm";
+import type { Db } from "../src/db/client.js";
+import { activeRuns, workflowRuns } from "../src/db/schema.js";
+import { sweepOrphanedRunningRuns } from "../src/lib/telemetry/run-telemetry.js";
+
+export interface OrphanedRunningRunCandidate {
+  runId: string;
+  status: string | null;
+  ticketKey: string | null;
+}
+
+export interface CleanupOptions {
+  apply: boolean;
+  confirmProduction: boolean;
+}
+
+export interface CleanupResult {
+  mode: "dry-run" | "apply";
+  candidates: OrphanedRunningRunCandidate[];
+  remainingCandidates: number;
+}
+
+export type Sweep = (db: Db) => Promise<number>;
+
+export interface CleanupCliDependencies {
+  environment?: NodeJS.ProcessEnv;
+  getDb?: () => Promise<Db>;
+  sweep?: Sweep;
+  write?: (text: string) => void;
+}
+
+export function parseCleanupArguments(argv: readonly string[]): CleanupOptions {
+  const options: CleanupOptions = { apply: false, confirmProduction: false };
+  for (const arg of argv) {
+    if (arg === "--apply") {
+      options.apply = true;
+    } else if (arg === "--confirm-production") {
+      options.confirmProduction = true;
+    } else {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+  }
+  return options;
+}
+
+export function assertProductionAcknowledged(
+  options: CleanupOptions,
+  environment: NodeJS.ProcessEnv,
+): void {
+  const isProduction =
+    environment.NODE_ENV === "production" ||
+    environment.VERCEL_ENV === "production";
+  if (options.apply && isProduction && !options.confirmProduction) {
+    throw new Error(
+      "Refusing --apply in production without --confirm-production.",
+    );
+  }
+}
+
+/**
+ * Read-only view of the exact predicate used by sweepOrphanedRunningRuns.
+ * Keep this query aligned with that sweep until a shared read helper exists.
+ */
+export async function listOrphanedRunningRuns(
+  db: Db,
+): Promise<OrphanedRunningRunCandidate[]> {
+  return db
+    .select({
+      runId: workflowRuns.runId,
+      status: workflowRuns.status,
+      ticketKey: workflowRuns.ticketKey,
+    })
+    .from(workflowRuns)
+    .where(
+      and(
+        eq(workflowRuns.status, "running"),
+        isNotNull(workflowRuns.subjectKey),
+        sql`not exists (
+          select 1 from ${activeRuns}
+          where ${activeRuns.runId} = ${workflowRuns.runId}
+        )`,
+      ),
+    )
+    .orderBy(asc(workflowRuns.runId));
+}
+
+export async function runCleanup(
+  db: Db,
+  options: CleanupOptions,
+  sweep: Sweep = sweepOrphanedRunningRuns,
+): Promise<CleanupResult> {
+  const candidates = await listOrphanedRunningRuns(db);
+  if (!options.apply) {
+    return { mode: "dry-run", candidates, remainingCandidates: candidates.length };
+  }
+
+  await sweep(db);
+  const remainingCandidates = await listOrphanedRunningRuns(db);
+  if (remainingCandidates.length !== 0) {
+    throw new Error(
+      `Orphan cleanup postcondition failed: ${remainingCandidates.length} eligible run(s) remain.`,
+    );
+  }
+
+  return { mode: "apply", candidates, remainingCandidates: 0 };
+}
+
+export function formatCleanupResult(result: CleanupResult): string {
+  const lines = [`${result.mode} candidates: ${result.candidates.length}`];
+  for (const candidate of result.candidates) {
+    lines.push(
+      `${candidate.runId}\t${candidate.status ?? "-"}\t${candidate.ticketKey ?? "-"}`,
+    );
+  }
+  if (result.mode === "apply") {
+    lines.push(`remaining candidates: ${result.remainingCandidates}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function runCleanupCli(
+  argv: readonly string[] = process.argv.slice(2),
+  dependencies: CleanupCliDependencies = {},
+): Promise<void> {
+  const options = parseCleanupArguments(argv);
+  assertProductionAcknowledged(options, dependencies.environment ?? process.env);
+
+  const db = dependencies.getDb
+    ? await dependencies.getDb()
+    : (await import("../src/db/client.js")).getDb();
+  const result = await runCleanup(db, options, dependencies.sweep);
+  (dependencies.write ?? ((text: string) => process.stdout.write(text)))
+    (formatCleanupResult(result));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    await runCleanupCli();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/apps/worker/src/lib/telemetry/orphan-maintenance.test.ts
+++ b/apps/worker/src/lib/telemetry/orphan-maintenance.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "../../db/test-db.js";
+import type { Db } from "../../db/client.js";
+import { activeRuns, workflowRuns } from "../../db/schema.js";
+import {
+  assertProductionAcknowledged,
+  formatCleanupResult,
+  listOrphanedRunningRuns,
+  parseCleanupArguments,
+  runCleanup,
+  runCleanupCli,
+} from "../../../scripts/cleanup-orphaned-running-runs.js";
+import { sweepOrphanedRunningRuns } from "./run-telemetry.js";
+
+let db: Db;
+
+beforeEach(async () => {
+  db = await createTestDb();
+});
+
+describe("cleanup-orphaned-running-runs", () => {
+  it("defaults to a read-only dry-run and prints only safe candidate fields", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_dry_run",
+      subjectKey: "ticket:jira:AIW-271",
+      ticketKey: "AIW-271",
+      status: "running",
+      statusReason: null,
+    });
+    const output: string[] = [];
+
+    await runCleanupCli([], { getDb: async () => db, write: (text) => output.push(text) });
+
+    expect(output.join("")).toBe("dry-run candidates: 1\nwrun_dry_run\trunning\tAIW-271\n");
+    expect(
+      (await db.select().from(workflowRuns).where(eq(workflowRuns.runId, "wrun_dry_run")))[0]
+        ?.status,
+    ).toBe("running");
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => parseCleanupArguments(["--poll"])).toThrow("Unknown flag: --poll");
+  });
+
+  it("requires production confirmation for apply", () => {
+    expect(() =>
+      assertProductionAcknowledged(
+        parseCleanupArguments(["--apply"]),
+        { NODE_ENV: "production" },
+      ),
+    ).toThrow("--confirm-production");
+    expect(() =>
+      assertProductionAcknowledged(
+        parseCleanupArguments(["--apply", "--confirm-production"]),
+        { VERCEL_ENV: "production" },
+      ),
+    ).not.toThrow();
+  });
+
+  it("selects exactly eligible candidates and excludes claims, gates, awaiting, and terminal rows", async () => {
+    await db.insert(workflowRuns).values([
+      {
+        runId: "wrun_eligible",
+        subjectKey: "ticket:jira:AIW-271",
+        ticketKey: "AIW-271",
+        status: "running",
+      },
+      {
+        runId: "wrun_claimed",
+        subjectKey: "ticket:jira:AIW-272",
+        ticketKey: "AIW-272",
+        status: "running",
+      },
+      { runId: "wrun_gate", workflowId: "wf_post_pr_gate", status: "running" },
+      {
+        runId: "wrun_awaiting",
+        subjectKey: "ticket:jira:AIW-273",
+        ticketKey: "AIW-273",
+        status: "awaiting",
+      },
+      {
+        runId: "wrun_success",
+        subjectKey: "ticket:jira:AIW-274",
+        ticketKey: "AIW-274",
+        status: "success",
+      },
+    ]);
+    await db.insert(activeRuns).values({
+      subjectKey: "ticket:jira:AIW-272",
+      ticketKey: "AIW-272",
+      ownerToken: "owner-272",
+      runId: "wrun_claimed",
+      state: "bound",
+      runKind: "ticket",
+    });
+
+    await expect(listOrphanedRunningRuns(db)).resolves.toEqual([
+      { runId: "wrun_eligible", status: "running", ticketKey: "AIW-271" },
+    ]);
+  });
+
+  it("uses the existing sweep only with --apply and verifies the postcondition", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_apply",
+      subjectKey: "ticket:jira:AIW-271",
+      ticketKey: "AIW-271",
+      status: "running",
+    });
+    const sweep = vi.fn((candidateDb: Db) => sweepOrphanedRunningRuns(candidateDb));
+
+    const result = await runCleanup(db, parseCleanupArguments(["--apply"]), sweep);
+
+    expect(sweep).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ mode: "apply", remainingCandidates: 0 });
+    expect(
+      (await db.select().from(workflowRuns).where(eq(workflowRuns.runId, "wrun_apply")))[0]
+        ?.status,
+    ).toBe("blocked");
+  });
+
+  it("fails when eligible candidates remain after apply", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_still_orphaned",
+      subjectKey: "ticket:jira:AIW-271",
+      ticketKey: "AIW-271",
+      status: "running",
+    });
+
+    await expect(
+      runCleanup(db, parseCleanupArguments(["--apply"]), vi.fn(async () => 0)),
+    ).rejects.toThrow("postcondition failed");
+  });
+
+  it("propagates update failures", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_update_failure",
+      subjectKey: "ticket:jira:AIW-271",
+      ticketKey: "AIW-271",
+      status: "running",
+    });
+
+    await expect(
+      runCleanup(
+        db,
+        parseCleanupArguments(["--apply"]),
+        vi.fn(async () => {
+          throw new Error("database update failed");
+        }),
+      ),
+    ).rejects.toThrow("database update failed");
+  });
+
+  it("propagates database failures as command failures", async () => {
+    await expect(
+      listOrphanedRunningRuns({
+        select: () => {
+          throw new Error("database unavailable");
+        },
+      } as unknown as Db),
+    ).rejects.toThrow("database unavailable");
+    await expect(
+      runCleanupCli([], { getDb: async () => { throw new Error("database unavailable"); } }),
+    ).rejects.toThrow("database unavailable");
+  });
+
+  it("formats apply output without payloads", () => {
+    expect(
+      formatCleanupResult({
+        mode: "apply",
+        candidates: [{ runId: "wrun_1", status: "running", ticketKey: null }],
+        remainingCandidates: 0,
+      }),
+    ).toBe("apply candidates: 1\nwrun_1\trunning\t-\nremaining candidates: 0\n");
+  });
+});


### PR DESCRIPTION
Broad /cron/poll rejected; default dry-run; --apply plus --confirm-production; exact existing sweep; tests 82/typecheck.
