### PR TITLE
fix(worker): mirror the pre-PR gate output in the workflow block catalog

### DIFF
--- a/docs/workflow-workspace/index.html
+++ b/docs/workflow-workspace/index.html
@@ -1060,6 +1060,7 @@
             ...typedPaths("number", "fixCycles"),
             ...typedPaths("string", "outcome", "summary"),
           ],
+          optionalOutputs: typedPaths("object | null", "gate"),
           statuses: ["ok"],
         }),
         run_checks: runtimeContract(["commands"], {
@@ -1069,7 +1070,10 @@
             ...typedPaths("string", "outcome"),
             ...typedPaths("unknown[]", "results", "failures"),
           ],
-          optionalOutputs: typedPaths("string", "skipReason"),
+          optionalOutputs: [
+            ...typedPaths("string", "skipReason"),
+            ...typedPaths("object | null", "gate"),
+          ],
           statuses: ["ok"],
         }),
         transform: runtimeContract([], {


### PR DESCRIPTION
## Problem

`main` has been red since b9334a62 (#307). That PR added an optional `gate` output to `run_pre_pr_checks` and `run_checks` in the worker block registry, but did not mirror it in the hand-maintained canvas catalog, so `block-catalog-sync.test.ts > is a bijection with the worker registry and exactly mirrors every default contract` fails.

Four commits on main have shipped over a red suite as a result, including two Artur releases (2026.08.5, 2026.08.6). The release pipeline gates on snapshot integrity, not on source CI, so nothing stopped them.

## Fix

Add the same optional output to both blocks in `docs/workflow-workspace/index.html`.

`gate` is `nullableType(objectType({configurationVersion, fingerprint}))` and is deliberately kept out of `normalOutputRequired`, so in catalog terms it is an **optional** output. The test's `outputPaths` only recurses into `schema.type === "object"`, and this schema is `nullable`, so it contributes exactly one path (`gate`) whose `schemaType` renders as `object | null` - not three nested paths.

## Verification

CI on this PR is the verification: the failing test is part of the standard suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)