### PR TITLE
fix(dashboard): load the rolled back version into the editor canvas

### DIFF
--- a/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
+++ b/apps/dashboard/components/cockpit/screens/workflow-editor.tsx
@@ -70,6 +70,7 @@ import {
 import { useWorkflowValidationController } from "@/lib/workflow-editor/use-validation-controller";
 import { useWorkflowDataCatalog } from "@/lib/workflow-editor/use-workflow-data-catalog";
 import {
+  draftDiffersFromDeployed,
   workflowDeploymentAfterSave,
   workflowEditorActions,
 } from "@/lib/workflow-editor/editor-actions";
@@ -448,6 +449,20 @@ export function WorkflowEditorScreen({
       : null,
   );
   const dirty = editorHistoryIsDirty(editorHistory, semanticKey);
+  // Independent of `dirty` (canvas vs. saved draft): flags the saved draft no
+  // longer matching what is deployed, which a rollback produces without ever
+  // touching the canvas or the draft, so `dirty` alone would stay false.
+  const deployedSemanticKey = useMemo(
+    () => (deployed ? semanticKeyForDefinition(deployed.definition) : null),
+    [deployed],
+  );
+  const draftSemanticKey = baselineDraft
+    ? semanticKeyForDefinition(baselineDraft)
+    : null;
+  const showDraftDiffersFromDeployed = draftDiffersFromDeployed(
+    draftSemanticKey,
+    deployedSemanticKey,
+  );
   const runnableTriggerIds = useMemo(() => {
     if (!canDispatch || !deployed) return new Set<string>();
     const deployedTypes = new Map(
@@ -474,6 +489,8 @@ export function WorkflowEditorScreen({
     structurallyValid: nodesValid(nodes),
     hasDraft: baselineDraft !== null,
   });
+  const canResetToDeployed =
+    canEdit && deployed !== null && semanticKey !== deployedSemanticKey;
 
   useEffect(() => {
     if (!dirty) return;
@@ -975,6 +992,36 @@ export function WorkflowEditorScreen({
     }
   }
 
+  // Rollback and "Reset to deployed" both need the canvas to show a specific,
+  // already-known definition instead of whatever the draft last held. The
+  // loaded content is compared against the saved draft (not the definition
+  // just loaded), so a rollback that lands on a different graph than the
+  // draft correctly shows as unsaved rather than being silently treated as
+  // the new baseline.
+  function loadDefinitionIntoCanvas(definition: WorkflowDefinition) {
+    const flow = toFlowDefinition(definition);
+    const nextDocument: WorkflowEditorDocument = {
+      nodes: flow.nodes,
+      edges: flow.edges,
+      budgets: executionLimitsFromDefinition(definition),
+      repositoryScope: repositoryScopeFromDefinition(definition),
+      edgeGeometry: structuredClone(edgeGeometry),
+    };
+    setSchemaVersion(flow.schemaVersion);
+    editorDocumentRef.current = nextDocument;
+    dispatchEditorHistory({
+      type: "reset",
+      value: nextDocument,
+      savedSemanticKey: baselineDraft ? semanticKeyForDefinition(baselineDraft) : null,
+    });
+    setFitSignal((signal) => signal + 1);
+  }
+
+  function resetToDeployed() {
+    if (!deployed) return;
+    loadDefinitionIntoCanvas(deployed.definition);
+  }
+
   async function rollback(version: number) {
     setBusy(`rollback-${version}`);
     setError(null);
@@ -991,6 +1038,7 @@ export function WorkflowEditorScreen({
       const body = (await res.json()) as WorkflowDefinitionDeploymentResponse;
       setDeployed(body.deployed);
       setMetas((prev) => prev.map((meta) => (meta.id === body.meta.id ? body.meta : meta)));
+      loadDefinitionIntoCanvas(body.deployed.definition);
       setConfirmRestore(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to roll back version");
@@ -1258,6 +1306,14 @@ export function WorkflowEditorScreen({
           headerVersionBadge={deployed ? `deployed v${deployed.version}` : "not deployed"}
           headerInlineExtra={
             <>
+              {showDraftDiffersFromDeployed && (
+                <span
+                  title="The saved draft no longer matches the deployed version. Use Reset to deployed to load what is live into the canvas."
+                  className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.04em] text-amber-800"
+                >
+                  Draft differs from deployed
+                </span>
+              )}
               {repositoryScopeSummary !== null && (
                 <span
                   title="Repositories pinned to this workflow. Every ticket entering it inherits them."
@@ -1299,6 +1355,16 @@ export function WorkflowEditorScreen({
                   className="appearance-none cursor-pointer border border-emerald-600 bg-emerald-600 text-white py-1.5 px-3 rounded-[3px] font-mono text-[11px] tracking-[0.04em] uppercase disabled:opacity-40 disabled:cursor-default"
                 >
                   {busy === "deploy" ? "Deploying…" : "Deploy"}
+                </button>
+              )}
+              {canEdit && deployed !== null && (
+                <button
+                  onClick={resetToDeployed}
+                  disabled={!canResetToDeployed || busy !== null}
+                  title="Load the deployed version's nodes and edges into the canvas."
+                  className={headerButtonClass}
+                >
+                  Reset to deployed
                 </button>
               )}
               <button

--- a/apps/dashboard/lib/workflow-editor/editor-actions.test.ts
+++ b/apps/dashboard/lib/workflow-editor/editor-actions.test.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowDefinitionValidationResponse,
 } from "@shared/contracts";
 import {
+  draftDiffersFromDeployed,
   workflowDeploymentAfterSave,
   workflowEditorActions,
 } from "./editor-actions.ts";
@@ -71,4 +72,21 @@ test("dirty deploy stops when saved-snapshot validation diverges from the immedi
     kind: "invalid",
     validation: authoritative,
   });
+});
+
+test("draftDiffersFromDeployed flags a saved draft that no longer matches what is deployed", () => {
+  // AIW-288: a rollback rewrites the deployed pointer without touching the
+  // saved draft, so the two semantic keys diverge even though nothing about
+  // the draft itself changed.
+  assert.equal(draftDiffersFromDeployed('{"v":9}', '{"v":6}'), true);
+});
+
+test("draftDiffersFromDeployed reports no divergence once the draft matches deployed again", () => {
+  assert.equal(draftDiffersFromDeployed('{"v":6}', '{"v":6}'), false);
+});
+
+test("draftDiffersFromDeployed has nothing to compare when either side is missing", () => {
+  assert.equal(draftDiffersFromDeployed(null, '{"v":6}'), false);
+  assert.equal(draftDiffersFromDeployed('{"v":9}', null), false);
+  assert.equal(draftDiffersFromDeployed(null, null), false);
 });

--- a/apps/dashboard/lib/workflow-editor/editor-actions.ts
+++ b/apps/dashboard/lib/workflow-editor/editor-actions.ts
@@ -14,6 +14,24 @@ export function workflowEditorActions(input: WorkflowEditorActionInput) {
   };
 }
 
+/**
+ * Independent of the canvas "dirty" flag (canvas vs. saved draft): a rollback
+ * changes what is deployed without ever touching the saved draft, so the
+ * draft can look saved (canvas matches it) while no longer matching what is
+ * live. Either key being absent (no draft yet, or nothing deployed yet) means
+ * there is nothing to compare, so it reports no divergence.
+ */
+export function draftDiffersFromDeployed(
+  draftSemanticKey: string | null,
+  deployedSemanticKey: string | null,
+): boolean {
+  return (
+    draftSemanticKey !== null &&
+    deployedSemanticKey !== null &&
+    draftSemanticKey !== deployedSemanticKey
+  );
+}
+
 export type WorkflowDeploymentSaveDecision =
   | { kind: "ready"; validation: WorkflowDefinitionValidationResponse }
   | { kind: "invalid"; validation: WorkflowDefinitionValidationResponse }


### PR DESCRIPTION
## Summary
- AIW-288: rolling back a workflow version updated the DEPLOYED pointer but left the canvas showing whatever draft was previously loaded, with no supported way to load the rolled-back graph.
- `rollback()` now loads the response's `deployed.definition` into the canvas (same as the switch-definition path), so what you see immediately matches what you just made live.
- Added a `Draft differs from deployed` header indicator, independent of the existing `dirty` (canvas vs. saved draft) flag, since a rollback changes what is deployed without ever touching the saved draft, so `dirty` alone stays false and the mismatch was previously invisible.
- Added a `Reset to deployed` header action that loads the deployed version into the canvas on demand (self-disables once the canvas already matches deployed).

## Root cause
`rollback()` in `apps/dashboard/components/cockpit/screens/workflow-editor.tsx` only called `setDeployed`/`setMetas` after a successful rollback; it never touched the canvas state (`editorHistory`). The sibling `applyAuthoritativeDetail` handler (used when switching definitions) already did the equivalent conversion + `dispatchEditorHistory({ type: "reset", ... })`, so this factors that pattern into a small shared helper (`loadDefinitionIntoCanvas`) reused by both `rollback()` and the new `resetToDeployed()`.

The loaded canvas content is compared against the saved draft's semantic key (not the definition just loaded), so a rollback that lands on a different graph than the draft correctly shows as unsaved (`Unsaved changes` badge, `Save draft` enabled) rather than silently becoming the new "saved" baseline — the persisted draft server-side is untouched by rollback, matching current server behavior in `apps/worker/src/workflow-definition/store.ts` (`rollbackWorkflowDefinition` only updates `deployed_version`).

## Files changed
- `apps/dashboard/components/cockpit/screens/workflow-editor.tsx` — `loadDefinitionIntoCanvas` helper, `resetToDeployed()`, wired into `rollback()`; new `Draft differs from deployed` badge and `Reset to deployed` button.
- `apps/dashboard/lib/workflow-editor/editor-actions.ts` — new pure `draftDiffersFromDeployed(draftSemanticKey, deployedSemanticKey)` predicate.
- `apps/dashboard/lib/workflow-editor/editor-actions.test.ts` — unit tests for the new predicate.

## Test plan
- [x] `pnpm --filter ai-workflow-dashboard typecheck` — passes
- [x] `node --experimental-test-module-mocks --import tsx --test lib/workflow-editor/**/*.test.ts` (run from `apps/dashboard`) — 195/195 pass, including the new `draftDiffersFromDeployed` cases
- [ ] Manual: roll a workflow back to an older version in History and confirm the canvas shows that version's nodes/edges without manual editing, the badge appears when the draft still differs, and `Reset to deployed` loads the deployed version on demand

https://claude.ai/code/session_015kfeohXE66xx7RJPxZ2pvH