### PR TITLE
fix(worker): unblock internal workflow dogfood

### DIFF
--- a/apps/worker/src/mcp/server.test.ts
+++ b/apps/worker/src/mcp/server.test.ts
@@ -156,7 +156,7 @@ describe("createMcpServer", () => {
     );
     expect(called.structuredContent).toMatchObject({
       data: {
-        protocolVersions: ["2025-11-25"],
+        protocolVersions: ["2025-11-25", "2025-06-18"],
         serverVersion: "0.1.0",
         enabledDomains: ["system", "tickets", "runs", "workflows", "prompts"],
         // These deps carry no messaging adapter, which is the same answer a

--- a/apps/worker/src/mcp/server.ts
+++ b/apps/worker/src/mcp/server.ts
@@ -16,6 +16,10 @@ import { registerWorkflowAuthoringTools } from "./tools/workflow-authoring.js";
 import { registerWorkflowTools } from "./tools/workflows.js";
 
 export const MCP_PROTOCOL_VERSION = "2025-11-25" as const;
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS = [
+  MCP_PROTOCOL_VERSION,
+  "2025-06-18",
+] as const;
 
 export function createMcpServer(deps: McpToolDependencies): McpServer {
   const server = new McpServer({
@@ -31,7 +35,7 @@ export function createMcpServer(deps: McpToolDependencies): McpServer {
       toolName: "system.capabilities",
       targetRefs: [],
       operation: async () => ({
-        protocolVersions: [MCP_PROTOCOL_VERSION],
+        protocolVersions: [...MCP_SUPPORTED_PROTOCOL_VERSIONS],
         serverVersion: env.MCP_SERVER_VERSION,
         contractHash: MCP_CONTRACT_HASH,
         deploymentClass: "dedicated-worker",

--- a/apps/worker/src/mcp/surface-e2e.test.ts
+++ b/apps/worker/src/mcp/surface-e2e.test.ts
@@ -753,7 +753,7 @@ describe("A. the client cycle and the published surface", () => {
 
     expect(result.isError).not.toBe(true);
     expect(envelope.data).toMatchObject({
-      protocolVersions: ["2025-11-25"],
+      protocolVersions: ["2025-11-25", "2025-06-18"],
       serverVersion: "0.1.0",
       contractHash: SNAPSHOT.contractHash,
       deploymentClass: "dedicated-worker",

--- a/apps/worker/src/mcp/transport.test.ts
+++ b/apps/worker/src/mcp/transport.test.ts
@@ -184,6 +184,26 @@ describe("stateless MCP Streamable HTTP", () => {
     });
   });
 
+  it("negotiates 2025-06-18 and accepts it on a sessionless follow-up", async () => {
+    const initialized = await post(initializeRequest(11, "2025-06-18"));
+
+    expect(initialized.status).toBe(200);
+    expect(initialized.headers.get("mcp-session-id")).toBeNull();
+    await expect(initialized.json()).resolves.toMatchObject({
+      jsonrpc: "2.0",
+      id: 11,
+      result: { protocolVersion: "2025-06-18" },
+    });
+
+    const listed = await post(
+      { jsonrpc: "2.0", id: 12, method: "tools/list", params: {} },
+      { "mcp-protocol-version": "2025-06-18" },
+    );
+
+    expect(listed.status).toBe(200);
+    await expect(listedToolNames(listed)).resolves.toEqual([...PUBLISHED].sort());
+  });
+
   it("creates a fresh server and transport for every POST", async () => {
     const first = await post(initializeRequest(7));
     const second = await post(initializeRequest(7));
@@ -261,26 +281,36 @@ describe("stateless MCP Streamable HTTP", () => {
     });
   });
 
-  it("rejects batches and protocol versions other than 2025-11-25", async () => {
+  it("rejects batches and unknown initialize protocol versions", async () => {
     const batch = await post([initializeRequest(1), initializeRequest(2)]);
-    const oldVersion = await post({
-      ...initializeRequest(5),
-      params: { ...initializeRequest(5).params, protocolVersion: "2025-06-18" },
-    });
+    const unknownVersion = await post(initializeRequest(5, "2099-01-01"));
 
     expect(batch.status).toBe(400);
-    expect(oldVersion.status).toBe(400);
+    expect(unknownVersion.status).toBe(400);
     await expect(batch.json()).resolves.toMatchObject({
       error: { data: { code: "VALIDATION_FAILED" } },
     });
-    await expect(oldVersion.json()).resolves.toMatchObject({
+    await expect(unknownVersion.json()).resolves.toMatchObject({
+      error: { data: { code: "VALIDATION_FAILED" } },
+    });
+  });
+
+  it("rejects an unknown initialize header before authentication", async () => {
+    const response = await post(initializeRequest(6), {
+      "mcp-protocol-version": "2099-01-01",
+    });
+
+    expect(response.status).toBe(400);
+    expect(state.requireMcpActor).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      id: 6,
       error: { data: { code: "VALIDATION_FAILED" } },
     });
   });
 
   it.each([
     ["missing", {}],
-    ["wrong", { "mcp-protocol-version": "2025-06-18" }],
+    ["unknown", { "mcp-protocol-version": "2099-01-01" }],
   ])("rejects a tools/list follow-up with a %s protocol version before auth", async (_case, headers) => {
     const response = await post(
       { jsonrpc: "2.0", id: 9, method: "tools/list", params: {} },
@@ -710,13 +740,13 @@ async function toolErrorText(response: Response): Promise<string> {
   return body.result?.content?.[0]?.text ?? "";
 }
 
-function initializeRequest(id: number) {
+function initializeRequest(id: number, protocolVersion = "2025-11-25") {
   return {
     jsonrpc: "2.0" as const,
     id,
     method: "initialize" as const,
     params: {
-      protocolVersion: "2025-11-25",
+      protocolVersion,
       capabilities: {},
       clientInfo: { name: "task-5-test", version: "1.0.0" },
     },

--- a/apps/worker/src/mcp/transport.ts
+++ b/apps/worker/src/mcp/transport.ts
@@ -30,7 +30,7 @@ import { authorizeTool, policyFor } from "./policy.js";
 import { consumeMcpRateLimit } from "./rate-limit-store.js";
 import { requireMcpActor } from "./request-context.js";
 import { hashCanonicalJson } from "./sanitize-result.js";
-import { createMcpServer, MCP_PROTOCOL_VERSION } from "./server.js";
+import { createMcpServer, MCP_SUPPORTED_PROTOCOL_VERSIONS } from "./server.js";
 import { catalogedTool, mcpToolErrorResult } from "./tool-catalog.js";
 
 type JsonRpcId = string | number | null;
@@ -591,15 +591,21 @@ function hasSupportedProtocol(event: H3Event, body: unknown): boolean {
   if (request.method === "initialize") {
     const params = request.params;
     return (
-      (!headerVersion || headerVersion === MCP_PROTOCOL_VERSION) &&
+      (!headerVersion || isSupportedProtocolVersion(headerVersion)) &&
       Boolean(
         params &&
           typeof params === "object" &&
-          (params as Record<string, unknown>).protocolVersion === MCP_PROTOCOL_VERSION,
+          isSupportedProtocolVersion(
+            (params as Record<string, unknown>).protocolVersion,
+          ),
       )
     );
   }
-  return typeof request.method !== "string" || headerVersion === MCP_PROTOCOL_VERSION;
+  return typeof request.method !== "string" || isSupportedProtocolVersion(headerVersion);
+}
+
+function isSupportedProtocolVersion(value: unknown): boolean {
+  return MCP_SUPPORTED_PROTOCOL_VERSIONS.some((version) => version === value);
 }
 
 function jsonRpcId(body: unknown): JsonRpcId {

--- a/apps/worker/src/workflow-definition/scenarios/support-investigation.scenario.test.ts
+++ b/apps/worker/src/workflow-definition/scenarios/support-investigation.scenario.test.ts
@@ -150,7 +150,9 @@ function scriptInvestigation(
 describe("support investigation workflow", () => {
   it("answers a Zendesk question with a bounded response and never prepares a workspace", async () => {
     const scenario = baseScenario("zendesk", ZENDESK_CASE);
-    scriptInvestigation(scenario, "question", "The evidence explains the expected Safari behaviour.");
+    scriptInvestigation(scenario, "question", "The evidence explains the expected Safari behaviour.", {
+      evidence: [{ ref: "slack:C_SUPPORT:1", source: "slack", title: "Raw support thread", excerpt: "Internal customer details", author: "U123", origin: "C_SUPPORT", timestamp: "2026-08-12T09:00:00Z", link: "https://slack.example.test/archives/C_SUPPORT/p1" }],
+    });
     scenario.script({ nodeId: "classify" }, {
       kind: "next",
       output: classifierOutput("question", "The requester asks for an explanation, not a code change."),
@@ -160,6 +162,9 @@ describe("support investigation workflow", () => {
     const outcome = await scenario.execute();
     expect(outcome.result.outcome).toBe("completed");
     expect(portsOf(outcome, "code-route")).toEqual(["false"]);
+    expect(executorRunsOf(outcome, "notify-non-code")[0]?.resolvedInputs?.message).toBe(
+      "Support investigation summary\n\nCase: zendesk #35436 — The login button does nothing on Safari\nClassification: question\nRationale / evidence summary: The requester asks for an explanation, not a code change.\n\nResponse draft / investigation theory:\nThe evidence explains the expected Safari behaviour.",
+    );
     expectNeverInvoked(outcome, ["prepare", "implementation", "checks", "finalize", "open-pr"]);
   });
 

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -756,7 +756,7 @@ function supportInvestigationDefinition(
       configuration: {
         operation: "format_text",
         template:
-          "Support investigation summary\n\nCase:\n{{data:steps.entry.output.supportCase}}\n\nClassification: {{data:steps.classify.output.classification}}\nRationale: {{data:steps.classify.output.rationale}}\n\nResponse draft:\n{{data:steps.investigate.output.theory}}\n\nEvidence:\n{{data:steps.investigate.output.evidence}}",
+          "Support investigation summary\n\nCase: {{data:steps.entry.output.supportCase.provider}} #{{data:steps.entry.output.supportCase.sourceId}} — {{data:steps.entry.output.supportCase.title}}\nClassification: {{data:steps.classify.output.classification}}\nRationale / evidence summary: {{data:steps.classify.output.rationale}}\n\nResponse draft / investigation theory:\n{{data:steps.investigate.output.theory}}",
       },
     },
     {

--- a/apps/worker/src/workflows/blocks/investigate.test.ts
+++ b/apps/worker/src/workflows/blocks/investigate.test.ts
@@ -355,6 +355,37 @@ describe("investigate execute", () => {
     expectOutputConformsToRegistry("investigate", result.output!);
   });
 
+  it("omits maxItems from the keyword schema and caps normalized keywords at runtime", async () => {
+    const keywords = [
+      "  keyword-1  ",
+      "",
+      "   ",
+      ...Array.from({ length: 11 }, (_, index) => `keyword-${index + 2}`),
+    ];
+    mocks.generateStructured
+      .mockResolvedValueOnce({ object: { keywords }, text: "", usage: null })
+      .mockResolvedValueOnce(THEORY_RESULT);
+    mocks.searchSlackChannels.mockResolvedValue({ matches: [], skipped: [] });
+
+    await execute(
+      makeNode("investigate", { providers: ["slack"], slackChannels: ["C1"] }),
+      {},
+      makeCtx(),
+    );
+
+    const keywordSchema = JSON.parse(mocks.generateStructured.mock.calls[0][0].schema);
+    expect(keywordSchema.properties.keywords).toEqual({
+      type: "array",
+      items: { type: "string" },
+    });
+    expect(keywordSchema.properties.keywords).not.toHaveProperty("maxItems");
+    expect(mocks.searchSlackChannels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keywords: Array.from({ length: 10 }, (_, index) => `keyword-${index + 1}`),
+      }),
+    );
+  });
+
   it("normalizes both providers onto the same evidence fields", async () => {
     mockHappyPath();
 

--- a/apps/worker/src/workflows/blocks/investigate.ts
+++ b/apps/worker/src/workflows/blocks/investigate.ts
@@ -95,7 +95,6 @@ const KEYWORDS_SCHEMA = JSON.stringify({
     keywords: {
       type: "array",
       items: { type: "string" },
-      maxItems: MAX_KEYWORDS,
     },
   },
   required: ["keywords"],


### PR DESCRIPTION
## Summary
- accept the Codex legacy Streamable HTTP MCP protocol while keeping the current version preferred
- keep investigation keyword limits at runtime without unsupported structured-output schema syntax
- format support Slack summaries without dumping raw case/evidence JSON

## Verification
- 
 RUN  v3.2.4 /private/tmp/ai-workflow-prod-orchestration.dJAbxo/repo/apps/worker

 ✓ src/workflows/blocks/investigate.test.ts (42 tests) 20ms
 ✓ src/workflow-definition/scenarios/support-investigation.scenario.test.ts (5 tests) 10ms
 ✓ src/workflow-definition/default-v2.test.ts (12 tests) 110ms
 ✓ src/mcp/server.test.ts (6 tests) 13ms
 ✓ src/mcp/transport.test.ts (36 tests) 1239ms
 ✓ src/mcp/surface-e2e.test.ts (42 tests) 1437ms

 Test Files  6 passed (6)
      Tests  143 passed (143)
   Start at  11:07:07
   Duration  2.52s (transform 1.16s, setup 0ms, collect 4.61s, tests 2.83s, environment 0ms, prepare 338ms) (143 passed)
- 
> worker@ typecheck /private/tmp/ai-workflow-prod-orchestration.dJAbxo/repo/apps/worker
> pnpm build:shared && tsc --noEmit


> worker@ build:shared /private/tmp/ai-workflow-prod-orchestration.dJAbxo/repo/apps/worker
> pnpm --filter @shared/contracts build && pnpm --filter @shared/conditions build


> @shared/contracts@0.0.0 build /private/tmp/ai-workflow-prod-orchestration.dJAbxo/repo/apps/shared/contracts
> tsc -p tsconfig.build.json


> @shared/conditions@0.0.0 build /private/tmp/ai-workflow-prod-orchestration.dJAbxo/repo/apps/shared/conditions
> tsc -p tsconfig.build.json
- 

Independent Sol review: ship.