### PR TITLE
docs(release): record the Artur 2026.08.8 release rehearsal

### DIFF
--- a/docs/releases/artur/rehearsals/2026.08.8.json
+++ b/docs/releases/artur/rehearsals/2026.08.8.json
@@ -1,0 +1,11 @@
+{
+  "version": "2026.08.8",
+  "sourceCommit": "0a3757375c9acc15897a0ef314bdfa9fa21487fb",
+  "runId": "wrun_01M0DZ6XDGBMV31JB3A8QH32P2",
+  "runUrl": "https://ai-workflow-app-dashboard.vercel.app/trace/wrun_01M0DZ6XDGBMV31JB3A8QH32P2",
+  "repository": "Blazity/aiw-checks-fixture",
+  "checksDurationSec": 1366,
+  "outcome": "success",
+  "recordedAt": "2026-08-19T22:06:13Z",
+  "recordedBy": "filip.maszota@blazity.com"
+}


### PR DESCRIPTION
Records the production rehearsal that the Artur synchronization gate requires for 2026.08.8.

The run went end to end on our own production against `Blazity/aiw-checks-fixture`, at the exact source commit the release pins, and reached the **open pull request** node green. It opened [aiw-checks-fixture#4](https://github.com/Blazity/aiw-checks-fixture/pull/4).

| Field | Value |
| --- | --- |
| Run | `wrun_01M0DZ6XDGBMV31JB3A8QH32P2` |
| Source commit | `0a3757375c9acc15897a0ef314bdfa9fa21487fb` |
| Checks phase | 1366 s (the 300 s floor exists because one Vercel invocation ends there) |
| Outcome | success |

## What the rehearsal turned up

Five earlier attempts at this rehearsal all died at the publication gate with "The checks could not be started". The only thing that changed for the green run was `maxFixCycles: 3` on the pre-PR checks node, with the same ticket, the same repository and the same commit.

That means the fixture's checks fail on the first pass and the repair agent has been quietly fixing them. [#320](https://github.com/Blazity/ai-workflow/pull/320), which is in this release, turns that repair off by default, so the same work now stops at the gate instead of publishing. Worth saying plainly to anyone whose runs have been green up to now: some of that green may have been the repair loop rather than clean checks.

Two smaller things surfaced on the way and are not addressed here:

* Nothing in the product names the check command that failed. Not the Jira comment, not `runs.diagnose`, not the trace API. Narrowing the cause above took five runs of roughly twenty minutes each; one log line would have settled it.
* The Pre-PR checks page still says "Failed checks trigger up to 3 agent fix cycles, then block publication", which #320 made untrue.
