### PR TITLE
refactor(worker): switch db driver from neon-http to node-postgres

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -60,6 +60,7 @@
     "drizzle-orm": "^0.45.2",
     "h3": "^1",
     "nitropack": "^2",
+    "pg": "^8.20.0",
     "pino": "^10.3.1",
     "re2-wasm": "^1.0.2",
     "resend": "^6.16.0",
@@ -71,6 +72,7 @@
   },
   "devDependencies": {
     "@electric-sql/pglite": "^0.5.1",
+    "@types/pg": "^8.18.0",
     "@types/tar-stream": "^3.1.4",
     "@workflow/vitest": "4.0.16",
     "@workflow/world-postgres": "4.3.3",

--- a/apps/worker/scripts/db-migrate.ts
+++ b/apps/worker/scripts/db-migrate.ts
@@ -40,12 +40,13 @@ if (!url) {
 execSync("pnpm exec drizzle-kit migrate", { stdio: "inherit" });
 
 // TLS the same way as the runtime client (src/db/client.ts): both Neon and
-// Railway require it, rejectUnauthorized:false keeps the handshake encrypted
-// without a CA bundle. This is the same TCP endpoint drizzle-kit migrate above
-// already connects to.
+// Railway require it; the explicit ssl object wins over the URL's sslmode and
+// rejectUnauthorized:true verifies the server cert against node's built-in CA
+// bundle (Neon chains to public roots). This is the same TCP endpoint
+// drizzle-kit migrate above already connects to.
 const pool = new pg.Pool({
   connectionString: url,
-  ssl: { rejectUnauthorized: false },
+  ssl: { rejectUnauthorized: true },
   max: 1,
 });
 const vercelEnv = process.env.VERCEL_ENV ?? "development";

--- a/apps/worker/scripts/db-migrate.ts
+++ b/apps/worker/scripts/db-migrate.ts
@@ -22,8 +22,10 @@ import { config } from "dotenv";
 config({ path: [".env.local", ".env"], quiet: true });
 
 import { execSync } from "node:child_process";
-import { neon } from "@neondatabase/serverless";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle } from "drizzle-orm/node-postgres";
+// pg is CommonJS whose module.exports is a constructed instance, so Pool is
+// only reachable via the default export, not as a named binding.
+import pg from "pg";
 import type { Db } from "../src/db/client.js";
 import * as schema from "../src/db/schema.js";
 import { getCurrentSystemHarnessProfileReference } from "../src/harness-profiles/store.js";
@@ -37,26 +39,40 @@ if (!url) {
 
 execSync("pnpm exec drizzle-kit migrate", { stdio: "inherit" });
 
-const sql = neon(url);
+// TLS the same way as the runtime client (src/db/client.ts): both Neon and
+// Railway require it, rejectUnauthorized:false keeps the handshake encrypted
+// without a CA bundle. This is the same TCP endpoint drizzle-kit migrate above
+// already connects to.
+const pool = new pg.Pool({
+  connectionString: url,
+  ssl: { rejectUnauthorized: false },
+  max: 1,
+});
 const vercelEnv = process.env.VERCEL_ENV ?? "development";
 // Normalize: strip Neon's -pooler suffix and any port so pooled vs direct
 // URLs for the same branch compare equal (a host mismatch takes the
 // permissive re-claim path, which must mean a genuinely different endpoint).
 const host = new URL(url).hostname.toLowerCase().replace(/-pooler(?=\.)/, "");
 
-await sql`
-  INSERT INTO env_marker (id, env, endpoint_host)
-  VALUES (1, ${vercelEnv}, ${host})
-  ON CONFLICT (id) DO NOTHING
-`;
-const rows = await sql`SELECT env, endpoint_host FROM env_marker WHERE id = 1`;
-const marker = rows[0] as { env: string; endpoint_host: string };
+await pool.query(
+  `INSERT INTO env_marker (id, env, endpoint_host)
+   VALUES (1, $1, $2)
+   ON CONFLICT (id) DO NOTHING`,
+  [vercelEnv, host],
+);
+const { rows } = await pool.query<{ env: string; endpoint_host: string }>(
+  "SELECT env, endpoint_host FROM env_marker WHERE id = 1",
+);
+const marker = rows[0];
 
 if (marker.endpoint_host !== host) {
   console.warn(
     `[db-migrate] branch copied from '${marker.env}' (${marker.endpoint_host}) — re-claiming for '${vercelEnv}'.`,
   );
-  await sql`UPDATE env_marker SET env = ${vercelEnv}, endpoint_host = ${host} WHERE id = 1`;
+  await pool.query("UPDATE env_marker SET env = $1, endpoint_host = $2 WHERE id = 1", [
+    vercelEnv,
+    host,
+  ]);
 } else if (marker.env !== vercelEnv) {
   console.error(
     `[db-migrate] FATAL: this Neon branch is already claimed by VERCEL_ENV='${marker.env}', ` +
@@ -69,7 +85,7 @@ if (marker.endpoint_host !== host) {
 }
 
 if (process.exitCode !== 1) {
-  const db = drizzle({ client: sql, schema }) as unknown as Db;
+  const db = drizzle({ client: pool, schema }) as unknown as Db;
   const provider =
     process.env.AGENT_KIND === "codex" ? "codex" : "claude";
   const profileReference =
@@ -83,3 +99,8 @@ if (process.exitCode !== 1) {
   });
   console.log("[db-migrate] Workflow templates are ready.");
 }
+
+// Close the pool so the process exits (a node-postgres Pool keeps the event
+// loop alive; the old fetch-based neon client did not). process.exitCode is
+// preserved across this await.
+await pool.end();

--- a/apps/worker/scripts/seed-auth-user.ts
+++ b/apps/worker/scripts/seed-auth-user.ts
@@ -44,12 +44,22 @@ if (ssoKeys.some(Boolean) && !ssoKeys.every(Boolean)) {
   );
 }
 
-const { neon } = await import("@neondatabase/serverless");
-const { drizzle } = await import("drizzle-orm/neon-http");
+// pg is CommonJS whose module.exports is a constructed instance, so Pool is
+// only reachable via the default export, not as a named binding.
+const { default: pg } = await import("pg");
+const { drizzle } = await import("drizzle-orm/node-postgres");
 const schema = await import("../src/db/schema.js");
 const { bootstrapDashboardAuth, createAuth } = await import("../src/auth.js");
 
-const db = drizzle({ client: neon(DATABASE_URL!), schema }) as unknown as Parameters<
+// TLS matches the runtime client (src/db/client.ts): Neon and Railway both
+// require it, rejectUnauthorized:false keeps the handshake encrypted without a
+// CA bundle. Single connection — this seeder makes one short burst of writes.
+const pool = new pg.Pool({
+  connectionString: DATABASE_URL!,
+  ssl: { rejectUnauthorized: false },
+  max: 1,
+});
+const db = drizzle({ client: pool, schema }) as unknown as Parameters<
   typeof createAuth
 >[0];
 
@@ -96,3 +106,7 @@ console.log(
     }`,
   ].join("; ") + ".",
 );
+
+// Close the pool so the process exits (a node-postgres Pool keeps the event
+// loop alive; the old fetch-based neon client did not).
+await pool.end();

--- a/apps/worker/scripts/seed-auth-user.ts
+++ b/apps/worker/scripts/seed-auth-user.ts
@@ -52,11 +52,13 @@ const schema = await import("../src/db/schema.js");
 const { bootstrapDashboardAuth, createAuth } = await import("../src/auth.js");
 
 // TLS matches the runtime client (src/db/client.ts): Neon and Railway both
-// require it, rejectUnauthorized:false keeps the handshake encrypted without a
-// CA bundle. Single connection — this seeder makes one short burst of writes.
+// require it; the explicit ssl object wins over the URL's sslmode and
+// rejectUnauthorized:true verifies the server cert against node's built-in CA
+// bundle (Neon chains to public roots). Single connection — this seeder makes
+// one short burst of writes.
 const pool = new pg.Pool({
   connectionString: DATABASE_URL!,
-  ssl: { rejectUnauthorized: false },
+  ssl: { rejectUnauthorized: true },
   max: 1,
 });
 const db = drizzle({ client: pool, schema }) as unknown as Parameters<

--- a/apps/worker/src/db/client.ts
+++ b/apps/worker/src/db/client.ts
@@ -31,15 +31,18 @@ let _db: Db | null = null;
  * warm-but-idle instance stops holding connections between bursts, and a
  * connection that cannot be acquired fails within 10s rather than hanging.
  *
- * Both Neon and Railway require TLS. `rejectUnauthorized: false` keeps the
- * handshake encrypted without shipping a CA bundle (there is no CA convention
- * in this repo); a Neon `sslmode=require` URL still connects.
+ * Both Neon and Railway require TLS. The explicit `ssl` object wins over the
+ * URL's `sslmode=require`, and `rejectUnauthorized: true` verifies the server
+ * certificate against node's built-in Mozilla CA bundle (Neon chains to public
+ * roots — confirmed with `sslmode=verify-full&sslrootcert=system`). No explicit
+ * `ca` is pinned; if a future host does not chain to public roots, pin its CA
+ * via `ssl.ca` rather than disabling verification.
  */
 export function getDb(): Db {
   if (!_db) {
     _pool = new Pool({
       connectionString: env.DATABASE_URL,
-      ssl: { rejectUnauthorized: false },
+      ssl: { rejectUnauthorized: true },
       max: 3,
       idleTimeoutMillis: 10_000,
       connectionTimeoutMillis: 10_000,

--- a/apps/worker/src/db/client.ts
+++ b/apps/worker/src/db/client.ts
@@ -1,29 +1,50 @@
-import { neon } from "@neondatabase/serverless";
-import { drizzle } from "drizzle-orm/neon-http";
+import { drizzle } from "drizzle-orm/node-postgres";
 import type { PgDatabase } from "drizzle-orm/pg-core";
+import { Pool } from "pg";
 import { env } from "../../env.js";
 import * as schema from "./schema.js";
 
 /**
  * Driver-agnostic database handle. `any` for the query-result HKT so both
- * the neon-http production driver and the pglite test driver are
+ * the node-postgres production driver and the pglite test driver are
  * assignable — adapters only use the query-builder surface, which is
  * identical across drivers.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Db = PgDatabase<any, typeof schema>;
 
+let _pool: Pool | null = null;
 let _db: Db | null = null;
 
 /**
- * Lazily-created singleton. neon() is fetch-based (no sockets, no pools),
- * so a module-level singleton is safe in serverless functions AND inside
- * Workflow DevKit step bundles (same constraint the Upstash REST client
- * satisfied).
+ * Lazily-created singleton over a node-postgres Pool. The Pool is a
+ * module-level singleton reused across invocations (mirroring the old
+ * fetch-client memoization), so a warm instance opens its TCP connections
+ * once and hands them back to the pool between invocations.
+ *
+ * Connection-count math on Vercel Fluid Compute: many warm instances can be
+ * live at once and each keeps its OWN pool, so the ceiling of live TCP
+ * connections is `max` × (warm instances). Keep `max` small (3) so a burst of
+ * warm instances cannot exhaust the Postgres/pooler connection budget, while
+ * still leaving a few connections for the several invocations Fluid runs
+ * concurrently inside one instance. Idle clients are dropped after 10s so a
+ * warm-but-idle instance stops holding connections between bursts, and a
+ * connection that cannot be acquired fails within 10s rather than hanging.
+ *
+ * Both Neon and Railway require TLS. `rejectUnauthorized: false` keeps the
+ * handshake encrypted without shipping a CA bundle (there is no CA convention
+ * in this repo); a Neon `sslmode=require` URL still connects.
  */
 export function getDb(): Db {
   if (!_db) {
-    _db = drizzle({ client: neon(env.DATABASE_URL), schema });
+    _pool = new Pool({
+      connectionString: env.DATABASE_URL,
+      ssl: { rejectUnauthorized: false },
+      max: 3,
+      idleTimeoutMillis: 10_000,
+      connectionTimeoutMillis: 10_000,
+    });
+    _db = drizzle({ client: _pool, schema });
   }
   return _db;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       nitropack:
         specifier: ^2
         version: 2.13.1(@electric-sql/pglite@0.5.1)(@upstash/redis@1.37.0)(@vercel/functions@3.5.0(@aws-sdk/credential-provider-web-identity@3.972.49))(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.18.0)(@upstash/redis@1.37.0)(kysely@0.29.2)(pg@8.20.0)(postgres@3.4.8))
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -204,6 +207,9 @@ importers:
       '@electric-sql/pglite':
         specifier: ^0.5.1
         version: 0.5.1
+      '@types/pg':
+        specifier: ^8.18.0
+        version: 8.18.0
       '@types/tar-stream':
         specifier: ^3.1.4
         version: 3.1.4
@@ -2621,6 +2627,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}


### PR DESCRIPTION
## Why

Prerequisite for migrating the worker off Neon. Today the runtime DB client is bound to Neon's HTTP driver (`@neondatabase/serverless` + `drizzle-orm/neon-http`), which only speaks Neon's fetch/WebSocket protocol and cannot reach a plain Postgres over TCP. Railway Postgres (and Neon over TCP) require a standard wire-protocol driver.

This swaps the runtime client (and the two build-time DB scripts) to standard `node-postgres` (`pg` + `drizzle-orm/node-postgres`). The adapters are untouched: `Db` stays the driver-agnostic `PgDatabase<any, …>`, so every store/query keeps working across the node-postgres production driver and the pglite test driver.

Two facts make this safe now:
- **Fluid Compute supports TCP.** The old fetch-based driver was chosen because serverless functions historically discouraged raw sockets/pools. Vercel Fluid Compute runs steps on a Node runtime with real TCP, so a pooled TCP driver is now viable.
- **The migrate path already used TCP.** `db-migrate.ts` runs `drizzle-kit migrate`, which already connects to Neon over TCP via `DATABASE_URL`. This PR just moves the script's own `env_marker` writes onto that same TCP connection instead of a separate neon-http one.

No env var changes: still `DATABASE_URL`. No behavior changes: **no** `db.transaction()` added anywhere (write paths stay per-statement, exactly as before).

## Connection-count reasoning (Fluid Compute)

The Pool is kept as a module-level singleton reused across invocations (mirrors the previous `getDb()` memoization). On Fluid Compute many warm instances can be live at once and **each keeps its own pool**, so the ceiling of live TCP connections is `max` × (warm instances).

- `max: 3` — small on purpose: a burst of warm instances cannot exhaust the Neon-pooler / Railway connection budget, while still leaving a few connections for the several invocations Fluid runs concurrently inside one instance. `max: 1` would serialize intra-instance concurrency; a large `max` multiplies dangerously across warm instances.
- `idleTimeoutMillis: 10_000` — idle clients are dropped after 10s so a warm-but-idle instance stops holding connections between bursts.
- `connectionTimeoutMillis: 10_000` — a connection that cannot be acquired fails within 10s rather than hanging past the function timeout.

The two build-time scripts (`db-migrate.ts`, `seed-auth-user.ts`) use `max: 1` (one short burst of writes) and call `pool.end()` at the end so the tsx process exits (a `pg` Pool keeps the event loop alive; the old fetch client did not).

## SSL

Both Neon and Railway require TLS. The Pool is configured with an explicit `ssl: { rejectUnauthorized: true }` object, which wins over the URL's `sslmode=require` (pg's connection-string parser leaves `ssl` unset for `require`). The server certificate **is verified** against node's built-in Mozilla CA bundle — no explicit `ca` is pinned.

**TLS is now verified. Neon confirmed via verify-full against system roots** (`psql "<direct-url>?sslmode=verify-full&sslrootcert=system"` connects, so Neon chains to public roots and node's default CA bundle verifies it). Before the Railway cutover, Railway's cert must be verify-full tested the same way; if Railway does not chain to public roots, pin its CA via `ssl.ca` (or a per-host config) rather than reverting to `rejectUnauthorized:false`.

## What changed

- `apps/worker/src/db/client.ts` — runtime client: `neon()` → `pg.Pool` singleton + `drizzle-orm/node-postgres`, with the pooling/SSL config above.
- `apps/worker/scripts/db-migrate.ts` — `env_marker` writes moved from neon-http tagged-template SQL to `pool.query(…)` parameterized statements; `drizzle` client is now the pg Pool; `await pool.end()` added. `drizzle-kit migrate` (the subprocess) is unchanged.
- `apps/worker/scripts/seed-auth-user.ts` — same pg Pool swap for the auth bootstrap; `await pool.end()` added.
- `apps/worker/package.json` — added `pg` (dep) and `@types/pg` (dev). `@neondatabase/serverless` **kept** (still used by other files, see below).
- `pnpm-lock.yaml` — importer entries for `pg@8.20.0` / `@types/pg@8.18.0` (both were already resolved transitively, so no new resolution).

## Other `@neondatabase/serverless` importers (left working on purpose)

`@neondatabase/serverless` is intentionally **not removed** — these still import it and are out of scope for this PR:

- `apps/worker/scripts/clear-run-registry.ts` (ops script)
- `apps/worker/e2e/scripts/check-db.ts`
- `apps/worker/e2e/helpers/registry.ts`
- `apps/worker/e2e/helpers/schedule.ts`
- `apps/worker/e2e/harness-profiles/preview-canary.ts`

(The many `// neon-http has no transactions` comments across `src/` are left untouched: the code is still per-statement, so the constraint they document still holds.)

## Validation plan

1. Merge and deploy **pointing `DATABASE_URL` at the existing Neon endpoint over TCP first** (decouples the driver swap from the provider move). Confirm login/session reads, a dispatch, and the post-PR gate all work.
2. Once Neon-over-TCP is green, swap `DATABASE_URL` to Railway Postgres and re-run the same smoke checks.

## Risks

- **Connection exhaustion.** New failure mode vs neon-http (which held zero connections). Mitigated by `max: 3` + `idleTimeoutMillis`, but under heavy fan-out `max × warm-instances` could still pressure the pooler; watch Neon/Railway connection metrics on first deploy and tune `max` down if needed.
- **TLS / Railway cert.** The connection now verifies the server cert (`rejectUnauthorized: true`) against node's built-in CA bundle; Neon is confirmed to chain to public roots. Risk sits at the Railway cutover: if Railway's cert does not chain to public roots, the connection will (correctly) refuse until its CA is pinned via `ssl.ca`. Verify-full test Railway before switching `DATABASE_URL`.
- **WDK step bundling.** `pg` uses `net`/`tls`/`dns`. `getDb()` is only called inside `use step` code (Node runtime with TCP), same import graph as before, so this should bundle like `pino`-in-step does — but it is the one thing not verifiable without a Vercel build. First preview build is the real gate.
- **Not locally verified.** The worktree has no installed `node_modules`, so no local `tsc`/build was run (per task constraints). CI (`pnpm install --frozen-lockfile` → `typecheck` → `test`) is the gate; the lockfile was updated so frozen install stays green. Scripts (`scripts/**`) are not in the tsconfig include, so they are exercised only at deploy-build time, not by CI typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

