### PR TITLE
fix(worker): degrade GitLab review publication when self-approval is refused

### DIFF
--- a/apps/worker/src/adapters/vcs/gitlab.test.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.test.ts
@@ -1180,6 +1180,50 @@ describe("GitLabAdapter", () => {
       ).toBe(false);
     });
 
+    // GitLab forbids an author approving their own merge request, and MR approvals
+    // are a paid-tier feature; either way the /approve call is refused. The review
+    // is already on the merge request by then, so a refused approval must degrade
+    // to a warning rather than discard a completed review.
+    it("publishes the review even when GitLab refuses the approval", async () => {
+      mockMergeRequestNotes.all.mockResolvedValueOnce([]);
+      mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);
+      mockMergeRequests.show.mockResolvedValueOnce({
+        sha: "reviewed-head",
+        diff_refs: {
+          base_sha: "base",
+          start_sha: "start",
+          head_sha: "reviewed-head",
+        },
+      });
+      mockFetch
+        .mockResolvedValueOnce(gitLabResponse({ id: 555 }, { status: 201 }))
+        .mockResolvedValueOnce(
+          gitLabResponse(
+            { message: "You cannot approve your own merge request" },
+            { status: 403, statusText: "Forbidden" },
+          ),
+        );
+
+      const result = await glAdapter().publishPRReview(42, {
+        idempotencyKey: "review-hash",
+        headSha: "reviewed-head",
+        decision: "approve",
+        summary: "Approved.",
+        comments: [],
+        commentFindingDigests: [],
+      });
+
+      expect(result).toEqual({ id: "555", commentIds: [] });
+      // The summary note was posted, then the approval was attempted and refused.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[0]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/notes",
+      );
+      expect(mockFetch.mock.calls[1]![0]).toBe(
+        "https://gitlab.com/api/v4/projects/blazity%2Fdemo-app/merge_requests/42/approve",
+      );
+    });
+
     it("publishes GitLab multiline positions and preserves id alignment", async () => {
       mockMergeRequestNotes.all.mockResolvedValueOnce([]);
       mockMergeRequestDiscussions.all.mockResolvedValueOnce([]);

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -681,10 +681,7 @@ export class GitLabAdapter implements
       // original path: the approval is what a protected branch reads, and GitLab
       // drops it whenever the merge request changes.
       if (publication.decision === "approve") {
-        await this.gitLabRest<unknown>(
-          `/projects/${this.encodedProjectId}/merge_requests/${prId}/approve`,
-          { method: "POST", body: { sha: publication.headSha } },
-        );
+        await this.approveMergeRequestBestEffort(prId, publication.headSha);
       }
       // A retry has to be able to finish the sweep: the publish can succeed and the
       // state update that records it can be lost, so the round already being on the
@@ -817,10 +814,7 @@ export class GitLabAdapter implements
             { method: "PUT", body: { body } },
           );
     if (publication.decision === "approve") {
-      await this.gitLabRest<unknown>(
-        `/projects/${this.encodedProjectId}/merge_requests/${prId}/approve`,
-        { method: "POST", body: { sha: publication.headSha } },
-      );
+      await this.approveMergeRequestBestEffort(prId, publication.headSha);
     }
     // Only once this round's findings are on the merge request. Run earlier, a
     // failure between the sweep and the summary left every superseded discussion
@@ -897,6 +891,30 @@ export class GitLabAdapter implements
       `/projects/${this.encodedProjectId}/merge_requests/${prId}/discussions/${encodeURIComponent(discussionId)}`,
       { method: "PUT", body: { resolved: true } },
     );
+  }
+
+  /**
+   * Best-effort MR approval. The approval is a protected-branch convenience, not
+   * the review itself: GitLab refuses an author's approval of their own merge
+   * request (and MR approvals are a paid-tier feature), so a refused approval must
+   * never discard a review that is already on the merge request. It degrades to a
+   * warning exactly as an unplaceable inline comment degrades to the summary.
+   */
+  private async approveMergeRequestBestEffort(
+    prId: number,
+    headSha: string,
+  ): Promise<void> {
+    try {
+      await this.gitLabRest<unknown>(
+        `/projects/${this.encodedProjectId}/merge_requests/${prId}/approve`,
+        { method: "POST", body: { sha: headSha } },
+      );
+    } catch (error) {
+      console.warn(
+        `GitLab refused to approve merge request !${prId} (self-approval or approvals unavailable); the review was published without an approval.`,
+        error instanceof Error ? error.message : String(error),
+      );
+    }
   }
 
   private gitLabLineRangePosition(


### PR DESCRIPTION
## Problem

Post-PR review runs a full multi-agent review, then `publishRunOwnedPrReview` publishes it to the pull/merge request. In the GitLab adapter the `/approve` call was unwrapped, so when GitLab refuses the approval (the reviewing bot authored the MR, and GitLab forbids author self-approval; or MR approvals are a paid-tier feature) the whole publication threw and a COMPLETED review was discarded.

Observed on the Arthur tenant: Post-PR review on a merge request reviewed cleanly (verdict `approve`, 0 findings) but the run failed at the `post-review` block with `PR review publication failed`. The inline-comment POST a few lines above already degrades gracefully on error; the approval did not.

## Fix

Both `/approve` call sites (the already-published-head early-return path and the fresh-publish path) now call a new private helper `approveMergeRequestBestEffort`, which wraps the `/approve` REST call in try/catch and degrades to a `console.warn` on failure. The review (summary note + inline discussions) still publishes; only the approval is best-effort. A refused approval no longer discards a review that is already on the merge request.

## Notes

The identical fix is deployed to the Arthur tenant. Test added in `gitlab.test.ts` asserting the review still publishes when `/approve` is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
