### PR TITLE
chore(release): gate the Artur sync on green source CI and a recorded rehearsal

### DIFF
--- a/.github/workflows/sync-artur-release.yml
+++ b/.github/workflows/sync-artur-release.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  # Reading the CI verdict of the released commit needs the Actions API. The
+  # Artur App token minted later in this job is scoped to ai-workflow-arthur
+  # and cannot read this repository, so the source CI gate uses the job token.
+  actions: read
 
 concurrency:
   group: artur-release-sync
@@ -76,6 +80,42 @@ jobs:
         run: |
           echo "target_sha=$(jq -r '.targetSourceCommit' .release-notes/approved-source.json)" >> "$GITHUB_OUTPUT"
           echo "notes_pr=$(jq -r '.releaseNotesPullRequest' .release-notes/approved-source.json)" >> "$GITHUB_OUTPUT"
+      - name: Require green source CI at the released commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ steps.source.outputs.target_sha }}
+        run: |
+          # Only push runs judge main. A manual dispatch or a merge-group run
+          # can share this SHA, and dispatches cancel each other through the CI
+          # concurrency group, so counting them would let a stray cancelled run
+          # block a release the push run already passed.
+          runs="$(gh api --paginate --slurp \
+            "repos/Blazity/ai-workflow/actions/workflows/ci.yml/runs?head_sha=$TARGET_SHA&per_page=100" \
+            | jq '[.[].workflow_runs[] | select(.event == "push") | {status, conclusion, url: .html_url}]')"
+          if [[ "$(jq 'length' <<<"$runs")" -eq 0 ]]; then
+            echo "No CI push run exists for $TARGET_SHA, so the released commit was never verified on main. Missing CI is not a pass: run CI on that commit, and release only once it is green." >&2
+            exit 1
+          fi
+          pending="$(jq -r '[.[] | select(.status != "completed") | .url] | join(", ")' <<<"$runs")"
+          if [[ -n "$pending" ]]; then
+            echo "CI has not finished at $TARGET_SHA: $pending. Wait for the run to complete, then rerun this synchronization from Actions." >&2
+            exit 1
+          fi
+          # A cancelled, skipped, failed, timed-out or action_required push
+          # run all land here. Only an explicit success releases.
+          failed="$(jq -r '[.[] | select(.conclusion != "success") | "\(.conclusion // "no conclusion") \(.url)"] | join("; ")' <<<"$runs")"
+          if [[ -n "$failed" ]]; then
+            echo "CI did not succeed at $TARGET_SHA: $failed. Fix the source, cut the release from a commit whose CI is green, and do not ship over a red main." >&2
+            exit 1
+          fi
+      - name: Require a recorded green rehearsal at the released commit
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          TARGET_SHA: ${{ steps.source.outputs.target_sha }}
+        run: |
+          pnpm release-notes validate-rehearsal \
+            --version "$VERSION" \
+            --source-commit "$TARGET_SHA"
       - name: Check out immutable source snapshot
         uses: actions/checkout@v4
         with:

--- a/docs/releases/artur/README.md
+++ b/docs/releases/artur/README.md
@@ -14,7 +14,9 @@ its Vercel production deployment and smoke tests succeed.
    edit the non-technical English wording where needed, and approve it. Before
    merging, run the tenant-database check in
    [`upgrade-preflight.md`](upgrade-preflight.md). Merge only after the check
-   identifies no unrepaired deployed workflows.
+   identifies no unrepaired deployed workflows. Rehearse the pinned
+   `targetSourceCommit` and merge its record first; synchronization refuses to
+   run without one, see [`rehearsals/README.md`](rehearsals/README.md).
 3. The merge automatically runs **Sync Approved Artur Release**. It copies the
    complete application tree from the pinned `targetSourceCommit` into a new
    `release/artur-<version>` branch in `Blazity/ai-workflow-arthur`.

--- a/docs/releases/artur/rehearsals/README.md
+++ b/docs/releases/artur/rehearsals/README.md
@@ -1,0 +1,117 @@
+# Artur release rehearsals
+
+A rehearsal is one real end-to-end run on our own production instance, at the
+exact source commit the release ships, against a repository whose pre-PR checks
+have the same shape as the client's: a toolchain setup phase followed by long
+running checks. The run must reach the **open pull request** node green.
+
+**Sync Approved Artur Release** refuses to touch `Blazity/ai-workflow-arthur`
+until a rehearsal record for the released version exists here and matches the
+released commit. Two releases have already gone out over a red source `main`,
+one of them broke the client, because snapshot integrity and an approved
+release-note pull request were the only gates.
+
+## Order of operations
+
+The order is not free. `targetSourceCommit` is frozen into the release note's
+YAML front matter when **Prepare Artur Release** runs, and the synchronization
+gate compares the rehearsal against that frozen SHA. A rehearsal recorded
+before preparation cannot match it, because merging the rehearsal record itself
+moves the tip of `main`. Follow this sequence:
+
+1. Run **Actions → Prepare Artur Release** for the version. It pins
+   `targetSourceCommit` into `docs/releases/artur/<version>.md`.
+2. Read the pinned SHA out of the front matter of that generated note. That is
+   the SHA to rehearse, and nothing else passes the gate.
+3. Deploy that exact SHA to our own production and run the rehearsal (below).
+4. Commit `docs/releases/artur/rehearsals/<version>.json` with `sourceCommit`
+   set to the pinned SHA, and merge it in its own pull request. It cannot ride
+   along with the release note: `validate-source` requires the release-note
+   pull request to change exactly one file, the note itself.
+5. Merge the release-note pull request. That merge starts the synchronization,
+   which reads the rehearsal record from `main` and finds both gates satisfied.
+
+**Run preparation once.** Re-running it after other commits land moves the
+pinned target, and a rehearsal recorded against the old target no longer
+matches, so the synchronization aborts until you rehearse the new SHA.
+
+## Running one
+
+1. Make sure production runs a deployment built from the pinned SHA.
+2. Dispatch a workflow on production against a fixture repository with real
+   check commands, for example `Blazity/aiw-checks-fixture`. Its checks must
+   install a toolchain and then run the real suite. Stub commands such as
+   `echo ok` do not count, see the floor below.
+3. Watch the run to the **open pull request** node. If it stops earlier, or
+   stops on a clarification, there is no rehearsal: fix the cause and run again.
+4. Read the duration of the checks phase from the run trace and record the run.
+
+## Recording one
+
+Write `docs/releases/artur/rehearsals/<version>.json`, with every field present
+and no extra fields:
+
+```json
+{
+  "version": "2026.08.8",
+  "sourceCommit": "0123456789abcdef0123456789abcdef01234567",
+  "runId": "wrun_01K5NRQ8ABCDEF",
+  "runUrl": "https://ai-workflow.blazity.com/runs/wrun_01K5NRQ8ABCDEF",
+  "repository": "Blazity/aiw-checks-fixture",
+  "checksDurationSec": 1180,
+  "outcome": "success",
+  "recordedAt": "2026-08-19T10:00:00Z",
+  "recordedBy": "someone@blazity.com"
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `version` | The version being released, matching the file name. |
+| `sourceCommit` | 40 lowercase hex characters, the pinned `targetSourceCommit`. |
+| `runId` | The production run id, `wrun_...`. |
+| `runUrl` | Absolute link to that run, so a reviewer can reopen it. |
+| `repository` | `owner/name` of the rehearsed repository. |
+| `checksDurationSec` | Whole seconds the checks phase took, from the trace. |
+| `outcome` | Exactly `success`, nothing else passes. |
+| `recordedAt` | ISO 8601 UTC timestamp, such as `2026-08-19T10:00:00Z`. |
+| `recordedBy` | The person who ran the rehearsal and can answer for it. |
+
+To check a record before merging anything:
+
+```bash
+pnpm release-notes validate-rehearsal --version <version> --source-commit <target_sha>
+```
+
+## Why checks must run at least 300 seconds
+
+Vercel allows 300 seconds per invocation. The client outage came from a check
+batch that outlived a single invocation, so a rehearsal that finishes inside
+one invocation never reaches the failure mode that actually bit the client. A
+run whose checks finished in 12 seconds because they were `echo ok` stubs
+proves the pipeline can open a pull request and proves nothing else.
+
+This is not hypothetical. The client configuration "worked" for weeks precisely
+because its heaviest repository had no check commands configured at all, so
+nothing ever ran long enough to cross the limit until it did.
+
+A rehearsal below the floor is rejected. Do not lower the floor to make a
+release pass: give the fixture repository checks that really take longer than
+five minutes.
+
+## Worked example of a run that must NOT be recorded
+
+Run `wrun_01M0CGC9GEMEBC3THA2DNBECNJ` on our production reproduced the client
+failure. Its `checks` node lived 358631 ms and then died with:
+
+```
+Step "step//./src/workflows/agent//runPrePrChecksStep" failed after 0 retries: terminated
+```
+
+358 seconds is above the 300 second floor, so duration alone would have let
+this through. The run never reached the **open pull request** node, so its
+`outcome` is not `success` and the gate rejects it. Duration proves the checks
+were long enough to be worth believing; `outcome` proves they actually passed.
+Both fields are required, and neither substitutes for the other. Recording this
+run with `"outcome": "success"` would be a false statement about production,
+and it is exactly the shape of release that broke the client.

--- a/scripts/release-notes/cli.ts
+++ b/scripts/release-notes/cli.ts
@@ -10,6 +10,7 @@ import { collectRelease } from "./collect.js";
 import { generateReleaseDraft } from "./generate.js";
 import { parseVersion } from "./classify.js";
 import { validateApprovedSourceRelease } from "./manifest.js";
+import { validateRehearsalEvidence } from "./rehearsal.js";
 import { extractShareableNotes, renderReleaseNotes } from "./render.js";
 import {
   findUnbackportedDestinationCommits,
@@ -195,6 +196,22 @@ async function validateSourceCommand(
   await mkdir(path.dirname(outputPath), { recursive: true });
   await writeFile(outputPath, `${JSON.stringify(validation, null, 2)}\n`);
   return validation;
+}
+
+async function validateRehearsalCommand(argv: string[]): Promise<unknown> {
+  const version = parseVersion(requiredArg(argv, "version"));
+  const rehearsalPath = path.resolve(
+    arg(
+      argv,
+      "rehearsal",
+      path.join("docs", "releases", "artur", "rehearsals", `${version}.json`),
+    ),
+  );
+  return validateRehearsalEvidence({
+    version,
+    sourceCommit: requiredArg(argv, "source-commit"),
+    rehearsalPath,
+  });
 }
 
 async function shareableCommand(argv: string[]): Promise<unknown> {
@@ -397,6 +414,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<unknow
     "guard-artur": () => guardArturCommand(argv),
     "validate-source": () =>
       validateSourceCommand(argv, deps.validate ?? validateApprovedSourceRelease),
+    "validate-rehearsal": () => validateRehearsalCommand(argv),
     "sync-artur": () => syncArturCommand(argv, deps),
     shareable: () => shareableCommand(argv),
   };
@@ -404,7 +422,7 @@ export async function runCli(argv: string[], deps: CliDeps = {}): Promise<unknow
   const execute = commands[command];
   if (!execute) {
     throw new Error(
-      "Usage: pnpm release-notes <prepare|guard-artur|validate-source|sync-artur|shareable> [options]",
+      "Usage: pnpm release-notes <prepare|guard-artur|validate-source|validate-rehearsal|sync-artur|shareable> [options]",
     );
   }
   return execute();

--- a/scripts/release-notes/rehearsal.test.ts
+++ b/scripts/release-notes/rehearsal.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runCli } from "./cli.js";
+import { validateRehearsalEvidence } from "./rehearsal.js";
+
+const version = "2026.08.8";
+const sourceCommit = "b".repeat(40);
+
+function rehearsal(overrides: Record<string, unknown> = {}) {
+  return {
+    version,
+    sourceCommit,
+    runId: "wrun_01K5NRQ8ABCDEF",
+    runUrl: "https://ai-workflow.blazity.com/runs/wrun_01K5NRQ8ABCDEF",
+    repository: "Blazity/aiw-checks-fixture",
+    checksDurationSec: 1180,
+    outcome: "success",
+    recordedAt: "2026-08-19T10:00:00Z",
+    recordedBy: "someone@blazity.com",
+    ...overrides,
+  };
+}
+
+async function recordPath(contents: string): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "artur-rehearsal-"));
+  const file = path.join(directory, `${version}.json`);
+  await writeFile(file, contents);
+  return file;
+}
+
+test("accepts a rehearsal of the released commit whose checks outlived one invocation", async () => {
+  const rehearsalPath = await recordPath(JSON.stringify(rehearsal()));
+  const record = await validateRehearsalEvidence({ version, sourceCommit, rehearsalPath });
+  assert.equal(record.runId, "wrun_01K5NRQ8ABCDEF");
+  assert.equal(record.checksDurationSec, 1180);
+});
+
+test("accepts checks that last exactly the one-invocation limit", async () => {
+  const rehearsalPath = await recordPath(JSON.stringify(rehearsal({ checksDurationSec: 300 })));
+  await assert.doesNotReject(validateRehearsalEvidence({ version, sourceCommit, rehearsalPath }));
+});
+
+test("blocks a release with no recorded rehearsal", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "artur-rehearsal-missing-"));
+  await assert.rejects(
+    validateRehearsalEvidence({
+      version,
+      sourceCommit,
+      rehearsalPath: path.join(directory, `${version}.json`),
+    }),
+    /No rehearsal is recorded for 2026\.08\.8/,
+  );
+});
+
+test("blocks a rehearsal record that is not valid JSON", async () => {
+  const rehearsalPath = await recordPath("{ not json");
+  await assert.rejects(
+    validateRehearsalEvidence({ version, sourceCommit, rehearsalPath }),
+    /is not valid JSON/,
+  );
+});
+
+test("blocks a rehearsal record with a missing field", async () => {
+  const { checksDurationSec: _omitted, ...withoutDuration } = rehearsal();
+  const rehearsalPath = await recordPath(JSON.stringify(withoutDuration));
+  await assert.rejects(
+    validateRehearsalEvidence({ version, sourceCommit, rehearsalPath }),
+    /does not match the required shape.*checksDurationSec/s,
+  );
+});
+
+test("blocks a rehearsal record with a malformed commit, timestamp or URL", async () => {
+  const rehearsalPath = await recordPath(
+    JSON.stringify(
+      rehearsal({ sourceCommit: "B".repeat(40), recordedAt: "19-08-2026", runUrl: "runs/1" }),
+    ),
+  );
+  await assert.rejects(
+    validateRehearsalEvidence({ version, sourceCommit, rehearsalPath }),
+    /sourceCommit.*runUrl.*recordedAt/s,
+  );
+});
+
+test("blocks a rehearsal of a different source commit", async () => {
+  const rehearsalPath = await recordPath(
+    JSON.stringify(rehearsal({ sourceCommit: "c".repeat(40) })),
+  );
+  await assert.rejects(
+    validateRehearsalEvidence({ version, sourceCommit, rehearsalPath }),
+    /ran at source commit cccc.*ships bbbb/s,
+  );
+});
+
+test("blocks a rehearsal that did not end in success", async () => {
+  const rehearsalPath = await recordPath(JSON.stringify(rehearsal({ outcome: "failed" })));
+  await assert.rejects(
+    validateRehearsalEvidence({ version, sourceCommit, rehearsalPath }),
+    /ended with outcome "failed"/,
+  );
+});
+
+test("blocks a rehearsal whose checks never crossed one invocation", async () => {
+  const rehearsalPath = await recordPath(JSON.stringify(rehearsal({ checksDurationSec: 299 })));
+  await assert.rejects(
+    validateRehearsalEvidence({ version, sourceCommit, rehearsalPath }),
+    /299 seconds, below the 300 second floor/,
+  );
+});
+
+test("blocks a rehearsal whose checks were stubs", async () => {
+  const rehearsalPath = await recordPath(JSON.stringify(rehearsal({ checksDurationSec: 12 })));
+  await assert.rejects(
+    validateRehearsalEvidence({ version, sourceCommit, rehearsalPath }),
+    /12 seconds, below the 300 second floor/,
+  );
+});
+
+test("validate-rehearsal CLI reads the recorded rehearsal for the released version", async () => {
+  const rehearsalPath = await recordPath(JSON.stringify(rehearsal()));
+  await assert.doesNotReject(
+    runCli([
+      "validate-rehearsal",
+      "--version",
+      version,
+      "--source-commit",
+      sourceCommit,
+      "--rehearsal",
+      rehearsalPath,
+    ]),
+  );
+  await assert.rejects(
+    runCli(["validate-rehearsal", "--version", version, "--rehearsal", rehearsalPath]),
+    /Missing required argument: --source-commit/,
+  );
+});

--- a/scripts/release-notes/rehearsal.ts
+++ b/scripts/release-notes/rehearsal.ts
@@ -1,0 +1,103 @@
+import { readFile } from "node:fs/promises";
+
+import { z } from "zod";
+
+import { releaseVersionSchema } from "./types.js";
+
+// Vercel gives each invocation 300 seconds. The client outage came from a check
+// batch that outlived a single invocation, so a rehearsal that never crossed
+// that boundary never touched the failure mode that reached the client. A run
+// whose checks finished in 12 seconds because they were `echo ok` stubs proves
+// the pipeline can open a pull request and proves nothing else. That is not
+// hypothetical: the client configuration "worked" for weeks precisely because
+// its heaviest repository had no check commands configured at all.
+const MINIMUM_CHECKS_DURATION_SEC = 300;
+
+const rehearsalRecordSchema = z
+  .object({
+    version: releaseVersionSchema,
+    sourceCommit: z
+      .string()
+      .regex(/^[0-9a-f]{40}$/, "must be a 40 character lowercase Git SHA"),
+    runId: z
+      .string()
+      .regex(/^wrun_[0-9A-Za-z]+$/, "must be a production run id such as wrun_01K5NRQ8"),
+    runUrl: z.string().url("must be the absolute URL of the rehearsal run"),
+    repository: z
+      .string()
+      .regex(/^[^/\s]+\/[^/\s]+$/, "must be the owner/name of the rehearsed repository"),
+    checksDurationSec: z
+      .number()
+      .int("must be a whole number of seconds")
+      .nonnegative("must not be negative"),
+    outcome: z.string().min(1, "must record how the rehearsal run ended"),
+    recordedAt: z
+      .string()
+      .datetime("must be an ISO 8601 UTC timestamp such as 2026-08-19T10:00:00Z"),
+    recordedBy: z.string().min(1, "must name the person who ran the rehearsal"),
+  })
+  .strict();
+
+export type RehearsalRecord = z.infer<typeof rehearsalRecordSchema>;
+
+export interface RehearsalInput {
+  version: string;
+  sourceCommit: string;
+  rehearsalPath: string;
+}
+
+const HOW_TO_REHEARSE =
+  "See docs/releases/artur/rehearsals/README.md for how to run a rehearsal and record it.";
+
+export async function validateRehearsalEvidence(
+  input: RehearsalInput,
+): Promise<RehearsalRecord> {
+  let raw: string;
+  try {
+    raw = await readFile(input.rehearsalPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    throw new Error(
+      `No rehearsal is recorded for ${input.version}: ${input.rehearsalPath} does not exist. Run an end-to-end rehearsal on production against a repository with real pre-PR checks, at source commit ${input.sourceCommit}, and commit the record. ${HOW_TO_REHEARSE}`,
+    );
+  }
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `Rehearsal record ${input.rehearsalPath} is not valid JSON: ${error instanceof Error ? error.message : String(error)}. Repair the file so it parses, then rerun the synchronization. ${HOW_TO_REHEARSE}`,
+    );
+  }
+  const parsed = rehearsalRecordSchema.safeParse(parsedJson);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => `${issue.path.join(".") || "record"}: ${issue.message}`)
+      .join("; ");
+    throw new Error(
+      `Rehearsal record ${input.rehearsalPath} does not match the required shape: ${issues}. Correct the listed fields and commit the record again. ${HOW_TO_REHEARSE}`,
+    );
+  }
+  const record = parsed.data;
+  if (record.version !== input.version) {
+    throw new Error(
+      `Rehearsal record ${input.rehearsalPath} states version ${record.version} but this release is ${input.version}. Record the rehearsal under the version being released.`,
+    );
+  }
+  if (record.sourceCommit !== input.sourceCommit) {
+    throw new Error(
+      `Rehearsal for ${input.version} ran at source commit ${record.sourceCommit}, but the approved release ships ${input.sourceCommit}. A rehearsal of a different commit proves nothing: rehearse a deployment built from ${input.sourceCommit} and record that run.`,
+    );
+  }
+  if (record.outcome !== "success") {
+    throw new Error(
+      `Rehearsal ${record.runId} for ${input.version} ended with outcome "${record.outcome}", not "success". Fix what broke, rehearse again until the run opens its pull request green, then record that run: ${record.runUrl}`,
+    );
+  }
+  if (record.checksDurationSec < MINIMUM_CHECKS_DURATION_SEC) {
+    throw new Error(
+      `Rehearsal ${record.runId} for ${input.version} ran checks for ${record.checksDurationSec} seconds, below the ${MINIMUM_CHECKS_DURATION_SEC} second floor. Vercel allows 300 seconds per invocation and the client outage came from a check batch that outlived one invocation, so a shorter rehearsal proves nothing about that failure mode. Rehearse against a repository whose checks really run past 300 seconds (toolchain setup plus the long checks), not against stub commands.`,
+    );
+  }
+  return record;
+}

--- a/scripts/release-notes/workflows.test.ts
+++ b/scripts/release-notes/workflows.test.ts
@@ -68,6 +68,26 @@ test("synchronization workflow opens a full snapshot PR in the Artur repository"
   assert.doesNotMatch(source, /pull_request_target|PERSONAL_ACCESS_TOKEN|git remote set-url/);
 });
 
+test("synchronization workflow gates on source CI and a recorded rehearsal", async () => {
+  const source = await readFile(".github/workflows/sync-artur-release.yml", "utf8");
+  const workflow = parse(source);
+  assert.equal(workflow.permissions.actions, "read");
+  assert.match(source, /actions\/workflows\/ci\.yml\/runs\?head_sha=\$TARGET_SHA/);
+  assert.match(source, /select\(\.event == "push"\)/);
+  assert.match(source, /release-notes validate-rehearsal/);
+  const steps = workflow.jobs.sync.steps as Array<{ id?: string; name?: string }>;
+  const index = (name: string) => steps.findIndex((step) => step.name === name);
+  const exported = steps.findIndex((step) => step.id === "source");
+  const arturToken = steps.findIndex((step) => step.id === "artur-token");
+  for (const gate of [
+    "Require green source CI at the released commit",
+    "Require a recorded green rehearsal at the released commit",
+  ]) {
+    assert.ok(index(gate) > exported, `${gate} must run after the source target is resolved`);
+    assert.ok(index(gate) < arturToken, `${gate} must run before Artur is touched`);
+  }
+});
+
 test("source repository no longer contains a direct Artur deployment workflow", async () => {
   await assert.rejects(access(".github/workflows/release-artur.yml"));
 });


### PR DESCRIPTION
## Why

Two Artur releases went out over a red source `main`, and one of them broke the client's runs while people were working in that tenant. The release pipeline gates on snapshot integrity and on approval of the release-note PR. It never checks that the source was healthy at the released commit, and it never checks that anyone exercised the released build end to end.

## What this adds

Two gates in `sync-artur-release.yml`, both placed after `steps.source.outputs.target_sha` is exported and before anything touches the client repository.

**Gate 1: the source was green at the released commit.** Only `event == "push"` runs of `ci.yml` at that SHA are considered, because the push run is the one that judges `main`. A stray cancelled manual dispatch must not block a release the push run already passed. Zero push runs, an unfinished push run, or any push run whose conclusion is not `success` all abort. Missing CI is never treated as a pass.

**Gate 2: a recorded green rehearsal at the same commit.** A new `release-notes validate-rehearsal` subcommand reads `docs/releases/artur/rehearsals/<version>.json` and asserts the record's `version`, that `sourceCommit` equals the released SHA exactly, that `outcome` is `success`, and that `checksDurationSec` is at least 300.

The 300 second floor is the part that carries the gate. Vercel allows 300 seconds per invocation, and the client's failure came from a pre-PR check batch that outlived one invocation. A rehearsal whose checks finished in 12 seconds because they were `echo ok` stubs proves the pipeline can open a pull request and proves nothing about that failure mode. That is not hypothetical: the client's configuration "worked" for weeks precisely because its heaviest repository had no check commands configured at all.

Duration alone is not enough either, which is why `outcome` is checked separately. Run `wrun_01M0CGC9GEMEBC3THA2DNBECNJ` on our own production ran its `checks` node for 358631 ms, comfortably over the floor, and still died with `Step "step//./src/workflows/agent//runPrePrChecksStep" failed after 0 retries: terminated`.

## Order of operations

`targetSourceCommit` is frozen into the release note's front matter at preparation time (`render.ts`), and `manifest.ts` only checks that it is an ancestor of `main`. So the rehearsal has to happen after preparation, not before: merging the rehearsal record itself moves `main`, so a rehearsal recorded first can never match the SHA preparation will pin. `docs/releases/artur/rehearsals/README.md` documents the corrected sequence and calls out that preparation must be run once.

The record ships in its own pull request rather than alongside the note, because `validateApprovedSourceRelease` requires the release-note PR to touch exactly one file. That existing gate is left intact.

## Merge order

**This must not merge before the pre-PR checks fix lands.** Today a rehearsal cannot succeed at all: the `checks` node dies on any configuration whose commands outlive one invocation. Merging this first would block releases with no way to satisfy the gate.

## Verification

- `rehearsal.test.ts`, `workflows.test.ts`, `cli.test.ts`: 25 tests, all passing.
- `tsc -p scripts/release-notes/tsconfig.json`: no diagnostics.
- Gate 1 was checked by extracting the real `run:` script from the parsed YAML and executing it against simulated `gh api --paginate --slurp` payloads with a stub `gh` on `PATH`: green push passes; green push plus a cancelled dispatch passes; dispatch only, no runs, in-progress, cancelled, skipped, and two push runs with one red all abort with their own message.
- `actionlint` and `shellcheck` are not installed and nothing was installed, so the workflow is not linted against the Actions schema. YAML well-formedness is established only by the `yaml` parser reading the file in `workflows.test.ts`.
