### PR TITLE
fix(worker): slow cron cadence to let Neon compute sleep

### DIFF
--- a/apps/worker/vercel.json
+++ b/apps/worker/vercel.json
@@ -2,11 +2,11 @@
   "crons": [
     {
       "path": "/cron/poll",
-      "schedule": "* * * * *"
+      "schedule": "*/15 * * * *"
     },
     {
       "path": "/cron/harness-capabilities",
-      "schedule": "*/5 * * * *"
+      "schedule": "*/30 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Slow down two Vercel cron schedules in the worker to reduce Neon Postgres compute cost.

## Changes
- `/cron/poll`: `* * * * *` -> `*/15 * * * *`
- `/cron/harness-capabilities`: `*/5 * * * *` -> `*/30 * * * *`

## Rationale
The every-minute poll never lets Neon autosuspend (5 min idle) fire, keeping compute awake 24/7 and driving roughly $120/mo in compute. Dispatch is event-driven from jira/gitlab/github webhooks, so the poll is only a backstop; a 15 min backstop is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
