### PR TITLE
fix(worker): create the Arthur injection task on demand so the screen runs

### DIFF
--- a/apps/worker/src/workflows/blocks/arthur-injection-check.test.ts
+++ b/apps/worker/src/workflows/blocks/arthur-injection-check.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   env: {} as Record<string, string | undefined>,
   validatePrompt: vi.fn(),
+  ensureArthurTask: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({ env: mocks.env }));
@@ -13,12 +14,17 @@ vi.mock("../../sandbox/arthur-client.js", () => ({
   },
 }));
 
+vi.mock("./prepare-workspace.js", () => ({
+  ensureArthurTask: mocks.ensureArthurTask,
+}));
+
 import { execute, paramsSchema } from "./arthur-injection-check.js";
 import { makeCtx, makeNode, runControlErrorCases } from "./test-support.js";
 
 function configureArthur() {
   mocks.env.GENAI_ENGINE_API_KEY = "key";
   mocks.env.GENAI_ENGINE_TRACE_ENDPOINT = "https://arthur.example/api/v1/traces";
+  mocks.ensureArthurTask.mockResolvedValue("task-1");
 }
 
 describe("arthur_injection_check paramsSchema", () => {
@@ -45,13 +51,27 @@ describe("arthur_injection_check execute", () => {
     });
   });
 
-  it("skips when the run has no Arthur task", async () => {
+  it("skips when an Arthur task cannot be created for the run", async () => {
     configureArthur();
+    mocks.ensureArthurTask.mockResolvedValue(null);
     const result = await execute(makeNode("arthur_injection_check"), {}, makeCtx());
     expect(result).toEqual({
       kind: "next",
       output: { status: "skipped", reason: "arthur_task_missing" },
     });
+  });
+
+  it("creates an Arthur task on demand when the run has none, then screens", async () => {
+    configureArthur();
+    mocks.ensureArthurTask.mockResolvedValue("task-created");
+    mocks.validatePrompt.mockResolvedValue({ ok: true, findings: [] });
+    const ctx = makeCtx();
+
+    const result = await execute(makeNode("arthur_injection_check"), {}, ctx);
+
+    expect(mocks.ensureArthurTask).toHaveBeenCalledWith(ctx);
+    expect(mocks.validatePrompt).toHaveBeenCalledWith("task-created", "Ticket description");
+    expect(result).toEqual({ kind: "next", output: { status: "ok", findings: [] } });
   });
 
   it("validates ticket content and reports ok", async () => {

--- a/apps/worker/src/workflows/blocks/arthur-injection-check.ts
+++ b/apps/worker/src/workflows/blocks/arthur-injection-check.ts
@@ -46,7 +46,9 @@ export const execute: BlockExecuteFn = async (
   if (!env.GENAI_ENGINE_API_KEY || !env.GENAI_ENGINE_TRACE_ENDPOINT) {
     return { kind: "next", output: { status: "skipped", reason: "arthur_not_configured" } };
   }
-  if (!ctx.arthur.taskId) {
+  const { ensureArthurTask } = await import("./prepare-workspace.js");
+  const taskId = await ensureArthurTask(ctx);
+  if (!taskId) {
     return { kind: "next", output: { status: "skipped", reason: "arthur_task_missing" } };
   }
 
@@ -63,7 +65,7 @@ export const execute: BlockExecuteFn = async (
   }
 
   try {
-    const { ok, findings } = await blockArthurValidatePromptStep(ctx.arthur.taskId, content);
+    const { ok, findings } = await blockArthurValidatePromptStep(taskId, content);
     return {
       kind: "next",
       output: {


### PR DESCRIPTION
## Problem

The `arthur_injection_check` block screens a ticket for prompt injection via Arthur's GenAI Engine `validate_prompt`, keyed by an Arthur task id (`ctx.arthur.taskId`). But the block only *reads* that id and returns `status: "skipped"` / `reason: "arthur_task_missing"` when it is null. The id is created on demand by `ensureArthurTask(ctx)` (`prepare-workspace.ts`), which is only called by `prepare_workspace`, the agent sandbox, and the agent block.

In a screen-first workflow such as the built-in Injection detection template, the injection check is the first real block, so nothing has created an Arthur task yet and the screen *always* skips, even when the GenAI Engine is fully configured.

Observed on the Arthur tenant: dispatching the Injection detection workflow on a ticket returned `status: skipped` / `arthur_task_missing` from the screen and took the "screen unavailable" branch, so no ticket is ever actually screened.

## Fix

`arthur_injection_check` now calls `ensureArthurTask(ctx)` itself (the same helper `prepare_workspace` uses), which creates the Arthur task on demand keyed by the ticket identifier, and screens against the returned id. It still degrades to `status: "skipped"` when Arthur is unconfigured or when a task cannot be created.

## Tests

`arthur-injection-check.test.ts` now mocks `ensureArthurTask`: the previous "no task" case asserts a skip when a task cannot be created, and a new case asserts the block creates a task on demand and then screens. Narrow test file green (11/11).

## Notes

The identical fix is deployed to the Arthur tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
