### PR TITLE
fix(worker): detect and resync drifted embedded carry schemas in stored definitions (AIW-245)

### DIFF
--- a/apps/worker/drizzle/0051_carry_schema_resync.sql
+++ b/apps/worker/drizzle/0051_carry_schema_resync.sql
@@ -1,0 +1,104 @@
+CREATE TABLE "carry_schema_resync_audit" (
+	"definition_id" integer NOT NULL,
+	"version" integer NOT NULL,
+	"node_index" integer NOT NULL,
+	"node_id" text,
+	"carry_index" integer NOT NULL,
+	"source_key" text NOT NULL,
+	"before_schema" jsonb NOT NULL,
+	"applied_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk" PRIMARY KEY("definition_id","version","node_index","carry_index")
+);
+--> statement-breakpoint
+-- >>> AIW-245 carry schema resync data migration (generated below; do not hand-edit) <<<
+-- Re-syncs code-owned JSON schemas embedded BY VALUE in a stored definition's
+-- loop carry (configuration.carry; loops are schema-version 2) with the current
+-- constants in apps/shared/contracts. A run never reads the constant: the
+-- definition froze a copy when it was saved, and when the constant changed shape
+-- ("critical"|"suggestion" -> "Blocker"|"High"|"Medium"|"Nit") every stored copy
+-- went stale and its definition began failing validation with no migration
+-- having touched it. That is AIW-245.
+--
+-- Guard: there is NO authorship marker inside a definition JSON. So a carry
+-- schema is rewritten ONLY when it byte-matches (jsonb =) a KNOWN PRIOR platform
+-- shape. Value alone still cannot prove the copy was the platform's rather than a
+-- customer step output of the same shape, so BEFORE rewriting, each matched carry
+-- is recorded in carry_schema_resync_audit (coordinate + before-value) -- the
+-- INSERT is ON CONFLICT DO NOTHING and the UPDATE is a strict no-op once the copy
+-- is current, so a re-run captures and changes nothing. An operator can read the
+-- audit for the exact rows changed and revert from before_schema.
+--
+-- Every reachable version snapshot is corrected, not just the deployed one: the
+-- statements have no version filter. Each is standalone (no explicit
+-- transaction: neon-http has none) and guards every jsonb_array_elements against
+-- a non-array so one malformed row cannot abort the whole migration.
+--
+-- Generated; do not hand-edit the shapes. Regenerate with
+-- scripts/generate-carry-schema-resync-migration.ts (see its header).
+INSERT INTO "carry_schema_resync_audit"
+  ("definition_id", "version", "node_index", "node_id", "carry_index", "source_key", "before_schema")
+SELECT
+  "v"."definition_id",
+  "v"."version",
+  ("node_ord" - 1)::int,
+  "node"->>'id',
+  ("carry_ord" - 1)::int,
+  'review_result',
+  "carry"->'schema'
+FROM "workflow_definition_versions" AS "v"
+CROSS JOIN LATERAL jsonb_array_elements(
+  CASE WHEN jsonb_typeof("v"."definition"->'nodes') = 'array' THEN "v"."definition"->'nodes' ELSE '[]'::jsonb END
+) WITH ORDINALITY AS "n"("node", "node_ord")
+CROSS JOIN LATERAL jsonb_array_elements(
+  CASE WHEN jsonb_typeof("node"->'configuration'->'carry') = 'array' THEN "node"->'configuration'->'carry' ELSE '[]'::jsonb END
+) WITH ORDINALITY AS "c"("carry", "carry_ord")
+WHERE "carry"->'schema' IN ($aiw_carry_resync${"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":true,"properties":{"decision":{"enum":["approve","request_changes"],"type":"string"},"feedback":{"type":"string"},"findings":{"items":{"additionalProperties":true,"properties":{"description":{"type":"string"},"endLine":{"type":"number"},"file":{"type":"string"},"severity":{"enum":["critical","suggestion"],"type":"string"},"startLine":{"type":"number"}},"required":["file","description","severity"],"type":"object"},"type":"array"}},"required":["decision","findings"],"type":"object"}$aiw_carry_resync$::jsonb, $aiw_carry_resync${"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":true,"properties":{"decision":{"enum":["approve","request_changes"],"type":"string"},"feedback":{"type":"string"},"findings":{"items":{"additionalProperties":true,"properties":{"description":{"type":"string"},"endLine":{"type":"number"},"file":{"type":"string"},"severity":{"enum":["Blocker","High","Medium","Nit"],"type":"string"},"startLine":{"type":"number"}},"required":["file","description","severity"],"type":"object"},"type":"array"}},"required":["decision","findings"],"type":"object"}$aiw_carry_resync$::jsonb)
+ON CONFLICT ("definition_id", "version", "node_index", "carry_index") DO NOTHING;
+--> statement-breakpoint
+UPDATE "workflow_definition_versions" AS "v"
+SET "definition" = jsonb_set(
+  "v"."definition",
+  '{nodes}',
+  COALESCE((
+    SELECT jsonb_agg("rewritten_node" ORDER BY "node_ord")
+    FROM (
+      SELECT
+        CASE
+          WHEN jsonb_typeof("node"->'configuration'->'carry') = 'array'
+          THEN jsonb_set(
+            "node",
+            '{configuration,carry}',
+            COALESCE((
+              SELECT jsonb_agg("rewritten_carry" ORDER BY "carry_ord")
+              FROM (
+                SELECT
+                  CASE
+                    WHEN "carry"->'schema' IN ($aiw_carry_resync${"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":true,"properties":{"decision":{"enum":["approve","request_changes"],"type":"string"},"feedback":{"type":"string"},"findings":{"items":{"additionalProperties":true,"properties":{"description":{"type":"string"},"endLine":{"type":"number"},"file":{"type":"string"},"severity":{"enum":["critical","suggestion"],"type":"string"},"startLine":{"type":"number"}},"required":["file","description","severity"],"type":"object"},"type":"array"}},"required":["decision","findings"],"type":"object"}$aiw_carry_resync$::jsonb, $aiw_carry_resync${"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":true,"properties":{"decision":{"enum":["approve","request_changes"],"type":"string"},"feedback":{"type":"string"},"findings":{"items":{"additionalProperties":true,"properties":{"description":{"type":"string"},"endLine":{"type":"number"},"file":{"type":"string"},"severity":{"enum":["Blocker","High","Medium","Nit"],"type":"string"},"startLine":{"type":"number"}},"required":["file","description","severity"],"type":"object"},"type":"array"}},"required":["decision","findings"],"type":"object"}$aiw_carry_resync$::jsonb)
+                    THEN jsonb_set("carry", '{schema}', $aiw_carry_resync${"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":true,"properties":{"decision":{"enum":["approve","request_changes"],"type":"string"},"feedback":{"type":"string"},"findings":{"items":{"additionalProperties":true,"properties":{"description":{"type":"string"},"endLine":{"type":"number"},"file":{"type":"string"},"repo":{"type":"string"},"severity":{"enum":["Blocker","High","Medium","Nit"],"type":"string"},"startLine":{"type":"number"}},"required":["file","description","severity"],"type":"object"},"type":"array"}},"required":["decision","findings"],"type":"object"}$aiw_carry_resync$::jsonb)
+                    ELSE "carry"
+                  END AS "rewritten_carry",
+                  "carry_ord"
+                FROM jsonb_array_elements("node"->'configuration'->'carry')
+                     WITH ORDINALITY AS "c"("carry", "carry_ord")
+              ) AS "carries"
+            ), '[]'::jsonb)
+          )
+          ELSE "node"
+        END AS "rewritten_node",
+        "node_ord"
+      FROM jsonb_array_elements(
+        CASE WHEN jsonb_typeof("v"."definition"->'nodes') = 'array' THEN "v"."definition"->'nodes' ELSE '[]'::jsonb END
+      ) WITH ORDINALITY AS "n"("node", "node_ord")
+    ) AS "nodes"
+  ), "v"."definition"->'nodes')
+)
+WHERE EXISTS (
+  SELECT 1
+  FROM jsonb_array_elements(
+    CASE WHEN jsonb_typeof("v"."definition"->'nodes') = 'array' THEN "v"."definition"->'nodes' ELSE '[]'::jsonb END
+  ) AS "node"
+  CROSS JOIN LATERAL jsonb_array_elements(
+    CASE WHEN jsonb_typeof("node"->'configuration'->'carry') = 'array' THEN "node"->'configuration'->'carry' ELSE '[]'::jsonb END
+  ) AS "carry"
+  WHERE "carry"->'schema' IN ($aiw_carry_resync${"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":true,"properties":{"decision":{"enum":["approve","request_changes"],"type":"string"},"feedback":{"type":"string"},"findings":{"items":{"additionalProperties":true,"properties":{"description":{"type":"string"},"endLine":{"type":"number"},"file":{"type":"string"},"severity":{"enum":["critical","suggestion"],"type":"string"},"startLine":{"type":"number"}},"required":["file","description","severity"],"type":"object"},"type":"array"}},"required":["decision","findings"],"type":"object"}$aiw_carry_resync$::jsonb, $aiw_carry_resync${"$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":true,"properties":{"decision":{"enum":["approve","request_changes"],"type":"string"},"feedback":{"type":"string"},"findings":{"items":{"additionalProperties":true,"properties":{"description":{"type":"string"},"endLine":{"type":"number"},"file":{"type":"string"},"severity":{"enum":["Blocker","High","Medium","Nit"],"type":"string"},"startLine":{"type":"number"}},"required":["file","description","severity"],"type":"object"},"type":"array"}},"required":["decision","findings"],"type":"object"}$aiw_carry_resync$::jsonb)
+);

--- a/apps/worker/drizzle/meta/0051_snapshot.json
+++ b/apps/worker/drizzle/meta/0051_snapshot.json
@@ -1,0 +1,7196 @@
+{
+  "id": "3ac82b91-0de5-4d10-9ff9-9ea4991b8369",
+  "prevId": "d9ae2f20-1c7a-4d42-8197-a780d0852d71",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.carry_schema_resync_audit": {
+      "name": "carry_schema_resync_audit",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_index": {
+          "name": "node_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carry_index": {
+          "name": "carry_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_schema": {
+          "name": "before_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk": {
+          "name": "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk",
+          "columns": [
+            "definition_id",
+            "version",
+            "node_index",
+            "carry_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispatch_capacity_queue": {
+      "name": "dispatch_capacity_queue",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_capability_catalogs": {
+      "name": "harness_capability_catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_hash": {
+          "name": "catalog_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "harness_capability_catalogs_scope_unique": {
+          "name": "harness_capability_catalogs_scope_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_capability_catalogs_organization_id_organization_id_fk": {
+          "name": "harness_capability_catalogs_organization_id_organization_id_fk",
+          "tableFrom": "harness_capability_catalogs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_capability_catalogs_provider_check": {
+          "name": "harness_capability_catalogs_provider_check",
+          "value": "\"harness_capability_catalogs\".\"provider\" in ('claude', 'codex')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_content_sha256": {
+          "name": "local_content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifacts_source_kind_check": {
+          "name": "harness_skill_artifacts_source_kind_check",
+          "value": "\"harness_skill_artifacts\".\"source_kind\" in ('github', 'local')"
+        },
+        "harness_skill_artifacts_source_shape_check": {
+          "name": "harness_skill_artifacts_source_shape_check",
+          "value": "(\n        \"harness_skill_artifacts\".\"source_kind\" <> 'github'\n        or (\n          \"harness_skill_artifacts\".\"source_owner\" is not null\n          and \"harness_skill_artifacts\".\"source_repository\" is not null\n          and \"harness_skill_artifacts\".\"source_path\" is not null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is not null\n          and \"harness_skill_artifacts\".\"local_path\" is null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is null\n        )\n      ) and (\n        \"harness_skill_artifacts\".\"source_kind\" <> 'local'\n        or (\n          \"harness_skill_artifacts\".\"local_path\" is not null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is not null\n          and \"harness_skill_artifacts\".\"source_owner\" is null\n          and \"harness_skill_artifacts\".\"source_repository\" is null\n          and \"harness_skill_artifacts\".\"source_path\" is null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is null\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_events": {
+      "name": "mcp_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutation_class": {
+          "name": "mutation_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_refs": {
+          "name": "target_refs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_hash": {
+          "name": "output_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key_hash": {
+          "name": "idempotency_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_version": {
+          "name": "server_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_hash": {
+          "name": "contract_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_audit_events_organization_occurred_at_idx": {
+          "name": "mcp_audit_events_organization_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_audit_events_request_id_idx": {
+          "name": "mcp_audit_events_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_events_organization_id_organization_id_fk": {
+          "name": "mcp_audit_events_organization_id_organization_id_fk",
+          "tableFrom": "mcp_audit_events",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_idempotency_keys": {
+      "name": "mcp_idempotency_keys",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_response": {
+          "name": "safe_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_idempotency_keys_namespace_unique": {
+          "name": "mcp_idempotency_keys_namespace_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_idempotency_keys_expires_at_idx": {
+          "name": "mcp_idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_idempotency_keys_organization_id_organization_id_fk": {
+          "name": "mcp_idempotency_keys_organization_id_organization_id_fk",
+          "tableFrom": "mcp_idempotency_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_idempotency_keys_state_check": {
+          "name": "mcp_idempotency_keys_state_check",
+          "value": "\"mcp_idempotency_keys\".\"state\" in ('started', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_rate_limit_windows": {
+      "name": "mcp_rate_limit_windows",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_rate_limit_windows_expires_at_idx": {
+          "name": "mcp_rate_limit_windows_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_rate_limit_windows_organization_id_organization_id_fk": {
+          "name": "mcp_rate_limit_windows_organization_id_organization_id_fk",
+          "tableFrom": "mcp_rate_limit_windows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_rate_limit_windows_organization_id_actor_subject_client_id_tool_name_window_started_at_pk": {
+          "name": "mcp_rate_limit_windows_organization_id_actor_subject_client_id_tool_name_window_started_at_pk",
+          "columns": [
+            "organization_id",
+            "actor_subject",
+            "client_id",
+            "tool_name",
+            "window_started_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_occurrences": {
+      "name": "schedule_occurrences",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_at": {
+          "name": "occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_count": {
+          "name": "dropped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dropped_count_capped": {
+          "name": "dropped_count_capped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocking_run_id": {
+          "name": "blocking_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedule_occurrences_one_pending_per_schedule_idx": {
+          "name": "schedule_occurrences_one_pending_per_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedule_occurrences\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_occurrences_run_id_idx": {
+          "name": "schedule_occurrences_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_occurrences_schedule_id_workflow_schedules_id_fk": {
+          "name": "schedule_occurrences_schedule_id_workflow_schedules_id_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_occurrences_definition_version_fk": {
+          "name": "schedule_occurrences_definition_version_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedule_occurrences_schedule_id_occurrence_at_pk": {
+          "name": "schedule_occurrences_schedule_id_occurrence_at_pk",
+          "columns": [
+            "schedule_id",
+            "occurrence_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedule_occurrences_outcome_check": {
+          "name": "schedule_occurrences_outcome_check",
+          "value": "\"schedule_occurrences\".\"outcome\" is null or \"schedule_occurrences\".\"outcome\" in ('started', 'skipped_overlap', 'skipped_stale', 'superseded', 'expired', 'cancelled', 'run_cancelled', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_rate_limits": {
+      "name": "trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_kind": {
+          "name": "window_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trigger_rate_limits_pk": {
+          "name": "trigger_rate_limits_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "window_kind",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_rejection_counters": {
+      "name": "trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trigger_rejection_counters_definition_id_node_id_day_reason_pk": {
+          "name": "trigger_rejection_counters_definition_id_node_id_day_reason_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "day",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_deliveries": {
+      "name": "webhook_trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "webhook_trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_trigger_deliveries_definition_version_fk": {
+          "name": "webhook_trigger_deliveries_definition_version_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_deliveries_endpoint_id_delivery_id_pk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_delivery_id_pk",
+          "columns": [
+            "endpoint_id",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_endpoints": {
+      "name": "webhook_trigger_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_scheme": {
+          "name": "auth_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hmac_sha256'"
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_timestamp": {
+          "name": "require_timestamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timestamp_header": {
+          "name": "timestamp_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp_tolerance_seconds": {
+          "name": "timestamp_tolerance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_secret_ciphertext": {
+          "name": "previous_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_endpoints_definition_node_idx": {
+          "name": "webhook_trigger_endpoints_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk": {
+          "name": "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "webhook_trigger_endpoints",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhook_trigger_endpoints_auth_scheme_check": {
+          "name": "webhook_trigger_endpoints_auth_scheme_check",
+          "value": "\"webhook_trigger_endpoints\".\"auth_scheme\" in ('hmac_sha256', 'shared_token')"
+        },
+        "webhook_trigger_endpoints_timestamp_tolerance_check": {
+          "name": "webhook_trigger_endpoints_timestamp_tolerance_check",
+          "value": "\"webhook_trigger_endpoints\".\"timestamp_tolerance_seconds\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rate_limits": {
+      "name": "webhook_trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inbox'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_rate_limits",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rejection_counters": {
+      "name": "webhook_trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk": {
+          "name": "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publication_comments": {
+      "name": "workflow_pr_review_publication_comments",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk",
+          "tableFrom": "workflow_pr_review_publication_comments",
+          "tableTo": "workflow_pr_review_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_pr_review_publication_comments_publication_id_content_hash_pk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_content_hash_pk",
+          "columns": [
+            "publication_id",
+            "content_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publication_comments_state_check": {
+          "name": "workflow_pr_review_publication_comments_state_check",
+          "value": "\"workflow_pr_review_publication_comments\".\"state\" in ('pending', 'published')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publications": {
+      "name": "workflow_pr_review_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_comment_count": {
+          "name": "inline_comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summary_fallback_count": {
+          "name": "summary_fallback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_pr_review_publications_content_unique": {
+          "name": "workflow_pr_review_publications_content_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pr_review_publications_run_idx": {
+          "name": "workflow_pr_review_publications_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_pr_review_publications",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publications_state_check": {
+          "name": "workflow_pr_review_publications_state_check",
+          "value": "\"workflow_pr_review_publications\".\"state\" in ('pending', 'published')"
+        },
+        "workflow_pr_review_publications_decision_check": {
+          "name": "workflow_pr_review_publications_decision_check",
+          "value": "\"workflow_pr_review_publications\".\"decision\" in ('approve', 'request_changes')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_external_checks": {
+      "name": "workflow_run_external_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "closure_intent": {
+          "name": "closure_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_external_checks_attempt_unique": {
+          "name": "workflow_run_external_checks_attempt_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_reconcile_idx": {
+          "name": "workflow_run_external_checks_reconcile_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_run_idx": {
+          "name": "workflow_run_external_checks_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_external_checks_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_external_checks_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_external_checks",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_external_checks_state_check": {
+          "name": "workflow_run_external_checks_state_check",
+          "value": "\"workflow_run_external_checks\".\"state\" in ('creating', 'pending', 'closing', 'completed')"
+        },
+        "workflow_run_external_checks_conclusion_check": {
+          "name": "workflow_run_external_checks_conclusion_check",
+          "value": "\"workflow_run_external_checks\".\"conclusion\" is null or \"workflow_run_external_checks\".\"conclusion\" in ('success', 'failure', 'neutral', 'cancelled', 'timed_out', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_started_at": {
+          "name": "entry_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_deadline_at": {
+          "name": "startup_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_startup_watchdog_idx": {
+          "name": "workflow_runs_startup_watchdog_idx",
+          "columns": [
+            {
+              "expression": "startup_deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_runs\".\"entry_started_at\" is null and coalesce(\"workflow_runs\".\"status\", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "overlap_policy": {
+          "name": "overlap_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "catch_up_grace_minutes": {
+          "name": "catch_up_grace_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_watermark_at": {
+          "name": "evaluation_watermark_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_occurrence_at": {
+          "name": "last_started_occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_run_id": {
+          "name": "last_started_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_schedules_definition_node_idx": {
+          "name": "workflow_schedules_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_schedules_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_schedules_overlap_policy_check": {
+          "name": "workflow_schedules_overlap_policy_check",
+          "value": "\"workflow_schedules\".\"overlap_policy\" in ('skip', 'queue', 'allow')"
+        },
+        "workflow_schedules_catch_up_grace_check": {
+          "name": "workflow_schedules_catch_up_grace_check",
+          "value": "\"workflow_schedules\".\"catch_up_grace_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expires_at_idx": {
+          "name": "oauth_access_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_expires_at_idx": {
+          "name": "oauth_refresh_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memory_documents": {
+      "name": "agent_memory_documents",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memory_documents_ticket_key_idx": {
+          "name": "agent_memory_documents_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_documents_updated_at_idx": {
+          "name": "agent_memory_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_memory_documents_subject_key_doc_path_pk": {
+          "name": "agent_memory_documents_subject_key_doc_path_pk",
+          "columns": [
+            "subject_key",
+            "doc_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1786886939711,
       "tag": "0050_dispatch_capacity_queue",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1786895976609,
+      "tag": "0051_carry_schema_resync",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -21,6 +21,7 @@
     "mcp:contract:generate": "tsx scripts/generate-mcp-contract.ts",
     "mcp:contract:check": "tsx scripts/generate-mcp-contract.ts --check",
     "check:prompt-drift": "tsx src/prompt-library/builtin-prompt-drift-gate.ts",
+    "check:carry-schema-drift": "tsx src/workflow-definition/carry-schema-drift-gate.ts",
     "build:arthur-tracer": "node scripts/build-arthur-tracer.mjs",
     "test:e2e": "pnpm test:e2e:agent && pnpm test:e2e:orchestration && pnpm test:e2e:capacity",
     "test:e2e:agent": "pnpm build:shared && vitest run --config e2e/vitest.e2e.config.ts --project agent",

--- a/apps/worker/scripts/generate-carry-schema-resync-migration.ts
+++ b/apps/worker/scripts/generate-carry-schema-resync-migration.ts
@@ -1,0 +1,199 @@
+/**
+ * Appends the DATA half of the carry-schema resync migration onto the DDL half
+ * that drizzle-kit generates for the carry_schema_resync_audit table.
+ *
+ * A run never reads the code constant: a workflow definition freezes a copy of
+ * REVIEW_RESULT_JSON_SCHEMA (and PR_CHECK_OUTPUT_SCHEMA) inside its own JSON when
+ * it is saved, and deployment validation compares that frozen copy against the
+ * type it derives live from the current constant. When the constant changes
+ * shape the frozen copy goes stale and a previously-valid definition starts
+ * failing validation with nothing having touched it (AIW-245). This migration
+ * rewrites the stale copies, capturing a pre-image of each into the audit table
+ * first so the rewrite is observable and reversible on production.
+ *
+ * The prior and current shapes come from the SAME registry the drift gate uses
+ * (src/workflow-definition/carry-schema-drift.ts -> RESYNC_TARGETS), so the gate
+ * and the migration can never disagree on which shapes are the platform's. There
+ * is NO authorship marker inside a definition JSON, so the only guard is a
+ * structural byte-for-byte (jsonb =) match against a KNOWN PRIOR platform shape.
+ *
+ * Usage, from apps/worker (build the shared package first, the shapes are read
+ * from the built @shared/contracts the runtime itself consumes):
+ *
+ *   pnpm build:shared
+ *   pnpm exec drizzle-kit generate --name=carry_schema_resync   # writes the DDL
+ *   pnpm exec tsx scripts/generate-carry-schema-resync-migration.ts \
+ *     drizzle/<generated file>.sql                               # appends the data
+ *
+ * Re-running is safe: the data half is delimited by a sentinel and rewritten in
+ * place, so it never doubles up. Never point it at a migration already applied
+ * anywhere; generate a fresh numbered file instead.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import {
+  canonicalizeSchema,
+  RESYNC_TARGETS,
+} from "../src/workflow-definition/carry-schema-drift.js";
+
+/** Dollar-quote tag, so the JSON is copied verbatim instead of being escaped.
+ *  Verified absent from every shape below. */
+const TAG = "$aiw_carry_resync$";
+const BREAKPOINT = "--> statement-breakpoint";
+const SENTINEL =
+  "-- >>> AIW-245 carry schema resync data migration (generated below; do not hand-edit) <<<";
+
+const DATA_HEADER = `${SENTINEL}
+-- Re-syncs code-owned JSON schemas embedded BY VALUE in a stored definition's
+-- loop carry (configuration.carry; loops are schema-version 2) with the current
+-- constants in apps/shared/contracts. A run never reads the constant: the
+-- definition froze a copy when it was saved, and when the constant changed shape
+-- ("critical"|"suggestion" -> "Blocker"|"High"|"Medium"|"Nit") every stored copy
+-- went stale and its definition began failing validation with no migration
+-- having touched it. That is AIW-245.
+--
+-- Guard: there is NO authorship marker inside a definition JSON. So a carry
+-- schema is rewritten ONLY when it byte-matches (jsonb =) a KNOWN PRIOR platform
+-- shape. Value alone still cannot prove the copy was the platform's rather than a
+-- customer step output of the same shape, so BEFORE rewriting, each matched carry
+-- is recorded in carry_schema_resync_audit (coordinate + before-value) -- the
+-- INSERT is ON CONFLICT DO NOTHING and the UPDATE is a strict no-op once the copy
+-- is current, so a re-run captures and changes nothing. An operator can read the
+-- audit for the exact rows changed and revert from before_schema.
+--
+-- Every reachable version snapshot is corrected, not just the deployed one: the
+-- statements have no version filter. Each is standalone (no explicit
+-- transaction: neon-http has none) and guards every jsonb_array_elements against
+-- a non-array so one malformed row cannot abort the whole migration.
+--
+-- Generated; do not hand-edit the shapes. Regenerate with
+-- scripts/generate-carry-schema-resync-migration.ts (see its header).`;
+
+/** Guarded array expansion: never throws on a row whose value is not an array. */
+function guardedArray(expr: string): string {
+  return `CASE WHEN jsonb_typeof(${expr}) = 'array' THEN ${expr} ELSE '[]'::jsonb END`;
+}
+
+/** Captures the pre-image of every carry about to be rewritten, keyed by its
+ *  coordinate so a re-run inserts nothing new. */
+function buildAuditInsert(sourceKey: string, priorList: string): string {
+  return `INSERT INTO "carry_schema_resync_audit"
+  ("definition_id", "version", "node_index", "node_id", "carry_index", "source_key", "before_schema")
+SELECT
+  "v"."definition_id",
+  "v"."version",
+  ("node_ord" - 1)::int,
+  "node"->>'id',
+  ("carry_ord" - 1)::int,
+  '${sourceKey}',
+  "carry"->'schema'
+FROM "workflow_definition_versions" AS "v"
+CROSS JOIN LATERAL jsonb_array_elements(
+  ${guardedArray(`"v"."definition"->'nodes'`)}
+) WITH ORDINALITY AS "n"("node", "node_ord")
+CROSS JOIN LATERAL jsonb_array_elements(
+  ${guardedArray(`"node"->'configuration'->'carry'`)}
+) WITH ORDINALITY AS "c"("carry", "carry_ord")
+WHERE "carry"->'schema' IN (${priorList})
+ON CONFLICT ("definition_id", "version", "node_index", "carry_index") DO NOTHING;`;
+}
+
+/** Rewrites every carry schema matching a prior shape to the current shape. The
+ *  WHERE guard makes the row a no-op when it carries no matching shape. */
+function buildUpdate(current: string, priorList: string): string {
+  return `UPDATE "workflow_definition_versions" AS "v"
+SET "definition" = jsonb_set(
+  "v"."definition",
+  '{nodes}',
+  COALESCE((
+    SELECT jsonb_agg("rewritten_node" ORDER BY "node_ord")
+    FROM (
+      SELECT
+        CASE
+          WHEN jsonb_typeof("node"->'configuration'->'carry') = 'array'
+          THEN jsonb_set(
+            "node",
+            '{configuration,carry}',
+            COALESCE((
+              SELECT jsonb_agg("rewritten_carry" ORDER BY "carry_ord")
+              FROM (
+                SELECT
+                  CASE
+                    WHEN "carry"->'schema' IN (${priorList})
+                    THEN jsonb_set("carry", '{schema}', ${TAG}${current}${TAG}::jsonb)
+                    ELSE "carry"
+                  END AS "rewritten_carry",
+                  "carry_ord"
+                FROM jsonb_array_elements("node"->'configuration'->'carry')
+                     WITH ORDINALITY AS "c"("carry", "carry_ord")
+              ) AS "carries"
+            ), '[]'::jsonb)
+          )
+          ELSE "node"
+        END AS "rewritten_node",
+        "node_ord"
+      FROM jsonb_array_elements(
+        ${guardedArray(`"v"."definition"->'nodes'`)}
+      ) WITH ORDINALITY AS "n"("node", "node_ord")
+    ) AS "nodes"
+  ), "v"."definition"->'nodes')
+)
+WHERE EXISTS (
+  SELECT 1
+  FROM jsonb_array_elements(
+    ${guardedArray(`"v"."definition"->'nodes'`)}
+  ) AS "node"
+  CROSS JOIN LATERAL jsonb_array_elements(
+    ${guardedArray(`"node"->'configuration'->'carry'`)}
+  ) AS "carry"
+  WHERE "carry"->'schema' IN (${priorList})
+);`;
+}
+
+const target = process.argv[2];
+if (!target) {
+  console.error(
+    "Usage: tsx scripts/generate-carry-schema-resync-migration.ts <output .sql path>",
+  );
+  process.exit(1);
+}
+
+if (RESYNC_TARGETS.length === 0) {
+  console.error("No resync targets have known prior shapes; nothing to generate.");
+  process.exit(1);
+}
+
+const statements: string[] = [];
+for (const source of RESYNC_TARGETS) {
+  const current = canonicalizeSchema(source.current);
+  const priors = source.knownPrior.map((prior) => canonicalizeSchema(prior));
+  for (const literal of [current, ...priors]) {
+    if (literal.includes(TAG)) {
+      throw new Error(`dollar-quote tag ${TAG} appears inside a "${source.key}" shape`);
+    }
+    if (literal.includes(BREAKPOINT)) {
+      throw new Error(`statement breakpoint marker appears inside a "${source.key}" shape`);
+    }
+  }
+  const priorList = priors.map((prior) => `${TAG}${prior}${TAG}::jsonb`).join(", ");
+  // Capture MUST precede rewrite: the pre-image is only recoverable while the
+  // carry still holds the prior shape.
+  statements.push(buildAuditInsert(source.key, priorList));
+  statements.push(buildUpdate(current, priorList));
+  console.log(
+    `${source.key}: ${priors.length} prior shape(s), ${Buffer.byteLength(current, "utf8")} bytes current, quoting is safe`,
+  );
+}
+
+// Keep the DDL half that drizzle-kit generated; replace only the data half so
+// re-running never doubles it up.
+let ddl = readFileSync(target, "utf8");
+const sentinelAt = ddl.indexOf(SENTINEL);
+if (sentinelAt !== -1) {
+  ddl = ddl.slice(0, sentinelAt);
+}
+ddl = ddl.replace(new RegExp(`(?:\\s*${BREAKPOINT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})?\\s*$`), "");
+
+const sql = `${ddl}\n${BREAKPOINT}\n${DATA_HEADER}\n${statements.join(`\n${BREAKPOINT}\n`)}\n`;
+
+writeFileSync(target, sql, "utf8");
+console.log(`Wrote ${target} (${Buffer.byteLength(sql, "utf8")} bytes).`);

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -864,6 +864,42 @@ export const workflowDefinitionVersions = pgTable(
 );
 
 /**
+ * Pre-image audit of every loop carry schema that migration 0051 (AIW-245)
+ * rewrote in place. The resync matches a stored carry schema by value against a
+ * known prior platform shape, but value alone cannot prove the stored copy was
+ * the platform's rather than a customer's step output that happens to be the
+ * same shape. So before rewriting, the migration records the exact coordinate
+ * and the before-value here, giving an operator the rows changed and the value
+ * to revert. The primary key doubles as the idempotency key: the pre-image
+ * INSERT is ON CONFLICT DO NOTHING, so re-running the migration captures nothing
+ * new. No foreign key, deliberately: the audit must survive a later delete of
+ * the version row it describes.
+ */
+export const carrySchemaResyncAudit = pgTable(
+  "carry_schema_resync_audit",
+  {
+    definitionId: integer("definition_id").notNull(),
+    version: integer("version").notNull(),
+    /** 0-based index into the definition's nodes array. */
+    nodeIndex: integer("node_index").notNull(),
+    nodeId: text("node_id"),
+    /** 0-based index into the loop node's configuration.carry array. */
+    carryIndex: integer("carry_index").notNull(),
+    /** Which EMBEDDED_SCHEMA_SOURCES entry the before-value matched. */
+    sourceKey: text("source_key").notNull(),
+    beforeSchema: jsonb("before_schema").$type<unknown>().notNull(),
+    appliedAt: timestamp("applied_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    primaryKey({
+      columns: [t.definitionId, t.version, t.nodeIndex, t.carryIndex],
+    }),
+  ],
+);
+
+/**
  * Named workflow definitions: one row per definition the dashboard manages.
  * trigger_types is denormalized from the head version, kept in sync by
  * save/restore, and backs the one-enabled-definition-per-trigger rule so the

--- a/apps/worker/src/workflow-definition/carry-schema-drift-gate.ts
+++ b/apps/worker/src/workflow-definition/carry-schema-drift-gate.ts
@@ -1,0 +1,138 @@
+import { fileURLToPath } from "node:url";
+import type { Db } from "../db/client.js";
+import {
+  describeCarrySchemaDrift,
+  findCarrySchemaDrift,
+  type CarrySchemaDriftReport,
+  type FindCarrySchemaDriftOptions,
+} from "./carry-schema-drift.js";
+
+/**
+ * The caller for the embedded-schema drift report.
+ *
+ * findCarrySchemaDrift only describes; this decides. Two callers use it:
+ *
+ *   1. The test suite (carry-schema-drift.test.ts), run against a database built
+ *      from the committed migrations. It catches a code constant changed shape
+ *      without a matching resync migration: a fixture carrying the prior shape
+ *      then reports drift and the suite goes red on the offending commit.
+ *
+ *   2. `runCarrySchemaDriftGate` as a command against a real DATABASE_URL, the
+ *      half that sees production rows. Run it after deploying a release that
+ *      changes any code-owned schema embedded by value in a template:
+ *
+ *        pnpm exec tsx src/workflow-definition/carry-schema-drift-gate.ts
+ *
+ * The gate fails on three conditions. Gating on `drift` alone would pass a walk
+ * that could not read part of the graph (`skipped`) and a walk that reached no
+ * snapshot at all (`definitionsWalked === 0`). The last is the important one: an
+ * empty result is the failure mode a check like this dies of, and it looks
+ * identical to success.
+ *
+ * `customerDivergent` and `unrecognizedOutputSchemas` are reported but never
+ * fail the gate: a customer's own carry schema and a template-local outputSchema
+ * are both legitimately not the platform's, and a resync must leave them alone.
+ */
+
+export type CarrySchemaDriftGateFailureCode =
+  | "drift"
+  | "incomplete_walk"
+  | "nothing_inspected";
+
+export interface CarrySchemaDriftGateFailure {
+  code: CarrySchemaDriftGateFailureCode;
+  detail: string;
+}
+
+export interface CarrySchemaDriftGateResult {
+  ok: boolean;
+  failures: CarrySchemaDriftGateFailure[];
+  report: CarrySchemaDriftReport;
+  message: string;
+}
+
+export function evaluateCarrySchemaDriftGate(
+  report: CarrySchemaDriftReport,
+): CarrySchemaDriftGateResult {
+  const failures: CarrySchemaDriftGateFailure[] = [];
+
+  if (report.drift.length > 0) {
+    failures.push({
+      code: "drift",
+      detail:
+        `${report.drift.length} embedded schema(s) a dispatch can still select match a ` +
+        `prior platform shape, not the current constant. A resync migration will correct these.`,
+    });
+  }
+  if (report.skipped.length > 0) {
+    failures.push({
+      code: "incomplete_walk",
+      detail:
+        `${report.skipped.length} definition snapshot(s) or node(s) could not be read, so the ` +
+        `report is incomplete and a clean drift list proves nothing.`,
+    });
+  }
+  if (report.definitionsWalked === 0) {
+    failures.push({
+      code: "nothing_inspected",
+      detail:
+        `No definition snapshot was read at all (definitionsWalked=0). An empty report is ` +
+        `not a clean one: the walk reached nothing to check.`,
+    });
+  }
+
+  const detail = describeCarrySchemaDrift(report);
+  return {
+    ok: failures.length === 0,
+    failures,
+    report,
+    message:
+      failures.length === 0
+        ? `Carry schema drift gate passed: ${report.embeds.length} embedded schema(s) across ` +
+          `${report.definitionsWalked} definition snapshot(s), ${report.customerDivergent.length} ` +
+          `customer schema(s) left untouched.`
+        : [
+            "Carry schema drift gate FAILED.",
+            ...failures.map((failure) => `  [${failure.code}] ${failure.detail}`),
+            ...(detail === "" ? [] : ["", detail]),
+          ].join("\n"),
+  };
+}
+
+export class CarrySchemaDriftError extends Error {
+  constructor(readonly result: CarrySchemaDriftGateResult) {
+    super(result.message);
+    this.name = "CarrySchemaDriftError";
+  }
+}
+
+/** Throws CarrySchemaDriftError unless every gate condition passes. */
+export async function assertNoCarrySchemaDrift(
+  db: Db,
+  options: FindCarrySchemaDriftOptions = {},
+): Promise<CarrySchemaDriftGateResult> {
+  const result = evaluateCarrySchemaDriftGate(
+    await findCarrySchemaDrift(db, options),
+  );
+  if (!result.ok) throw new CarrySchemaDriftError(result);
+  return result;
+}
+
+/** Command entry point. Resolves the database lazily so importing this module
+ *  never requires DATABASE_URL to be set. */
+export async function runCarrySchemaDriftGate(): Promise<number> {
+  const { getDb } = await import("../db/client.js");
+  const result = evaluateCarrySchemaDriftGate(
+    await findCarrySchemaDrift(getDb()),
+  );
+  console.log(result.message);
+  return result.ok ? 0 : 1;
+}
+
+// Only when executed directly, never on import.
+if (
+  process.argv[1] !== undefined &&
+  process.argv[1] === fileURLToPath(import.meta.url)
+) {
+  process.exitCode = await runCarrySchemaDriftGate();
+}

--- a/apps/worker/src/workflow-definition/carry-schema-drift.test.ts
+++ b/apps/worker/src/workflow-definition/carry-schema-drift.test.ts
@@ -1,0 +1,395 @@
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { describe, expect, it } from "vitest";
+import { REVIEW_RESULT_JSON_SCHEMA } from "@shared/contracts";
+import type { Db } from "../db/client.js";
+import * as schema from "../db/schema.js";
+import type { WorkflowBlockRegistryContext } from "./block-registry.js";
+import {
+  canonicalizeSchema,
+  collectDefinitionEmbeds,
+  EMBEDDED_SCHEMA_SOURCES,
+  findCarrySchemaDrift,
+} from "./carry-schema-drift.js";
+import {
+  assertNoCarrySchemaDrift,
+  CarrySchemaDriftError,
+  evaluateCarrySchemaDriftGate,
+} from "./carry-schema-drift-gate.js";
+import { workflowDefinitionTemplate, workflowDefinitionTemplates } from "./templates.js";
+import { validateWorkflowDefinitionCandidate } from "./validation.js";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+const migrationFiles = readdirSync(migrationsDir)
+  .filter((file) => file.endsWith(".sql"))
+  .sort();
+
+const registryContext: WorkflowBlockRegistryContext = {
+  agentProviders: { claude: true, codex: true },
+  llmProviders: { claude: true, codex: true },
+  defaultAgent: { provider: "claude", model: "claude-test" },
+  vcsProviders: ["github", "gitlab"],
+  vcsBotIdentities: ["github", "gitlab"],
+  slackConfigured: true,
+  arthurConfigured: true,
+  webhookTriggerConfigured: true,
+};
+
+interface TestDatabase {
+  client: PGlite;
+  db: Db;
+}
+
+async function migrateThrough(lastPrefix: string): Promise<TestDatabase> {
+  const client = new PGlite();
+  for (const file of migrationFiles) {
+    if (file.slice(0, 4) > lastPrefix) break;
+    await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+  }
+  return { client, db: drizzle({ client, schema }) as unknown as Db };
+}
+
+function resyncMigrationSql(): string {
+  const file = migrationFiles.find((name) =>
+    name.startsWith("0051_carry_schema_resync"),
+  );
+  if (!file) throw new Error("0051_carry_schema_resync migration not found");
+  return readFileSync(`${migrationsDir}${file}`, "utf8");
+}
+
+async function applyCarrySchemaResync(client: PGlite): Promise<void> {
+  await client.exec(resyncMigrationSql());
+}
+
+/** Re-runs only the data statements (INSERT + UPDATE), skipping the CREATE TABLE
+ *  so a second application does not fail on an existing table. Proves the data
+ *  half is idempotent. */
+async function applyCarrySchemaResyncDataOnly(client: PGlite): Promise<void> {
+  const parts = resyncMigrationSql().split("--> statement-breakpoint");
+  await client.exec(parts.slice(1).join("\n"));
+}
+
+async function retireFreshInstallDefinition(client: PGlite): Promise<void> {
+  await client.query(
+    `UPDATE workflow_definitions SET enabled = false, archived_at = now() WHERE id = 1`,
+  );
+}
+
+async function deployDefinition(
+  client: PGlite,
+  name: string,
+  definition: unknown,
+): Promise<number> {
+  const created = await client.query<{ id: number }>(
+    `INSERT INTO workflow_definitions (name, enabled, trigger_types, created_by_id, created_by_label)
+     VALUES ($1, false, '{}', 'u_admin', 'Admin') RETURNING id`,
+    [name],
+  );
+  const id = created.rows[0]!.id;
+  await client.query(
+    `INSERT INTO workflow_definition_versions (definition_id, version, definition, created_by_id, created_by_label)
+     VALUES ($1, 1, $2, 'u_admin', 'Admin')`,
+    [id, JSON.stringify(definition)],
+  );
+  await client.query(
+    `UPDATE workflow_definitions SET deployed_version = 1 WHERE id = $1`,
+    [id],
+  );
+  return id;
+}
+
+async function readStoredDefinition(
+  client: PGlite,
+  definitionId: number,
+): Promise<unknown> {
+  const rows = await client.query<{ definition: unknown }>(
+    `SELECT definition FROM workflow_definition_versions WHERE definition_id = $1 AND version = 1`,
+    [definitionId],
+  );
+  return rows.rows[0]!.definition;
+}
+
+const reviewResultSource = EMBEDDED_SCHEMA_SOURCES.find(
+  (source) => source.key === "review_result",
+)!;
+/** The exact severity "critical"|"suggestion" shape AIW-245 reproduces. */
+const OLD_ENUM_SHAPE = reviewResultSource.knownPrior[0]!;
+
+function reviewedTicketCurrent(): Record<string, unknown> {
+  const template = workflowDefinitionTemplate("reviewed-ticket-workflow", {
+    includeReview: true,
+    provider: "claude",
+  });
+  if (!template) throw new Error("reviewed-ticket-workflow template missing");
+  return template.definition as unknown as Record<string, unknown>;
+}
+
+/** Rewrites every carry schema that currently mirrors REVIEW_RESULT_JSON_SCHEMA
+ *  with `replacement`, leaving every other carry alone. */
+function swapReviewCarrySchemas(
+  definition: Record<string, unknown>,
+  replacement: unknown,
+  limit = Infinity,
+): Record<string, unknown> {
+  const clone = structuredClone(definition);
+  const currentCanonical = canonicalizeSchema(REVIEW_RESULT_JSON_SCHEMA);
+  let swapped = 0;
+  for (const node of clone.nodes as Record<string, unknown>[]) {
+    const config = node.configuration as Record<string, unknown> | undefined;
+    const carry = config?.carry;
+    if (!Array.isArray(carry)) continue;
+    for (const entry of carry as Record<string, unknown>[]) {
+      if (
+        swapped < limit &&
+        canonicalizeSchema(entry.schema) === currentCanonical
+      ) {
+        entry.schema = structuredClone(replacement);
+        swapped += 1;
+      }
+    }
+  }
+  return clone;
+}
+
+const stubCoordinates = {
+  definitionId: 0,
+  definitionName: "fixture",
+  definitionVersion: null as number | null,
+  source: "deployed" as const,
+};
+
+/**
+ * Committed hashes of every code-owned shape the registry knows. This is the
+ * forcing function for AIW-245: the gate can only detect drift for shapes it has
+ * enumerated, so if someone edits a code-owned schema constant without adding its
+ * previous shape to knownPrior and writing a resync migration, a stored def
+ * carrying the now-old shape would classify as unrecognized, the gate would pass,
+ * and the def would fail validation at dispatch -- the exact bug this ticket
+ * prevents. Changing a shape flips a hash here and reddens the build with the
+ * instruction to add the prior + migration.
+ */
+const EXPECTED_SHAPE_HASHES: Record<string, { current: string; knownPrior: string[] }> = {
+  review_result: {
+    current: "ee79c8877194c7112ef7891f72402ae942f29f35820469d4f72f9503529c92db",
+    knownPrior: [
+      "93b53e3360e6f8a3beeef804b90cecf40fce8b30a4a366a94b4650a37066fe4d",
+      "9dc1f3650bded4af204bad0dd7bfb032316075da1b893d1cb5cda97fe95ad6be",
+    ],
+  },
+  pr_check: {
+    current: "4d632fb28d86f3d13523993c4970c873ed2b60f545a2980ae9f58fa5c27538c5",
+    knownPrior: [],
+  },
+};
+
+const shapeHash = (value: unknown): string =>
+  createHash("sha256").update(canonicalizeSchema(value)).digest("hex");
+
+describe("carry schema drift", () => {
+  it("passes on the shipped reviewed-ticket workflow", async () => {
+    const { client, db } = await migrateThrough("9999");
+    await deployDefinition(client, "Reviewed ticket", reviewedTicketCurrent());
+
+    const result = await assertNoCarrySchemaDrift(db);
+
+    expect(result.ok).toBe(true);
+    expect(result.report.drift).toEqual([]);
+    expect(result.report.customerDivergent).toEqual([]);
+    expect(result.report.definitionsWalked).toBeGreaterThan(0);
+    // The three review carries are recognized as the current constant.
+    expect(
+      result.report.embeds.filter(
+        (embed) => embed.sourceKey === "review_result" && embed.classification === "current",
+      ).length,
+    ).toBeGreaterThanOrEqual(3);
+    expect(result.message).toContain("passed");
+  });
+
+  it("reports RED on a stored reviewed-ticket carrying the old severity enum", async () => {
+    const { client, db } = await migrateThrough("9999");
+    await retireFreshInstallDefinition(client);
+    await deployDefinition(
+      client,
+      "Reviewed ticket (stale enum)",
+      swapReviewCarrySchemas(reviewedTicketCurrent(), OLD_ENUM_SHAPE),
+    );
+
+    const report = await findCarrySchemaDrift(db);
+    const result = evaluateCarrySchemaDriftGate(report);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.code)).toEqual(["drift"]);
+    expect(report.drift).toHaveLength(3);
+    for (const embed of report.drift) {
+      expect(embed.sourceKey).toBe("review_result");
+      expect(embed.classification).toBe("prior");
+      expect(embed.kind).toBe("carry");
+    }
+    expect(result.message).toContain("review_result");
+    await expect(assertNoCarrySchemaDrift(db)).rejects.toBeInstanceOf(
+      CarrySchemaDriftError,
+    );
+  });
+
+  it("resyncs the stored old-enum definition so it validates clean (AC c)", async () => {
+    const { client } = await migrateThrough("0049");
+    const oldEnumDef = swapReviewCarrySchemas(reviewedTicketCurrent(), OLD_ENUM_SHAPE);
+
+    // Precondition: the shipped shape validates clean, the stale copy does not.
+    expect(
+      validateWorkflowDefinitionCandidate(reviewedTicketCurrent(), registryContext)
+        .response.valid,
+    ).toBe(true);
+    const before = validateWorkflowDefinitionCandidate(oldEnumDef, registryContext);
+    expect(before.response.valid).toBe(false);
+    expect(
+      before.response.issues.filter((issue) => issue.code === "binding.reference_type"),
+    ).not.toHaveLength(0);
+
+    const id = await deployDefinition(client, "Reviewed ticket (stale enum)", oldEnumDef);
+    await applyCarrySchemaResync(client);
+
+    const migrated = await readStoredDefinition(client, id);
+    const after = validateWorkflowDefinitionCandidate(migrated, registryContext);
+    expect(after.response.valid).toBe(true);
+    expect(
+      after.response.issues.filter((issue) => issue.code === "binding.reference_type"),
+    ).toHaveLength(0);
+    // Every review carry now byte-matches the current constant.
+    const embeds = collectDefinitionEmbeds(migrated, stubCoordinates).embeds;
+    for (const embed of embeds.filter((e) => e.sourceKey === "review_result")) {
+      expect(embed.classification).toBe("current");
+    }
+  });
+
+  it("leaves a customer-authored carry schema untouched and reports it", async () => {
+    const { client, db } = await migrateThrough("0049");
+    const customerSchema = {
+      ...(REVIEW_RESULT_JSON_SCHEMA as Record<string, unknown>),
+      title: "Customer review envelope",
+    };
+    // One carry diverges; the other two stay on the current constant.
+    const def = swapReviewCarrySchemas(reviewedTicketCurrent(), customerSchema, 1);
+    const id = await deployDefinition(client, "Customer reviewed ticket", def);
+
+    const report = await findCarrySchemaDrift(db);
+    expect(report.drift).toEqual([]);
+    expect(report.customerDivergent).toHaveLength(1);
+    expect(report.customerDivergent[0]!.sourceKey).toBeNull();
+    expect(report.customerDivergent[0]!.classification).toBe("unrecognized");
+
+    await applyCarrySchemaResync(client);
+    const after = await readStoredDefinition(client, id);
+    // The whole definition is byte-identical: the guard skipped it entirely.
+    expect(canonicalizeSchema(after)).toBe(canonicalizeSchema(def));
+    const customerEmbed = collectDefinitionEmbeds(after, stubCoordinates).embeds.find(
+      (embed) => embed.classification === "unrecognized" && embed.kind === "carry",
+    );
+    expect(customerEmbed).toBeDefined();
+    expect(canonicalizeSchema(customerSchema)).toContain("Customer review envelope");
+  });
+
+  it("fails when the walk reaches no snapshot at all", async () => {
+    const { client, db } = await migrateThrough("9999");
+    await retireFreshInstallDefinition(client);
+
+    const report = await findCarrySchemaDrift(db);
+    const result = evaluateCarrySchemaDriftGate(report);
+
+    expect(report.definitionsWalked).toBe(0);
+    expect(result.failures.map((failure) => failure.code)).toEqual(["nothing_inspected"]);
+    expect(result.message).toContain("An empty report is not a clean one");
+  });
+
+  it("captures a revertible pre-image of every carry it rewrites", async () => {
+    const { client } = await migrateThrough("0049");
+    const oldEnumDef = swapReviewCarrySchemas(reviewedTicketCurrent(), OLD_ENUM_SHAPE);
+    const id = await deployDefinition(client, "Reviewed ticket (stale enum)", oldEnumDef);
+
+    await applyCarrySchemaResync(client);
+
+    const audit = await client.query<{
+      node_id: string | null;
+      carry_index: number;
+      source_key: string;
+      before_schema: unknown;
+    }>(
+      `SELECT node_id, carry_index, source_key, before_schema
+       FROM carry_schema_resync_audit WHERE definition_id = $1 ORDER BY carry_index`,
+      [id],
+    );
+    expect(audit.rows).toHaveLength(3);
+    expect(audit.rows.map((row) => row.carry_index)).toEqual([0, 1, 2]);
+    for (const row of audit.rows) {
+      expect(row.source_key).toBe("review_result");
+      expect(row.node_id).toBe("retry");
+      // The recorded pre-image is exactly the value the migration overwrote, so
+      // an operator can revert from it.
+      expect(canonicalizeSchema(row.before_schema)).toBe(canonicalizeSchema(OLD_ENUM_SHAPE));
+    }
+
+    // Re-running the data half captures nothing new: the carries are current now.
+    await applyCarrySchemaResyncDataOnly(client);
+    const again = await client.query<{ n: number }>(
+      `SELECT count(*)::int AS n FROM carry_schema_resync_audit WHERE definition_id = $1`,
+      [id],
+    );
+    expect(again.rows[0]!.n).toBe(3);
+  });
+
+  it("pins every code-owned shape so it cannot change without a prior + migration", () => {
+    for (const source of EMBEDDED_SCHEMA_SOURCES) {
+      const expected = EXPECTED_SHAPE_HASHES[source.key];
+      expect(
+        expected,
+        `New embedded schema source "${source.key}" has no committed hash. Add it to EXPECTED_SHAPE_HASHES.`,
+      ).toBeDefined();
+      expect(
+        shapeHash(source.current),
+        `${source.label} changed shape. When you change a code-owned schema embedded by value: ` +
+          `add its previous shape to knownPrior in carry-schema-drift.ts, write a resync migration ` +
+          `(see AIW-245 / scripts/generate-carry-schema-resync-migration.ts), then update ` +
+          `EXPECTED_SHAPE_HASHES.current for "${source.key}".`,
+      ).toBe(expected!.current);
+      expect(
+        source.knownPrior.map(shapeHash),
+        `The known prior shapes for "${source.key}" changed. A prior must never be removed once ` +
+          `shipped -- a stored def may still carry it -- and a new prior must ship with a resync migration.`,
+      ).toEqual(expected!.knownPrior);
+    }
+    // A source committed here must still exist: guards against silent deletion.
+    for (const key of Object.keys(EXPECTED_SHAPE_HASHES)) {
+      expect(EMBEDDED_SCHEMA_SOURCES.map((source) => source.key)).toContain(key);
+    }
+  });
+
+  it("recognizes every carry schema shipped by a built-in template as current", () => {
+    for (const template of workflowDefinitionTemplates({
+      includeReview: true,
+      includeLeakReview: true,
+      provider: "claude",
+    })) {
+      const { embeds, skipped } = collectDefinitionEmbeds(
+        template.definition,
+        stubCoordinates,
+      );
+      expect(skipped).toEqual([]);
+      for (const embed of embeds.filter((e) => e.kind === "carry")) {
+        expect({
+          template: template.id,
+          field: embed.field,
+          sourceKey: embed.sourceKey,
+          classification: embed.classification,
+        }).toEqual({
+          template: template.id,
+          field: embed.field,
+          sourceKey: expect.any(String),
+          classification: "current",
+        });
+      }
+    }
+  });
+});

--- a/apps/worker/src/workflow-definition/carry-schema-drift.ts
+++ b/apps/worker/src/workflow-definition/carry-schema-drift.ts
@@ -1,0 +1,736 @@
+import {
+  REVIEW_RESULT_JSON_SCHEMA,
+  type JsonSchema202012,
+} from "@shared/contracts";
+import { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
+import type { Db } from "../db/client.js";
+import {
+  approvalRequests,
+  manualDispatchRequests,
+  triggerDeliveries,
+  workflowDefinitions,
+  workflowDefinitionVersions,
+} from "../db/schema.js";
+import { defaultWorkflowDefinition } from "./default.js";
+import { PR_CHECK_OUTPUT_SCHEMA } from "./templates.js";
+
+/**
+ * Drift alarm for code-owned JSON schemas embedded BY VALUE into stored workflow
+ * definitions.
+ *
+ * A loop `carry` freezes a copy of a schema constant inside the definition JSON
+ * (templates.ts embeds REVIEW_RESULT_JSON_SCHEMA into the review carries and
+ * PR_CHECK_OUTPUT_SCHEMA into the post-PR "check" carry). Deployment-time
+ * validation then compares that frozen copy against the type it derives LIVE
+ * from the current constant: the review carries bind `steps.*-review.output`,
+ * whose type block-registry.ts builds from the CURRENT REVIEW_RESULT_JSON_SCHEMA.
+ * So the moment the constant changes shape (severity "critical"|"suggestion" ->
+ * "Blocker"|"High"|"Medium"|"Nit"), every previously-valid stored definition
+ * that carried the old copy starts failing validation with no migration having
+ * touched it. That is AIW-245.
+ *
+ * This walks the same way builtin-prompt-drift does: from what a dispatch can
+ * still select back to the constant. For every reachable definition snapshot it
+ * finds every embedded schema and keys it, by structural equality, to the
+ * code-owned source it mirrors:
+ *
+ *   - equals a source's CURRENT shape  -> healthy.
+ *   - equals a source's KNOWN PRIOR shape -> drift a resync migration corrects.
+ *   - equals nothing known, in a carry -> a customer authored their own schema.
+ *     There is no authorship marker inside a definition (unlike prompt version
+ *     rows), so this is the only safe signal: a resync must never overwrite it.
+ *   - equals nothing known, in an outputSchema -> a template-local declaration
+ *     (planningOutput and friends), reported but harmless: an outputSchema is
+ *     self-declaring, it is not compared against a live code type.
+ *
+ * `definitionsWalked` and `skipped` exist for the same reason they do in
+ * builtin-prompt-drift: the dangerous failure of a check like this is not a
+ * wrong answer, it is walking nothing and reporting clean. Every path that
+ * cannot read what it expected records a `skipped` entry instead of continuing
+ * quietly.
+ */
+
+/** Why a definition snapshot is reachable, so a finding says which dispatch path
+ *  can still serve it. Mirrors builtin-prompt-drift's pin sources. */
+export type CarrySchemaPinSource =
+  | "deployed"
+  | "fresh_install_default"
+  | "approval"
+  | "trigger_delivery"
+  | "manual_dispatch";
+
+/** Manual dispatch rows that have not yet produced a started run, so their
+ *  pinned version can still be executed. Mirrors the status check constraint. */
+const LIVE_MANUAL_DISPATCH_STATUSES = [
+  "pending",
+  "reserved",
+  "prepared",
+  "candidate_started",
+];
+
+/**
+ * A code-owned schema that a platform template embeds by value into a stored
+ * definition. `current` is what the running code compares against; `knownPrior`
+ * are earlier platform shapes a resync migration rewrites to `current`. A stored
+ * embed that matches none of these is a customer's own schema, never touched.
+ */
+export interface EmbeddedSchemaSource {
+  key: string;
+  label: string;
+  current: JsonSchema202012;
+  /** Verified against git history; see the shape constants below. */
+  knownPrior: JsonSchema202012[];
+}
+
+/**
+ * REVIEW_RESULT before commit 5d30f5d5 gave findings four severities: severity
+ * was "critical"|"suggestion" and there was no `repo` field. This is the exact
+ * shape AIW-245 reproduces (a stored carry under this shape fails validation
+ * with six errors, because the current review-agent output enum is disjoint).
+ */
+const REVIEW_RESULT_PRIOR_TWO_SEVERITY: JsonSchema202012 = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+  properties: {
+    decision: {
+      type: "string",
+      enum: ["approve", "request_changes"],
+    },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          file: { type: "string" },
+          description: { type: "string" },
+          severity: {
+            type: "string",
+            enum: ["critical", "suggestion"],
+          },
+          startLine: { type: "number" },
+          endLine: { type: "number" },
+        },
+        required: ["file", "description", "severity"],
+        additionalProperties: true,
+      },
+    },
+    feedback: { type: "string" },
+  },
+  required: ["decision", "findings"],
+  additionalProperties: true,
+};
+
+/**
+ * REVIEW_RESULT between commits 5d30f5d5 and e7ce4f82: four severities were in
+ * place but the cross-repo `repo` field had not been added yet. A definition
+ * saved in that window carries this shape.
+ */
+const REVIEW_RESULT_PRIOR_NO_REPO: JsonSchema202012 = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+  properties: {
+    decision: {
+      type: "string",
+      enum: ["approve", "request_changes"],
+    },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          file: { type: "string" },
+          description: { type: "string" },
+          severity: {
+            type: "string",
+            enum: ["Blocker", "High", "Medium", "Nit"],
+          },
+          startLine: { type: "number" },
+          endLine: { type: "number" },
+        },
+        required: ["file", "description", "severity"],
+        additionalProperties: true,
+      },
+    },
+    feedback: { type: "string" },
+  },
+  required: ["decision", "findings"],
+  additionalProperties: true,
+};
+
+/** The registry of code-owned schemas embedded by value in platform templates.
+ *  Shared with the resync migration generator so the gate and the migration can
+ *  never disagree on which shapes are the platform's. */
+export const EMBEDDED_SCHEMA_SOURCES: EmbeddedSchemaSource[] = [
+  {
+    key: "review_result",
+    label: "REVIEW_RESULT_JSON_SCHEMA",
+    current: REVIEW_RESULT_JSON_SCHEMA,
+    knownPrior: [REVIEW_RESULT_PRIOR_TWO_SEVERITY, REVIEW_RESULT_PRIOR_NO_REPO],
+  },
+  {
+    key: "pr_check",
+    label: "PR_CHECK_OUTPUT_SCHEMA",
+    current: PR_CHECK_OUTPUT_SCHEMA,
+    knownPrior: [],
+  },
+];
+
+/** Prior shapes the resync migration rewrites, keyed to the current shape it
+ *  rewrites them to. Only sources that actually have known prior shapes appear.
+ *  Consumed by scripts/generate-carry-schema-resync-migration.ts. */
+export const RESYNC_TARGETS = EMBEDDED_SCHEMA_SOURCES.filter(
+  (source) => source.knownPrior.length > 0,
+).map((source) => ({
+  key: source.key,
+  current: source.current,
+  knownPrior: source.knownPrior,
+}));
+
+/** Deterministic serialization with recursively sorted object keys. JSON Schema
+ *  treats object key order as meaningless, and a stored embed comes back from
+ *  jsonb in the driver's own key order, so structural equality is the only
+ *  correct comparison. Array order (enum, required) is preserved, which matters. */
+export function canonicalizeSchema(value: unknown): string {
+  const sort = (input: unknown): unknown => {
+    if (Array.isArray(input)) return input.map(sort);
+    if (input !== null && typeof input === "object") {
+      return Object.fromEntries(
+        Object.keys(input as Record<string, unknown>)
+          .sort()
+          .map((key) => [key, sort((input as Record<string, unknown>)[key])]),
+      );
+    }
+    return input;
+  };
+  return JSON.stringify(sort(value));
+}
+
+interface SourceMatch {
+  sourceKey: string;
+  classification: "current" | "prior";
+}
+
+const SCHEMA_INDEX: Map<string, SourceMatch> = (() => {
+  const index = new Map<string, SourceMatch>();
+  for (const source of EMBEDDED_SCHEMA_SOURCES) {
+    index.set(canonicalizeSchema(source.current), {
+      sourceKey: source.key,
+      classification: "current",
+    });
+    for (const prior of source.knownPrior) {
+      index.set(canonicalizeSchema(prior), {
+        sourceKey: source.key,
+        classification: "prior",
+      });
+    }
+  }
+  return index;
+})();
+
+/** Keys one embedded schema to its code-owned source. Returns null when it
+ *  matches nothing known (a customer schema or a template-local outputSchema). */
+export function classifyEmbeddedSchema(schema: unknown): SourceMatch | null {
+  if (schema === null || typeof schema !== "object" || Array.isArray(schema)) {
+    return null;
+  }
+  return SCHEMA_INDEX.get(canonicalizeSchema(schema)) ?? null;
+}
+
+export type EmbeddedSchemaKind = "carry" | "output_schema";
+
+export interface EmbeddedSchemaFinding {
+  definitionId: number;
+  definitionName: string;
+  /** null for the synthetic fresh-install graph, which has no version row. */
+  definitionVersion: number | null;
+  source: CarrySchemaPinSource;
+  nodeId: string;
+  /** Locatable path to the embed inside the node, e.g.
+   *  "configuration/carry/0/schema" or "configuration/outputSchema". */
+  field: string;
+  kind: EmbeddedSchemaKind;
+  /** The code-owned source it mirrors, or null when unrecognized. */
+  sourceKey: string | null;
+  classification: "current" | "prior" | "unrecognized";
+}
+
+export interface SkippedWalkTarget {
+  reason:
+    | "definition_version_missing"
+    | "definition_shape"
+    | "definition_has_no_nodes"
+    | "node_shape"
+    | "output_schema_unparseable";
+  definitionId: number;
+  definitionVersion: number | null;
+  source: CarrySchemaPinSource;
+  nodeId: string | null;
+  detail: string;
+}
+
+export interface CarrySchemaDriftReport {
+  /** Every embedded schema reached across every selectable snapshot. */
+  embeds: EmbeddedSchemaFinding[];
+  /** Embeds matching a KNOWN PRIOR platform shape: stale copies a resync
+   *  migration will rewrite to the current constant. */
+  drift: EmbeddedSchemaFinding[];
+  /** Carry embeds matching no known platform shape: a customer authored their
+   *  own schema. Reported, never rewritten. */
+  customerDivergent: EmbeddedSchemaFinding[];
+  /** outputSchema embeds matching no known platform shape: self-declaring
+   *  template-local schemas. Informational only. */
+  unrecognizedOutputSchemas: EmbeddedSchemaFinding[];
+  /** Snapshots opened and read. `definitionsWalked === 0` is the empty-report
+   *  failure that looks identical to success. */
+  definitionsWalked: number;
+  /** Everything the walk could not read. Non-empty means the report is
+   *  incomplete and must not be treated as a pass. */
+  skipped: SkippedWalkTarget[];
+}
+
+export function describeCarrySchemaDrift(
+  report: CarrySchemaDriftReport,
+): string {
+  const lines = [
+    ...report.drift.map(
+      (embed) =>
+        `${embed.sourceKey} embed reached by definition ${embed.definitionId} ` +
+        `("${embed.definitionName}" ${
+          embed.definitionVersion === null
+            ? "code default"
+            : `v${embed.definitionVersion}`
+        }, via ${embed.source}) block "${embed.nodeId}" field "${embed.field}": ` +
+        `stored schema matches a prior platform shape, not the current constant.`,
+    ),
+    ...report.customerDivergent.map(
+      (embed) =>
+        `CUSTOMER SCHEMA (left untouched) definition ${embed.definitionId} block ` +
+        `"${embed.nodeId}" field "${embed.field}": does not match any known ` +
+        `platform shape.`,
+    ),
+    ...report.skipped.map(
+      (skip) =>
+        `NOT WALKED (${skip.reason}) definition ${skip.definitionId} ` +
+        `${skip.definitionVersion === null ? "code default" : `v${skip.definitionVersion}`} ` +
+        `via ${skip.source}${skip.nodeId === null ? "" : ` block "${skip.nodeId}"`}: ${skip.detail}`,
+    ),
+  ];
+  return lines.join("\n");
+}
+
+interface WalkTarget {
+  definitionId: number;
+  definitionName: string;
+  definitionVersion: number | null;
+  source: CarrySchemaPinSource;
+  definition: unknown;
+}
+
+export interface FindCarrySchemaDriftOptions {
+  /** Whether the fresh-install fallback graph is built with its review agent.
+   *  The default v1 graph carries no loop, so this changes nothing for carry
+   *  drift; kept for parity with builtin-prompt-drift's over-covering default. */
+  includeReview?: boolean;
+}
+
+/** Every definition snapshot a dispatch can still select. Ported from
+ *  builtin-prompt-drift's collectWalkTargets: deployed pointer, the versionless
+ *  fresh-install default, and every approval / trigger-delivery / manual-dispatch
+ *  pin, deduplicated on definition plus version. */
+async function collectWalkTargets(
+  db: Db,
+  options: FindCarrySchemaDriftOptions,
+  skipped: SkippedWalkTarget[],
+): Promise<WalkTarget[]> {
+  const targets: WalkTarget[] = [];
+  const seen = new Set<string>();
+  const add = (target: WalkTarget): void => {
+    const key = `${target.definitionId}@${target.definitionVersion ?? "default"}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    targets.push(target);
+  };
+
+  for (const row of await db
+    .select({
+      id: workflowDefinitions.id,
+      name: workflowDefinitions.name,
+      version: workflowDefinitionVersions.version,
+      definition: workflowDefinitionVersions.definition,
+    })
+    .from(workflowDefinitions)
+    .innerJoin(
+      workflowDefinitionVersions,
+      and(
+        eq(workflowDefinitionVersions.definitionId, workflowDefinitions.id),
+        eq(
+          workflowDefinitionVersions.version,
+          workflowDefinitions.deployedVersion,
+        ),
+      ),
+    )
+    .where(
+      and(
+        isNull(workflowDefinitions.archivedAt),
+        isNotNull(workflowDefinitions.deployedVersion),
+      ),
+    )) {
+    add({
+      definitionId: row.id,
+      definitionName: row.name,
+      definitionVersion: row.version,
+      source: "deployed",
+      definition: row.definition,
+    });
+  }
+
+  // Fresh install: the enabled ticket definition with no stored version at all,
+  // for which definition-step.ts serves the code default graph.
+  for (const row of await db
+    .select({
+      id: workflowDefinitions.id,
+      name: workflowDefinitions.name,
+      triggerTypes: workflowDefinitions.triggerTypes,
+    })
+    .from(workflowDefinitions)
+    .where(
+      and(
+        isNull(workflowDefinitions.archivedAt),
+        eq(workflowDefinitions.enabled, true),
+        isNull(workflowDefinitions.deployedVersion),
+      ),
+    )) {
+    if (!row.triggerTypes.includes("trigger_ticket_ai")) continue;
+    const anyVersion = await db
+      .select({ version: workflowDefinitionVersions.version })
+      .from(workflowDefinitionVersions)
+      .where(eq(workflowDefinitionVersions.definitionId, row.id))
+      .limit(1);
+    if (anyVersion.length > 0) continue;
+    add({
+      definitionId: row.id,
+      definitionName: row.name,
+      definitionVersion: null,
+      source: "fresh_install_default",
+      definition: defaultWorkflowDefinition({
+        includeReview: options.includeReview ?? true,
+        includeLeakReview: false,
+      }),
+    });
+  }
+
+  const reachable: {
+    definitionId: number;
+    definitionVersion: number | null;
+    source: CarrySchemaPinSource;
+  }[] = [
+    ...(
+      await db
+        .selectDistinct({
+          definitionId: approvalRequests.definitionId,
+          definitionVersion: approvalRequests.definitionVersion,
+        })
+        .from(approvalRequests)
+        .where(eq(approvalRequests.status, "pending"))
+    ).map((row) => ({ ...row, source: "approval" as const })),
+    ...(
+      await db
+        .selectDistinct({
+          definitionId: triggerDeliveries.definitionId,
+          definitionVersion: triggerDeliveries.definitionVersion,
+        })
+        .from(triggerDeliveries)
+        .where(eq(triggerDeliveries.pending, true))
+    ).map((row) => ({ ...row, source: "trigger_delivery" as const })),
+    ...(
+      await db
+        .selectDistinct({
+          definitionId: manualDispatchRequests.definitionId,
+          definitionVersion: manualDispatchRequests.definitionVersion,
+        })
+        .from(manualDispatchRequests)
+        .where(
+          inArray(manualDispatchRequests.status, LIVE_MANUAL_DISPATCH_STATUSES),
+        )
+    ).map((row) => ({ ...row, source: "manual_dispatch" as const })),
+  ];
+
+  const pending = new Map<string, (typeof reachable)[number]>();
+  for (const entry of reachable) {
+    const key = `${entry.definitionId}@${entry.definitionVersion ?? "deployed"}`;
+    if (!pending.has(key)) pending.set(key, entry);
+  }
+
+  if (pending.size > 0) {
+    const definitionRows = await db
+      .select({
+        id: workflowDefinitions.id,
+        name: workflowDefinitions.name,
+        deployedVersion: workflowDefinitions.deployedVersion,
+      })
+      .from(workflowDefinitions)
+      .where(
+        inArray(
+          workflowDefinitions.id,
+          [...new Set([...pending.values()].map((entry) => entry.definitionId))],
+        ),
+      );
+    const definitionById = new Map(definitionRows.map((row) => [row.id, row]));
+
+    const wanted: {
+      definitionId: number;
+      definitionName: string;
+      version: number;
+      source: CarrySchemaPinSource;
+    }[] = [];
+    const wantedKeys = new Set<string>();
+    for (const entry of pending.values()) {
+      const definitionRow = definitionById.get(entry.definitionId);
+      const version =
+        entry.definitionVersion ?? definitionRow?.deployedVersion ?? null;
+      if (
+        definitionRow &&
+        version === null &&
+        seen.has(`${entry.definitionId}@default`)
+      ) {
+        continue;
+      }
+      if (!definitionRow || version === null) {
+        skipped.push({
+          reason: "definition_version_missing",
+          definitionId: entry.definitionId,
+          definitionVersion: entry.definitionVersion,
+          source: entry.source,
+          nodeId: null,
+          detail: definitionRow
+            ? "reachable snapshot pins no version and the definition has none deployed"
+            : "reachable snapshot points at a definition that no longer exists",
+        });
+        continue;
+      }
+      const key = `${entry.definitionId}@${version}`;
+      if (seen.has(key) || wantedKeys.has(key)) continue;
+      wantedKeys.add(key);
+      wanted.push({
+        definitionId: entry.definitionId,
+        definitionName: definitionRow.name,
+        version,
+        source: entry.source,
+      });
+    }
+
+    if (wanted.length > 0) {
+      const versionRows = await db
+        .select({
+          definitionId: workflowDefinitionVersions.definitionId,
+          version: workflowDefinitionVersions.version,
+          definition: workflowDefinitionVersions.definition,
+        })
+        .from(workflowDefinitionVersions)
+        .where(
+          or(
+            ...wanted.map((entry) =>
+              and(
+                eq(
+                  workflowDefinitionVersions.definitionId,
+                  entry.definitionId,
+                ),
+                eq(workflowDefinitionVersions.version, entry.version),
+              ),
+            ),
+          ),
+        );
+      const definitionByKey = new Map(
+        versionRows.map((row) => [`${row.definitionId}@${row.version}`, row]),
+      );
+      for (const entry of wanted) {
+        const versionRow = definitionByKey.get(
+          `${entry.definitionId}@${entry.version}`,
+        );
+        if (!versionRow) {
+          skipped.push({
+            reason: "definition_version_missing",
+            definitionId: entry.definitionId,
+            definitionVersion: entry.version,
+            source: entry.source,
+            nodeId: null,
+            detail: "reachable snapshot pins a version row that does not exist",
+          });
+          continue;
+        }
+        add({
+          definitionId: entry.definitionId,
+          definitionName: entry.definitionName,
+          definitionVersion: entry.version,
+          source: entry.source,
+          definition: versionRow.definition,
+        });
+      }
+    }
+  }
+
+  return targets;
+}
+
+interface EmbedCoordinates {
+  definitionId: number;
+  definitionName: string;
+  definitionVersion: number | null;
+  source: CarrySchemaPinSource;
+}
+
+/**
+ * Pure per-definition walk: every embedded schema in one definition, classified.
+ * No database, so it is reused by both the DB walk and the shipped-template
+ * completeness test. `outputSchema` is stored as a JSON string; `carry[].schema`
+ * as an object.
+ */
+export function collectDefinitionEmbeds(
+  definition: unknown,
+  coordinates: EmbedCoordinates,
+): { embeds: EmbeddedSchemaFinding[]; skipped: SkippedWalkTarget[] } {
+  const embeds: EmbeddedSchemaFinding[] = [];
+  const skipped: SkippedWalkTarget[] = [];
+  const shapeSkip = (
+    reason: SkippedWalkTarget["reason"],
+    nodeId: string | null,
+    detail: string,
+  ): void => {
+    skipped.push({
+      reason,
+      definitionId: coordinates.definitionId,
+      definitionVersion: coordinates.definitionVersion,
+      source: coordinates.source,
+      nodeId,
+      detail,
+    });
+  };
+
+  const value = definition as { schemaVersion?: unknown; nodes?: unknown } | null;
+  if (value === null || typeof value !== "object" || !Array.isArray(value.nodes)) {
+    shapeSkip(
+      "definition_shape",
+      null,
+      "stored definition is not an object with a nodes array",
+    );
+    return { embeds, skipped };
+  }
+  if (value.nodes.length === 0) {
+    shapeSkip("definition_has_no_nodes", null, "stored definition has an empty nodes array");
+    return { embeds, skipped };
+  }
+  const containerKey = value.schemaVersion === 2 ? "configuration" : "params";
+
+  const record = (
+    nodeId: string,
+    field: string,
+    kind: EmbeddedSchemaKind,
+    schema: unknown,
+  ): void => {
+    const match = classifyEmbeddedSchema(schema);
+    embeds.push({
+      definitionId: coordinates.definitionId,
+      definitionName: coordinates.definitionName,
+      definitionVersion: coordinates.definitionVersion,
+      source: coordinates.source,
+      nodeId,
+      field,
+      kind,
+      sourceKey: match?.sourceKey ?? null,
+      classification: match?.classification ?? "unrecognized",
+    });
+  };
+
+  for (const raw of value.nodes) {
+    if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+      shapeSkip("node_shape", null, "node entry is not an object");
+      continue;
+    }
+    const node = raw as Record<string, unknown>;
+    const nodeId = typeof node.id === "string" ? node.id : null;
+    if (nodeId === null) {
+      shapeSkip("node_shape", null, "node is missing a string id");
+      continue;
+    }
+    const container = node[containerKey];
+    if (container === null || typeof container !== "object" || Array.isArray(container)) {
+      continue;
+    }
+    const config = container as Record<string, unknown>;
+
+    // Carries are a v2-only construct, and the resync migration only rewrites
+    // configuration.carry. Surfacing a v1 params carry the migration could never
+    // clear would be a permanent false red, so the gate and the migration agree:
+    // carry drift is checked on v2 configuration only.
+    if (value.schemaVersion === 2 && Array.isArray(config.carry)) {
+      config.carry.forEach((entry, index) => {
+        if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+          return;
+        }
+        const schema = (entry as Record<string, unknown>).schema;
+        if (schema === undefined) return;
+        record(nodeId, `${containerKey}/carry/${index}/schema`, "carry", schema);
+      });
+    }
+
+    if (typeof config.outputSchema === "string") {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(config.outputSchema);
+      } catch {
+        shapeSkip(
+          "output_schema_unparseable",
+          nodeId,
+          `block "${nodeId}" outputSchema is not valid JSON`,
+        );
+        continue;
+      }
+      record(nodeId, `${containerKey}/outputSchema`, "output_schema", parsed);
+    }
+  }
+
+  return { embeds, skipped };
+}
+
+export async function findCarrySchemaDrift(
+  db: Db,
+  options: FindCarrySchemaDriftOptions = {},
+): Promise<CarrySchemaDriftReport> {
+  const skipped: SkippedWalkTarget[] = [];
+  const targets = await collectWalkTargets(db, options, skipped);
+
+  const embeds: EmbeddedSchemaFinding[] = [];
+  let definitionsWalked = 0;
+  for (const target of targets) {
+    const result = collectDefinitionEmbeds(target.definition, {
+      definitionId: target.definitionId,
+      definitionName: target.definitionName,
+      definitionVersion: target.definitionVersion,
+      source: target.source,
+    });
+    // A snapshot only counts as walked when it was a readable definition with
+    // nodes: a shape skip means nothing was inspected there.
+    const unreadable = result.skipped.some(
+      (skip) =>
+        skip.reason === "definition_shape" ||
+        skip.reason === "definition_has_no_nodes",
+    );
+    if (!unreadable) definitionsWalked += 1;
+    embeds.push(...result.embeds);
+    skipped.push(...result.skipped);
+  }
+
+  return {
+    embeds,
+    drift: embeds.filter((embed) => embed.classification === "prior"),
+    customerDivergent: embeds.filter(
+      (embed) => embed.kind === "carry" && embed.classification === "unrecognized",
+    ),
+    unrecognizedOutputSchemas: embeds.filter(
+      (embed) =>
+        embed.kind === "output_schema" && embed.classification === "unrecognized",
+    ),
+    definitionsWalked,
+    skipped,
+  };
+}

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -2,6 +2,7 @@ import {
   REVIEW_RESULT_JSON_SCHEMA,
   type HarnessProvider,
   type HarnessProfileReference,
+  type JsonSchema202012,
   type WorkflowDefinitionTemplate,
   type WorkflowDataReferenceV2,
   type WorkflowDefinitionV2,
@@ -1238,23 +1239,31 @@ function postPrReviewDefinition(
   ]);
 }
 
+/**
+ * Code-owned shape the post-PR autofix loop embeds BY VALUE into its "check"
+ * carry (binds the create_pr_check output). Lifted to a named export so
+ * carry-schema-drift.ts can key a stored embed to this source constant rather
+ * than guessing, the same way it keys the review carries to
+ * REVIEW_RESULT_JSON_SCHEMA.
+ */
+export const PR_CHECK_OUTPUT_SCHEMA: JsonSchema202012 = {
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    headSha: { type: "string" },
+    name: { type: "string" },
+  },
+  required: ["id", "headSha", "name"],
+  additionalProperties: false,
+};
+
 function postPrAutofixDefinition(
   provider: HarnessProvider,
   profileReference?: HarnessProfileReference,
 ): WorkflowDefinitionV2 {
   const profile = () =>
     builtinHarnessProfileConfiguration(provider, profileReference);
-  const checkSchema = {
-    $schema: "https://json-schema.org/draft/2020-12/schema",
-    type: "object",
-    properties: {
-      id: { type: "string" },
-      headSha: { type: "string" },
-      name: { type: "string" },
-    },
-    required: ["id", "headSha", "name"],
-    additionalProperties: false,
-  };
   const reviewResultReferences = (): WorkflowDataReferenceV2[] =>
     REVIEW_IDS.map(
       (reviewer) =>
@@ -1343,7 +1352,7 @@ function postPrAutofixDefinition(
         carry: [
           {
             name: "check",
-            schema: checkSchema,
+            schema: PR_CHECK_OUTPUT_SCHEMA,
             binding: {
               kind: "reference",
               reference: "steps.create-check.output.check" as WorkflowDataReferenceV2,


### PR DESCRIPTION
## Goal

A code-owned JSON schema that is embedded by value into stored workflow definitions must not silently invalidate a previously-valid, untouched definition when it changes. Closes [AIW-245](https://blazity.atlassian.net/browse/AIW-245). When such a schema drifts, the change is detected, the affected stored definitions are migrated, and a test keeps it from regressing.

## Problem

`REVIEW_RESULT_JSON_SCHEMA` is copied by value into a stored definition's loop `carry` at save time (a run never re-reads the constant). When its severity enum changed (`critical`|`suggestion` -> `Blocker`|`High`|`Medium`|`Nit`), every deployed "Reviewed ticket workflow" began failing validation with 6 errors, with no migration having touched it. Nothing told anyone.

## What changed

**Detection gate** (`carry-schema-drift.ts` + `-gate.ts`, ported from `builtin-prompt-drift`). It walks EVERY reachable version snapshot (deployed, fresh-install, and every approval / trigger-delivery / manual-dispatch pin, via a faithful copy of `collectWalkTargets`) and enumerates EVERY by-value embedded schema (all `configuration.carry[].schema`, keyed structurally to a source registry: `REVIEW_RESULT_JSON_SCHEMA`, `PR_CHECK_OUTPUT_SCHEMA`). Each embed is classified `current` / `drift` (matches a known prior platform shape) / `customerDivergent` (matches nothing known, left untouched and reported).

**Resync migration** (`0051_carry_schema_resync.sql`). It rewrites a stored carry schema ONLY when it byte-matches (`jsonb =`) a known prior platform shape, across all version rows (no version filter). Because a definition JSON carries no authorship marker, and a value alone cannot prove the copy was the platform's rather than a customer step output of the same shape, the migration FIRST records a pre-image of every carry it will rewrite into a new `carry_schema_resync_audit` table (coordinate + before-value), so a mistaken rewrite is reversible. The pre-image INSERT is `ON CONFLICT DO NOTHING` and the UPDATE is a strict no-op once current, so a re-run captures and changes nothing.

**Forcing function** (test). A committed hash of every code-owned `current` shape: change a schema constant without adding its previous shape to `knownPrior` (and a resync migration), and the build goes red with instructions. This is the mechanism that actually prevents AIW-245 from recurring silently.

## Safety details worked through in review

- Migration guards every `jsonb_array_elements(nodes)` against a non-array node list, so one malformed row cannot abort the no-transaction migration.
- Gate and migration agree on scope: only v2 `configuration.carry` (carries are v2-only), so a v1 `params` carry cannot become a permanent red the migration can never clear.
- No `db.transaction` (neon-http has none); each statement is standalone and idempotent.

## Migration / ordering

Numbered 0051 (rebased after AIW-277 took 0050). Journal contiguous 49 -> 50 (dispatch_capacity_queue) -> 51 (carry_schema_resync); the 0051 snapshot chains its `prevId` to the 0050 snapshot and models both tables.

## Tests

- `carry-schema-drift.test.ts` (8): gate RED on the old-enum "Reviewed ticket workflow" fixture; migration resyncs it so `validateWorkflowDefinitionCandidate` flips to valid with zero `binding.reference_type` errors; a customer-diverged carry left byte-identical + reported; the audit pre-image captured and revertible; the shape-hash forcing test; template completeness; empty-walk `nothing_inspected`.
- `pnpm build:shared`, `pnpm exec tsc --noEmit` clean; scoped regression `schema.test.ts` + `post-pr-autofix.scenario.test.ts` = 224 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AIW-245]: https://blazity.atlassian.net/browse/AIW-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ