### PR TITLE
fix(worker): launch the pre-PR repair agent detached so it survives invocation boundaries

### DIFF
--- a/apps/worker/src/pre-pr-checks/runner.test.ts
+++ b/apps/worker/src/pre-pr-checks/runner.test.ts
@@ -396,6 +396,114 @@ describe("runPrePrChecksWithFixes", () => {
     expect(checkRuns).toBe(1);
   });
 
+  it("launches the repair wrapper detached and reads its sentinel instead of holding the command open", async () => {
+    // A blocking launch keeps one sandbox ndjson stream open for the whole
+    // repair agent. Production runs whose pre-PR checks crossed a function
+    // invocation boundary lost that stream mid-flight, and the SDK's parse
+    // error was reported as a launch that never produced a process: empty
+    // output, empty logs, no exit code, for an agent that was in fact running.
+    // The launch has to return before the agent finishes, and completion has to
+    // come from the wrapper's sentinel file.
+    vi.useFakeTimers();
+    try {
+      let checkRuns = 0;
+      let sentinelReads = 0;
+      let sentinelReadsWhenLaunchReturned = -1;
+      mockRunCommand.mockImplementation((cmd, args) => {
+        const artifact = phaseArtifactCommand(cmd, args, "codex");
+        if (artifact) return artifact;
+        if (isWrapperLaunch(cmd)) {
+          sentinelReadsWhenLaunchReturned = sentinelReads;
+          // A detached command has not exited when runCommand resolves.
+          return detachedCommand();
+        }
+        if (isSentinelRead(cmd, args)) {
+          sentinelReads++;
+          return commandResult(sentinelReads >= 2 ? 0 : 1);
+        }
+        if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+          return commandResult(0, JSON.stringify(manifest));
+        }
+        if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
+          return commandResult(0, "web-head");
+        }
+        if (isConfiguredCheck(cmd)) {
+          checkRuns++;
+          return checkRuns === 1
+            ? commandResult(1, "", "Type error")
+            : commandResult(0, "ok");
+        }
+        return commandResult(0, "");
+      });
+
+      const pending = runPrePrChecksWithFixes(
+        "sbx-test-123",
+        { repositories: [config.repositories[0]!] },
+        "codex",
+        "gpt-5",
+      );
+      const result = await drainPollTicks(pending);
+
+      expect(result.passed).toBe(true);
+      expect(result.fixCycles).toBe(1);
+      expect(result.agentFailure).toBeUndefined();
+      expect(mockRunCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cmd: "bash",
+          args: ["/tmp/pre-pr-fix-1-wrapper.sh"],
+          cwd: "/vercel/sandbox",
+          detached: true,
+        }),
+      );
+      expect(mockRunCommand).toHaveBeenCalledWith("test", [
+        "-f",
+        "/tmp/pre-pr-fix-1-done",
+      ]);
+      // The launch resolved before any sentinel existed, and the phase only
+      // ended once a later poll found one: completion is driven by the poll,
+      // not by the launch call.
+      expect(sentinelReadsWhenLaunchReturned).toBe(0);
+      expect(sentinelReads).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("propagates a deadline abort raised while the repair phase is polled", async () => {
+    // The deadline that used to abort the blocking launch now expires during
+    // the poll, and it must stay a real TimeoutError rather than become a
+    // "could not be launched" failure attributed to the provider.
+    let sentinelReads = 0;
+    mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex");
+      if (artifact) return artifact;
+      if (isWrapperLaunch(cmd)) return detachedCommand();
+      if (isSentinelRead(cmd, args)) {
+        sentinelReads++;
+        return commandResult(1);
+      }
+      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+        return commandResult(0, JSON.stringify(manifest));
+      }
+      if (isHeadInspection(cmd)) return commandResult(0, "web-head");
+      if (isConfiguredCheck(cmd)) return commandResult(1, "", "still failing");
+      return commandResult(0, "");
+    });
+
+    await expect(
+      runPrePrChecksWithFixes(
+        "sbx-test-123",
+        { repositories: [config.repositories[0]!] },
+        "codex",
+        "gpt-5",
+        3,
+        50,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+
+    expect(sentinelReads).toBeGreaterThan(0);
+  });
+
   it("names the cause when the repair process cannot be launched at all", async () => {
     // Production runs died here with a failure that named only the boundary:
     // no exit code, no captured bytes, and the thrown error destroyed at the
@@ -742,6 +850,40 @@ function isConfiguredCheck(cmd: unknown): boolean {
     Array.isArray(objectCommand.args) &&
     objectCommand.args.includes("pnpm typecheck")
   );
+}
+
+/** What a detached `runCommand` resolves to: the process is still running, so
+ *  there is no exit code yet. */
+function detachedCommand() {
+  return {
+    exitCode: null,
+    stdout: vi.fn().mockResolvedValue(""),
+    stderr: vi.fn().mockResolvedValue(""),
+  };
+}
+
+function isSentinelRead(cmd: unknown, args: unknown): boolean {
+  return cmd === "test" && Array.isArray(args) && args[0] === "-f";
+}
+
+/** Run the fake clock forward until the polled run settles, so a poll tick
+ *  costs the suite nothing. */
+async function drainPollTicks<T>(pending: Promise<T>): Promise<T> {
+  let settled = false;
+  const watched = pending.then(
+    (value) => {
+      settled = true;
+      return value;
+    },
+    (error) => {
+      settled = true;
+      throw error;
+    },
+  );
+  for (let tick = 0; tick < 20 && !settled; tick++) {
+    await vi.advanceTimersByTimeAsync(5_000);
+  }
+  return watched;
 }
 
 function isWrapperLaunch(cmd: unknown): boolean {

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -1,4 +1,7 @@
-import type { Sandbox as SandboxType } from "@vercel/sandbox";
+import type {
+  Command as SandboxCommand,
+  Sandbox as SandboxType,
+} from "@vercel/sandbox";
 import { getSandboxCredentials } from "../sandbox/credentials.js";
 import {
   parseWorkspaceManifest,
@@ -118,6 +121,7 @@ export async function runPrePrChecksWithFixes(
   while (!result.passed && fixCycles < maxFixCycles) {
     fixCycles++;
     const fixer = await runFixAgent(
+      sandboxId,
       sandbox,
       result,
       agentKind,
@@ -261,7 +265,57 @@ async function hasRepositoryChanged(
   return !repo.preAgentSha || repo.preAgentSha !== headSha;
 }
 
+/** How often the detached Pre-PR repair wrapper's sentinel file is read. The
+ *  phase polls inside the caller's step rather than across workflow ticks, so
+ *  the tick is a plain sleep and can be far shorter than the 30s ceiling in
+ *  workflows/blocks/poll-phase.ts. */
+const PRE_PR_REPAIR_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Wait for the detached repair wrapper to touch its sentinel file.
+ *
+ * The only bound is the caller's deadline `signal`, which is what bounded the
+ * blocking runCommand this replaced: an expired deadline rejects with the
+ * signal's own reason, so a real AbortError/TimeoutError still propagates out
+ * of the repair phase instead of being reported as a failed launch. Returns
+ * "stopped" when the sandbox is gone, the same verdict checkPhaseDone gives
+ * every other polled agent phase.
+ */
+async function waitForRepairPhase(
+  sandboxId: string,
+  sentinelFile: string,
+  signal?: AbortSignal,
+): Promise<"done" | "stopped"> {
+  const { checkPhaseDone } = await import("../sandbox/poll-agent.js");
+  for (;;) {
+    signal?.throwIfAborted();
+    const status = await checkPhaseDone(sandboxId, sentinelFile);
+    if (status === true) return "done";
+    if (status === "stopped") return "stopped";
+    await sleepUntilNextPoll(PRE_PR_REPAIR_POLL_INTERVAL_MS, signal);
+  }
+}
+
+function sleepUntilNextPoll(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 async function runFixAgent(
+  sandboxId: string,
   sandbox: SandboxSession,
   failedRun: PrePrCheckRunResult,
   agentKind: "claude" | "codex",
@@ -387,12 +441,21 @@ async function runFixAgent(
     if (failure.ok) throw new Error("unreachable");
     return { usage: null, failure };
   }
-  let launch: SandboxCommandResult;
+  let launch: SandboxCommand;
   try {
+    // Detached, like every other agent phase (see writeAndStartPhase in
+    // workflows/agent.ts): the sandbox SDK keeps one ndjson stream open for the
+    // whole of a blocking runCommand, and a repair agent outlives the function
+    // invocation that started it. When that invocation ends mid-stream the SDK
+    // raises a parse/stream error rather than an abort, which reached the
+    // generic catch below and reported a launch failure with no exit code and
+    // no bytes for an agent that was in fact running. A detached launch returns
+    // at once and completion is read from the wrapper's sentinel file instead.
     launch = await sandbox.runCommand({
       cmd: "bash",
       args: [paths.wrapper],
       cwd: "/vercel/sandbox",
+      detached: true,
       ...(signal ? { signal } : {}),
     });
   } catch (error) {
@@ -438,7 +501,9 @@ async function runFixAgent(
     if (failure.ok) throw new Error("unreachable");
     return { usage: null, failure };
   }
-  if (launch.exitCode !== 0) {
+  // A detached launch has no exit code yet while the wrapper runs; only a
+  // wrapper that already exited non-zero is a launch that failed.
+  if (launch.exitCode !== null && launch.exitCode !== 0) {
     const { commandProtocolFailure } = await import("../sandbox/agents/protocol.js");
     return {
       usage: null,
@@ -451,6 +516,21 @@ async function runFixAgent(
         detail: "The Pre-PR repair process could not be launched.",
       }),
     };
+  }
+  const phaseStatus = await waitForRepairPhase(sandboxId, paths.sentinel, signal);
+  if (phaseStatus === "stopped") {
+    const { protocolFailure } = await import("../sandbox/agents/protocol.js");
+    const failure = protocolFailure({
+      spec: adapter.cliSpec,
+      phase,
+      artifacts: { stdout: "", stderr: "", structuredOutput: null, exitCode: null },
+      failureKind: "provider_error",
+      category: "provider",
+      message: "The current agent phase could not be completed.",
+      detail: "The sandbox stopped before the Pre-PR repair process finished.",
+    });
+    if (failure.ok) throw new Error("unreachable");
+    return { usage: null, failure };
   }
   const artifacts = await collectPhaseFromSandbox(sandbox, paths);
   const usage = adapter.extractUsage(artifacts.stdout, artifacts.structuredOutput);


### PR DESCRIPTION
## Problem

Pre-PR repair runs died with a failure that named only the boundary: OUTPUT and LOGS were both empty, no exit code, no bytes, for a repair agent that was in fact running. Only runs whose pre-PR checks took 660-760s ever hit it.

## Mechanism

`runFixAgent` was the only agent launch in the codebase that was not detached:

```ts
launch = await sandbox.runCommand({ cmd: "bash", args: [paths.wrapper], cwd: "/vercel/sandbox", ...(signal ? { signal } : {}) });
```

A blocking `runCommand` makes the Vercel Sandbox SDK hold one ndjson stream open for the whole command (`sandbox.js` awaits `commandStream.finished`, `api-client.js` parses a final chunk). A repair agent outlives the function invocation that started it. When the invocation is frozen or killed mid-stream, the stream ends early and the SDK throws a `ZodError` (final chunk `undefined`) or a `StreamError`. Neither is an `AbortError`/`TimeoutError`, so the rethrow guard did not rethrow and the generic catch reported "the repair process could not be launched" with empty artifacts. That is why only the long-check runs were affected, and why the panels were blank.

## Fix

Convert the repair launch to the detached + poll shape every other agent phase already uses (`writeAndStartPhase` in `workflows/agent.ts`, `checkPhaseDone` in `sandbox/poll-agent.ts`):

- launch with `detached: true`, so `runCommand` returns at once and no stream is held open for the agent's lifetime;
- read the wrapper's sentinel file through the existing `checkPhaseDone` helper on a 5s tick;
- the caller's deadline `signal` is still the only bound, exactly as it was for the blocking call, and it rejects with the signal's own reason so a genuine `AbortError`/`TimeoutError` keeps propagating instead of turning into a bogus provider failure;
- the non-zero-exit branch now fires only for a wrapper that has already exited (`exitCode !== null && exitCode !== 0`), mirroring `agent.ts`;
- a sandbox that disappears mid-phase ends the wait with a named failure instead of looping.

The `chmod` `setup_failed` branch, the `cli_exit` classification, the artifact collection + usage extraction + protocol validation tail, and the cause-carrying catch added in #309 are all unchanged; the catch is now a backstop rather than the main path.

## Tests

`apps/worker/src/pre-pr-checks/runner.test.ts`, two new cases:

- **launches the repair wrapper detached and reads its sentinel instead of holding the command open** - asserts `detached: true` on the launch, that the launch resolves before any sentinel exists, and that the phase ends only once a later `test -f <sentinel>` poll finds one.
- **propagates a deadline abort raised while the repair phase is polled** - a deadline expiring during the poll still rejects with a `TimeoutError` rather than becoming an `agentFailure`.

Both fail against the blocking launch and pass with the fix. 20/20 in the file; worker `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
