### PR TITLE
fix(worker): prevent manual dispatch run leakage

### DIFF
--- a/apps/worker/src/db/queries/runs-read.test.ts
+++ b/apps/worker/src/db/queries/runs-read.test.ts
@@ -19,6 +19,7 @@ import {
   isRunRecordedFailed,
   hasDurableRunPublication,
   fetchRunModels,
+  findLiveRunClaimByRunId,
 } from "./runs-read.js";
 
 /** Minimal fixture: attributeRunModel only reads `.nodeId` / `.manifest.model.id`. */
@@ -534,6 +535,26 @@ describe("isRunRecordedFailed", () => {
 
   it("is false for a missing run", async () => {
     expect(await isRunRecordedFailed(db, "wrun_missing")).toBe(false);
+  });
+});
+
+describe("findLiveRunClaimByRunId", () => {
+  it("returns the manual ticket metadata needed for atomic cancellation withdrawal", async () => {
+    await db.insert(activeRuns).values({
+      subjectKey: "ticket:jira:AIW-274",
+      ticketKey: "AIW-274",
+      ownerToken: "owner-manual",
+      runId: "wrun_manual",
+      state: "bound",
+      runKind: "manual_ticket",
+    });
+
+    await expect(findLiveRunClaimByRunId(db, "wrun_manual")).resolves.toEqual({
+      subjectKey: "ticket:jira:AIW-274",
+      ticketKey: "AIW-274",
+      ownerToken: "owner-manual",
+      kind: "manual_ticket",
+    });
   });
 });
 

--- a/apps/worker/src/db/queries/runs-read.ts
+++ b/apps/worker/src/db/queries/runs-read.ts
@@ -11,6 +11,7 @@ import type {
   WorkflowRow,
 } from "@shared/contracts";
 import type { Db } from "../client.js";
+import type { RunKind } from "../../adapters/run-registry/types.js";
 import { activeRuns, workflowOwnedBranches, workflowRuns } from "../schema.js";
 import { attributeRunModel } from "../../lib/overview/attribute-run-model.js";
 
@@ -216,20 +217,31 @@ export async function hasDurableRunPublication(db: Db, runId: string): Promise<b
  * claims (one row per active subject) and has no index on run_id, but the table
  * is tiny, so the scan is cheap. Returns the subject and its exact owner token
  * so an operator cancel can drive cancelSubjectRunDetailed for a run that has no
- * ticket at all (a webhook or schedule trigger). Null when no live claim carries
- * this run id: the run is already terminal or unknown, and the caller falls back
- * to workflow_runs.
+ * ticket at all (a webhook or schedule trigger). The ticket and kind let manual
+ * ticket cancellation withdraw its AI-column enrolment before release. Null
+ * when no live claim carries this run id: the run is already terminal or
+ * unknown, and the caller falls back to workflow_runs.
  */
 export async function findLiveRunClaimByRunId(
   db: Db,
   runId: string,
-): Promise<{ subjectKey: string; ownerToken: string } | null> {
+): Promise<{
+  subjectKey: string;
+  ticketKey: string | null;
+  ownerToken: string;
+  kind: RunKind;
+} | null> {
   const [row] = await db
-    .select({ subjectKey: activeRuns.subjectKey, ownerToken: activeRuns.ownerToken })
+    .select({
+      subjectKey: activeRuns.subjectKey,
+      ticketKey: activeRuns.ticketKey,
+      ownerToken: activeRuns.ownerToken,
+      kind: activeRuns.runKind,
+    })
     .from(activeRuns)
     .where(eq(activeRuns.runId, runId))
     .limit(1);
-  return row ?? null;
+  return row ? { ...row, kind: row.kind as RunKind } : null;
 }
 
 /**

--- a/apps/worker/src/lib/cancel-run.test.ts
+++ b/apps/worker/src/lib/cancel-run.test.ts
@@ -19,6 +19,14 @@ const state = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
 
+vi.mock("../../env.js", () => ({
+  env: {
+    COLUMN_AI: "AI",
+    COLUMN_BACKLOG: "Backlog",
+    JIRA_BACKLOG_TRANSITION_ID: undefined,
+  },
+}));
+
 vi.mock("workflow/api", () => ({ getRun: state.getRun }));
 vi.mock("workflow/runtime", () => ({
   getWorld: () => ({ steps: { list: state.listSteps } }),
@@ -33,7 +41,10 @@ vi.mock("../clarifications/store.js", () => ({
 vi.mock("../approvals/store.js", () => ({
   retireApprovalCancellation: state.retireApproval,
 }));
-vi.mock("./ticket-transition.js", () => ({ moveTicketForRun: state.moveTicket }));
+vi.mock("./ticket-transition.js", () => ({
+  moveTicketForRun: state.moveTicket,
+  withdrawTicketFromAiForRun: state.moveTicket,
+}));
 vi.mock("./telemetry/run-telemetry.js", () => ({
   recordRunStatusReason: state.recordStatusReason,
   markRunBlockedOnCancel: state.markBlockedOnCancel,
@@ -341,6 +352,44 @@ describe("cancelRunById", () => {
       db,
       "run-1",
       "cancelled by operator kate",
+    );
+  });
+
+  it("withdraws a cancelled manual ticket before releasing its claim", async () => {
+    state.findLiveClaim.mockResolvedValue({
+      subjectKey: "ticket:jira:PROJ-1",
+      ticketKey: "PROJ-1",
+      ownerToken: "owner-a",
+      kind: "manual_ticket",
+    });
+    const runRegistry = registry(active({ kind: "manual_ticket" }));
+    const issueTracker = {} as IssueTrackerAdapter;
+
+    await expect(
+      cancelRunById(outerDb, "run-1", {
+        actorLabel: "operator kate",
+        runRegistry,
+        issueTracker,
+      }),
+    ).resolves.toEqual({
+      outcome: "cancelled",
+      subjectKey: "ticket:jira:PROJ-1",
+    });
+    expect(state.moveTicket).toHaveBeenCalledWith({
+      db: outerDb,
+      issueTracker,
+      ticketKey: "PROJ-1",
+      aiColumn: expect.any(String),
+      target: expect.any(String),
+      owner: expect.objectContaining({
+        subjectKey: "ticket:jira:PROJ-1",
+        ownerToken: "owner-a",
+        runId: "run-1",
+      }),
+      requiredOwnerState: "cancelling",
+    });
+    expect(state.moveTicket.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(runRegistry.releaseCancellation).mock.invocationCallOrder[0]!,
     );
   });
 

--- a/apps/worker/src/lib/cancel-run.ts
+++ b/apps/worker/src/lib/cancel-run.ts
@@ -188,6 +188,7 @@ export interface CancelRunByIdResult {
 export interface CancelRunByIdDeps {
   actorLabel: string;
   runRegistry: RunRegistryAdapter;
+  issueTracker?: IssueTrackerAdapter;
 }
 
 /**
@@ -217,13 +218,48 @@ export async function cancelRunById(
   const claim = await findLiveRunClaimByRunId(db, runId);
   if (claim) {
     const reason = `cancelled by ${actorLabel}`;
-    const result = await cancelSubjectRunDetailed(
-      claim.subjectKey,
-      { ownerToken: claim.ownerToken, runId },
-      runRegistry,
-      undefined,
-      reason,
-    );
+    if (claim.kind === "manual_ticket" && (!claim.ticketKey || !opts.issueTracker)) {
+      logger.warn(
+        { subjectKey: claim.subjectKey, runId },
+        "cancel_manual_ticket_withdrawal_unavailable",
+      );
+      return { outcome: "unconfirmed", subjectKey: claim.subjectKey };
+    }
+    const result = claim.kind === "manual_ticket"
+      ? await cancelOwnedSubject(
+          claim.subjectKey,
+          { ownerToken: claim.ownerToken, runId },
+          runRegistry,
+          undefined,
+          async (owner) => {
+            const [{ env }, { withdrawTicketFromAiForRun }] = await Promise.all([
+              import("../../env.js"),
+              import("./ticket-transition.js"),
+            ]);
+            await withdrawTicketFromAiForRun({
+              db,
+              issueTracker: opts.issueTracker!,
+              ticketKey: claim.ticketKey!,
+              aiColumn: env.COLUMN_AI,
+              target: env.JIRA_BACKLOG_TRANSITION_ID
+                ? {
+                    name: env.COLUMN_BACKLOG,
+                    transitionId: env.JIRA_BACKLOG_TRANSITION_ID,
+                  }
+                : env.COLUMN_BACKLOG,
+              owner,
+              requiredOwnerState: "cancelling",
+            });
+          },
+          reason,
+        )
+      : await cancelSubjectRunDetailed(
+          claim.subjectKey,
+          { ownerToken: claim.ownerToken, runId },
+          runRegistry,
+          undefined,
+          reason,
+        );
     // alreadyTerminal implies cancelled, so it must be checked first: the run
     // reached a terminal Workflow status on its own and keeps that outcome, so
     // no status is written (only the lingering claim was released).

--- a/apps/worker/src/lib/dispatch.test.ts
+++ b/apps/worker/src/lib/dispatch.test.ts
@@ -295,9 +295,19 @@ describe("dispatchTicket owner reservation", () => {
     expect(result).toEqual({ started: false, reason: "wrong_project_key" });
   });
 
-  it("returns already_claimed when the subject reservation loses", async () => {
-    const result = await dispatchTicket("PROJ-42", adapters(registry({ reserveResult: false })), 3);
+  it("does not auto-enrol a subject already claimed by a manual dispatch", async () => {
+    const manualClaim = entry({
+      subjectKey: "ticket:jira:PROJ-42",
+      ticketKey: "PROJ-42",
+      ownerToken: "owner:manual",
+      runId: "run-manual",
+      kind: "manual_ticket",
+    });
+    const connected = adapters(registry({ initial: [manualClaim] }));
+    const result = await dispatchTicket("PROJ-42", connected, 3);
     expect(result).toEqual({ started: false, reason: "already_claimed" });
+    expect(connected.issueTracker.fetchTicket).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
   });
 
   it("returns at_capacity without reserving when bound capacity is full", async () => {

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -26,6 +26,7 @@ const mockHasDurableRunPublication = vi.fn();
 const mockDb = {} as Db;
 const mockStopSandboxesByIds = vi.fn();
 const mockListWorkflowSteps = vi.fn();
+const mockAssertActiveRunOwnerState = vi.hoisted(() => vi.fn());
 vi.mock("workflow/api", () => ({ getRun: (...args: any[]) => mockGetRun(...args) }));
 vi.mock("workflow/runtime", () => ({
   getWorld: () => ({
@@ -50,6 +51,9 @@ vi.mock("./run-start-lifecycle.js", () => ({
 }));
 vi.mock("../sandbox/stop-ticket-sandboxes.js", () => ({
   stopSandboxesByIds: (...args: any[]) => mockStopSandboxesByIds(...args),
+}));
+vi.mock("./active-run-owner.js", () => ({
+  assertActiveRunOwnerState: (...args: any[]) => mockAssertActiveRunOwnerState(...args),
 }));
 
 function entry(overrides: Partial<ActiveRunEntry> = {}): ActiveRunEntry {
@@ -135,6 +139,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
       cursor: null,
       hasMore: false,
     });
+    mockAssertActiveRunOwnerState.mockResolvedValue(undefined);
   });
 
   it("leaves a fresh unbound reservation for its candidate", async () => {
@@ -347,6 +352,72 @@ describe("reconcileRuns owner-CAS recovery", () => {
     // Genuinely a "done"/success outcome for the injection-block scenario, so
     // it must not be reported to operators as a cancellation.
     expect(onTicketCancelled).not.toHaveBeenCalled();
+  });
+
+  it.each(["Review", "Done"])(
+    "releases a terminal manual ticket without overwriting live Jira %s from a stale AI snapshot",
+    async (liveStatus) => {
+      const manual = entry({ kind: "manual_ticket" });
+      const runRegistry = registry([manual]);
+      const tracker = issueTracker(liveStatus);
+      mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+      const onReleased = vi.fn();
+      const { reconcileRuns } = await import("./reconcile.js");
+
+      await expect(
+        reconcileRuns(
+          new Set(["PROJ-1"]),
+          runRegistry,
+          tracker,
+          undefined,
+          onReleased,
+          undefined,
+          mockDb,
+        ),
+      ).resolves.toEqual({ cancelled: 0, cleaned: 1 });
+      expect(mockCancelRunDetailed).not.toHaveBeenCalled();
+      expect(tracker.fetchTicket).toHaveBeenCalledOnce();
+      expect(tracker.moveTicket).not.toHaveBeenCalled();
+      expect(mockAssertActiveRunOwnerState).toHaveBeenCalledWith(
+        mockDb,
+        manual,
+        "bound",
+      );
+      expect(runRegistry.release).toHaveBeenCalledWith(
+        manual.subjectKey,
+        manual.ownerToken,
+        manual.runId,
+      );
+      expect(onReleased).toHaveBeenCalledWith(manual.subjectKey);
+    },
+  );
+
+  it("retains a manual claim when stale-snapshot withdrawal cannot be confirmed", async () => {
+    const manual = entry({ kind: "manual_ticket" });
+    const runRegistry = registry([manual]);
+    const tracker = issueTracker("AI");
+    const moveError = new Error("response lost");
+    vi.mocked(tracker.fetchTicket)
+      .mockResolvedValueOnce({ trackerStatus: "AI" } as never)
+      .mockResolvedValueOnce({ trackerStatus: "AI" } as never);
+    vi.mocked(tracker.moveTicket).mockRejectedValue(moveError);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(["PROJ-1"]),
+        runRegistry,
+        tracker,
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
+    ).resolves.toEqual({ cancelled: 0, cleaned: 0 });
+    expect(tracker.moveTicket).toHaveBeenCalledWith("PROJ-1", "Backlog");
+    expect(tracker.fetchTicket).toHaveBeenCalledTimes(2);
+    expect(runRegistry.release).not.toHaveBeenCalled();
   });
 
   it("does not evict a ticket-triggered run that is still executing", async () => {

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -25,6 +25,7 @@ import type { Db } from "../db/client.js";
 import { confirmWorkflowStepsDrained } from "./workflow-step-drain.js";
 import { reconcileStartupWatchdog } from "./run-start-lifecycle.js";
 import { ticketSubjectKey } from "./subject-key.js";
+import { withdrawTicketFromAiForRun } from "./ticket-transition.js";
 
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
 const STALE_RESERVATION_MS = 5 * 60 * 1000;
@@ -169,13 +170,21 @@ export async function reconcileRuns(
     }
 
     if (ticketStillInAiColumn) {
-      cleaned += await cleanStuckTicketRun(
-        boundEntry,
-        entry.ticketKey as string,
-        runRegistry,
-        issueTracker,
-        onSubjectReleased,
-      );
+      cleaned += entry.kind === "manual_ticket"
+        ? await cleanFinishedManualTicket(
+            boundEntry,
+            runRegistry,
+            issueTracker,
+            onSubjectReleased,
+            db,
+          )
+        : await cleanStuckTicketRun(
+            boundEntry,
+            entry.ticketKey as string,
+            runRegistry,
+            issueTracker,
+            onSubjectReleased,
+          );
       continue;
     }
 
@@ -450,6 +459,52 @@ async function cleanFinishedRun(
         error: error instanceof Error ? error.message : String(error),
       },
       "reconcile_run_status_unreachable_owner_retained",
+    );
+    return 0;
+  }
+}
+
+async function cleanFinishedManualTicket(
+  entry: ActiveRunEntry & { runId: string },
+  runRegistry: RunRegistryAdapter,
+  issueTracker?: IssueTrackerAdapter,
+  onSubjectReleased?: SubjectReleasedCallback,
+  db?: Db,
+): Promise<number> {
+  try {
+    const status = await getRun(entry.runId).status;
+    if (!TERMINAL_STATUSES.has(status)) return 0;
+    if (!(await confirmWorkflowStepsDrained(entry.subjectKey, entry.runId))) return 0;
+    if (!entry.ticketKey || !issueTracker || !db) return 0;
+
+    await withdrawTicketFromAiForRun({
+      db,
+      issueTracker,
+      ticketKey: entry.ticketKey,
+      aiColumn: env.COLUMN_AI,
+      target: env.JIRA_BACKLOG_TRANSITION_ID
+        ? { name: env.COLUMN_BACKLOG, transitionId: env.JIRA_BACKLOG_TRANSITION_ID }
+        : env.COLUMN_BACKLOG,
+      owner: entry,
+      requiredOwnerState: "bound",
+    });
+
+    const released = await cleanupAndRelease(entry, runRegistry);
+    if (!released) return 0;
+    await notifySubjectReleased(entry.subjectKey, onSubjectReleased);
+    logger.info(
+      { subjectKey: entry.subjectKey, runId: entry.runId, status },
+      "reconcile_cleaned_finished_manual_ticket",
+    );
+    return 1;
+  } catch (error) {
+    logger.warn(
+      {
+        subjectKey: entry.subjectKey,
+        runId: entry.runId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "reconcile_manual_ticket_withdrawal_unconfirmed",
     );
     return 0;
   }

--- a/apps/worker/src/lib/ticket-transition.test.ts
+++ b/apps/worker/src/lib/ticket-transition.test.ts
@@ -4,7 +4,10 @@ import type { IssueTrackerAdapter } from "../adapters/issue-tracker/types.js";
 const assertOwner = vi.hoisted(() => vi.fn());
 vi.mock("./active-run-owner.js", () => ({ assertActiveRunOwnerState: assertOwner }));
 
-import { moveTicketForRun } from "./ticket-transition.js";
+import {
+  moveTicketForRun,
+  withdrawTicketFromAiForRun,
+} from "./ticket-transition.js";
 
 const db = {} as never;
 const owner = {
@@ -84,4 +87,101 @@ describe("moveTicketForRun", () => {
     });
     expect(assertOwner).toHaveBeenCalledWith(db, owner, "cancelling");
   });
+});
+
+describe("withdrawTicketFromAiForRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    assertOwner.mockResolvedValue(undefined);
+  });
+
+  it("moves an AI-column ticket only while the exact cancelling owner is held", async () => {
+    const order: string[] = [];
+    assertOwner.mockImplementation(async () => { order.push("owner"); });
+    const issueTracker = tracker(
+      vi.fn().mockResolvedValue({ trackerStatus: "AI" }),
+      vi.fn().mockImplementation(async () => { order.push("move"); }),
+    );
+
+    await withdrawTicketFromAiForRun({
+      db,
+      issueTracker,
+      ticketKey: "AIW-101",
+      aiColumn: "AI",
+      target: "Backlog",
+      owner,
+      requiredOwnerState: "cancelling",
+    });
+
+    expect(order).toEqual(["owner", "move"]);
+    expect(issueTracker.moveTicket).toHaveBeenCalledWith("AIW-101", "Backlog");
+  });
+
+  it("preserves a workflow-selected destination outside AI", async () => {
+    const issueTracker = tracker(
+      vi.fn().mockResolvedValue({ trackerStatus: "Review" }),
+    );
+
+    await withdrawTicketFromAiForRun({
+      db,
+      issueTracker,
+      ticketKey: "AIW-101",
+      aiColumn: "AI",
+      target: "Backlog",
+      owner,
+      requiredOwnerState: "bound",
+    });
+
+    expect(assertOwner).toHaveBeenCalledWith(db, owner, "bound");
+    expect(issueTracker.moveTicket).not.toHaveBeenCalled();
+  });
+
+  it("accepts an ambiguous move when a fresh read confirms the ticket left AI", async () => {
+    const fetchTicket = vi.fn()
+      .mockResolvedValueOnce({ trackerStatus: "AI" })
+      .mockResolvedValueOnce({ trackerStatus: "Review" });
+    const issueTracker = tracker(
+      fetchTicket,
+      vi.fn().mockRejectedValue(new Error("response lost")),
+    );
+
+    await expect(withdrawTicketFromAiForRun({
+      db,
+      issueTracker,
+      ticketKey: "AIW-101",
+      aiColumn: "AI",
+      target: "Backlog",
+      owner,
+      requiredOwnerState: "bound",
+    })).resolves.toBeUndefined();
+    expect(fetchTicket).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["AI", "unreadable"])(
+    "propagates the original move error when the post-error read is %s",
+    async (postErrorStatus) => {
+      const moveError = new Error("response lost");
+      const fetchTicket = postErrorStatus === "AI"
+        ? vi.fn()
+            .mockResolvedValueOnce({ trackerStatus: "AI" })
+            .mockResolvedValueOnce({ trackerStatus: "AI" })
+        : vi.fn()
+            .mockResolvedValueOnce({ trackerStatus: "AI" })
+            .mockRejectedValueOnce(new Error("read lost"));
+      const issueTracker = tracker(
+        fetchTicket,
+        vi.fn().mockRejectedValue(moveError),
+      );
+
+      await expect(withdrawTicketFromAiForRun({
+        db,
+        issueTracker,
+        ticketKey: "AIW-101",
+        aiColumn: "AI",
+        target: "Backlog",
+        owner,
+        requiredOwnerState: "bound",
+      })).rejects.toBe(moveError);
+    },
+  );
 });

--- a/apps/worker/src/lib/ticket-transition.ts
+++ b/apps/worker/src/lib/ticket-transition.ts
@@ -35,6 +35,42 @@ export async function moveTicketForRun(input: {
 }
 
 /**
+ * Withdraw a ticket from the AI column while its exact run still owns the
+ * subject. A manual dispatch uses the AI column only as execution state, so
+ * releasing that owner while the ticket is still there would let the default
+ * pickup path claim it as new work.
+ */
+export async function withdrawTicketFromAiForRun(input: {
+  db: Db;
+  issueTracker: Pick<IssueTrackerAdapter, "fetchTicket" | "moveTicket">;
+  ticketKey: string;
+  aiColumn: IssueTrackerMoveTarget;
+  target: IssueTrackerMoveTarget;
+  owner: TicketTransitionOwner;
+  requiredOwnerState: "bound" | "cancelling";
+}): Promise<void> {
+  const current = await input.issueTracker.fetchTicket(input.ticketKey);
+  await assertActiveRunOwnerState(
+    input.db,
+    input.owner,
+    input.requiredOwnerState,
+  );
+  if (!ticketMatchesMoveTarget(current, input.aiColumn)) return;
+
+  try {
+    await input.issueTracker.moveTicket(input.ticketKey, input.target);
+  } catch (error) {
+    try {
+      const afterError = await input.issueTracker.fetchTicket(input.ticketKey);
+      if (!ticketMatchesMoveTarget(afterError, input.aiColumn)) return;
+    } catch {
+      // Preserve the original mutation error.
+    }
+    throw error;
+  }
+}
+
+/**
  * The ownerless half of a ticket move: read where the ticket is, skip the write when it
  * is already there, and turn a provider that accepted the transition but lost its
  * response into a success with one live re-read.

--- a/apps/worker/src/manual-dispatch/resolve.ts
+++ b/apps/worker/src/manual-dispatch/resolve.ts
@@ -233,9 +233,8 @@ async function resolveTicketDispatch(
       },
       {
         title: alreadyInAi ? `Keep in ${env.COLUMN_AI}` : `Move ${ticket.trackerStatus} → ${env.COLUMN_AI}`,
-        description: alreadyInAi
-          ? "Ticket is already ready for execution"
-          : "Jira changes before execution",
+        description:
+          "Manual ownership suppresses automatic pickup until this run withdraws or moves the ticket",
       },
       {
         title: `Start deployed v${deployed.definition.version}`,

--- a/apps/worker/src/mcp/tools/run-control.ts
+++ b/apps/worker/src/mcp/tools/run-control.ts
@@ -331,6 +331,7 @@ export function registerRunControlTools(server: McpServer, deps: McpToolDependen
             // person reading why their run stopped sees which client stopped it.
             actorLabel: `MCP ${deps.actor.clientId}`,
             runRegistry: deps.adapters.runRegistry,
+            issueTracker: deps.adapters.issueTracker,
           });
 
           switch (result.outcome) {

--- a/apps/worker/src/routes/api/v1/runs/[runId]/cancel.post.ts
+++ b/apps/worker/src/routes/api/v1/runs/[runId]/cancel.post.ts
@@ -46,6 +46,7 @@ export default defineEventHandler(
       const result = await cancelRunForOperator(db, runId, {
         actorLabel,
         runRegistry: adapters.runRegistry,
+        issueTracker: adapters.issueTracker,
       });
 
       switch (result.outcome) {


### PR DESCRIPTION
## Defect

A coordinator-consented manual MCP ticket dispatch reserves the subject and moves the ticket into the shared `Ai` column. The Jira webhook and poll pickup path also treat that column as default-workflow enrolment, so releasing the manual run's claim while the ticket remained there allowed unconsented default runs to start on consecutive pickups. This was observed in production as `wrun_01KZYCWTYMDN6EVNV7BETD71XM` and `wrun_01KZYD0FDD1DBT6YYK4GXMXD9J`.

## Invariant and approach

One coordinator-consented manual dispatch causes at most that one consented run. The existing manual subject reservation remains the immediate auto-pickup marker; this change adds owner-fenced withdrawal from `Ai` before a `manual_ticket` claim can be released on natural terminal reconciliation or operator cancellation. If Jira withdrawal cannot be confirmed, ownership is retained for retry, and a workflow-selected destination outside `Ai` is preserved. The manual-dispatch preflight now states that manual ownership suppresses automatic pickup until the run withdraws or moves the ticket.

## Focused verification

```text
pnpm --filter worker test -- src/lib/dispatch.test.ts src/lib/reconcile.test.ts src/lib/cancel-run.test.ts src/lib/ticket-transition.test.ts src/db/queries/runs-read.test.ts src/manual-dispatch/resolve.test.ts src/routes/api/v1/runs/cancel.test.ts src/mcp/tools/run-control.test.ts
Test Files  8 passed (8)
Tests       183 passed (183)

pnpm --filter worker typecheck
exit 0
```

No full local suite was run; CI provides breadth.

> **Overlaps the dispatch/capacity subsystem being changed off-main by AIW-277/279 - coordinate before merge; do not merge without reviewing against that work.**

Generated by an AI coding agent via Orca.
