### PR TITLE
fix(worker): cancelled run must record completedAt/durationSec (RUN-CANCEL-BOOKKEEPING-001)

### DIFF
--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -747,6 +747,36 @@ describe("live clarification park status", () => {
     expect(await row("wrun_missing")).toBeUndefined();
   });
 
+  // RUN-CANCEL-BOOKKEEPING-001: "blocked" is terminal, so the cancel settle
+  // must finalize the same completion bookkeeping a normally-finished run gets,
+  // not leave the row terminal-yet-never-completed.
+  it("markRunBlockedOnCancel finalizes completedAt/durationSec like a completed run", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_cancel_bookkeeping",
+      subjectKey: "ticket:jira:PROJ-1",
+      workflowId: "wf_agent",
+      workflowName: "Agent",
+      ticketKey: "PROJ-1",
+      status: "awaiting",
+      startedAt: new Date("2026-06-15T10:00:05Z"),
+    });
+    await markRunBlockedOnCancel(db, "wrun_cancel_bookkeeping");
+    const r = await row("wrun_cancel_bookkeeping");
+    expect(r.status).toBe("blocked");
+    expect(r.completedAt).not.toBeNull();
+    expect(r.durationSec).not.toBeNull();
+    expect(r.durationSec!).toBeGreaterThan(0); // now() - startedAt
+  });
+
+  it("markRunBlockedOnCancel stamps completedAt but no duration when no start was recorded", async () => {
+    await seed("wrun_cancel_no_start", "awaiting");
+    await markRunBlockedOnCancel(db, "wrun_cancel_no_start");
+    const r = await row("wrun_cancel_no_start");
+    expect(r.status).toBe("blocked");
+    expect(r.completedAt).not.toBeNull(); // the settle time itself
+    expect(r.durationSec).toBeNull(); // no start to measure from, no fabricated zero
+  });
+
   // A workflow step can be re-executed after a worker restart, so every writer
   // has to survive being called twice with the same argument.
   it("repeating any of the three writes changes nothing", async () => {
@@ -812,6 +842,25 @@ describe("markRunBlockedByOperator", () => {
   it("is a tolerant no-op for a missing run", async () => {
     await markRunBlockedByOperator(db, "wrun_op_missing", "cancelled by operator kate");
     expect(await row("wrun_op_missing")).toBeUndefined();
+  });
+
+  // RUN-CANCEL-BOOKKEEPING-001: the operator settle is terminal too, so it must
+  // finalize the same completion bookkeeping recordRunUsage writes.
+  it("finalizes completedAt/durationSec like a completed run", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_op_bookkeeping",
+      subjectKey: "sched:demo:hourly",
+      workflowId: "wf_agent",
+      workflowName: "Agent",
+      status: "running",
+      startedAt: new Date("2026-06-15T10:00:05Z"),
+    });
+    await markRunBlockedByOperator(db, "wrun_op_bookkeeping", "cancelled by operator kate");
+    const r = await row("wrun_op_bookkeeping");
+    expect(r.status).toBe("blocked");
+    expect(r.completedAt).not.toBeNull();
+    expect(r.durationSec).not.toBeNull();
+    expect(r.durationSec!).toBeGreaterThan(0); // now() - startedAt
   });
 
   // A workflow step can be re-executed after a worker restart, so the write has

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -539,11 +539,23 @@ export async function markRunResumed(db: Db, runId: string): Promise<void> {
  * open). The run never resumes to clear it itself and the cron never downgrades
  * a frozen status, so without this the cancelled row keeps showing awaiting
  * input. Guarded on exactly "awaiting" so it only ever touches a parked run.
+ *
+ * "blocked" is terminal, so the settle also finalizes the lifecycle the way
+ * recordRunUsage does on completion: completedAt keeps a precise value if one
+ * was already recorded, else stamps now(); durationSec is filled from a known
+ * start. Without this a cancelled run reads terminal-yet-never-completed, with
+ * no duration, forever (the cron never touches a frozen status and keepIfNull
+ * only keeps what the settle wrote).
  */
 export async function markRunBlockedOnCancel(db: Db, runId: string): Promise<void> {
   await db
     .update(workflowRuns)
-    .set({ status: "blocked", updatedAt: sql`now()` })
+    .set({
+      status: "blocked",
+      completedAt: sql`coalesce(${workflowRuns.completedAt}, now())`,
+      durationSec: durationFromStart(),
+      updatedAt: sql`now()`,
+    })
     .where(and(eq(workflowRuns.runId, runId), eq(workflowRuns.status, "awaiting")));
 }
 
@@ -570,7 +582,15 @@ export async function markRunBlockedByOperator(
 ): Promise<void> {
   await db
     .update(workflowRuns)
-    .set({ status: "blocked", statusReason: reason, updatedAt: sql`now()` })
+    .set({
+      status: "blocked",
+      statusReason: reason,
+      // Terminal settle, so finalize completedAt/durationSec exactly like
+      // recordRunUsage does on completion (see markRunBlockedOnCancel).
+      completedAt: sql`coalesce(${workflowRuns.completedAt}, now())`,
+      durationSec: durationFromStart(),
+      updatedAt: sql`now()`,
+    })
     .where(
       and(
         eq(workflowRuns.runId, runId),


### PR DESCRIPTION
## Defect (RUN-CANCEL-BOOKKEEPING-001, P3, observed on prod)

When a run is cancelled, it is settled as terminal (`status = 'blocked'`) but its completion bookkeeping is never written: `completedAt` stays null and `durationSec` stays null, whereas a normally-finished run sets both via `recordRunUsage`. On prod this reads as a terminal-yet-never-completed run with no duration.

Root cause: the two cancel-settle writers in `apps/worker/src/lib/telemetry/run-telemetry.ts` wrote only the status:

- `markRunBlockedOnCancel` (cancel of a run parked on a clarification; also used when a ticket disappears) set `{ status, updatedAt }` only.
- `markRunBlockedByOperator` (operator cancel-by-id) set `{ status, statusReason, updatedAt }` only.

Nothing backfills afterwards: the poll cron never touches a frozen terminal status, and its `keepIfNull` upsert only preserves what the settle wrote, so the nulls are permanent.

## Outcome and approach (parity with normal completion)

Both cancel-settle writers now finalize the lifecycle with the exact same derivation `recordRunUsage` uses on normal completion (no new formula):

- `completedAt: coalesce(existing, now())` (keeps a precise value if one was already recorded, else stamps the settle time)
- `durationSec: durationFromStart()` (the same module-private helper: seconds from `startedAt`/`createdAt` to now, kept null when no start was ever recorded rather than fabricating a zero)

The existing status guards (`awaiting`-only, respectively `awaiting|running`) are untouched, so a run that reached its own terminal outcome first keeps it, and the write stays idempotent (a second call no-ops on the already-blocked row).

Out of scope, noted for completeness: the orphan sweeps (`sweepOrphanedAwaitingRuns`, `sweepOrphanedRunningRuns`) and the self-move/supersede writers share the status-only pattern but are backstops, not the cancel path. Also, a ticket-column cancel of a RUNNING (non-parked) run never reaches either writer; its terminal `blocked` stays cron-driven, and the cron snapshot does carry `completedAt`/`durationSec` from the Workflow world (`collect-snapshots.ts`), so that flavor is covered when the cron fires.

## Focused test output

New tests in `run-telemetry.test.ts` prove a cancelled run ends `blocked` with non-null `completedAt`, a `durationSec` computed from the recorded start, and null duration (but a stamped `completedAt`) when no start exists, mirroring the existing `recordRunUsage` assertions.

```
pnpm --filter worker test src/lib/telemetry/run-telemetry.test.ts
 Test Files  1 passed (1)
      Tests  76 passed (76)

pnpm --filter worker test src/lib/cancel-run.test.ts
 Test Files  1 passed (1)
      Tests  25 passed (25)

pnpm --filter worker typecheck
 (tsc --noEmit, exit 0)
```

## Coordination flag

Sibling draft PR RUN-DISPATCH-LEAK-001 (P2) touches the manual-dispatch/cancel-ticket path; coordinate at merge. This PR touches only `lib/telemetry/run-telemetry.ts` (+ its test file), none of the P2 files (`manual-dispatch/service.ts`, `lib/dispatch.ts`, `routes/webhooks/jira.post.ts`, `lib/ticket-transition.ts`).

Generated by an AI coding agent via Orca.
