### PR TITLE
feat(worker): expose MCP workflow graph read and enabled toggle (AIW-286)

### DIFF
--- a/apps/worker/src/mcp/contracts.test.ts
+++ b/apps/worker/src/mcp/contracts.test.ts
@@ -56,6 +56,8 @@ describe("MCP public contracts", () => {
       "blocks.list",
       "blocks.get",
       "runs.stats",
+      "workflows.get_graph",
+      "workflows.set_enabled",
     ]);
     expect(new Set(FIRST_SLICE_TOOLS).size).toBe(FIRST_SLICE_TOOLS.length);
   });

--- a/apps/worker/src/mcp/contracts.ts
+++ b/apps/worker/src/mcp/contracts.ts
@@ -86,6 +86,16 @@ export const FIRST_SLICE_TOOLS = [
   // per-run detail and nothing that rolled runs up, the same gap prompts.list
   // once closed for prompts.get.
   "runs.stats",
+  // Appended last, again to keep the published order of everything before them
+  // byte-identical. These two close the last gap in authoring a workflow from a
+  // client: workflows.save_draft takes a WHOLE graph, but nothing returned an
+  // existing definition's graph with its per-node configuration and the revision
+  // tokens a save or a publish is gated on, so an agent could only edit a graph it
+  // had itself just composed; and workflows.set_enabled is the definition's own
+  // enable switch, the field workflows.publish inherits rather than sets, so an
+  // agent could deploy a graph but never turn the definition on or off.
+  "workflows.get_graph",
+  "workflows.set_enabled",
 ] as const;
 export type McpToolName = (typeof FIRST_SLICE_TOOLS)[number];
 

--- a/apps/worker/src/mcp/contracts/mcp-contract.json
+++ b/apps/worker/src/mcp/contracts/mcp-contract.json
@@ -1,5 +1,5 @@
 {
-  "contractHash": "9d49bdaa24bf72887ec0477a779ab5f81f88e8805afd4806685b0ddb6b3561fe",
+  "contractHash": "623636ee5d127b0d2b69418f8d1c25b23c5a009e140eca520f75ed646cb09ed3",
   "errorCodes": [
     "UNAUTHENTICATED",
     "INSUFFICIENT_SCOPE",
@@ -914,6 +914,65 @@
         "destructiveHint": false,
         "idempotentHint": true,
         "openWorldHint": false
+      }
+    },
+    {
+      "name": "workflows.get_graph",
+      "description": "Read a definition's workflow graph, in the exact `{schemaVersion, nodes, edges}` shape workflows.save_draft accepts, for BOTH the current draft and the deployed version. Every node carries its full `configuration`, `inputs` and `additionalInputs`, and the pinned `repositoryScope` rides along too, so a graph fetched here can be edited and sent straight back to workflows.save_draft without losing anything: saving the unmodified draft yields the same `graphHash` this tool reports for it in `draftGraphHash`. `draftRevision` is the token workflows.save_draft takes as `expectedDraftRevision` (0 for a definition that has never been saved, where `draft` is null), and `deployedVersion` is the token workflows.publish takes as `expectedDeployedVersion` (null when nothing is deployed yet, where `deployed` is null). `draftGraphHash` and `deployedGraphHash` are sha256 over the canonical JSON of each stored version, directly comparable with the `graphHash` workflows.save_draft and workflows.publish report for the same version. Any secret configured for this deployment is redacted from the reply exactly as everywhere else on this surface; a stored graph does not carry one, so that redaction leaves the round trip lossless. An unknown or archived definition is NOT_FOUND.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "definitionId": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 2147483647
+          }
+        },
+        "required": [
+          "definitionId"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "workflows.set_enabled",
+      "description": "Turn a definition's `enabled` switch on or off, independent of publishing: this is the one field workflows.publish inherits rather than sets. Runs through exactly the dashboard's own guardrails. Enabling a definition with no deployable version is refused with CONFLICT, and enabling one whose deployed graph no longer passes the deployment gate with VALIDATION_FAILED. Enabling a definition whose trigger another enabled definition already owns is refused with CONFLICT naming that definition (for example, a second `trigger_ticket_ai` while one is already enabled), so two definitions cannot silently answer the same event. Enabling arms the deployed head's real-event triggers, minting webhook endpoints and syncing schedule rows, so from then on real ticket and pull request events execute this graph; disabling releases those bindings, so they stop. `enabled` in the reply is the resulting state and `triggerTypes` the triggers now (or no longer) live. Idempotent per idempotencyKey. A concurrent change to the definition is refused with CONFLICT: reload before retrying.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "definitionId": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 2147483647
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "idempotencyKey": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "definitionId",
+          "enabled",
+          "idempotencyKey"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": true,
+        "openWorldHint": true
       }
     }
   ]

--- a/apps/worker/src/mcp/policy.ts
+++ b/apps/worker/src/mcp/policy.ts
@@ -228,6 +228,30 @@ const DISPATCH_PREFLIGHT_POLICY = {
   roles: DISPATCH_POLICY.roles,
 } as const satisfies McpToolPolicy;
 
+// Reading a whole authorable graph: every node's configuration, the pinned
+// repositories, and the revision tokens a save or a publish is gated on. It is the
+// read half of authoring, exactly what workflows.save_draft consumes, so it rides
+// workflows:write and its role list the way dispatch_preflight rides runs:dispatch
+// -- discovery that feeds a privileged action is gated behind that action's scope.
+// workflows.list stays mcp:read because naming what exists is coarse discovery; this
+// hands back the instruction itself, so it costs the authoring consent.
+const WORKFLOW_GRAPH_READ_POLICY = {
+  ...READ_POLICY,
+  scope: WORKFLOW_WRITE_POLICY.scope,
+  roles: WORKFLOW_WRITE_POLICY.roles,
+} as const satisfies McpToolPolicy;
+
+// Flipping a definition's enable switch, the same switch the dashboard's toggle sets
+// and the one workflows.publish INHERITS rather than changes. Enabling arms the
+// deployed head's real-event triggers -- the store mints the webhook endpoints and
+// syncs the schedule rows of a live head -- so from that moment real ticket and pull
+// request events execute the graph, and disabling releases those bindings again. That
+// is the same destructive, open-world replacement of what the platform runs that a
+// publish is, so it takes the publish annotations, and it rides the same
+// workflows:write scope and admin/owner list: deciding what runs for real events is
+// the authoring authority, not the dispatch one.
+const WORKFLOW_SET_ENABLED_POLICY = WORKFLOW_PUBLISH_POLICY;
+
 const TOOL_POLICY = {
   "system.capabilities": READ_POLICY,
   "tickets.get": READ_POLICY,
@@ -249,6 +273,11 @@ const TOOL_POLICY = {
   "workflows.create": WORKFLOW_WRITE_POLICY,
   "workflows.save_draft": WORKFLOW_WRITE_POLICY,
   "workflows.publish": WORKFLOW_PUBLISH_POLICY,
+  // A read shaped like the authoring writes it feeds, and the enable switch those
+  // writes inherit but never set. See the two policies above for why both ride
+  // workflows:write rather than mcp:read or runs:dispatch.
+  "workflows.get_graph": WORKFLOW_GRAPH_READ_POLICY,
+  "workflows.set_enabled": WORKFLOW_SET_ENABLED_POLICY,
   // A plain read: seeing THAT a run is waiting and what it asked is what a
   // read-only client needs to report a stuck run to a person, and gating it behind
   // the dispatch scope would hide the question from the client most likely to be

--- a/apps/worker/src/mcp/server.test.ts
+++ b/apps/worker/src/mcp/server.test.ts
@@ -55,6 +55,8 @@ const PUBLISHED: McpToolName[] = [
   "blocks.list",
   "blocks.get",
   "runs.stats",
+  "workflows.get_graph",
+  "workflows.set_enabled",
 ];
 
 const cleanups: Array<() => Promise<void>> = [];

--- a/apps/worker/src/mcp/server.ts
+++ b/apps/worker/src/mcp/server.ts
@@ -14,7 +14,10 @@ import { registerRunStatsTools } from "./tools/run-stats.js";
 import { registerRunTools } from "./tools/runs.js";
 import { registerTicketWriteTools } from "./tools/ticket-write.js";
 import { registerTicketTools } from "./tools/tickets.js";
-import { registerWorkflowAuthoringTools } from "./tools/workflow-authoring.js";
+import {
+  registerWorkflowAuthoringTools,
+  registerWorkflowGraphTools,
+} from "./tools/workflow-authoring.js";
 import { registerWorkflowTools } from "./tools/workflows.js";
 
 export const MCP_PROTOCOL_VERSION = "2025-11-25" as const;
@@ -67,6 +70,9 @@ export function createMcpServer(deps: McpToolDependencies): McpServer {
   registerTicketWriteTools(server, deps);
   registerBlockTools(server, deps);
   registerRunStatsTools(server, deps);
+  // Last, so workflows.get_graph and workflows.set_enabled enumerate at the end of
+  // tools/list, matching their appended position in FIRST_SLICE_TOOLS.
+  registerWorkflowGraphTools(server, deps);
 
   return server;
 }

--- a/apps/worker/src/mcp/surface-e2e.test.ts
+++ b/apps/worker/src/mcp/surface-e2e.test.ts
@@ -129,6 +129,8 @@ const PUBLISHED = [
   "blocks.list",
   "blocks.get",
   "runs.stats",
+  "workflows.get_graph",
+  "workflows.set_enabled",
 ];
 
 const READ_ANNOTATIONS = {
@@ -231,6 +233,14 @@ const EXPECTED_ANNOTATIONS: Record<string, Record<string, boolean>> = {
   "blocks.list": READ_ANNOTATIONS,
   "blocks.get": READ_ANNOTATIONS,
   "runs.stats": READ_ANNOTATIONS,
+  // Reading a whole authorable graph changes nothing, so it keeps the read
+  // annotations even though it is gated behind workflows:write, exactly as
+  // dispatch_preflight keeps them behind runs:dispatch.
+  "workflows.get_graph": READ_ANNOTATIONS,
+  // Flipping the enable switch arms or releases a live head's real-event triggers,
+  // the same destructive, open-world change to what the platform runs that a publish
+  // is.
+  "workflows.set_enabled": WORKFLOW_PUBLISH_ANNOTATIONS,
 };
 
 const DOMAINS = ["system", "tickets", "runs", "workflows", "prompts", "blocks"];

--- a/apps/worker/src/mcp/tool-catalog.test.ts
+++ b/apps/worker/src/mcp/tool-catalog.test.ts
@@ -63,6 +63,8 @@ const CATALOGUED = [
   "blocks.list",
   "blocks.get",
   "runs.stats",
+  "workflows.get_graph",
+  "workflows.set_enabled",
 ] as const;
 
 // Captured off the real McpServer, through the real createMcpServer, because the

--- a/apps/worker/src/mcp/tool-catalog.ts
+++ b/apps/worker/src/mcp/tool-catalog.ts
@@ -455,6 +455,28 @@ export const MCP_TOOL_CATALOG = {
       .strict(),
     annotations: policyFor("runs.stats").annotations,
   },
+  "workflows.get_graph": {
+    description:
+      "Read a definition's workflow graph, in the exact `{schemaVersion, nodes, edges}` shape workflows.save_draft accepts, for BOTH the current draft and the deployed version. Every node carries its full `configuration`, `inputs` and `additionalInputs`, and the pinned `repositoryScope` rides along too, so a graph fetched here can be edited and sent straight back to workflows.save_draft without losing anything: saving the unmodified draft yields the same `graphHash` this tool reports for it in `draftGraphHash`. `draftRevision` is the token workflows.save_draft takes as `expectedDraftRevision` (0 for a definition that has never been saved, where `draft` is null), and `deployedVersion` is the token workflows.publish takes as `expectedDeployedVersion` (null when nothing is deployed yet, where `deployed` is null). `draftGraphHash` and `deployedGraphHash` are sha256 over the canonical JSON of each stored version, directly comparable with the `graphHash` workflows.save_draft and workflows.publish report for the same version. Any secret configured for this deployment is redacted from the reply exactly as everywhere else on this surface; a stored graph does not carry one, so that redaction leaves the round trip lossless. An unknown or archived definition is NOT_FOUND.",
+    inputSchema: z
+      .object({
+        definitionId: z.number().int().positive().max(DEFINITION_ID_MAX),
+      })
+      .strict(),
+    annotations: policyFor("workflows.get_graph").annotations,
+  },
+  "workflows.set_enabled": {
+    description:
+      "Turn a definition's `enabled` switch on or off, independent of publishing: this is the one field workflows.publish inherits rather than sets. Runs through exactly the dashboard's own guardrails. Enabling a definition with no deployable version is refused with CONFLICT, and enabling one whose deployed graph no longer passes the deployment gate with VALIDATION_FAILED. Enabling a definition whose trigger another enabled definition already owns is refused with CONFLICT naming that definition (for example, a second `trigger_ticket_ai` while one is already enabled), so two definitions cannot silently answer the same event. Enabling arms the deployed head's real-event triggers, minting webhook endpoints and syncing schedule rows, so from then on real ticket and pull request events execute this graph; disabling releases those bindings, so they stop. `enabled` in the reply is the resulting state and `triggerTypes` the triggers now (or no longer) live. Idempotent per idempotencyKey. A concurrent change to the definition is refused with CONFLICT: reload before retrying.",
+    inputSchema: z
+      .object({
+        definitionId: z.number().int().positive().max(DEFINITION_ID_MAX),
+        enabled: z.boolean(),
+        idempotencyKey: z.string().uuid(),
+      })
+      .strict(),
+    annotations: policyFor("workflows.set_enabled").annotations,
+  },
 } satisfies Record<McpToolName, McpToolDefinition>;
 
 export const MCP_ENABLED_DOMAINS = [

--- a/apps/worker/src/mcp/tools/workflow-authoring.test.ts
+++ b/apps/worker/src/mcp/tools/workflow-authoring.test.ts
@@ -63,7 +63,10 @@ import {
 import type { McpActorContext, McpScope } from "../contracts.js";
 import { actorFor, depsFor } from "../test-support.js";
 import { WORKFLOW_MAX_EDGES, WORKFLOW_MAX_NODES } from "../tool-catalog.js";
-import { registerWorkflowAuthoringTools } from "./workflow-authoring.js";
+import {
+  registerWorkflowAuthoringTools,
+  registerWorkflowGraphTools,
+} from "./workflow-authoring.js";
 
 const ORG_ID = "org-execute";
 
@@ -218,13 +221,12 @@ async function seedDraft(id: number, version: number, definition: unknown): Prom
 
 async function connectedClient(actor: Partial<McpActorContext> = { scopes: WRITE_ONLY }) {
   const server = new McpServer({ name: "workflow-authoring-test", version: "0.1.0" });
-  registerWorkflowAuthoringTools(
-    server,
-    depsFor(db, () => now, {
-      actor: actorFor(actor),
-      adapters: { messaging: { notifyForTicket } } as unknown as Adapters,
-    }),
-  );
+  const toolDeps = depsFor(db, () => now, {
+    actor: actorFor(actor),
+    adapters: { messaging: { notifyForTicket } } as unknown as Adapters,
+  });
+  registerWorkflowAuthoringTools(server, toolDeps);
+  registerWorkflowGraphTools(server, toolDeps);
   const client = new Client({ name: "workflow-authoring-test-client", version: "1.0.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   cleanups.push(() => client.close(), () => server.close());
@@ -1137,4 +1139,209 @@ describe("who may author a workflow", () => {
       expect(await auditedErrorCodes()).toEqual(["FORBIDDEN"]);
     });
   }
+});
+
+async function getGraph(
+  client: Client,
+  over: Record<string, unknown> = {},
+): Promise<ToolResult> {
+  return client.callTool({
+    name: "workflows.get_graph",
+    arguments: { definitionId, ...over },
+  });
+}
+
+async function setEnabled(
+  client: Client,
+  over: Record<string, unknown> = {},
+): Promise<ToolResult> {
+  return client.callTool({
+    name: "workflows.set_enabled",
+    arguments: { definitionId, enabled: true, idempotencyKey: KEY_ONE, ...over },
+  });
+}
+
+describe("workflows.get_graph", () => {
+  it("returns the current draft as a whole graph, with the save and publish tokens", async () => {
+    const client = await connectedClient();
+    // Saved through the tool so the reference hash is the one save_draft reports for
+    // the version it actually stored.
+    const saved = dataOf(await saveDraft(client));
+
+    const result = await getGraph(client);
+
+    expect(result.isError).not.toBe(true);
+    const data = dataOf(result);
+    expect(data.definitionId).toBe(definitionId);
+    expect(data.name).toBe("Seeded workflow");
+    expect(data.enabled).toBe(false);
+    // The two optimistic-concurrency tokens: draftRevision is save_draft's
+    // expectedDraftRevision, deployedVersion is publish's expectedDeployedVersion.
+    expect(data.draftRevision).toBe(1);
+    expect(data.deployedVersion).toBeNull();
+    expect(data.deployed).toBeNull();
+    expect(data.deployedGraphHash).toBeNull();
+    // The digest matches the one save_draft reported for the very version it wrote,
+    // so an agent can confirm the graph it holds is the stored one.
+    expect(data.draftGraphHash).toBe(saved.graphHash);
+    // A whole {schemaVersion, nodes, edges} graph, every node carrying its own
+    // configuration, inputs and additionalInputs, which is exactly what save_draft
+    // takes back.
+    const draft = data.draft as {
+      schemaVersion: number;
+      nodes: Array<Record<string, unknown>>;
+      edges: unknown[];
+    };
+    expect(draft.schemaVersion).toBe(2);
+    expect(draft.edges).toEqual([]);
+    expect(draft.nodes[0]).toMatchObject({
+      id: TRIGGER_NODE_ID,
+      type: "trigger_ticket_ai",
+      configuration: {},
+      inputs: {},
+      additionalInputs: [],
+    });
+  });
+
+  it("round-trips losslessly: saving the unmodified fetched draft yields the same graphHash", async () => {
+    const client = await connectedClient();
+    await saveDraft(client);
+
+    const fetched = dataOf(await getGraph(client));
+    // Send the fetched draft straight back as the next draft, unchanged.
+    const resaved = dataOf(
+      await saveDraft(client, {
+        definition: fetched.draft,
+        expectedDraftRevision: 1,
+        idempotencyKey: KEY_TWO,
+      }),
+    );
+
+    expect(resaved.draftRevision).toBe(2);
+    expect(resaved.graphHash).toBe(fetched.draftGraphHash);
+  });
+
+  it("returns the deployed graph and the version a publish would replace once one is live", async () => {
+    await seedDraft(definitionId, 1, graph());
+    const client = await connectedClient();
+    const published = dataOf(await publish(client));
+
+    const data = dataOf(await getGraph(client));
+
+    expect(data.deployedVersion).toBe(1);
+    expect(data.deployedGraphHash).toBe(published.graphHash);
+    // Nothing new was saved after the publish, so the draft head still IS the
+    // deployed version and the two graphs are identical.
+    expect(data.draftRevision).toBe(1);
+    expect(data.deployed).toEqual(data.draft);
+    expect((data.deployed as { schemaVersion: number }).schemaVersion).toBe(2);
+  });
+
+  it("answers NOT_FOUND for an unknown definition", async () => {
+    const client = await connectedClient();
+
+    const result = await getGraph(client, { definitionId: 999_999 });
+
+    expect(result.isError).toBe(true);
+    expect(errorPayload(result).code).toBe("NOT_FOUND");
+  });
+
+  it("refuses a token that does not carry workflows:write", async () => {
+    const client = await connectedClient({ scopes: EVERY_OTHER_SCOPE });
+
+    const result = await getGraph(client);
+
+    expect(result.isError).toBe(true);
+    expect(errorPayload(result).code).toBe("INSUFFICIENT_SCOPE");
+  });
+});
+
+describe("workflows.set_enabled", () => {
+  it("turns the switch on for a deployed definition and reports its live triggers", async () => {
+    // A schedule trigger is self-routed, so enabling it collides with no other
+    // definition and the switch flips cleanly.
+    await seedDraft(definitionId, 1, scheduleGraph());
+    const client = await connectedClient();
+    await publish(client);
+
+    const result = await setEnabled(client, { idempotencyKey: KEY_TWO });
+
+    expect(result.isError).not.toBe(true);
+    expect(dataOf(result)).toEqual({
+      definitionId,
+      name: "Seeded workflow",
+      enabled: true,
+      triggerTypes: ["trigger_schedule"],
+    });
+    expect((await definitionRows()).find((row) => row.id === definitionId)).toMatchObject({
+      enabled: true,
+    });
+  });
+
+  it("turns an enabled definition off", async () => {
+    // The platform's own "Ticket workflow", seeded enabled by migration.
+    const platform = await platformDefinition();
+    const client = await connectedClient();
+
+    const result = await client.callTool({
+      name: "workflows.set_enabled",
+      arguments: { definitionId: platform.id, enabled: false, idempotencyKey: KEY_ONE },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(dataOf(result)).toMatchObject({ definitionId: platform.id, enabled: false });
+  });
+
+  it("refuses enabling a second trigger_ticket_ai and names the definition already holding it", async () => {
+    await seedDraft(definitionId, 1, graph());
+    const client = await connectedClient();
+    await publish(client);
+
+    const result = await setEnabled(client, { idempotencyKey: KEY_TWO });
+
+    expect(result.isError).toBe(true);
+    const error = errorPayload(result);
+    expect(error.code).toBe("CONFLICT");
+    // The named conflict is the whole point: the seeded, enabled "Ticket workflow"
+    // already owns trigger_ticket_ai, so the refusal says which definition it is.
+    expect(error.message).toContain(PLATFORM_DEFINITION_NAME);
+    // Refused before any write, so the definition stays disabled.
+    expect((await definitionRows()).find((row) => row.id === definitionId)).toMatchObject({
+      enabled: false,
+    });
+  });
+
+  it("refuses enabling a definition that has no deployable version", async () => {
+    const client = await connectedClient();
+
+    const result = await setEnabled(client, { idempotencyKey: KEY_TWO });
+
+    expect(result.isError).toBe(true);
+    expect(errorPayload(result).code).toBe("CONFLICT");
+  });
+
+  it("replays under the same key rather than toggling twice", async () => {
+    const platform = await platformDefinition();
+    const client = await connectedClient();
+    const args = {
+      definitionId: platform.id,
+      enabled: false,
+      idempotencyKey: KEY_ONE,
+    };
+
+    const first = await client.callTool({ name: "workflows.set_enabled", arguments: args });
+    const second = await client.callTool({ name: "workflows.set_enabled", arguments: args });
+
+    expect(first.isError).not.toBe(true);
+    expect(dataOf(second)).toEqual(dataOf(first));
+  });
+
+  it("refuses a token that does not carry workflows:write", async () => {
+    const client = await connectedClient({ scopes: EVERY_OTHER_SCOPE });
+
+    const result = await setEnabled(client, { idempotencyKey: KEY_TWO });
+
+    expect(result.isError).toBe(true);
+    expect(errorPayload(result).code).toBe("INSUFFICIENT_SCOPE");
+  });
 });

--- a/apps/worker/src/mcp/tools/workflow-authoring.ts
+++ b/apps/worker/src/mcp/tools/workflow-authoring.ts
@@ -17,14 +17,18 @@ import { workflowBlockRegistryContextFromEnv } from "../../workflow-definition/m
 import {
   createWorkflowDefinition,
   deployWorkflowDefinition,
+  getCurrentWorkflowDefinitionVersion,
+  getDeployedWorkflowDefinitionVersion,
+  getWorkflowDefinition,
   getWorkflowDefinitionVersion,
   saveWorkflowDefinitionDraft,
+  updateWorkflowDefinition,
   WorkflowDefinitionStoreError,
   WorkflowDefinitionValidationError,
 } from "../../workflow-definition/store.js";
 import { validateWorkflowDefinitionCandidate } from "../../workflow-definition/validation.js";
 import { McpPublicError, type McpToolDependencies } from "../contracts.js";
-import { executeMcpMutation } from "../execute-tool.js";
+import { executeMcpMutation, executeMcpRead } from "../execute-tool.js";
 import { hashCanonicalJson } from "../sanitize-result.js";
 import { registerCatalogTool } from "../tool-catalog.js";
 import {
@@ -139,6 +143,40 @@ type PublishData = {
   // repository path outlives the call in that row. It is not in the audit row,
   // which carries the count alone.
   repositoriesOutsideAllowlist: string[];
+};
+
+type GraphData = {
+  definitionId: number;
+  name: string;
+  // The definition's own enable switch, so a reader that fetched the graph to edit
+  // it also learns whether it is answering real events right now.
+  enabled: boolean;
+  // The token workflows.save_draft takes as expectedDraftRevision. 0 (and draft
+  // null) for a definition created with no graph yet.
+  draftRevision: number;
+  // The token workflows.publish takes as expectedDeployedVersion. null (and deployed
+  // null) when nothing is deployed.
+  deployedVersion: number | null;
+  // The stored draft/deployed graphs in the exact {schemaVersion, nodes, edges}
+  // shape workflows.save_draft accepts, read back through the SAME version-row path
+  // save_draft hashes (mapVersionRow, no editor layout applied over them), so
+  // re-saving an unmodified draft canonicalizes to the same bytes and the same hash.
+  draft: WorkflowDefinition | null;
+  deployed: WorkflowDefinition | null;
+  // sha256 over the canonical JSON of each stored version, by the same rule
+  // save_draft and publish hash, so an agent can confirm a round trip without
+  // re-deriving it.
+  draftGraphHash: string | null;
+  deployedGraphHash: string | null;
+};
+
+type SetEnabledData = {
+  definitionId: number;
+  name: string;
+  // The resulting state and the triggers that are now (or, on a disable, no longer)
+  // live for real events.
+  enabled: boolean;
+  triggerTypes: string[];
 };
 
 /**
@@ -641,6 +679,124 @@ export function registerWorkflowAuthoringTools(
             liveOnRealEvents,
             dormantTriggerNodeIds: dormant,
             repositoriesOutsideAllowlist: outsideAllowlist,
+          };
+        },
+      });
+      return {
+        content: [{ type: "text", text: JSON.stringify(envelope) }],
+        structuredContent: envelope,
+      };
+    },
+  );
+}
+
+/**
+ * The two tools AIW-286 added, kept in their own registrar for one reason only:
+ * tools/list enumerates in registration order and the contract publishes in
+ * FIRST_SLICE_TOOLS order, so the two orders have to agree. These names were
+ * appended to the END of that list to keep the published bytes of everything before
+ * them unchanged, so server.ts registers this LAST, after runs.stats, rather than
+ * beside create/save_draft/publish where the code would otherwise sit.
+ *
+ * workflows.get_graph is the read half of authoring: it returns an existing
+ * definition's graph, draft and deployed, in the exact shape workflows.save_draft
+ * takes back, with the two revision tokens a save and a publish are gated on.
+ * workflows.set_enabled is the definition's own enable switch, the one field a
+ * publish inherits rather than sets.
+ */
+export function registerWorkflowGraphTools(
+  server: McpServer,
+  deps: McpToolDependencies,
+): void {
+  registerCatalogTool(
+    server,
+    "workflows.get_graph",
+    async (input) => {
+      const envelope = await executeMcpRead({
+        deps,
+        toolName: "workflows.get_graph",
+        targetRefs: [String(input.definitionId)],
+        operation: async (): Promise<GraphData> => {
+          const definition = await getWorkflowDefinition(deps.db, input.definitionId);
+          // NOT_FOUND for the same two states the dashboard's GET route hides behind
+          // a 404 ([id].get.ts): a missing row and an archived one. An archived
+          // definition still has versions, but it is retired and cannot be saved or
+          // published, so handing its graph back would only invite a write that the
+          // store then refuses with "Definition is archived".
+          if (!definition || definition.archivedAt) {
+            throw new McpPublicError("NOT_FOUND", "Unknown definition", false);
+          }
+          // The head version IS the draft (every save appends a version and the max
+          // is the draft head), and the deployed pointer names the live one. Both are
+          // read through mapVersionRow, so their `.definition` is the canonical
+          // {schemaVersion, nodes, edges} save_draft reads back and hashes -- not the
+          // layout-applied shape getWorkflowDefinitionDraft returns for the editor,
+          // which would hash to something no other reader sees.
+          const [draftVersion, deployedVersion] = await Promise.all([
+            getCurrentWorkflowDefinitionVersion(deps.db, input.definitionId),
+            getDeployedWorkflowDefinitionVersion(deps.db, input.definitionId),
+          ]);
+          const draft = draftVersion?.definition ?? null;
+          const deployed = deployedVersion?.definition ?? null;
+          return {
+            definitionId: definition.id,
+            name: definition.name,
+            enabled: definition.enabled,
+            draftRevision: definition.draftRevision,
+            deployedVersion: definition.deployedVersion,
+            draft,
+            deployed,
+            draftGraphHash: draft ? graphDigest(draft) : null,
+            deployedGraphHash: deployed ? graphDigest(deployed) : null,
+          };
+        },
+      });
+      return {
+        content: [{ type: "text", text: JSON.stringify(envelope) }],
+        structuredContent: envelope,
+      };
+    },
+  );
+
+  registerCatalogTool(
+    server,
+    "workflows.set_enabled",
+    async (input) => {
+      const envelope = await executeMcpMutation({
+        deps,
+        toolName: "workflows.set_enabled",
+        // Which definition and which direction the switch was moved. Never the graph:
+        // this tool does not touch one, and the direction is what an operator reading
+        // the audit trail wants next to the id.
+        targetRefs: [String(input.definitionId), input.enabled ? "enable" : "disable"],
+        idempotencyKey: input.idempotencyKey,
+        payloadHash: `sha256:${hashCanonicalJson({
+          definitionId: input.definitionId,
+          enabled: input.enabled,
+        })}`,
+        operation: async (): Promise<SetEnabledData> => {
+          const actor = storeActor(deps.actor);
+          let updated: Awaited<ReturnType<typeof updateWorkflowDefinition>>;
+          try {
+            // updateWorkflowDefinition IS the dashboard's PATCH path
+            // ([id].patch.ts:41): the deployable-version gate, the "one enabled owner
+            // per trigger" overlap check that names the conflicting definition, the
+            // compare-and-set on the definition row, and the webhook/schedule
+            // arming of the live head all live in the store, so this tool cannot be
+            // the way around any of them.
+            updated = await updateWorkflowDefinition(deps.db, {
+              definitionId: input.definitionId,
+              enabled: input.enabled,
+              actor,
+            });
+          } catch (error) {
+            throwPublicStoreError(error);
+          }
+          return {
+            definitionId: updated.id,
+            name: updated.name,
+            enabled: updated.enabled,
+            triggerTypes: updated.triggerTypes,
           };
         },
       });

--- a/apps/worker/src/mcp/transport.test.ts
+++ b/apps/worker/src/mcp/transport.test.ts
@@ -123,6 +123,8 @@ const PUBLISHED = [
   "blocks.list",
   "blocks.get",
   "runs.stats",
+  "workflows.get_graph",
+  "workflows.set_enabled",
 ];
 
 async function listedToolNames(response: Response): Promise<string[]> {


### PR DESCRIPTION
## AIW-286: Expose a workflow graph read and an enabled/disabled toggle over MCP

`workflows.save_draft` needs a whole graph, but no MCP tool returned an existing definition's graph with per-node configuration, and nothing let a client flip a definition's `enabled` switch. This adds both, growing the published MCP surface from 25 to 27 tools.

### `workflows.get_graph` (read, `workflows:write`)
Returns a definition's graph for **both** the current draft and the deployed version, each in the exact `{schemaVersion, nodes, edges}` shape `workflows.save_draft` accepts, with every node's `configuration`, `inputs`, `additionalInputs` and the pinned `repositoryScope`. Also returns:
- `draftRevision` (the `expectedDraftRevision` token `save_draft` takes; `0`/`draft: null` when never saved)
- `deployedVersion` (the `expectedDeployedVersion` token `publish` takes; `null`/`deployed: null` when nothing is deployed)
- `draftGraphHash` / `deployedGraphHash`, directly comparable with the `graphHash` `save_draft`/`publish` report.

The graphs are read through the same version-row path `save_draft` hashes (`mapVersionRow`, no editor layout applied), so **the round trip is lossless**: re-saving an unmodified fetched draft yields the same `graphHash` (covered by a test). Secret redaction is inherited from the shared `executeMcpRead` envelope (`configuredSecrets()`), exactly as `runs.trace`; a stored graph carries no secrets, so redaction leaves the round trip intact.

### `workflows.set_enabled` (mutation, `workflows:write`)
Flips a definition's `enabled` switch independent of publishing, through the dashboard's own `updateWorkflowDefinition` guardrails (deployable-version gate, trigger-overlap check, compare-and-set, webhook/schedule arming). Enabling a second `trigger_ticket_ai` definition while one is already enabled is refused as a **named** `CONFLICT` (the store's message names the conflicting definition) rather than silently accepted.

### Notes
- **Scope decision:** `get_graph` is gated behind `workflows:write` (read-shaped policy), not `mcp:read`. It hands back the full authorable instruction plus the concurrency tokens a save/publish consume, so it is the read half of authoring, mirroring how `workflows.dispatch_preflight` rides `runs:dispatch`. Coarse discovery (`workflows.list`) stays `mcp:read`.
- Existing `workflows.create` / `save_draft` / `publish` contracts are untouched.
- The two tools register **last** (`registerWorkflowGraphTools`) so tools/list order matches their appended position in `FIRST_SLICE_TOOLS`.
- The hash-pinned contract artifact (`contracts/mcp-contract.json`) was regenerated: **27 tools, new hash `623636ee5d127b0d2b69418f8d1c25b23c5a009e140eca520f75ed646cb09ed3`**. The literal tool lists in `contracts.test.ts`, `server.test.ts`, `transport.test.ts`, `tool-catalog.test.ts` and `surface-e2e.test.ts` were extended accordingly.

### Verification
- `vitest run` on all touched MCP suites (tool-catalog, contracts, contract-artifact, policy, server, transport, surface-e2e, mcp-readiness, workflow-authoring): **191 tests pass**, including 11 new (lossless round trip + named conflict).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kfeohXE66xx7RJPxZ2pvH