### PR TITLE
fix(worker): carry the real cause when the pre-PR repair agent fails to launch

### DIFF
--- a/apps/worker/src/pre-pr-checks/runner.test.ts
+++ b/apps/worker/src/pre-pr-checks/runner.test.ts
@@ -25,6 +25,7 @@ vi.mock("../lib/logger.js", () => ({
   logger: {
     info: vi.fn(),
     warn: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -386,9 +387,86 @@ describe("runPrePrChecksWithFixes", () => {
     expect(result.fixCycles).toBe(1);
     expect(result.agentFailure).toMatchObject({
       category: "provider",
-      diagnostic: { failureKind: "cli_exit", exitCode: 7 },
+      diagnostic: {
+        failureKind: "cli_exit",
+        exitCode: 7,
+        detail: "The CLI exited with code 7.",
+      },
     });
     expect(checkRuns).toBe(1);
+  });
+
+  it("names the cause when the repair process cannot be launched at all", async () => {
+    // Production runs died here with a failure that named only the boundary:
+    // no exit code, no captured bytes, and the thrown error destroyed at the
+    // catch. Every distinct launch cause has to reach the run record instead.
+    const launchWith = (thrown: unknown) => {
+      mockRunCommand.mockImplementation((cmd, args) => {
+        if (isWrapperLaunch(cmd)) throw thrown;
+        if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+          return commandResult(0, JSON.stringify(manifest));
+        }
+        if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
+          return commandResult(0, "web-head");
+        }
+        if (isConfiguredCheck(cmd)) return commandResult(1, "", "still failing");
+        return commandResult(0, "");
+      });
+      return runPrePrChecksWithFixes(
+        "sbx-test-123",
+        { repositories: [config.repositories[0]!] },
+        "codex",
+        "gpt-5",
+      );
+    };
+
+    const reset = await launchWith(new Error("sandbox connection reset"));
+    expect(reset.agentFailure).toMatchObject({
+      diagnostic: {
+        failureKind: "setup_failed",
+        detail: expect.stringContaining("sandbox connection reset"),
+      },
+    });
+
+    const refused = await launchWith(
+      Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:443"), {
+        code: "ECONNREFUSED",
+      }),
+    );
+    expect(refused.agentFailure?.diagnostic.detail).toContain(
+      "ECONNREFUSED: connect ECONNREFUSED 10.0.0.1:443",
+    );
+  });
+
+  it("bounds a very long launch failure cause instead of embedding it whole", async () => {
+    const thrownMessage = "sandbox refused the launch. ".repeat(200);
+    mockRunCommand.mockImplementation((cmd, args) => {
+      if (isWrapperLaunch(cmd)) throw new Error(thrownMessage);
+      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+        return commandResult(0, JSON.stringify(manifest));
+      }
+      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
+        return commandResult(0, "web-head");
+      }
+      if (isConfiguredCheck(cmd)) return commandResult(1, "", "still failing");
+      return commandResult(0, "");
+    });
+
+    const result = await runPrePrChecksWithFixes(
+      "sbx-test-123",
+      { repositories: [config.repositories[0]!] },
+      "codex",
+      "gpt-5",
+    );
+
+    const detail = result.agentFailure?.diagnostic.detail ?? "";
+    expect(detail).toContain("The Pre-PR repair process could not be launched:");
+    expect(detail).not.toContain(thrownMessage);
+    // Sentence plus the bound the repair cause is clamped to, and nothing more,
+    // so a runaway error text cannot become the run status.
+    expect(detail.length).toBeLessThanOrEqual(
+      "The Pre-PR repair process could not be launched: ".length + 200,
+    );
   });
 
   it("keeps valid repair usage when malformed protocol output becomes an execution failure", async () => {
@@ -663,6 +741,18 @@ function isConfiguredCheck(cmd: unknown): boolean {
     objectCommand.cmd === "bash" &&
     Array.isArray(objectCommand.args) &&
     objectCommand.args.includes("pnpm typecheck")
+  );
+}
+
+function isWrapperLaunch(cmd: unknown): boolean {
+  const objectCommand = cmd as { cmd?: unknown; args?: unknown };
+  return (
+    typeof cmd === "object" &&
+    cmd !== null &&
+    objectCommand.cmd === "bash" &&
+    Array.isArray(objectCommand.args) &&
+    typeof objectCommand.args[0] === "string" &&
+    objectCommand.args[0].endsWith("-wrapper.sh")
   );
 }
 

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -26,6 +26,12 @@ import {
 
 export const MAX_PRE_PR_FIX_CYCLES = 3;
 
+/** Longest launch cause carried into the Pre-PR repair failure detail. Same
+ *  bound the workspace gate puts on a carried inspection reason (AIW-223): long
+ *  enough for a connection or spawn verdict, short enough that the composed
+ *  sentence stays a failure detail rather than a payload. */
+const PRE_PR_LAUNCH_CAUSE_MAX_LENGTH = 200;
+
 export interface PrePrCheckFailure {
   provider: WorkspaceRepo["provider"];
   repoPath: string;
@@ -396,15 +402,38 @@ async function runFixAgent(
     ) {
       throw error;
     }
-    const { protocolFailure } = await import("../sandbox/agents/protocol.js");
+    const { protocolFailure, redactDiagnosticText } = await import(
+      "../sandbox/agents/protocol.js"
+    );
+    const { logger } = await import("../lib/logger.js");
+    // The thrown error used to be discarded here, so a launch that never
+    // produced a process left no exit code, no bytes and no cause: the only
+    // reachable text named the boundary. Carry the reason, redacted and bounded
+    // exactly like a diagnostic tail so a runaway error text cannot become the
+    // run status. The kind is `setup_failed`, not `provider_error`: nothing was
+    // sent to a provider, this is the same "the phase never started" family as
+    // the chmod failure above, and calling it a provider error is what made
+    // every occurrence read as spent provider credits.
+    const code = (error as { code?: unknown }).code;
+    const label =
+      typeof code === "string" && code
+        ? code
+        : error instanceof Error
+          ? error.name
+          : "";
+    const message = error instanceof Error ? error.message : String(error);
+    const cause = redactDiagnosticText(
+      label && label !== "Error" ? `${label}: ${message}` : message,
+    ).slice(0, PRE_PR_LAUNCH_CAUSE_MAX_LENGTH);
+    logger.error({ phase, cause }, "pre_pr_repair_launch_failed");
     const failure = protocolFailure({
       spec: adapter.cliSpec,
       phase,
       artifacts: { stdout: "", stderr: "", structuredOutput: null, exitCode: null },
-      failureKind: "provider_error",
+      failureKind: "setup_failed",
       category: "provider",
       message: "The current agent phase could not be completed.",
-      detail: "The Pre-PR repair process could not be launched.",
+      detail: `The Pre-PR repair process could not be launched: ${cause}`,
     });
     if (failure.ok) throw new Error("unreachable");
     return { usage: null, failure };


### PR DESCRIPTION
The catch around the `sandbox.runCommand` that launches the pre-PR repair agent discarded the thrown error entirely: it was never attached to the failure and never logged. The recorded failure was hardcoded `provider_error` with `exitCode: null` and empty stdout/stderr, so the client saw only "The Pre-PR repair process could not be launched." with $0.00 usage and zero bytes, and the real cause was unrecoverable from the MCP API, the dashboard observation and the Vercel runtime logs alike.

The caught error's message (prefixed with its `code`, or its `name` when that is not the generic `Error`) is now redacted with the same `redactDiagnosticText` the diagnostic tails use, bounded at 200 characters like the inspection reason AIW-223 carries, appended to the existing detail sentence, and logged at error level as `pre_pr_repair_launch_failed`. The kind moves from `provider_error` to `setup_failed`: nothing was sent to a provider, this is the same "the phase never started" family as the chmod failure ten lines above, and `provider_error`'s candidate causes are literally what made every occurrence read as spent provider credits.

Affected production runs: wrun_01M0AFQMH36RFG34QFXD4SZG07 (2026-08-18) plus several on 2026-08-17, which we misattributed to OpenAI credits and sandbox instability for two days with no evidence either way.

Observability only: no change to the checks execution logic, the gate, or the cli_exit path. Three sibling launch catches (`workflows/agent.ts`, `blocks/fix-agent.ts`, `blocks/generic-agent.ts`) still discard their thrown error the same way and are deliberately left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kfeohXE66xx7RJPxZ2pvH