### PR TITLE
fix(worker): brand Slack help header as ai-workflow

### DIFF
--- a/apps/worker/src/lib/slack/format.ts
+++ b/apps/worker/src/lib/slack/format.ts
@@ -81,7 +81,7 @@ export function formatInspectAll(
 }
 
 export const HELP_TEXT = [
-  "*Blazebot commands*",
+  "*ai-workflow commands*",
   "• `/ai-workflow list` — show every tracked workflow",
   "• `/ai-workflow status <KEY>` — show the run + sandbox tied to a ticket",
   "• `/ai-workflow cancel <KEY>` — cancel the workflow run + move ticket to backlog",

--- a/apps/worker/src/routes/webhooks/slack.post.test.ts
+++ b/apps/worker/src/routes/webhooks/slack.post.test.ts
@@ -265,6 +265,6 @@ describe("POST /webhooks/slack", () => {
     );
     const json = await res.json();
     expect(json.response_type).toBe("ephemeral");
-    expect(json.text).toContain("Blazebot commands");
+    expect(json.text).toContain("ai-workflow commands");
   });
 });


### PR DESCRIPTION
Renames the Slack `/ai-workflow` help header from `*Blazebot commands*` to `*ai-workflow commands*`, matching the command list beneath it (every command already uses `/ai-workflow`). Demo-visible branding fix for the Arthur release.

Scope is deliberately narrow: only the display header. The `blazebot/memory` path, `CHAT_SDK_BOT_NAME` default, and `<!-- blazebot:repo-memory -->` marker are intentionally untouched (load-bearing / require a resync migration).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Slack help text to display the “ai-workflow commands” heading.

- **Bug Fixes**
  - Aligned the empty-command help response with the updated command heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->