### PR TITLE
test(worker): budget exhaustive schedule invariants

### DIFF
--- a/apps/worker/src/schedule-trigger/occurrence.test.ts
+++ b/apps/worker/src/schedule-trigger/occurrence.test.ts
@@ -337,7 +337,7 @@ describe("compileSchedulePreset", () => {
         }
       }
     }
-  });
+  }, 30_000);
 
   it("shows the invariant has teeth by failing for the same preset in the author's zone", () => {
     // Not a rule, a demonstration: this is exactly what the compiler avoids by
@@ -1185,7 +1185,7 @@ describe("dueOccurrence never moves the watermark backwards (R1)", () => {
         ).toBe(new Set(fired).size);
       }
     }
-  });
+  }, 30_000);
 });
 
 describe("dueOccurrence loses no occurrence to a watermark inside a repeated hour (R2)", () => {


### PR DESCRIPTION
## Symptom

Two exhaustive invariant tests in `apps/worker/src/schedule-trigger/occurrence.test.ts` timed out under serial single-worker runs (`vitest run --no-file-parallelism --maxWorkers=1`):

- `compileSchedulePreset > never compiles to a schedule the evaluator would refuse, in any zone or season` (loop at 301-337)
- `dueOccurrence never moves the watermark backwards (R1) > fires no occurrence instant twice when evaluations are chained across the transition` (loop at 1148-1185)

## Diagnosis

The cause is the test budget, not an evaluator regression. The worker package sets `testTimeout: 15_000` in `vitest.config.ts` (since June), and these two pure-CPU sweeps exhaust it only when the host is under CPU contention from parallel sessions. `occurrence.ts` and its test have exactly two commits ever (creation on Aug 7 and this fix), so no recently introduced slowdown is being masked.

## Fix

Explicit `30_000` budgets on exactly those two tests. Two lines, nothing else. The style matches existing budgeted tests in the worker package.

## Proof

- Author: focused serial suite `src/schedule-trigger` green.
- Independent review (separate session): diff scope exact, isolated runs 78/78 deterministic (stable 1.3s and 2.1s timings), focused serial suite 200/200 in 50.4s.

## Reviewer caveat

The timeout does not reproduce on an idle machine; both tests run 7-11x under the old 15s budget. It reproduces only under host CPU contention, which is the normal state of the dogfooding host running parallel agent sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated two long-running tests with extended timeouts to reduce premature test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->