### PR TITLE
feat(worker): add a setup phase to pre-PR checks

### DIFF
--- a/apps/dashboard/components/cockpit/screens/pre-pr-checks.tsx
+++ b/apps/dashboard/components/cockpit/screens/pre-pr-checks.tsx
@@ -30,7 +30,10 @@ export function PrePrChecksScreen({
   const savedRepos = versions[0]?.config.repositories ?? [];
   const dirty = JSON.stringify(repos) !== JSON.stringify(savedRepos);
   const valid = repos.every(
-    (r) => r.commands.length > 0 && r.commands.every((c) => c.trim().length > 0),
+    (r) =>
+      r.commands.length > 0 &&
+      r.commands.every((c) => c.trim().length > 0) &&
+      (r.setup ?? []).every((c) => c.trim().length > 0),
   );
 
   function applyVersion(version: PrePrCheckConfigVersion) {
@@ -134,6 +137,54 @@ export function PrePrChecksScreen({
                 Remove
               </button>
             )}
+          </div>
+          <div className="font-body text-[12px] font-semibold text-neutral-800">Setup</div>
+          <p className="font-body text-[11px] text-neutral-500 mb-[6px]">
+            Runs once before the checks below, for installing a toolchain the sandbox does not
+            ship. A failed setup command blocks the run and is never sent to the agent fix cycles.
+          </p>
+          {(repo.setup ?? []).map((command, si) => (
+            <div key={`setup-${si}`} className="flex items-center gap-2 mb-[6px]">
+              <span className="font-mono text-[11px] text-neutral-400 w-4 text-right">{si + 1}.</span>
+              <input
+                value={command}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  updateRepo(index, {
+                    ...repo,
+                    setup: (repo.setup ?? []).map((c, i) => (i === si ? e.target.value : c)),
+                  })
+                }
+                placeholder="make bootstrap"
+                className="flex-1 rounded-[3px] border border-neutral-200 bg-white px-2 py-[6px] font-mono text-[12px] text-neutral-900 disabled:bg-app-bg"
+              />
+              {canEdit && (
+                <button
+                  onClick={() =>
+                    updateRepo(index, {
+                      ...repo,
+                      setup: (repo.setup ?? []).filter((_, i) => i !== si),
+                    })
+                  }
+                  aria-label="Remove setup command"
+                  className="appearance-none border-none bg-transparent font-mono text-[13px] text-neutral-400 hover:text-red-600 cursor-pointer"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          ))}
+          {canEdit && (
+            <button
+              onClick={() => updateRepo(index, { ...repo, setup: [...(repo.setup ?? []), ""] })}
+              className="appearance-none border-none bg-transparent font-body text-[12px] text-mariner cursor-pointer px-0"
+            >
+              + Add setup command
+            </button>
+          )}
+
+          <div className="font-body text-[12px] font-semibold text-neutral-800 mt-3 mb-[6px]">
+            Checks
           </div>
           {repo.commands.map((command, ci) => (
             <div key={ci} className="flex items-center gap-2 mb-[6px]">

--- a/apps/shared/contracts/domain.ts
+++ b/apps/shared/contracts/domain.ts
@@ -225,6 +225,8 @@ export type VcsProviderKind = "github" | "gitlab";
 export interface PrePrCheckRepositoryConfig {
   provider: VcsProviderKind;
   repoPath: string;
+  /** Provisioning commands run before `commands`. Absent in older configs. */
+  setup?: string[];
   commands: string[];
 }
 

--- a/apps/worker/src/pre-pr-checks/config.test.ts
+++ b/apps/worker/src/pre-pr-checks/config.test.ts
@@ -16,6 +16,50 @@ describe("prePrCheckConfigSchema", () => {
     expect(prePrCheckConfigSchema.safeParse({ repositories: [] }).success).toBe(true);
   });
 
+  it("accepts a stored config with no setup key and defaults it to empty", () => {
+    const result = prePrCheckConfigSchema.safeParse({
+      repositories: [{ provider: "github", repoPath: "acme/web", commands: ["pnpm test"] }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repositories[0]!.setup).toEqual([]);
+    }
+  });
+
+  it("accepts per-repo setup commands and keeps their order", () => {
+    const result = prePrCheckConfigSchema.safeParse({
+      repositories: [
+        {
+          provider: "github",
+          repoPath: "acme/web",
+          setup: ["make bootstrap", "make deps"],
+          commands: ["make lint"],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.repositories[0]!.setup).toEqual(["make bootstrap", "make deps"]);
+    }
+  });
+
+  it("accepts an empty setup list but rejects a blank setup command", () => {
+    expect(
+      prePrCheckConfigSchema.safeParse({
+        repositories: [
+          { provider: "github", repoPath: "acme/web", setup: [], commands: ["pnpm test"] },
+        ],
+      }).success,
+    ).toBe(true);
+    expect(
+      prePrCheckConfigSchema.safeParse({
+        repositories: [
+          { provider: "github", repoPath: "acme/web", setup: ["   "], commands: ["pnpm test"] },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+
   it("rejects a repository with no commands", () => {
     const result = prePrCheckConfigSchema.safeParse({
       repositories: [{ provider: "github", repoPath: "acme/web", commands: [] }],

--- a/apps/worker/src/pre-pr-checks/config.ts
+++ b/apps/worker/src/pre-pr-checks/config.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 export interface PrePrCheckRepositoryConfig {
   provider: "github" | "gitlab";
   repoPath: string;
+  /**
+   * Provisioning commands run before this repository's checks: toolchain
+   * installs the sandbox image does not ship. Optional and absent from every
+   * config stored before this field existed, so it must stay defaultable.
+   */
+  setup?: string[];
   commands: string[];
 }
 
@@ -19,6 +25,9 @@ export const prePrCheckConfigSchema = z
         .object({
           provider: z.enum(["github", "gitlab"]),
           repoPath: z.string().trim().min(1),
+          // No .min(1): a repository without provisioning is the normal case,
+          // and every config stored before this field omits the key entirely.
+          setup: z.array(z.string().trim().min(1)).default([]),
           commands: z.array(z.string().trim().min(1)).min(1),
         })
         .strict(),

--- a/apps/worker/src/pre-pr-checks/runner.test.ts
+++ b/apps/worker/src/pre-pr-checks/runner.test.ts
@@ -178,6 +178,147 @@ describe("runPrePrChecksWithFixes", () => {
     expect(result.failures).toHaveLength(1);
   });
 
+  it("runs a repository's setup commands before its checks, in authored order", async () => {
+    const shellCommands: string[] = [];
+    mockRunCommand.mockImplementation((cmd, args) => {
+      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+        return commandResult(0, JSON.stringify(manifest));
+      }
+      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
+        return commandResult(0, "web-head");
+      }
+      const shell = shellCommand(cmd);
+      if (shell) shellCommands.push(shell);
+      return commandResult(0, "");
+    });
+
+    const result = await runPrePrChecksWithFixes(
+      "sbx-test-123",
+      {
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/web",
+            setup: ["make bootstrap", "make deps"],
+            commands: ["pnpm typecheck"],
+          },
+        ],
+      },
+      "codex",
+      "gpt-5",
+      0,
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.setupFailed).toBe(false);
+    expect(shellCommands).toEqual(["make bootstrap", "make deps", "pnpm typecheck"]);
+    expect(mockRunCommand).toHaveBeenCalledWith({
+      cmd: "bash",
+      args: ["-lc", "make bootstrap"],
+      cwd: "/vercel/sandbox",
+    });
+  });
+
+  it("stops a repository's checks and runs no fix cycles when its setup fails", async () => {
+    const shellCommands: string[] = [];
+    mockRunCommand.mockImplementation((cmd, args) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex");
+      if (artifact) return artifact;
+      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+        return commandResult(0, JSON.stringify(manifest));
+      }
+      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
+        return commandResult(0, "web-head");
+      }
+      const shell = shellCommand(cmd);
+      if (shell) {
+        shellCommands.push(shell);
+        if (shell === "make bootstrap") {
+          return commandResult(127, "", "bash: line 1: toolchain: command not found");
+        }
+      }
+      return commandResult(0, "");
+    });
+
+    const result = await runPrePrChecksWithFixes(
+      "sbx-test-123",
+      {
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/web",
+            setup: ["make bootstrap"],
+            commands: ["pnpm typecheck"],
+          },
+        ],
+      },
+      "codex",
+      "gpt-5",
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.setupFailed).toBe(true);
+    expect(result.fixCycles).toBe(0);
+    expect(result.results).toEqual([]);
+    expect(shellCommands).toEqual(["make bootstrap"]);
+    expect(mockWriteFiles).not.toHaveBeenCalled();
+  });
+
+  it("reports a setup failure distinctly from a check failure", async () => {
+    mockRunCommand.mockImplementation((cmd, args) => {
+      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+        return commandResult(0, JSON.stringify(manifest));
+      }
+      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
+        return commandResult(0, "changed-head");
+      }
+      const shell = shellCommand(cmd);
+      if (shell === "make bootstrap") {
+        return commandResult(127, "", "bash: line 1: toolchain: command not found");
+      }
+      if (shell === "pnpm test") return commandResult(1, "", "2 tests failed");
+      return commandResult(0, "");
+    });
+
+    const result = await runPrePrChecksWithFixes(
+      "sbx-test-123",
+      {
+        repositories: [
+          {
+            provider: "github",
+            repoPath: "acme/web",
+            setup: ["make bootstrap"],
+            commands: ["pnpm typecheck"],
+          },
+          { provider: "gitlab", repoPath: "acme/api", commands: ["pnpm test"] },
+        ],
+      },
+      "codex",
+      "gpt-5",
+      0,
+    );
+
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0]).toMatchObject({
+      provider: "github",
+      repoPath: "acme/web",
+      command: "make bootstrap",
+      exitCode: 127,
+      phase: "setup",
+    });
+    expect(result.failures[1]).toMatchObject({
+      provider: "gitlab",
+      repoPath: "acme/api",
+      command: "pnpm test",
+    });
+    expect(result.failures[1]!.phase).toBeUndefined();
+    expect(result.summary).toContain("SETUP FAILED for github:acme/web");
+    expect(result.summary).toContain("toolchain: command not found");
+    expect(result.summary).toContain("no agent fix cycles were run");
+    expect(result.summary).toContain("gitlab:acme/api");
+    expect(result.summary).not.toContain("SETUP FAILED for gitlab:acme/api");
+  });
+
   it("fails a check that exits 0 while reporting its dependencies are not installed", async () => {
     mockRunCommand.mockImplementation((cmd, args) => {
       if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
@@ -729,6 +870,22 @@ function phaseArtifactCommand(
   if (path.endsWith("-stderr.txt")) return commandResult(0, "");
   if (path.endsWith("-exit-code")) return commandResult(0, String(phaseExitCode));
   if (path.endsWith("-result.json")) return commandResult(0, "repair complete");
+  return null;
+}
+
+/** The shell command text of a `bash -lc` invocation, or null for anything else. */
+function shellCommand(cmd: unknown): string | null {
+  const objectCommand = cmd as { cmd?: unknown; args?: unknown };
+  if (
+    typeof cmd === "object" &&
+    cmd !== null &&
+    objectCommand.cmd === "bash" &&
+    Array.isArray(objectCommand.args) &&
+    objectCommand.args[0] === "-lc" &&
+    typeof objectCommand.args[1] === "string"
+  ) {
+    return objectCommand.args[1];
+  }
   return null;
 }
 

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -39,6 +39,12 @@ export interface PrePrCheckFailure {
   exitCode: number;
   stdout: string;
   stderr: string;
+  /**
+   * Present when the failing command came from the repository's `setup` phase
+   * instead of its checks. A setup failure means the workspace could not be
+   * provisioned, which no code edit can repair.
+   */
+  phase?: "setup";
 }
 
 export type CheckOutcome =
@@ -64,6 +70,8 @@ export interface PrePrCheckRunResult {
   /** Every normally started command, in workspace/repository and authored command order. */
   results: PrePrCheckCommandResult[];
   failures: PrePrCheckFailure[];
+  /** True when at least one repository's setup phase failed. Suppresses fix cycles. */
+  setupFailed: boolean;
   summary: string;
   /** Runtime/protocol failure from a launched repair agent. */
   agentFailure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
@@ -100,6 +108,7 @@ export async function runPrePrChecksWithFixes(
       budgetFailure: null,
       results: [],
       failures: [],
+      setupFailed: false,
       summary: "No pre-PR checks configured.",
     };
   }
@@ -115,7 +124,11 @@ export async function runPrePrChecksWithFixes(
   const fixCycleUsages: Array<PhaseUsage | null> = [];
   let budgetState = budget?.state;
 
-  while (!result.passed && fixCycles < maxFixCycles) {
+  // A setup failure never enters the repair loop: the workspace is missing a
+  // tool the checks need, and no edit the fixer can make to the repository will
+  // install it. Before this guard the platform spent its whole fix budget
+  // rewriting code in response to "command not found".
+  while (!result.passed && !result.setupFailed && fixCycles < maxFixCycles) {
     fixCycles++;
     const fixer = await runFixAgent(
       sandbox,
@@ -158,20 +171,31 @@ async function runConfiguredPrePrChecks(
 ): Promise<PrePrCheckRunResult> {
   const manifest = await readWorkspaceManifest(sandbox);
   const checksByRepo = new Map(
-    config.repositories.map((repo) => [repositoryKey(repo), repo.commands]),
+    config.repositories.map((repo) => [repositoryKey(repo), repo]),
   );
   const results: PrePrCheckCommandResult[] = [];
   const failures: PrePrCheckFailure[] = [];
   let ranChecks = 0;
+  let setupFailed = false;
 
   for (const repo of manifest.repositories) {
-    const commands = checksByRepo.get(repositoryKey(repo));
-    if (!commands) continue;
+    const configured = checksByRepo.get(repositoryKey(repo));
+    if (!configured) continue;
 
     const changed = await hasRepositoryChanged(sandbox, repo, signal);
     if (!changed) continue;
 
-    for (const command of commands) {
+    const setupFailure = await runRepositorySetup(sandbox, repo, configured.setup ?? [], signal);
+    if (setupFailure) {
+      // The repository could not be provisioned, so its checks would only
+      // report the same missing tooling once per command. Stop here and let the
+      // next repository still run.
+      setupFailed = true;
+      failures.push(setupFailure);
+      continue;
+    }
+
+    for (const command of configured.commands) {
       ranChecks++;
       const result = await sandbox.runCommand({
         cmd: "bash",
@@ -218,12 +242,49 @@ async function runConfiguredPrePrChecks(
     budgetFailure: null,
     results,
     failures,
+    setupFailed,
     summary: failures.length > 0
       ? formatPrePrCheckFailures(failures)
       : ranChecks === 0
         ? "No pre-PR checks matched changed repositories."
         : `Pre-PR checks passed (${ranChecks} command${ranChecks === 1 ? "" : "s"}).`,
   };
+}
+
+/**
+ * Runs a repository's provisioning commands, in authored order, before its
+ * checks. Returns the first failure, or null when every command exited 0.
+ * These commands install the toolchain the checks need (the sandbox image ships
+ * one runtime only), so they run in the repository directory through the same
+ * login shell the checks use and any PATH they export through the shell profile
+ * is visible to later commands.
+ */
+async function runRepositorySetup(
+  sandbox: SandboxSession,
+  repo: WorkspaceRepo,
+  setup: string[],
+  signal?: AbortSignal,
+): Promise<PrePrCheckFailure | null> {
+  for (const command of setup) {
+    const result = await sandbox.runCommand({
+      cmd: "bash",
+      args: ["-lc", command],
+      cwd: repo.localPath,
+      ...(signal ? { signal } : {}),
+    });
+    if (result.exitCode !== 0) {
+      return {
+        provider: repo.provider,
+        repoPath: repo.repoPath,
+        command,
+        exitCode: result.exitCode,
+        stdout: await commandStdout(result),
+        stderr: await commandStderr(result),
+        phase: "setup",
+      };
+    }
+  }
+  return null;
 }
 
 async function readWorkspaceManifest(sandbox: SandboxSession): Promise<WorkspaceManifest> {
@@ -497,14 +558,24 @@ function formatPrePrCheckFailures(failures: PrePrCheckFailure[]): string {
         .join("\n")
         .slice(0, 2_000);
       return [
-        `${failure.provider}:${failure.repoPath}`,
+        failure.phase === "setup"
+          ? `SETUP FAILED for ${failure.provider}:${failure.repoPath}`
+          : `${failure.provider}:${failure.repoPath}`,
         `Command: ${failure.command}`,
         `Exit code: ${failure.exitCode}`,
         output ? `Output:\n${output}` : "Output: (empty)",
+        ...(failure.phase === "setup" ? [SETUP_FAILURE_REASON] : []),
       ].join("\n");
     })
     .join("\n\n");
 }
+
+const SETUP_FAILURE_REASON =
+  "This is a setup command, not a check: it runs once before this repository's " +
+  "checks to provision its toolchain. The repository's checks were skipped and " +
+  "no agent fix cycles were run, because editing the code cannot repair a " +
+  "workspace that could not be provisioned. Fix the setup command in the " +
+  "dashboard's Pre-PR checks configuration.";
 
 function repositoryKey(repo: Pick<WorkspaceRepo, "provider" | "repoPath">): string {
   return `${repo.provider}:${repo.repoPath}`;

--- a/apps/worker/src/pre-pr-checks/store.test.ts
+++ b/apps/worker/src/pre-pr-checks/store.test.ts
@@ -15,6 +15,16 @@ const CONFIG_A: PrePrCheckConfig = {
 const CONFIG_B: PrePrCheckConfig = {
   repositories: [{ provider: "gitlab", repoPath: "acme/api", commands: ["bun test"] }],
 };
+const CONFIG_WITH_SETUP: PrePrCheckConfig = {
+  repositories: [
+    {
+      provider: "github",
+      repoPath: "acme/service",
+      setup: ["make bootstrap", "make deps"],
+      commands: ["make lint"],
+    },
+  ],
+};
 const ACTOR = { actorRole: "admin" as const, actorId: "user_admin", actorLabel: "admin@example.com" };
 
 let db: Db;
@@ -41,6 +51,19 @@ describe("pre-PR check config store", () => {
 
     const versions = await listPrePrCheckConfigVersions(db);
     expect(versions.map((v) => v.version)).toEqual([v2.version, v1.version]);
+  });
+
+  it("round-trips a repository setup phase", async () => {
+    const saved = await savePrePrCheckConfig(db, { ...ACTOR, config: CONFIG_WITH_SETUP });
+    expect(saved.config).toEqual(CONFIG_WITH_SETUP);
+    expect((await getCurrentPrePrCheckConfig(db))?.config).toEqual(CONFIG_WITH_SETUP);
+  });
+
+  it("keeps a config saved without a setup key readable as-is", async () => {
+    await savePrePrCheckConfig(db, { ...ACTOR, config: CONFIG_A });
+    const current = await getCurrentPrePrCheckConfig(db);
+    expect(current?.config).toEqual(CONFIG_A);
+    expect(current?.config.repositories[0]!.setup).toBeUndefined();
   });
 
   it("rejects writes from members with 403", async () => {

--- a/apps/worker/src/routes/api/v1/pre-pr-checks.test.ts
+++ b/apps/worker/src/routes/api/v1/pre-pr-checks.test.ts
@@ -92,7 +92,10 @@ describe("PUT /api/v1/pre-pr-checks", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.version.version).toBe(1);
-    expect(body.version.config).toEqual(VALID_CONFIG);
+    // A body without a setup key is stored with the phase normalized to empty.
+    expect(body.version.config).toEqual({
+      repositories: [{ ...VALID_CONFIG.repositories[0], setup: [] }],
+    });
     expect(body.version.createdByLabel).toBe("Admin");
   });
 


### PR DESCRIPTION
## The production failure

A client tenant's pre-PR checks all fail with `bash: line 1: uv: command not found` (exit 127). The Run Workspace sandbox is created with a hardcoded `runtime: "node24"` (`apps/worker/src/sandbox/manager.ts`), which ships no Python toolchain, and two of the tenant's three repositories need `uv`:

```
cd genai-engine && uv sync --frozen --group dev --group linters
cd scope/app_plane && uv sync --frozen && uv pip install -r ../lint_requirements.txt
```

The check configuration had no place to install a toolchain. Each check command runs as its own `bash -lc` invocation, so an install folded into command 1 does not reliably reach command 2. Worse, every one of those failures then burned the full repair budget (up to 3 fix cycles, roughly 800 seconds) asking the agent to edit code that can never install a missing binary.

## What this adds

An optional per-repository `setup: string[]` in the pre-PR check configuration.

- **Runs before the repository's checks**, in authored order, in the repository directory, through the same login shell the checks use, so a PATH the install exports through the shell profile is visible to every later command.
- **A failed setup command stops that repository's checks** and marks the run's checks as not passed. Other repositories still run.
- **A setup failure never enters the fix-agent loop.** `runPrePrChecksWithFixes` now guards the repair loop on `!result.setupFailed`: no code edit can provision a workspace, so spending the repair budget on it is pure waste.
- **It is reported distinctly.** A setup failure carries `phase: "setup"` and renders as `SETUP FAILED for <provider>:<repoPath>` with the command, exit code, output, and a sentence saying the checks were skipped, no fix cycles were run, and the fix belongs in the dashboard configuration, not in the code.

The feature is generic: nothing about `uv`, Python, or any specific toolchain is hardcoded, and the sandbox runtime is unchanged.

## Compatibility

`setup` is optional with a `.default([])`, so every stored configuration (none of which has the key) still parses under the schema's `.strict()`. `commands` keeps its `.min(1)`; `setup` has no minimum. The config lives in a single `jsonb` column (`pre_pr_check_config_versions.config`), so **no migration is needed** and the store round-trips the new field unchanged.

One visible normalization: a config saved through `PUT /api/v1/pre-pr-checks` now comes back with `setup: []` filled in per repository.

## Dashboard

`/checks` gains a "Setup" list per repository above a newly labelled "Checks" list, mirroring the commands list exactly (edit, add, remove), with the caption: runs once before the checks below, for installing a toolchain the sandbox does not ship; a failed setup command blocks the run and is never sent to the agent fix cycles.

## Behavioral note

Setup runs as part of a repository's check execution rather than being memoized across repair cycles. In practice this changes nothing for the failure this PR targets, since a setup failure short-circuits the repair loop entirely; and when a *check* fails, re-running the provisioning step is what lets the checks see any dependency the fixer just added.

## Verification

```
 ✓ src/pre-pr-checks/config.test.ts (8 tests)
 ✓ src/pre-pr-checks/runner.test.ts (21 tests)
 ✓ src/pre-pr-checks/store.test.ts (8 tests)
 Test Files  3 passed (3)
      Tests  37 passed (37)
```

Plus the routes and blocks that consume the config: `pre-pr-checks.test.ts`, `run-checks.test.ts`, `io-blocks.edge.test.ts`, `workspace-gate.test.ts`, 73 passed (73). `worker` and `ai-workflow-dashboard` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
