### PR TITLE
fix(worker): narrow unsupported MCP OAuth scopes at authorize (offline_access)

### DIFF
--- a/apps/worker/src/auth.test.ts
+++ b/apps/worker/src/auth.test.ts
@@ -363,6 +363,58 @@ describe("MCP OAuth provider", () => {
   });
 
   /**
+   * Claude Code's native OAuth appends offline_access to the authorize request
+   * to obtain a refresh token. offline_access is not a grantable MCP scope, and
+   * the raw provider would fail the whole authorize with
+   * error=invalid_scope&error_description=The following scopes are invalid:
+   * offline_access, so no native client could connect (AIW-282 / AIW-272). The
+   * before-hook narrows the request to the supported subset, so the flow instead
+   * advances (here, to login, since the request carries no session) carrying only
+   * the scopes this deployment can grant.
+   */
+  it("narrows an unsupported authorize scope instead of failing the whole flow", async () => {
+    const db = await createTestDb();
+    await db.insert(organization).values({
+      id: "org_fixed",
+      name: "AI Workflow",
+      slug: "ai-workflow",
+    });
+    const auth = createAuth(db, {
+      ...OPTS,
+      mcp: { organizationId: "org_fixed", allowPublicDcr: true },
+    });
+
+    const registered = await registerPublicClient(auth, "http://127.0.0.1:43110/callback");
+    expect(registered.status, await registered.clone().text()).toBe(200);
+    const { client_id: clientId } = (await registered.json()) as { client_id: string };
+
+    const query = new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: "http://127.0.0.1:43110/callback",
+      scope: "mcp:read runs:dispatch offline_access",
+      state: "state-xyz",
+      code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      code_challenge_method: "S256",
+    });
+    const res = await auth.handler(
+      new Request(
+        `http://localhost:3000/api/auth/oauth2/authorize?${query.toString()}`,
+        { method: "GET", headers: { origin: "http://localhost:3000" } },
+      ),
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    // Not the invalid_scope failure the raw provider emits for offline_access.
+    expect(location).not.toContain("invalid_scope");
+    // Unauthenticated, so it advances to the login page rather than erroring...
+    expect(location).toContain("/mcp-auth/login");
+    // ...forwarding only the scopes this deployment can actually grant.
+    expect(new URL(location).searchParams.get("scope")).toBe("mcp:read runs:dispatch");
+  });
+
+  /**
    * The MCP branch of createAuth also mounts jwt(), and jwt() hooks
    * /get-session to mint a JWT from a key it reads out of the jwks table. So
    * with MCP on, a broken jwks store does not break sign-in, it breaks every

--- a/apps/worker/src/auth.ts
+++ b/apps/worker/src/auth.ts
@@ -16,7 +16,11 @@ import { createError } from "h3";
 
 import type { Db } from "./db/client.js";
 import { account, member, organization, ssoProvider, verification } from "./db/schema.js";
-import { createMcpOAuthProvider, validateMcpOAuthHookRequest } from "./mcp/oauth.js";
+import {
+  createMcpOAuthProvider,
+  narrowMcpAuthorizeScope,
+  validateMcpOAuthHookRequest,
+} from "./mcp/oauth.js";
 
 export type AuthOptions = {
   secret: string;
@@ -116,6 +120,10 @@ export function createAuth(db: Db, options: AuthOptions) {
     hooks: mcpDeployment
       ? {
           before: createAuthMiddleware(async (ctx) => {
+            narrowMcpAuthorizeScope(
+              ctx.path,
+              ctx.query as Record<string, unknown> | undefined,
+            );
             await validateMcpOAuthHookRequest(
               db,
               mcpDeployment,

--- a/apps/worker/src/mcp/oauth.test.ts
+++ b/apps/worker/src/mcp/oauth.test.ts
@@ -6,6 +6,7 @@ import { MCP_SCOPES } from "./contracts.js";
 import {
   canonicalMcpResource,
   createMcpOAuthOptions,
+  narrowMcpAuthorizeScope,
   validateMcpOAuthHookRequest,
   validateMcpOAuthRequest,
 } from "./oauth.js";
@@ -143,6 +144,42 @@ describe("MCP OAuth provider options", () => {
         organizationId: "org_fixed",
       }),
     ).toThrow("OAuth service client is not authorized");
+  });
+
+  it("narrows offline_access out of an authorize scope, keeping the supported subset", () => {
+    const query: Record<string, unknown> = {
+      scope: "mcp:read runs:dispatch offline_access",
+    };
+    narrowMcpAuthorizeScope("/oauth2/authorize", query);
+    expect(query.scope).toBe("mcp:read runs:dispatch");
+  });
+
+  it("leaves a fully-supported authorize scope byte-identical", () => {
+    const query: Record<string, unknown> = { scope: "mcp:read runs:dispatch" };
+    narrowMcpAuthorizeScope("/oauth2/authorize", query);
+    expect(query.scope).toBe("mcp:read runs:dispatch");
+  });
+
+  it("drops any unsupported scope, not only offline_access", () => {
+    const query: Record<string, unknown> = {
+      scope: "mcp:read admin:all offline_access",
+    };
+    narrowMcpAuthorizeScope("/oauth2/authorize", query);
+    expect(query.scope).toBe("mcp:read");
+  });
+
+  it("collapses to empty rather than widening when nothing grantable remains", () => {
+    // Must NOT delete the key: a missing scope makes the provider fall back to the
+    // client's full registered default set, which would widen the grant.
+    const query: Record<string, unknown> = { scope: "offline_access" };
+    narrowMcpAuthorizeScope("/oauth2/authorize", query);
+    expect(query.scope).toBe("");
+  });
+
+  it("leaves non-authorize requests untouched", () => {
+    const query: Record<string, unknown> = { scope: "mcp:read offline_access" };
+    narrowMcpAuthorizeScope("/oauth2/token", query);
+    expect(query.scope).toBe("mcp:read offline_access");
   });
 
   it("rejects conflicting Basic and body client identities using Basic precedence", async () => {

--- a/apps/worker/src/mcp/oauth.ts
+++ b/apps/worker/src/mcp/oauth.ts
@@ -126,6 +126,35 @@ export function createMcpOAuthProvider(deployment: McpOAuthDeployment) {
   return oauthProvider(options as OAuthOptions<string[]>);
 }
 
+// A native OAuth client (Claude Code) appends offline_access to its authorize
+// request to ask for a refresh token. offline_access is not one of MCP_SCOPES,
+// and the provider hard-rejects the WHOLE authorize with invalid_scope the moment
+// any requested scope is unknown to it (@better-auth/oauth-provider@1.6.20,
+// dist/index.mjs:3873-3880), so the connection dies before consent instead of
+// degrading. RFC 6749 §3.3 lets the authorization server issue a narrower scope
+// than the one requested, so we drop the scopes we cannot grant and let the flow
+// continue with the supported subset. This runs in the before-hook, ahead of the
+// provider, mutating the same ctx.query.scope it later validates, signs into the
+// consent redirect, and stores on the authorization code, so the narrowed set is
+// exactly what consent lists and what the issued token carries. It only ever
+// REMOVES scopes and never widens a grant: it filters against MCP_SCOPES, not the
+// client's registration, so a scope the client never registered still reaches the
+// provider's own client-scope check and is still rejected there. When nothing
+// grantable remains the scope collapses to "" rather than being deleted, so the
+// provider does not fall back to the client's full registered default set.
+export function narrowMcpAuthorizeScope(
+  path: string,
+  query: Record<string, unknown> | undefined,
+): void {
+  if (path !== "/oauth2/authorize") return;
+  if (!query || typeof query.scope !== "string") return;
+  const supported = new Set<string>(MCP_SCOPES);
+  query.scope = query.scope
+    .split(" ")
+    .filter((scope) => scope && supported.has(scope))
+    .join(" ");
+}
+
 export function validateMcpOAuthRequest(input: McpOAuthRequest): void {
   if (input.path === "/oauth2/register") {
     if (!input.allowPublicDcr) return;


### PR DESCRIPTION
## Problem (AIW-282 / AIW-272)

Connecting a native MCP client (Claude Code) to the Arthur tenant fails at the OAuth callback with:

```
error=invalid_scope&error_description=The following scopes are invalid: offline_access
```

Claude Code's native OAuth requests `offline_access` (to obtain a refresh token). `offline_access` is **not** in `MCP_SCOPES`, so at `/oauth2/authorize` the provider (`@better-auth/oauth-provider@1.6.20`, `dist/index.mjs:3873-3880`) finds an unknown scope and **hard-rejects the whole authorization** rather than degrading. No native client can connect. (`refresh_token` is advertised in `grant_types_supported` but `offline_access` was never grantable, so a client that asks for it is turned away outright — the sibling of AIW-282, where native clients also can't obtain write scopes.)

## Fix — graceful scope narrowing (RFC 6749 §3.3)

Rather than adding full `offline_access` + refresh-token support (long-lived tokens, broader security surface, and revocation is already known to be a no-op on this stateless-JWKS deployment), this takes the **least-risky** path the task calls for: drop the scopes we cannot grant and proceed with the supported subset. RFC 6749 §3.3 explicitly permits the authorization server to issue a **narrower** scope than requested.

A new `narrowMcpAuthorizeScope(path, query)` runs in the existing Better Auth `before`-hook, **ahead of the provider**, and rewrites `ctx.query.scope` on the `/oauth2/authorize` request to keep only `MCP_SCOPES`. Because it mutates the same `query` object the provider then validates, signs into the consent redirect, and stores on the authorization code, the narrowed set is exactly what consent lists and what the issued token carries.

### Security invariants preserved
- **No widening.** It filters against `MCP_SCOPES`, not the client's registration, and only ever *removes* — a scope the client never registered still reaches the provider's own client-scope check and is still rejected there.
- **No fallback expansion.** When nothing grantable remains, the scope collapses to `""` (not deleted), so the provider does **not** fall back to the client's full registered default set.
- **Untouched paths.** Gated to `/oauth2/authorize` only; `client_credentials`/no-`sub` write-scope stripping (in `request-context.ts`), Basic/DCR validation, PKCE, and flow binding are unchanged.
- **Consent honesty.** Narrowing happens before `oAuthState.set`, so the signed consent redirect and the custom consent page (`allowedScopes`, also `MCP_SCOPES`-based) present only the scopes actually granted.

## Verification

- `src/mcp/oauth.test.ts` — 23/23 pass, incl. 5 new unit tests (drops `offline_access`, keeps supported subset, drops any unsupported scope, collapses-not-widens when only unsupported asked, leaves non-authorize paths untouched).
- `src/auth.test.ts` — 19/19 pass, incl. a new integration test driving the real `auth.handler` on `/oauth2/authorize?scope=mcp:read runs:dispatch offline_access`: it now advances to login carrying only `mcp:read runs:dispatch` instead of redirecting with `error=invalid_scope`.
- **Red check:** with the fix disabled, the new integration test reproduces the exact production symptom (`?error=invalid_scope&error_description=The+following+scopes+are+invalid%3A+offline_access`), confirming it is a genuine regression guard.
- `tsc --noEmit`: zero errors in the changed files.

## Deploy note

This is the **shared** worker codebase. The **Arthur tenant must be redeployed** (separate manual step, not part of this PR) before the dogfood connection is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)