### PR TITLE
fix(worker): run pre-PR checks detached so they survive the invocation ceiling

### DIFF
--- a/apps/worker/src/pre-pr-checks/runner.test.ts
+++ b/apps/worker/src/pre-pr-checks/runner.test.ts
@@ -41,6 +41,7 @@ import {
   buildRepoCheckBatchScript,
   collectPrePrRepairStep,
   collectRepoCheckBatchStep,
+  formatPrePrCheckFailures,
   listWorkspaceRepositoriesStep,
   parseBatchReaderOutput,
   repoCheckBatchPaths,
@@ -197,10 +198,17 @@ describe("the batch reader shell", () => {
     present: "two lines\nof output",
     empty: "",
     oversized: `HEAD${"x".repeat(20_000)}TAIL`,
-    blocked: `${"y".repeat(9_000)}error: run \`yarn install\` first`,
+    // Both signals, buried where neither the head slice nor the tail slice
+    // reaches, which is what makes the whole-file grep load bearing.
+    blocked: `${"y".repeat(9_000)}Yarn: dependencies are not installed. Run \`yarn install\` to run this command.${"z".repeat(9_000)}`,
+    // One signal each, which our own green test suite really does print: its
+    // test titles name the absent-dependencies message. Neither may fail a
+    // check that exited 0.
+    absenceOnly: "ok 12 - fails a check whose dependencies are not installed",
+    installerOnly: "All 40 tests passed. Tip: run `pnpm install` after pulling.",
   };
 
-  function read(scanBlockedDependencies = true, profileNoise = "") {
+  function read(profileNoise = "") {
     const dir = mkdtempSync(join(tmpdir(), "pre-pr-reader-"));
     try {
       for (const [name, content] of Object.entries(files)) {
@@ -209,7 +217,6 @@ describe("the batch reader shell", () => {
       const script = buildBatchReaderScript({
         dir,
         names: [...Object.keys(files), "absent"],
-        scanBlockedDependencies,
       });
       const stdout = execFileSync("bash", ["-lc", `${profileNoise}${script}`], {
         encoding: "utf8",
@@ -238,20 +245,22 @@ describe("the batch reader shell", () => {
     expect(Buffer.from(oversized.tail!, "base64").toString()).toContain("TAIL");
   });
 
-  it("finds a blocked-dependency phrase the truncation would have cut away", () => {
+  it("finds the blocked-dependency signals the truncation would have cut away", () => {
     const { parsed } = read();
+    const blocked = parsed.get("blocked")!;
 
-    expect(parsed.get("blocked")!.blocked).toBe(true);
-    // Proof that only the whole-file grep could have found it.
-    expect(Buffer.from(parsed.get("blocked")!.head, "base64").toString()).not.toContain(
-      "yarn install",
-    );
+    expect(blocked.blocked).toBe(true);
+    // Proof that only the whole-file grep could have found them: the message is
+    // in neither end the reader carries back.
+    expect(Buffer.from(blocked.head, "base64").toString()).not.toContain("yarn install");
+    expect(Buffer.from(blocked.tail!, "base64").toString()).not.toContain("yarn install");
   });
 
-  it("reports nothing blocked when the caller did not ask for the scan", () => {
-    const { parsed } = read(false);
+  it("needs both signals, so a green suite that mentions one stays green", () => {
+    const { parsed } = read();
 
-    expect(parsed.get("blocked")!.blocked).toBe(false);
+    expect(parsed.get("absenceOnly")!.blocked).toBe(false);
+    expect(parsed.get("installerOnly")!.blocked).toBe(false);
   });
 
   it("skips whatever the shell profile printed instead of absorbing it", () => {
@@ -259,7 +268,7 @@ describe("the batch reader shell", () => {
     // commands append to. Without a token to match, output with no trailing
     // newline glues itself onto the first record and turns a batch that ran to
     // completion into "the wrapper never started".
-    const { stdout, parsed } = read(true, 'printf "nvm: version 20.11.1";');
+    const { stdout, parsed } = read('printf "nvm: version 20.11.1";');
 
     expect(stdout.startsWith("nvm: version")).toBe(true);
     // Every record survives: the leading newline ends the profile's line, and
@@ -270,11 +279,13 @@ describe("the batch reader shell", () => {
     expect(parsed.get("absent")).toBeDefined();
     expect([...parsed.keys()].sort()).toEqual([
       "absent",
+      "absenceOnly",
       "blocked",
       "empty",
+      "installerOnly",
       "oversized",
       "present",
-    ]);
+    ].sort());
   });
 });
 
@@ -491,7 +502,8 @@ describe("collectRepoCheckBatchStep", () => {
     mockRunCommand.mockImplementation(
       batchOutputFiles(paths, {
         "exit-0": "0",
-        "stdout-0": "Yarn checks were blocked because dependencies are not installed",
+        "stdout-0":
+          "Yarn checks were blocked because dependencies are not installed. Run `yarn install`.",
       }),
     );
 
@@ -509,7 +521,7 @@ describe("collectRepoCheckBatchStep", () => {
       { provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 0 },
     ]);
     expect(collected.failures).toHaveLength(1);
-    expect(collected.failures[0]!.stderr.toLowerCase()).toContain("did not actually run");
+    expect(collected.failures[0]!.note!.toLowerCase()).toContain("did not actually run");
   });
 
   it("separates a workspace it could not enter from a setup command that failed", async () => {
@@ -639,12 +651,12 @@ describe("collectRepoCheckBatchStep", () => {
     expect(mockRunCommand).not.toHaveBeenCalled();
   });
 
-  it("catches a blocked-dependency phrase that the truncation cuts in half", async () => {
-    // The phrase the guard matches is `run \`yarn install\``, and head -c and
-    // tail -c cut on bytes. A log long enough to be truncated puts the phrase
-    // in the middle, where no amount of carried text can find it: the reader
-    // greps the whole file instead, and the collector trusts that flag.
-    const middle = `${"y".repeat(20_000)}error Yarn checks blocked: run \`yarn install\`${"z".repeat(20_000)}`;
+  it("catches blocked dependencies that the truncation cuts in half", async () => {
+    // head -c and tail -c cut on bytes. A log long enough to be truncated puts
+    // the message in the middle, where no amount of carried text can find it:
+    // the reader greps the whole file instead, and the collector trusts that
+    // flag.
+    const middle = `${"y".repeat(20_000)}error Yarn: dependencies are not installed, run \`yarn install\`${"z".repeat(20_000)}`;
     mockRunCommand.mockImplementation(
       batchOutputFiles(paths, { "exit-0": "0", "stdout-0": middle }),
     );
@@ -660,20 +672,23 @@ describe("collectRepoCheckBatchStep", () => {
     );
 
     expect(collected.failures).toHaveLength(1);
-    expect(collected.failures[0]!.stderr).toContain("did not actually run");
-    // The carried text really does not contain the phrase: the flag is what
+    // The reason travels as its own field, never folded into a stream where
+    // the consumer's head-and-tail bound would delete it.
+    expect(collected.failures[0]!.note).toContain("did not actually run");
+    expect(collected.failures[0]!.stderr).toBe("");
+    // The carried text really does not contain the message: the flag is what
     // caught it.
     expect(collected.failures[0]!.stdout).not.toContain("yarn install");
   });
 
-  it("passes a green check whose output happens to name missing dependencies", async () => {
-    // run_checks' explicit commands mode runs whatever an author typed and its
-    // description promises nothing but the exit code. This repository's own
-    // test names contain the phrase, so a scan there fails a green suite.
+  it("passes a green check that only mentions one of the two signals", async () => {
+    // This repository's own test titles contain the absent-dependencies
+    // sentence, so a single-signal scan fails our own green suite. Both modes
+    // scan now, so the rule itself has to be the thing that does not fire.
     mockRunCommand.mockImplementation(
       batchOutputFiles(paths, {
         "exit-0": "0",
-        "stdout-0": "PASS installs when dependencies are not installed (12 tests)",
+        "stdout-0": "PASS fails a check whose dependencies are not installed (12 tests)",
       }),
     );
 
@@ -685,8 +700,6 @@ describe("collectRepoCheckBatchStep", () => {
       ["pnpm test"],
       paths,
       "/vercel/sandbox",
-      true,
-      false,
     );
 
     expect(collected.failures).toEqual([]);
@@ -695,25 +708,126 @@ describe("collectRepoCheckBatchStep", () => {
     ]);
   });
 
-  it("still fails the same output when the configured checks asked for the scan", async () => {
-    mockRunCommand.mockImplementation(
-      batchOutputFiles(paths, {
-        "exit-0": "0",
-        "stdout-0": "PASS installs when dependencies are not installed (12 tests)",
-      }),
-    );
+  it("gives every failure the same share, first and last alike", async () => {
+    // A share computed from what is left over grows as the budget is spent, so
+    // the FIRST failure got the smallest slice and the last the largest: at 16
+    // failures, 1024 characters against 4153. The entry an operator reads first
+    // must not be the most truncated one.
+    const commands = Array.from({ length: 16 }, (_, index) => `pnpm test-${index}`);
+    const files: Record<string, string> = {};
+    for (let index = 0; index < commands.length; index++) {
+      files[`exit-${index}`] = "1";
+      files[`stderr-${index}`] = "E".repeat(20_000);
+    }
+    mockRunCommand.mockImplementation(batchOutputFiles(paths, files));
 
     const collected = await collectRepoCheckBatchStep(
       "sbx-test-123",
       "github",
       "acme/web",
       [],
-      ["pnpm test"],
+      commands,
       paths,
       "/vercel/sandbox",
     );
 
-    expect(collected.failures).toHaveLength(1);
+    const sizes = collected.failures.map((failure) => failure.stderr.length);
+    expect(collected.failures).toHaveLength(16);
+    expect(new Set(sizes).size).toBe(1);
+  });
+
+  it("gives an empty stream's half of the share to the other", async () => {
+    // A fixed 50/50 split wastes half the share whenever a tool writes to one
+    // stream, which is the common case: the failure keeps 1024 characters of a
+    // 2048 share and the other half is spent on nothing.
+    const commands = Array.from({ length: 16 }, (_, index) => `pnpm test-${index}`);
+    const files: Record<string, string> = {};
+    for (let index = 0; index < commands.length; index++) {
+      files[`exit-${index}`] = "1";
+      files[`stderr-${index}`] = "E".repeat(20_000);
+    }
+    mockRunCommand.mockImplementation(batchOutputFiles(paths, files));
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      commands,
+      paths,
+      "/vercel/sandbox",
+    );
+
+    // 32768 / 16 is 2048, and stdout is empty, so stderr keeps the whole share.
+    expect(collected.failures[0]!.stdout).toBe("");
+    expect(collected.failures[0]!.stderr.length).toBeGreaterThan(2_000);
+  });
+
+  it("stops at the aggregate bound and says how many failures it left out", async () => {
+    // Nothing bounds how many commands a repository may configure, and a floor
+    // per failure means the aggregate grows with the count: 40 failing commands
+    // returned 80 000 characters into the run's event log. The walk stops, and
+    // what it dropped is stated rather than silently missing.
+    const commands = Array.from({ length: 40 }, (_, index) => `pnpm test-${index}`);
+    const files: Record<string, string> = {};
+    for (let index = 0; index < commands.length; index++) {
+      files[`exit-${index}`] = "1";
+      files[`stderr-${index}`] = "E".repeat(20_000);
+    }
+    mockRunCommand.mockImplementation(batchOutputFiles(paths, files));
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      commands,
+      paths,
+      "/vercel/sandbox",
+    );
+
+    const payload = collected.failures.reduce(
+      (sum, failure) => sum + failure.stdout.length + failure.stderr.length,
+      0,
+    );
+    expect(payload).toBeLessThanOrEqual(32 * 1024 + 2_000);
+    expect(collected.failures.length).toBeLessThan(40);
+    const last = collected.failures.at(-1)!;
+    expect(last.phase).toBe("omitted");
+    expect(last.note).toContain(
+      `${40 - (collected.failures.length - 1)} further failing commands`,
+    );
+    // And the operator reads it, rather than counting entries to notice.
+    const summary = formatPrePrCheckFailures(collected.failures);
+    expect(summary).toContain("are not listed");
+    // Named for what it is: this batch ran to the end, the report is what ran
+    // out of room.
+    expect(summary).toContain("FAILURES OMITTED for github:acme/web");
+    expect(summary).not.toContain("CHECK BATCH ABANDONED");
+  });
+
+  it("reports a reader that lost its own output as a reader failure", async () => {
+    // A login profile that redirects the shell's stdout (`exec 1>/dev/null`)
+    // makes the reader exit 0 having emitted nothing. The reader always asks
+    // for `launch`, and the script emits a record per name whether the file is
+    // there or not, so zero records can only be the reader's own output being
+    // lost. Calling it "the wrapper never started" sends the operator to look
+    // at the wrapper.
+    mockRunCommand.mockImplementation(() => commandResult(0, ""));
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.failures[0]!.stderr).toContain("could not be read");
+    expect(collected.failures[0]!.stderr).not.toContain("never started");
+    expect(collected.failures[0]!.phase).toBe("workspace");
   });
 
   it("treats an empty launch marker as a wrapper that never started", async () => {
@@ -860,14 +974,16 @@ describe("collectRepoCheckBatchStep", () => {
   });
 
   it("never truncates the sentence that explains a failure", async () => {
-    // The explanation is appended at the tail, so any bound that treats it as
-    // payload drops it first and leaves an operator reading "Exit code: 0" in a
-    // list titled failures with nothing saying why a zero exit is a failure.
+    // The explanation travels as its own field. Folded into a stream it is
+    // payload, and every consumer bounds the JOIN of the two streams head and
+    // tail, which deletes exactly the boundary between them: an operator would
+    // read "Exit code: 0" in a list titled failures with nothing saying why.
     const commands = Array.from({ length: 12 }, (_, index) => `pnpm test-${index}`);
     const files: Record<string, string> = {};
     for (let index = 0; index < commands.length; index++) {
       files[`exit-${index}`] = "0";
-      files[`stdout-${index}`] = `${"y".repeat(30_000)} dependencies are not installed`;
+      files[`stdout-${index}`] =
+        `${"y".repeat(30_000)} dependencies are not installed, run \`pnpm install\``;
     }
     mockRunCommand.mockImplementation(batchOutputFiles(paths, files));
 
@@ -884,8 +1000,12 @@ describe("collectRepoCheckBatchStep", () => {
     expect(collected.failures).toHaveLength(12);
     for (const failure of collected.failures) {
       expect(failure.exitCode).toBe(0);
-      expect(failure.stderr).toContain("did not actually run");
+      expect(failure.note).toContain("did not actually run");
     }
+    // And it reaches the operator, after the output it explains rather than
+    // inside it.
+    const summary = formatPrePrCheckFailures(collected.failures);
+    expect(summary.match(/did not actually run/g)).toHaveLength(12);
   });
 
   it("marks nothing when a stream fits inside the cap", async () => {
@@ -924,7 +1044,7 @@ describe("collectRepoCheckBatchStep", () => {
     expect(collected.results).toEqual([]);
     expect(collected.failures).toHaveLength(1);
     expect(collected.failures[0]).toMatchObject({ command: "pnpm test", exitCode: -1 });
-    expect(collected.failures[0]!.stderr).toContain("interrupted");
+    expect(collected.failures[0]!.note).toContain("interrupted");
   });
 });
 

--- a/apps/worker/src/pre-pr-checks/runner.test.ts
+++ b/apps/worker/src/pre-pr-checks/runner.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WORKSPACE_MANIFEST_PATH } from "../sandbox/repo-workspace.js";
 
@@ -33,10 +37,12 @@ vi.mock("../lib/logger.js", () => ({
 
 import {
   boundFailureOutput,
+  buildBatchReaderScript,
   buildRepoCheckBatchScript,
   collectPrePrRepairStep,
   collectRepoCheckBatchStep,
   listWorkspaceRepositoriesStep,
+  parseBatchReaderOutput,
   repoCheckBatchPaths,
   startPrePrRepairStep,
   startRepoCheckBatchStep,
@@ -179,6 +185,96 @@ describe("buildRepoCheckBatchScript", () => {
     expect(repoCheckBatchPaths(1, 1, "1111111111111111").dir).not.toBe(
       repoCheckBatchPaths(1, 1, "2222222222222222").dir,
     );
+  });
+});
+
+
+describe("the batch reader shell", () => {
+  // The collector suite above runs this same script for every case it covers.
+  // This suite reads its records directly, so the wire format itself is pinned
+  // rather than inferred from what the collector made of it.
+  const files = {
+    present: "two lines\nof output",
+    empty: "",
+    oversized: `HEAD${"x".repeat(20_000)}TAIL`,
+    blocked: `${"y".repeat(9_000)}error: run \`yarn install\` first`,
+  };
+
+  function read(scanBlockedDependencies = true, profileNoise = "") {
+    const dir = mkdtempSync(join(tmpdir(), "pre-pr-reader-"));
+    try {
+      for (const [name, content] of Object.entries(files)) {
+        writeFileSync(join(dir, name), content);
+      }
+      const script = buildBatchReaderScript({
+        dir,
+        names: [...Object.keys(files), "absent"],
+        scanBlockedDependencies,
+      });
+      const stdout = execFileSync("bash", ["-lc", `${profileNoise}${script}`], {
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+      });
+      return { stdout, parsed: parseBatchReaderOutput(stdout) };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("emits one record per file, whatever state the file is in", () => {
+    const { parsed } = read();
+
+    expect(parsed.get("present")).toMatchObject({ bytes: 19, blocked: false, tail: null });
+    expect(Buffer.from(parsed.get("present")!.head, "base64").toString()).toBe(files.present);
+    // Empty and absent are different answers: one command ran and produced
+    // nothing, the other never ran at all.
+    expect(parsed.get("empty")).toMatchObject({ bytes: 0, head: "", tail: null });
+    expect(parsed.get("absent")).toMatchObject({ bytes: -1, head: "", tail: null });
+    // Oversized keeps both ends and reports the true size, so the collector can
+    // say how much it dropped.
+    const oversized = parsed.get("oversized")!;
+    expect(oversized.bytes).toBe(files.oversized.length);
+    expect(Buffer.from(oversized.head, "base64").toString()).toContain("HEAD");
+    expect(Buffer.from(oversized.tail!, "base64").toString()).toContain("TAIL");
+  });
+
+  it("finds a blocked-dependency phrase the truncation would have cut away", () => {
+    const { parsed } = read();
+
+    expect(parsed.get("blocked")!.blocked).toBe(true);
+    // Proof that only the whole-file grep could have found it.
+    expect(Buffer.from(parsed.get("blocked")!.head, "base64").toString()).not.toContain(
+      "yarn install",
+    );
+  });
+
+  it("reports nothing blocked when the caller did not ask for the scan", () => {
+    const { parsed } = read(false);
+
+    expect(parsed.get("blocked")!.blocked).toBe(false);
+  });
+
+  it("skips whatever the shell profile printed instead of absorbing it", () => {
+    // The reader runs under `bash -lc`, which sources the profile our setup
+    // commands append to. Without a token to match, output with no trailing
+    // newline glues itself onto the first record and turns a batch that ran to
+    // completion into "the wrapper never started".
+    const { stdout, parsed } = read(true, 'printf "nvm: version 20.11.1";');
+
+    expect(stdout.startsWith("nvm: version")).toBe(true);
+    // Every record survives: the leading newline ends the profile's line, and
+    // the marker means a line that is not a record is skipped rather than read
+    // as a file called "nvm:".
+    expect(parsed.get("present")).toBeDefined();
+    expect(parsed.get("empty")).toBeDefined();
+    expect(parsed.get("absent")).toBeDefined();
+    expect([...parsed.keys()].sort()).toEqual([
+      "absent",
+      "blocked",
+      "empty",
+      "oversized",
+      "present",
+    ]);
   });
 });
 
@@ -499,7 +595,7 @@ describe("collectRepoCheckBatchStep", () => {
     // absence is a more informative diagnosis than the one the command loop
     // would reach a moment later ("exit-0 is missing").
     mockRunCommand.mockImplementation(
-      batchOutputFiles(paths, { launch: undefined as unknown as string }),
+      batchOutputFiles(paths, { launch: undefined }),
     );
 
     for (const batchFinished of [true, false]) {
@@ -568,6 +664,73 @@ describe("collectRepoCheckBatchStep", () => {
     // The carried text really does not contain the phrase: the flag is what
     // caught it.
     expect(collected.failures[0]!.stdout).not.toContain("yarn install");
+  });
+
+  it("passes a green check whose output happens to name missing dependencies", async () => {
+    // run_checks' explicit commands mode runs whatever an author typed and its
+    // description promises nothing but the exit code. This repository's own
+    // test names contain the phrase, so a scan there fails a green suite.
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, {
+        "exit-0": "0",
+        "stdout-0": "PASS installs when dependencies are not installed (12 tests)",
+      }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm test"],
+      paths,
+      "/vercel/sandbox",
+      true,
+      false,
+    );
+
+    expect(collected.failures).toEqual([]);
+    expect(collected.results).toEqual([
+      { provider: "github", repoPath: "acme/web", command: "pnpm test", exitCode: 0 },
+    ]);
+  });
+
+  it("still fails the same output when the configured checks asked for the scan", async () => {
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, {
+        "exit-0": "0",
+        "stdout-0": "PASS installs when dependencies are not installed (12 tests)",
+      }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm test"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.failures).toHaveLength(1);
+  });
+
+  it("treats an empty launch marker as a wrapper that never started", async () => {
+    mockRunCommand.mockImplementation(batchOutputFiles(paths, { launch: "" }));
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.failures[0]!.stderr).toContain("never started");
+    expect(collected.failures[0]!.stderr).not.toContain("does not belong");
   });
 
   it("reads the whole batch in one sandbox round trip", async () => {
@@ -652,22 +815,24 @@ describe("collectRepoCheckBatchStep", () => {
     expect(stderr).toContain("FAILED_FIRST");
     expect(stderr).toContain("FAILED test_end.py::test_last");
     expect(stderr).toContain(
-      `[... ${long.length - 8_192} bytes of this command's output omitted ...]`,
+      `[... ${long.length - 4_096} bytes of this command's output omitted ...]`,
     );
-    // Sized against what a consumer reads (2000 characters), not against what
+    // Sized against what a consumer shows (2000 characters), not against what
     // the event log tolerates: bytes past this are carried, persisted and then
     // thrown away unread.
-    expect(stderr.length).toBeLessThanOrEqual(8_192 + 200);
+    expect(stderr.length).toBeLessThanOrEqual(4_096 + 200);
   });
 
-  it("bounds what one collect returns in total, not only per stream", async () => {
-    // Twelve verbose commands multiply the per-stream bound by twelve, and all
-    // of it lands in the run's event log as a step return value.
+  it("bounds what one collect returns in total without erasing the last failure", async () => {
+    // A dozen verbose failing commands multiply the per-stream bound, and all
+    // of it lands in the run's event log as a step return value. Spending the
+    // aggregate first-come, first-served would hand back the last failures
+    // empty, and the last is as likely as any to be the one being read.
     const commands = Array.from({ length: 12 }, (_, index) => `pnpm test-${index}`);
     const files: Record<string, string> = {};
     for (let index = 0; index < commands.length; index++) {
       files[`exit-${index}`] = "1";
-      files[`stderr-${index}`] = "E".repeat(6_000);
+      files[`stderr-${index}`] = `START-${index}${"E".repeat(20_000)}END-${index}`;
     }
     mockRunCommand.mockImplementation(batchOutputFiles(paths, files));
 
@@ -686,12 +851,41 @@ describe("collectRepoCheckBatchStep", () => {
       0,
     );
     expect(collected.failures).toHaveLength(12);
-    // The aggregate bound, plus the one marker sentence each truncated entry
-    // carries to say what it lost, and nothing more.
-    expect(total).toBeLessThanOrEqual(32 * 1024 + 12 * 200);
-    // The first failures keep their text: they are where a reader starts.
-    expect(collected.failures[0]!.stderr).toBe("E".repeat(6_000));
-    expect(collected.failures.at(-1)!.stderr).toContain("the batch as a whole reached");
+    expect(total).toBeLessThanOrEqual(32 * 1024);
+    // Every failure keeps both ends of its own output, the last one included.
+    for (const [index, failure] of collected.failures.entries()) {
+      expect(failure.stderr).toContain(`START-${index}`);
+      expect(failure.stderr).toContain(`END-${index}`);
+    }
+  });
+
+  it("never truncates the sentence that explains a failure", async () => {
+    // The explanation is appended at the tail, so any bound that treats it as
+    // payload drops it first and leaves an operator reading "Exit code: 0" in a
+    // list titled failures with nothing saying why a zero exit is a failure.
+    const commands = Array.from({ length: 12 }, (_, index) => `pnpm test-${index}`);
+    const files: Record<string, string> = {};
+    for (let index = 0; index < commands.length; index++) {
+      files[`exit-${index}`] = "0";
+      files[`stdout-${index}`] = `${"y".repeat(30_000)} dependencies are not installed`;
+    }
+    mockRunCommand.mockImplementation(batchOutputFiles(paths, files));
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      commands,
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.failures).toHaveLength(12);
+    for (const failure of collected.failures) {
+      expect(failure.exitCode).toBe(0);
+      expect(failure.stderr).toContain("did not actually run");
+    }
   });
 
   it("marks nothing when a stream fits inside the cap", async () => {
@@ -1041,54 +1235,44 @@ function sandboxWithHead(head: string) {
 }
 
 /**
- * Serves one batch directory over the single reader command the collector
- * makes, in the reader's own wire format: `<name> <bytes> <b64head> <b64tail>`
- * per requested file, `-1` bytes for a file that does not exist. The launch
- * marker is served by default, because every collect checks it first.
+ * Serves one batch directory by running the collector's OWN reader script under
+ * a real bash, against real files in a temporary directory.
+ *
+ * Deliberately not a JavaScript reimplementation of the reader. That script is
+ * load-bearing (it decides whether a check passed, whether a batch ran at all,
+ * and what an operator is shown), and a fake that reimplements it proves only
+ * that the fake agrees with itself. Everything the collector suite covers,
+ * present and missing and empty and oversized files, therefore exercises the
+ * shell as written.
+ *
+ * The launch marker is served by default, because every collect checks it
+ * first. A value of undefined means "this file does not exist".
  */
-function batchOutputFiles(paths: RepoCheckBatchPaths, files: Record<string, string>) {
-  const all: Record<string, string> = { launch: paths.launchId, ...files };
+function batchOutputFiles(
+  paths: RepoCheckBatchPaths,
+  files: Record<string, string | undefined>,
+) {
+  const all: Record<string, string | undefined> = { launch: paths.launchId, ...files };
   return (cmd: unknown) => {
     const script = batchReaderScript(cmd);
     if (script === null) return commandResult(0, "");
-    const lines: string[] = [];
-    for (const match of script.matchAll(/^emit '([^']+)' '([^']+)'$/gm)) {
-      const name = match[1]!;
-      const content = all[name];
-      if (content === undefined) {
-        lines.push(`${name} -1 0 - -`);
-        continue;
+    const dir = mkdtempSync(join(tmpdir(), "pre-pr-batch-"));
+    try {
+      for (const [name, content] of Object.entries(all)) {
+        if (content !== undefined) writeFileSync(join(dir, name), content);
       }
-      const buffer = Buffer.from(content, "utf8");
-      const encode = (part: Buffer) => part.toString("base64") || "-";
-      // The reader greps the whole file, before any truncation, so the fake
-      // has to answer from the whole file too.
-      const blocked = MISSING_DEPENDENCY_PHRASES.some((phrase) =>
-        content.toLowerCase().includes(phrase.toLowerCase()),
-      )
-        ? "1"
-        : "0";
-      lines.push(
-        buffer.length <= 8_192
-          ? `${name} ${buffer.length} ${blocked} ${encode(buffer)} -`
-          : `${name} ${buffer.length} ${blocked} ${encode(buffer.subarray(0, 4_096))} ${encode(
-              buffer.subarray(buffer.length - 4_096),
-            )}`,
-      );
+      // The collector built this script against its own /tmp path; point it at
+      // the directory this test actually populated. Nothing else is rewritten.
+      const stdout = execFileSync("bash", ["-lc", script.split(paths.dir).join(dir)], {
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+      });
+      return commandResult(0, stdout);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
-    return commandResult(0, lines.join("\n"));
   };
 }
-
-/** The phrases the reader greps for, as the production script builds them. */
-const MISSING_DEPENDENCY_PHRASES = [
-  "dependencies are not installed",
-  "dependencies must be installed",
-  "run `yarn install`",
-  "run 'yarn install'",
-  "run `npm install`",
-  "run `pnpm install`",
-];
 
 /** The reader is the one `bash -lc` call the collector makes. */
 function batchReaderScript(cmd: unknown): string | null {

--- a/apps/worker/src/pre-pr-checks/runner.test.ts
+++ b/apps/worker/src/pre-pr-checks/runner.test.ts
@@ -1,16 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { PrePrCheckConfig } from "./config.js";
 import { WORKSPACE_MANIFEST_PATH } from "../sandbox/repo-workspace.js";
-import { createRunBudgetState } from "../workflows/run-budget.js";
 
 const mockRunCommand = vi.fn();
 const mockWriteFiles = vi.fn();
+
+let sandboxStatus = "running";
 
 vi.mock("@vercel/sandbox", () => ({
   Sandbox: {
     get: vi.fn(() => ({
       sandboxId: "sbx-test-123",
-      status: "running",
+      get status() {
+        return sandboxStatus;
+      },
       runCommand: mockRunCommand,
       writeFiles: mockWriteFiles,
     })),
@@ -29,22 +31,17 @@ vi.mock("../lib/logger.js", () => ({
   },
 }));
 
-import { runPrePrChecksWithFixes } from "./runner.js";
-
-const config: PrePrCheckConfig = {
-  repositories: [
-    {
-      provider: "github",
-      repoPath: "acme/web",
-      commands: ["pnpm typecheck"],
-    },
-    {
-      provider: "gitlab",
-      repoPath: "acme/api",
-      commands: ["pnpm test"],
-    },
-  ],
-};
+import {
+  boundFailureOutput,
+  buildRepoCheckBatchScript,
+  collectPrePrRepairStep,
+  collectRepoCheckBatchStep,
+  listWorkspaceRepositoriesStep,
+  repoCheckBatchPaths,
+  startPrePrRepairStep,
+  startRepoCheckBatchStep,
+  type RepoCheckBatchPaths,
+} from "./runner.js";
 
 const manifest = {
   version: 1,
@@ -72,350 +69,820 @@ const manifest = {
   ],
 };
 
-describe("runPrePrChecksWithFixes", () => {
+describe("buildRepoCheckBatchScript", () => {
+  const paths = repoCheckBatchPaths(0, 0, "aaaabbbbccccdddd");
+
+  it("runs every setup and check command through its own login shell", () => {
+    // The semantic this pins: Arthur's real setup appends a PATH export to the
+    // shell profile and every later command depends on picking it up. That only
+    // works while each command starts a fresh login shell of its own, so a
+    // refactor that concatenates the batch into one shell body, or that makes
+    // the wrapper itself the single login shell, must fail here.
+    const script = buildRepoCheckBatchScript({
+      paths,
+      localPath: "/vercel/sandbox",
+      setup: ["curl -LsSf https://astral.sh/uv/install.sh | sh", "uv sync"],
+      commands: ["uv run mypy ."],
+    });
+
+    expect(script).toContain('bash -lc "$2"');
+    expect(script.match(/^run_pre_pr_command /gm)).toHaveLength(3);
+    expect(script).toContain(
+      "run_pre_pr_command 0 'curl -LsSf https://astral.sh/uv/install.sh | sh'",
+    );
+    expect(script).toContain("run_pre_pr_command 1 'uv sync'");
+    expect(script).toContain("run_pre_pr_command 2 'uv run mypy .'");
+    // One `bash -lc` dispatcher, never one per authored command inlined.
+    expect(script.match(/bash -lc/g)).toHaveLength(1);
+  });
+
+  it("stops the batch at a failing setup command and never at a check", () => {
+    const script = buildRepoCheckBatchScript({
+      paths,
+      localPath: "/vercel/sandbox",
+      setup: ["make bootstrap", "make deps"],
+      commands: ["pnpm lint", "pnpm test"],
+    });
+
+    expect(script).toContain(
+      "run_pre_pr_command 0 'make bootstrap'\n[ \"$PRE_PR_EXIT\" -eq 0 ] || stop_batch 0",
+    );
+    expect(script).toContain(
+      "run_pre_pr_command 1 'make deps'\n[ \"$PRE_PR_EXIT\" -eq 0 ] || stop_batch 1",
+    );
+    // Checks keep running after one of them fails, exactly as the blocking
+    // runner did: only setup short-circuits.
+    expect(script).not.toContain("stop_batch 2");
+    expect(script).not.toContain("stop_batch 3");
+  });
+
+  it("clears the prior cycle's files first and touches the sentinel last", () => {
+    const script = buildRepoCheckBatchScript({
+      paths,
+      localPath: "/vercel/sandbox",
+      setup: [],
+      commands: ["pnpm lint"],
+    });
+
+    const lines = script.trimEnd().split("\n");
+    expect(lines[lines.length - 1]).toBe(`touch ${paths.sentinel}`);
+    expect(script.indexOf(`rm -f ${paths.sentinel}`)).toBeLessThan(
+      script.indexOf("run_pre_pr_command 0"),
+    );
+    expect(script.indexOf(`rm -rf ${paths.dir}`)).toBeLessThan(
+      script.indexOf("run_pre_pr_command 0"),
+    );
+  });
+
+  it("writes its own identity before it can write any output file", () => {
+    // The collector refuses a directory whose launch marker is not its own, so
+    // the marker has to be written before anything else could appear there.
+    const script = buildRepoCheckBatchScript({
+      paths,
+      localPath: "/vercel/sandbox",
+      setup: [],
+      commands: ["pnpm lint"],
+    });
+
+    expect(script).toContain(`echo '${paths.launchId}' > ${paths.dir}/launch`);
+    expect(script.indexOf(`${paths.dir}/launch`)).toBeLessThan(
+      script.indexOf("run_pre_pr_command 0"),
+    );
+  });
+
+  it("installs no signal trap, because a trap here cannot work", () => {
+    // Two reasons, both fatal to the idea. Bash runs a trap only once the
+    // current foreground command finishes (SIGNALS in bash(1)), so a handler
+    // could never fire while a check is running, which is the only moment it
+    // would have anything to kill. And `kill 0` signals the whole process
+    // group, which includes whatever launched the wrapper. Killing the launched
+    // command is stopPhaseCommand's job, through the sandbox API.
+    const script = buildRepoCheckBatchScript({
+      paths,
+      localPath: "/vercel/sandbox",
+      setup: [],
+      commands: ["pnpm test"],
+    });
+
+    expect(script).not.toMatch(/^\s*trap /m);
+    expect(script).not.toMatch(/^\s*kill /m);
+  });
+
+  it("keeps every fix cycle, repository and launch on its own paths", () => {
+    const id = "aaaabbbbccccdddd";
+    expect(repoCheckBatchPaths(0, 1, id).dir).not.toBe(repoCheckBatchPaths(1, 1, id).dir);
+    expect(repoCheckBatchPaths(1, 0, id).sentinel).not.toBe(
+      repoCheckBatchPaths(1, 1, id).sentinel,
+    );
+    // Two launches of the same cycle and repository are still two directories:
+    // a shared one would let the union of two partial batches read as complete.
+    expect(repoCheckBatchPaths(1, 1, "1111111111111111").dir).not.toBe(
+      repoCheckBatchPaths(1, 1, "2222222222222222").dir,
+    );
+  });
+});
+
+describe("startRepoCheckBatchStep", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("runs configured checks only for changed repositories", async () => {
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, args[1] === "/vercel/sandbox" ? "web-head" : "api-base");
-      }
-      return commandResult(0, "");
-    });
+  it("launches a changed repository's batch detached and runs no command inline", async () => {
+    mockRunCommand.mockImplementation(sandboxWithHead("web-head"));
 
-    const result = await runPrePrChecksWithFixes("sbx-test-123", config, "codex", "gpt-5");
-
-    expect(result.outcome).toBe("passed");
-    expect(result.passed).toBe(true);
-    expect(result.fixCycles).toBe(0);
-    expect(result.results).toEqual([
-      {
-        provider: "github",
-        repoPath: "acme/web",
-        command: "pnpm typecheck",
-        exitCode: 0,
-      },
-    ]);
-    expect(mockRunCommand).toHaveBeenCalledWith({
-      cmd: "bash",
-      args: ["-lc", "pnpm typecheck"],
-      cwd: "/vercel/sandbox",
-    });
-    expect(mockRunCommand).not.toHaveBeenCalledWith({
-      cmd: "bash",
-      args: ["-lc", "pnpm test"],
-      cwd: "/vercel/sandbox/repos/gitlab__acme__api",
-    });
-  });
-
-  it("reports missing configuration without changing legacy pass behavior", async () => {
-    const result = await runPrePrChecksWithFixes(
+    const started = await startRepoCheckBatchStep(
       "sbx-test-123",
-      { repositories: [] },
-      "codex",
-      "gpt-5",
-    );
-
-    expect(result).toMatchObject({
-      outcome: "missing_configuration",
-      passed: true,
-      results: [],
-      failures: [],
-      summary: "No pre-PR checks configured.",
-    });
-    expect(mockRunCommand).not.toHaveBeenCalled();
-  });
-
-  it("retains every ordered command result after an ordinary command failure", async () => {
-    const commands = ["pnpm lint", "pnpm test"];
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      const command = (cmd as { args?: string[] })?.args?.[1];
-      if (command === "pnpm lint") return commandResult(1, "", "lint failed");
-      if (command === "pnpm test") return commandResult(0, "tests passed");
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes(
-      "sbx-test-123",
-      {
-        repositories: [{
-          provider: "github",
-          repoPath: "acme/web",
-          commands,
-        }],
-      },
-      "codex",
-      "gpt-5",
+      "github",
+      "acme/web",
+      ["make deps"],
+      ["pnpm typecheck"],
+      0,
       0,
     );
 
-    expect(result.outcome).toBe("failed");
-    expect(result.results).toEqual([
-      {
-        provider: "github",
-        repoPath: "acme/web",
-        command: "pnpm lint",
-        exitCode: 1,
-      },
-      {
-        provider: "github",
-        repoPath: "acme/web",
-        command: "pnpm test",
-        exitCode: 0,
-      },
-    ]);
-    expect(result.failures).toHaveLength(1);
+    expect(started).toMatchObject({
+      skipped: false,
+      commandId: "cmd-batch",
+      localPath: "/vercel/sandbox",
+    });
+    expect(started.skipped).toBe(false);
+    if (started.skipped) throw new Error("unreachable");
+    expect(started.paths.wrapper).toBe(
+      `/tmp/pre-pr-checks-c0-r0-${started.paths.launchId}-wrapper.sh`,
+    );
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cmd: "bash",
+        args: [started.paths.wrapper],
+        detached: true,
+      }),
+    );
+    // The invocation that launches the batch must not also await it: nothing
+    // here may run a configured command through a blocking runCommand.
+    expect(mockRunCommand).not.toHaveBeenCalledWith(
+      expect.objectContaining({ args: ["-lc", "pnpm typecheck"] }),
+    );
+    const wrapper = mockWriteFiles.mock.calls[0]![0][0].content.toString();
+    expect(wrapper).toContain("run_pre_pr_command 0 'make deps'");
+    expect(wrapper).toContain("run_pre_pr_command 1 'pnpm typecheck'");
   });
 
-  it("runs a repository's setup commands before its checks, in authored order", async () => {
-    const shellCommands: string[] = [];
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      const shell = shellCommand(cmd);
-      if (shell) shellCommands.push(shell);
-      return commandResult(0, "");
-    });
+  it("skips a repository whose HEAD never moved", async () => {
+    mockRunCommand.mockImplementation(sandboxWithHead("web-base"));
 
-    const result = await runPrePrChecksWithFixes(
+    const started = await startRepoCheckBatchStep(
       "sbx-test-123",
-      {
-        repositories: [
-          {
-            provider: "github",
-            repoPath: "acme/web",
-            setup: ["make bootstrap", "make deps"],
-            commands: ["pnpm typecheck"],
-          },
-        ],
-      },
-      "codex",
-      "gpt-5",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      0,
       0,
     );
 
-    expect(result.passed).toBe(true);
-    expect(result.setupFailed).toBe(false);
-    expect(shellCommands).toEqual(["make bootstrap", "make deps", "pnpm typecheck"]);
-    expect(mockRunCommand).toHaveBeenCalledWith({
-      cmd: "bash",
-      args: ["-lc", "make bootstrap"],
-      cwd: "/vercel/sandbox",
-    });
-  });
-
-  it("stops a repository's checks and runs no fix cycles when its setup fails", async () => {
-    const shellCommands: string[] = [];
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex");
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      const shell = shellCommand(cmd);
-      if (shell) {
-        shellCommands.push(shell);
-        if (shell === "make bootstrap") {
-          return commandResult(127, "", "bash: line 1: toolchain: command not found");
-        }
-      }
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes(
-      "sbx-test-123",
-      {
-        repositories: [
-          {
-            provider: "github",
-            repoPath: "acme/web",
-            setup: ["make bootstrap"],
-            commands: ["pnpm typecheck"],
-          },
-        ],
-      },
-      "codex",
-      "gpt-5",
-    );
-
-    expect(result.passed).toBe(false);
-    expect(result.setupFailed).toBe(true);
-    expect(result.fixCycles).toBe(0);
-    expect(result.results).toEqual([]);
-    expect(shellCommands).toEqual(["make bootstrap"]);
+    expect(started).toEqual({ skipped: true });
     expect(mockWriteFiles).not.toHaveBeenCalled();
   });
 
-  it("reports a setup failure distinctly from a check failure", async () => {
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "changed-head");
-      }
-      const shell = shellCommand(cmd);
-      if (shell === "make bootstrap") {
-        return commandResult(127, "", "bash: line 1: toolchain: command not found");
-      }
-      if (shell === "pnpm test") return commandResult(1, "", "2 tests failed");
-      return commandResult(0, "");
-    });
+  it("skips a configured repository the workspace never attached", async () => {
+    mockRunCommand.mockImplementation(sandboxWithHead("web-head"));
 
-    const result = await runPrePrChecksWithFixes(
+    const started = await startRepoCheckBatchStep(
       "sbx-test-123",
-      {
-        repositories: [
-          {
-            provider: "github",
-            repoPath: "acme/web",
-            setup: ["make bootstrap"],
-            commands: ["pnpm typecheck"],
-          },
-          { provider: "gitlab", repoPath: "acme/api", commands: ["pnpm test"] },
-        ],
-      },
-      "codex",
-      "gpt-5",
+      "github",
+      "acme/absent",
+      [],
+      ["pnpm typecheck"],
+      0,
       0,
     );
 
-    expect(result.failures).toHaveLength(2);
-    expect(result.failures[0]).toMatchObject({
-      provider: "github",
-      repoPath: "acme/web",
-      command: "make bootstrap",
-      exitCode: 127,
-      phase: "setup",
-    });
-    expect(result.failures[1]).toMatchObject({
-      provider: "gitlab",
-      repoPath: "acme/api",
-      command: "pnpm test",
-    });
-    expect(result.failures[1]!.phase).toBeUndefined();
-    expect(result.summary).toContain("SETUP FAILED for github:acme/web");
-    expect(result.summary).toContain("toolchain: command not found");
-    expect(result.summary).toContain("no agent fix cycles were run");
-    expect(result.summary).toContain("gitlab:acme/api");
-    expect(result.summary).not.toContain("SETUP FAILED for gitlab:acme/api");
+    expect(started).toEqual({ skipped: true });
+    expect(mockWriteFiles).not.toHaveBeenCalled();
   });
 
-  it("fails a check that exits 0 while reporting its dependencies are not installed", async () => {
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      // The check tool self-skips on missing deps and exits 0.
-      return commandResult(
-        0,
-        "Yarn checks were blocked because dependencies are not installed",
-      );
-    });
+  it("starts an unchanged repository, and inspects no HEAD, when change is not required", async () => {
+    // The explicit-commands mode of run_checks runs in every attached
+    // repository whether or not its HEAD moved, and never inspected HEAD at
+    // all, so it must not start failing on an unreadable git directory.
+    mockRunCommand.mockImplementation(sandboxWithHead("web-base"));
 
-    const result = await runPrePrChecksWithFixes(
+    const started = await startRepoCheckBatchStep(
       "sbx-test-123",
-      { repositories: [config.repositories[0]!] },
-      "codex",
-      "gpt-5",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm lint"],
       0,
+      0,
+      false,
     );
 
-    expect(result.outcome).toBe("failed");
-    expect(result.passed).toBe(false);
-    expect(result.failures).toHaveLength(1);
-    expect(result.failures[0]).toMatchObject({
-      provider: "github",
-      repoPath: "acme/web",
-      command: "pnpm typecheck",
-    });
-    expect(result.summary.toLowerCase()).toContain("did not actually run");
+    expect(started).toMatchObject({ skipped: false, commandId: "cmd-batch" });
+    expect(mockRunCommand).not.toHaveBeenCalledWith("git", expect.anything());
   });
 
   it("treats inability to inspect a repository as an execution failure", async () => {
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
+    mockRunCommand.mockImplementation((cmd: unknown, args: unknown) => {
+      if (cmd === "cat" && Array.isArray(args) && args[0] === WORKSPACE_MANIFEST_PATH) {
         return commandResult(0, JSON.stringify(manifest));
       }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(128, "", "repository disappeared");
-      }
+      if (cmd === "git") return commandResult(128, "", "repository disappeared");
       return commandResult(0, "");
     });
 
     await expect(
-      runPrePrChecksWithFixes("sbx-test-123", config, "codex", "gpt-5"),
+      startRepoCheckBatchStep("sbx-test-123", "github", "acme/web", [], ["pnpm typecheck"], 0, 0),
     ).rejects.toThrow("Could not inspect workspace HEAD for github:acme/web");
   });
+});
 
-  it("sends failed check logs back to the agent and retries", async () => {
-    let checkRuns = 0;
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "claude");
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        checkRuns++;
-        return checkRuns === 1
-          ? commandResult(1, "", "Type error on line 12")
-          : commandResult(0, "ok");
-      }
+describe("listWorkspaceRepositoriesStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns every attached repository in manifest order", async () => {
+    mockRunCommand.mockImplementation(sandboxWithHead("web-head"));
+
+    await expect(listWorkspaceRepositoriesStep("sbx-test-123")).resolves.toEqual([
+      { provider: "github", repoPath: "acme/web" },
+      { provider: "gitlab", repoPath: "acme/api" },
+    ]);
+  });
+
+  it("fails when the workspace manifest is missing", async () => {
+    mockRunCommand.mockImplementation(() => commandResult(1, "", "no such file"));
+
+    await expect(listWorkspaceRepositoriesStep("sbx-test-123")).rejects.toThrow(
+      "Workspace manifest not found",
+    );
+  });
+});
+
+describe("collectRepoCheckBatchStep", () => {
+  const paths = repoCheckBatchPaths(0, 0, "aaaabbbbccccdddd");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sandboxStatus = "running";
+  });
+
+  it("retains every ordered check result and reports the failing one", async () => {
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, {
+        "exit-0": "1",
+        "stderr-0": "lint failed",
+        "exit-1": "0",
+        "stdout-1": "tests passed",
+      }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm lint", "pnpm test"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.results).toEqual([
+      { provider: "github", repoPath: "acme/web", command: "pnpm lint", exitCode: 1 },
+      { provider: "github", repoPath: "acme/web", command: "pnpm test", exitCode: 0 },
+    ]);
+    expect(collected.failures).toHaveLength(1);
+    expect(collected.failures[0]).toMatchObject({ command: "pnpm lint", stderr: "lint failed" });
+    expect(collected.setupFailed).toBe(false);
+  });
+
+  it("stops a repository's checks at a failing setup command", async () => {
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, {
+        "stopped-at": "0",
+        "exit-0": "127",
+        "stderr-0": "bash: line 1: toolchain: command not found",
+      }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      ["make bootstrap"],
+      ["pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.setupFailed).toBe(true);
+    expect(collected.results).toEqual([]);
+    expect(collected.failures).toEqual([
+      {
+        provider: "github",
+        repoPath: "acme/web",
+        command: "make bootstrap",
+        exitCode: 127,
+        stdout: "",
+        stderr: "bash: line 1: toolchain: command not found",
+        phase: "setup",
+      },
+    ]);
+  });
+
+  it("fails a check that exits 0 while reporting its dependencies are not installed", async () => {
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, {
+        "exit-0": "0",
+        "stdout-0": "Yarn checks were blocked because dependencies are not installed",
+      }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.results).toEqual([
+      { provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 0 },
+    ]);
+    expect(collected.failures).toHaveLength(1);
+    expect(collected.failures[0]!.stderr.toLowerCase()).toContain("did not actually run");
+  });
+
+  it("separates a workspace it could not enter from a setup command that failed", async () => {
+    // Both stop the repository, but only one is the operator's configuration.
+    // Reporting a vanished directory as setupFailed suppressed the fix cycles
+    // of every other repository in the run, for a fault none of them caused.
+    mockRunCommand.mockImplementation(batchOutputFiles(paths, { "stopped-at": "-1" }));
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.setupFailed).toBe(false);
+    expect(collected.results).toEqual([]);
+    // The phase is the mechanism: it is what excludes this failure from the
+    // repair prompt and keeps it out of the run-wide setup suppression.
+    expect(collected.failures[0]).toMatchObject({
+      command: "(repository workspace)",
+      phase: "workspace",
+    });
+    expect(collected.failures[0]!.stderr).toContain("not one of its");
+    expect(collected.failures[0]!.stderr).toContain("/vercel/sandbox");
+  });
+
+  it("refuses output that belongs to a different launch", async () => {
+    // Two wrappers sharing one directory would union their files into a set
+    // that looks complete while no single process ran the batch end to end.
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, { launch: "ffffffffffffffff", "exit-0": "0" }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.results).toEqual([]);
+    expect(collected.setupFailed).toBe(false);
+    expect(collected.failures[0]!.phase).toBe("workspace");
+    expect(collected.failures[0]!.stderr).toContain("does not belong to the batch");
+  });
+
+  it("says the reader failed rather than blaming the launch marker", async () => {
+    // The reader runs under `bash -lc`, which sources the very profile these
+    // setup commands append to. Reporting that failure as "this output does not
+    // belong to the batch that was launched for it" tells the operator their
+    // checks ran under a foreign wrapper, and fails the gate as an unrepairable
+    // workspace incident, for a broken shell profile.
+    mockRunCommand.mockImplementation((cmd: unknown) =>
+      batchReaderScript(cmd) === null
+        ? commandResult(0, "")
+        : commandResult(2, "", "/etc/profile.d/uv.sh: line 3: syntax error"),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.failures[0]!.stderr).toContain("could not be read back out of the Run");
+    expect(collected.failures[0]!.stderr).not.toContain("does not belong to the batch");
+    expect(collected.failures[0]!.phase).toBe("workspace");
+  });
+
+  it("says the wrapper never started when its marker is absent", async () => {
+    // The wrapper writes the marker before it does anything else, so its
+    // absence is a more informative diagnosis than the one the command loop
+    // would reach a moment later ("exit-0 is missing").
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, { launch: undefined as unknown as string }),
+    );
+
+    for (const batchFinished of [true, false]) {
+      const collected = await collectRepoCheckBatchStep(
+        "sbx-test-123",
+        "github",
+        "acme/web",
+        [],
+        ["pnpm typecheck"],
+        paths,
+        "/vercel/sandbox",
+        batchFinished,
+      );
+
+      expect(collected.failures[0]!.stderr).toContain("never started");
+      expect(collected.results).toEqual([]);
+    }
+  });
+
+  it("reads no files at all from a sandbox that is no longer running", async () => {
+    // This step is called on the path where the poll just gave up, having
+    // observed the sandbox as not running twice. Its maxRetries is 0, so an SDK
+    // error thrown here replaces the informative stall sentence with an
+    // unclassified run failure, in the exact case the mechanism exists for.
+    sandboxStatus = "stopped";
+    mockRunCommand.mockImplementation(batchOutputFiles(paths, { "exit-0": "0" }));
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+      false,
+    );
+
+    expect(collected.failures[0]!.stderr).toContain("no longer running");
+    expect(collected.results).toEqual([]);
+    expect(mockRunCommand).not.toHaveBeenCalled();
+  });
+
+  it("catches a blocked-dependency phrase that the truncation cuts in half", async () => {
+    // The phrase the guard matches is `run \`yarn install\``, and head -c and
+    // tail -c cut on bytes. A log long enough to be truncated puts the phrase
+    // in the middle, where no amount of carried text can find it: the reader
+    // greps the whole file instead, and the collector trusts that flag.
+    const middle = `${"y".repeat(20_000)}error Yarn checks blocked: run \`yarn install\`${"z".repeat(20_000)}`;
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, { "exit-0": "0", "stdout-0": middle }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["yarn lint"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.failures).toHaveLength(1);
+    expect(collected.failures[0]!.stderr).toContain("did not actually run");
+    // The carried text really does not contain the phrase: the flag is what
+    // caught it.
+    expect(collected.failures[0]!.stdout).not.toContain("yarn install");
+  });
+
+  it("reads the whole batch in one sandbox round trip", async () => {
+    // Three reads per command inside a step whose maxRetries is 0 is the same
+    // unbounded-await shape this change exists to remove, with a friendlier
+    // constant: twenty commands would be sixty sequential round trips.
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, {
+        "exit-0": "0",
+        "exit-1": "0",
+        "exit-2": "0",
+        "exit-3": "0",
+      }),
+    );
+
+    await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      ["make deps"],
+      ["pnpm lint", "pnpm test", "pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(mockRunCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("names where an abandoned batch stopped without inventing later results", async () => {
+    // A stalled batch is collected too: those files are the only record of
+    // which command it died on. The commands after it never started, so they
+    // are not results of any kind.
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, {
+        "exit-0": "0",
+        "exit-1": "0",
+        "stdout-2": "collecting tests...",
+      }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      ["make deps"],
+      ["pnpm lint", "uv run pytest tests/ -m integration", "pnpm typecheck"],
+      paths,
+      "/vercel/sandbox",
+      false,
+    );
+
+    expect(collected.progress).toEqual({
+      completed: 2,
+      total: 4,
+      stoppedAt: "uv run pytest tests/ -m integration",
+    });
+    expect(collected.results.map((result) => result.command)).toEqual(["pnpm lint"]);
+    expect(collected.failures).toEqual([]);
+  });
+
+  it("keeps both ends of a long stream and names the bytes it dropped", async () => {
+    // What this step returns is persisted in the run's event log, so a twenty
+    // minute pytest log must never be carried back whole. Both ends survive
+    // because tools disagree about where the answer is: tsc and mypy put the
+    // root cause first, pytest puts the verdict last.
+    const long = `FAILED_FIRST${"x".repeat(80_000)}FAILED test_end.py::test_last`;
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, { "exit-0": "1", "stderr-0": long }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm test"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    const stderr = collected.failures[0]!.stderr;
+    expect(stderr).toContain("FAILED_FIRST");
+    expect(stderr).toContain("FAILED test_end.py::test_last");
+    expect(stderr).toContain(
+      `[... ${long.length - 8_192} bytes of this command's output omitted ...]`,
+    );
+    // Sized against what a consumer reads (2000 characters), not against what
+    // the event log tolerates: bytes past this are carried, persisted and then
+    // thrown away unread.
+    expect(stderr.length).toBeLessThanOrEqual(8_192 + 200);
+  });
+
+  it("bounds what one collect returns in total, not only per stream", async () => {
+    // Twelve verbose commands multiply the per-stream bound by twelve, and all
+    // of it lands in the run's event log as a step return value.
+    const commands = Array.from({ length: 12 }, (_, index) => `pnpm test-${index}`);
+    const files: Record<string, string> = {};
+    for (let index = 0; index < commands.length; index++) {
+      files[`exit-${index}`] = "1";
+      files[`stderr-${index}`] = "E".repeat(6_000);
+    }
+    mockRunCommand.mockImplementation(batchOutputFiles(paths, files));
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      commands,
+      paths,
+      "/vercel/sandbox",
+    );
+
+    const total = collected.failures.reduce(
+      (sum, failure) => sum + failure.stdout.length + failure.stderr.length,
+      0,
+    );
+    expect(collected.failures).toHaveLength(12);
+    // The aggregate bound, plus the one marker sentence each truncated entry
+    // carries to say what it lost, and nothing more.
+    expect(total).toBeLessThanOrEqual(32 * 1024 + 12 * 200);
+    // The first failures keep their text: they are where a reader starts.
+    expect(collected.failures[0]!.stderr).toBe("E".repeat(6_000));
+    expect(collected.failures.at(-1)!.stderr).toContain("the batch as a whole reached");
+  });
+
+  it("marks nothing when a stream fits inside the cap", async () => {
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, { "exit-0": "1", "stderr-0": "2 tests failed" }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm test"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.failures[0]!.stderr).toBe("2 tests failed");
+  });
+
+  it("never reads a command with no recorded exit status as a pass", async () => {
+    mockRunCommand.mockImplementation(
+      batchOutputFiles(paths, { "stdout-0": "half a test run" }),
+    );
+
+    const collected = await collectRepoCheckBatchStep(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm test"],
+      paths,
+      "/vercel/sandbox",
+    );
+
+    expect(collected.results).toEqual([]);
+    expect(collected.failures).toHaveLength(1);
+    expect(collected.failures[0]).toMatchObject({ command: "pnpm test", exitCode: -1 });
+    expect(collected.failures[0]!.stderr).toContain("interrupted");
+  });
+});
+
+describe("startPrePrRepairStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("launches the repair wrapper detached instead of holding the command open", async () => {
+    // A blocking launch keeps one sandbox ndjson stream open for the whole
+    // repair agent. Production runs whose pre-PR checks crossed a function
+    // invocation boundary lost that stream mid-flight, and the SDK's parse
+    // error was reported as a launch that never produced a process: empty
+    // output, empty logs, no exit code, for an agent that was in fact running.
+    mockRunCommand.mockImplementation((cmd: unknown) => {
+      if (isWrapperLaunch(cmd)) return detachedCommand();
       return commandResult(0, "");
     });
 
-    const result = await runPrePrChecksWithFixes("sbx-test-123", config, "claude", "claude-opus-4-6");
-
-    expect(result.passed).toBe(true);
-    expect(result.fixCycles).toBe(1);
-    expect(mockWriteFiles).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        {
-          path: "/tmp/pre-pr-fix-1-requirements.md",
-          content: expect.any(Buffer),
-        },
-        {
-          path: "/tmp/pre-pr-fix-1-wrapper.sh",
-          content: expect.any(Buffer),
-        },
-      ]),
+    const started = await startPrePrRepairStep(
+      "sbx-test-123",
+      "codex",
+      "gpt-5",
+      1,
+      "github:acme/web\nCommand: pnpm typecheck\nType error on line 12",
     );
-    const prompt = mockWriteFiles.mock.calls[0][0]
+
+    expect(started).toMatchObject({
+      ok: true,
+      commandId: "cmd-detached",
+      phase: "pre-pr-fix-1",
+    });
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cmd: "bash",
+        args: ["/tmp/pre-pr-fix-1-wrapper.sh"],
+        cwd: "/vercel/sandbox",
+        detached: true,
+      }),
+    );
+    const prompt = mockWriteFiles.mock.calls[0]![0]
       .find((file: { path: string; content: Buffer }) => file.path.endsWith("requirements.md"))
       .content.toString();
     expect(prompt).toContain("github:acme/web");
     expect(prompt).toContain("Type error on line 12");
   });
 
-  it("returns authoritative Claude usage for every launched fix cycle", async () => {
-    let checkRuns = 0;
+  it("names the cause when the repair process cannot be launched at all", async () => {
+    // Production runs died here with a failure that named only the boundary:
+    // no exit code, no captured bytes, and the thrown error destroyed at the
+    // catch. Every distinct launch cause has to reach the run record instead.
+    const launchWith = (thrown: unknown) => {
+      mockRunCommand.mockImplementation((cmd: unknown) => {
+        if (isWrapperLaunch(cmd)) throw thrown;
+        return commandResult(0, "");
+      });
+      return startPrePrRepairStep("sbx-test-123", "codex", "gpt-5", 1, "still failing");
+    };
+
+    const reset = await launchWith(new Error("sandbox connection reset"));
+    expect(reset).toMatchObject({
+      ok: false,
+      failure: {
+        diagnostic: {
+          failureKind: "setup_failed",
+          detail: expect.stringContaining("sandbox connection reset"),
+        },
+      },
+    });
+
+    const refused = await launchWith(
+      Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:443"), {
+        code: "ECONNREFUSED",
+      }),
+    );
+    expect(refused.ok).toBe(false);
+    if (refused.ok) throw new Error("unreachable");
+    expect(refused.failure.diagnostic.detail).toContain(
+      "ECONNREFUSED: connect ECONNREFUSED 10.0.0.1:443",
+    );
+  });
+
+  it("bounds a very long launch failure cause instead of embedding it whole", async () => {
+    const thrownMessage = "sandbox refused the launch. ".repeat(200);
+    mockRunCommand.mockImplementation((cmd: unknown) => {
+      if (isWrapperLaunch(cmd)) throw new Error(thrownMessage);
+      return commandResult(0, "");
+    });
+
+    const started = await startPrePrRepairStep(
+      "sbx-test-123",
+      "codex",
+      "gpt-5",
+      1,
+      "still failing",
+    );
+
+    expect(started.ok).toBe(false);
+    if (started.ok) throw new Error("unreachable");
+    const detail = started.failure.diagnostic.detail ?? "";
+    expect(detail).toContain("The Pre-PR repair process could not be launched:");
+    expect(detail).not.toContain(thrownMessage);
+    // Sentence plus the bound the repair cause is clamped to, and nothing more,
+    // so a runaway error text cannot become the run status.
+    expect(detail.length).toBeLessThanOrEqual(
+      "The Pre-PR repair process could not be launched: ".length + 200,
+    );
+  });
+
+  it("reports a wrapper that exited before it started as a launch failure", async () => {
+    mockRunCommand.mockImplementation((cmd: unknown, args: unknown) => {
+      const artifact = phaseArtifactCommand(cmd, args, "codex");
+      if (artifact) return artifact;
+      if (isWrapperLaunch(cmd)) return commandResult(7, "", "boom");
+      return commandResult(0, "");
+    });
+
+    const started = await startPrePrRepairStep(
+      "sbx-test-123",
+      "codex",
+      "gpt-5",
+      1,
+      "still failing",
+    );
+
+    expect(started).toMatchObject({
+      ok: false,
+      failure: { diagnostic: { failureKind: "cli_exit", exitCode: 7 } },
+    });
+  });
+});
+
+describe("collectPrePrRepairStep", () => {
+  const paths = {
+    wrapper: "/tmp/pre-pr-fix-1-wrapper.sh",
+    input: "/tmp/pre-pr-fix-1-requirements.md",
+    stdout: "/tmp/pre-pr-fix-1-stdout.txt",
+    stderr: "/tmp/pre-pr-fix-1-stderr.txt",
+    exitCode: "/tmp/pre-pr-fix-1-exit-code",
+    sentinel: "/tmp/pre-pr-fix-1-done",
+    structuredOutput: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns authoritative Claude usage for a finished repair", async () => {
     const claudeOutput = JSON.stringify({
       type: "result",
+      subtype: "success",
+      is_error: false,
       cost_usd: 0.42,
       duration_ms: 12_000,
       duration_api_ms: 10_000,
@@ -427,299 +894,47 @@ describe("runPrePrChecksWithFixes", () => {
         output_tokens: 40,
       },
     });
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "claude", claudeOutput);
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        checkRuns++;
-        return checkRuns === 1
-          ? commandResult(1, "", "Type error")
-          : commandResult(0, "ok");
-      }
-      return commandResult(0, "");
-    });
+    mockRunCommand.mockImplementation((cmd: unknown, args: unknown) =>
+      phaseArtifactCommand(cmd, args, "claude", claudeOutput) ?? commandResult(0, ""),
+    );
 
-    const result = await runPrePrChecksWithFixes(
+    const collected = await collectPrePrRepairStep(
       "sbx-test-123",
-      config,
       "claude",
-      "claude-opus-4-6",
+      "pre-pr-fix-1",
+      paths,
+      "none",
+      0,
     );
 
-    expect(result.fixCycleUsages).toEqual([
-      {
-        cost_usd: 0.42,
-        tokens: { input: 120, cached_input: 30, output: 40 },
-        duration_ms: 12_000,
-        duration_api_ms: 10_000,
-        num_turns: 2,
-      },
-    ]);
-    const wrapper = mockWriteFiles.mock.calls[0][0]
-      .find((file: { path: string; content: Buffer }) => file.path.endsWith("wrapper.sh"))
-      .content.toString();
-    expect(wrapper).toContain("claude");
-    expect(wrapper).toContain("--output-format json");
+    expect(collected.failure).toBeUndefined();
+    expect(collected.usage).toEqual({
+      cost_usd: 0.42,
+      tokens: { input: 120, cached_input: 30, output: 40 },
+      duration_ms: 12_000,
+      duration_api_ms: 10_000,
+      num_turns: 2,
+    });
   });
 
-  it("returns null usage for a launched fix cycle whose CLI output has no usage", async () => {
-    let checkRuns = 0;
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex");
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        checkRuns++;
-        return checkRuns === 1
-          ? commandResult(1, "", "Type error")
-          : commandResult(0, "ok");
-      }
-      return commandResult(0, "");
-    });
+  it("returns null usage when the CLI output carries none", async () => {
+    mockRunCommand.mockImplementation((cmd: unknown, args: unknown) =>
+      phaseArtifactCommand(cmd, args, "codex") ?? commandResult(0, ""),
+    );
 
-    const result = await runPrePrChecksWithFixes(
+    const collected = await collectPrePrRepairStep(
       "sbx-test-123",
-      config,
       "codex",
-      "gpt-5",
+      "pre-pr-fix-1",
+      paths,
+      "none",
+      0,
     );
 
-    expect(result.fixCycles).toBe(1);
-    expect(result.fixCycleUsages).toEqual([null]);
+    expect(collected).toEqual({ usage: null });
   });
 
-  it("returns an execution failure when the repair process exits nonzero", async () => {
-    let checkRuns = 0;
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex", undefined, 7);
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        checkRuns++;
-        return commandResult(1, "", "still failing");
-      }
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes(
-      "sbx-test-123",
-      { repositories: [config.repositories[0]!] },
-      "codex",
-      "gpt-5",
-    );
-
-    expect(result.passed).toBe(false);
-    expect(result.fixCycles).toBe(1);
-    expect(result.agentFailure).toMatchObject({
-      category: "provider",
-      diagnostic: {
-        failureKind: "cli_exit",
-        exitCode: 7,
-        detail: "The CLI exited with code 7.",
-      },
-    });
-    expect(checkRuns).toBe(1);
-  });
-
-  it("launches the repair wrapper detached and reads its sentinel instead of holding the command open", async () => {
-    // A blocking launch keeps one sandbox ndjson stream open for the whole
-    // repair agent. Production runs whose pre-PR checks crossed a function
-    // invocation boundary lost that stream mid-flight, and the SDK's parse
-    // error was reported as a launch that never produced a process: empty
-    // output, empty logs, no exit code, for an agent that was in fact running.
-    // The launch has to return before the agent finishes, and completion has to
-    // come from the wrapper's sentinel file.
-    vi.useFakeTimers();
-    try {
-      let checkRuns = 0;
-      let sentinelReads = 0;
-      let sentinelReadsWhenLaunchReturned = -1;
-      mockRunCommand.mockImplementation((cmd, args) => {
-        const artifact = phaseArtifactCommand(cmd, args, "codex");
-        if (artifact) return artifact;
-        if (isWrapperLaunch(cmd)) {
-          sentinelReadsWhenLaunchReturned = sentinelReads;
-          // A detached command has not exited when runCommand resolves.
-          return detachedCommand();
-        }
-        if (isSentinelRead(cmd, args)) {
-          sentinelReads++;
-          return commandResult(sentinelReads >= 2 ? 0 : 1);
-        }
-        if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-          return commandResult(0, JSON.stringify(manifest));
-        }
-        if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-          return commandResult(0, "web-head");
-        }
-        if (isConfiguredCheck(cmd)) {
-          checkRuns++;
-          return checkRuns === 1
-            ? commandResult(1, "", "Type error")
-            : commandResult(0, "ok");
-        }
-        return commandResult(0, "");
-      });
-
-      const pending = runPrePrChecksWithFixes(
-        "sbx-test-123",
-        { repositories: [config.repositories[0]!] },
-        "codex",
-        "gpt-5",
-      );
-      const result = await drainPollTicks(pending);
-
-      expect(result.passed).toBe(true);
-      expect(result.fixCycles).toBe(1);
-      expect(result.agentFailure).toBeUndefined();
-      expect(mockRunCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          cmd: "bash",
-          args: ["/tmp/pre-pr-fix-1-wrapper.sh"],
-          cwd: "/vercel/sandbox",
-          detached: true,
-        }),
-      );
-      expect(mockRunCommand).toHaveBeenCalledWith("test", [
-        "-f",
-        "/tmp/pre-pr-fix-1-done",
-      ]);
-      // The launch resolved before any sentinel existed, and the phase only
-      // ended once a later poll found one: completion is driven by the poll,
-      // not by the launch call.
-      expect(sentinelReadsWhenLaunchReturned).toBe(0);
-      expect(sentinelReads).toBe(2);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("propagates a deadline abort raised while the repair phase is polled", async () => {
-    // The deadline that used to abort the blocking launch now expires during
-    // the poll, and it must stay a real TimeoutError rather than become a
-    // "could not be launched" failure attributed to the provider.
-    let sentinelReads = 0;
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex");
-      if (artifact) return artifact;
-      if (isWrapperLaunch(cmd)) return detachedCommand();
-      if (isSentinelRead(cmd, args)) {
-        sentinelReads++;
-        return commandResult(1);
-      }
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (isHeadInspection(cmd)) return commandResult(0, "web-head");
-      if (isConfiguredCheck(cmd)) return commandResult(1, "", "still failing");
-      return commandResult(0, "");
-    });
-
-    await expect(
-      runPrePrChecksWithFixes(
-        "sbx-test-123",
-        { repositories: [config.repositories[0]!] },
-        "codex",
-        "gpt-5",
-        3,
-        50,
-      ),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
-
-    expect(sentinelReads).toBeGreaterThan(0);
-  });
-
-  it("names the cause when the repair process cannot be launched at all", async () => {
-    // Production runs died here with a failure that named only the boundary:
-    // no exit code, no captured bytes, and the thrown error destroyed at the
-    // catch. Every distinct launch cause has to reach the run record instead.
-    const launchWith = (thrown: unknown) => {
-      mockRunCommand.mockImplementation((cmd, args) => {
-        if (isWrapperLaunch(cmd)) throw thrown;
-        if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-          return commandResult(0, JSON.stringify(manifest));
-        }
-        if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-          return commandResult(0, "web-head");
-        }
-        if (isConfiguredCheck(cmd)) return commandResult(1, "", "still failing");
-        return commandResult(0, "");
-      });
-      return runPrePrChecksWithFixes(
-        "sbx-test-123",
-        { repositories: [config.repositories[0]!] },
-        "codex",
-        "gpt-5",
-      );
-    };
-
-    const reset = await launchWith(new Error("sandbox connection reset"));
-    expect(reset.agentFailure).toMatchObject({
-      diagnostic: {
-        failureKind: "setup_failed",
-        detail: expect.stringContaining("sandbox connection reset"),
-      },
-    });
-
-    const refused = await launchWith(
-      Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:443"), {
-        code: "ECONNREFUSED",
-      }),
-    );
-    expect(refused.agentFailure?.diagnostic.detail).toContain(
-      "ECONNREFUSED: connect ECONNREFUSED 10.0.0.1:443",
-    );
-  });
-
-  it("bounds a very long launch failure cause instead of embedding it whole", async () => {
-    const thrownMessage = "sandbox refused the launch. ".repeat(200);
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (isWrapperLaunch(cmd)) throw new Error(thrownMessage);
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) return commandResult(1, "", "still failing");
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes(
-      "sbx-test-123",
-      { repositories: [config.repositories[0]!] },
-      "codex",
-      "gpt-5",
-    );
-
-    const detail = result.agentFailure?.diagnostic.detail ?? "";
-    expect(detail).toContain("The Pre-PR repair process could not be launched:");
-    expect(detail).not.toContain(thrownMessage);
-    // Sentence plus the bound the repair cause is clamped to, and nothing more,
-    // so a runaway error text cannot become the run status.
-    expect(detail.length).toBeLessThanOrEqual(
-      "The Pre-PR repair process could not be launched: ".length + 200,
-    );
-  });
-
-  it("keeps valid repair usage when malformed protocol output becomes an execution failure", async () => {
-    let checkRuns = 0;
+  it("keeps valid repair usage when malformed protocol output becomes a failure", async () => {
     const malformedWithUsage = [
       JSON.stringify({ type: "thread.started", thread_id: "normalized" }),
       "{malformed",
@@ -728,229 +943,80 @@ describe("runPrePrChecksWithFixes", () => {
         usage: { input_tokens: 10, cached_input_tokens: 2, output_tokens: 3 },
       }),
     ].join("\n");
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex", malformedWithUsage);
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        checkRuns++;
-        return commandResult(1, "", "still failing");
-      }
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes(
-      "sbx-test-123",
-      { repositories: [config.repositories[0]!] },
-      "codex",
-      "gpt-5",
+    mockRunCommand.mockImplementation((cmd: unknown, args: unknown) =>
+      phaseArtifactCommand(cmd, args, "codex", malformedWithUsage) ?? commandResult(0, ""),
     );
 
-    expect(result.agentFailure).toMatchObject({
+    const collected = await collectPrePrRepairStep(
+      "sbx-test-123",
+      "codex",
+      "pre-pr-fix-1",
+      paths,
+      "none",
+      0,
+    );
+
+    expect(collected.failure).toMatchObject({
       category: "parsing",
       diagnostic: { failureKind: "invalid_json" },
     });
-    expect(result.fixCycleUsages).toEqual([
-      {
-        cost_usd: null,
-        tokens: { input: 8, cached_input: 2, output: 3 },
-        duration_ms: 0,
-        duration_api_ms: 0,
-        num_turns: 1,
-      },
-    ]);
-    expect(checkRuns).toBe(1);
+    expect(collected.usage).toEqual({
+      cost_usd: null,
+      tokens: { input: 8, cached_input: 2, output: 3 },
+      duration_ms: 0,
+      duration_api_ms: 0,
+      num_turns: 1,
+    });
   });
 
-  it("stops before another check or fixer when the first fix cycle exceeds the token cap", async () => {
-    let checkRuns = 0;
-    const oneRepoConfig: PrePrCheckConfig = { repositories: [config.repositories[0]!] };
-    const codexOutput = JSON.stringify({
-      type: "turn.completed",
-      usage: { input_tokens: 10, cached_input_tokens: 2, output_tokens: 3 },
-    });
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex", codexOutput);
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        checkRuns++;
-        return commandResult(1, "", "still failing");
-      }
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes(
+  it("distinguishes a repair that outlived its cap from a sandbox that died", async () => {
+    const timedOut = await collectPrePrRepairStep(
       "sbx-test-123",
-      oneRepoConfig,
       "codex",
-      "gpt-5",
-      3,
-      undefined,
-      {
-        state: createRunBudgetState(),
-        limits: { maxDurationMs: 60_000, maxTokens: 12 },
-        price: { input: 0.001, cached_input: 0.0001, output: 0.002 },
-      },
+      "pre-pr-fix-1",
+      paths,
+      "timed_out",
+      480_000,
+    );
+    const stopped = await collectPrePrRepairStep(
+      "sbx-test-123",
+      "codex",
+      "pre-pr-fix-1",
+      paths,
+      "sandbox_stopped",
+      480_000,
     );
 
-    expect(result.fixCycles).toBe(1);
-    expect(result.fixCycleUsages).toHaveLength(1);
-    expect(result.budgetFailure).toMatchObject({
-      status: "budget_exceeded",
-      metric: "tokens",
-      limit: 12,
-      consumed: 13,
-    });
-    expect(checkRuns).toBe(1);
-    expect(mockWriteFiles).toHaveBeenCalledTimes(1);
-  });
-
-  it("stops before cycle two when the first fix cycle has unknown capped usage", async () => {
-    let checkRuns = 0;
-    const oneRepoConfig: PrePrCheckConfig = { repositories: [config.repositories[0]!] };
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex");
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        checkRuns++;
-        return commandResult(1, "", "still failing");
-      }
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes(
-      "sbx-test-123",
-      oneRepoConfig,
-      "codex",
-      "gpt-5",
-      3,
-      undefined,
-      {
-        state: createRunBudgetState(),
-        limits: { maxDurationMs: 60_000, maxTokens: 100 },
-        price: { input: 0.001, cached_input: 0.0001, output: 0.002 },
-      },
+    // The time that actually elapsed, never the 25 minute constant: the cap
+    // that applies is the smaller of that constant and what is left of the
+    // run's duration budget, so a run with eight minutes left is stopped at
+    // eight and must not be told it got twenty-five.
+    expect(timedOut.failure?.diagnostic.detail).toBe(
+      "The Pre-PR repair process ran for 8 minutes without finishing and was stopped.",
     );
+    expect(stopped.failure?.diagnostic.detail).toBe(
+      "The sandbox stopped before the Pre-PR repair process finished.",
+    );
+    expect(timedOut.usage).toBeNull();
+    // A stall never reads the sandbox back: there is nothing to collect.
+    expect(mockRunCommand).not.toHaveBeenCalled();
+  });
+});
 
-    expect(result.fixCycleUsages).toEqual([null]);
-    expect(result.budgetFailure).toMatchObject({
-      status: "budget_unverifiable",
-      metric: "tokens",
-      limit: 100,
-    });
-    expect(checkRuns).toBe(1);
-    expect(mockWriteFiles).toHaveBeenCalledTimes(1);
+describe("boundFailureOutput", () => {
+  it("keeps both ends of an oversized failure and names what it dropped", () => {
+    const text = `HEAD${"m".repeat(5_000)}TAIL`;
+
+    const bounded = boundFailureOutput(text, 2_000);
+
+    expect(bounded.startsWith("HEAD")).toBe(true);
+    expect(bounded.endsWith("TAIL")).toBe(true);
+    expect(bounded).toContain(`[... ${text.length - 2_000} characters omitted ...]`);
+    expect(bounded.length).toBe(2_000);
   });
 
-  it("fails after three unsuccessful fix cycles", async () => {
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex");
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        return commandResult(1, "", "still failing");
-      }
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes("sbx-test-123", config, "codex", "gpt-5");
-
-    expect(result.passed).toBe(false);
-    expect(result.fixCycles).toBe(3);
-    expect(result.summary).toContain("still failing");
-  });
-
-  it("caps fix cycles at a caller-supplied maxFixCycles", async () => {
-    mockRunCommand.mockImplementation((cmd, args) => {
-      const artifact = phaseArtifactCommand(cmd, args, "codex");
-      if (artifact) return artifact;
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        return commandResult(1, "", "still failing");
-      }
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes("sbx-test-123", config, "codex", "gpt-5", 1);
-
-    expect(result.passed).toBe(false);
-    expect(result.fixCycles).toBe(1);
-  });
-
-  it("runs no fix cycles when maxFixCycles is 0", async () => {
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        return commandResult(1, "", "still failing");
-      }
-      return commandResult(0, "");
-    });
-
-    const result = await runPrePrChecksWithFixes("sbx-test-123", config, "codex", "gpt-5", 0);
-
-    expect(result.passed).toBe(false);
-    expect(result.fixCycles).toBe(0);
-    expect(mockWriteFiles).not.toHaveBeenCalled();
-  });
-
-  it("passes one deadline signal to long checks and starts no later command or fix cycle", async () => {
-    let startedChecks = 0;
-    mockRunCommand.mockImplementation((cmd, args) => {
-      if (cmd === "cat" && args[0] === WORKSPACE_MANIFEST_PATH) {
-        return commandResult(0, JSON.stringify(manifest));
-      }
-      if (isHeadInspection(cmd)) {
-        return commandResult(0, "web-head");
-      }
-      if (cmd === "git" && args[0] === "-C" && args[2] === "rev-parse") {
-        return commandResult(0, "web-head");
-      }
-      if (isConfiguredCheck(cmd)) {
-        expect((cmd as { signal?: AbortSignal }).signal).toBeInstanceOf(AbortSignal);
-        startedChecks += 1;
-        throw new DOMException("duration expired", "TimeoutError");
-      }
-      return commandResult(0, "");
-    });
-
-    await expect(
-      runPrePrChecksWithFixes("sbx-test-123", config, "codex", "gpt-5", 3, 25),
-    ).rejects.toMatchObject({ name: "TimeoutError" });
-
-    expect(startedChecks).toBe(1);
-    expect(mockWriteFiles).not.toHaveBeenCalled();
+  it("leaves output that already fits untouched", () => {
+    expect(boundFailureOutput("2 tests failed", 2_000)).toBe("2 tests failed");
   });
 });
 
@@ -960,6 +1026,77 @@ function commandResult(exitCode: number, stdout = "", stderr = "") {
     stdout: vi.fn().mockResolvedValue(stdout),
     stderr: vi.fn().mockResolvedValue(stderr),
   };
+}
+
+/** Sandbox that serves the manifest and reports `head` for every rev-parse. */
+function sandboxWithHead(head: string) {
+  return (cmd: unknown, args: unknown) => {
+    if (cmd === "cat" && Array.isArray(args) && args[0] === WORKSPACE_MANIFEST_PATH) {
+      return commandResult(0, JSON.stringify(manifest));
+    }
+    if (cmd === "git") return commandResult(0, head);
+    if (isWrapperLaunch(cmd)) return batchLaunch();
+    return commandResult(0, "");
+  };
+}
+
+/**
+ * Serves one batch directory over the single reader command the collector
+ * makes, in the reader's own wire format: `<name> <bytes> <b64head> <b64tail>`
+ * per requested file, `-1` bytes for a file that does not exist. The launch
+ * marker is served by default, because every collect checks it first.
+ */
+function batchOutputFiles(paths: RepoCheckBatchPaths, files: Record<string, string>) {
+  const all: Record<string, string> = { launch: paths.launchId, ...files };
+  return (cmd: unknown) => {
+    const script = batchReaderScript(cmd);
+    if (script === null) return commandResult(0, "");
+    const lines: string[] = [];
+    for (const match of script.matchAll(/^emit '([^']+)' '([^']+)'$/gm)) {
+      const name = match[1]!;
+      const content = all[name];
+      if (content === undefined) {
+        lines.push(`${name} -1 0 - -`);
+        continue;
+      }
+      const buffer = Buffer.from(content, "utf8");
+      const encode = (part: Buffer) => part.toString("base64") || "-";
+      // The reader greps the whole file, before any truncation, so the fake
+      // has to answer from the whole file too.
+      const blocked = MISSING_DEPENDENCY_PHRASES.some((phrase) =>
+        content.toLowerCase().includes(phrase.toLowerCase()),
+      )
+        ? "1"
+        : "0";
+      lines.push(
+        buffer.length <= 8_192
+          ? `${name} ${buffer.length} ${blocked} ${encode(buffer)} -`
+          : `${name} ${buffer.length} ${blocked} ${encode(buffer.subarray(0, 4_096))} ${encode(
+              buffer.subarray(buffer.length - 4_096),
+            )}`,
+      );
+    }
+    return commandResult(0, lines.join("\n"));
+  };
+}
+
+/** The phrases the reader greps for, as the production script builds them. */
+const MISSING_DEPENDENCY_PHRASES = [
+  "dependencies are not installed",
+  "dependencies must be installed",
+  "run `yarn install`",
+  "run 'yarn install'",
+  "run `npm install`",
+  "run `pnpm install`",
+];
+
+/** The reader is the one `bash -lc` call the collector makes. */
+function batchReaderScript(cmd: unknown): string | null {
+  const objectCommand = cmd as { cmd?: unknown; args?: unknown };
+  if (typeof cmd !== "object" || cmd === null) return null;
+  if (objectCommand.cmd !== "bash" || !Array.isArray(objectCommand.args)) return null;
+  if (objectCommand.args[0] !== "-lc") return null;
+  return typeof objectCommand.args[1] === "string" ? objectCommand.args[1] : null;
 }
 
 function phaseArtifactCommand(
@@ -981,66 +1118,24 @@ function phaseArtifactCommand(
   return null;
 }
 
-/** The shell command text of a `bash -lc` invocation, or null for anything else. */
-function shellCommand(cmd: unknown): string | null {
-  const objectCommand = cmd as { cmd?: unknown; args?: unknown };
-  if (
-    typeof cmd === "object" &&
-    cmd !== null &&
-    objectCommand.cmd === "bash" &&
-    Array.isArray(objectCommand.args) &&
-    objectCommand.args[0] === "-lc" &&
-    typeof objectCommand.args[1] === "string"
-  ) {
-    return objectCommand.args[1];
-  }
-  return null;
-}
-
-function isConfiguredCheck(cmd: unknown): boolean {
-  const objectCommand = cmd as { cmd?: unknown; args?: unknown };
-  return (
-    typeof cmd === "object" &&
-    cmd !== null &&
-    "cmd" in cmd &&
-    objectCommand.cmd === "bash" &&
-    Array.isArray(objectCommand.args) &&
-    objectCommand.args.includes("pnpm typecheck")
-  );
-}
-
 /** What a detached `runCommand` resolves to: the process is still running, so
  *  there is no exit code yet. */
 function detachedCommand() {
   return {
     exitCode: null,
+    cmdId: "cmd-detached",
     stdout: vi.fn().mockResolvedValue(""),
     stderr: vi.fn().mockResolvedValue(""),
   };
 }
 
-function isSentinelRead(cmd: unknown, args: unknown): boolean {
-  return cmd === "test" && Array.isArray(args) && args[0] === "-f";
-}
-
-/** Run the fake clock forward until the polled run settles, so a poll tick
- *  costs the suite nothing. */
-async function drainPollTicks<T>(pending: Promise<T>): Promise<T> {
-  let settled = false;
-  const watched = pending.then(
-    (value) => {
-      settled = true;
-      return value;
-    },
-    (error) => {
-      settled = true;
-      throw error;
-    },
-  );
-  for (let tick = 0; tick < 20 && !settled; tick++) {
-    await vi.advanceTimersByTimeAsync(5_000);
-  }
-  return watched;
+function batchLaunch() {
+  return {
+    exitCode: null,
+    cmdId: "cmd-batch",
+    stdout: vi.fn().mockResolvedValue(""),
+    stderr: vi.fn().mockResolvedValue(""),
+  };
 }
 
 function isWrapperLaunch(cmd: unknown): boolean {
@@ -1052,16 +1147,5 @@ function isWrapperLaunch(cmd: unknown): boolean {
     Array.isArray(objectCommand.args) &&
     typeof objectCommand.args[0] === "string" &&
     objectCommand.args[0].endsWith("-wrapper.sh")
-  );
-}
-
-function isHeadInspection(cmd: unknown): boolean {
-  const objectCommand = cmd as { cmd?: unknown; args?: unknown };
-  return (
-    typeof cmd === "object" &&
-    cmd !== null &&
-    objectCommand.cmd === "git" &&
-    Array.isArray(objectCommand.args) &&
-    objectCommand.args.includes("rev-parse")
   );
 }

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -402,6 +402,18 @@ export async function collectRepoCheckBatchStep(
    * reporting those as failures would invent results the run never produced.
    */
   batchFinished = true,
+  /**
+   * Whether an exit-0 check that printed a "dependencies are not installed"
+   * phrase is reported as a failure.
+   *
+   * On for the dashboard's configured checks, where a self-skipping tool once
+   * cleared the pre-PR gate on a workspace that was never dependency-installed.
+   * Off for run_checks' explicit `commands` mode, which never had this scan:
+   * that block runs whatever an author typed and its description promises
+   * nothing but the exit code, so a green suite whose output happens to
+   * contain one of six English sentences must not be reported as failed.
+   */
+  scanBlockedDependencies = true,
 ): Promise<CollectedRepoCheckBatch> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
@@ -426,7 +438,7 @@ export async function collectRepoCheckBatchStep(
     return workspaceIncident(BATCH_SANDBOX_GONE_REASON);
   }
 
-  const read = await readBatchFiles(sandbox, paths, total);
+  const read = await readBatchFiles(sandbox, paths, total, scanBlockedDependencies);
   // "The reader failed" and "the marker disagrees" are different diagnoses and
   // must never be reported as each other. The reader runs under `bash -lc`,
   // which sources the very profile these setup commands append to, so a broken
@@ -441,7 +453,7 @@ export async function collectRepoCheckBatchStep(
   // directory, the wrapper path and the sentinel, so two launches cannot share
   // a path set at all.
   const launch = files.get("launch");
-  if (!launch || launch.bytes < 0) {
+  if (!launch || launch.bytes <= 0) {
     // The wrapper writes this marker before anything else it does, so its
     // absence means the wrapper never ran, which is worth saying plainly
     // instead of arriving later as "the first command recorded no exit".
@@ -477,7 +489,7 @@ export async function collectRepoCheckBatchStep(
   // the first command with no recorded exit.
   const lastIndex = stoppedAt === null ? total - 1 : stoppedAt;
   const results: PrePrCheckCommandResult[] = [];
-  const failures: PrePrCheckFailure[] = [];
+  const failures: RawBatchFailure[] = [];
   let setupFailed = false;
   let completed = 0;
   let stoppedAtCommand: string | null = null;
@@ -498,15 +510,14 @@ export async function collectRepoCheckBatchStep(
       }
       // The wrapper said it reached this command and then recorded no status,
       // so the batch was interrupted between the two. Never a pass.
-      const stdout = streamText(files.get(`stdout-${index}`));
-      const stderr = streamText(files.get(`stderr-${index}`));
       failures.push({
         provider,
         repoPath,
         command,
         exitCode: -1,
-        stdout,
-        stderr: [stderr, BATCH_MISSING_EXIT_REASON].filter(Boolean).join("\n"),
+        stdout: streamText(files.get(`stdout-${index}`)),
+        stderr: streamText(files.get(`stderr-${index}`)),
+        note: BATCH_MISSING_EXIT_REASON,
         ...(isSetup ? { phase: "setup" as const } : {}),
       });
       if (isSetup) setupFailed = true;
@@ -528,15 +539,16 @@ export async function collectRepoCheckBatchStep(
     results.push({ provider, repoPath, command, exitCode });
     // A configured check that exits 0 while reporting that it never ran (its
     // dependencies are not installed) must fail loudly instead of being trusted
-    // as a pass. The Run Workspace is never dependency-installed, so a check tool
-    // that self-skips on missing deps with a success exit code once let a blocked
-    // check clear the pre-PR gate: the branch was pushed and the PR's own CI then
-    // caught the lint failure the gate exists to prevent. The scanned text keeps
-    // both ends of the stream, so a tool that prints this first and then floods
-    // its output is still caught.
-    // The flag comes from the reader, which greps the whole file. Scanning the
-    // text carried back here would miss a phrase that straddles the truncation
-    // cut, which is exactly the false pass this guard exists to catch.
+    // as a pass. The Run Workspace is never dependency-installed, so a check
+    // tool that self-skips on missing deps with a success exit code once let a
+    // blocked check clear the pre-PR gate: the branch was pushed and the PR's
+    // own CI then caught the lint failure the gate exists to prevent.
+    //
+    // The flag comes from the reader, which greps the whole file: scanning the
+    // text carried back here would miss a phrase straddling the truncation cut,
+    // which is exactly the false pass this catches. And the reader only looks
+    // when the caller asked for it, because for a mode with no such history the
+    // scan is six English phrases away from failing a green suite.
     const blockedByMissingDependencies =
       exitCode === 0 &&
       Boolean(files.get(`stdout-${index}`)?.blocked || files.get(`stderr-${index}`)?.blocked);
@@ -547,16 +559,15 @@ export async function collectRepoCheckBatchStep(
         command,
         exitCode,
         stdout,
-        stderr: blockedByMissingDependencies
-          ? [stderr, MISSING_DEPENDENCY_FAILURE_REASON].filter(Boolean).join("\n")
-          : stderr,
+        stderr,
+        ...(blockedByMissingDependencies ? { note: MISSING_DEPENDENCY_FAILURE_REASON } : {}),
       });
     }
   }
 
   return {
     results,
-    failures: boundCollectedFailures(failures),
+    failures: finalizeBatchFailures(failures),
     setupFailed,
     progress: { completed, total, stoppedAt: stoppedAtCommand },
   };
@@ -564,28 +575,47 @@ export async function collectRepoCheckBatchStep(
 collectRepoCheckBatchStep.maxRetries = 0;
 
 /**
- * Bound what one collect may return in total, not just per stream.
- *
- * The per-stream bound is a bound on one file; a batch of twelve verbose
- * commands multiplies it by twelve, and all of it is persisted in the run's
- * event log as a step return value, in a repository that has lost runs to
- * CORRUPTED_EVENT_LOG. Earlier failures keep their text because they are the
- * ones a reader starts from.
+ * A failure before its payload is bounded. `note` is the sentence that explains
+ * the failure, kept apart from the command's own output on purpose: it is
+ * appended at the end, so any truncation that treats it as payload drops it
+ * first and leaves an operator reading `Exit code: 0` under a heading that says
+ * failures, with nothing anywhere saying why a zero exit failed.
  */
-function boundCollectedFailures(failures: PrePrCheckFailure[]): PrePrCheckFailure[] {
+interface RawBatchFailure extends PrePrCheckFailure {
+  note?: string;
+}
+
+/**
+ * Bound what one collect returns in total, then append the sentences.
+ *
+ * Two rules. Every failure gets at least BATCH_FAILURE_FLOOR_CHARS, because a
+ * repository with three verbose failing checks would otherwise spend the whole
+ * aggregate on the first two and hand back the third empty, and the third is
+ * as likely as either to be the one being read. What is left over is shared
+ * out, so a lone failure still gets room. The aggregate is therefore a target
+ * rather than a hard ceiling: n failures can reach n floors, which for a
+ * pathological batch is above the target and still far below carrying whole
+ * logs.
+ *
+ * The bounding itself is head plus tail (boundFailureOutput), never a head
+ * slice: a compiler puts the root cause first and a test runner puts the
+ * verdict last.
+ */
+function finalizeBatchFailures(failures: RawBatchFailure[]): PrePrCheckFailure[] {
   let remaining = BATCH_COLLECT_MAX_CHARS;
-  return failures.map((failure) => {
-    const stderr = failure.stderr.slice(0, remaining);
-    remaining -= stderr.length;
-    const stdout = failure.stdout.slice(0, remaining);
-    remaining -= stdout.length;
-    const dropped =
-      failure.stderr.length - stderr.length + (failure.stdout.length - stdout.length);
-    if (dropped === 0) return failure;
+  return failures.map((failure, index) => {
+    const share = Math.max(
+      BATCH_FAILURE_FLOOR_CHARS,
+      Math.floor(remaining / (failures.length - index)),
+    );
+    const { note, ...rest } = failure;
+    const stderr = boundFailureOutput(failure.stderr, Math.ceil(share / 2));
+    const stdout = boundFailureOutput(failure.stdout, Math.floor(share / 2));
+    remaining = Math.max(0, remaining - stderr.length - stdout.length);
     return {
-      ...failure,
+      ...rest,
       stdout,
-      stderr: `${stderr}\n[... ${dropped} characters of this command's output omitted: the batch as a whole reached ${BATCH_COLLECT_MAX_CHARS} characters ...]`,
+      stderr: note ? [stderr, note].filter(Boolean).join("\n") : stderr,
     };
   });
 }
@@ -599,6 +629,86 @@ interface BatchFileRead {
   /** The reader found a "dependencies are not installed" phrase anywhere in the
    *  whole file, before any truncation. */
   blocked: boolean;
+}
+
+/**
+ * Marker every reader record starts with.
+ *
+ * The reader runs under `bash -lc`, which sources the shell profile these
+ * setup commands append to, so anything that profile prints lands on the same
+ * stdout. Without a token to match, a profile that prints without a trailing
+ * newline glues its text onto the first record, `parts[0]` stops being a file
+ * name, and a batch that ran to completion is diagnosed as a wrapper that never
+ * started: confident, wrong, and impossible for the operator to falsify.
+ * Unrecognised lines are skipped instead.
+ */
+const BATCH_READ_MARKER = "PREPRCHK";
+
+/**
+ * The shell the reader runs. Pure and exported so it can be executed under a
+ * real bash in the tests: it is load-bearing, and a JavaScript reimplementation
+ * of it in a fake proves only that the fake agrees with itself.
+ */
+export function buildBatchReaderScript(opts: {
+  dir: string;
+  names: string[];
+  scanBlockedDependencies: boolean;
+}): string {
+  const cap = BATCH_STREAM_HEAD_BYTES + BATCH_STREAM_TAIL_BYTES;
+  const scan = opts.scanBlockedDependencies
+    ? `  if grep -qiF ${MISSING_DEPENDENCY_PHRASES.map((phrase) => `-e ${shellQuote(phrase)}`).join(" ")} -- "$2"; then k=1; else k=0; fi`
+    : "  k=0";
+  return [
+    "emit() {",
+    `  if [ ! -f "$2" ]; then printf '${BATCH_READ_MARKER} %s -1 0 - -\n' "$1"; return; fi`,
+    '  b=$(wc -c < "$2" | tr -d " \t")',
+    scan,
+    `  if [ "$b" -le ${cap} ]; then`,
+    '    h=$(base64 < "$2" | tr -d "\n"); t=-',
+    "  else",
+    `    h=$(head -c ${BATCH_STREAM_HEAD_BYTES} "$2" | base64 | tr -d "\n")`,
+    `    t=$(tail -c ${BATCH_STREAM_TAIL_BYTES} "$2" | base64 | tr -d "\n")`,
+    "  fi",
+    '  [ -z "$h" ] && h=-',
+    '  [ -z "$t" ] && t=-',
+    `  printf '${BATCH_READ_MARKER} %s %s %s %s %s\n' "$1" "$b" "$k" "$h" "$t"`,
+    "}",
+    // Terminate whatever the profile printed before the first record starts.
+    // The marker lets the parser skip a profile's line; it cannot rescue a
+    // record the profile glued itself onto, and in production the first record
+    // is the launch marker, whose loss is diagnosed as "the wrapper never
+    // started". One newline costs nothing and removes the case.
+    "printf '\\n'",
+    ...opts.names.map(
+      (name) => `emit ${shellQuote(name)} ${shellQuote(`${opts.dir}/${name}`)}`,
+    ),
+  ].join("\n");
+}
+
+/** Parse one reader record. Anything that is not a record is not a file: the
+ *  shell profile shares this stdout. */
+export function parseBatchReaderOutput(stdout: string): Map<string, BatchFileRead> {
+  const files = new Map<string, BatchFileRead>();
+  for (const line of stdout.split("\n")) {
+    const parts = line.trim().split(" ");
+    if (parts.length !== 6 || parts[0] !== BATCH_READ_MARKER) continue;
+    const [, name, bytesText, blocked, head, tail] = parts as [
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+    ];
+    if (!/^-?\d+$/.test(bytesText)) continue;
+    files.set(name, {
+      bytes: Number(bytesText),
+      head: head === "-" ? "" : head,
+      tail: tail === "-" ? null : tail,
+      blocked: blocked === "1",
+    });
+  }
+  return files;
 }
 
 /**
@@ -623,55 +733,20 @@ async function readBatchFiles(
   sandbox: SandboxSession,
   paths: RepoCheckBatchPaths,
   total: number,
+  scanBlockedDependencies: boolean,
 ): Promise<{ ok: boolean; files: Map<string, BatchFileRead> }> {
   const names = ["launch", "stopped-at"];
   for (let index = 0; index < total; index++) {
     names.push(`exit-${index}`, `stdout-${index}`, `stderr-${index}`);
   }
-  const cap = BATCH_STREAM_HEAD_BYTES + BATCH_STREAM_TAIL_BYTES;
-  const blockedPatterns = MISSING_DEPENDENCY_PHRASES.map(
-    (phrase) => `-e ${shellQuote(phrase)}`,
-  ).join(" ");
-  const script = [
-    "emit() {",
-    '  if [ ! -f "$2" ]; then printf \'%s -1 0 - -\\n\' "$1"; return; fi',
-    '  b=$(wc -c < "$2" | tr -d " \\t")',
-    `  if grep -qiF ${blockedPatterns} -- "$2"; then k=1; else k=0; fi`,
-    `  if [ "$b" -le ${cap} ]; then`,
-    '    h=$(base64 < "$2" | tr -d "\\n"); t=-',
-    "  else",
-    `    h=$(head -c ${BATCH_STREAM_HEAD_BYTES} "$2" | base64 | tr -d "\\n")`,
-    `    t=$(tail -c ${BATCH_STREAM_TAIL_BYTES} "$2" | base64 | tr -d "\\n")`,
-    "  fi",
-    '  [ -z "$h" ] && h=-',
-    '  [ -z "$t" ] && t=-',
-    '  printf \'%s %s %s %s %s\\n\' "$1" "$b" "$k" "$h" "$t"',
-    "}",
-    ...names.map((name) => `emit ${shellQuote(name)} ${shellQuote(`${paths.dir}/${name}`)}`),
-  ].join("\n");
-
+  const script = buildBatchReaderScript({
+    dir: paths.dir,
+    names,
+    scanBlockedDependencies,
+  });
   const result = await sandbox.runCommand({ cmd: "bash", args: ["-lc", script] });
-  const files = new Map<string, BatchFileRead>();
-  if (result.exitCode !== 0) return { ok: false, files };
-  for (const line of (await result.stdout()).split("\n")) {
-    const parts = line.trim().split(" ");
-    if (parts.length !== 5) continue;
-    const [name, bytesText, blocked, head, tail] = parts as [
-      string,
-      string,
-      string,
-      string,
-      string,
-    ];
-    if (!/^-?\d+$/.test(bytesText)) continue;
-    files.set(name, {
-      bytes: Number(bytesText),
-      head: head === "-" ? "" : head,
-      tail: tail === "-" ? null : tail,
-      blocked: blocked === "1",
-    });
-  }
-  return { ok: true, files };
+  if (result.exitCode !== 0) return { ok: false, files: new Map() };
+  return { ok: true, files: parseBatchReaderOutput(await result.stdout()) };
 }
 
 /** Decode one read back to text, splicing in what the reader left out. */
@@ -1043,6 +1118,10 @@ export function formatPrePrCheckFailures(
    * opposite case.
    */
   suppressingRepositories: string[] = [],
+  /** Fix cycles this run had already spent when these failures were collected.
+   *  Suppression is evaluated per pass, so the sentence must speak for the
+   *  cycles that remain, not claim the fixer never ran. */
+  fixCyclesRun = 0,
 ): string {
   const suppressed = suppressingRepositories.length > 0;
   return failures
@@ -1066,19 +1145,23 @@ export function formatPrePrCheckFailures(
         ...(failure.phase === "setup" ? [SETUP_FAILURE_REASON] : []),
         ...(failure.phase === "workspace" ? [WORKSPACE_FAILURE_REASON] : []),
         ...(suppressed && failure.phase === undefined
-          ? [suppressedBySetupFailure(suppressingRepositories)]
+          ? [suppressedBySetupFailure(suppressingRepositories, fixCyclesRun)]
           : []),
       ].join("\n");
     })
     .join("\n\n");
 }
 
-function suppressedBySetupFailure(repositories: string[]): string {
+function suppressedBySetupFailure(repositories: string[], fixCyclesRun: number): string {
+  const opening =
+    fixCyclesRun === 0
+      ? "No agent fix cycles were run for this failure either."
+      : `No further agent fix cycles were run for this failure (${fixCyclesRun} had already run).`;
   return (
-    "No agent fix cycles were run for this failure either. Setup failed for " +
-    `${repositories.join(", ")}, and a setup failure suppresses the fix cycles ` +
-    "of the whole run, because a fixer cannot install a toolchain by editing " +
-    "code. Fix that setup command and this check gets its fix cycles back."
+    `${opening} Setup failed for ${repositories.join(", ")}, and a setup failure ` +
+    "suppresses the fix cycles of the whole run, because a fixer cannot install " +
+    "a toolchain by editing code. Fix that setup command and this check gets " +
+    "its fix cycles back."
   );
 }
 
@@ -1088,34 +1171,6 @@ const SETUP_FAILURE_REASON =
   "no agent fix cycles were run, because editing the code cannot repair a " +
   "workspace that could not be provisioned. Fix the setup command in the " +
   "dashboard's Pre-PR checks configuration.";
-
-/**
- * How much of each end of a per-command stream the collector carries out of the
- * sandbox.
- *
- * Sized against what a consumer actually reads, not against what the event log
- * will tolerate: every path that shows one of these streams bounds it to
- * FAILURE_OUTPUT_MAX_CHARS (2000) first, so bytes beyond a few kilobytes are
- * carried across a step boundary, persisted in the run's event log, and then
- * thrown away unread. Anyone tempted to raise this should raise the consumer
- * bound instead, and check what it costs in the log.
- *
- * Both ends, never just one. A compiler puts the root cause first and a test
- * runner puts the verdict last. Which end a phrase lands in no longer decides
- * anything, though: the missing-dependency question is answered by the reader,
- * which greps the whole file.
- */
-const BATCH_STREAM_HEAD_BYTES = 4 * 1024;
-const BATCH_STREAM_TAIL_BYTES = 4 * 1024;
-
-/**
- * Ceiling on the text one collect may return in total.
- *
- * The per-stream bound above is per file; a batch of a dozen verbose commands
- * multiplies it. This is the number that reaches the event log, so it is the
- * one that matters when a run has already been lost to CORRUPTED_EVENT_LOG.
- */
-const BATCH_COLLECT_MAX_CHARS = 32 * 1024;
 
 /**
  * How much of a failure's output a reader actually receives.
@@ -1145,6 +1200,45 @@ export function boundFailureOutput(text: string, maxChars = FAILURE_OUTPUT_MAX_C
   const head = Math.ceil(budget / 2);
   return `${text.slice(0, head)}${marker}${text.slice(text.length - (budget - head))}`;
 }
+
+/**
+ * How much of each end of a per-command stream the collector carries out of the
+ * sandbox.
+ *
+ * Sized against what a consumer actually shows, not against what the event log
+ * will tolerate: every path that displays one of these streams bounds it to
+ * FAILURE_OUTPUT_MAX_CHARS (2000) first, so bytes far beyond that are carried
+ * across a step boundary, persisted in the run's event log, and then thrown
+ * away unread. Anyone tempted to raise this should raise the consumer bound
+ * instead, and check what it costs in the log.
+ *
+ * Both ends, never just one. A compiler puts the root cause first and a test
+ * runner puts the verdict last. Which end a phrase lands in no longer decides
+ * anything, though: the missing-dependency question is answered by the reader,
+ * which greps the whole file.
+ */
+const BATCH_STREAM_HEAD_BYTES = 2 * 1024;
+const BATCH_STREAM_TAIL_BYTES = 2 * 1024;
+
+/**
+ * Target for the text one collect returns in total, and the floor no single
+ * failure drops below.
+ *
+ * The per-stream bound above is per file; a repository with a dozen verbose
+ * failing commands multiplies it, and all of it is persisted in the run's
+ * event log as a step return value, in a repository that has lost runs to
+ * CORRUPTED_EVENT_LOG. The floor is what stops that accounting from erasing
+ * the last failure of three, and it is the consumer bound, so a failure at the
+ * floor still shows an operator everything they would have been shown anyway.
+ */
+const BATCH_COLLECT_MAX_CHARS = 32 * 1024;
+/**
+ * The floor is the consumer bound, and the two halves of a failure (stdout and
+ * stderr) split it. A failure held at the floor therefore still carries
+ * everything a consumer would have shown: those consumers bound the JOIN of the
+ * two streams to FAILURE_OUTPUT_MAX_CHARS. Nothing is lost by being last.
+ */
+const BATCH_FAILURE_FLOOR_CHARS = FAILURE_OUTPUT_MAX_CHARS;
 
 /** Elapsed wall clock, for a message an operator reads. Rounded, because the
  *  precision is not the point and a false precision invites arithmetic. */

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -1,15 +1,12 @@
-import type {
-  Command as SandboxCommand,
-  Sandbox as SandboxType,
-} from "@vercel/sandbox";
+import type { Command as SandboxCommand } from "@vercel/sandbox";
 import { getSandboxCredentials } from "../sandbox/credentials.js";
 import {
   parseWorkspaceManifest,
   WORKSPACE_MANIFEST_PATH,
+  WORKSPACE_ROOT_DIR,
   type WorkspaceManifest,
   type WorkspaceRepo,
 } from "../sandbox/repo-workspace.js";
-import type { PrePrCheckConfig } from "./config.js";
 import type {
   AgentProtocolResult,
   CollectedPhaseArtifacts,
@@ -19,12 +16,10 @@ import type {
 } from "../sandbox/agents/types.js";
 import type { TokenPrice } from "../sandbox/agents/pricing.js";
 import type { ResolvedHarnessRuntime } from "../sandbox/harness-runtime.js";
-import {
-  checkRunBudget,
-  recordBudgetUsage,
-  type RunBudgetFailure,
-  type RunBudgetLimits,
-  type RunBudgetState,
+import type {
+  RunBudgetFailure,
+  RunBudgetLimits,
+  RunBudgetState,
 } from "../workflows/run-budget.js";
 
 export const MAX_PRE_PR_FIX_CYCLES = 3;
@@ -35,6 +30,30 @@ export const MAX_PRE_PR_FIX_CYCLES = 3;
  *  sentence stays a failure detail rather than a payload. */
 const PRE_PR_LAUNCH_CAUSE_MAX_LENGTH = 200;
 
+/**
+ * Ceiling on one repository's detached check batch, in minutes.
+ *
+ * A ceiling only. The bound that actually applies is the smaller of this and
+ * the run's remaining duration budget, computed per batch by
+ * effectiveBatchCapMinutes in workflows/blocks/pre-pr-checks.ts, because the
+ * duration budget is not a constant: it is `maxDurationMs` from the definition
+ * when the plan sets one, and otherwise env.JOB_TIMEOUT_MS, whose schema
+ * default is 1_800_000 (30 minutes) while our production deployment runs
+ * 6_000_000 (100 minutes). So 60 is reachable on production and unreachable on
+ * a default deployment, and nothing may state it as the bound that applied.
+ *
+ * It is deliberately far above the 300s a Vercel function invocation gets,
+ * because that limit is what this whole launch/poll/collect shape exists to
+ * escape: a client tenant's `uv sync` plus linters plus mypy plus pytest is
+ * roughly 19 minutes of real work, and running it inside one step invocation
+ * killed the run mid-await with no recoverable cause.
+ */
+export const PRE_PR_CHECK_BATCH_MAX_MINUTES = 60;
+
+/** Ceiling on one Pre-PR repair agent, matching the 25 minutes every other
+ *  agent phase gets (DEFAULT_MAX_MINUTES in workflows/blocks/fix-agent.ts). */
+export const PRE_PR_REPAIR_MAX_MINUTES = 25;
+
 export interface PrePrCheckFailure {
   provider: WorkspaceRepo["provider"];
   repoPath: string;
@@ -43,11 +62,16 @@ export interface PrePrCheckFailure {
   stdout: string;
   stderr: string;
   /**
-   * Present when the failing command came from the repository's `setup` phase
-   * instead of its checks. A setup failure means the workspace could not be
-   * provisioned, which no code edit can repair.
+   * Set when the entry is not an ordinary check result.
+   *
+   * `setup` is an authored provisioning command that failed: the workspace
+   * could not be provisioned, which no code edit can repair, and the operator
+   * has a command to fix. `workspace` is the run's own workspace failing the
+   * repository (its directory unreachable, or its output files not belonging to
+   * the launch being collected): nothing about it is authored configuration, so
+   * it must never be reported as a setup command the operator should go and fix.
    */
-  phase?: "setup";
+  phase?: "setup" | "workspace";
 }
 
 export type CheckOutcome =
@@ -86,210 +110,623 @@ export interface PrePrFixBudgetContext {
   price: TokenPrice | null;
 }
 
-type SandboxInstance = Awaited<ReturnType<typeof SandboxType.create>>;
-type SandboxCommandResult = Awaited<ReturnType<SandboxInstance["runCommand"]>>;
-
 type SandboxSession = RunnableSandbox;
 
-export async function runPrePrChecksWithFixes(
-  sandboxId: string,
-  config: PrePrCheckConfig,
-  agentKind: "claude" | "codex",
-  model: string,
-  maxFixCycles: number = MAX_PRE_PR_FIX_CYCLES,
-  timeoutMs?: number,
-  budget?: PrePrFixBudgetContext,
-  runtime?: ResolvedHarnessRuntime,
-  arthurTaskId?: string | null,
-): Promise<PrePrCheckRunResult> {
-  if (config.repositories.length === 0) {
-    return {
-      outcome: "missing_configuration",
-      passed: true,
-      fixCycles: 0,
-      fixCycleUsages: [],
-      budgetFailure: null,
-      results: [],
-      failures: [],
-      setupFailed: false,
-      summary: "No pre-PR checks configured.",
-    };
-  }
-
-  const { Sandbox } = await import("@vercel/sandbox");
-  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
-  const signal = timeoutMs === undefined
-    ? undefined
-    : AbortSignal.timeout(Math.max(1, Math.floor(timeoutMs)));
-
-  let result = await runConfiguredPrePrChecks(sandbox, config, 0, signal);
-  let fixCycles = 0;
-  const fixCycleUsages: Array<PhaseUsage | null> = [];
-  let budgetState = budget?.state;
-
-  // A setup failure never enters the repair loop: the workspace is missing a
-  // tool the checks need, and no edit the fixer can make to the repository will
-  // install it. Before this guard the platform spent its whole fix budget
-  // rewriting code in response to "command not found".
-  while (!result.passed && !result.setupFailed && fixCycles < maxFixCycles) {
-    fixCycles++;
-    const fixer = await runFixAgent(
-      sandboxId,
-      sandbox,
-      result,
-      agentKind,
-      model,
-      fixCycles,
-      signal,
-      runtime,
-      arthurTaskId,
-    );
-    fixCycleUsages.push(fixer.usage);
-    if (fixer.failure) {
-      return {
-        ...result,
-        fixCycles,
-        fixCycleUsages,
-        budgetFailure: null,
-        agentFailure: fixer.failure,
-      };
-    }
-    if (budget && budgetState) {
-      budgetState = recordBudgetUsage(budgetState, fixer.usage, budget.price);
-      const check = checkRunBudget(budgetState, budget.limits);
-      if (check.status !== "ok") {
-        return { ...result, fixCycles, fixCycleUsages, budgetFailure: check };
-      }
-    }
-    result = await runConfiguredPrePrChecks(sandbox, config, fixCycles, signal);
-  }
-
-  return { ...result, fixCycles, fixCycleUsages, budgetFailure: null };
+/** Where one repository's detached check batch keeps its wrapper, its
+ *  per-command output files and its completion sentinel. */
+export interface RepoCheckBatchPaths {
+  /**
+   * Identity of the one launch these paths belong to.
+   *
+   * A cycle and repository pair is not a unique launch. If two wrappers ever
+   * share a path set, their output files union into a set that looks complete
+   * while no single process ran the batch end to end, and the collector reads
+   * a green result no run ever produced. Agent phases already key their
+   * artifacts by attempt for the same reason (phaseKey in workflows/agent.ts).
+   * A false pass on the pre-PR gate is the worst outcome this system has, so
+   * the identity is in the path AND written inside the directory, and the
+   * collector checks it.
+   */
+  launchId: string;
+  /** Holds `launch`, `stdout-<i>`, `stderr-<i>`, `exit-<i>` and, when the batch
+   *  stopped early, `stopped-at`. One file per command: a single delimited
+   *  transcript would have to be parsed back apart, and that parser is a bug
+   *  farm. */
+  dir: string;
+  wrapper: string;
+  sentinel: string;
 }
 
-async function runConfiguredPrePrChecks(
-  sandbox: SandboxSession,
-  config: PrePrCheckConfig,
-  fixCycles: number,
-  signal?: AbortSignal,
-): Promise<PrePrCheckRunResult> {
-  const manifest = await readWorkspaceManifest(sandbox);
-  const checksByRepo = new Map(
-    config.repositories.map((repo) => [repositoryKey(repo), repo]),
-  );
-  const results: PrePrCheckCommandResult[] = [];
-  const failures: PrePrCheckFailure[] = [];
-  let ranChecks = 0;
-  let setupFailed = false;
+/**
+ * Marker written to `stopped-at` when the wrapper could not even enter the
+ * repository directory, so a batch that produced no command result at all is
+ * reported as such instead of being read as a silent pass.
+ */
+const BATCH_NO_COMMAND_RAN = -1;
 
-  for (const repo of manifest.repositories) {
-    const configured = checksByRepo.get(repositoryKey(repo));
-    if (!configured) continue;
-
-    const changed = await hasRepositoryChanged(sandbox, repo, signal);
-    if (!changed) continue;
-
-    const setupFailure = await runRepositorySetup(sandbox, repo, configured.setup ?? [], signal);
-    if (setupFailure) {
-      // The repository could not be provisioned, so its checks would only
-      // report the same missing tooling once per command. Stop here and let the
-      // next repository still run.
-      setupFailed = true;
-      failures.push(setupFailure);
-      continue;
-    }
-
-    for (const command of configured.commands) {
-      ranChecks++;
-      const result = await sandbox.runCommand({
-        cmd: "bash",
-        args: ["-lc", command],
-        cwd: repo.localPath,
-        ...(signal ? { signal } : {}),
-      });
-      results.push({
-        provider: repo.provider,
-        repoPath: repo.repoPath,
-        command,
-        exitCode: result.exitCode,
-      });
-      const stdout = await commandStdout(result);
-      const stderr = await commandStderr(result);
-      // A configured check that exits 0 while reporting that it never ran (its
-      // dependencies are not installed) must fail loudly instead of being trusted
-      // as a pass. The Run Workspace is never dependency-installed, so a check tool
-      // that self-skips on missing deps with a success exit code once let a blocked
-      // check clear the pre-PR gate: the branch was pushed and the PR's own CI then
-      // caught the lint failure the gate exists to prevent.
-      const blockedByMissingDependencies =
-        result.exitCode === 0 && checkBlockedByMissingDependencies(stdout, stderr);
-      if (result.exitCode !== 0 || blockedByMissingDependencies) {
-        failures.push({
-          provider: repo.provider,
-          repoPath: repo.repoPath,
-          command,
-          exitCode: result.exitCode,
-          stdout,
-          stderr: blockedByMissingDependencies
-            ? [stderr, MISSING_DEPENDENCY_FAILURE_REASON].filter(Boolean).join("\n")
-            : stderr,
-        });
-      }
-    }
-  }
-
+export function repoCheckBatchPaths(
+  fixCycle: number,
+  repoIndex: number,
+  launchId: string,
+): RepoCheckBatchPaths {
+  // Namespaced by fix cycle so cycle N never reads cycle N-1's output files, by
+  // repository so two repositories cannot collide, and by launch so two
+  // wrappers for the same repository and cycle cannot either.
+  const id = `pre-pr-checks-c${fixCycle}-r${repoIndex}-${launchId}`;
   return {
-    outcome: failures.length > 0 ? "failed" : "passed",
-    passed: failures.length === 0,
-    fixCycles,
-    fixCycleUsages: [],
-    budgetFailure: null,
-    results,
-    failures,
-    setupFailed,
-    summary: failures.length > 0
-      ? formatPrePrCheckFailures(failures)
-      : ranChecks === 0
-        ? "No pre-PR checks matched changed repositories."
-        : `Pre-PR checks passed (${ranChecks} command${ranChecks === 1 ? "" : "s"}).`,
+    launchId,
+    dir: `/tmp/${id}`,
+    wrapper: `/tmp/${id}-wrapper.sh`,
+    sentinel: `/tmp/${id}-done`,
   };
 }
 
 /**
- * Runs a repository's provisioning commands, in authored order, before its
- * checks. Returns the first failure, or null when every command exited 0.
- * These commands install the toolchain the checks need (the sandbox image ships
- * one runtime only), so they run in the repository directory through the same
- * login shell the checks use and any PATH they export through the shell profile
- * is visible to later commands.
+ * Filename-safe identity for one wrapper launch. Generated inside the start
+ * step, so the value a replay sees is the one the recorded step returned, while
+ * a body that genuinely executes twice gets two different path sets.
+ *
+ * Deliberately the global Web Crypto rather than `node:crypto`: this module is
+ * statically imported by workflow-scope block modules, and a Node builtin in
+ * that import graph fails only the Vercel build, never vitest or a local one.
  */
-async function runRepositorySetup(
-  sandbox: SandboxSession,
-  repo: WorkspaceRepo,
+function newLaunchId(): string {
+  return globalThis.crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+}
+
+/**
+ * The wrapper one repository's setup commands and check commands run inside,
+ * detached from the invocation that launched it.
+ *
+ * Every command still gets its own login shell. Setup commands provision the
+ * toolchain the checks need, and they do it by appending a PATH export to the
+ * shell profile; only a fresh login shell per later command picks that up. So
+ * this must never collapse the batch into one shell body, and the wrapper
+ * itself must not be that single login shell either.
+ */
+export function buildRepoCheckBatchScript(opts: {
+  paths: RepoCheckBatchPaths;
+  localPath: string;
+  setup: string[];
+  commands: string[];
+}): string {
+  const { paths, localPath, setup, commands } = opts;
+  const setupLines = setup.map((command, index) =>
+    [
+      `run_pre_pr_command ${index} ${shellQuote(command)}`,
+      // A setup failure means the toolchain is missing, so this repository's
+      // checks would only report the same thing once per command. Stop here and
+      // record where; the caller still runs the other repositories.
+      `[ "$PRE_PR_EXIT" -eq 0 ] || stop_batch ${index}`,
+    ].join("\n"),
+  );
+  const checkLines = commands.map(
+    (command, index) =>
+      `run_pre_pr_command ${setup.length + index} ${shellQuote(command)}`,
+  );
+  return `#!/bin/bash
+
+# No trap here, deliberately. Bash runs a trap only when the current foreground
+# command finishes (SIGNALS in bash(1)), so a handler could not fire while a
+# check is running, which is the only moment it would have anything to kill;
+# and \`kill 0\` signals the whole process group, which includes whatever
+# launched this wrapper. Killing the launched command is stopPhaseCommand's job
+# (workflows/blocks/poll-phase.ts), which kills it through the sandbox API by
+# command id. What that does not reach is the command's own children: an
+# abandoned check keeps running until the sandbox is torn down. That is wasted
+# sandbox CPU after the run has already stopped believing the batch, not a
+# correctness problem, and it is accepted rather than papered over with a
+# backgrounding scheme whose failure modes would be new.
+
+# --- Cleanup this cycle's stale files ---
+rm -f ${paths.sentinel}
+rm -rf ${paths.dir}
+mkdir -p ${paths.dir}
+
+# Identity first, before any command can write an output file, so the collector
+# can tell this launch's files from another wrapper's.
+echo ${shellQuote(paths.launchId)} > ${paths.dir}/launch
+
+run_pre_pr_command() {
+  bash -lc "$2" > ${paths.dir}/stdout-$1 2> ${paths.dir}/stderr-$1
+  PRE_PR_EXIT=$?
+  echo "$PRE_PR_EXIT" > ${paths.dir}/exit-$1
+}
+
+stop_batch() {
+  echo "$1" > ${paths.dir}/stopped-at
+  touch ${paths.sentinel}
+  exit 0
+}
+
+cd ${shellQuote(localPath)} || stop_batch ${BATCH_NO_COMMAND_RAN}
+
+${[...setupLines, ...checkLines].join("\n")}
+
+# --- Signal completion, last, once every output file is written ---
+touch ${paths.sentinel}
+`;
+}
+
+/**
+ * Write and launch one repository's check batch, detached, and return at once.
+ *
+ * Returns `skipped` when the repository is not in this run's workspace, and,
+ * under `requireChange`, when its HEAD never moved: the same filter the
+ * blocking runner applied before running any command.
+ */
+export async function startRepoCheckBatchStep(
+  sandboxId: string,
+  provider: WorkspaceRepo["provider"],
+  repoPath: string,
   setup: string[],
-  signal?: AbortSignal,
-): Promise<PrePrCheckFailure | null> {
-  for (const command of setup) {
-    const result = await sandbox.runCommand({
-      cmd: "bash",
-      args: ["-lc", command],
-      cwd: repo.localPath,
-      ...(signal ? { signal } : {}),
-    });
-    if (result.exitCode !== 0) {
-      return {
-        provider: repo.provider,
-        repoPath: repo.repoPath,
+  commands: string[],
+  fixCycle: number,
+  repoIndex: number,
+  /**
+   * Whether to inspect HEAD and skip a repository the agent never touched.
+   * True for the configured pre-PR checks, which only verify what changed.
+   * False for the explicit `commands` mode of run_checks, whose contract is to
+   * run in every attached repository whether or not its HEAD moved; that mode
+   * never inspected HEAD at all, so it must not start failing on a repository
+   * whose git directory cannot be read.
+   */
+  requireChange = true,
+): Promise<
+  | { skipped: true }
+  | {
+      skipped: false;
+      commandId: string;
+      localPath: string;
+      paths: RepoCheckBatchPaths;
+    }
+> {
+  "use step";
+  const { Sandbox } = await import("@vercel/sandbox");
+  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+  const manifest = await readWorkspaceManifest(sandbox);
+  const repo = manifest.repositories.find(
+    (candidate) =>
+      candidate.provider === provider && candidate.repoPath === repoPath,
+  );
+  if (!repo) return { skipped: true };
+
+  if (requireChange) {
+    const headResult = await sandbox.runCommand("git", [
+      "-C",
+      repo.localPath,
+      "rev-parse",
+      "HEAD",
+    ]);
+    const headSha =
+      headResult.exitCode === 0 ? (await headResult.stdout()).trim() : "";
+    if (!headSha) {
+      throw new Error(
+        `Could not inspect workspace HEAD for ${provider}:${repoPath}`,
+      );
+    }
+    if (repo.preAgentSha && repo.preAgentSha === headSha) return { skipped: true };
+  }
+
+  const paths = repoCheckBatchPaths(fixCycle, repoIndex, newLaunchId());
+  await sandbox.writeFiles([
+    {
+      path: paths.wrapper,
+      content: Buffer.from(
+        buildRepoCheckBatchScript({
+          paths,
+          localPath: repo.localPath,
+          setup,
+          commands,
+        }),
+      ),
+    },
+  ]);
+  const chmod = await sandbox.runCommand("chmod", ["+x", paths.wrapper]);
+  if (chmod.exitCode !== 0) {
+    throw new Error(
+      `The Pre-PR check wrapper for ${provider}:${repoPath} could not be made executable.`,
+    );
+  }
+  const launch = await sandbox.runCommand({
+    cmd: "bash",
+    args: [paths.wrapper],
+    cwd: WORKSPACE_ROOT_DIR,
+    detached: true,
+  });
+  // A detached launch has no exit code yet while the wrapper runs; only a
+  // wrapper that already exited non-zero is a launch that failed.
+  if (launch.exitCode !== null && launch.exitCode !== 0) {
+    throw new Error(
+      `The Pre-PR check batch for ${provider}:${repoPath} exited ${launch.exitCode} before it started.`,
+    );
+  }
+  return {
+    skipped: false,
+    commandId: launch.cmdId,
+    localPath: repo.localPath,
+    paths,
+  };
+}
+startRepoCheckBatchStep.maxRetries = 0;
+
+/** What one collected batch got through, for reporting a stall honestly. */
+export interface RepoCheckBatchProgress {
+  /** Commands that recorded an exit status. */
+  completed: number;
+  /** Commands the batch was asked to run, setup included. */
+  total: number;
+  /** The command that was still running when the batch was abandoned, or null
+   *  when every command recorded a status. */
+  stoppedAt: string | null;
+}
+
+export interface CollectedRepoCheckBatch {
+  results: PrePrCheckCommandResult[];
+  failures: PrePrCheckFailure[];
+  /**
+   * An authored setup command failed. Suppresses fix cycles run-wide.
+   *
+   * A workspace directory that could not be entered is deliberately NOT one of
+   * these: no setup command was authored, so nothing about it is the operator's
+   * configuration and it must not silence the other repositories. Those arrive
+   * as failures carrying phase "workspace", which is what callers filter on.
+   */
+  setupFailed: boolean;
+  progress: RepoCheckBatchProgress;
+}
+
+/**
+ * Read a batch's per-command files back into ordered results and failures.
+ *
+ * A detached command has no live stream, so every byte comes from the files the
+ * wrapper wrote, and they are read whether the batch finished or was abandoned:
+ * on a stall those files are the only record of which command it died on, and
+ * leaving them unread reproduces the blindness this whole change exists to end.
+ */
+export async function collectRepoCheckBatchStep(
+  sandboxId: string,
+  provider: WorkspaceRepo["provider"],
+  repoPath: string,
+  setup: string[],
+  commands: string[],
+  paths: RepoCheckBatchPaths,
+  localPath: string,
+  /**
+   * Whether the wrapper reported completion by touching its sentinel.
+   *
+   * True for a normal collect: every command the wrapper reached recorded an
+   * exit, so a missing one means the batch was interrupted and that command
+   * must not read as a pass. False when collecting an abandoned batch, where
+   * the commands after the one that was still running never started at all;
+   * reporting those as failures would invent results the run never produced.
+   */
+  batchFinished = true,
+): Promise<CollectedRepoCheckBatch> {
+  "use step";
+  const { Sandbox } = await import("@vercel/sandbox");
+  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+  const total = setup.length + commands.length;
+  const commandAt = (index: number): string =>
+    index < setup.length ? setup[index]! : commands[index - setup.length]!;
+  const emptyProgress: RepoCheckBatchProgress = { completed: 0, total, stoppedAt: null };
+  const workspaceIncident = (reason: string): CollectedRepoCheckBatch => ({
+    results: [],
+    failures: [batchFailure(provider, repoPath, "(check batch)", reason, "workspace")],
+    setupFailed: false,
+    progress: emptyProgress,
+  });
+
+  // Ask the sandbox's status before asking it for bytes. This step is called on
+  // the path where the poll just gave up, which is precisely when the sandbox
+  // may be gone, and a command sent to a dead sandbox throws out of a step whose
+  // maxRetries is 0. Same guard checkPhaseDone makes for the same reason
+  // (sandbox/poll-agent.ts).
+  if (sandbox.status !== "running") {
+    return workspaceIncident(BATCH_SANDBOX_GONE_REASON);
+  }
+
+  const read = await readBatchFiles(sandbox, paths, total);
+  // "The reader failed" and "the marker disagrees" are different diagnoses and
+  // must never be reported as each other. The reader runs under `bash -lc`,
+  // which sources the very profile these setup commands append to, so a broken
+  // profile fails the read while the batch itself is fine.
+  if (!read.ok) return workspaceIncident(BATCH_READER_FAILED_REASON);
+  const files = read.files;
+
+  // Identity before content. A directory whose `launch` marker is not this
+  // launch's was written by a different wrapper, so nothing in it describes the
+  // batch being collected and none of it may become a pass. Belt and braces
+  // rather than the primary guarantee: the launch id is already part of the
+  // directory, the wrapper path and the sentinel, so two launches cannot share
+  // a path set at all.
+  const launch = files.get("launch");
+  if (!launch || launch.bytes < 0) {
+    // The wrapper writes this marker before anything else it does, so its
+    // absence means the wrapper never ran, which is worth saying plainly
+    // instead of arriving later as "the first command recorded no exit".
+    return workspaceIncident(BATCH_NEVER_STARTED_REASON);
+  }
+  if (decodeBatchFile(launch) !== paths.launchId) {
+    return workspaceIncident(BATCH_IDENTITY_REASON);
+  }
+
+  const stoppedAtFile = files.get("stopped-at");
+  const stoppedAtText = stoppedAtFile ? decodeBatchFile(stoppedAtFile) : "";
+  const stoppedAt = /^-?\d+$/.test(stoppedAtText) ? Number(stoppedAtText) : null;
+  if (stoppedAt === BATCH_NO_COMMAND_RAN) {
+    return {
+      results: [],
+      failures: [
+        batchFailure(
+          provider,
+          repoPath,
+          "(repository workspace)",
+          `${BATCH_WORKSPACE_MISSING_REASON} Directory: ${localPath}.`,
+          "workspace",
+        ),
+      ],
+      setupFailed: false,
+      progress: emptyProgress,
+    };
+  }
+
+  // `stopped-at` is the authority on how far a finished wrapper got: absent
+  // means every command ran, an index means only the commands up to and
+  // including it did. An abandoned batch wrote no marker, so its boundary is
+  // the first command with no recorded exit.
+  const lastIndex = stoppedAt === null ? total - 1 : stoppedAt;
+  const results: PrePrCheckCommandResult[] = [];
+  const failures: PrePrCheckFailure[] = [];
+  let setupFailed = false;
+  let completed = 0;
+  let stoppedAtCommand: string | null = null;
+
+  for (let index = 0; index <= lastIndex; index++) {
+    const isSetup = index < setup.length;
+    const command = commandAt(index);
+    const exitFile = files.get(`exit-${index}`);
+    const exitText = exitFile ? decodeBatchFile(exitFile) : "";
+    const exitCode = /^-?\d+$/.test(exitText) ? Number(exitText) : null;
+
+    if (exitCode === null) {
+      if (!batchFinished) {
+        // The batch was abandoned here. This command was still running and the
+        // ones after it never started, so neither is a result of any kind.
+        stoppedAtCommand = command;
+        break;
+      }
+      // The wrapper said it reached this command and then recorded no status,
+      // so the batch was interrupted between the two. Never a pass.
+      const stdout = streamText(files.get(`stdout-${index}`));
+      const stderr = streamText(files.get(`stderr-${index}`));
+      failures.push({
+        provider,
+        repoPath,
         command,
-        exitCode: result.exitCode,
-        stdout: await commandStdout(result),
-        stderr: await commandStderr(result),
-        phase: "setup",
-      };
+        exitCode: -1,
+        stdout,
+        stderr: [stderr, BATCH_MISSING_EXIT_REASON].filter(Boolean).join("\n"),
+        ...(isSetup ? { phase: "setup" as const } : {}),
+      });
+      if (isSetup) setupFailed = true;
+      continue;
+    }
+
+    completed++;
+    const stdout = streamText(files.get(`stdout-${index}`));
+    const stderr = streamText(files.get(`stderr-${index}`));
+
+    if (isSetup) {
+      if (exitCode !== 0) {
+        setupFailed = true;
+        failures.push({ provider, repoPath, command, exitCode, stdout, stderr, phase: "setup" });
+      }
+      continue;
+    }
+
+    results.push({ provider, repoPath, command, exitCode });
+    // A configured check that exits 0 while reporting that it never ran (its
+    // dependencies are not installed) must fail loudly instead of being trusted
+    // as a pass. The Run Workspace is never dependency-installed, so a check tool
+    // that self-skips on missing deps with a success exit code once let a blocked
+    // check clear the pre-PR gate: the branch was pushed and the PR's own CI then
+    // caught the lint failure the gate exists to prevent. The scanned text keeps
+    // both ends of the stream, so a tool that prints this first and then floods
+    // its output is still caught.
+    // The flag comes from the reader, which greps the whole file. Scanning the
+    // text carried back here would miss a phrase that straddles the truncation
+    // cut, which is exactly the false pass this guard exists to catch.
+    const blockedByMissingDependencies =
+      exitCode === 0 &&
+      Boolean(files.get(`stdout-${index}`)?.blocked || files.get(`stderr-${index}`)?.blocked);
+    if (exitCode !== 0 || blockedByMissingDependencies) {
+      failures.push({
+        provider,
+        repoPath,
+        command,
+        exitCode,
+        stdout,
+        stderr: blockedByMissingDependencies
+          ? [stderr, MISSING_DEPENDENCY_FAILURE_REASON].filter(Boolean).join("\n")
+          : stderr,
+      });
     }
   }
-  return null;
+
+  return {
+    results,
+    failures: boundCollectedFailures(failures),
+    setupFailed,
+    progress: { completed, total, stoppedAt: stoppedAtCommand },
+  };
 }
+collectRepoCheckBatchStep.maxRetries = 0;
+
+/**
+ * Bound what one collect may return in total, not just per stream.
+ *
+ * The per-stream bound is a bound on one file; a batch of twelve verbose
+ * commands multiplies it by twelve, and all of it is persisted in the run's
+ * event log as a step return value, in a repository that has lost runs to
+ * CORRUPTED_EVENT_LOG. Earlier failures keep their text because they are the
+ * ones a reader starts from.
+ */
+function boundCollectedFailures(failures: PrePrCheckFailure[]): PrePrCheckFailure[] {
+  let remaining = BATCH_COLLECT_MAX_CHARS;
+  return failures.map((failure) => {
+    const stderr = failure.stderr.slice(0, remaining);
+    remaining -= stderr.length;
+    const stdout = failure.stdout.slice(0, remaining);
+    remaining -= stdout.length;
+    const dropped =
+      failure.stderr.length - stderr.length + (failure.stdout.length - stdout.length);
+    if (dropped === 0) return failure;
+    return {
+      ...failure,
+      stdout,
+      stderr: `${stderr}\n[... ${dropped} characters of this command's output omitted: the batch as a whole reached ${BATCH_COLLECT_MAX_CHARS} characters ...]`,
+    };
+  });
+}
+
+/** One file as the batch reader emitted it. `bytes` is -1 for a file that does
+ *  not exist, which is how "this command never ran" arrives. */
+interface BatchFileRead {
+  bytes: number;
+  head: string;
+  tail: string | null;
+  /** The reader found a "dependencies are not installed" phrase anywhere in the
+   *  whole file, before any truncation. */
+  blocked: boolean;
+}
+
+/**
+ * Read every file of one batch in a single sandbox round trip.
+ *
+ * Three reads per command times twenty commands is sixty sequential round trips
+ * inside one step whose maxRetries is 0, which is the same unbounded-await
+ * shape this change exists to remove, only with a friendlier constant. One
+ * command returns the lot.
+ *
+ * The payloads are base64 so the line format cannot be broken by the content:
+ * base64's alphabet contains neither a space nor a newline, so splitting on
+ * them is exact rather than a guess. That is the one delimiter this path is
+ * willing to parse.
+ *
+ * The reader also answers the one question truncation would otherwise destroy:
+ * whether the tool reported that it could not run. It greps the whole file, so
+ * a phrase straddling the cut is still found, and `ok` separates a reader that
+ * failed from a batch that produced nothing.
+ */
+async function readBatchFiles(
+  sandbox: SandboxSession,
+  paths: RepoCheckBatchPaths,
+  total: number,
+): Promise<{ ok: boolean; files: Map<string, BatchFileRead> }> {
+  const names = ["launch", "stopped-at"];
+  for (let index = 0; index < total; index++) {
+    names.push(`exit-${index}`, `stdout-${index}`, `stderr-${index}`);
+  }
+  const cap = BATCH_STREAM_HEAD_BYTES + BATCH_STREAM_TAIL_BYTES;
+  const blockedPatterns = MISSING_DEPENDENCY_PHRASES.map(
+    (phrase) => `-e ${shellQuote(phrase)}`,
+  ).join(" ");
+  const script = [
+    "emit() {",
+    '  if [ ! -f "$2" ]; then printf \'%s -1 0 - -\\n\' "$1"; return; fi',
+    '  b=$(wc -c < "$2" | tr -d " \\t")',
+    `  if grep -qiF ${blockedPatterns} -- "$2"; then k=1; else k=0; fi`,
+    `  if [ "$b" -le ${cap} ]; then`,
+    '    h=$(base64 < "$2" | tr -d "\\n"); t=-',
+    "  else",
+    `    h=$(head -c ${BATCH_STREAM_HEAD_BYTES} "$2" | base64 | tr -d "\\n")`,
+    `    t=$(tail -c ${BATCH_STREAM_TAIL_BYTES} "$2" | base64 | tr -d "\\n")`,
+    "  fi",
+    '  [ -z "$h" ] && h=-',
+    '  [ -z "$t" ] && t=-',
+    '  printf \'%s %s %s %s %s\\n\' "$1" "$b" "$k" "$h" "$t"',
+    "}",
+    ...names.map((name) => `emit ${shellQuote(name)} ${shellQuote(`${paths.dir}/${name}`)}`),
+  ].join("\n");
+
+  const result = await sandbox.runCommand({ cmd: "bash", args: ["-lc", script] });
+  const files = new Map<string, BatchFileRead>();
+  if (result.exitCode !== 0) return { ok: false, files };
+  for (const line of (await result.stdout()).split("\n")) {
+    const parts = line.trim().split(" ");
+    if (parts.length !== 5) continue;
+    const [name, bytesText, blocked, head, tail] = parts as [
+      string,
+      string,
+      string,
+      string,
+      string,
+    ];
+    if (!/^-?\d+$/.test(bytesText)) continue;
+    files.set(name, {
+      bytes: Number(bytesText),
+      head: head === "-" ? "" : head,
+      tail: tail === "-" ? null : tail,
+      blocked: blocked === "1",
+    });
+  }
+  return { ok: true, files };
+}
+
+/** Decode one read back to text, splicing in what the reader left out. */
+function decodeBatchFile(file: BatchFileRead): string {
+  if (file.bytes < 0) return "";
+  const head = Buffer.from(file.head, "base64").toString("utf8");
+  if (file.tail === null) return head.trim();
+  const omitted = file.bytes - BATCH_STREAM_HEAD_BYTES - BATCH_STREAM_TAIL_BYTES;
+  const tail = Buffer.from(file.tail, "base64").toString("utf8");
+  return `${head.trimStart()}\n[... ${omitted} bytes of this command's output omitted ...]\n${tail.trimEnd()}`;
+}
+
+function streamText(file: BatchFileRead | undefined): string {
+  return file ? decodeBatchFile(file) : "";
+}
+
+function batchFailure(
+  provider: WorkspaceRepo["provider"],
+  repoPath: string,
+  command: string,
+  reason: string,
+  phase: PrePrCheckFailure["phase"],
+): PrePrCheckFailure {
+  return {
+    provider,
+    repoPath,
+    command,
+    exitCode: -1,
+    stdout: "",
+    stderr: reason,
+    ...(phase ? { phase } : {}),
+  };
+}
+
+/**
+ * Every repository attached to this run's workspace, in manifest order.
+ *
+ * The configured pre-PR checks walk their own configuration and let the start
+ * step resolve each entry, but the explicit `commands` mode of run_checks runs
+ * in every attached repository, so its walk needs the manifest before it can
+ * start anything.
+ */
+export async function listWorkspaceRepositoriesStep(
+  sandboxId: string,
+): Promise<Array<{ provider: WorkspaceRepo["provider"]; repoPath: string }>> {
+  "use step";
+  const { Sandbox } = await import("@vercel/sandbox");
+  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+  const manifest = await readWorkspaceManifest(sandbox);
+  return manifest.repositories.map((repo) => ({
+    provider: repo.provider,
+    repoPath: repo.repoPath,
+  }));
+}
+listWorkspaceRepositoriesStep.maxRetries = 0;
 
 async function readWorkspaceManifest(sandbox: SandboxSession): Promise<WorkspaceManifest> {
   const manifestResult = await sandbox.runCommand("cat", [WORKSPACE_MANIFEST_PATH]);
@@ -299,96 +736,29 @@ async function readWorkspaceManifest(sandbox: SandboxSession): Promise<Workspace
   return parseWorkspaceManifest(await manifestResult.stdout());
 }
 
-async function hasRepositoryChanged(
-  sandbox: SandboxSession,
-  repo: WorkspaceRepo,
-  signal?: AbortSignal,
-): Promise<boolean> {
-  const headResult = signal
-    ? await sandbox.runCommand({
-        cmd: "git",
-        args: ["-C", repo.localPath, "rev-parse", "HEAD"],
-        signal,
-      })
-    : await sandbox.runCommand("git", ["-C", repo.localPath, "rev-parse", "HEAD"]);
-  if (headResult.exitCode !== 0) {
-    throw new Error(
-      `Could not inspect workspace HEAD for ${repo.provider}:${repo.repoPath}`,
-    );
-  }
-
-  const headSha = (await headResult.stdout()).trim();
-  if (!headSha) {
-    throw new Error(
-      `Could not inspect workspace HEAD for ${repo.provider}:${repo.repoPath}`,
-    );
-  }
-  return !repo.preAgentSha || repo.preAgentSha !== headSha;
-}
-
-/** How often the detached Pre-PR repair wrapper's sentinel file is read. The
- *  phase polls inside the caller's step rather than across workflow ticks, so
- *  the tick is a plain sleep and can be far shorter than the 30s ceiling in
- *  workflows/blocks/poll-phase.ts. */
-const PRE_PR_REPAIR_POLL_INTERVAL_MS = 5_000;
-
 /**
- * Wait for the detached repair wrapper to touch its sentinel file.
- *
- * The only bound is the caller's deadline `signal`, which is what bounded the
- * blocking runCommand this replaced: an expired deadline rejects with the
- * signal's own reason, so a real AbortError/TimeoutError still propagates out
- * of the repair phase instead of being reported as a failed launch. Returns
- * "stopped" when the sandbox is gone, the same verdict checkPhaseDone gives
- * every other polled agent phase.
+ * Materialize the pinned harness, write the repair prompt and wrapper, and
+ * launch the repair agent detached. Completion is read from the wrapper's
+ * sentinel by the caller's poll, never by holding this invocation open.
  */
-async function waitForRepairPhase(
+export async function startPrePrRepairStep(
   sandboxId: string,
-  sentinelFile: string,
-  signal?: AbortSignal,
-): Promise<"done" | "stopped"> {
-  const { checkPhaseDone } = await import("../sandbox/poll-agent.js");
-  for (;;) {
-    signal?.throwIfAborted();
-    const status = await checkPhaseDone(sandboxId, sentinelFile);
-    if (status === true) return "done";
-    if (status === "stopped") return "stopped";
-    await sleepUntilNextPoll(PRE_PR_REPAIR_POLL_INTERVAL_MS, signal);
-  }
-}
-
-function sleepUntilNextPoll(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(signal.reason);
-      return;
-    }
-    const onAbort = () => {
-      clearTimeout(timer);
-      reject(signal?.reason);
-    };
-    const timer = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
-}
-
-async function runFixAgent(
-  sandboxId: string,
-  sandbox: SandboxSession,
-  failedRun: PrePrCheckRunResult,
   agentKind: "claude" | "codex",
   model: string,
   fixCycle: number,
-  signal?: AbortSignal,
+  failureSummary: string,
   runtime?: ResolvedHarnessRuntime,
   arthurTaskId?: string | null,
-): Promise<{
-  usage: PhaseUsage | null;
-  failure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
-}> {
+): Promise<
+  | { ok: true; commandId: string; phase: string; paths: PhaseArtifactPaths }
+  | {
+      ok: false;
+      failure: Extract<AgentProtocolResult<unknown>, { ok: false }>;
+    }
+> {
+  "use step";
+  const { Sandbox } = await import("@vercel/sandbox");
+  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
   const { createAgentAdapter } = await import("../sandbox/agents/index.js");
   const effectiveAgentKind =
     runtime?.manifest.schemaVersion === 2
@@ -482,7 +852,7 @@ async function runFixAgent(
   await sandbox.writeFiles([
     {
       path: paths.input,
-      content: Buffer.from(buildFixPrompt(failedRun)),
+      content: Buffer.from(buildFixPrompt(failureSummary)),
     },
     { path: paths.wrapper, content: Buffer.from(script) },
   ]);
@@ -500,7 +870,7 @@ async function runFixAgent(
       detail: "The Pre-PR repair wrapper could not be made executable.",
     });
     if (failure.ok) throw new Error("unreachable");
-    return { usage: null, failure };
+    return { ok: false, failure };
   }
   let launch: SandboxCommand;
   try {
@@ -515,17 +885,10 @@ async function runFixAgent(
     launch = await sandbox.runCommand({
       cmd: "bash",
       args: [paths.wrapper],
-      cwd: "/vercel/sandbox",
+      cwd: WORKSPACE_ROOT_DIR,
       detached: true,
-      ...(signal ? { signal } : {}),
     });
   } catch (error) {
-    if (
-      error instanceof DOMException ||
-      (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError"))
-    ) {
-      throw error;
-    }
     const { protocolFailure, redactDiagnosticText } = await import(
       "../sandbox/agents/protocol.js"
     );
@@ -560,14 +923,14 @@ async function runFixAgent(
       detail: `The Pre-PR repair process could not be launched: ${cause}`,
     });
     if (failure.ok) throw new Error("unreachable");
-    return { usage: null, failure };
+    return { ok: false, failure };
   }
   // A detached launch has no exit code yet while the wrapper runs; only a
   // wrapper that already exited non-zero is a launch that failed.
   if (launch.exitCode !== null && launch.exitCode !== 0) {
     const { commandProtocolFailure } = await import("../sandbox/agents/protocol.js");
     return {
-      usage: null,
+      ok: false,
       failure: await commandProtocolFailure({
         spec: adapter.cliSpec,
         phase,
@@ -578,8 +941,42 @@ async function runFixAgent(
       }),
     };
   }
-  const phaseStatus = await waitForRepairPhase(sandboxId, paths.sentinel, signal);
-  if (phaseStatus === "stopped") {
+  return { ok: true, commandId: launch.cmdId, phase, paths };
+}
+startPrePrRepairStep.maxRetries = 0;
+
+/** Why a polled repair phase produced no sentinel. `none` means it finished. */
+export type PrePrPhaseStall = "none" | "timed_out" | "sandbox_stopped";
+
+/**
+ * Read a finished repair phase's artifacts, or turn a stalled poll into an
+ * agent failure. The two stalls stay distinguishable: a phase that outlived its
+ * cap and a sandbox that died under it are different operational faults.
+ */
+export async function collectPrePrRepairStep(
+  sandboxId: string,
+  agentKind: "claude" | "codex",
+  phase: string,
+  paths: PhaseArtifactPaths,
+  stall: PrePrPhaseStall,
+  /** Tick time the repair poll consumed. Reported instead of the constant: the
+   *  cap that applies is the smaller of PRE_PR_REPAIR_MAX_MINUTES and what the
+   *  run's remaining duration budget allows, so naming the constant tells an
+   *  operator the agent got 25 minutes when it may have had eight. */
+  elapsedMs: number,
+  runtime?: ResolvedHarnessRuntime,
+): Promise<{
+  usage: PhaseUsage | null;
+  failure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
+}> {
+  "use step";
+  const { createAgentAdapter } = await import("../sandbox/agents/index.js");
+  const effectiveAgentKind =
+    runtime?.manifest.schemaVersion === 2
+      ? runtime.manifest.harness.provider
+      : agentKind;
+  const adapter = createAgentAdapter(effectiveAgentKind, runtime?.cliSpec);
+  if (stall !== "none") {
     const { protocolFailure } = await import("../sandbox/agents/protocol.js");
     const failure = protocolFailure({
       spec: adapter.cliSpec,
@@ -588,16 +985,22 @@ async function runFixAgent(
       failureKind: "provider_error",
       category: "provider",
       message: "The current agent phase could not be completed.",
-      detail: "The sandbox stopped before the Pre-PR repair process finished.",
+      detail:
+        stall === "sandbox_stopped"
+          ? "The sandbox stopped before the Pre-PR repair process finished."
+          : `The Pre-PR repair process ran for ${formatElapsed(elapsedMs)} without finishing and was stopped.`,
     });
     if (failure.ok) throw new Error("unreachable");
     return { usage: null, failure };
   }
+  const { Sandbox } = await import("@vercel/sandbox");
+  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
   const artifacts = await collectPhaseFromSandbox(sandbox, paths);
   const usage = adapter.extractUsage(artifacts.stdout, artifacts.structuredOutput);
   const protocol = adapter.validateFreeformProtocol(artifacts, phase);
   return protocol.ok ? { usage } : { usage, failure: protocol };
 }
+collectPrePrRepairStep.maxRetries = 0;
 
 async function collectPhaseFromSandbox(
   sandbox: SandboxSession,
@@ -621,33 +1024,62 @@ async function collectPhaseFromSandbox(
   };
 }
 
-function buildFixPrompt(failedRun: PrePrCheckRunResult): string {
+function buildFixPrompt(failureSummary: string): string {
   return `Pre-PR checks failed for the Run Workspace.
 
 Fix the issues, commit your fixes, and do not push or create pull requests.
 
-${failedRun.summary}`;
+${failureSummary}`;
 }
 
-function formatPrePrCheckFailures(failures: PrePrCheckFailure[]): string {
+export function formatPrePrCheckFailures(
+  failures: PrePrCheckFailure[],
+  /**
+   * Repositories whose setup failed, if any. Setup failure suppresses fix
+   * cycles for the WHOLE run, so without this an unrelated repository's entry
+   * shows a plainly repairable failure next to fixCycles: 0 and says nothing
+   * about why nothing was attempted. Naming the blast radius where the reader
+   * is already looking is the same job WORKSPACE_FAILURE_REASON does for the
+   * opposite case.
+   */
+  suppressingRepositories: string[] = [],
+): string {
+  const suppressed = suppressingRepositories.length > 0;
   return failures
     .map((failure) => {
-      const output = [failure.stderr, failure.stdout]
-        .map((part) => part.trim())
-        .filter(Boolean)
-        .join("\n")
-        .slice(0, 2_000);
+      const repoKey = `${failure.provider}:${failure.repoPath}`;
+      const output = boundFailureOutput(
+        [failure.stderr, failure.stdout]
+          .map((part) => part.trim())
+          .filter(Boolean)
+          .join("\n"),
+      );
       return [
         failure.phase === "setup"
-          ? `SETUP FAILED for ${failure.provider}:${failure.repoPath}`
-          : `${failure.provider}:${failure.repoPath}`,
+          ? `SETUP FAILED for ${repoKey}`
+          : failure.phase === "workspace"
+            ? `WORKSPACE UNAVAILABLE for ${repoKey}`
+            : repoKey,
         `Command: ${failure.command}`,
         `Exit code: ${failure.exitCode}`,
         output ? `Output:\n${output}` : "Output: (empty)",
         ...(failure.phase === "setup" ? [SETUP_FAILURE_REASON] : []),
+        ...(failure.phase === "workspace" ? [WORKSPACE_FAILURE_REASON] : []),
+        ...(suppressed && failure.phase === undefined
+          ? [suppressedBySetupFailure(suppressingRepositories)]
+          : []),
       ].join("\n");
     })
     .join("\n\n");
+}
+
+function suppressedBySetupFailure(repositories: string[]): string {
+  return (
+    "No agent fix cycles were run for this failure either. Setup failed for " +
+    `${repositories.join(", ")}, and a setup failure suppresses the fix cycles ` +
+    "of the whole run, because a fixer cannot install a toolchain by editing " +
+    "code. Fix that setup command and this check gets its fix cycles back."
+  );
 }
 
 const SETUP_FAILURE_REASON =
@@ -657,36 +1089,128 @@ const SETUP_FAILURE_REASON =
   "workspace that could not be provisioned. Fix the setup command in the " +
   "dashboard's Pre-PR checks configuration.";
 
-function repositoryKey(repo: Pick<WorkspaceRepo, "provider" | "repoPath">): string {
-  return `${repo.provider}:${repo.repoPath}`;
+/**
+ * How much of each end of a per-command stream the collector carries out of the
+ * sandbox.
+ *
+ * Sized against what a consumer actually reads, not against what the event log
+ * will tolerate: every path that shows one of these streams bounds it to
+ * FAILURE_OUTPUT_MAX_CHARS (2000) first, so bytes beyond a few kilobytes are
+ * carried across a step boundary, persisted in the run's event log, and then
+ * thrown away unread. Anyone tempted to raise this should raise the consumer
+ * bound instead, and check what it costs in the log.
+ *
+ * Both ends, never just one. A compiler puts the root cause first and a test
+ * runner puts the verdict last. Which end a phrase lands in no longer decides
+ * anything, though: the missing-dependency question is answered by the reader,
+ * which greps the whole file.
+ */
+const BATCH_STREAM_HEAD_BYTES = 4 * 1024;
+const BATCH_STREAM_TAIL_BYTES = 4 * 1024;
+
+/**
+ * Ceiling on the text one collect may return in total.
+ *
+ * The per-stream bound above is per file; a batch of a dozen verbose commands
+ * multiplies it. This is the number that reaches the event log, so it is the
+ * one that matters when a run has already been lost to CORRUPTED_EVENT_LOG.
+ */
+const BATCH_COLLECT_MAX_CHARS = 32 * 1024;
+
+/**
+ * How much of a failure's output a reader actually receives.
+ *
+ * Deliberately far below the stream bytes above, and measuring a different
+ * thing: that bound is what may enter the event log, this is what fits in a
+ * fix prompt and a run summary next to everything else a failure carries. The
+ * two must not be collapsed into one number, and a head slice of a
+ * tail-truncated stream is the specific mistake to avoid: on a long log it
+ * lands in the middle, showing neither the first error nor the summary.
+ */
+export const FAILURE_OUTPUT_MAX_CHARS = 2_000;
+
+/**
+ * Keep both ends of a failure's output within `maxChars`.
+ *
+ * Half from each end, so `tsc` and `mypy` (root cause first) and `pytest`
+ * (verdict last) both survive the same bound.
+ */
+export function boundFailureOutput(text: string, maxChars = FAILURE_OUTPUT_MAX_CHARS): string {
+  if (text.length <= maxChars) return text;
+  const omitted = text.length - maxChars;
+  const marker = `\n[... ${omitted} characters omitted ...]\n`;
+  const budget = maxChars - marker.length;
+  // Nothing sensible to split when the bound cannot even hold the marker.
+  if (budget <= 0) return text.slice(0, maxChars);
+  const head = Math.ceil(budget / 2);
+  return `${text.slice(0, head)}${marker}${text.slice(text.length - (budget - head))}`;
 }
+
+/** Elapsed wall clock, for a message an operator reads. Rounded, because the
+ *  precision is not the point and a false precision invites arithmetic. */
+export function formatElapsed(ms: number): string {
+  if (ms < 90_000) {
+    const seconds = Math.round(ms / 1_000);
+    return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+  const minutes = Math.round(ms / 60_000);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
+const BATCH_WORKSPACE_MISSING_REASON =
+  "The repository's workspace directory could not be entered, so not one of its " +
+  "commands ran.";
+
+const BATCH_IDENTITY_REASON =
+  "This repository's check output does not belong to the batch that was " +
+  "launched for it, so none of it describes this run. Nothing was verified.";
+
+const BATCH_NEVER_STARTED_REASON =
+  "This repository's check batch left no trace at all: the wrapper writes its " +
+  "own marker before it runs anything, and that marker is absent, so the batch " +
+  "never started. Nothing was verified.";
+
+const BATCH_READER_FAILED_REASON =
+  "This repository's check output could not be read back out of the Run " +
+  "Workspace, so what the checks did is unknown. The commands may well have " +
+  "run; nothing about their result can be claimed either way.";
+
+const BATCH_SANDBOX_GONE_REASON =
+  "The Run Workspace sandbox was no longer running when this repository's check " +
+  "output was collected, so nothing could be read back. Nothing was verified.";
+
+const WORKSPACE_FAILURE_REASON =
+  "This is the run's own workspace failing, not a command anyone configured. " +
+  "No setup or check command of this repository is at fault and none needs " +
+  "editing; the other repositories are unaffected and their fix cycles still run.";
+
+const BATCH_MISSING_EXIT_REASON =
+  "This command's exit status was never recorded, so the pre-PR check batch was " +
+  "interrupted while it ran. The command is reported as failed rather than passed.";
 
 const MISSING_DEPENDENCY_FAILURE_REASON =
   "Pre-PR check exited 0 but its dependencies are not installed, so the check did not actually run.";
 
 /**
- * True when a check tool reported it could not run because the project's
- * dependencies are not installed (yarn/npm/pnpm all print a variant of this,
- * and some exit 0 while doing so). Matched against the tool's own output so an
+ * What a check tool prints when it cannot run because the project's
+ * dependencies are not installed (yarn/npm/pnpm all print a variant, and some
+ * exit 0 while doing so). The batch reader greps each stream for these, so an
  * exit-0 "success" that never executed the check is surfaced as a failure
  * instead of silently certifying the workspace.
+ *
+ * Matched by `grep -iF`, so these are literal, case-insensitive substrings: no
+ * regular expression metacharacters, and the backticks are the ones the tools
+ * really print.
  */
-function checkBlockedByMissingDependencies(stdout: string, stderr: string): boolean {
-  const haystack = `${stderr}\n${stdout}`.toLowerCase();
-  return (
-    haystack.includes("dependencies are not installed") ||
-    haystack.includes("dependencies must be installed") ||
-    haystack.includes("run `yarn install`") ||
-    haystack.includes("run 'yarn install'") ||
-    haystack.includes("run `npm install`") ||
-    haystack.includes("run `pnpm install`")
-  );
-}
+const MISSING_DEPENDENCY_PHRASES = [
+  "dependencies are not installed",
+  "dependencies must be installed",
+  "run `yarn install`",
+  "run 'yarn install'",
+  "run `npm install`",
+  "run `pnpm install`",
+];
 
-async function commandStdout(result: SandboxCommandResult): Promise<string> {
-  return (await result.stdout()).trim();
-}
-
-async function commandStderr(result: SandboxCommandResult): Promise<string> {
-  return ((await result.stderr?.()) ?? "").trim();
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
 }

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -62,6 +62,18 @@ export interface PrePrCheckFailure {
   stdout: string;
   stderr: string;
   /**
+   * Why this failure is reported, when the command's own output does not say
+   * it. Rendered on its own line, never folded into a stream.
+   *
+   * Folding it in makes it payload, and payload is what truncation eats: every
+   * consumer bounds the JOIN of the two streams head-and-tail, so a note
+   * appended to stderr sits exactly at the boundary between them, which is the
+   * middle that a head-and-tail bound deletes. An operator then reads
+   * `Exit code: 0` under a heading that says failures with nothing anywhere
+   * saying why a zero exit failed.
+   */
+  note?: string;
+  /**
    * Set when the entry is not an ordinary check result.
    *
    * `setup` is an authored provisioning command that failed: the workspace
@@ -70,8 +82,15 @@ export interface PrePrCheckFailure {
    * repository (its directory unreachable, or its output files not belonging to
    * the launch being collected): nothing about it is authored configuration, so
    * it must never be reported as a setup command the operator should go and fix.
+   * `batch` is the batch itself never reporting (it outlived its bound, or its
+   * sandbox went), which is neither a command's result nor a repairable one.
+   * `omitted` is this collect running out of aggregate budget: one entry
+   * standing for the failures it could not carry.
+   *
+   * Everything with a phase is excluded from the repair prompt, and from the
+   * sentences that only make sense for an ordinary failing check.
    */
-  phase?: "setup" | "workspace";
+  phase?: "setup" | "workspace" | "batch" | "omitted";
 }
 
 export type CheckOutcome =
@@ -402,18 +421,6 @@ export async function collectRepoCheckBatchStep(
    * reporting those as failures would invent results the run never produced.
    */
   batchFinished = true,
-  /**
-   * Whether an exit-0 check that printed a "dependencies are not installed"
-   * phrase is reported as a failure.
-   *
-   * On for the dashboard's configured checks, where a self-skipping tool once
-   * cleared the pre-PR gate on a workspace that was never dependency-installed.
-   * Off for run_checks' explicit `commands` mode, which never had this scan:
-   * that block runs whatever an author typed and its description promises
-   * nothing but the exit code, so a green suite whose output happens to
-   * contain one of six English sentences must not be reported as failed.
-   */
-  scanBlockedDependencies = true,
 ): Promise<CollectedRepoCheckBatch> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
@@ -438,13 +445,20 @@ export async function collectRepoCheckBatchStep(
     return workspaceIncident(BATCH_SANDBOX_GONE_REASON);
   }
 
-  const read = await readBatchFiles(sandbox, paths, total, scanBlockedDependencies);
+  const read = await readBatchFiles(sandbox, paths, total);
   // "The reader failed" and "the marker disagrees" are different diagnoses and
   // must never be reported as each other. The reader runs under `bash -lc`,
   // which sources the very profile these setup commands append to, so a broken
   // profile fails the read while the batch itself is fine.
   if (!read.ok) return workspaceIncident(BATCH_READER_FAILED_REASON);
   const files = read.files;
+  // Zero records is the reader losing its own stdout, not a batch that never
+  // started. `names` always asks for `launch` and `stopped-at`, and the script
+  // emits one record per name whether or not the file exists, so a successful
+  // reader cannot return nothing. A login profile that redirects the shell's
+  // stdout (`exec 1>/dev/null`) produces exactly this, and reporting it as
+  // "the wrapper never started" sends the operator to look at the wrapper.
+  if (files.size === 0) return workspaceIncident(BATCH_READER_FAILED_REASON);
 
   // Identity before content. A directory whose `launch` marker is not this
   // launch's was written by a different wrapper, so nothing in it describes the
@@ -489,7 +503,7 @@ export async function collectRepoCheckBatchStep(
   // the first command with no recorded exit.
   const lastIndex = stoppedAt === null ? total - 1 : stoppedAt;
   const results: PrePrCheckCommandResult[] = [];
-  const failures: RawBatchFailure[] = [];
+  const failures: PrePrCheckFailure[] = [];
   let setupFailed = false;
   let completed = 0;
   let stoppedAtCommand: string | null = null;
@@ -546,9 +560,10 @@ export async function collectRepoCheckBatchStep(
     //
     // The flag comes from the reader, which greps the whole file: scanning the
     // text carried back here would miss a phrase straddling the truncation cut,
-    // which is exactly the false pass this catches. And the reader only looks
-    // when the caller asked for it, because for a mode with no such history the
-    // scan is six English phrases away from failing a green suite.
+    // which is exactly the false pass this catches. Two independent signals are
+    // required before a zero exit is called a failure, so a green suite that
+    // merely mentions one of the phrases stays green
+    // (MISSING_DEPENDENCY_ABSENCE_PHRASES).
     const blockedByMissingDependencies =
       exitCode === 0 &&
       Boolean(files.get(`stdout-${index}`)?.blocked || files.get(`stderr-${index}`)?.blocked);
@@ -575,49 +590,79 @@ export async function collectRepoCheckBatchStep(
 collectRepoCheckBatchStep.maxRetries = 0;
 
 /**
- * A failure before its payload is bounded. `note` is the sentence that explains
- * the failure, kept apart from the command's own output on purpose: it is
- * appended at the end, so any truncation that treats it as payload drops it
- * first and leaves an operator reading `Exit code: 0` under a heading that says
- * failures, with nothing anywhere saying why a zero exit failed.
+ * Bound what one collect returns in total.
+ *
+ * Every failure gets the same share, so the entry an operator reads first is
+ * not the most truncated: a share that grows as the budget is spent gave the
+ * first failure 1024 characters and the sixteenth 4153. The share is at least
+ * BATCH_FAILURE_FLOOR_CHARS, because a repository with three verbose failing
+ * checks would otherwise spend everything on the first two and hand back the
+ * third empty, and the third is as likely as either to be the one being read.
+ *
+ * A share is split across a failure's two streams by what they actually hold,
+ * not 50/50: half of a fixed split is wasted whenever the output is on one
+ * stream, which for a check tool is the common case.
+ *
+ * The budget is then a hard stop, not a target. Nothing bounds how many
+ * commands a repository may configure, and this return value is persisted in
+ * the run's event log, in a repository that has lost runs to
+ * CORRUPTED_EVENT_LOG. What does not fit is reported as an entry of its own:
+ * an omitted failure that says nothing is a silent truncation, which is the
+ * failure mode this whole change exists to end.
  */
-interface RawBatchFailure extends PrePrCheckFailure {
-  note?: string;
+function finalizeBatchFailures(failures: PrePrCheckFailure[]): PrePrCheckFailure[] {
+  const share = Math.max(
+    BATCH_FAILURE_FLOOR_CHARS,
+    Math.floor(BATCH_COLLECT_MAX_CHARS / Math.max(1, failures.length)),
+  );
+  const bounded: PrePrCheckFailure[] = [];
+  let used = 0;
+
+  for (const [index, failure] of failures.entries()) {
+    if (used >= BATCH_COLLECT_MAX_CHARS) {
+      const omitted = failures.length - index;
+      bounded.push({
+        provider: failure.provider,
+        repoPath: failure.repoPath,
+        command: `(${omitted} further failing command${omitted === 1 ? "" : "s"})`,
+        exitCode: -1,
+        stdout: "",
+        stderr: "",
+        note: `${omitted} further failing command${omitted === 1 ? "" : "s"} of this repository are not listed: the collected output reached ${BATCH_COLLECT_MAX_CHARS} characters, which is all one step return value may carry into the run's event log. Re-run the checks after fixing the ones above.`,
+        phase: "omitted",
+      });
+      break;
+    }
+    const [stderrShare, stdoutShare] = splitStreamShare(
+      share,
+      failure.stderr.length,
+      failure.stdout.length,
+    );
+    const stderr = boundFailureOutput(failure.stderr, stderrShare);
+    const stdout = boundFailureOutput(failure.stdout, stdoutShare);
+    used += stderr.length + stdout.length;
+    bounded.push({ ...failure, stdout, stderr });
+  }
+  return bounded;
 }
 
 /**
- * Bound what one collect returns in total, then append the sentences.
+ * Divide one failure's share between its two streams by what each holds.
  *
- * Two rules. Every failure gets at least BATCH_FAILURE_FLOOR_CHARS, because a
- * repository with three verbose failing checks would otherwise spend the whole
- * aggregate on the first two and hand back the third empty, and the third is
- * as likely as either to be the one being read. What is left over is shared
- * out, so a lone failure still gets room. The aggregate is therefore a target
- * rather than a hard ceiling: n failures can reach n floors, which for a
- * pathological batch is above the target and still far below carrying whole
- * logs.
- *
- * The bounding itself is head plus tail (boundFailureOutput), never a head
- * slice: a compiler puts the root cause first and a test runner puts the
- * verdict last.
+ * A stream shorter than its half keeps everything and hands the rest to the
+ * other, so a failure whose output is entirely on stderr keeps the whole share
+ * of it rather than half. Both streams fitting means neither is cut at all.
  */
-function finalizeBatchFailures(failures: RawBatchFailure[]): PrePrCheckFailure[] {
-  let remaining = BATCH_COLLECT_MAX_CHARS;
-  return failures.map((failure, index) => {
-    const share = Math.max(
-      BATCH_FAILURE_FLOOR_CHARS,
-      Math.floor(remaining / (failures.length - index)),
-    );
-    const { note, ...rest } = failure;
-    const stderr = boundFailureOutput(failure.stderr, Math.ceil(share / 2));
-    const stdout = boundFailureOutput(failure.stdout, Math.floor(share / 2));
-    remaining = Math.max(0, remaining - stderr.length - stdout.length);
-    return {
-      ...rest,
-      stdout,
-      stderr: note ? [stderr, note].filter(Boolean).join("\n") : stderr,
-    };
-  });
+function splitStreamShare(
+  share: number,
+  stderrLength: number,
+  stdoutLength: number,
+): [number, number] {
+  if (stderrLength + stdoutLength <= share) return [stderrLength, stdoutLength];
+  const half = Math.floor(share / 2);
+  const stderrShare = Math.min(stderrLength, half);
+  const stdoutShare = Math.min(stdoutLength, share - stderrShare);
+  return [share - stdoutShare, stdoutShare];
 }
 
 /** One file as the batch reader emitted it. `bytes` is -1 for a file that does
@@ -626,8 +671,8 @@ interface BatchFileRead {
   bytes: number;
   head: string;
   tail: string | null;
-  /** The reader found a "dependencies are not installed" phrase anywhere in the
-   *  whole file, before any truncation. */
+  /** The reader found both missing-dependency signals anywhere in the whole
+   *  file, before any truncation. */
   blocked: boolean;
 }
 
@@ -649,20 +694,18 @@ const BATCH_READ_MARKER = "PREPRCHK";
  * real bash in the tests: it is load-bearing, and a JavaScript reimplementation
  * of it in a fake proves only that the fake agrees with itself.
  */
-export function buildBatchReaderScript(opts: {
-  dir: string;
-  names: string[];
-  scanBlockedDependencies: boolean;
-}): string {
+export function buildBatchReaderScript(opts: { dir: string; names: string[] }): string {
   const cap = BATCH_STREAM_HEAD_BYTES + BATCH_STREAM_TAIL_BYTES;
-  const scan = opts.scanBlockedDependencies
-    ? `  if grep -qiF ${MISSING_DEPENDENCY_PHRASES.map((phrase) => `-e ${shellQuote(phrase)}`).join(" ")} -- "$2"; then k=1; else k=0; fi`
-    : "  k=0";
+  const anyOf = (phrases: string[]): string =>
+    `grep -qiF ${phrases.map((phrase) => `-e ${shellQuote(phrase)}`).join(" ")} -- "$2"`;
   return [
     "emit() {",
     `  if [ ! -f "$2" ]; then printf '${BATCH_READ_MARKER} %s -1 0 - -\n' "$1"; return; fi`,
     '  b=$(wc -c < "$2" | tr -d " \t")',
-    scan,
+    // Two signals, both required. See MISSING_DEPENDENCY_ABSENCE_PHRASES.
+    `  if ${anyOf(MISSING_DEPENDENCY_ABSENCE_PHRASES)} && ${anyOf(
+      MISSING_DEPENDENCY_INSTALL_PHRASES,
+    )}; then k=1; else k=0; fi`,
     `  if [ "$b" -le ${cap} ]; then`,
     '    h=$(base64 < "$2" | tr -d "\n"); t=-',
     "  else",
@@ -733,17 +776,12 @@ async function readBatchFiles(
   sandbox: SandboxSession,
   paths: RepoCheckBatchPaths,
   total: number,
-  scanBlockedDependencies: boolean,
 ): Promise<{ ok: boolean; files: Map<string, BatchFileRead> }> {
   const names = ["launch", "stopped-at"];
   for (let index = 0; index < total; index++) {
     names.push(`exit-${index}`, `stdout-${index}`, `stderr-${index}`);
   }
-  const script = buildBatchReaderScript({
-    dir: paths.dir,
-    names,
-    scanBlockedDependencies,
-  });
+  const script = buildBatchReaderScript({ dir: paths.dir, names });
   const result = await sandbox.runCommand({ cmd: "bash", args: ["-lc", script] });
   if (result.exitCode !== 0) return { ok: false, files: new Map() };
   return { ok: true, files: parseBatchReaderOutput(await result.stdout()) };
@@ -1138,10 +1176,17 @@ export function formatPrePrCheckFailures(
           ? `SETUP FAILED for ${repoKey}`
           : failure.phase === "workspace"
             ? `WORKSPACE UNAVAILABLE for ${repoKey}`
-            : repoKey,
+            : failure.phase === "batch"
+              ? `CHECK BATCH ABANDONED for ${repoKey}`
+              : failure.phase === "omitted"
+                ? `FAILURES OMITTED for ${repoKey}`
+                : repoKey,
         `Command: ${failure.command}`,
         `Exit code: ${failure.exitCode}`,
         output ? `Output:\n${output}` : "Output: (empty)",
+        // After the output and outside the bound: the note explains the entry
+        // and must survive whatever truncation the output took.
+        ...(failure.note ? [failure.note] : []),
         ...(failure.phase === "setup" ? [SETUP_FAILURE_REASON] : []),
         ...(failure.phase === "workspace" ? [WORKSPACE_FAILURE_REASON] : []),
         ...(suppressed && failure.phase === undefined
@@ -1286,23 +1331,42 @@ const MISSING_DEPENDENCY_FAILURE_REASON =
   "Pre-PR check exited 0 but its dependencies are not installed, so the check did not actually run.";
 
 /**
- * What a check tool prints when it cannot run because the project's
- * dependencies are not installed (yarn/npm/pnpm all print a variant, and some
- * exit 0 while doing so). The batch reader greps each stream for these, so an
- * exit-0 "success" that never executed the check is surfaced as a failure
- * instead of silently certifying the workspace.
+ * Two independent signals a check tool prints when it exits 0 without running,
+ * because the project's dependencies are not installed. The reader fails such a
+ * check only when BOTH appear: a statement that the dependencies are absent,
+ * AND an instruction to run an installer.
+ *
+ * One signal is not enough, and this repository is the proof: its own test
+ * titles contain "dependencies are not installed", so a green suite printing a
+ * verbose test list would be reported as a blocked check. Requiring the
+ * installer instruction as well keeps that suite passing while still failing
+ * the real message, because a tool telling you it did nothing always tells you
+ * what to run: `yarn install`, `npm install`, `npm ci`, `pnpm install`,
+ * `bun install`. Verified both ways by executing the reader against captured
+ * output (see runner.test.ts, "the batch reader shell").
  *
  * Matched by `grep -iF`, so these are literal, case-insensitive substrings: no
- * regular expression metacharacters, and the backticks are the ones the tools
- * really print.
+ * regular expression metacharacters, and no dependence on how a tool decorates
+ * the command it names (backticks, quotes, indentation).
+ *
+ * Residual risk, deliberately accepted: a suite that exits 0 while printing
+ * both signals, for instance a skipped test whose title names an installer,
+ * still reads as blocked. The next lever would be requiring both on one line,
+ * which yarn's and npm's real one-line messages satisfy; it is not taken yet
+ * because nothing has produced that false positive.
  */
-const MISSING_DEPENDENCY_PHRASES = [
+const MISSING_DEPENDENCY_ABSENCE_PHRASES = [
   "dependencies are not installed",
   "dependencies must be installed",
-  "run `yarn install`",
-  "run 'yarn install'",
-  "run `npm install`",
-  "run `pnpm install`",
+  "dependencies were not installed",
+];
+
+const MISSING_DEPENDENCY_INSTALL_PHRASES = [
+  "yarn install",
+  "npm install",
+  "npm ci",
+  "pnpm install",
+  "bun install",
 ];
 
 function shellQuote(value: string): string {

--- a/apps/worker/src/sandbox/agents/protocol.ts
+++ b/apps/worker/src/sandbox/agents/protocol.ts
@@ -11,12 +11,16 @@ import type {
   RunnableSandbox,
   SerializableAgentCliSpec,
 } from "./types.js";
+import { redactDiagnosticText } from "./redact.js";
 import { AgentRuntimeError } from "./runtime-error.js";
 
 export {
   AgentRuntimeError,
   isAgentRuntimeError,
 } from "./runtime-error.js";
+// Re-exported so every existing caller keeps its import. It lives in a module
+// of its own because workflow scope needs it and cannot have node:crypto.
+export { redactDiagnosticText } from "./redact.js";
 
 const DIAGNOSTIC_TAIL_BYTES = 2 * 1024;
 const MAX_SCHEMA_ISSUES = 20;
@@ -392,20 +396,6 @@ export function eventMetadata(value: unknown): AgentProtocolDiagnostic["event"] 
   if (typeof record.is_error === "boolean") metadata.isError = record.is_error;
   if (typeof item?.type === "string") metadata.itemType = item.type;
   return Object.keys(metadata).length > 0 ? metadata : undefined;
-}
-
-export function redactDiagnosticText(value: string): string {
-  let redacted = value;
-  const sensitiveValues = Object.entries(process.env)
-    .filter(([key, secret]) =>
-      secret && secret.length >= 8 && /(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)/i.test(key),
-    )
-    .map(([, secret]) => secret as string);
-  for (const secret of sensitiveValues) redacted = redacted.split(secret).join("[REDACTED]");
-  return redacted
-    .replace(/\b(?:sk-ant-[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+|glpat-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
-    .replace(/\b(Bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
-    .replace(/\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+/gi, "$1=[REDACTED]");
 }
 
 export function hashText(value: string): string {

--- a/apps/worker/src/sandbox/agents/redact.ts
+++ b/apps/worker/src/sandbox/agents/redact.ts
@@ -1,0 +1,26 @@
+/**
+ * Diagnostic redaction, deliberately alone in a module of its own.
+ *
+ * It lives here rather than in protocol.ts so it can be imported from workflow
+ * scope: protocol.ts imports `node:crypto` for its schema hashing, and a Node
+ * builtin anywhere in the workflow module graph fails the Vercel build alone,
+ * never vitest or a local build, which is what makes it worth stating. This
+ * module imports nothing at all.
+ *
+ * Redacting before a value crosses into a step is not cosmetic. Workflow
+ * journals step arguments durably, so an unredacted secret handed to a step is
+ * written to the run's event log whatever the step then does with it.
+ */
+export function redactDiagnosticText(value: string): string {
+  let redacted = value;
+  const sensitiveValues = Object.entries(process.env)
+    .filter(([key, secret]) =>
+      secret && secret.length >= 8 && /(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)/i.test(key),
+    )
+    .map(([, secret]) => secret as string);
+  for (const secret of sensitiveValues) redacted = redacted.split(secret).join("[REDACTED]");
+  return redacted
+    .replace(/\b(?:sk-ant-[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]+|github_pat_[A-Za-z0-9_]+|glpat-[A-Za-z0-9_-]+)\b/g, "[REDACTED]")
+    .replace(/\b(Bearer\s+)[^\s,;]+/gi, "$1[REDACTED]")
+    .replace(/\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+/gi, "$1=[REDACTED]");
+}

--- a/apps/worker/src/workflows/agent-pre-pr-checks-failure.test.ts
+++ b/apps/worker/src/workflows/agent-pre-pr-checks-failure.test.ts
@@ -1,24 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  getCurrentPrePrCheckConfig: vi.fn(),
-  runPrePrChecksWithFixes: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
 }));
 
-vi.mock("../db/client.js", () => ({ getDb: () => ({ kind: "db" }) }));
-vi.mock("../pre-pr-checks/store.js", () => ({
-  getCurrentPrePrCheckConfig: (...args: any[]) =>
-    mocks.getCurrentPrePrCheckConfig(...args),
-}));
-vi.mock("../pre-pr-checks/runner.js", () => ({
-  runPrePrChecksWithFixes: (...args: any[]) =>
-    mocks.runPrePrChecksWithFixes(...args),
-}));
 vi.mock("../lib/logger.js", () => ({
   logger: { info: mocks.info, warn: mocks.warn, error: mocks.error },
+}));
+// The real redactor reads process.env to find the secrets it blanks, which
+// makes its output depend on the machine running the suite. Redaction itself
+// is pinned below against an injected redactor.
+vi.mock("../sandbox/agents/protocol.js", () => ({
+  redactDiagnosticText: (value: string) => value,
 }));
 vi.mock("../../env.js", () => ({
   env: { DASHBOARD_ORIGIN: "https://dashboard.example.com" },
@@ -27,9 +22,10 @@ vi.mock("../../env.js", () => ({
 import {
   PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH,
   PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH,
+  describePrePrChecksFailureStep,
+  prePrChecksFailureInput,
   prePrChecksFailureMustPropagate,
   prePrChecksFailureReport,
-  runPrePrChecksStep,
 } from "./agent.js";
 import { isDurationAbortError } from "./run-budget.js";
 import { isRunControlError } from "./run-control-error.js";
@@ -43,39 +39,19 @@ function namedError(name: string, message: string): Error {
   return error;
 }
 
-function runStep() {
-  return runPrePrChecksStep("sbx-test-123", "codex", "gpt-5");
+/**
+ * What the call site does with a throw it may not propagate: flatten it in
+ * workflow scope, then compose and log the sentence inside the step. The
+ * checks stopped being a step of their own (they are launched detached and
+ * polled), so this pair is the seam that carries what #316 landed.
+ */
+function describe_(error: unknown, version: number | null = 7) {
+  return describePrePrChecksFailureStep(prePrChecksFailureInput(error), version);
 }
 
 describe("pre-PR checks step failure cause", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
-      version: 7,
-      config: { repositories: [] },
-    });
-  });
-
-  it("returns the checks result and the loaded version when nothing throws", async () => {
-    mocks.runPrePrChecksWithFixes.mockResolvedValue({
-      outcome: "passed",
-      passed: true,
-      fixCycles: 0,
-      fixCycleUsages: [],
-      budgetFailure: null,
-      summary: "All checks passed.",
-    });
-
-    await expect(runStep()).resolves.toEqual({
-      outcome: "passed",
-      passed: true,
-      fixCycles: 0,
-      fixCycleUsages: [],
-      budgetFailure: null,
-      summary: "All checks passed.",
-      configurationVersion: 7,
-    });
-    expect(mocks.error).not.toHaveBeenCalled();
   });
 
   it("names the thrown cause instead of leaving Workflow's wrapper to speak alone", async () => {
@@ -83,11 +59,7 @@ describe("pre-PR checks step failure cause", () => {
     // wrun_01M0CAZKV3YMNFBCZJA8MT95GW died here reading only "exceeded max
     // retries", with no sanitized output captured and nothing in the runtime
     // logs. Whatever the step throws has to reach the operator-facing text.
-    mocks.runPrePrChecksWithFixes.mockRejectedValue(
-      new Error("sandbox connection reset"),
-    );
-
-    await expect(runStep()).rejects.toThrow(
+    await expect(describe_(new Error("sandbox connection reset"))).resolves.toBe(
       `${MESSAGE_LEAD}sandbox connection reset`,
     );
     expect(mocks.error).toHaveBeenCalledTimes(1);
@@ -109,31 +81,25 @@ describe("pre-PR checks step failure cause", () => {
   });
 
   it("prefers a system error code over a class name that says nothing", async () => {
-    mocks.runPrePrChecksWithFixes.mockRejectedValue(
-      Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:443"), {
-        code: "ECONNREFUSED",
-      }),
-    );
+    const error = Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:443"), {
+      code: "ECONNREFUSED",
+    });
 
-    await expect(runStep()).rejects.toThrow(
+    await expect(describe_(error)).resolves.toBe(
       `${MESSAGE_LEAD}ECONNREFUSED: connect ECONNREFUSED 10.0.0.1:443`,
     );
   });
 
   it("bounds a runaway cause instead of embedding it whole", async () => {
     const thrownMessage = "sandbox refused the launch. ".repeat(200);
-    mocks.runPrePrChecksWithFixes.mockRejectedValue(new Error(thrownMessage));
 
-    const thrown = await runStep().then(
-      () => null,
-      (err: unknown) => err as Error,
-    );
+    const message = await describe_(new Error(thrownMessage));
 
-    expect(thrown?.message).toContain(MESSAGE_LEAD);
-    expect(thrown?.message).not.toContain(thrownMessage);
+    expect(message).toContain(MESSAGE_LEAD);
+    expect(message).not.toContain(thrownMessage);
     // Sentence plus the bound the cause is clamped to, and nothing more, so a
     // runaway error text cannot become the run status.
-    expect(thrown?.message.length).toBeLessThanOrEqual(
+    expect(message.length).toBeLessThanOrEqual(
       MESSAGE_LEAD.length + PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH,
     );
     const logged = mocks.error.mock.calls[0]?.[0] as { cause: string };
@@ -141,33 +107,20 @@ describe("pre-PR checks step failure cause", () => {
   });
 
   it.each(runControlErrorCases())(
-    "rethrows %s untouched so the call site still recognizes it",
-    async (_label, error) => {
-      mocks.runPrePrChecksWithFixes.mockRejectedValue(error);
-
-      await expect(runStep()).rejects.toBe(error);
-      const thrown = await runStep().then(
-        () => null,
-        (err: unknown) => err,
-      );
-      expect(isRunControlError(thrown)).toBe(true);
-      expect(mocks.error).not.toHaveBeenCalled();
+    "keeps %s out of the wrap so the call site still recognizes it",
+    (_label, error) => {
+      expect(prePrChecksFailureMustPropagate(error)).toBe(true);
+      expect(isRunControlError(error)).toBe(true);
     },
   );
 
   it.each([["AbortError"], ["TimeoutError"]])(
-    "rethrows a %s untouched so the duration budget stop survives",
-    async (name) => {
+    "keeps a %s out of the wrap so the duration budget stop survives",
+    (name) => {
       const error = namedError(name, "The operation was aborted.");
-      mocks.runPrePrChecksWithFixes.mockRejectedValue(error);
 
-      await expect(runStep()).rejects.toBe(error);
-      const thrown = await runStep().then(
-        () => null,
-        (err: unknown) => err,
-      );
-      expect(isDurationAbortError(thrown)).toBe(true);
-      expect(mocks.error).not.toHaveBeenCalled();
+      expect(prePrChecksFailureMustPropagate(error)).toBe(true);
+      expect(isDurationAbortError(error)).toBe(true);
     },
   );
 
@@ -184,18 +137,18 @@ describe("pre-PR checks step failure cause", () => {
     expect(prePrChecksFailureMustPropagate(new Error("sandbox died"))).toBe(false);
 
     const rewrappedBudget = new Error(
-      prePrChecksFailureReport(budgetStop, identity).message,
+      prePrChecksFailureReport(prePrChecksFailureInput(budgetStop), identity).message,
     );
     expect(isRunControlError(rewrappedBudget)).toBe(false);
     const rewrappedAbort = new Error(
-      prePrChecksFailureReport(abort, identity).message,
+      prePrChecksFailureReport(prePrChecksFailureInput(abort), identity).message,
     );
     expect(isDurationAbortError(rewrappedAbort)).toBe(false);
   });
 
   it("redacts the cause and the stack tail through the caller's redactor", () => {
     const report = prePrChecksFailureReport(
-      new Error("auth failed for token=abcd1234"),
+      prePrChecksFailureInput(new Error("auth failed for token=abcd1234")),
       (value) => value.replace("abcd1234", "[REDACTED]"),
     );
 
@@ -204,7 +157,10 @@ describe("pre-PR checks step failure cause", () => {
   });
 
   it("names a non-Error throw rather than dropping it", () => {
-    const report = prePrChecksFailureReport("sandbox vanished", (v) => v);
+    const report = prePrChecksFailureReport(
+      prePrChecksFailureInput("sandbox vanished"),
+      (v) => v,
+    );
 
     expect(report.message).toBe(`${MESSAGE_LEAD}sandbox vanished`);
     expect(report.name).toBe("string");

--- a/apps/worker/src/workflows/agent-pre-pr-checks-failure.test.ts
+++ b/apps/worker/src/workflows/agent-pre-pr-checks-failure.test.ts
@@ -78,14 +78,24 @@ describe("pre-PR checks step failure cause", () => {
     );
   });
 
-  it("prefers a system error code over a class name that says nothing", async () => {
-    const error = Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:443"), {
+  it("labels the cause with the class name, the only thing left of the error", async () => {
+    // Everything caught here was thrown inside a step, and Workflow reduces a
+    // thrown error to name, message and stack at the VM boundary and revives it
+    // as a plain Error. A system error code would name the cause far better
+    // than `Error` does, but `.code` cannot reach this side, so nothing may be
+    // built on it: a label that can never fire reads as coverage that does not
+    // exist. Recovering it would mean parsing the message.
+    const error = Object.assign(namedError("SandboxError", "connect ECONNREFUSED 10.0.0.1:443"), {
       code: "ECONNREFUSED",
     });
 
     await expect(describe_(error)).resolves.toBe(
-      `${MESSAGE_LEAD}ECONNREFUSED: connect ECONNREFUSED 10.0.0.1:443`,
+      `${MESSAGE_LEAD}SandboxError: connect ECONNREFUSED 10.0.0.1:443`,
     );
+    // A plain Error adds nothing worth prefixing, and a non-Error throw's
+    // `typeof` is noise on top of its own text.
+    await expect(describe_(new Error("plain"))).resolves.toBe(`${MESSAGE_LEAD}plain`);
+    await expect(describe_("just a string")).resolves.toBe(`${MESSAGE_LEAD}just a string`);
   });
 
   it("bounds a runaway cause instead of embedding it whole", async () => {
@@ -212,4 +222,21 @@ describe("pre-PR checks step failure cause", () => {
       "The Pre-PR checks step failed (SandboxError), and the cause could not be recorded.",
     );
   });
+
+  it.each(runControlErrorCases())(
+    "rethrows %s from the reporting step instead of degrading",
+    async (_label, controlError) => {
+      // The degraded sentence is for a reporting path that broke. A cancelled
+      // run surfaces at every step, this one included, and swallowing it here
+      // would report a Pre-PR checks failure for a run the operator cancelled,
+      // and let it carry on being cancelled anyway.
+      mocks.error.mockImplementation(() => {
+        throw controlError;
+      });
+
+      await expect(
+        prePrChecksFailureMessage(new Error("sandbox connection reset"), 7),
+      ).rejects.toBe(controlError);
+    },
+  );
 });

--- a/apps/worker/src/workflows/agent-pre-pr-checks-failure.test.ts
+++ b/apps/worker/src/workflows/agent-pre-pr-checks-failure.test.ts
@@ -9,18 +9,16 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../lib/logger.js", () => ({
   logger: { info: mocks.info, warn: mocks.warn, error: mocks.error },
 }));
-// The real redactor reads process.env to find the secrets it blanks, which
-// makes its output depend on the machine running the suite. Redaction itself
-// is pinned below against an injected redactor.
-vi.mock("../sandbox/agents/protocol.js", () => ({
-  redactDiagnosticText: (value: string) => value,
-}));
+// The regex half of the real redactor is what these assert against; its
+// process.env half would make the output depend on the machine running the
+// suite, and there is no secret in these fixtures for it to find.
 vi.mock("../../env.js", () => ({
   env: { DASHBOARD_ORIGIN: "https://dashboard.example.com" },
 }));
 
 import {
   PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH,
+  prePrChecksFailureMessage,
   PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH,
   describePrePrChecksFailureStep,
   prePrChecksFailureInput,
@@ -165,5 +163,53 @@ describe("pre-PR checks step failure cause", () => {
     expect(report.message).toBe(`${MESSAGE_LEAD}sandbox vanished`);
     expect(report.name).toBe("string");
     expect(report.stackTail).toBe("");
+  });
+
+  it("redacts and bounds before the value can be journaled", async () => {
+    // Workflow journals step arguments durably, so whatever the flattener
+    // returns is written into the run's event log verbatim. Redacting inside
+    // the step would protect only the sentence an operator reads.
+    const secret = "glpat-AAAAAAAAAAAAAAAAAAAA";
+    const error = new Error(
+      `clone failed for https://oauth2:${secret}@gitlab.com/acme/api.git ${"pad ".repeat(200)}`,
+    );
+
+    const input = prePrChecksFailureInput(error);
+
+    expect(input.message).not.toContain(secret);
+    expect(input.message).toContain("[REDACTED]");
+    expect(input.message.length).toBe(PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH);
+    expect(input.stack.length).toBeLessThanOrEqual(
+      PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH,
+    );
+  });
+
+  it("survives a throw with no properties at all", async () => {
+    // `throw null` and a bare Promise.reject() both reach here. A TypeError
+    // raised inside the reporting path would lose the cause it exists to carry
+    // and hand the operator an unrelated error.
+    for (const thrown of [null, undefined]) {
+      expect(() => prePrChecksFailureInput(thrown)).not.toThrow();
+      await expect(describe_(thrown)).resolves.toContain(MESSAGE_LEAD);
+    }
+  });
+
+  it("degrades to a fixed sentence when the reporting step itself fails", async () => {
+    // The step is the only place the cause is logged and its maxRetries is 0.
+    // A failed dynamic import on a cold start, or an invocation killed
+    // mid-step, must not substitute the reporting path's own error for the
+    // report.
+    mocks.error.mockImplementation(() => {
+      throw new Error("logger transport is gone");
+    });
+
+    const message = await prePrChecksFailureMessage(
+      Object.assign(new Error("sandbox connection reset"), { name: "SandboxError" }),
+      7,
+    );
+
+    expect(message).toBe(
+      "The Pre-PR checks step failed (SandboxError), and the cause could not be recorded.",
+    );
   });
 });

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -171,6 +171,7 @@ import {
   type RunBudgetObservation,
   type RunBudgetState,
 } from "./run-budget.js";
+import { redactDiagnosticText } from "../sandbox/agents/redact.js";
 import { isRunControlError } from "./run-control-error.js";
 import { execute as executeFetchPrContext } from "./blocks/fetch-pr-context.js";
 import { execute as executeInvestigate } from "./blocks/investigate.js";
@@ -2422,15 +2423,42 @@ export interface PrePrChecksFailureInput {
   stack: string;
 }
 
+/**
+ * Flatten a thrown value into the parts the failure report needs, redacted and
+ * bounded before it can go anywhere.
+ *
+ * Redacted here rather than in the step: Workflow journals step arguments
+ * durably, so whatever this returns is written into the run's event log
+ * verbatim. An SDK error carrying a `Bearer`, an `sk-ant-` or a `glpat-` in a
+ * clone URL would otherwise be persisted in full, with the redaction
+ * protecting only the sentence an operator reads. Redaction runs before
+ * truncation so a secret is blanked rather than cut in half.
+ *
+ * Bounded here for the same reason: the step keeps exactly these bytes anyway,
+ * so anything beyond them would be journaled and then dropped.
+ *
+ * Flattened at all because an Error does not survive step argument
+ * serialization: its name, its `code` and its stack, which is every field the
+ * report is made of, are dropped in transit.
+ */
 export function prePrChecksFailureInput(error: unknown): PrePrChecksFailureInput {
   const isError = error instanceof Error;
-  const code = (error as { code?: unknown }).code;
+  // Optional on purpose. `throw null` and a bare `Promise.reject()` both reach
+  // here, and a TypeError raised inside the reporting path would destroy the
+  // very cause this exists to carry.
+  const code = (error as { code?: unknown } | null | undefined)?.code;
   const name = isError ? error.name : typeof error;
+  const stack = isError ? error.stack ?? "" : "";
   return {
     name,
-    message: isError ? error.message : String(error),
+    message: redactDiagnosticText(isError ? error.message : String(error)).slice(
+      0,
+      PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH,
+    ),
     label: typeof code === "string" && code ? code : isError ? name : "",
-    stack: isError ? error.stack ?? "" : "",
+    stack: stack
+      ? redactDiagnosticText(stack).slice(-PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH)
+      : "",
   };
 }
 
@@ -2438,9 +2466,10 @@ export function prePrChecksFailureInput(error: unknown): PrePrChecksFailureInput
  * What a Pre-PR checks failure is allowed to say, composed in one pure place
  * so the bound and the wording can be pinned directly.
  *
- * `redact` is a parameter rather than an import: the redactor lives in
- * `sandbox/agents/protocol.js`, which must stay out of the workflow module
- * scope.
+ * `redact` is a parameter rather than an import so this stays a pure function
+ * that can be pinned against a stub redactor. The real one is imported
+ * directly at the top of this module: it lives alone in
+ * `sandbox/agents/redact.js` precisely so workflow scope may import it.
  */
 export function prePrChecksFailureReport(
   error: PrePrChecksFailureInput,
@@ -2477,8 +2506,11 @@ export async function describePrePrChecksFailureStep(
 ): Promise<string> {
   "use step";
   const { logger } = await import("../lib/logger.js");
-  const { redactDiagnosticText } = await import("../sandbox/agents/protocol.js");
-  const report = prePrChecksFailureReport(error, redactDiagnosticText);
+  const { redactDiagnosticText: redact } = await import("../sandbox/agents/redact.js");
+  // Redacted a second time, deliberately. The caller redacts before the step
+  // boundary so the journal never holds a secret; this keeps the step correct
+  // on its own terms for any input it is given, and redaction is idempotent.
+  const report = prePrChecksFailureReport(error, redact);
   logger.error(
     {
       version: configurationVersion,
@@ -2491,6 +2523,28 @@ export async function describePrePrChecksFailureStep(
   return report.message;
 }
 describePrePrChecksFailureStep.maxRetries = 0;
+
+/**
+ * The sentence to throw for a Pre-PR checks failure, whatever happens to the
+ * reporting path itself.
+ *
+ * describePrePrChecksFailureStep is the only place the cause is logged and its
+ * maxRetries is 0, so a failed dynamic import on a cold start, or an invocation
+ * killed mid-step, would otherwise replace the real cause with the reporting
+ * path's own error. Degrading loses the detail; substituting loses the
+ * incident, which is the failure #316 exists to end.
+ */
+export async function prePrChecksFailureMessage(
+  error: unknown,
+  configurationVersion: number | null,
+): Promise<string> {
+  const input = prePrChecksFailureInput(error);
+  try {
+    return await describePrePrChecksFailureStep(input, configurationVersion);
+  } catch {
+    return `The Pre-PR checks step failed (${input.name.slice(0, 60)}), and the cause could not be recorded.`;
+  }
+}
 
 async function markTicketFailed(
   ticketIdentifier: string,
@@ -5254,12 +5308,7 @@ async function agentWorkflowBody(
               // the operator, and before #316 that arrived as Workflow's own
               // "exceeded max retries" with no name, no message and nothing in
               // the runtime logs.
-              throw new Error(
-                await describePrePrChecksFailureStep(
-                  prePrChecksFailureInput(err),
-                  prePrConfig.version,
-                ),
-              );
+              throw new Error(await prePrChecksFailureMessage(err, prePrConfig.version));
             }
             recordPrePrFixCycleUsages(
               ctx,

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -152,6 +152,11 @@ import {
 } from "./blocks/call-llm.js";
 import { pollPhaseUntilDone } from "./blocks/poll-phase.js";
 import {
+  loadPrePrCheckConfigStep,
+  runPrePrChecksWithFixes,
+} from "./blocks/pre-pr-checks.js";
+import type { PrePrCheckRunResult } from "../pre-pr-checks/runner.js";
+import {
   RunBudgetError,
   addActiveElapsed,
   createRunBudgetState,
@@ -2369,7 +2374,7 @@ async function resolveHarnessRuntimesStep(
 }
 resolveHarnessRuntimesStep.maxRetries = 0;
 
-/** Longest failure cause carried into the Pre-PR checks step error message.
+/** Longest failure cause carried into the Pre-PR checks failure message.
  *  Same bound the Pre-PR repair launch failure puts on its carried cause
  *  (#309): long enough for a sandbox, kill or stream verdict, short enough that
  *  the composed block failure stays a detail rather than a payload. */
@@ -2380,7 +2385,7 @@ export const PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH = 200;
 export const PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH = 600;
 
 /**
- * Errors `runPrePrChecksStep` must rethrow untouched.
+ * Errors the Pre-PR checks call site must rethrow untouched.
  *
  * Both predicates identify an error structurally, by `name`
  * (run-budget.ts:52, run-budget.ts:280) or by a sentinel in its message
@@ -2394,112 +2399,98 @@ export function prePrChecksFailureMustPropagate(error: unknown): boolean {
 }
 
 /**
- * What a Pre-PR checks step failure is allowed to say, composed in one pure
- * place so the bound and the wording can be pinned directly.
+ * The parts of a thrown value the failure report needs, flattened where the
+ * throw is caught.
+ *
+ * A separate shape because the report is now composed inside a step and the
+ * catch is in workflow scope: Workflow serializes step arguments, and an Error
+ * does not survive that. Its name, its `code` and its stack are all dropped,
+ * which is every field the report is made of. Flattening here keeps the
+ * `instanceof Error` question where the real value still exists.
+ */
+export interface PrePrChecksFailureInput {
+  /** `error.name`, or the `typeof` of a non-Error throw. Log record only. */
+  name: string;
+  message: string;
+  /**
+   * What to prefix the cause with, or empty for no prefix. A system error code
+   * when there is one, because `ECONNREFUSED` names the cause where `Error`
+   * names nothing; the class name otherwise; nothing at all for a non-Error
+   * throw, whose `typeof` would only add noise to its own text.
+   */
+  label: string;
+  stack: string;
+}
+
+export function prePrChecksFailureInput(error: unknown): PrePrChecksFailureInput {
+  const isError = error instanceof Error;
+  const code = (error as { code?: unknown }).code;
+  const name = isError ? error.name : typeof error;
+  return {
+    name,
+    message: isError ? error.message : String(error),
+    label: typeof code === "string" && code ? code : isError ? name : "",
+    stack: isError ? error.stack ?? "" : "",
+  };
+}
+
+/**
+ * What a Pre-PR checks failure is allowed to say, composed in one pure place
+ * so the bound and the wording can be pinned directly.
  *
  * `redact` is a parameter rather than an import: the redactor lives in
  * `sandbox/agents/protocol.js`, which must stay out of the workflow module
  * scope.
  */
 export function prePrChecksFailureReport(
-  error: unknown,
+  error: PrePrChecksFailureInput,
   redact: (value: string) => string,
 ): { name: string; cause: string; stackTail: string; message: string } {
-  const name = error instanceof Error ? error.name : typeof error;
-  const message = error instanceof Error ? error.message : String(error);
-  // Prefer a system error code over the class name: `ECONNREFUSED` names the
-  // cause where `Error` names nothing.
-  const code = (error as { code?: unknown }).code;
-  const label =
-    typeof code === "string" && code ? code : error instanceof Error ? name : "";
   const cause = redact(
-    label && label !== "Error" ? `${label}: ${message}` : message,
+    error.label && error.label !== "Error"
+      ? `${error.label}: ${error.message}`
+      : error.message,
   ).slice(0, PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH);
-  const stack = error instanceof Error ? error.stack ?? "" : "";
   return {
-    name,
+    name: error.name,
     cause,
-    stackTail: stack
-      ? redact(stack).slice(-PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH)
+    stackTail: error.stack
+      ? redact(error.stack).slice(-PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH)
       : "",
     message: `The Pre-PR checks step failed: ${cause}`,
   };
 }
 
-export async function runPrePrChecksStep(
-  sandboxId: string,
-  agentKind: AgentKind,
-  model: string,
-  maxFixCycles?: number,
-  timeoutMs?: number,
-  budget?: {
-    state: RunBudgetState;
-    limits: RunBudgetLimits;
-    price: { input: number; cached_input: number; output: number } | null;
-  },
-  runtime?: ResolvedHarnessRuntime,
-  arthurTaskId?: string | null,
-): Promise<{
-  configurationVersion: number | null;
-  outcome: "passed" | "failed" | "missing_configuration";
-  passed: boolean;
-  fixCycles: number;
-  fixCycleUsages: Array<PhaseUsage | null>;
-  budgetFailure: RunBudgetFailure | null;
-  summary: string;
-  agentFailure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
-}> {
+/**
+ * Redact, bound and log a Pre-PR checks failure, and return the one sentence
+ * the operator is allowed to see.
+ *
+ * A step, because both halves of this need the server: pino may only be used
+ * inside a step, and the redactor reads process.env to find the secrets it
+ * blanks. The checks themselves are no longer a step (they are launched
+ * detached and polled across ticks), so without this the catch in workflow
+ * scope could neither redact nor log.
+ */
+export async function describePrePrChecksFailureStep(
+  error: PrePrChecksFailureInput,
+  configurationVersion: number | null,
+): Promise<string> {
   "use step";
-  const { getDb } = await import("../db/client.js");
-  const { getCurrentPrePrCheckConfig } = await import("../pre-pr-checks/store.js");
-  const { emptyPrePrCheckConfig } = await import("../pre-pr-checks/config.js");
-  const { runPrePrChecksWithFixes } = await import("../pre-pr-checks/runner.js");
   const { logger } = await import("../lib/logger.js");
-  const current = await getCurrentPrePrCheckConfig(getDb());
-  logger.info(
-    { version: current?.version ?? null },
-    "pre_pr_checks_config_version",
+  const { redactDiagnosticText } = await import("../sandbox/agents/protocol.js");
+  const report = prePrChecksFailureReport(error, redactDiagnosticText);
+  logger.error(
+    {
+      version: configurationVersion,
+      name: report.name,
+      cause: report.cause,
+      stackTail: report.stackTail,
+    },
+    "pre_pr_checks_step_failed",
   );
-  let result: Awaited<ReturnType<typeof runPrePrChecksWithFixes>>;
-  try {
-    result = await runPrePrChecksWithFixes(
-      sandboxId,
-      current?.config ?? emptyPrePrCheckConfig,
-      agentKind,
-      model,
-      maxFixCycles,
-      timeoutMs,
-      budget,
-      runtime,
-      arthurTaskId,
-    );
-  } catch (err) {
-    // Nothing used to be caught here, so a throw reached the operator as
-    // Workflow's own wrapper alone ("exceeded max retries"): no error name, no
-    // message, no captured output, and nothing in the runtime logs either.
-    // Carry the reason, redacted and bounded exactly like a diagnostic tail.
-    // Run-control and duration-abort errors rethrow untouched, because the call
-    // site turns them into a budget stop by matching their identity.
-    if (prePrChecksFailureMustPropagate(err)) throw err;
-    const { redactDiagnosticText } = await import("../sandbox/agents/protocol.js");
-    const report = prePrChecksFailureReport(err, redactDiagnosticText);
-    logger.error(
-      {
-        version: current?.version ?? null,
-        name: report.name,
-        cause: report.cause,
-        stackTail: report.stackTail,
-      },
-      "pre_pr_checks_step_failed",
-    );
-    throw new Error(report.message);
-  }
-  return {
-    ...result,
-    configurationVersion: current?.version ?? null,
-  };
+  return report.message;
 }
-runPrePrChecksStep.maxRetries = 0;
+describePrePrChecksFailureStep.maxRetries = 0;
 
 async function markTicketFailed(
   ticketIdentifier: string,
@@ -5224,22 +5215,30 @@ async function agentWorkflowBody(
               state.implementationModel;
             const budget = await ctx.observeBudget();
             if (budget.check.status !== "ok") throw new RunBudgetError(budget.check);
-            let prePrChecks: Awaited<ReturnType<typeof runPrePrChecksStep>>;
+            // Loading the configuration is a step; running the checks is not.
+            // They are launched detached and polled across ticks, because a
+            // client tenant's real checks outlive the 300s one function
+            // invocation gets and used to kill the run with no recoverable
+            // cause. See workflows/blocks/pre-pr-checks.ts.
+            const prePrConfig = await loadPrePrCheckConfigStep();
+            let prePrChecks: PrePrCheckRunResult;
             try {
-              prePrChecks = await runPrePrChecksStep(
-                ctx.sandboxId,
-                repairKind,
-                repairModel,
-                maxFixCycles,
-                Math.max(1, Math.floor(budget.remainingDurationMs)),
-                {
+              prePrChecks = await runPrePrChecksWithFixes({
+                sandboxId: ctx.sandboxId,
+                config: prePrConfig.config,
+                agentKind: repairKind,
+                model: repairModel,
+                ...(maxFixCycles === undefined ? {} : { maxFixCycles }),
+                observeBudget: blockBudgetObserver(ctx, execution),
+                cancellation: execution?.cancellation,
+                budget: {
                   state: budgetState,
                   limits: budgetLimits,
                   price: priceLookup?.(repairModel) ?? null,
                 },
-                repairRuntime,
-                ctx.arthur.taskId,
-              );
+                runtime: repairRuntime,
+                arthurTaskId: ctx.arthur.taskId,
+              });
             } catch (err) {
               if (isRunControlError(err)) throw err;
               const after = await ctx.observeBudget();
@@ -5247,7 +5246,20 @@ async function agentWorkflowBody(
               if (isDurationAbortError(err)) {
                 throw new RunBudgetError(durationBudgetFailure(after, "Pre-PR checks"));
               }
-              throw err;
+              // Everything prePrChecksFailureMustPropagate covers has already
+              // left through the two branches above, so what remains cannot
+              // have an identity that wrapping destroys. It must still be
+              // wrapped: the checks are no longer a step, so an unbounded,
+              // unredacted throw would travel from workflow scope straight to
+              // the operator, and before #316 that arrived as Workflow's own
+              // "exceeded max retries" with no name, no message and nothing in
+              // the runtime logs.
+              throw new Error(
+                await describePrePrChecksFailureStep(
+                  prePrChecksFailureInput(err),
+                  prePrConfig.version,
+                ),
+              );
             }
             recordPrePrFixCycleUsages(
               ctx,
@@ -5272,14 +5284,11 @@ async function agentWorkflowBody(
                 },
               };
             }
-            if (
-              prePrChecks.configurationVersion !== null &&
-              ctx.workspaceManifest
-            ) {
+            if (prePrConfig.version !== null && ctx.workspaceManifest) {
               ctx.prePrGate = await recordSuccessfulWorkspaceGate({
                 sandboxId: ctx.sandboxId,
                 workspaceManifest: ctx.workspaceManifest,
-                configurationVersion: prePrChecks.configurationVersion,
+                configurationVersion: prePrConfig.version,
               });
             }
             return {

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -2414,10 +2414,17 @@ export interface PrePrChecksFailureInput {
   name: string;
   message: string;
   /**
-   * What to prefix the cause with, or empty for no prefix. A system error code
-   * when there is one, because `ECONNREFUSED` names the cause where `Error`
-   * names nothing; the class name otherwise; nothing at all for a non-Error
+   * What to prefix the cause with: the class name, or empty for a non-Error
    * throw, whose `typeof` would only add noise to its own text.
+   *
+   * The class name is all there is to prefix with. This catch sits in workflow
+   * scope and every error it sees was thrown inside a step, and Workflow
+   * reduces a thrown error to its name, message and stack at the VM boundary
+   * and revives it as a plain Error on this side. A system error code
+   * (`ECONNREFUSED`) would name the cause far better than `Error` does, but
+   * `.code` is gone by the time anything here can read it. Recovering it would
+   * mean parsing the message, the way isReplayedRunControlStepError parses for
+   * run-control errors, and no incident has yet asked for it.
    */
   label: string;
   stack: string;
@@ -2434,6 +2441,15 @@ export interface PrePrChecksFailureInput {
  * protecting only the sentence an operator reads. Redaction runs before
  * truncation so a secret is blanked rather than cut in half.
  *
+ * The redactor runs in workflow scope here and again inside the step, and the
+ * two cannot disagree within an invocation: the workflow VM shims `process` as
+ * a frozen spread of `process.env` taken when the context is built, so both
+ * sides read the same snapshot. The narrow consequence is that a secret added
+ * or rotated AFTER the context was built is absent from that snapshot, so its
+ * literal value would cross the boundary into the journal unblanked while the
+ * operator's sentence stays clean. The pattern rules below (`sk-ant-`, `gh?_`,
+ * `glpat-`, `Bearer`) do not depend on the environment and still catch it.
+ *
  * Bounded here for the same reason: the step keeps exactly these bytes anyway,
  * so anything beyond them would be journaled and then dropped.
  *
@@ -2443,10 +2459,6 @@ export interface PrePrChecksFailureInput {
  */
 export function prePrChecksFailureInput(error: unknown): PrePrChecksFailureInput {
   const isError = error instanceof Error;
-  // Optional on purpose. `throw null` and a bare `Promise.reject()` both reach
-  // here, and a TypeError raised inside the reporting path would destroy the
-  // very cause this exists to carry.
-  const code = (error as { code?: unknown } | null | undefined)?.code;
   const name = isError ? error.name : typeof error;
   const stack = isError ? error.stack ?? "" : "";
   return {
@@ -2455,7 +2467,7 @@ export function prePrChecksFailureInput(error: unknown): PrePrChecksFailureInput
       0,
       PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH,
     ),
-    label: typeof code === "string" && code ? code : isError ? name : "",
+    label: isError ? name : "",
     stack: stack
       ? redactDiagnosticText(stack).slice(-PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH)
       : "",
@@ -2494,11 +2506,11 @@ export function prePrChecksFailureReport(
  * Redact, bound and log a Pre-PR checks failure, and return the one sentence
  * the operator is allowed to see.
  *
- * A step, because both halves of this need the server: pino may only be used
- * inside a step, and the redactor reads process.env to find the secrets it
- * blanks. The checks themselves are no longer a step (they are launched
- * detached and polled across ticks), so without this the catch in workflow
- * scope could neither redact nor log.
+ * A step, because the logging needs the server: pino may only be used inside a
+ * step, never in workflow scope, and the checks themselves are no longer a step
+ * (they are launched detached and polled across ticks), so without this the
+ * catch in workflow scope could not log at all. The redaction is not what
+ * forces a step, it already ran in workflow scope before the boundary.
  */
 export async function describePrePrChecksFailureStep(
   error: PrePrChecksFailureInput,
@@ -2541,7 +2553,13 @@ export async function prePrChecksFailureMessage(
   const input = prePrChecksFailureInput(error);
   try {
     return await describePrePrChecksFailureStep(input, configurationVersion);
-  } catch {
+  } catch (reportingError) {
+    // A cancelled run surfaces at every step, this one included, and it is not
+    // a reporting failure: swallowing it would turn a cancellation into a
+    // Pre-PR checks failure and let the run carry on being cancelled anyway.
+    // Same rethrow this file makes at every other step boundary, including the
+    // catch that calls this one.
+    if (isRunControlError(reportingError)) throw reportingError;
     return `The Pre-PR checks step failed (${input.name.slice(0, 60)}), and the cause could not be recorded.`;
   }
 }

--- a/apps/worker/src/workflows/blocks/io-blocks.edge.test.ts
+++ b/apps/worker/src/workflows/blocks/io-blocks.edge.test.ts
@@ -12,8 +12,13 @@ const mocks = vi.hoisted(() => ({
   upsertWorkflowOwnedBranch: vi.fn(),
   finalizeWorkspacePublication: vi.fn(),
   sandboxGet: vi.fn(),
-  getCurrentPrePrCheckConfig: vi.fn(),
+  loadPrePrCheckConfigStep: vi.fn(),
   runPrePrChecksWithFixes: vi.fn(),
+  resolvePhaseStall: vi.fn(),
+  listWorkspaceRepositoriesStep: vi.fn(),
+  startRepoCheckBatchStep: vi.fn(),
+  collectRepoCheckBatchStep: vi.fn(),
+  pollPhaseUntilDone: vi.fn(),
   loggerWarn: vi.fn(),
   buildOctokit: vi.fn(),
   assertActiveRunOwner: vi.fn(),
@@ -33,12 +38,23 @@ vi.mock("../workspace-publication.js", () => ({
 }));
 vi.mock("@vercel/sandbox", () => ({ Sandbox: { get: mocks.sandboxGet } }));
 vi.mock("../../sandbox/credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
-vi.mock("../../pre-pr-checks/store.js", () => ({
-  getCurrentPrePrCheckConfig: mocks.getCurrentPrePrCheckConfig,
-}));
-vi.mock("../../pre-pr-checks/runner.js", () => ({
+vi.mock("./pre-pr-checks.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./pre-pr-checks.js")>()),
+  loadPrePrCheckConfigStep: mocks.loadPrePrCheckConfigStep,
   runPrePrChecksWithFixes: mocks.runPrePrChecksWithFixes,
+  resolvePhaseStall: mocks.resolvePhaseStall,
 }));
+// run_checks drives these steps on its explicit-commands path; both of its
+// modes launch detached and poll, so neither runs a command inline any more.
+// Only the steps are replaced: the derived cap, the output bounding and the
+// stall sentence stay real.
+vi.mock("../../pre-pr-checks/runner.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../pre-pr-checks/runner.js")>()),
+  listWorkspaceRepositoriesStep: mocks.listWorkspaceRepositoriesStep,
+  startRepoCheckBatchStep: mocks.startRepoCheckBatchStep,
+  collectRepoCheckBatchStep: mocks.collectRepoCheckBatchStep,
+}));
+vi.mock("./poll-phase.js", () => ({ pollPhaseUntilDone: mocks.pollPhaseUntilDone }));
 vi.mock("../../lib/logger.js", () => ({
   logger: { warn: mocks.loggerWarn, info: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
@@ -520,48 +536,48 @@ describe("post_pr_comment edge cases", () => {
 // run_checks: edge cases
 // ---------------------------------------------------------------------------
 describe("run_checks edge cases", () => {
-  function manifest(repoPaths: string[]): string {
-    return JSON.stringify({
-      version: 1,
-      repositories: repoPaths.map((repoPath) => ({
-        provider: "github",
-        repoPath,
-        slug: repoPath.split("/")[1],
-        localPath: `/vercel/sandbox/repos/${repoPath.split("/")[1]}`,
-        defaultBranch: "main",
-        branchName: "blazebot/awt-1",
-        selectedRationale: "selected",
-      })),
-    });
+  function batchStarted(repoIndex: unknown) {
+    return {
+      skipped: false,
+      commandId: `cmd-${repoIndex}`,
+      localPath: "/vercel/sandbox",
+      paths: {
+        launchId: `launch${repoIndex}`,
+        dir: `/tmp/batch-${repoIndex}`,
+        wrapper: `/tmp/batch-${repoIndex}-wrapper.sh`,
+        sentinel: `/tmp/batch-${repoIndex}-done`,
+      },
+    };
   }
 
-  function sandbox(opts: { manifest?: string; manifestExit?: number; commandExit?: number }) {
+  /** What the collect step returns, with the fields run_checks never sets. */
+  function edgeCollected(
+    results: Array<{ provider: string; repoPath: string; command: string; exitCode: number }>,
+  ) {
     return {
-      runCommand: vi.fn(async (cmdOrSpec: unknown, args?: string[]) => {
-        if (cmdOrSpec === "cat" && args) {
-          return {
-            exitCode: opts.manifestExit ?? 0,
-            stdout: async () => opts.manifest ?? "",
-            stderr: async () => "",
-          };
-        }
-        const exitCode = opts.commandExit ?? 0;
-        return {
-          exitCode,
-          stdout: async () => (exitCode === 0 ? "passed" : "boom"),
-          stderr: async () => "",
-        };
-      }),
+      results,
+      failures: [],
+      setupFailed: false,
+      progress: { completed: results.length, total: results.length, stoppedAt: null },
     };
   }
 
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getDb.mockReturnValue({ db: true });
+    mocks.pollPhaseUntilDone.mockResolvedValue(true);
+    mocks.resolvePhaseStall.mockResolvedValue("none");
+    mocks.startRepoCheckBatchStep.mockImplementation(async (...args: unknown[]) =>
+      batchStarted(args[6]),
+    );
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(edgeCollected([]));
   });
 
-  it("uses the empty config when getCurrentPrePrCheckConfig returns null", async () => {
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue(null);
+  it("uses the empty config when no pre-PR-checks configuration is stored", async () => {
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({
+      version: null,
+      config: emptyPrePrCheckConfig,
+    });
     mocks.runPrePrChecksWithFixes.mockResolvedValue({
       passed: true,
       fixCycles: 0,
@@ -572,17 +588,19 @@ describe("run_checks edge cases", () => {
     await executeRunChecks(makeNode("run_checks"), {}, makeCtx());
 
     expect(mocks.runPrePrChecksWithFixes).toHaveBeenCalledWith(
-      "sbx-1",
-      emptyPrePrCheckConfig,
-      "claude",
-      "claude-model",
-      0,
-      1_800_000,
+      expect.objectContaining({
+        sandboxId: "sbx-1",
+        config: emptyPrePrCheckConfig,
+        agentKind: "claude",
+        model: "claude-model",
+        maxFixCycles: 0,
+        observeBudget: expect.any(Function),
+      }),
     );
   });
 
   it("reports ok true when the configured checks pass", async () => {
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({ version: 1, config: { repositories: [] } });
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({ version: 1, config: { repositories: [] } });
     mocks.runPrePrChecksWithFixes.mockResolvedValue({
       passed: true,
       fixCycles: 0,
@@ -598,7 +616,9 @@ describe("run_checks edge cases", () => {
   });
 
   it("fails when the workspace manifest is missing", async () => {
-    mocks.sandboxGet.mockResolvedValue(sandbox({ manifestExit: 1 }));
+    mocks.listWorkspaceRepositoriesStep.mockRejectedValue(
+      new Error("Workspace manifest not found in sandbox at /vercel/sandbox/aiw-repos.json"),
+    );
 
     const result = await executeRunChecks(
       makeNode("run_checks", { commands: ["pnpm lint"] }),
@@ -611,7 +631,7 @@ describe("run_checks edge cases", () => {
   });
 
   it("routes an empty commands array to the configured pre-PR-checks path", async () => {
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({ version: 1, config: { repositories: [] } });
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({ version: 1, config: { repositories: [] } });
     mocks.runPrePrChecksWithFixes.mockResolvedValue({
       passed: true,
       fixCycles: 0,
@@ -622,11 +642,25 @@ describe("run_checks edge cases", () => {
     await executeRunChecks(makeNode("run_checks", { commands: [] }), {}, makeCtx());
 
     expect(mocks.runPrePrChecksWithFixes).toHaveBeenCalledTimes(1);
-    expect(mocks.sandboxGet).not.toHaveBeenCalled();
+    expect(mocks.listWorkspaceRepositoriesStep).not.toHaveBeenCalled();
   });
 
   it("runs each command per repository and keys results per repo", async () => {
-    mocks.sandboxGet.mockResolvedValue(sandbox({ manifest: manifest(["acme/api", "acme/web"]) }));
+    mocks.listWorkspaceRepositoriesStep.mockResolvedValue([
+      { provider: "github", repoPath: "acme/api" },
+      { provider: "github", repoPath: "acme/web" },
+    ]);
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(
+        edgeCollected([
+          { provider: "github", repoPath: "acme/api", command: "pnpm lint", exitCode: 0 },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        edgeCollected([
+          { provider: "github", repoPath: "acme/web", command: "pnpm lint", exitCode: 0 },
+        ]),
+      );
 
     const result = await executeRunChecks(
       makeNode("run_checks", { commands: ["pnpm lint"] }),

--- a/apps/worker/src/workflows/blocks/poll-phase.test.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.test.ts
@@ -16,7 +16,11 @@ vi.mock("../../sandbox/poll-agent.js", () => ({ checkPhaseDone: mocks.checkPhase
 vi.mock("../../sandbox/credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
 vi.mock("@vercel/sandbox", () => ({ Sandbox: { get: mocks.sandboxGet } }));
 
-import { pollPhaseUntilDone } from "./poll-phase.js";
+import {
+  PHASE_POLL_TICK_MAX_MS,
+  pollPhaseUntilDone,
+  type PhasePollOutcome,
+} from "./poll-phase.js";
 import {
   createV2InvocationCancellationController,
   V2InvocationCancelledError,
@@ -187,5 +191,139 @@ describe("pollPhaseUntilDone", () => {
     expect(mocks.getCommand).toHaveBeenCalledWith("cmd-cancelled");
     expect(mocks.kill).toHaveBeenCalledOnce();
     expect(mocks.checkPhaseDone).not.toHaveBeenCalled();
+  });
+
+  it("keeps a caller that passes no tuning on today's behaviour", async () => {
+    // Agent phases share this function and are not in scope for the check
+    // batches: the flat 30s tick, no pre-check and one fatal stopped reading
+    // must all survive untouched when the argument is omitted.
+    const observeBudget = vi.fn().mockResolvedValue(ok(600_000));
+    mocks.checkPhaseDone.mockResolvedValueOnce(false).mockResolvedValueOnce("stopped");
+
+    await expect(
+      pollPhaseUntilDone("sbx-1", "/tmp/done", 25, "cmd-default", observeBudget),
+    ).resolves.toBe(false);
+
+    expect(mocks.delay).toHaveBeenCalledTimes(2);
+    expect(mocks.delay).toHaveBeenNthCalledWith(1, PHASE_POLL_TICK_MAX_MS);
+    // One stopped reading ends it, exactly as before this tuning existed.
+    expect(mocks.checkPhaseDone).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a finished phase without sleeping when asked to check first", async () => {
+    const observeBudget = vi.fn().mockResolvedValue(ok(600_000));
+    mocks.checkPhaseDone.mockResolvedValue(true);
+    const outcome: PhasePollOutcome = { elapsedMs: 0, ticks: 0, reason: "finished" };
+
+    await expect(
+      pollPhaseUntilDone("sbx-1", "/tmp/done", 25, "cmd-quick", observeBudget, undefined, {
+        checkBeforeFirstTick: true,
+        outcome,
+      }),
+    ).resolves.toBe(true);
+
+    expect(mocks.delay).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ elapsedMs: 0, ticks: 0, reason: "finished" });
+  });
+
+  it("ramps the tick toward the ceiling and never past it", async () => {
+    const observeBudget = vi.fn().mockResolvedValue(ok(600_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+
+    await pollPhaseUntilDone("sbx-1", "/tmp/done", 25, "cmd-ramp", observeBudget, undefined, {
+      initialTickMs: 2_000,
+      tickGrowthFactor: 4,
+      maxTicks: 5,
+    });
+
+    expect(mocks.delay.mock.calls.map((call) => call[0])).toEqual([
+      2_000,
+      8_000,
+      30_000,
+      30_000,
+      30_000,
+    ]);
+  });
+
+  it("stops appending ticks at the tick cap and says so", async () => {
+    const observeBudget = vi.fn().mockResolvedValue(ok(600_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+    const outcome: PhasePollOutcome = { elapsedMs: 0, ticks: 0, reason: "finished" };
+
+    await expect(
+      pollPhaseUntilDone("sbx-1", "/tmp/done", 600, "cmd-ticks", observeBudget, undefined, {
+        maxTicks: 3,
+        outcome,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mocks.delay).toHaveBeenCalledTimes(3);
+    expect(outcome).toEqual({ elapsedMs: 90_000, ticks: 3, reason: "tick_cap" });
+  });
+
+  it("survives one unreachable reading but not two in a row", async () => {
+    // checkPhaseDone reports "stopped" for any failure to reach the sandbox,
+    // not only for a sandbox that is gone. A batch polled for tens of minutes
+    // asks it dozens of times, so one blip may not abandon the run's checks.
+    const observeBudget = vi.fn().mockResolvedValue(ok(600_000));
+    mocks.checkPhaseDone
+      .mockResolvedValueOnce("stopped")
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce("stopped")
+      .mockResolvedValueOnce(true);
+
+    await expect(
+      pollPhaseUntilDone("sbx-1", "/tmp/done", 25, "cmd-blip", observeBudget, undefined, {
+        stoppedObservations: 2,
+      }),
+    ).resolves.toBe(true);
+
+    const outcome: PhasePollOutcome = { elapsedMs: 0, ticks: 0, reason: "finished" };
+    mocks.checkPhaseDone.mockResolvedValue("stopped");
+    await expect(
+      pollPhaseUntilDone("sbx-1", "/tmp/done", 25, "cmd-dead", observeBudget, undefined, {
+        stoppedObservations: 2,
+        outcome,
+      }),
+    ).resolves.toBe(false);
+
+    expect(outcome.reason).toBe("sandbox_stopped");
+  });
+
+  it("reports the elapsed time a duration cap actually consumed", async () => {
+    const observeBudget = vi.fn().mockResolvedValue(ok(600_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+    const outcome: PhasePollOutcome = { elapsedMs: 0, ticks: 0, reason: "finished" };
+
+    await expect(
+      pollPhaseUntilDone("sbx-1", "/tmp/done", 2, "cmd-cap", observeBudget, undefined, {
+        outcome,
+      }),
+    ).resolves.toBe(false);
+
+    // Four 30s ticks fill the two minute cap exactly, and that is what the
+    // caller reports, rather than the cap it asked for.
+    expect(outcome).toEqual({ elapsedMs: 120_000, ticks: 4, reason: "duration_cap" });
+  });
+
+  it("takes its time bound in milliseconds when the caller has one", async () => {
+    // A caller deriving its bound from the remaining duration budget cannot
+    // express it in whole minutes: flooring makes the phase cap expire before
+    // the budget does, so a run that ran out of time reports a timed-out phase
+    // instead of halting as budget_exceeded.
+    const observeBudget = vi.fn().mockResolvedValue(ok(600_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+    const outcome: PhasePollOutcome = { elapsedMs: 0, ticks: 0, reason: "finished" };
+
+    await expect(
+      pollPhaseUntilDone("sbx-1", "/tmp/done", 25, "cmd-ms", observeBudget, undefined, {
+        phaseLimitMs: 45_000,
+        outcome,
+      }),
+    ).resolves.toBe(false);
+
+    // 45s of bound, not the 25 minutes the positional argument still carries.
+    expect(mocks.delay.mock.calls.map((call) => call[0])).toEqual([30_000, 15_000]);
+    expect(outcome).toEqual({ elapsedMs: 45_000, ticks: 2, reason: "duration_cap" });
   });
 });

--- a/apps/worker/src/workflows/blocks/poll-phase.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.ts
@@ -5,7 +5,71 @@ import {
 } from "../../workflow-definition/invocation-context.js";
 
 /**
- * Wait for an agent phase's sentinel file, polling every 30s up to maxMinutes.
+ * Longest a single tick may sleep.
+ *
+ * Coupled to the deployed step function's duration limit, not chosen for
+ * responsiveness: see poll-delay.ts. Ramping a tick beyond this ceiling is not
+ * available, however long the phase is, so `tickGrowthFactor` ramps up to it
+ * and stops.
+ */
+export const PHASE_POLL_TICK_MAX_MS = 30_000;
+
+/** What a poll consumed, and why it ended. Filled in by pollPhaseUntilDone when
+ *  the caller supplies one, so a caller can report the bound that actually
+ *  applied instead of restating the bound it asked for. */
+export interface PhasePollOutcome {
+  /** Tick time actually consumed. The cap the caller passed is an upper bound
+   *  on this, never a description of it. */
+  elapsedMs: number;
+  ticks: number;
+  reason: "finished" | "duration_cap" | "tick_cap" | "sandbox_stopped";
+}
+
+/**
+ * Optional poll behaviour. Every field defaults to the behaviour agent phases
+ * have today, so omitting the argument entirely changes nothing: a flat 30s
+ * tick, no pre-check, no tick ceiling, and one "stopped" observation is enough
+ * to abandon the phase.
+ */
+export interface PhasePollTuning {
+  /** Read the sentinel once before sleeping at all, so an already finished
+   *  phase costs no tick of latency. Default false. */
+  checkBeforeFirstTick?: boolean;
+  /** Length of the first tick, ramped by `tickGrowthFactor` toward
+   *  PHASE_POLL_TICK_MAX_MS. Default PHASE_POLL_TICK_MAX_MS, meaning no ramp. */
+  initialTickMs?: number;
+  /** Multiplier applied to the tick after each poll. Default 1, meaning no ramp. */
+  tickGrowthFactor?: number;
+  /** Hard ceiling on the number of ticks, and so on the number of step records
+   *  one poll can append to the run's event log. Default unbounded. */
+  maxTicks?: number;
+  /**
+   * Time bound in milliseconds, replacing `maxMinutes` when given.
+   *
+   * Callers that derive their bound from the run's remaining duration budget
+   * cannot express it in whole minutes: flooring makes the phase cap expire
+   * before the budget does, so the budget stop is pre-empted by a phase timeout
+   * and the run reports a timed-out phase instead of halting as
+   * budget_exceeded. Default: `maxMinutes * 60_000`, exactly as before.
+   */
+  phaseLimitMs?: number;
+  /**
+   * Consecutive "stopped" readings required before the phase is abandoned.
+   * Default 1, which is what every caller did before this existed.
+   *
+   * checkPhaseDone reports "stopped" both for a sandbox that is genuinely gone
+   * and for any error reaching it, so a caller that polls for a long time and
+   * treats a single reading as fatal is betting on never seeing a transient
+   * network fault. Raising this trades one extra tick of latency on a real
+   * sandbox death for immunity to a single blip.
+   */
+  stoppedObservations?: number;
+  /** Record to fill in with what the poll consumed and why it ended. */
+  outcome?: PhasePollOutcome;
+}
+
+/**
+ * Wait for an agent phase's sentinel file, polling up to maxMinutes.
  * Returns false when the phase stopped without finishing or the cap ran out.
  * Plain async orchestration (not a "use step"): it drives the checkPhaseDone
  * step, so it is safe to share between block executors.
@@ -24,12 +88,44 @@ export async function pollPhaseUntilDone(
   commandId: string,
   observeBudget: (requireRemainingDuration?: boolean) => Promise<RunBudgetObservation>,
   cancellation?: V2InvocationCancellation,
+  tuning: PhasePollTuning = {},
 ): Promise<boolean> {
   const { delayPhasePollStep } = await import("./poll-delay.js");
   const { checkPhaseDone } = await import("../../sandbox/poll-agent.js");
-  const phaseLimitMs = maxMinutes * 60_000;
+  const phaseLimitMs = tuning.phaseLimitMs ?? maxMinutes * 60_000;
+  const maxTicks = tuning.maxTicks ?? Number.POSITIVE_INFINITY;
+  const tickGrowthFactor = tuning.tickGrowthFactor ?? 1;
+  const stoppedObservations = Math.max(1, tuning.stoppedObservations ?? 1);
+  let tickMs = Math.min(
+    tuning.initialTickMs ?? PHASE_POLL_TICK_MAX_MS,
+    PHASE_POLL_TICK_MAX_MS,
+  );
   let phaseElapsedMs = 0;
-  while (phaseElapsedMs < phaseLimitMs) {
+  let ticks = 0;
+  let consecutiveStopped = 0;
+  const record = (reason: PhasePollOutcome["reason"]): void => {
+    if (!tuning.outcome) return;
+    tuning.outcome.elapsedMs = phaseElapsedMs;
+    tuning.outcome.ticks = ticks;
+    tuning.outcome.reason = reason;
+  };
+
+  if (tuning.checkBeforeFirstTick) {
+    const status = await checkPhaseDone(sandboxId, sentinelFile);
+    if (status === true) {
+      record("finished");
+      return true;
+    }
+    if (status === "stopped") {
+      consecutiveStopped = 1;
+      if (consecutiveStopped >= stoppedObservations) {
+        record("sandbox_stopped");
+        return false;
+      }
+    }
+  }
+
+  while (phaseElapsedMs < phaseLimitMs && ticks < maxTicks) {
     if (cancellation?.cancelled) {
       await stopPhaseCommand(sandboxId, commandId);
       throw new V2InvocationCancelledError(cancellation.reason);
@@ -39,7 +135,7 @@ export async function pollPhaseUntilDone(
       await stopPhaseCommand(sandboxId, commandId);
       throw new RunBudgetError(before.check);
     }
-    const sleepMs = Math.min(30_000, phaseLimitMs - phaseElapsedMs, before.remainingDurationMs);
+    const sleepMs = Math.min(tickMs, phaseLimitMs - phaseElapsedMs, before.remainingDurationMs);
     if (sleepMs <= 0) {
       const limit = before.durationLimitMs ?? before.activeElapsedMs ?? 0;
       const consumed = before.activeElapsedMs ?? limit;
@@ -71,6 +167,8 @@ export async function pollPhaseUntilDone(
       await delayPhasePollStep(Math.ceil(sleepMs));
     }
     phaseElapsedMs += sleepMs;
+    ticks++;
+    tickMs = Math.min(PHASE_POLL_TICK_MAX_MS, tickMs * tickGrowthFactor);
 
     if (cancellation?.cancelled) {
       await stopPhaseCommand(sandboxId, commandId);
@@ -78,12 +176,23 @@ export async function pollPhaseUntilDone(
     }
     const after = await observeBudget(false);
     const status = await checkPhaseDone(sandboxId, sentinelFile);
-    if (status === true) return true;
+    if (status === true) {
+      record("finished");
+      return true;
+    }
     if (after.check.status !== "ok") {
       await stopPhaseCommand(sandboxId, commandId);
       throw new RunBudgetError(after.check);
     }
-    if (status === "stopped") return false;
+    if (status === "stopped") {
+      consecutiveStopped++;
+      if (consecutiveStopped >= stoppedObservations) {
+        record("sandbox_stopped");
+        return false;
+      }
+    } else {
+      consecutiveStopped = 0;
+    }
     if (after.remainingDurationMs === 0) {
       const limit = after.durationLimitMs ?? after.activeElapsedMs ?? 0;
       const consumed = after.activeElapsedMs ?? limit;
@@ -98,6 +207,7 @@ export async function pollPhaseUntilDone(
     }
   }
   await stopPhaseCommand(sandboxId, commandId);
+  record(ticks >= maxTicks ? "tick_cap" : "duration_cap");
   return false;
 }
 

--- a/apps/worker/src/workflows/blocks/pre-pr-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/pre-pr-checks.test.ts
@@ -239,6 +239,51 @@ describe("runPrePrChecksWithFixes", () => {
     expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
   });
 
+  it("does not claim the fixer never ran when it already had", async () => {
+    // Suppression is evaluated per pass while the sentence speaks for the run,
+    // so a run that spent a cycle and then hit a setup failure on the re-run
+    // would otherwise tell the operator no fix cycles ran, with fixCycles: 1
+    // sitting next to it.
+    const apiFailure = {
+      provider: "gitlab" as const,
+      repoPath: "acme/api",
+      command: "pnpm test",
+      exitCode: 1,
+      stdout: "",
+      stderr: "still failing",
+    };
+    const setupFailure = {
+      provider: "github" as const,
+      repoPath: "acme/web",
+      command: "make bootstrap",
+      exitCode: 127,
+      stdout: "",
+      stderr: "toolchain: command not found",
+      phase: "setup" as const,
+    };
+    // Pass one: web is fine, api fails a check, so one fix cycle runs.
+    // Pass two: web's setup has broken, which suppresses the rest of the run.
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(collected())
+      .mockResolvedValueOnce(collected({ failures: [apiFailure] }))
+      .mockResolvedValueOnce(collected({ setupFailed: true, failures: [setupFailure] }))
+      .mockResolvedValueOnce(collected({ failures: [apiFailure] }));
+    mocks.startPrePrRepairStep.mockResolvedValue({
+      ok: true,
+      commandId: "cmd-fix",
+      phase: "pre-pr-fix-1",
+      paths: { sentinel: "/tmp/pre-pr-fix-1-done" },
+    });
+    mocks.collectPrePrRepairStep.mockResolvedValue({ usage: null });
+
+    const result = await runPrePrChecksWithFixes(options({ config, maxFixCycles: 3 }));
+
+    expect(result.fixCycles).toBe(1);
+    expect(result.summary).toContain("No further agent fix cycles were run");
+    expect(result.summary).toContain("1 had already run");
+    expect(result.summary).not.toContain("No agent fix cycles were run for this failure either");
+  });
+
   it("fails the checks when the poll runs out of its cap, never passing them", async () => {
     mocks.pollPhaseUntilDone.mockImplementation(pollEnds("duration_cap", 1_500_000));
     // Not "stopped": the sandbox is alive, the sentinel simply never appeared.
@@ -270,7 +315,7 @@ describe("runPrePrChecksWithFixes", () => {
     // of where it died. It is read as abandoned, so the commands after the one
     // that was running are not reported at all.
     expect(mocks.collectRepoCheckBatchStep).toHaveBeenCalledTimes(1);
-    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]!.at(-1)).toBe(false);
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]![7]).toBe(false);
     expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
   });
 
@@ -329,7 +374,7 @@ describe("runPrePrChecksWithFixes", () => {
 
     expect(result.passed).toBe(true);
     expect(result.summary).toBe("Pre-PR checks passed (1 command).");
-    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]!.at(-1)).toBe(true);
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]![7]).toBe(true);
   });
 
   it("repairs a failing check and re-runs the batch in its own cycle namespace", async () => {

--- a/apps/worker/src/workflows/blocks/pre-pr-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/pre-pr-checks.test.ts
@@ -101,7 +101,7 @@ function collected(overrides: {
     exitCode: number;
     stdout: string;
     stderr: string;
-    phase?: "setup" | "workspace";
+    phase?: "setup" | "workspace" | "batch" | "omitted";
   }>;
   setupFailed?: boolean;
   progress?: { completed: number; total: number; stoppedAt: string | null };
@@ -316,6 +316,47 @@ describe("runPrePrChecksWithFixes", () => {
     // that was running are not reported at all.
     expect(mocks.collectRepoCheckBatchStep).toHaveBeenCalledTimes(1);
     expect(mocks.collectRepoCheckBatchStep.mock.calls[0]![7]).toBe(false);
+    expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
+  });
+
+  it("never reports a stall as a check whose fix cycles were suppressed", async () => {
+    // A stall is not a check result: nothing was verified. Without a phase it
+    // reads as an ordinary failing check, so with a setup failure earlier in
+    // the same pass it collects the sentence explaining that its fix cycles
+    // were suppressed, and it would be handed to the repair agent to fix.
+    mocks.pollPhaseUntilDone
+      .mockImplementationOnce(pollEnds("finished", 30_000))
+      .mockImplementation(pollEnds("duration_cap", 1_500_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(
+        collected({
+          setupFailed: true,
+          failures: [{
+            provider: "github",
+            repoPath: "acme/web",
+            command: "make bootstrap",
+            exitCode: 127,
+            stdout: "",
+            stderr: "toolchain: command not found",
+            phase: "setup",
+          }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        collected({ progress: { completed: 0, total: 1, stoppedAt: "pnpm test" } }),
+      );
+
+    const result = await runPrePrChecksWithFixes(options({ config }));
+
+    const entries = result.summary.split("\n\n");
+    const setupEntry = entries.find((entry) => entry.startsWith("SETUP FAILED"));
+    const stallEntry = entries.find((entry) => entry.includes("this is a timeout"));
+    expect(setupEntry).toBeDefined();
+    expect(stallEntry).toContain("CHECK BATCH ABANDONED for gitlab:acme/api");
+    // The proof the phase is doing the work: an ordinary failing check in this
+    // same summary would carry the suppression sentence.
+    expect(stallEntry).not.toContain("No agent fix cycles were run");
     expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
   });
 

--- a/apps/worker/src/workflows/blocks/pre-pr-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/pre-pr-checks.test.ts
@@ -1,0 +1,812 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrePrCheckConfig } from "../../pre-pr-checks/config.js";
+import { createRunBudgetState, type RunBudgetObservation } from "../run-budget.js";
+
+const mocks = vi.hoisted(() => ({
+  startRepoCheckBatchStep: vi.fn(),
+  collectRepoCheckBatchStep: vi.fn(),
+  startPrePrRepairStep: vi.fn(),
+  collectPrePrRepairStep: vi.fn(),
+  pollPhaseUntilDone: vi.fn(),
+  checkPhaseDone: vi.fn(),
+  getCurrentPrePrCheckConfig: vi.fn(),
+  loggerInfo: vi.fn(),
+}));
+
+vi.mock("../../sandbox/credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
+vi.mock("../../db/client.js", () => ({ getDb: () => ({ kind: "db" }) }));
+vi.mock("../../pre-pr-checks/store.js", () => ({
+  getCurrentPrePrCheckConfig: (...args: unknown[]) =>
+    mocks.getCurrentPrePrCheckConfig(...args),
+}));
+vi.mock("../../lib/logger.js", () => ({
+  logger: { info: mocks.loggerInfo, warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../../pre-pr-checks/runner.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../pre-pr-checks/runner.js")>()),
+  startRepoCheckBatchStep: mocks.startRepoCheckBatchStep,
+  collectRepoCheckBatchStep: mocks.collectRepoCheckBatchStep,
+  startPrePrRepairStep: mocks.startPrePrRepairStep,
+  collectPrePrRepairStep: mocks.collectPrePrRepairStep,
+}));
+vi.mock("./poll-phase.js", () => ({ pollPhaseUntilDone: mocks.pollPhaseUntilDone }));
+vi.mock("../../sandbox/poll-agent.js", () => ({ checkPhaseDone: mocks.checkPhaseDone }));
+
+import { loadPrePrCheckConfigStep, runPrePrChecksWithFixes } from "./pre-pr-checks.js";
+import type { PhasePollOutcome, PhasePollTuning } from "./poll-phase.js";
+
+const config: PrePrCheckConfig = {
+  repositories: [
+    { provider: "github", repoPath: "acme/web", setup: ["make bootstrap"], commands: ["pnpm typecheck"] },
+    { provider: "gitlab", repoPath: "acme/api", commands: ["pnpm test"] },
+  ],
+};
+
+const oneRepoConfig: PrePrCheckConfig = {
+  repositories: [{ provider: "github", repoPath: "acme/web", commands: ["pnpm typecheck"] }],
+};
+
+const observeBudget = vi.fn(
+  async (): Promise<RunBudgetObservation> => ({
+    check: { status: "ok" },
+    remainingDurationMs: 1_800_000,
+  }),
+);
+
+function options(overrides: Partial<Parameters<typeof runPrePrChecksWithFixes>[0]> = {}) {
+  return {
+    sandboxId: "sbx-test-123",
+    config: oneRepoConfig,
+    agentKind: "codex" as const,
+    model: "gpt-5",
+    observeBudget,
+    ...overrides,
+  };
+}
+
+function started(repoIndex: number) {
+  return {
+    skipped: false as const,
+    commandId: `cmd-${repoIndex}`,
+    localPath: "/vercel/sandbox",
+    paths: {
+      launchId: `launch${repoIndex}`,
+      dir: `/tmp/pre-pr-checks-c0-r${repoIndex}-launch${repoIndex}`,
+      wrapper: `/tmp/pre-pr-checks-c0-r${repoIndex}-launch${repoIndex}-wrapper.sh`,
+      sentinel: `/tmp/pre-pr-checks-c0-r${repoIndex}-launch${repoIndex}-done`,
+    },
+  };
+}
+
+/**
+ * A poll that ends the way the real one does: it records what it consumed into
+ * the tuning it was handed before returning. Everything downstream of a stall
+ * reads that record rather than a constant, so a fake that skips it would let
+ * the assertions pass against numbers no poll produced.
+ */
+function pollEnds(reason: PhasePollOutcome["reason"], elapsedMs: number) {
+  return async (...args: unknown[]) => {
+    const tuning = args[6] as PhasePollTuning | undefined;
+    if (tuning?.outcome) Object.assign(tuning.outcome, { reason, elapsedMs, ticks: 12 });
+    return reason === "finished";
+  };
+}
+
+function collected(overrides: {
+  results?: Array<{ provider: "github" | "gitlab"; repoPath: string; command: string; exitCode: number }>;
+  failures?: Array<{
+    provider: "github" | "gitlab";
+    repoPath: string;
+    command: string;
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    phase?: "setup" | "workspace";
+  }>;
+  setupFailed?: boolean;
+  progress?: { completed: number; total: number; stoppedAt: string | null };
+} = {}) {
+  const results = overrides.results ?? [];
+  const failures = overrides.failures ?? [];
+  return {
+    results,
+    failures,
+    setupFailed: overrides.setupFailed ?? false,
+    progress: overrides.progress ?? {
+      completed: results.length,
+      total: results.length,
+      stoppedAt: null,
+    },
+  };
+}
+
+describe("runPrePrChecksWithFixes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("finished", 30_000));
+    mocks.startRepoCheckBatchStep.mockImplementation(async (
+      _sandboxId: string,
+      _provider: string,
+      _repoPath: string,
+      _setup: string[],
+      _commands: string[],
+      _fixCycle: number,
+      repoIndex: number,
+    ) => started(repoIndex));
+  });
+
+  it("reports missing configuration without launching anything", async () => {
+    const result = await runPrePrChecksWithFixes(options({ config: { repositories: [] } }));
+
+    expect(result).toMatchObject({
+      outcome: "missing_configuration",
+      passed: true,
+      results: [],
+      failures: [],
+      summary: "No pre-PR checks configured.",
+    });
+    expect(mocks.startRepoCheckBatchStep).not.toHaveBeenCalled();
+  });
+
+  it("skips a repository the start step declined and reports no matching checks", async () => {
+    mocks.startRepoCheckBatchStep.mockResolvedValue({ skipped: true });
+
+    const result = await runPrePrChecksWithFixes(options());
+
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe("No pre-PR checks matched changed repositories.");
+    expect(mocks.collectRepoCheckBatchStep).not.toHaveBeenCalled();
+  });
+
+  it("keeps a second repository running after the first one's setup fails, and starts no fix cycle", async () => {
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(
+        collected({
+          setupFailed: true,
+          failures: [{
+            provider: "github",
+            repoPath: "acme/web",
+            command: "make bootstrap",
+            exitCode: 127,
+            stdout: "",
+            stderr: "bash: line 1: toolchain: command not found",
+            phase: "setup",
+          }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        collected({
+          results: [{ provider: "gitlab", repoPath: "acme/api", command: "pnpm test", exitCode: 0 }],
+        }),
+      );
+
+    const result = await runPrePrChecksWithFixes(options({ config }));
+
+    expect(result.setupFailed).toBe(true);
+    expect(result.passed).toBe(false);
+    expect(result.fixCycles).toBe(0);
+    expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
+    // The second repository was still started, polled and collected.
+    expect(mocks.startRepoCheckBatchStep).toHaveBeenCalledTimes(2);
+    expect(result.results).toEqual([
+      { provider: "gitlab", repoPath: "acme/api", command: "pnpm test", exitCode: 0 },
+    ]);
+    expect(result.summary).toContain("SETUP FAILED for github:acme/web");
+    expect(result.summary).toContain("no agent fix cycles were run");
+  });
+
+  it("says on every entry that one repository's setup failure suppressed the run", async () => {
+    // Suppression is run-wide, so an unrelated repository's entry otherwise
+    // shows a plainly repairable failure next to fixCycles: 0 and says nothing
+    // about why nothing was attempted.
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(
+        collected({
+          setupFailed: true,
+          failures: [{
+            provider: "github",
+            repoPath: "acme/web",
+            command: "make bootstrap",
+            exitCode: 127,
+            stdout: "",
+            stderr: "toolchain: command not found",
+            phase: "setup",
+          }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        collected({
+          results: [{ provider: "gitlab", repoPath: "acme/api", command: "pnpm test", exitCode: 1 }],
+          failures: [{
+            provider: "gitlab",
+            repoPath: "acme/api",
+            command: "pnpm test",
+            exitCode: 1,
+            stdout: "",
+            stderr: "Type error on line 12",
+          }],
+        }),
+      );
+
+    const result = await runPrePrChecksWithFixes(options({ config }));
+
+    expect(result.fixCycles).toBe(0);
+    const apiEntry = result.summary.split("\n\n").find((entry) => entry.startsWith("gitlab:acme/api"));
+    expect(apiEntry).toContain("No agent fix cycles were run for this failure either");
+    expect(apiEntry).toContain("github:acme/web");
+    // The repair prompt is a different document and stays free of it: the
+    // fixer is never run in this state at all.
+    expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
+  });
+
+  it("fails the checks when the poll runs out of its cap, never passing them", async () => {
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("duration_cap", 1_500_000));
+    // Not "stopped": the sandbox is alive, the sentinel simply never appeared.
+    mocks.checkPhaseDone.mockResolvedValue(false);
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        progress: {
+          completed: 3,
+          total: 5,
+          stoppedAt: "uv run pytest tests/ -m integration",
+        },
+      }),
+    );
+
+    const result = await runPrePrChecksWithFixes(options());
+
+    expect(result.passed).toBe(false);
+    expect(result.outcome).toBe("failed");
+    expect(result.fixCycles).toBe(0);
+    // The elapsed time the poll actually consumed, not the cap it was given:
+    // the cap is derived from the remaining budget and the poll can end early,
+    // so a fixed sentence would eventually be a false one.
+    expect(result.summary).toContain("ran for 25 minutes without finishing");
+    expect(result.summary).toContain(
+      "while running `uv run pytest tests/ -m integration`; 3 of 5 commands had finished",
+    );
+    expect(result.summary).toContain("this is a timeout");
+    // The abandoned batch is still read back: those files are the only record
+    // of where it died. It is read as abandoned, so the commands after the one
+    // that was running are not reported at all.
+    expect(mocks.collectRepoCheckBatchStep).toHaveBeenCalledTimes(1);
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]!.at(-1)).toBe(false);
+    expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
+  });
+
+  it("keeps the stall diagnosis when the abandoned batch cannot be read either", async () => {
+    // The sandbox-death path collects from a sandbox already observed as not
+    // running twice, and the collect step's maxRetries is 0. Letting that
+    // rejection out replaces the stall sentence with an unclassified run
+    // failure: neither a run-control error nor a budget error, so agent.ts
+    // kills the run with no usable cause, in the exact case this mechanism was
+    // written for.
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("sandbox_stopped", 120_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+    mocks.collectRepoCheckBatchStep.mockRejectedValue(
+      new Error("sandbox sbx-test-123 is not running"),
+    );
+
+    const result = await runPrePrChecksWithFixes(options());
+
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain("sandbox stopped while");
+    // No invented progress: the files were never read, so no count is claimed.
+    expect(result.summary).toContain("how far it got could not be read back");
+    expect(result.summary).not.toContain("0 of");
+  });
+
+  it("fails with a reason distinct from the timeout when the sandbox stopped", async () => {
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("sandbox_stopped", 120_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({ progress: { completed: 1, total: 2, stoppedAt: "pnpm test" } }),
+    );
+
+    const result = await runPrePrChecksWithFixes(options());
+
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain("sandbox stopped while");
+    expect(result.summary).toContain("1 of 2 commands had finished");
+    expect(result.summary).not.toContain("this is a timeout");
+    // Same category as a setup failure: the fixer has nothing to act on, and
+    // handing it an infrastructure fault burns the whole fix budget rewriting
+    // code that was never shown to be wrong.
+    expect(result.fixCycles).toBe(0);
+    expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
+  });
+
+  it("collects normally when the sentinel appears between the last tick and the check", async () => {
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("duration_cap", 1_500_000));
+    mocks.checkPhaseDone.mockResolvedValue(true);
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 0 }],
+      }),
+    );
+
+    const result = await runPrePrChecksWithFixes(options());
+
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe("Pre-PR checks passed (1 command).");
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]!.at(-1)).toBe(true);
+  });
+
+  it("repairs a failing check and re-runs the batch in its own cycle namespace", async () => {
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(
+        collected({
+          results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 1 }],
+          failures: [{
+            provider: "github",
+            repoPath: "acme/web",
+            command: "pnpm typecheck",
+            exitCode: 1,
+            stdout: "",
+            stderr: "Type error on line 12",
+          }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        collected({
+          results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 0 }],
+        }),
+      );
+    mocks.startPrePrRepairStep.mockResolvedValue({
+      ok: true,
+      commandId: "cmd-fix",
+      phase: "pre-pr-fix-1",
+      paths: { sentinel: "/tmp/pre-pr-fix-1-done" },
+    });
+    mocks.collectPrePrRepairStep.mockResolvedValue({ usage: null });
+
+    const result = await runPrePrChecksWithFixes(options());
+
+    expect(result.passed).toBe(true);
+    expect(result.fixCycles).toBe(1);
+    expect(result.fixCycleUsages).toEqual([null]);
+    // The fixer is handed the failing summary, and the re-run writes to cycle 1.
+    expect(mocks.startPrePrRepairStep).toHaveBeenCalledWith(
+      "sbx-test-123",
+      "codex",
+      "gpt-5",
+      1,
+      expect.stringContaining("Type error on line 12"),
+      undefined,
+      undefined,
+    );
+    expect(mocks.startRepoCheckBatchStep.mock.calls.map((call) => call[5])).toEqual([0, 1]);
+  });
+
+  it("stops the fix loop when the re-run after a repair stalls", async () => {
+    // The guard has to hold on every pass, not just the first: a batch that
+    // stalls after cycle one must not start cycle two.
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 1 }],
+        failures: [{
+          provider: "github",
+          repoPath: "acme/web",
+          command: "pnpm typecheck",
+          exitCode: 1,
+          stdout: "",
+          stderr: "still failing",
+        }],
+      }),
+    );
+    mocks.startPrePrRepairStep.mockResolvedValue({
+      ok: true,
+      commandId: "cmd-fix",
+      phase: "pre-pr-fix-1",
+      paths: { sentinel: "/tmp/pre-pr-fix-1-done" },
+    });
+    mocks.collectPrePrRepairStep.mockResolvedValue({ usage: null });
+    // Batch one finishes, the repair finishes, the re-run never reports.
+    mocks.pollPhaseUntilDone
+      .mockImplementationOnce(pollEnds("finished", 30_000))
+      .mockImplementationOnce(pollEnds("finished", 30_000))
+      .mockImplementation(pollEnds("duration_cap", 1_500_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+
+    const result = await runPrePrChecksWithFixes(options({ maxFixCycles: 3 }));
+
+    expect(result.fixCycles).toBe(1);
+    expect(mocks.startPrePrRepairStep).toHaveBeenCalledTimes(1);
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain("ran for 25 minutes without finishing");
+  });
+
+  it("bounds a batch by the run's remaining duration, not by the constant alone", async () => {
+    // The constant is a ceiling. What actually bounds a batch is the run's
+    // duration budget, which is maxDurationMs from the definition or else
+    // JOB_TIMEOUT_MS, so it differs per deployment and per plan.
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(collected());
+    observeBudget.mockResolvedValueOnce({
+      check: { status: "ok" as const },
+      remainingDurationMs: 1_800_000,
+    });
+
+    await runPrePrChecksWithFixes(options());
+
+    const tuning = mocks.pollPhaseUntilDone.mock.calls[0]![6] as PhasePollTuning;
+    // Milliseconds, and deliberately ABOVE the remaining budget. Flooring to
+    // whole minutes hands the poll a cap at or below the budget, so the phase
+    // timeout fires first and a run that has simply run out of time reports
+    // "the checks ran for 29 minutes without finishing" instead of halting as
+    // budget_exceeded. Which of the two fired would not even be deterministic:
+    // tick overhead competes with the discarded sub-minute remainder.
+    expect(tuning.phaseLimitMs).toBe(1_860_000);
+  });
+
+  it("never lets a batch outlive the documented ceiling, however long the budget", async () => {
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(collected());
+    observeBudget.mockResolvedValueOnce({
+      check: { status: "ok" as const },
+      remainingDurationMs: 6_000_000,
+    });
+
+    await runPrePrChecksWithFixes(options());
+
+    const tuning = mocks.pollPhaseUntilDone.mock.calls[0]![6] as PhasePollTuning;
+    expect(tuning.phaseLimitMs).toBe(60 * 60_000);
+  });
+
+  it("refuses to launch a batch on an already exhausted budget", async () => {
+    // The poll would raise the same error on its first tick, but only after a
+    // wrapper had been written, chmodded and started in the sandbox.
+    observeBudget.mockResolvedValueOnce({
+      check: {
+        status: "budget_exceeded" as const,
+        metric: "tokens" as const,
+        limit: 10,
+        consumed: 11,
+        reason: "budget_exceeded: tokens 11 reached limit 10",
+      },
+      remainingDurationMs: 600_000,
+    });
+
+    await expect(runPrePrChecksWithFixes(options())).rejects.toMatchObject({
+      name: "RunBudgetError",
+    });
+    expect(mocks.startRepoCheckBatchStep).not.toHaveBeenCalled();
+  });
+
+  it("polls with a ramp and survives a single unreachable reading", async () => {
+    // checkPhaseDone reports "stopped" for any failure to reach the sandbox,
+    // not only for a sandbox that is gone, and a long batch asks it dozens of
+    // times. One reading may not end a check run.
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(collected());
+
+    await runPrePrChecksWithFixes(options());
+
+    const tuning = mocks.pollPhaseUntilDone.mock.calls[0]![6] as PhasePollTuning;
+    expect(tuning).toMatchObject({ checkBeforeFirstTick: true, stoppedObservations: 2 });
+    expect(tuning.initialTickMs!).toBeLessThan(30_000);
+    expect(tuning.tickGrowthFactor!).toBeGreaterThan(1);
+    expect(tuning.maxTicks!).toBeGreaterThan(0);
+  });
+
+  it("keeps another repository's fix cycles when one repository's workspace is gone", async () => {
+    // A vanished workspace directory is the run's own failure, not the
+    // operator's configuration. Reporting it as a setup failure suppressed the
+    // fix cycles of every other repository in the run.
+    const workspaceFailure = {
+      provider: "github" as const,
+      repoPath: "acme/web",
+      command: "(repository workspace)",
+      exitCode: -1,
+      stdout: "",
+      stderr: "The repository's workspace directory could not be entered.",
+      phase: "workspace" as const,
+    };
+    const apiFailure = {
+      provider: "gitlab" as const,
+      repoPath: "acme/api",
+      command: "pnpm test",
+      exitCode: 1,
+      stdout: "",
+      stderr: "Type error on line 12",
+    };
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(
+        collected({ failures: [workspaceFailure] }),
+      )
+      .mockResolvedValueOnce(
+        collected({
+          results: [{ provider: "gitlab", repoPath: "acme/api", command: "pnpm test", exitCode: 1 }],
+          failures: [apiFailure],
+        }),
+      )
+      .mockResolvedValueOnce(
+        collected({ failures: [workspaceFailure] }),
+      )
+      .mockResolvedValueOnce(
+        collected({
+          results: [{ provider: "gitlab", repoPath: "acme/api", command: "pnpm test", exitCode: 0 }],
+        }),
+      );
+    mocks.startPrePrRepairStep.mockResolvedValue({
+      ok: true,
+      commandId: "cmd-fix",
+      phase: "pre-pr-fix-1",
+      paths: { sentinel: "/tmp/pre-pr-fix-1-done" },
+    });
+    mocks.collectPrePrRepairStep.mockResolvedValue({ usage: null });
+
+    const result = await runPrePrChecksWithFixes(options({ config }));
+
+    expect(result.setupFailed).toBe(false);
+    expect(mocks.startPrePrRepairStep).toHaveBeenCalledTimes(1);
+    // The fixer sees the check it can repair and not the infrastructure fault
+    // it cannot: asking it to edit code in response to a missing directory is
+    // how a fix budget gets spent on nothing.
+    const prompt = mocks.startPrePrRepairStep.mock.calls[0]![4] as string;
+    expect(prompt).toContain("Type error on line 12");
+    expect(prompt).not.toContain("workspace directory could not be entered");
+    expect(result.summary).toContain("WORKSPACE UNAVAILABLE for github:acme/web");
+  });
+
+  it("runs no fix cycle when the only failure is the workspace's own", async () => {
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        failures: [{
+          provider: "github",
+          repoPath: "acme/web",
+          command: "(repository workspace)",
+          exitCode: -1,
+          stdout: "",
+          stderr: "The repository's workspace directory could not be entered.",
+          phase: "workspace",
+        }],
+      }),
+    );
+
+    const result = await runPrePrChecksWithFixes(options());
+
+    expect(result.passed).toBe(false);
+    expect(result.setupFailed).toBe(false);
+    expect(result.fixCycles).toBe(0);
+    expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
+  });
+
+  it("runs a repository configured twice only once, on its last entry", async () => {
+    // The blocking runner keyed the configuration into a Map, so a duplicate
+    // only ever ran its last occurrence. Running both would double a batch
+    // whose wall clock is measured in tens of minutes.
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(collected());
+
+    await runPrePrChecksWithFixes(
+      options({
+        config: {
+          repositories: [
+            { provider: "github", repoPath: "acme/web", commands: ["pnpm lint"] },
+            { provider: "github", repoPath: "acme/web", commands: ["pnpm typecheck"] },
+          ],
+        },
+      }),
+    );
+
+    expect(mocks.startRepoCheckBatchStep).toHaveBeenCalledTimes(1);
+    expect(mocks.startRepoCheckBatchStep).toHaveBeenCalledWith(
+      "sbx-test-123",
+      "github",
+      "acme/web",
+      [],
+      ["pnpm typecheck"],
+      0,
+      0,
+      true,
+    );
+  });
+
+  it("stops at maxFixCycles and reports the last failing summary", async () => {
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 1 }],
+        failures: [{
+          provider: "github",
+          repoPath: "acme/web",
+          command: "pnpm typecheck",
+          exitCode: 1,
+          stdout: "",
+          stderr: "still failing",
+        }],
+      }),
+    );
+    mocks.startPrePrRepairStep.mockResolvedValue({
+      ok: true,
+      commandId: "cmd-fix",
+      phase: "pre-pr-fix-1",
+      paths: { sentinel: "/tmp/pre-pr-fix-1-done" },
+    });
+    mocks.collectPrePrRepairStep.mockResolvedValue({ usage: null });
+
+    const result = await runPrePrChecksWithFixes(options({ maxFixCycles: 2 }));
+
+    expect(result.passed).toBe(false);
+    expect(result.fixCycles).toBe(2);
+    expect(result.summary).toContain("still failing");
+  });
+
+  it("runs no fix cycles when maxFixCycles is 0", async () => {
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 1 }],
+        failures: [{
+          provider: "github",
+          repoPath: "acme/web",
+          command: "pnpm typecheck",
+          exitCode: 1,
+          stdout: "",
+          stderr: "still failing",
+        }],
+      }),
+    );
+
+    const result = await runPrePrChecksWithFixes(options({ maxFixCycles: 0 }));
+
+    expect(result.fixCycles).toBe(0);
+    expect(mocks.startPrePrRepairStep).not.toHaveBeenCalled();
+  });
+
+  it("returns a repair agent failure without starting another cycle", async () => {
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 1 }],
+        failures: [{
+          provider: "github",
+          repoPath: "acme/web",
+          command: "pnpm typecheck",
+          exitCode: 1,
+          stdout: "",
+          stderr: "still failing",
+        }],
+      }),
+    );
+    mocks.startPrePrRepairStep.mockResolvedValue({
+      ok: false,
+      failure: { ok: false, category: "provider", diagnostic: { failureKind: "setup_failed" } },
+    });
+
+    const result = await runPrePrChecksWithFixes(options());
+
+    expect(result.fixCycles).toBe(1);
+    expect(result.agentFailure).toMatchObject({
+      diagnostic: { failureKind: "setup_failed" },
+    });
+    expect(mocks.startPrePrRepairStep).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the repair stall reason the poll produced", async () => {
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 1 }],
+        failures: [{
+          provider: "github",
+          repoPath: "acme/web",
+          command: "pnpm typecheck",
+          exitCode: 1,
+          stdout: "",
+          stderr: "still failing",
+        }],
+      }),
+    );
+    mocks.startPrePrRepairStep.mockResolvedValue({
+      ok: true,
+      commandId: "cmd-fix",
+      phase: "pre-pr-fix-1",
+      paths: { sentinel: "/tmp/pre-pr-fix-1-done" },
+    });
+    // The batch poll succeeds; only the repair poll runs out. The kind of stall
+    // comes from the poll, which is the only thing that saw the sandbox go: one
+    // more sentinel read cannot tell a dead sandbox from a transient fault.
+    mocks.pollPhaseUntilDone
+      .mockImplementationOnce(pollEnds("finished", 30_000))
+      .mockImplementationOnce(pollEnds("sandbox_stopped", 60_000));
+    mocks.checkPhaseDone.mockResolvedValue(false);
+    mocks.collectPrePrRepairStep.mockResolvedValue({
+      usage: null,
+      failure: { ok: false, category: "provider", diagnostic: { failureKind: "provider_error" } },
+    });
+
+    const result = await runPrePrChecksWithFixes(options({ maxFixCycles: 1 }));
+
+    expect(mocks.collectPrePrRepairStep).toHaveBeenCalledWith(
+      "sbx-test-123",
+      "codex",
+      "pre-pr-fix-1",
+      expect.anything(),
+      "sandbox_stopped",
+      // The elapsed time the repair poll consumed, so its failure detail can
+      // name the bound that applied instead of the 25 minute constant.
+      60_000,
+      undefined,
+    );
+    expect(result.agentFailure).toBeDefined();
+  });
+
+  it("stops before another check or fixer when the first fix cycle exceeds the token cap", async () => {
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [{ provider: "github", repoPath: "acme/web", command: "pnpm typecheck", exitCode: 1 }],
+        failures: [{
+          provider: "github",
+          repoPath: "acme/web",
+          command: "pnpm typecheck",
+          exitCode: 1,
+          stdout: "",
+          stderr: "still failing",
+        }],
+      }),
+    );
+    mocks.startPrePrRepairStep.mockResolvedValue({
+      ok: true,
+      commandId: "cmd-fix",
+      phase: "pre-pr-fix-1",
+      paths: { sentinel: "/tmp/pre-pr-fix-1-done" },
+    });
+    mocks.collectPrePrRepairStep.mockResolvedValue({
+      usage: {
+        cost_usd: null,
+        tokens: { input: 8, cached_input: 2, output: 3 },
+        duration_ms: 0,
+        duration_api_ms: 0,
+        num_turns: 1,
+      },
+    });
+
+    const result = await runPrePrChecksWithFixes(
+      options({
+        budget: {
+          state: createRunBudgetState(),
+          limits: { maxDurationMs: 60_000, maxTokens: 12 },
+          price: { input: 0.001, cached_input: 0.0001, output: 0.002 },
+        },
+      }),
+    );
+
+    expect(result.fixCycles).toBe(1);
+    expect(result.budgetFailure).toMatchObject({
+      status: "budget_exceeded",
+      metric: "tokens",
+      limit: 12,
+      consumed: 13,
+    });
+    expect(mocks.startPrePrRepairStep).toHaveBeenCalledTimes(1);
+    expect(mocks.startRepoCheckBatchStep).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("loadPrePrCheckConfigStep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("carries the stored version out with the configuration it loaded", async () => {
+    // The version is what records the workspace gate, so it has to travel from
+    // this step to the gate write. It used to leave with the checks result;
+    // the checks are no longer a step, so it leaves with the config instead.
+    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+      version: 7,
+      config: { repositories: [] },
+    });
+
+    await expect(loadPrePrCheckConfigStep()).resolves.toEqual({
+      version: 7,
+      config: { repositories: [] },
+    });
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      { version: 7 },
+      "pre_pr_checks_config_version",
+    );
+  });
+
+  it("falls back to the empty configuration when nothing is stored", async () => {
+    mocks.getCurrentPrePrCheckConfig.mockResolvedValue(undefined);
+
+    await expect(loadPrePrCheckConfigStep()).resolves.toEqual({
+      version: null,
+      config: { repositories: [] },
+    });
+  });
+});

--- a/apps/worker/src/workflows/blocks/pre-pr-checks.ts
+++ b/apps/worker/src/workflows/blocks/pre-pr-checks.ts
@@ -330,10 +330,6 @@ export async function runRepoCheckBatch(args: {
   fixCycle: number;
   repoIndex: number;
   requireChange: boolean;
-  /** Whether an exit-0 check that says its dependencies are missing counts as
-   *  a failure. Only the configured checks carry that history; see
-   *  collectRepoCheckBatchStep. */
-  scanBlockedDependencies: boolean;
   observeBudget: PrePrChecksOptions["observeBudget"];
   cancellation?: V2InvocationCancellation;
 }): Promise<RepoCheckBatchRun> {
@@ -363,7 +359,6 @@ export async function runRepoCheckBatch(args: {
       started.paths,
       started.localPath,
       batchFinished,
-      args.scanBlockedDependencies,
     );
 
   const outcome = newPhasePollOutcome();
@@ -465,7 +460,6 @@ async function runCheckBatches(
       fixCycle,
       repoIndex,
       requireChange: true,
-      scanBlockedDependencies: true,
       observeBudget: options.observeBudget,
       cancellation: options.cancellation,
     });
@@ -599,6 +593,12 @@ function stalledBatches(
     exitCode: -1,
     stdout: "",
     stderr: batchStallReason(stall, elapsedMs, collected.progress),
+    // The batch never reported, so this is not a check result at all. Without a
+    // phase it reads as an ordinary failing check: it would be handed to the
+    // repair agent, and under a setup failure elsewhere it would collect the
+    // sentence saying its fix cycles were suppressed, when the reason nothing
+    // was fixed is that nothing was verified.
+    phase: "batch",
   };
   const allResults = [...results, ...collected.results];
   const allFailures = [...failures, ...collected.failures, stallFailure];

--- a/apps/worker/src/workflows/blocks/pre-pr-checks.ts
+++ b/apps/worker/src/workflows/blocks/pre-pr-checks.ts
@@ -1,0 +1,677 @@
+import type { PrePrCheckConfig } from "../../pre-pr-checks/config.js";
+import {
+  MAX_PRE_PR_FIX_CYCLES,
+  PRE_PR_CHECK_BATCH_MAX_MINUTES,
+  PRE_PR_REPAIR_MAX_MINUTES,
+  collectPrePrRepairStep,
+  collectRepoCheckBatchStep,
+  formatElapsed,
+  formatPrePrCheckFailures,
+  startPrePrRepairStep,
+  startRepoCheckBatchStep,
+  type CollectedRepoCheckBatch,
+  type PrePrCheckCommandResult,
+  type PrePrCheckFailure,
+  type PrePrCheckRunResult,
+  type PrePrFixBudgetContext,
+  type PrePrPhaseStall,
+  type RepoCheckBatchProgress,
+} from "../../pre-pr-checks/runner.js";
+import type { AgentProtocolResult, PhaseUsage } from "../../sandbox/agents/types.js";
+import type { ResolvedHarnessRuntime } from "../../sandbox/harness-runtime.js";
+import type { V2InvocationCancellation } from "../../workflow-definition/invocation-context.js";
+import {
+  RunBudgetError,
+  checkRunBudget,
+  isRunBudgetError,
+  recordBudgetUsage,
+  type RunBudgetObservation,
+} from "../run-budget.js";
+import {
+  pollPhaseUntilDone,
+  type PhasePollOutcome,
+  type PhasePollTuning,
+} from "./poll-phase.js";
+
+export interface PrePrChecksOptions {
+  sandboxId: string;
+  config: PrePrCheckConfig;
+  agentKind: "claude" | "codex";
+  model: string;
+  maxFixCycles?: number;
+  /** Run-global budget observer. It replaces the wall-clock deadline this path
+   *  used to carry: pollPhaseUntilDone re-reads it on every tick, so the bound
+   *  survives a replay instead of being recomputed from Date.now(). */
+  observeBudget: (
+    requireRemainingDuration?: boolean,
+  ) => Promise<RunBudgetObservation>;
+  cancellation?: V2InvocationCancellation;
+  budget?: PrePrFixBudgetContext;
+  runtime?: ResolvedHarnessRuntime;
+  arthurTaskId?: string | null;
+}
+
+/**
+ * Hard ceiling on the ticks one batch poll may append to the run's event log.
+ *
+ * Generous against the duration cap on purpose: at the ramp below a poll needs
+ * roughly 125 ticks to cover a full hour, so this never bites before the time
+ * bound does at today's cap. It exists so raising that cap cannot quietly turn
+ * into thousands of step records in a run that has lost runs to
+ * CORRUPTED_EVENT_LOG before.
+ */
+const BATCH_POLL_MAX_TICKS = 200;
+
+/** A fresh record for one poll to report what it consumed. */
+export function newPhasePollOutcome(): PhasePollOutcome {
+  return { elapsedMs: 0, ticks: 0, reason: "finished" };
+}
+
+/**
+ * How both check modes poll a batch.
+ *
+ * The ramp is the point: checks that finish in seconds should not pay a full
+ * 30s tick of latency, and checks that run for twenty minutes should not pay
+ * 40 step records for the privilege. It starts at two seconds, ramps toward the
+ * 30s ceiling poll-delay.ts documents, and never past it.
+ *
+ * `stoppedObservations: 2` is not a nicety. checkPhaseDone reports "stopped"
+ * for any failure to reach the sandbox, not only for a sandbox that is gone,
+ * and a long batch asks it dozens of times; treating one reading as fatal
+ * converts a single transient fault into an abandoned check run.
+ */
+export function batchPollTuning(outcome: PhasePollOutcome): PhasePollTuning {
+  return {
+    checkBeforeFirstTick: true,
+    initialTickMs: 2_000,
+    tickGrowthFactor: 1.6,
+    maxTicks: BATCH_POLL_MAX_TICKS,
+    stoppedObservations: 2,
+    outcome,
+  };
+}
+
+/**
+ * How far the batch cap is allowed to exceed the remaining duration budget.
+ *
+ * Deliberately positive. If the phase cap expires first, the poll returns
+ * "the checks ran for N minutes without finishing" and the run takes the
+ * checks-failed branch, when what actually happened is that the run ran out of
+ * time and should halt as budget_exceeded. Overshooting by a minute makes the
+ * budget observer, which the poll re-reads on every tick, always the one that
+ * fires.
+ */
+const BATCH_CAP_BUDGET_MARGIN_MS = 60_000;
+
+/**
+ * The time bound that actually applies to one batch, in milliseconds, and the
+ * gate that refuses to start one at all.
+ *
+ * PRE_PR_CHECK_BATCH_MAX_MINUTES is only a ceiling. What really bounds a batch
+ * is the run's remaining duration budget, which is `maxDurationMs` from the
+ * definition or else env.JOB_TIMEOUT_MS (workflows/agent.ts, where budgetLimits
+ * is built), and therefore varies per deployment and per plan. Deriving the
+ * bound from the live observation keeps the two from drifting apart.
+ *
+ * Milliseconds, not minutes: flooring to a whole minute discards up to 59
+ * seconds of budget and hands the poll a cap that is always at or below the
+ * budget, so the phase timeout systematically pre-empts the budget stop.
+ *
+ * It also throws on an exhausted token or cost budget, before anything is
+ * launched. The poll would raise the same error on its first tick, but only
+ * after a wrapper had been written, chmodded and started in the sandbox.
+ */
+export async function batchCapMs(
+  observeBudget: PrePrChecksOptions["observeBudget"],
+): Promise<number> {
+  const observed = await observeBudget(false);
+  if (observed.check.status !== "ok") throw new RunBudgetError(observed.check);
+  return Math.min(
+    PRE_PR_CHECK_BATCH_MAX_MINUTES * 60_000,
+    observed.remainingDurationMs + BATCH_CAP_BUDGET_MARGIN_MS,
+  );
+}
+
+/**
+ * Load the dashboard's current Pre-PR check configuration.
+ *
+ * The version log stays inside this step: pino may only be used inside a
+ * "use step", and moving it to workflow scope fails the Vercel build alone,
+ * never vitest or a local build.
+ */
+export async function loadPrePrCheckConfigStep(): Promise<{
+  version: number | null;
+  config: PrePrCheckConfig;
+}> {
+  "use step";
+  const { getDb } = await import("../../db/client.js");
+  const { getCurrentPrePrCheckConfig } = await import("../../pre-pr-checks/store.js");
+  const { emptyPrePrCheckConfig } = await import("../../pre-pr-checks/config.js");
+  const { logger } = await import("../../lib/logger.js");
+  const current = await getCurrentPrePrCheckConfig(getDb());
+  logger.info(
+    { version: current?.version ?? null },
+    "pre_pr_checks_config_version",
+  );
+  return {
+    version: current?.version ?? null,
+    config: current?.config ?? emptyPrePrCheckConfig,
+  };
+}
+loadPrePrCheckConfigStep.maxRetries = 0;
+
+/**
+ * Run the configured Pre-PR checks, repairing and re-running them up to
+ * `maxFixCycles` times.
+ *
+ * This is plain async orchestration, deliberately NOT a "use step", exactly
+ * like pollPhaseUntilDone. Every awaited thing inside it is a short step: a
+ * launch, a poll tick, a collect. A client tenant whose checks take ~1124s
+ * used to run all of them inside one step invocation, which Vercel kills at
+ * 300s; the re-invocation then hit the step's own re-invocation guard and the
+ * run died with no recoverable cause. Nothing here may block near that limit
+ * again, so no long-running command may ever be awaited from this scope.
+ */
+export async function runPrePrChecksWithFixes(
+  options: PrePrChecksOptions,
+): Promise<PrePrCheckRunResult> {
+  const maxFixCycles = options.maxFixCycles ?? MAX_PRE_PR_FIX_CYCLES;
+  if (options.config.repositories.length === 0) {
+    return {
+      outcome: "missing_configuration",
+      passed: true,
+      fixCycles: 0,
+      fixCycleUsages: [],
+      budgetFailure: null,
+      results: [],
+      failures: [],
+      setupFailed: false,
+      summary: "No pre-PR checks configured.",
+    };
+  }
+
+  let batch = await runCheckBatches(options, 0);
+  let fixCycles = 0;
+  const fixCycleUsages: Array<PhaseUsage | null> = [];
+  let budgetState = options.budget?.state;
+
+  // Three separate reasons never to enter the repair loop, and none of them is
+  // a check that failed. A setup failure means the workspace is missing a tool
+  // and no edit the fixer can make will install it; before that guard the
+  // platform spent its whole fix budget rewriting code in response to "command
+  // not found". A stalled batch verified nothing, so there is nothing to hand a
+  // fixer. And a run whose only failures are the workspace's own (unreachable
+  // directory, foreign output files) has nothing repairable in it either.
+  while (
+    !batch.passed &&
+    !batch.setupFailed &&
+    !batch.stalled &&
+    batch.hasRepairableFailures &&
+    fixCycles < maxFixCycles
+  ) {
+    fixCycles++;
+    const fixer = await runFixCycle(options, batch.repairSummary, fixCycles);
+    fixCycleUsages.push(fixer.usage);
+    if (fixer.failure) {
+      return withFixCycles(batch, fixCycles, fixCycleUsages, null, fixer.failure);
+    }
+    if (options.budget && budgetState) {
+      budgetState = recordBudgetUsage(budgetState, fixer.usage, options.budget.price);
+      const check = checkRunBudget(budgetState, options.budget.limits);
+      if (check.status !== "ok") {
+        return withFixCycles(batch, fixCycles, fixCycleUsages, check);
+      }
+    }
+    batch = await runCheckBatches(options, fixCycles);
+  }
+
+  return withFixCycles(batch, fixCycles, fixCycleUsages, null);
+}
+
+/** One pass over every configured repository, plus why it ended. */
+interface CheckBatchesResult {
+  outcome: Exclude<PrePrCheckRunResult["outcome"], "missing_configuration">;
+  passed: boolean;
+  results: PrePrCheckCommandResult[];
+  failures: PrePrCheckFailure[];
+  setupFailed: boolean;
+  /** True when a repository's batch never reported a result: it outlived its
+   *  cap, or the sandbox under it died. Distinct from a failed check. */
+  stalled: boolean;
+  /** At least one failure a code edit could plausibly repair. Workspace and
+   *  setup failures are not among them. */
+  hasRepairableFailures: boolean;
+  summary: string;
+  /** What a fixer is shown: the repairable failures only, so it is never asked
+   *  to edit code in response to the run's own infrastructure. */
+  repairSummary: string;
+}
+
+function withFixCycles(
+  batch: CheckBatchesResult,
+  fixCycles: number,
+  fixCycleUsages: Array<PhaseUsage | null>,
+  budgetFailure: PrePrCheckRunResult["budgetFailure"],
+  agentFailure?: Extract<AgentProtocolResult<unknown>, { ok: false }>,
+): PrePrCheckRunResult {
+  return {
+    outcome: batch.outcome,
+    passed: batch.passed,
+    results: batch.results,
+    failures: batch.failures,
+    setupFailed: batch.setupFailed,
+    summary: batch.summary,
+    fixCycles,
+    fixCycleUsages,
+    budgetFailure,
+    ...(agentFailure ? { agentFailure } : {}),
+  };
+}
+
+/** Ordinary check failures: the only kind a repair agent can act on. */
+function repairableFailures(failures: PrePrCheckFailure[]): PrePrCheckFailure[] {
+  return failures.filter((failure) => failure.phase === undefined);
+}
+
+function batchesResult(
+  results: PrePrCheckCommandResult[],
+  failures: PrePrCheckFailure[],
+  setupFailedRepositories: string[],
+  ranChecks: number,
+): CheckBatchesResult {
+  const repairable = repairableFailures(failures);
+  return {
+    outcome: failures.length > 0 ? "failed" : "passed",
+    passed: failures.length === 0,
+    results,
+    failures,
+    setupFailed: setupFailedRepositories.length > 0,
+    stalled: false,
+    hasRepairableFailures: repairable.length > 0,
+    summary:
+      failures.length > 0
+        ? formatPrePrCheckFailures(failures, setupFailedRepositories)
+        : ranChecks === 0
+          ? "No pre-PR checks matched changed repositories."
+          : `Pre-PR checks passed (${ranChecks} command${ranChecks === 1 ? "" : "s"}).`,
+    repairSummary: formatPrePrCheckFailures(repairable),
+  };
+}
+
+/** What one repository's batch did, from launch to collected files. */
+export interface RepoCheckBatchRun {
+  /** The repository was not started: not attached, or unchanged. */
+  skipped: boolean;
+  collected: CollectedRepoCheckBatch;
+  /** Set when the batch never reported: it outlived its bound, or the sandbox
+   *  under it went. Whatever `collected` holds is then a partial record. */
+  stall: Exclude<PrePrPhaseStall, "none"> | null;
+  /** Tick time the poll consumed, for a message that names the real bound. */
+  elapsedMs: number;
+}
+
+/**
+ * Run one repository's batch: launch it detached, poll it across ticks, and
+ * read back whatever it wrote.
+ *
+ * Shared by both check modes. They differ only in where the commands come from
+ * and how the result is shaped for their caller; everything between the launch
+ * and the collected files (the derived cap, the budget gate, the stall
+ * classification, the guarded collect of an abandoned batch) is one behaviour
+ * and must not drift into two.
+ */
+export async function runRepoCheckBatch(args: {
+  sandboxId: string;
+  provider: PrePrCheckFailure["provider"];
+  repoPath: string;
+  setup: string[];
+  commands: string[];
+  fixCycle: number;
+  repoIndex: number;
+  requireChange: boolean;
+  observeBudget: PrePrChecksOptions["observeBudget"];
+  cancellation?: V2InvocationCancellation;
+}): Promise<RepoCheckBatchRun> {
+  const total = args.setup.length + args.commands.length;
+  const capMs = await batchCapMs(args.observeBudget);
+  const started = await startRepoCheckBatchStep(
+    args.sandboxId,
+    args.provider,
+    args.repoPath,
+    args.setup,
+    args.commands,
+    args.fixCycle,
+    args.repoIndex,
+    args.requireChange,
+  );
+  if (started.skipped) {
+    return { skipped: true, collected: unreadableBatch(), stall: null, elapsedMs: 0 };
+  }
+
+  const collect = (batchFinished: boolean): Promise<CollectedRepoCheckBatch> =>
+    collectRepoCheckBatchStep(
+      args.sandboxId,
+      args.provider,
+      args.repoPath,
+      args.setup,
+      args.commands,
+      started.paths,
+      started.localPath,
+      batchFinished,
+    );
+
+  const outcome = newPhasePollOutcome();
+  let done: boolean;
+  try {
+    done = await pollPhaseUntilDone(
+      args.sandboxId,
+      started.paths.sentinel,
+      PRE_PR_CHECK_BATCH_MAX_MINUTES,
+      started.commandId,
+      args.observeBudget,
+      args.cancellation,
+      { ...batchPollTuning(outcome), phaseLimitMs: capMs },
+    );
+  } catch (error) {
+    // A budget stop still ends the run, but the wrapper's files say exactly how
+    // far the checks got and the operator has no other way to find out.
+    throw await budgetErrorNamingProgress(error, args.provider, args.repoPath, collect);
+  }
+
+  if (!done) {
+    const stall = await resolvePhaseStall(
+      args.sandboxId,
+      started.paths.sentinel,
+      outcome,
+    );
+    if (stall !== "none") {
+      return {
+        skipped: false,
+        collected: await collectAbandonedBatch(collect),
+        stall,
+        elapsedMs: outcome.elapsedMs,
+      };
+    }
+  }
+
+  return {
+    skipped: false,
+    collected: await collect(true),
+    stall: null,
+    elapsedMs: outcome.elapsedMs,
+  };
+}
+
+/**
+ * Read back a batch the run has already stopped believing.
+ *
+ * Guarded, because this runs exactly when the sandbox may be gone: the poll
+ * gave up, and on the sandbox-death path it did so after observing the sandbox
+ * as not running twice. The collect step's maxRetries is 0, so an SDK error
+ * escaping here would replace the informative stall sentence with an
+ * unclassified failure, in the very case this whole mechanism exists for.
+ * Losing the detail is acceptable; losing the diagnosis is not.
+ */
+async function collectAbandonedBatch(
+  collect: (batchFinished: boolean) => Promise<CollectedRepoCheckBatch>,
+): Promise<CollectedRepoCheckBatch> {
+  try {
+    return await collect(false);
+  } catch {
+    return unreadableBatch();
+  }
+}
+
+/**
+ * A batch with no record: either nothing was started for this repository, or
+ * its files could not be read back.
+ *
+ * `total: 0` is the signal, and formatProgress reads it as "how far it got
+ * could not be read back" rather than "0 of 0 commands finished". Inventing a
+ * count here would put a number in an operator's failure message that no file
+ * in the sandbox supports.
+ */
+function unreadableBatch(): CollectedRepoCheckBatch {
+  return {
+    results: [],
+    failures: [],
+    setupFailed: false,
+    progress: { completed: 0, total: 0, stoppedAt: null },
+  };
+}
+
+async function runCheckBatches(
+  options: PrePrChecksOptions,
+  fixCycle: number,
+): Promise<CheckBatchesResult> {
+  const results: PrePrCheckCommandResult[] = [];
+  const failures: PrePrCheckFailure[] = [];
+  const setupFailedRepositories: string[] = [];
+  let ranChecks = 0;
+
+  for (const [repoIndex, repo] of uniqueConfiguredRepositories(options.config).entries()) {
+    const run = await runRepoCheckBatch({
+      sandboxId: options.sandboxId,
+      provider: repo.provider,
+      repoPath: repo.repoPath,
+      setup: repo.setup ?? [],
+      commands: repo.commands,
+      fixCycle,
+      repoIndex,
+      requireChange: true,
+      observeBudget: options.observeBudget,
+      cancellation: options.cancellation,
+    });
+    if (run.skipped) continue;
+    if (run.stall) {
+      return stalledBatches(
+        repo.provider,
+        repo.repoPath,
+        run.stall,
+        run.elapsedMs,
+        run.collected,
+        results,
+        failures,
+      );
+    }
+
+    results.push(...run.collected.results);
+    failures.push(...run.collected.failures);
+    ranChecks += run.collected.results.length;
+    if (run.collected.setupFailed) {
+      setupFailedRepositories.push(`${repo.provider}:${repo.repoPath}`);
+    }
+  }
+
+  return batchesResult(results, failures, setupFailedRepositories, ranChecks);
+}
+
+/**
+ * Configured repositories deduplicated by provider and path, the last entry
+ * winning.
+ *
+ * The blocking runner keyed the configuration into a Map before walking the
+ * workspace, so a duplicate entry only ever ran its last occurrence. Walking
+ * the configuration directly would run both, and running one repository's
+ * batch twice doubles a wall clock measured in tens of minutes.
+ */
+function uniqueConfiguredRepositories(
+  config: PrePrCheckConfig,
+): PrePrCheckConfig["repositories"] {
+  return [
+    ...new Map(
+      config.repositories.map((repo) => [`${repo.provider}:${repo.repoPath}`, repo]),
+    ).values(),
+  ];
+}
+
+/**
+ * Why a poll ended without a sentinel.
+ *
+ * The reason comes from the poll itself, which knows whether it ran out of
+ * ticks or saw the sandbox go: guessing it from one more sentinel read would
+ * call every failure to reach the sandbox a dead sandbox. That read is still
+ * made, for one thing only: the sentinel may have appeared between the poll's
+ * last tick and now, and a finished batch must not be reported as a stall.
+ *
+ * Shared with the explicit-commands mode of run_checks, which has no fix loop
+ * to suppress but the same rule about never reading a stall as a pass.
+ */
+export async function resolvePhaseStall(
+  sandboxId: string,
+  sentinelFile: string,
+  outcome: PhasePollOutcome,
+): Promise<PrePrPhaseStall> {
+  const { checkPhaseDone } = await import("../../sandbox/poll-agent.js");
+  if ((await checkPhaseDone(sandboxId, sentinelFile)) === true) return "none";
+  return outcome.reason === "sandbox_stopped" ? "sandbox_stopped" : "timed_out";
+}
+
+/** Where the batch got to, named from the files the wrapper actually wrote. */
+function formatProgress(progress: RepoCheckBatchProgress): string {
+  // total 0 is the unreadable-batch marker, not a batch of no commands: the
+  // files could not be read, so any count would be invented.
+  if (progress.total === 0) return "; how far it got could not be read back";
+  const counted = `${progress.completed} of ${progress.total} command${
+    progress.total === 1 ? "" : "s"
+  } had finished`;
+  return progress.stoppedAt
+    ? ` while running \`${progress.stoppedAt}\`; ${counted}`
+    : `; ${counted}`;
+}
+
+/**
+ * The sentence a stalled batch reports, in either check mode.
+ *
+ * It states the time that actually elapsed, never the cap that was requested: a
+ * poll can end early, the cap itself is derived from the remaining budget, and
+ * a message that can be false is worse than no message.
+ */
+export function batchStallReason(
+  stall: Exclude<PrePrPhaseStall, "none">,
+  elapsedMs: number,
+  progress: RepoCheckBatchProgress,
+): string {
+  const where = formatProgress(progress);
+  return stall === "sandbox_stopped"
+    ? `The Run Workspace sandbox stopped while this repository's checks were running${where}. ` +
+        "Nothing was verified: this is a lost workspace, not a failing check."
+    : `The checks for this repository ran for ${formatElapsed(elapsedMs)} without finishing and ` +
+        `were stopped${where}. Nothing was verified: this is a timeout, not a passing or a ` +
+        "failing check result.";
+}
+
+/**
+ * A stalled batch fails the checks and abandons the pass. It stops the walk
+ * too: a sandbox that died or a batch that outlived its cap makes every later
+ * repository's result meaningless.
+ *
+ * What the batch did manage is still reported. Those commands really ran, and
+ * the operator needs them to see where it stopped.
+ */
+function stalledBatches(
+  provider: PrePrCheckFailure["provider"],
+  repoPath: string,
+  stall: Exclude<PrePrPhaseStall, "none">,
+  elapsedMs: number,
+  collected: CollectedRepoCheckBatch,
+  results: PrePrCheckCommandResult[],
+  failures: PrePrCheckFailure[],
+): CheckBatchesResult {
+  const stallFailure: PrePrCheckFailure = {
+    provider,
+    repoPath,
+    command: collected.progress.stoppedAt ?? "(pre-PR check batch)",
+    exitCode: -1,
+    stdout: "",
+    stderr: batchStallReason(stall, elapsedMs, collected.progress),
+  };
+  const allResults = [...results, ...collected.results];
+  const allFailures = [...failures, ...collected.failures, stallFailure];
+  return {
+    outcome: "failed",
+    passed: false,
+    results: allResults,
+    failures: allFailures,
+    setupFailed: false,
+    stalled: true,
+    hasRepairableFailures: false,
+    summary: formatPrePrCheckFailures(allFailures),
+    repairSummary: "",
+  };
+}
+
+/**
+ * Attach how far the checks got to a budget stop, then hand it back for the
+ * caller to throw. Anything that is not a budget failure is returned untouched.
+ */
+export async function budgetErrorNamingProgress(
+  error: unknown,
+  provider: PrePrCheckFailure["provider"],
+  repoPath: string,
+  collect: (batchFinished: boolean) => Promise<CollectedRepoCheckBatch>,
+): Promise<unknown> {
+  if (!isRunBudgetError(error)) return error;
+  // Guarded for the same reason the stall path is: this reads a sandbox the run
+  // is already leaving, and a throw here would replace the budget stop with an
+  // unclassified failure, which is worse than a budget stop with no detail.
+  const collected = await collectAbandonedBatch(collect);
+  return new RunBudgetError({
+    ...error.failure,
+    reason:
+      `${error.failure.reason}; checks for ${provider}:${repoPath} stopped` +
+      `${formatProgress(collected.progress)}`,
+  });
+}
+
+async function runFixCycle(
+  options: PrePrChecksOptions,
+  failureSummary: string,
+  fixCycle: number,
+): Promise<{
+  usage: PhaseUsage | null;
+  failure?: Extract<AgentProtocolResult<unknown>, { ok: false }>;
+}> {
+  const started = await startPrePrRepairStep(
+    options.sandboxId,
+    options.agentKind,
+    options.model,
+    fixCycle,
+    failureSummary,
+    options.runtime,
+    options.arthurTaskId,
+  );
+  if (!started.ok) return { usage: null, failure: started.failure };
+
+  // The repair agent is polled across ticks for the same reason the checks are:
+  // waiting for it inside the step that launched it caps the phase at one
+  // function invocation.
+  const outcome = newPhasePollOutcome();
+  const done = await pollPhaseUntilDone(
+    options.sandboxId,
+    started.paths.sentinel,
+    PRE_PR_REPAIR_MAX_MINUTES,
+    started.commandId,
+    options.observeBudget,
+    options.cancellation,
+    {
+      ...batchPollTuning(outcome),
+      phaseLimitMs: Math.min(
+        PRE_PR_REPAIR_MAX_MINUTES * 60_000,
+        await batchCapMs(options.observeBudget),
+      ),
+    },
+  );
+  const stall = done
+    ? "none"
+    : await resolvePhaseStall(options.sandboxId, started.paths.sentinel, outcome);
+  return collectPrePrRepairStep(
+    options.sandboxId,
+    options.agentKind,
+    started.phase,
+    started.paths,
+    stall,
+    outcome.elapsedMs,
+    options.runtime,
+  );
+}

--- a/apps/worker/src/workflows/blocks/pre-pr-checks.ts
+++ b/apps/worker/src/workflows/blocks/pre-pr-checks.ts
@@ -278,6 +278,7 @@ function batchesResult(
   failures: PrePrCheckFailure[],
   setupFailedRepositories: string[],
   ranChecks: number,
+  fixCyclesRun: number,
 ): CheckBatchesResult {
   const repairable = repairableFailures(failures);
   return {
@@ -290,7 +291,7 @@ function batchesResult(
     hasRepairableFailures: repairable.length > 0,
     summary:
       failures.length > 0
-        ? formatPrePrCheckFailures(failures, setupFailedRepositories)
+        ? formatPrePrCheckFailures(failures, setupFailedRepositories, fixCyclesRun)
         : ranChecks === 0
           ? "No pre-PR checks matched changed repositories."
           : `Pre-PR checks passed (${ranChecks} command${ranChecks === 1 ? "" : "s"}).`,
@@ -329,6 +330,10 @@ export async function runRepoCheckBatch(args: {
   fixCycle: number;
   repoIndex: number;
   requireChange: boolean;
+  /** Whether an exit-0 check that says its dependencies are missing counts as
+   *  a failure. Only the configured checks carry that history; see
+   *  collectRepoCheckBatchStep. */
+  scanBlockedDependencies: boolean;
   observeBudget: PrePrChecksOptions["observeBudget"];
   cancellation?: V2InvocationCancellation;
 }): Promise<RepoCheckBatchRun> {
@@ -358,6 +363,7 @@ export async function runRepoCheckBatch(args: {
       started.paths,
       started.localPath,
       batchFinished,
+      args.scanBlockedDependencies,
     );
 
   const outcome = newPhasePollOutcome();
@@ -459,6 +465,7 @@ async function runCheckBatches(
       fixCycle,
       repoIndex,
       requireChange: true,
+      scanBlockedDependencies: true,
       observeBudget: options.observeBudget,
       cancellation: options.cancellation,
     });
@@ -472,6 +479,8 @@ async function runCheckBatches(
         run.collected,
         results,
         failures,
+        setupFailedRepositories,
+        fixCycle,
       );
     }
 
@@ -483,7 +492,7 @@ async function runCheckBatches(
     }
   }
 
-  return batchesResult(results, failures, setupFailedRepositories, ranChecks);
+  return batchesResult(results, failures, setupFailedRepositories, ranChecks, fixCycle);
 }
 
 /**
@@ -577,6 +586,11 @@ function stalledBatches(
   collected: CollectedRepoCheckBatch,
   results: PrePrCheckCommandResult[],
   failures: PrePrCheckFailure[],
+  /** Repositories earlier in this same pass whose setup failed. Carried so a
+   *  stall cannot quietly report setupFailed: false next to a summary that
+   *  says SETUP FAILED. */
+  setupFailedRepositories: string[],
+  fixCyclesRun: number,
 ): CheckBatchesResult {
   const stallFailure: PrePrCheckFailure = {
     provider,
@@ -593,10 +607,10 @@ function stalledBatches(
     passed: false,
     results: allResults,
     failures: allFailures,
-    setupFailed: false,
+    setupFailed: setupFailedRepositories.length > 0,
     stalled: true,
     hasRepairableFailures: false,
-    summary: formatPrePrCheckFailures(allFailures),
+    summary: formatPrePrCheckFailures(allFailures, setupFailedRepositories, fixCyclesRun),
     repairSummary: "",
   };
 }

--- a/apps/worker/src/workflows/blocks/run-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.test.ts
@@ -1,21 +1,33 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  sandboxGet: vi.fn(),
-  getDb: vi.fn(),
-  getCurrentPrePrCheckConfig: vi.fn(),
+  loadPrePrCheckConfigStep: vi.fn(),
   runPrePrChecksWithFixes: vi.fn(),
+  resolvePhaseStall: vi.fn(),
+  listWorkspaceRepositoriesStep: vi.fn(),
+  startRepoCheckBatchStep: vi.fn(),
+  collectRepoCheckBatchStep: vi.fn(),
+  pollPhaseUntilDone: vi.fn(),
   recordSuccessfulWorkspaceGate: vi.fn(),
 }));
 
-vi.mock("@vercel/sandbox", () => ({ Sandbox: { get: mocks.sandboxGet } }));
 vi.mock("../../sandbox/credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
-vi.mock("../../db/client.js", () => ({ getDb: mocks.getDb }));
-vi.mock("../../pre-pr-checks/store.js", () => ({
-  getCurrentPrePrCheckConfig: mocks.getCurrentPrePrCheckConfig,
+// Neither path is a step any more: both launch their checks detached and poll
+// them across ticks, so the block is exercised against the steps it drives.
+// Only the steps are replaced: the bounding, the derived cap and the stall
+// sentence stay real, because those are what this block is now made of.
+vi.mock("../../pre-pr-checks/runner.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../pre-pr-checks/runner.js")>()),
+  listWorkspaceRepositoriesStep: mocks.listWorkspaceRepositoriesStep,
+  startRepoCheckBatchStep: mocks.startRepoCheckBatchStep,
+  collectRepoCheckBatchStep: mocks.collectRepoCheckBatchStep,
 }));
-vi.mock("../../pre-pr-checks/runner.js", () => ({
+vi.mock("./poll-phase.js", () => ({ pollPhaseUntilDone: mocks.pollPhaseUntilDone }));
+vi.mock("./pre-pr-checks.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./pre-pr-checks.js")>()),
+  loadPrePrCheckConfigStep: mocks.loadPrePrCheckConfigStep,
   runPrePrChecksWithFixes: mocks.runPrePrChecksWithFixes,
+  resolvePhaseStall: mocks.resolvePhaseStall,
 }));
 // Isolate the gate-emission behavior from real sandbox inspection: keep the
 // invalidate mutator faithful (nulls the heap gate) and stub the recorder.
@@ -45,39 +57,6 @@ const trustedManifest: WorkspaceManifest = {
   }],
 };
 
-const manifest = JSON.stringify({
-  version: 1,
-  repositories: [
-    {
-      provider: "github",
-      repoPath: "acme/api",
-      slug: "api",
-      localPath: "/vercel/sandbox",
-      defaultBranch: "main",
-      branchName: "blazebot/awt-1",
-      selectedRationale: "selected",
-    },
-  ],
-});
-
-function sandboxRunningCommands(exitCodes: Record<string, number>) {
-  return {
-    runCommand: vi.fn(async (cmdOrSpec: unknown, args?: string[]) => {
-      if (cmdOrSpec === "cat" && args) {
-        return { exitCode: 0, stdout: async () => manifest, stderr: async () => "" };
-      }
-      const spec = cmdOrSpec as { args: string[] };
-      const command = spec.args[1];
-      const exitCode = exitCodes[command] ?? 0;
-      return {
-        exitCode,
-        stdout: async () => (exitCode === 0 ? "passed" : "boom output"),
-        stderr: async () => (exitCode === 0 ? "" : "boom error"),
-      };
-    }),
-  };
-}
-
 describe("run_checks paramsSchema", () => {
   it("accepts empty params, commands, or a required skip reason", () => {
     expect(paramsSchema.safeParse({}).success).toBe(true);
@@ -96,10 +75,63 @@ describe("run_checks paramsSchema", () => {
   });
 });
 
+/** What the collect step returns, with the fields this block never sets. */
+function collected(
+  overrides: Partial<{
+    results: Array<{ provider: string; repoPath: string; command: string; exitCode: number }>;
+    failures: Array<{
+      provider: string;
+      repoPath: string;
+      command: string;
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    }>;
+    progress: { completed: number; total: number; stoppedAt: string | null };
+  }> = {},
+) {
+  const results = overrides.results ?? [];
+  return {
+    results,
+    failures: overrides.failures ?? [],
+    setupFailed: false,
+    progress: overrides.progress ?? {
+      completed: results.length,
+      total: results.length,
+      stoppedAt: null,
+    },
+  };
+}
+
+/** A poll that records what it consumed before returning, as the real one does. */
+function pollEnds(reason: string, elapsedMs: number) {
+  return async (...args: unknown[]) => {
+    const tuning = args[6] as { outcome?: Record<string, unknown> } | undefined;
+    if (tuning?.outcome) Object.assign(tuning.outcome, { reason, elapsedMs, ticks: 12 });
+    return reason === "finished";
+  };
+}
+
 describe("run_checks execute", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getDb.mockReturnValue({ db: true });
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("finished", 30_000));
+    mocks.resolvePhaseStall.mockResolvedValue("none");
+    mocks.listWorkspaceRepositoriesStep.mockResolvedValue([
+      { provider: "github", repoPath: "acme/api" },
+    ]);
+    mocks.startRepoCheckBatchStep.mockImplementation(async (...args: unknown[]) => ({
+      skipped: false,
+      commandId: `cmd-${args[6]}`,
+      localPath: "/vercel/sandbox",
+      paths: {
+        launchId: `launch${args[6]}`,
+        dir: `/tmp/batch-${args[6]}`,
+        wrapper: `/tmp/batch-${args[6]}-wrapper.sh`,
+        sentinel: `/tmp/batch-${args[6]}-done`,
+      },
+    }));
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(collected());
   });
 
   it("fails when no workspace is attached", async () => {
@@ -129,9 +161,23 @@ describe("run_checks execute", () => {
   });
 
   it("returns kind next with ok false when explicit commands fail", async () => {
-    mocks.sandboxGet.mockResolvedValue(
-      sandboxRunningCommands({ "pnpm lint": 0, "pnpm test": 2 }),
-    );
+    mocks.collectRepoCheckBatchStep.mockResolvedValue({
+      results: [
+        { provider: "github", repoPath: "acme/api", command: "pnpm lint", exitCode: 0 },
+        { provider: "github", repoPath: "acme/api", command: "pnpm test", exitCode: 2 },
+      ],
+      failures: [
+        {
+          provider: "github",
+          repoPath: "acme/api",
+          command: "pnpm test",
+          exitCode: 2,
+          stdout: "boom output",
+          stderr: "boom error",
+        },
+      ],
+      setupFailed: false,
+    });
 
     const result = await execute(
       makeNode("run_checks", { commands: ["pnpm lint", "pnpm test"] }),
@@ -161,7 +207,13 @@ describe("run_checks execute", () => {
   });
 
   it("returns ok true when every command passes", async () => {
-    mocks.sandboxGet.mockResolvedValue(sandboxRunningCommands({}));
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [
+          { provider: "github", repoPath: "acme/api", command: "pnpm lint", exitCode: 0 },
+        ],
+      }),
+    );
 
     const result = await execute(
       makeNode("run_checks", { commands: ["pnpm lint"] }),
@@ -175,50 +227,186 @@ describe("run_checks execute", () => {
     expect(result.output!.failures).toEqual([]);
   });
 
-  it("aborts explicit commands at the remaining duration and starts no later command", async () => {
-    let startedCommands = 0;
-    const runCommand = vi.fn(async (cmdOrSpec: unknown, args?: string[]) => {
-      if (cmdOrSpec === "cat" && args) {
-        return { exitCode: 0, stdout: async () => manifest, stderr: async () => "" };
-      }
-      const spec = cmdOrSpec as { signal?: AbortSignal };
-      expect(spec.signal).toBeInstanceOf(AbortSignal);
-      startedCommands += 1;
-      throw new DOMException("duration expired", "TimeoutError");
+  it("runs explicit commands in every repository, with no setup and no change filter", async () => {
+    // This mode's contract: one flat command list, every attached repository,
+    // changed or not, and no provisioning phase of its own.
+    mocks.listWorkspaceRepositoriesStep.mockResolvedValue([
+      { provider: "github", repoPath: "acme/api" },
+      { provider: "github", repoPath: "acme/web" },
+    ]);
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(
+        collected({
+          results: [
+            { provider: "github", repoPath: "acme/api", command: "pnpm lint", exitCode: 0 },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        collected({
+          results: [
+            { provider: "github", repoPath: "acme/web", command: "pnpm lint", exitCode: 0 },
+          ],
+        }),
+      );
+
+    const result = await execute(
+      makeNode("run_checks", { commands: ["pnpm lint"] }),
+      {},
+      makeCtx(),
+    );
+
+    expect(result.output!.results).toEqual([
+      { repo: "github:acme/api", command: "pnpm lint", exitCode: 0 },
+      { repo: "github:acme/web", command: "pnpm lint", exitCode: 0 },
+    ]);
+    expect(mocks.startRepoCheckBatchStep).toHaveBeenCalledTimes(2);
+    for (const call of mocks.startRepoCheckBatchStep.mock.calls) {
+      expect(call[3]).toEqual([]);
+      expect(call[7]).toBe(false);
+    }
+  });
+
+  it("fails the block when an explicit batch stalls, never reporting a partial pass", async () => {
+    mocks.listWorkspaceRepositoriesStep.mockResolvedValue([
+      { provider: "github", repoPath: "acme/api" },
+      { provider: "github", repoPath: "acme/web" },
+    ]);
+    // The first repository finishes; the second never reports.
+    mocks.pollPhaseUntilDone
+      .mockImplementationOnce(pollEnds("finished", 30_000))
+      .mockImplementation(pollEnds("duration_cap", 1_500_000));
+    mocks.resolvePhaseStall.mockResolvedValue("timed_out");
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(
+        collected({
+          results: [
+            { provider: "github", repoPath: "acme/api", command: "pnpm lint", exitCode: 0 },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        collected({ progress: { completed: 0, total: 2, stoppedAt: "pnpm lint" } }),
+      );
+
+    const result = await execute(
+      makeNode("run_checks", { commands: ["pnpm lint", "pnpm test"] }),
+      {},
+      makeCtx(),
+    );
+
+    expect(result.kind).toBe("next");
+    expect(result.output!.ok).toBe(false);
+    expect(result.output!.outcome).toBe("failed");
+    const failures = result.output!.failures as Array<Record<string, unknown>>;
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      repo: "github:acme/web",
+      command: "pnpm lint",
+      exitCode: -1,
     });
-    mocks.sandboxGet.mockResolvedValue({ runCommand });
+    // The same rule as the configured path: a stall is never a pass, and the
+    // sentence says where the batch actually got to.
+    expect(failures[0]!.output).toContain("ran for 25 minutes without finishing");
+    expect(failures[0]!.output).toContain("0 of 2 commands had finished");
+    expect(failures[0]!.output).toContain("this is a timeout");
+    // The finished repository's commands are still reported, but they never
+    // become a pass, and the stalled batch is read back as abandoned.
+    expect(result.output!.results).toEqual([
+      { repo: "github:acme/api", command: "pnpm lint", exitCode: 0 },
+    ]);
+    expect(mocks.collectRepoCheckBatchStep).toHaveBeenCalledTimes(2);
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[1]!.at(-1)).toBe(false);
+  });
+
+  it("bounds an explicit batch by the run's remaining duration", async () => {
+    await execute(makeNode("run_checks", { commands: ["pnpm lint"] }), {}, makeCtx());
+
+    // makeCtx observes 30 minutes remaining, which is below the ceiling. The
+    // bound is milliseconds and sits just above the budget on purpose, so the
+    // budget stop is always the error that fires rather than a phase timeout
+    // that would report a failing check run instead of an exhausted run.
+    const tuning = mocks.pollPhaseUntilDone.mock.calls[0]![6] as {
+      phaseLimitMs?: number;
+    };
+    expect(tuning.phaseLimitMs).toBe(1_860_000);
+  });
+
+  it("bounds a failure's output instead of cutting its head off", async () => {
+    // The block's output field is read in the dashboard and fed to later
+    // prompts, so it stays small; but a head slice of a long log lands in the
+    // middle of it, showing neither the first error nor the verdict.
+    const long = `FIRST_ERROR${"x".repeat(9_000)}LAST_ERROR`;
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({
+        results: [
+          { provider: "github", repoPath: "acme/api", command: "pnpm test", exitCode: 1 },
+        ],
+        failures: [{
+          provider: "github",
+          repoPath: "acme/api",
+          command: "pnpm test",
+          exitCode: 1,
+          stdout: "",
+          stderr: long,
+        }],
+      }),
+    );
+
+    const result = await execute(
+      makeNode("run_checks", { commands: ["pnpm test"] }),
+      {},
+      makeCtx(),
+    );
+
+    const output = (result.output!.failures as Array<{ output: string }>)[0]!.output;
+    expect(output.startsWith("FIRST_ERROR")).toBe(true);
+    expect(output.endsWith("LAST_ERROR")).toBe(true);
+    expect(output).toContain("characters omitted");
+    expect(output.length).toBe(2_000);
+  });
+
+  it("rethrows a budget stop raised while an explicit batch is polled, naming its progress", async () => {
+    // The old wall-clock AbortSignal is gone. The bound is now the budget
+    // observer that pollPhaseUntilDone re-reads on every tick, and its stop
+    // must terminate the run rather than become a block failure edge. The
+    // batch's files are still read first: a run that ends here otherwise
+    // reports nothing at all about how far its checks got.
     const failure = {
       status: "budget_exceeded" as const,
       metric: "duration" as const,
       limit: 100,
       consumed: 100,
-      reason: "budget_exceeded: duration 100 reached limit 100 during Run checks",
+      reason: "budget_exceeded: duration 100 reached limit 100 while command is active",
     };
-    const ctx = makeCtx({
-      observeBudget: vi
-        .fn()
-        .mockResolvedValueOnce({
-          check: { status: "ok" },
-          remainingDurationMs: 25,
-          durationLimitMs: 100,
-          activeElapsedMs: 75,
-        })
-        .mockResolvedValueOnce({ check: failure, remainingDurationMs: 0 }),
-    });
+    mocks.pollPhaseUntilDone.mockRejectedValue(
+      Object.assign(new Error(failure.reason), { name: "RunBudgetError", failure }),
+    );
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({ progress: { completed: 1, total: 2, stoppedAt: "pnpm test" } }),
+    );
 
     await expect(
       execute(
         makeNode("run_checks", { commands: ["pnpm lint", "pnpm test"] }),
         {},
-        ctx,
+        makeCtx(),
       ),
-    ).rejects.toMatchObject({ name: "RunBudgetError", failure });
+    ).rejects.toMatchObject({
+      name: "RunBudgetError",
+      failure: {
+        status: "budget_exceeded",
+        metric: "duration",
+        reason: expect.stringContaining("while running `pnpm test`; 1 of 2 commands had finished"),
+      },
+    });
 
-    expect(startedCommands).toBe(1);
+    expect(mocks.collectRepoCheckBatchStep).toHaveBeenCalledTimes(1);
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]!.at(-1)).toBe(false);
   });
 
   it("runs the pre-PR-checks config report-only when no commands are set", async () => {
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({
       version: 3,
       config: { repositories: [{ provider: "github", repoPath: "acme/api", commands: ["pnpm lint"] }] },
     });
@@ -250,12 +438,16 @@ describe("run_checks execute", () => {
     const result = await execute(makeNode("run_checks"), {}, makeCtx());
 
     expect(mocks.runPrePrChecksWithFixes).toHaveBeenCalledWith(
-      "sbx-1",
-      { repositories: [{ provider: "github", repoPath: "acme/api", commands: ["pnpm lint"] }] },
-      "claude",
-      "claude-model",
-      0,
-      1_800_000,
+      expect.objectContaining({
+        sandboxId: "sbx-1",
+        config: {
+          repositories: [{ provider: "github", repoPath: "acme/api", commands: ["pnpm lint"] }],
+        },
+        agentKind: "claude",
+        model: "claude-model",
+        maxFixCycles: 0,
+        observeBudget: expect.any(Function),
+      }),
     );
     expect(result.kind).toBe("next");
     expect(result.output!.ok).toBe(false);
@@ -271,7 +463,7 @@ describe("run_checks execute", () => {
   it("durably emits the recorded gate in its passed configured output", async () => {
     const gate = { configurationVersion: 5, fingerprint: "fp-run-checks" };
     mocks.recordSuccessfulWorkspaceGate.mockResolvedValue(gate);
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({
       version: 5,
       config: { repositories: [{ provider: "github", repoPath: "acme/api", commands: ["pnpm lint"] }] },
     });
@@ -298,7 +490,7 @@ describe("run_checks execute", () => {
 
   it("emits a null gate when a configured run passes but records no gate", async () => {
     // No workspace manifest -> the record branch is skipped, so no durable gate.
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue({
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({
       version: 5,
       config: { repositories: [{ provider: "github", repoPath: "acme/api", commands: ["pnpm lint"] }] },
     });
@@ -318,7 +510,7 @@ describe("run_checks execute", () => {
   });
 
   it("distinguishes missing configured checks from an intentional skip", async () => {
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue(null);
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({ version: null, config: { repositories: [] } });
     mocks.runPrePrChecksWithFixes.mockResolvedValue({
       outcome: "missing_configuration",
       passed: true,
@@ -343,8 +535,8 @@ describe("run_checks execute", () => {
     });
   });
 
-  it("passes the remaining duration to configured checks and classifies their abort", async () => {
-    mocks.getCurrentPrePrCheckConfig.mockResolvedValue(null);
+  it("hands configured checks the run budget observer and classifies their abort", async () => {
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({ version: null, config: { repositories: [] } });
     mocks.runPrePrChecksWithFixes.mockRejectedValue(
       new DOMException("duration expired", "TimeoutError"),
     );
@@ -372,17 +564,21 @@ describe("run_checks execute", () => {
       failure,
     });
     expect(mocks.runPrePrChecksWithFixes).toHaveBeenCalledWith(
-      "sbx-1",
-      { repositories: [] },
-      "claude",
-      "claude-model",
-      0,
-      25,
+      expect.objectContaining({
+        sandboxId: "sbx-1",
+        config: { repositories: [] },
+        agentKind: "claude",
+        model: "claude-model",
+        maxFixCycles: 0,
+        // The wall-clock deadline is gone: pollPhaseUntilDone re-reads this
+        // observer on every tick instead.
+        observeBudget: expect.any(Function),
+      }),
     );
   });
 
   it("maps infrastructure errors to a failed result", async () => {
-    mocks.sandboxGet.mockRejectedValue(new Error("sandbox gone"));
+    mocks.listWorkspaceRepositoriesStep.mockRejectedValue(new Error("sandbox gone"));
 
     const result = await execute(
       makeNode("run_checks", { commands: ["pnpm lint"] }),
@@ -395,7 +591,7 @@ describe("run_checks execute", () => {
   });
 
   it.each(runControlErrorCases())("rethrows %s from checks", async (_label, error) => {
-    mocks.sandboxGet.mockRejectedValue(error);
+    mocks.listWorkspaceRepositoriesStep.mockRejectedValue(error);
 
     await expect(
       execute(

--- a/apps/worker/src/workflows/blocks/run-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.test.ts
@@ -267,14 +267,41 @@ describe("run_checks execute", () => {
     }
   });
 
-  it("asks for no missing-dependency scan, which this mode never had", async () => {
-    // The block runs whatever an author typed and its description promises
-    // nothing but the exit code. Six English phrases must not turn a green
-    // suite into a failed check; this repository's own test names contain the
-    // exact wording.
-    await execute(makeNode("run_checks", { commands: ["pnpm test"] }), {}, makeCtx());
+  it("keeps the sentence explaining a failure out of the truncated payload", async () => {
+    // A check that exits 0 because it never ran is reported as a failure, and
+    // the only thing saying why is the note. This block's failure shape has one
+    // `output` string, so the note is appended after the bound: folded in
+    // before it, it would sit at the join between the two streams, which is
+    // exactly the middle a head-and-tail bound deletes.
+    mocks.collectRepoCheckBatchStep.mockResolvedValue({
+      results: [{ provider: "github", repoPath: "acme/api", command: "yarn test", exitCode: 0 }],
+      failures: [
+        {
+          provider: "github",
+          repoPath: "acme/api",
+          command: "yarn test",
+          exitCode: 0,
+          stdout: `HEAD${"y".repeat(40_000)}TAIL`,
+          stderr: "",
+          note: "Pre-PR check exited 0 but its dependencies are not installed.",
+        },
+      ],
+      setupFailed: false,
+    });
 
-    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]![8]).toBe(false);
+    const result = await execute(
+      makeNode("run_checks", { commands: ["yarn test"] }),
+      {},
+      makeCtx(),
+    );
+
+    const { failures } = result.output! as unknown as {
+      failures: Array<{ output: string }>;
+    };
+    const output = failures[0]!.output;
+    expect(output).toContain("dependencies are not installed");
+    expect(output).toContain("HEAD");
+    expect(output).toContain("TAIL");
   });
 
   it("fails the block when an explicit batch stalls, never reporting a partial pass", async () => {

--- a/apps/worker/src/workflows/blocks/run-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.test.ts
@@ -267,6 +267,16 @@ describe("run_checks execute", () => {
     }
   });
 
+  it("asks for no missing-dependency scan, which this mode never had", async () => {
+    // The block runs whatever an author typed and its description promises
+    // nothing but the exit code. Six English phrases must not turn a green
+    // suite into a failed check; this repository's own test names contain the
+    // exact wording.
+    await execute(makeNode("run_checks", { commands: ["pnpm test"] }), {}, makeCtx());
+
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]![8]).toBe(false);
+  });
+
   it("fails the block when an explicit batch stalls, never reporting a partial pass", async () => {
     mocks.listWorkspaceRepositoriesStep.mockResolvedValue([
       { provider: "github", repoPath: "acme/api" },
@@ -316,7 +326,7 @@ describe("run_checks execute", () => {
       { repo: "github:acme/api", command: "pnpm lint", exitCode: 0 },
     ]);
     expect(mocks.collectRepoCheckBatchStep).toHaveBeenCalledTimes(2);
-    expect(mocks.collectRepoCheckBatchStep.mock.calls[1]!.at(-1)).toBe(false);
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[1]![7]).toBe(false);
   });
 
   it("bounds an explicit batch by the run's remaining duration", async () => {
@@ -402,7 +412,7 @@ describe("run_checks execute", () => {
     });
 
     expect(mocks.collectRepoCheckBatchStep).toHaveBeenCalledTimes(1);
-    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]!.at(-1)).toBe(false);
+    expect(mocks.collectRepoCheckBatchStep.mock.calls[0]![7]).toBe(false);
   });
 
   it("runs the pre-PR-checks config report-only when no commands are set", async () => {

--- a/apps/worker/src/workflows/blocks/run-checks.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import type { AgentKind } from "../../sandbox/agents/index.js";
-import type { CheckOutcome } from "../../pre-pr-checks/runner.js";
+import {
+  boundFailureOutput,
+  listWorkspaceRepositoriesStep,
+  type CheckOutcome,
+  type CollectedRepoCheckBatch,
+} from "../../pre-pr-checks/runner.js";
 import {
   RunBudgetError,
   durationBudgetFailure,
@@ -11,7 +15,19 @@ import {
   invalidateWorkspaceGate,
   recordSuccessfulWorkspaceGate,
 } from "../workspace-gate.js";
-import { executionError, type BlockExecuteFn, type BlockExecutionResult } from "./types.js";
+import {
+  batchStallReason,
+  loadPrePrCheckConfigStep,
+  runPrePrChecksWithFixes,
+  runRepoCheckBatch,
+  type PrePrChecksOptions,
+} from "./pre-pr-checks.js";
+import {
+  blockBudgetObserver,
+  executionError,
+  type BlockExecuteFn,
+  type BlockExecutionResult,
+} from "./types.js";
 
 export const paramsSchema = z
   .object({
@@ -29,6 +45,8 @@ export const paramsSchema = z
     }
   });
 
+/** Per-failure output the block reports. Kept at the historical size: it is a
+ *  block output field, read in the dashboard and fed to later prompts. */
 const OUTPUT_TRUNCATE = 2000;
 
 interface RunChecksStepResult {
@@ -37,63 +55,131 @@ interface RunChecksStepResult {
   failures: Array<{ repo: string; command: string; exitCode: number; output: string }>;
 }
 
-async function blockRunChecksCommandsStep(
+function toBlockResults(
+  collected: CollectedRepoCheckBatch,
+): RunChecksStepResult["results"] {
+  return collected.results.map((result) => ({
+    repo: `${result.provider}:${result.repoPath}`,
+    command: result.command,
+    exitCode: result.exitCode,
+  }));
+}
+
+function toBlockFailures(
+  collected: CollectedRepoCheckBatch,
+): RunChecksStepResult["failures"] {
+  return collected.failures.map((failure) => ({
+    repo: `${failure.provider}:${failure.repoPath}`,
+    command: failure.command,
+    exitCode: failure.exitCode,
+    output: boundFailureOutput(
+      [failure.stderr, failure.stdout]
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .join("\n"),
+      OUTPUT_TRUNCATE,
+    ),
+  }));
+}
+
+/**
+ * Explicit-commands checks: every authored command, in every workspace
+ * repository, launched detached per repository and polled across ticks.
+ *
+ * Deliberately NOT a "use step", for the same reason the configured path is
+ * not. This mode used to run its commands inline under an
+ * `AbortSignal.timeout(remainingDurationMs)`, which reads like a bound but is
+ * not one: that signal can only fire while the remaining budget happens to be
+ * under the 300s a function invocation gets, and above that the invocation is
+ * killed before the signal can reach it. So this was never the safe mode with
+ * a timeout, it was the same defect wearing a timeout that cannot fire. The
+ * real bound is the budget observer, which pollPhaseUntilDone re-reads on
+ * every tick.
+ */
+async function runExplicitCommands(
   sandboxId: string,
   commands: string[],
-  timeoutMs: number,
+  observeBudget: PrePrChecksOptions["observeBudget"],
+  cancellation: PrePrChecksOptions["cancellation"],
 ): Promise<RunChecksStepResult> {
-  "use step";
-  const signal = AbortSignal.timeout(Math.max(1, Math.floor(timeoutMs)));
-  const { Sandbox } = await import("@vercel/sandbox");
-  const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
-  const { parseWorkspaceManifest, WORKSPACE_MANIFEST_PATH } = await import(
-    "../../sandbox/repo-workspace.js"
-  );
-
-  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
-  const manifestResult = await sandbox.runCommand("cat", [WORKSPACE_MANIFEST_PATH]);
-  if (manifestResult.exitCode !== 0) {
-    throw new Error(`Workspace manifest not found in sandbox at ${WORKSPACE_MANIFEST_PATH}`);
-  }
-  const manifest = parseWorkspaceManifest(await manifestResult.stdout());
-
+  const repositories = await listWorkspaceRepositoriesStep(sandboxId);
   const results: RunChecksStepResult["results"] = [];
   const failures: RunChecksStepResult["failures"] = [];
-  for (const repo of manifest.repositories) {
-    const repoKey = `${repo.provider}:${repo.repoPath}`;
-    for (const command of commands) {
-      const result = await sandbox.runCommand({
-        cmd: "bash",
-        args: ["-lc", command],
-        cwd: repo.localPath,
-        signal,
-      });
-      results.push({ repo: repoKey, command, exitCode: result.exitCode });
-      if (result.exitCode !== 0) {
-        const stdout = (await result.stdout()).trim();
-        const stderr = ((await result.stderr?.()) ?? "").trim();
-        failures.push({
-          repo: repoKey,
-          command,
-          exitCode: result.exitCode,
-          output: [stderr, stdout].filter(Boolean).join("\n").slice(0, OUTPUT_TRUNCATE),
-        });
-      }
+
+  for (const [repoIndex, repo] of repositories.entries()) {
+    const run = await runRepoCheckBatch({
+      sandboxId,
+      provider: repo.provider,
+      repoPath: repo.repoPath,
+      // This mode authors no provisioning: the block takes one flat command
+      // list and nothing else, so its batches always carry an empty setup
+      // phase and the collector's setupFailed has nothing that can raise it.
+      setup: [],
+      commands,
+      fixCycle: 0,
+      repoIndex,
+      // Every attached repository runs, changed or not. That is this mode's
+      // contract, and it never inspected HEAD before.
+      requireChange: false,
+      observeBudget,
+      cancellation,
+    });
+    if (run.skipped) continue;
+
+    if (run.stall) {
+      // A batch that outlived its bound or lost its sandbox verified nothing,
+      // so it fails the block rather than reporting the commands that had
+      // already finished as a pass. The walk stops with it: every later
+      // repository's result would be meaningless anyway.
+      return {
+        outcome: "failed",
+        results: [...results, ...toBlockResults(run.collected)],
+        failures: [
+          ...failures,
+          ...toBlockFailures(run.collected),
+          {
+            repo: `${repo.provider}:${repo.repoPath}`,
+            command: run.collected.progress.stoppedAt ?? "(check batch)",
+            exitCode: -1,
+            output: boundFailureOutput(
+              batchStallReason(run.stall, run.elapsedMs, run.collected.progress),
+              OUTPUT_TRUNCATE,
+            ),
+          },
+        ],
+      };
     }
+
+    // run.collected.setupFailed cannot be true here: it is raised only by an
+    // authored setup command, of which this mode has none. A workspace that
+    // could not be entered arrives as an ordinary failing entry, which is all
+    // this block can carry anyway: its output contract has no phase field.
+    results.push(...toBlockResults(run.collected));
+    failures.push(...toBlockFailures(run.collected));
   }
+
   return {
     outcome: failures.length > 0 ? "failed" : "passed",
     results,
     failures,
   };
 }
-blockRunChecksCommandsStep.maxRetries = 0;
 
-async function blockRunChecksConfiguredStep(
+/**
+ * Report-only configured checks.
+ *
+ * Deliberately NOT a "use step": the checks themselves are launched detached
+ * and polled across ticks by runPrePrChecksWithFixes, because a real client
+ * tenant's checks take far longer than the 300s a single function invocation
+ * gets. Wrapping this in a step would put the whole poll back inside one
+ * invocation and reinstate exactly the defect the poll exists to avoid.
+ */
+async function runConfiguredChecks(
   sandboxId: string,
-  agentKind: AgentKind,
+  agentKind: PrePrChecksOptions["agentKind"],
   model: string,
-  timeoutMs: number,
+  observeBudget: PrePrChecksOptions["observeBudget"],
+  cancellation: PrePrChecksOptions["cancellation"],
 ): Promise<
   Omit<RunChecksStepResult, "outcome"> & {
     outcome: Exclude<CheckOutcome, "skipped">;
@@ -101,30 +187,27 @@ async function blockRunChecksConfiguredStep(
     summary: string;
   }
 > {
-  "use step";
-  const { getDb } = await import("../../db/client.js");
-  const { getCurrentPrePrCheckConfig } = await import("../../pre-pr-checks/store.js");
-  const { emptyPrePrCheckConfig } = await import("../../pre-pr-checks/config.js");
-  const { runPrePrChecksWithFixes } = await import("../../pre-pr-checks/runner.js");
-
-  const current = await getCurrentPrePrCheckConfig(getDb());
-  const run = await runPrePrChecksWithFixes(
+  const current = await loadPrePrCheckConfigStep();
+  const run = await runPrePrChecksWithFixes({
     sandboxId,
-    current?.config ?? emptyPrePrCheckConfig,
+    config: current.config,
     agentKind,
     model,
-    0,
-    timeoutMs,
-  );
+    maxFixCycles: 0,
+    observeBudget,
+    cancellation,
+  });
   const failures = run.failures.map((failure) => ({
     repo: `${failure.provider}:${failure.repoPath}`,
     command: failure.command,
     exitCode: failure.exitCode,
-    output: [failure.stderr, failure.stdout]
-      .map((part) => part.trim())
-      .filter(Boolean)
-      .join("\n")
-      .slice(0, OUTPUT_TRUNCATE),
+    output: boundFailureOutput(
+      [failure.stderr, failure.stdout]
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .join("\n"),
+      OUTPUT_TRUNCATE,
+    ),
   }));
   const results = (run.results ?? run.failures).map((result) => ({
     repo: `${result.provider}:${result.repoPath}`,
@@ -133,20 +216,19 @@ async function blockRunChecksConfiguredStep(
   }));
   const outcome =
     run.outcome ??
-    (current === null || current.config.repositories.length === 0
+    (current.config.repositories.length === 0
       ? "missing_configuration"
       : run.passed
         ? "passed"
         : "failed");
   return {
     outcome,
-    configurationVersion: current?.version ?? null,
+    configurationVersion: current.version,
     results,
     failures,
     summary: run.summary,
   };
 }
-blockRunChecksConfiguredStep.maxRetries = 0;
 
 /**
  * run_checks: report-only check runner. With a commands param it runs each
@@ -156,7 +238,13 @@ blockRunChecksConfiguredStep.maxRetries = 0;
  * ok: false } when checks ran and failed, reserving kind "execution_error" for
  * infrastructure errors (checks could not run at all).
  */
-export const execute: BlockExecuteFn = async (block, _steps, ctx): Promise<BlockExecutionResult> => {
+export const execute: BlockExecuteFn = async (
+  block,
+  _steps,
+  ctx,
+  _resolvedInputs,
+  execution,
+): Promise<BlockExecutionResult> => {
   const skipReason =
     typeof block.params.skipReason === "string" ? block.params.skipReason.trim() : "";
   if (skipReason) {
@@ -184,17 +272,22 @@ export const execute: BlockExecuteFn = async (block, _steps, ctx): Promise<Block
     : [];
   const budget = await ctx.observeBudget();
   if (budget.check.status !== "ok") throw new RunBudgetError(budget.check);
-  const timeoutMs = Math.max(1, Math.floor(budget.remainingDurationMs));
 
   try {
     const result =
       commands.length > 0
-        ? await blockRunChecksCommandsStep(ctx.sandboxId, commands, timeoutMs)
-        : await blockRunChecksConfiguredStep(
+        ? await runExplicitCommands(
+            ctx.sandboxId,
+            commands,
+            blockBudgetObserver(ctx, execution),
+            execution?.cancellation,
+          )
+        : await runConfiguredChecks(
             ctx.sandboxId,
             ctx.runDefaultKind,
             ctx.defaults[ctx.runDefaultKind],
-            timeoutMs,
+            blockBudgetObserver(ctx, execution),
+            execution?.cancellation,
           );
     if (
       "configurationVersion" in result &&

--- a/apps/worker/src/workflows/blocks/run-checks.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.ts
@@ -4,6 +4,7 @@ import {
   listWorkspaceRepositoriesStep,
   type CheckOutcome,
   type CollectedRepoCheckBatch,
+  type PrePrCheckFailure,
 } from "../../pre-pr-checks/runner.js";
 import {
   RunBudgetError,
@@ -68,18 +69,39 @@ function toBlockResults(
 function toBlockFailures(
   collected: CollectedRepoCheckBatch,
 ): RunChecksStepResult["failures"] {
-  return collected.failures.map((failure) => ({
+  return collected.failures.map(toBlockFailure);
+}
+
+function toBlockFailure(
+  failure: PrePrCheckFailure,
+): RunChecksStepResult["failures"][number] {
+  return {
     repo: `${failure.provider}:${failure.repoPath}`,
     command: failure.command,
     exitCode: failure.exitCode,
-    output: boundFailureOutput(
-      [failure.stderr, failure.stdout]
-        .map((part) => part.trim())
-        .filter(Boolean)
-        .join("\n"),
-      OUTPUT_TRUNCATE,
-    ),
-  }));
+    output: failureOutput(failure),
+  };
+}
+
+/**
+ * The command's own output, bounded, then the note on its own line.
+ *
+ * The note is appended AFTER the bound on purpose. This block's failure shape
+ * has one `output` string and no field for a note, so folding the note into a
+ * stream before bounding puts it at the join between stderr and stdout, which
+ * is the middle a head-and-tail bound deletes: an operator would read
+ * `exitCode: 0` under a heading that says failures with nothing saying why.
+ */
+function failureOutput(failure: PrePrCheckFailure): string {
+  const output = boundFailureOutput(
+    [failure.stderr, failure.stdout]
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .join("\n"),
+    OUTPUT_TRUNCATE,
+  );
+  if (!failure.note) return output;
+  return output ? `${output}\n${failure.note}` : failure.note;
 }
 
 /**
@@ -121,11 +143,6 @@ async function runExplicitCommands(
       // Every attached repository runs, changed or not. That is this mode's
       // contract, and it never inspected HEAD before.
       requireChange: false,
-      // And it never scanned output for missing-dependency phrases either. The
-      // block runs whatever an author typed and promises nothing but the exit
-      // code, so a green suite whose output mentions one of six English
-      // sentences must not come back failed.
-      scanBlockedDependencies: false,
       observeBudget,
       cancellation,
     });
@@ -202,18 +219,7 @@ async function runConfiguredChecks(
     observeBudget,
     cancellation,
   });
-  const failures = run.failures.map((failure) => ({
-    repo: `${failure.provider}:${failure.repoPath}`,
-    command: failure.command,
-    exitCode: failure.exitCode,
-    output: boundFailureOutput(
-      [failure.stderr, failure.stdout]
-        .map((part) => part.trim())
-        .filter(Boolean)
-        .join("\n"),
-      OUTPUT_TRUNCATE,
-    ),
-  }));
+  const failures = run.failures.map(toBlockFailure);
   const results = (run.results ?? run.failures).map((result) => ({
     repo: `${result.provider}:${result.repoPath}`,
     command: result.command,

--- a/apps/worker/src/workflows/blocks/run-checks.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.ts
@@ -121,6 +121,11 @@ async function runExplicitCommands(
       // Every attached repository runs, changed or not. That is this mode's
       // contract, and it never inspected HEAD before.
       requireChange: false,
+      // And it never scanned output for missing-dependency phrases either. The
+      // block runs whatever an author typed and promises nothing but the exit
+      // code, so a green suite whose output mentions one of six English
+      // sentences must not come back failed.
+      scanBlockedDependencies: false,
       observeBudget,
       cancellation,
     });


### PR DESCRIPTION
## The defect

Pre-PR checks ran inside ONE Vercel Workflow (WDK) step. Vercel kills an invocation at roughly 300 seconds, so any configuration whose commands outlive that died mid-`await`, and the run reported no recoverable cause.

Reproduced on our own production, not inferred from the client tenant. Run `wrun_01M0CGC9GEMEBC3THA2DNBECNJ` (ticket AWP-100, definition 14 v6) against a fixture repository shaped like the client's: setup phase installing `uv`, then `uv sync --frozen`, black, isort, autoflake, mypy, and a pytest marker that burns 600 seconds of wall clock.

- `checks` node lived 08:02:30.862Z to 08:08:29.493Z, **358631 ms**, then died.
- `Step "step//./src/workflows/agent//runPrePrChecksStep" failed after 0 retries: terminated`
- The underlying throw is an undici `TypeError: terminated` at `Fetch.onAborted` / `TLSSocket.onHttpSocketClose`: the outbound connection `sandbox.runCommand` was holding got cut.
- Not one line of `uv` output reached the worker, because that output travels on the very connection that was cut. That is the blindness this fix has to remove, not just the failure.

Two signatures describe one mechanism, and confusing them costs a day: `failed after 0 retries: terminated` is a real throw carrying its cause, while `exceeded max retries (1 retry)` is WDK's re-invocation guard firing before user code runs. Which one you see depends on whether the invocation managed to record a terminal event.

## The fix

Mirror the pattern this repository already uses for agent phases (`writeAndStartPhase` → `pollPhaseUntilDone` → `collectPhase`). Per repository, a generated wrapper runs that repository's setup commands then its check commands, writing per-command output files and touching a sentinel LAST. It is launched `detached: true` from a short step that returns the command id. `pollPhaseUntilDone` then polls with short steps, so no single invocation ever blocks near the ceiling. Fix cycles, the repository walk and the repair agent all moved from inside the step to workflow scope. Both modes of `run_checks` are covered: leaving the explicit-`commands` mode alone would have left the identical outage one dashboard toggle away.

Load-bearing detail: **every command inside the wrapper still runs as its own `bash -lc`**, and the wrapper itself is not a login shell. The client's setup appends a PATH export to the shell profile and relies on later commands picking it up. Collapsing the batch into one shell body would break toolchain setup silently. This is asserted on the generated text and was also proven by executing the wrapper under real bash.

## Review history

One reviewer pass approved both axes. Two adversarial passes then found twenty problems, all fixed. The ones worth naming, because each was a defect this change would have introduced:

- **A false PASS was reachable.** Two wrappers sharing a path set could union their outputs into a complete set of zero exits for a batch no single process ran end to end. Launch identity is now baked into the directory, the wrapper path and the sentinel.
- **The fix reproduced its own defect.** On the stall and budget paths the per-command exit files sat in the sandbox and nothing read them. They are collected now, and the operator gets "stopped while running `uv run pytest tests/ -m integration`; 3 of 5 commands had finished".
- **The evidence collector called a sandbox it had just observed as dead**, unguarded, so the mechanism failed in exactly the case it was written for.
- **`trap 'kill 0' TERM INT` was added and then removed.** Bash does not run a trap while a foreground command is executing, so it could only fire once the check had already finished, and `kill 0` signals the whole process group. Proven by execution rather than argued.
- **The fix agent was being handed the middle of a large log**: the collector kept the tail, then the consumer sliced the head. Head and tail both survive now, because `tsc` and `mypy` put the root cause first while `pytest` puts the summary last.
- **Budget exhaustion was reported as a check timeout**, non-deterministically, because the derived cap floored below the remaining budget.
- **The blocked-dependency guard was reading truncated text.** The reader now greps the whole file in the sandbox and emits a flag, so truncation is cosmetic again.

## Verification

- 143 tests across the six affected files, and 276 in the adjacent schema, block-registry and budget suites.
- Worker typecheck clean.
- The generated reader and wrapper executed under real bash against present, missing, empty and 40 KB files.

Production verification against the same fixture follows once this is deployed. PR #317 (the release gate) is deliberately held until then, because until this lands no rehearsal can succeed.
