### PR TITLE
fix(worker): record clarification decision inputs for run observability (AIW-267)

### DIFF
--- a/apps/worker/src/run-observability/agent-observations.test.ts
+++ b/apps/worker/src/run-observability/agent-observations.test.ts
@@ -139,6 +139,78 @@ describe("emitAgentInvocationObservations", () => {
     expect(log.value.tail).not.toContain("discard");
   });
 
+  it("records the clarification decision inputs when the phase reached one (AIW-267)", async () => {
+    const emit = vi.fn();
+    await emitAgentInvocationObservations({
+      observations: { emit },
+      provider: "codex",
+      model: "gpt-5",
+      phase: "research",
+      artifacts: {
+        stdout: "completed",
+        stderr: "",
+        structuredOutput: null,
+        exitCode: 0,
+      },
+      usage: null,
+      result: { ok: true, value: { status: "clarification_needed" } },
+      clarificationDecision: {
+        status: "clarification_needed",
+        questions: ["Which environment should this target?"],
+        suggestedAnswers: null,
+        ticketDigest: "ticket-digest",
+        ticketBytes: 42,
+        contextDigest: "context-digest",
+        contextBytes: 7,
+        harnessProfileHash: "harness-hash",
+      },
+    });
+
+    expect(emit).toHaveBeenCalledWith({
+      kind: "metadata",
+      value: expect.objectContaining({
+        provider: "codex",
+        model: "gpt-5",
+        phase: "research",
+        clarificationDecision: {
+          status: "clarification_needed",
+          questions: ["Which environment should this target?"],
+          suggestedAnswers: null,
+          ticketDigest: "ticket-digest",
+          ticketBytes: 42,
+          contextDigest: "context-digest",
+          contextBytes: 7,
+          harnessProfileHash: "harness-hash",
+        },
+      }),
+    });
+  });
+
+  it("omits clarificationDecision entirely when the caller does not provide one", async () => {
+    const emit = vi.fn();
+    await emitAgentInvocationObservations({
+      observations: { emit },
+      provider: "codex",
+      model: "gpt-5",
+      phase: "research",
+      artifacts: {
+        stdout: "completed",
+        stderr: "",
+        structuredOutput: null,
+        exitCode: 0,
+      },
+      usage: null,
+      result: { ok: true, value: { status: "completed" } },
+    });
+
+    const metadataCall = emit.mock.calls.find(
+      (call) => (call[0] as { kind: string }).kind === "metadata",
+    );
+    expect(
+      (metadataCall?.[0] as { value: Record<string, unknown> }).value,
+    ).not.toHaveProperty("clarificationDecision");
+  });
+
   it("removes structured output repeated inside provider logs", async () => {
     const emit = vi.fn();
     const structuredOutput = '{"result":"private output"}';

--- a/apps/worker/src/run-observability/agent-observations.ts
+++ b/apps/worker/src/run-observability/agent-observations.ts
@@ -33,6 +33,27 @@ interface AgentInvocationObservationBase {
   phase: string;
 }
 
+/**
+ * The inputs behind a clarification decision (AIW-267): recorded alongside the
+ * agent outcome so a future run's "did it ask, and why" stays diagnosable from
+ * the run ID alone, without Slack. ticketDigest/contextDigest are SHA-256
+ * digests of the ticket text and retrieved repo/context the model saw, not the
+ * raw content, so two runs of the same ticket stay comparable without storing
+ * ticket text twice. This whole object still passes through the same
+ * sanitizeReplayValue call the rest of the metadata envelope does before it is
+ * persisted, so no secret ever needs to be scrubbed here directly.
+ */
+export interface ClarificationDecisionObservation {
+  status: string;
+  questions: string[] | null;
+  suggestedAnswers: string[] | null;
+  ticketDigest: string;
+  ticketBytes: number;
+  contextDigest: string;
+  contextBytes: number;
+  harnessProfileHash: string | null;
+}
+
 type CollectedTimeoutArtifacts = CollectedPhaseArtifacts & {
   diagnosticSanitization?: {
     stdout: ReplaySanitizationMetadata;
@@ -142,6 +163,10 @@ export async function emitAgentInvocationObservations(input: AgentInvocationObse
   artifacts: CollectedPhaseArtifacts;
   usage: PhaseUsage | null;
   result: AgentProtocolResult<unknown>;
+  /** Present only when this invocation reached a structured clarification
+   *  decision (AIW-267). Omitted entirely rather than sent as null/undefined,
+   *  so it never overwrites a prior invocation's decision on replay. */
+  clarificationDecision?: ClarificationDecisionObservation;
 }): Promise<void> {
   try {
     await emitAgentArtifactObservations({
@@ -159,6 +184,9 @@ export async function emitAgentInvocationObservations(input: AgentInvocationObse
               failureKind: input.result.diagnostic.failureKind,
               event: input.result.diagnostic.event ?? null,
             },
+        ...(input.clarificationDecision
+          ? { clarificationDecision: input.clarificationDecision }
+          : {}),
       },
     });
   } catch {

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -50,7 +50,9 @@ import {
   emitAgentInvocationObservations,
   emitRepositoryWorkflowObservation,
   emitTimedOutAgentInvocationObservations,
+  type ClarificationDecisionObservation,
 } from "../run-observability/agent-observations.js";
+import type { ClarificationDecisionDigest } from "./clarification-decision-digest.js";
 import { persistWorkspaceMemoryStep } from "./memory-steps.js";
 import {
   distillRepoMemoryStep,
@@ -2674,6 +2676,50 @@ async function markV2RunObservationUnavailableStep(payload: {
 }
 markV2RunObservationUnavailableStep.maxRetries = 0;
 
+async function digestClarificationDecisionInputsStep(payload: {
+  ticketValue: unknown;
+  contextValue: unknown;
+}): Promise<ClarificationDecisionDigest> {
+  "use step";
+  const { digestClarificationDecisionInputs } = await import(
+    "./clarification-decision-digest.js"
+  );
+  return digestClarificationDecisionInputs(payload.ticketValue, payload.contextValue);
+}
+digestClarificationDecisionInputsStep.maxRetries = 0;
+
+/**
+ * AIW-267: builds the decision-inputs observation for a research/impl phase
+ * that reached a structured decision, so a future "why did it ask (or not)"
+ * question is answerable from the run ID alone. Best-effort like the rest of
+ * replay capture: a failed digest just means the observation is skipped, it
+ * never fails the phase.
+ */
+async function resolveClarificationDecisionObservation(input: {
+  status: string;
+  questions?: string[] | null;
+  suggestedAnswers?: string[] | null;
+  ticketValue: unknown;
+  contextValue: unknown;
+  harnessProfileHash: string | null;
+}): Promise<ClarificationDecisionObservation | undefined> {
+  try {
+    const digest = await digestClarificationDecisionInputsStep({
+      ticketValue: input.ticketValue,
+      contextValue: input.contextValue,
+    });
+    return {
+      status: input.status,
+      questions: input.questions ?? null,
+      suggestedAnswers: input.suggestedAnswers ?? null,
+      ...digest,
+      harnessProfileHash: input.harnessProfileHash,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 async function captureV2RunObservationStartStep(payload: {
   runId: string;
   definitionId: number | null;
@@ -4458,6 +4504,16 @@ async function agentWorkflowBody(
                 researchArtifactPhase,
                 runtime,
               );
+            const researchClarificationDecision = execution?.observations && researchResult.ok
+              ? await resolveClarificationDecisionObservation({
+                  status: researchResult.value.status,
+                  questions: researchResult.value.questions,
+                  suggestedAnswers: researchResult.value.suggestedAnswers,
+                  ticketValue: researchContext.ticket,
+                  contextValue: researchContext.repositoryContexts,
+                  harnessProfileHash: runtime?.manifestHash ?? null,
+                })
+              : undefined;
             await emitAgentInvocationObservations({
               observations: execution?.observations,
               provider: kind,
@@ -4466,6 +4522,9 @@ async function agentWorkflowBody(
               artifacts: researchArtifacts,
               usage: researchUsage,
               result: researchResult,
+              ...(researchClarificationDecision
+                ? { clarificationDecision: researchClarificationDecision }
+                : {}),
             });
             recordBlockPhaseUsage(
               ctx,
@@ -4701,6 +4760,16 @@ async function agentWorkflowBody(
                 implementationArtifactPhase,
                 runtime,
               );
+              const implClarificationDecision = execution?.observations && result.ok
+                ? await resolveClarificationDecisionObservation({
+                    status: result.value.result,
+                    questions: result.value.questions,
+                    suggestedAnswers: result.value.suggestedAnswers,
+                    ticketValue: implementationContext.ticket,
+                    contextValue: implementationContext.repositoryContexts,
+                    harnessProfileHash: runtime?.manifestHash ?? null,
+                  })
+                : undefined;
               await emitAgentInvocationObservations({
                 observations: execution?.observations,
                 provider: kind,
@@ -4709,6 +4778,9 @@ async function agentWorkflowBody(
                 artifacts: implArtifacts,
                 usage: implUsage,
                 result,
+                ...(implClarificationDecision
+                  ? { clarificationDecision: implClarificationDecision }
+                  : {}),
               });
               recordBlockPhaseUsage(
                 ctx,

--- a/apps/worker/src/workflows/clarification-decision-digest.test.ts
+++ b/apps/worker/src/workflows/clarification-decision-digest.test.ts
@@ -1,0 +1,87 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { digestClarificationDecisionInputs } from "./clarification-decision-digest.js";
+import { canonicalJson } from "./workspace-gate-fingerprint.js";
+
+describe("digestClarificationDecisionInputs", () => {
+  it("is deterministic for the same ticket value and context", () => {
+    const first = digestClarificationDecisionInputs(
+      { title: "Ticket body" },
+      { repo: "a" },
+    );
+    const second = digestClarificationDecisionInputs(
+      { title: "Ticket body" },
+      { repo: "a" },
+    );
+    expect(first).toEqual(second);
+  });
+
+  it("matches an independently computed sha256 of the canonicalized ticket value", () => {
+    const digest = digestClarificationDecisionInputs({ title: "Ticket body" }, null);
+    const ticketJson = canonicalJson({ title: "Ticket body" });
+    expect(digest.ticketDigest).toBe(
+      createHash("sha256").update(ticketJson, "utf8").digest("hex"),
+    );
+    expect(digest.ticketBytes).toBe(Buffer.byteLength(ticketJson, "utf8"));
+  });
+
+  it("produces the same digest for the same ticket regardless of key order (AIW-267 comparability)", () => {
+    // The resolved ticket value is spread from an externally-sourced object
+    // whose key order this code does not control, and conditionally includes
+    // a `clarifications` key. Two runs carrying the same ticket content must
+    // still hash identically for "same ticket -> same digest" to hold.
+    const inOneOrder = {
+      identifier: "AIW-267",
+      title: "Two identical tickets",
+      description: "Same content",
+      clarifications: [{ questions: ["Which env?"], answer: "prod" }],
+    };
+    const inAnotherOrder = {
+      clarifications: [{ questions: ["Which env?"], answer: "prod" }],
+      description: "Same content",
+      title: "Two identical tickets",
+      identifier: "AIW-267",
+    };
+    const context = { z: 1, a: 2 };
+    const reorderedContext = { a: 2, z: 1 };
+
+    const first = digestClarificationDecisionInputs(inOneOrder, context);
+    const second = digestClarificationDecisionInputs(inAnotherOrder, reorderedContext);
+
+    expect(first.ticketDigest).toBe(second.ticketDigest);
+    expect(first.contextDigest).toBe(second.contextDigest);
+  });
+
+  it("changes the ticket digest when the ticket value changes, holding context fixed", () => {
+    const context = { repo: "a" };
+    const first = digestClarificationDecisionInputs({ title: "Ticket A" }, context);
+    const second = digestClarificationDecisionInputs({ title: "Ticket B" }, context);
+    expect(first.ticketDigest).not.toBe(second.ticketDigest);
+    expect(first.contextDigest).toBe(second.contextDigest);
+  });
+
+  it("changes the context digest when the retrieved context changes, holding the ticket fixed", () => {
+    const ticket = { title: "Ticket A" };
+    const first = digestClarificationDecisionInputs(ticket, { repo: "a" });
+    const second = digestClarificationDecisionInputs(ticket, { repo: "b" });
+    expect(first.contextDigest).not.toBe(second.contextDigest);
+    expect(first.ticketDigest).toBe(second.ticketDigest);
+  });
+
+  it("treats undefined context the same as null", () => {
+    const ticket = { title: "Ticket A" };
+    const withNull = digestClarificationDecisionInputs(ticket, null);
+    const withUndefined = digestClarificationDecisionInputs(ticket, undefined);
+    expect(withNull.contextDigest).toBe(withUndefined.contextDigest);
+  });
+
+  it("never leaks raw ticket or context text into the digest output", () => {
+    const digest = digestClarificationDecisionInputs(
+      { description: "super secret ticket body" },
+      { token: "sk-should-not-appear" },
+    );
+    const serialized = JSON.stringify(digest);
+    expect(serialized).not.toContain("super secret ticket body");
+    expect(serialized).not.toContain("sk-should-not-appear");
+  });
+});

--- a/apps/worker/src/workflows/clarification-decision-digest.ts
+++ b/apps/worker/src/workflows/clarification-decision-digest.ts
@@ -1,0 +1,35 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "./workspace-gate-fingerprint.js";
+
+export interface ClarificationDecisionDigest {
+  ticketDigest: string;
+  ticketBytes: number;
+  contextDigest: string;
+  contextBytes: number;
+}
+
+/**
+ * Deterministic SHA-256 digests of the ticket input (title, description,
+ * comments, prior clarification answers) and the retrieved repo/context the
+ * model saw when it decided whether to ask for clarification (AIW-267).
+ * Digests instead of raw content, so the decision stays comparable across
+ * runs (same ticket + same context -> same digest) without storing the ticket
+ * body a second time. Both inputs go through the same recursively key-sorted,
+ * undefined-dropping canonicalJson the workspace fingerprint uses, since a
+ * plain JSON.stringify is sensitive to the source object's own key order (the
+ * ticket value is spread from an externally-sourced object) and would defeat
+ * "same ticket -> same digest".
+ */
+export function digestClarificationDecisionInputs(
+  ticketValue: unknown,
+  contextValue: unknown,
+): ClarificationDecisionDigest {
+  const ticketJson = canonicalJson(ticketValue ?? null);
+  const contextJson = canonicalJson(contextValue ?? null);
+  return {
+    ticketDigest: createHash("sha256").update(ticketJson, "utf8").digest("hex"),
+    ticketBytes: Buffer.byteLength(ticketJson, "utf8"),
+    contextDigest: createHash("sha256").update(contextJson, "utf8").digest("hex"),
+    contextBytes: Buffer.byteLength(contextJson, "utf8"),
+  };
+}

--- a/apps/worker/src/workflows/workspace-gate-fingerprint.ts
+++ b/apps/worker/src/workflows/workspace-gate-fingerprint.ts
@@ -25,7 +25,7 @@ export function fingerprintWorkspaceState(
   return createHash("sha256").update(canonicalJson(payload)).digest("hex");
 }
 
-function canonicalJson(value: unknown): string {
+export function canonicalJson(value: unknown): string {
   if (value === undefined) return "null";
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value) ?? "null";


### PR DESCRIPTION
## Goal

Make a future divergence between two structurally identical tickets (one asks for clarification, one proceeds to a PR) diagnosable from run observability alone, without needing the Slack QA thread. Closes [AIW-267](https://blazity.atlassian.net/browse/AIW-267).

## What changed

When the model makes the clarification-vs-proceed decision, we now record its decision inputs into the existing run-observability metadata pipeline, keyed by run ID:

- A new pure function `digestClarificationDecisionInputs(ticketValue, contextValue)` computes SHA-256 digests + byte counts of the canonicalized ticket input and the retrieved repo/context. It reuses the repo's existing `canonicalJson` (recursively key-sorted, undefined-dropping) so the same ticket content always yields the same digest across runs, which is the whole point: two "identical" tickets are now comparable by digest.
- The digest, plus the model's own structured `status`/`questions`/`suggestedAnswers` and the harness-profile manifest hash, is spread into the existing `kind: "metadata"` observation at both decision points (research phase and implementation phase), queryable via the untouched `getRunReplay`/`getRunReplayAttempt` read path.

## Privacy

No raw ticket or context text is stored: only SHA-256 digests + byte counts leave the process. Everything additionally passes through the existing `sanitizeReplayValue` sink defense-in-depth.

## No crash on V1

Emission is gated on `execution?.observations` (V2 replay capture only) and the digest step is best-effort (try/catch → `undefined`), so uninstrumented runs pay nothing and never fail the phase.

## Scope

Instruments only the two model-rubric decision points (the "Mandatory Clarity Gate" ask-vs-proceed), not the deterministic repo-discovery/expansion clarification branches, which are a structurally different classifier decision. Full runtime-context reconstruction of the two original Slack-only run IDs is out of scope (those runs predate this instrumentation); a classification verdict and a bounded follow-up are handled separately on the ticket.

## Tests

- `clarification-decision-digest.test.ts` (7): determinism, digest correctness against `canonicalJson`, key-order invariance (AIW-267 comparability), independent sensitivity to ticket vs context changes, undefined/null equivalence, no raw-content leakage.
- `agent-observations.test.ts` (+2): field included when given, omitted when not.
- `pnpm typecheck` clean; `pnpm vitest run src/workflows src/run-observability` = 1278 tests, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AIW-267]: https://blazity.atlassian.net/browse/AIW-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ