### PR TITLE
fix(worker): recover pre-PR workspace gate from durable checks output

### DIFF
--- a/apps/worker/src/workflow-definition/block-registry.ts
+++ b/apps/worker/src/workflow-definition/block-registry.ts
@@ -786,6 +786,16 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       ]),
       fixCycles: numberType(),
       summary: stringType(),
+      // Optional durable copy of the workspace gate captured on a passing run.
+      // finalize_workspace recovers it from this checkpointed output when the
+      // ephemeral ctx.prePrGate is lost on a cold scheduler resume. Kept out of
+      // normalOutputRequired so old runs and replays without it still validate.
+      gate: nullableType(
+        objectType({
+          configurationVersion: numberType(),
+          fingerprint: stringType(),
+        }),
+      ),
     }),
     normalOutputRequired: ["ok", "outcome", "fixCycles", "summary"],
     statusVariants: ["ok"],
@@ -810,6 +820,15 @@ const definitions: Record<WorkflowBlockType, ContractDefinition> = {
       results: arrayType(unknownType()),
       failures: arrayType(unknownType()),
       skipReason: stringType(),
+      // Same optional durable gate as run_pre_pr_checks: run_checks also records
+      // ctx.prePrGate on a passing configured run, so finalize can recover it on
+      // a cold scheduler resume. Optional, and kept out of normalOutputRequired.
+      gate: nullableType(
+        objectType({
+          configurationVersion: numberType(),
+          fingerprint: stringType(),
+        }),
+      ),
     }),
     normalOutputRequired: ["ok", "outcome", "results", "failures"],
     statusVariants: ["ok"],

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -5176,6 +5176,16 @@ async function agentWorkflowBody(
                 outcome: prePrChecks.outcome,
                 fixCycles: prePrChecks.fixCycles,
                 summary: prePrChecks.summary,
+                // Durably checkpoint the gate alongside the pass so finalize can
+                // recover it when the ephemeral ctx.prePrGate is lost on a cold
+                // scheduler resume. Same value just recorded to ctx.prePrGate;
+                // spread into a plain JSON object for the BlockOutput contract.
+                gate: ctx.prePrGate
+                  ? {
+                      configurationVersion: ctx.prePrGate.configurationVersion,
+                      fingerprint: ctx.prePrGate.fingerprint,
+                    }
+                  : null,
               },
             };
           }

--- a/apps/worker/src/workflows/blocks/finalize-workspace.test.ts
+++ b/apps/worker/src/workflows/blocks/finalize-workspace.test.ts
@@ -199,6 +199,93 @@ describe("finalize_workspace execute", () => {
     );
   });
 
+  it("recovers the gate from the durable checks output when heap state was lost on resume", async () => {
+    // Simulate a scheduler resume in a cold instance: the checks handler body
+    // never re-ran, so ctx.prePrGate (ephemeral heap) is null, but the checks
+    // node's durable checkpointed output still carries the gate value.
+    const recoveredGate = {
+      configurationVersion: 7,
+      fingerprint: "workspace-fingerprint",
+    };
+    const ctx = makeCtx({
+      selectedRepositories: [repo],
+      workspaceManifest: trustedManifest,
+    });
+    ctx.prePrGate = null;
+
+    await execute(
+      makeNode("finalize_workspace"),
+      {
+        checks: {
+          output: {
+            status: "ok",
+            ok: true,
+            outcome: "passed",
+            fixCycles: 0,
+            summary: "all checks passed",
+            gate: recoveredGate,
+          },
+        },
+      },
+      ctx,
+    );
+
+    expect(mocks.finalizeWorkspacePublication).toHaveBeenCalledWith(
+      expect.objectContaining({ prePrGate: recoveredGate }),
+    );
+  });
+
+  it("prefers the live heap gate over a durable checks output gate", async () => {
+    const ctx = makeCtx({
+      selectedRepositories: [repo],
+      workspaceManifest: trustedManifest,
+    }) as ReturnType<typeof makeCtx> & {
+      prePrGate: { configurationVersion: number; fingerprint: string } | null;
+    };
+    ctx.prePrGate = { configurationVersion: 9, fingerprint: "live-heap" };
+
+    await execute(
+      makeNode("finalize_workspace"),
+      {
+        checks: {
+          output: {
+            status: "ok",
+            ok: true,
+            outcome: "passed",
+            fixCycles: 0,
+            summary: "all checks passed",
+            gate: { configurationVersion: 7, fingerprint: "durable-stale" },
+          },
+        },
+      },
+      ctx,
+    );
+
+    expect(mocks.finalizeWorkspacePublication).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prePrGate: { configurationVersion: 9, fingerprint: "live-heap" },
+      }),
+    );
+  });
+
+  it("passes a null gate when neither heap nor any durable output carries one", async () => {
+    const ctx = makeCtx({
+      selectedRepositories: [repo],
+      workspaceManifest: trustedManifest,
+    });
+    ctx.prePrGate = null;
+
+    await execute(
+      makeNode("finalize_workspace"),
+      { research: { output: { status: "ok", summary: "no gate here" } } },
+      ctx,
+    );
+
+    expect(mocks.finalizeWorkspacePublication).toHaveBeenCalledWith(
+      expect.objectContaining({ prePrGate: null }),
+    );
+  });
+
   it("passes the exact triggering PR/MR source head into publication", async () => {
     const pr = makePrPayload({ headSha: "trigger-head" });
     await execute(

--- a/apps/worker/src/workflows/blocks/finalize-workspace.ts
+++ b/apps/worker/src/workflows/blocks/finalize-workspace.ts
@@ -1,8 +1,66 @@
 import { z } from "zod";
 import { isRunControlError } from "../run-control-error.js";
-import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
+import type { WorkspaceGate } from "../workspace-gate.js";
+import {
+  executionError,
+  type BlockExecuteFn,
+  type BlockExecutionResult,
+  type StepsRecord,
+} from "./types.js";
 
 export const paramsSchema = z.object({}).strict();
+
+/**
+ * Recover the workspace gate from a durable checks-node output. The gate is
+ * ephemeral heap state on ctx.prePrGate, so a scheduler resume in a cold Fluid
+ * instance (checks handler body not re-run) leaves it null while the checks
+ * node's checkpointed output still carries it. Both run_pre_pr_checks and
+ * run_checks emit a `gate` field; the `outcome`-string marker keeps recovery
+ * pinned to a checks-shaped output. Returns null when no step carries a valid
+ * gate (checks genuinely never passed), so the publication boundary still fails
+ * closed with `missing_gate`.
+ *
+ * Iterates in reverse so the most recently completed checks output wins when a
+ * run executed checks more than once (e.g. a loop): the last durable gate is the
+ * one the hot path would have held on ctx.prePrGate at finalize time.
+ *
+ * SAFETY: this recovers a gate purely from durable checks output, so it cannot
+ * observe an `invalidateWorkspaceGate` that ran AFTER checks but was never
+ * re-executed on the cold-resume path. If a workspace-mutating or sandbox-restore
+ * node sits BETWEEN the checks node and finalize, the hot path would have nulled
+ * the gate (forcing a re-check) while a cold resume can resurrect it here. The
+ * built-in linear ticket workflow has no such intervening node; custom workflows
+ * can. This is bounded by the publication-boundary guards, which still re-verify
+ * the immutable config version (configuration_changed) and the exact clean
+ * TRACKED-file fingerprint (workspace_changed) against the live workspace. The
+ * residual blind spot is untracked-only mutation, which mirrors the pre-existing
+ * untracked-file tolerance the fingerprint deliberately ignores
+ * (workspace-gate.ts inspectWorkspaceForGateStep, `--untracked-files=no`).
+ * A follow-up that binds recovery to finalize's direct control-flow predecessor
+ * (requires threading the definition edges into EngineCtx) would close it.
+ */
+export function recoverPrePrGateFromSteps(steps: StepsRecord): WorkspaceGate | null {
+  const outputs = Object.values(steps);
+  for (let index = outputs.length - 1; index >= 0; index -= 1) {
+    const output = outputs[index]?.output as Record<string, unknown> | undefined;
+    if (!output || typeof output.outcome !== "string" || !("gate" in output)) {
+      continue;
+    }
+    const gate = output.gate;
+    if (
+      gate !== null &&
+      typeof gate === "object" &&
+      typeof (gate as { configurationVersion?: unknown }).configurationVersion === "number" &&
+      typeof (gate as { fingerprint?: unknown }).fingerprint === "string"
+    ) {
+      return {
+        configurationVersion: (gate as WorkspaceGate).configurationVersion,
+        fingerprint: (gate as WorkspaceGate).fingerprint,
+      };
+    }
+  }
+  return null;
+}
 
 /**
  * finalize_workspace: retain the v1 `checks.*` compatibility gate, then rely on
@@ -13,7 +71,7 @@ export const paramsSchema = z.object({}).strict();
  */
 export const execute: BlockExecuteFn = async (
   block,
-  _steps,
+  steps,
   ctx,
   resolvedInputs = {},
 ): Promise<BlockExecutionResult> => {
@@ -52,7 +110,7 @@ export const execute: BlockExecuteFn = async (
       ticketKey: ctx.ticket.identifier,
       workspaceManifest: ctx.workspaceManifest,
       repositoryScope: ctx.repositoryScope,
-      prePrGate: ctx.prePrGate,
+      prePrGate: ctx.prePrGate ?? recoverPrePrGateFromSteps(steps),
       clarifications: ctx.clarifications,
       sourcePullRequest:
         ctx.entry.kind === "pr_trigger"

--- a/apps/worker/src/workflows/blocks/run-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   getDb: vi.fn(),
   getCurrentPrePrCheckConfig: vi.fn(),
   runPrePrChecksWithFixes: vi.fn(),
+  recordSuccessfulWorkspaceGate: vi.fn(),
 }));
 
 vi.mock("@vercel/sandbox", () => ({ Sandbox: { get: mocks.sandboxGet } }));
@@ -16,9 +17,33 @@ vi.mock("../../pre-pr-checks/store.js", () => ({
 vi.mock("../../pre-pr-checks/runner.js", () => ({
   runPrePrChecksWithFixes: mocks.runPrePrChecksWithFixes,
 }));
+// Isolate the gate-emission behavior from real sandbox inspection: keep the
+// invalidate mutator faithful (nulls the heap gate) and stub the recorder.
+vi.mock("../workspace-gate.js", () => ({
+  invalidateWorkspaceGate: (state: { prePrGate: unknown }) => {
+    state.prePrGate = null;
+  },
+  recordSuccessfulWorkspaceGate: mocks.recordSuccessfulWorkspaceGate,
+}));
 
+import type { WorkspaceManifest } from "../../sandbox/repo-workspace.js";
 import { execute, paramsSchema } from "./run-checks.js";
 import { makeCtx, makeNode, runControlErrorCases } from "./test-support.js";
+
+const trustedManifest: WorkspaceManifest = {
+  version: 1,
+  repositories: [{
+    provider: "github",
+    repoPath: "acme/api",
+    slug: "acme__api",
+    localPath: "/vercel/sandbox",
+    defaultBranch: "main",
+    branchName: "blazebot/awt-1",
+    selectedRationale: "selected",
+    expectedRemoteSha: "before",
+    preAgentSha: "before",
+  }],
+};
 
 const manifest = JSON.stringify({
   version: 1,
@@ -131,6 +156,7 @@ describe("run_checks execute", () => {
           output: "boom error\nboom output",
         },
       ],
+      gate: null,
     });
   });
 
@@ -242,6 +268,55 @@ describe("run_checks execute", () => {
     ]);
   });
 
+  it("durably emits the recorded gate in its passed configured output", async () => {
+    const gate = { configurationVersion: 5, fingerprint: "fp-run-checks" };
+    mocks.recordSuccessfulWorkspaceGate.mockResolvedValue(gate);
+    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+      version: 5,
+      config: { repositories: [{ provider: "github", repoPath: "acme/api", commands: ["pnpm lint"] }] },
+    });
+    mocks.runPrePrChecksWithFixes.mockResolvedValue({
+      outcome: "passed",
+      passed: true,
+      fixCycles: 0,
+      results: [],
+      failures: [],
+      summary: "passed",
+    });
+
+    const result = await execute(
+      makeNode("run_checks"),
+      {},
+      makeCtx({ workspaceManifest: trustedManifest }),
+    );
+
+    expect(mocks.recordSuccessfulWorkspaceGate).toHaveBeenCalledOnce();
+    expect(result.kind).toBe("next");
+    expect(result.output!.ok).toBe(true);
+    expect(result.output!.gate).toEqual(gate);
+  });
+
+  it("emits a null gate when a configured run passes but records no gate", async () => {
+    // No workspace manifest -> the record branch is skipped, so no durable gate.
+    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+      version: 5,
+      config: { repositories: [{ provider: "github", repoPath: "acme/api", commands: ["pnpm lint"] }] },
+    });
+    mocks.runPrePrChecksWithFixes.mockResolvedValue({
+      outcome: "passed",
+      passed: true,
+      fixCycles: 0,
+      results: [],
+      failures: [],
+      summary: "passed",
+    });
+
+    const result = await execute(makeNode("run_checks"), {}, makeCtx());
+
+    expect(mocks.recordSuccessfulWorkspaceGate).not.toHaveBeenCalled();
+    expect(result.output!.gate).toBeNull();
+  });
+
   it("distinguishes missing configured checks from an intentional skip", async () => {
     mocks.getCurrentPrePrCheckConfig.mockResolvedValue(null);
     mocks.runPrePrChecksWithFixes.mockResolvedValue({
@@ -263,6 +338,7 @@ describe("run_checks execute", () => {
         outcome: "missing_configuration",
         results: [],
         failures: [],
+        gate: null,
       },
     });
   });

--- a/apps/worker/src/workflows/blocks/run-checks.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.ts
@@ -218,6 +218,16 @@ export const execute: BlockExecuteFn = async (block, _steps, ctx): Promise<Block
         outcome: result.outcome,
         results: result.results,
         failures: result.failures,
+        // Durably checkpoint the gate just recorded to ctx.prePrGate so finalize
+        // can recover it on a cold scheduler resume. Spread into a plain JSON
+        // object for the BlockOutput contract. Null when no gate was recorded
+        // (commands path, failed/missing config, or no workspace manifest).
+        gate: ctx.prePrGate
+          ? {
+              configurationVersion: ctx.prePrGate.configurationVersion,
+              fingerprint: ctx.prePrGate.fingerprint,
+            }
+          : null,
       },
     };
   } catch (err) {

--- a/apps/worker/src/workflows/workspace-gate.test.ts
+++ b/apps/worker/src/workflows/workspace-gate.test.ts
@@ -20,6 +20,24 @@ import {
   recordSuccessfulWorkspaceGate,
 } from "./workspace-gate.js";
 import { fingerprintWorkspaceState } from "./workspace-gate-fingerprint.js";
+import { recoverPrePrGateFromSteps } from "./blocks/finalize-workspace.js";
+
+function checksStepsWithGate(
+  gate: { configurationVersion: number; fingerprint: string } | null,
+) {
+  return {
+    checks: {
+      output: {
+        status: "ok",
+        ok: true,
+        outcome: "passed",
+        fixCycles: 0,
+        summary: "all checks passed",
+        gate,
+      },
+    },
+  };
+}
 
 const manifest: WorkspaceManifest = {
   version: 1,
@@ -362,6 +380,107 @@ describe("workspace gate", () => {
         sandboxId: "sbx-1",
         workspaceManifest: manifest,
         gate,
+      }),
+    ).rejects.toMatchObject({ code: "workspace_changed" });
+  });
+
+  it("recovers a durable checks gate and returns null when none is present", () => {
+    const gate = { configurationVersion: 7, fingerprint: "abc" };
+    expect(recoverPrePrGateFromSteps(checksStepsWithGate(gate))).toEqual(gate);
+    // A passing checks node that recorded no gate (config absent/inapplicable).
+    expect(recoverPrePrGateFromSteps(checksStepsWithGate(null))).toBeNull();
+    // No checks node at all: nothing to recover.
+    expect(
+      recoverPrePrGateFromSteps({ research: { output: { status: "ok" } } }),
+    ).toBeNull();
+  });
+
+  it("recovers the most recently completed gate when checks ran more than once", () => {
+    const stale = { configurationVersion: 6, fingerprint: "stale" };
+    const fresh = { configurationVersion: 7, fingerprint: "fresh" };
+    // Insertion order models completion order: the fresher checks run finishes
+    // last, so reverse iteration returns it, matching the hot-path ctx.prePrGate.
+    const steps = {
+      firstChecks: {
+        output: {
+          status: "ok",
+          ok: true,
+          outcome: "passed",
+          fixCycles: 0,
+          summary: "",
+          gate: stale,
+        },
+      },
+      secondChecks: {
+        output: {
+          status: "ok",
+          ok: true,
+          outcome: "passed",
+          fixCycles: 0,
+          summary: "",
+          gate: fresh,
+        },
+      },
+    };
+    expect(recoverPrePrGateFromSteps(steps)).toEqual(fresh);
+  });
+
+  it("routes a recovered gate through the same guards: stale config version is still rejected", async () => {
+    // Record a real gate, then hand it back as a durable checks output, as if
+    // the heap gate was lost on a cold scheduler resume.
+    const gate = await recordSuccessfulWorkspaceGate({
+      sandboxId: "sbx-1",
+      workspaceManifest: manifest,
+      configurationVersion: 7,
+    });
+    const recovered = recoverPrePrGateFromSteps(checksStepsWithGate(gate));
+    expect(recovered).toEqual(gate);
+
+    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+      version: 8,
+      config: {
+        repositories: [{
+          provider: "github",
+          repoPath: "acme/web",
+          commands: ["pnpm test"],
+        }],
+      },
+    });
+
+    await expect(
+      assertCurrentWorkspaceGate({
+        sandboxId: "sbx-1",
+        workspaceManifest: manifest,
+        gate: recovered,
+      }),
+    ).rejects.toMatchObject({ code: "configuration_changed" });
+  });
+
+  it("routes a recovered gate through the same guards: changed workspace is still rejected", async () => {
+    const gate = await recordSuccessfulWorkspaceGate({
+      sandboxId: "sbx-1",
+      workspaceManifest: manifest,
+      configurationVersion: 7,
+    });
+    const recovered = recoverPrePrGateFromSteps(checksStepsWithGate(gate));
+
+    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+      version: 7,
+      config: {
+        repositories: [{
+          provider: "github",
+          repoPath: "acme/web",
+          commands: ["pnpm test"],
+        }],
+      },
+    });
+    heads.set("/vercel/sandbox", "web-mutated");
+
+    await expect(
+      assertCurrentWorkspaceGate({
+        sandboxId: "sbx-1",
+        workspaceManifest: manifest,
+        gate: recovered,
       }),
     ).rejects.toMatchObject({ code: "workspace_changed" });
   });


### PR DESCRIPTION
## Bug
The finalize workspace gate reads `ctx.prePrGate`, which is ephemeral heap state. On a cold scheduler resume in a fresh Fluid instance the checks handler body never re-runs, so `ctx.prePrGate` is null even though checks passed, producing an intermittent false `missing_gate` at the publication boundary (checks green, no PR). Reproduced live on Arthur: `wrun_01M0AAWPJ105KXABTRPXDCFPFZ`.

## Fix
Durably checkpoint the gate `{configurationVersion, fingerprint}` in the block OUTPUT of the checks nodes, and recover it in `finalize_workspace` via `recoverPrePrGateFromSteps(steps)` when `ctx.prePrGate` is null (`ctx.prePrGate ?? recover...`). Covers BOTH check paths: `run_pre_pr_checks` (agent.ts) and `run_checks` (run-checks.ts); the durable `gate` field is optional/nullable in the block registry and kept out of `normalOutputRequired`, so old runs and replays still validate.

The publication-boundary guards are untouched: a recovered gate is still routed through the same checks, so guards 2 of 3 (`configuration_changed` on a bumped config version, `workspace_changed` on a mutated tracked-file fingerprint) still fail closed. When no step carries a gate the result stays null, so genuine misses still yield `missing_gate`.

Follow-up (documented in the `recoverPrePrGateFromSteps` SAFETY note): binding recovery to finalize's direct control-flow predecessor (threading definition edges into `EngineCtx`) would close the residual blind spot where a workspace-mutating node sits between checks and finalize.