### PR TITLE
fix(worker): let an autofix run publish the head it pushed itself (AIW-310)

### DIFF
--- a/apps/worker/src/mcp/run-diagnosis.test.ts
+++ b/apps/worker/src/mcp/run-diagnosis.test.ts
@@ -313,6 +313,41 @@ describe("diagnoseRun", () => {
     });
   });
 
+  // Real shape from wrun_01M0EZGR2CEH4JG480D9N746AN: the finalize block wraps
+  // the staleness assertion in the generic provider sentence, so the prefix
+  // alone read as dependency_unavailable and advised checking the AI provider's
+  // status page for a pull request somebody had pushed to.
+  it("classifies a moved source pull request head ahead of the provider prefix", () => {
+    const result = diagnoseRun({
+      status: "failed",
+      error: {
+        message:
+          "An external service could not complete this block. (stale PR/MR head for " +
+          "github:acme/api #7: triggered at trigger-head, current head is pushed-head)",
+      },
+      steps: [],
+    });
+    expect(result).toEqual({
+      category: "source_pull_request_moved",
+      confidence: "low",
+      evidenceRefs: [],
+      nextActions: expect.any(Array),
+    });
+  });
+
+  it("classifies a retargeted source pull request the same way", () => {
+    const result = diagnoseRun({
+      status: "failed",
+      error: {
+        message:
+          "An external service could not complete this block. (stale PR/MR target for " +
+          "gitlab:group/demo #9: triggered at main, current target is develop)",
+      },
+      steps: [],
+    });
+    expect(result).toMatchObject({ category: "source_pull_request_moved" });
+  });
+
   // Real shape: agent-CLI runtime-prep/execution sentences set directly as
   // `options.message` (never composed from raw provider text): protocol.ts:
   // 122/131/243/418 ("The agent runtime could not be prepared.") and

--- a/apps/worker/src/mcp/run-diagnosis.ts
+++ b/apps/worker/src/mcp/run-diagnosis.ts
@@ -35,6 +35,7 @@ export type RunDiagnosisCategory =
   | "sandbox_timeout"
   | "workspace_unavailable"
   | "workspace_gate"
+  | "source_pull_request_moved"
   | "validation_failed"
   | "budget_exhausted"
   | "engine_error"
@@ -110,6 +111,10 @@ const NEXT_ACTIONS: Record<RunDiagnosisCategory, string[]> = {
     "Re-run the pre-publication checks before retrying publication.",
     "Confirm the run workspace was not modified after checks passed.",
   ],
+  source_pull_request_moved: [
+    "Someone other than this run pushed to the pull request, or retargeted it, while the run was working.",
+    "Re-read the pull request's own commit history; the run's work was not published.",
+  ],
   validation_failed: [
     "Review the block or trigger configuration that produced the invalid output.",
     "Check for a recent breaking change to the workflow definition.",
@@ -170,6 +175,15 @@ const LEAK_REVIEW_GATE_PREFIX = "Leak review blocked publication before the bran
 // messages (workflows/workspace-gate.ts:122-137) is required too.
 const WORKSPACE_GATE_PREFIX = SAFE_EXECUTION_ERROR_MESSAGES.checks;
 const WORKSPACE_GATE_KEYWORDS = ["Run Workspace", "pre-publication check"];
+// The staleness guards wrap their reason inside an external-service failure, so
+// prefix matching alone routes them to dependency_unavailable and tells the
+// reader to check the AI provider's status page. Nothing about them is a
+// dependency.
+const SOURCE_PULL_REQUEST_MOVED_KEYWORDS = [
+  "stale PR/MR head",
+  "stale PR/MR target",
+  "remote branch moved",
+];
 
 // "Run stopped on budget: <reason>", set as statusReason for a "failed" run
 // stopped by a budget check (workflows/agent.ts:2537-2543).
@@ -345,6 +359,17 @@ const RULES: readonly Rule[] = [
       const message = input.error?.message;
       if (!message || !message.startsWith(WORKSPACE_GATE_PREFIX)) return null;
       if (!WORKSPACE_GATE_KEYWORDS.some((keyword) => message.includes(keyword))) return null;
+      return { confidence: "low", evidenceRefs: evidenceFrom(input) };
+    },
+  },
+  {
+    category: "source_pull_request_moved",
+    match: (input) => {
+      const message = input.error?.message;
+      if (!message) return null;
+      if (!SOURCE_PULL_REQUEST_MOVED_KEYWORDS.some((keyword) => message.includes(keyword))) {
+        return null;
+      }
       return { confidence: "low", evidenceRefs: evidenceFrom(input) };
     },
   },

--- a/apps/worker/src/routes/webhooks/gitlab.post.test.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   env: {
-    GITLAB_WEBHOOK_SECRET: "secret",
+    GITLAB_WEBHOOK_SECRET: "secret" as string | undefined,
     GITLAB_PROJECT_ID: undefined as string | undefined,
     MAX_CONCURRENT_AGENTS: 3,
     VCS_BOT_LOGIN: "blazebot",
@@ -410,7 +410,22 @@ describe("POST /webhooks/gitlab", () => {
     const response = await makeApp()(makeRequest(validMergeRequestPayload(), "wrong"));
 
     expect(response.status).toBe(401);
+    expect(response.statusText).toBe("Invalid GitLab webhook token");
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
+  it("answers an unconfigured secret with 503 rather than the mismatch 401", async () => {
+    mocks.env.GITLAB_WEBHOOK_SECRET = undefined;
+    try {
+      const response = await makeApp()(makeRequest(validMergeRequestPayload(), "secret"));
+
+      expect(response.status).toBe(503);
+      expect(response.statusText).toBe("GitLab webhook secret is not configured");
+      expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
+      expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+    } finally {
+      mocks.env.GITLAB_WEBHOOK_SECRET = "secret";
+    }
   });
 
   it("supersedes the gate when a definition run starts for a bot MR", async () => {

--- a/apps/worker/src/routes/webhooks/gitlab.post.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.ts
@@ -30,8 +30,22 @@ const ALLOWED_ACTIONS = new Set(["opened", "update", "reopened"]);
 export default defineEventHandler(async (event) => {
   const rawBody = (await readRawBody(event, "utf8")) ?? "";
 
+  // GITLAB_WEBHOOK_SECRET is optional in the schema, and a non-null assertion
+  // used to turn an unset variable into the literal string "undefined". Every
+  // delivery then failed the comparison, so "nobody configured the secret" and
+  // "the secret drifted from the one GitLab sends" were byte-identical 401s.
+  // They need different answers, so they get different statuses.
+  const gitLabWebhookSecret = env.GITLAB_WEBHOOK_SECRET;
+  if (!gitLabWebhookSecret) {
+    logger.error({}, "gitlab_webhook_secret_not_configured");
+    throw createError({
+      statusCode: 503,
+      statusMessage: "GitLab webhook secret is not configured",
+    });
+  }
+
   try {
-    verifyGitLabWebhookToken(getHeader(event, "x-gitlab-token"), env.GITLAB_WEBHOOK_SECRET!);
+    verifyGitLabWebhookToken(getHeader(event, "x-gitlab-token"), gitLabWebhookSecret);
   } catch (err) {
     throw createError({ statusCode: 401, statusMessage: (err as Error).message });
   }

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
@@ -270,6 +270,68 @@ describe("trusted workspace publisher", () => {
     );
   });
 
+  describe("a source pull request the fix agent already pushed to", () => {
+    const twoRepos: WorkspaceManifest = {
+      version: 1,
+      repositories: [repository(), repository("acme/web", "/vercel/sandbox/repos/web")],
+    };
+    const sourcePullRequest = {
+      provider: "github" as const,
+      repoPath: "acme/api",
+      prId: 7,
+      headSha: "trigger",
+      baseRef: "main",
+    };
+
+    beforeEach(() => {
+      // acme/api already carries this workspace's head, which is what an agent
+      // that committed and pushed from the sandbox leaves behind, so prepare
+      // marks it pushed and only acme/web stays pending.
+      mocks.getBranchSha
+        .mockReset()
+        .mockResolvedValueOnce("after")
+        .mockResolvedValueOnce("before-acme/web")
+        .mockResolvedValue("after");
+      mocks.publisherCommand.mockImplementation(async (_name: string, args: string[]) => {
+        if (args.includes("rev-parse") && args.at(-1) === "HEAD") {
+          return command("before-acme/web");
+        }
+        if (args.includes("rev-parse") && args.at(-1) === "FETCH_HEAD") {
+          return command("after");
+        }
+        return command();
+      });
+    });
+
+    it("publishes the remaining repositories instead of failing on its own push", async () => {
+      mocks.getPrHead.mockResolvedValue({ headSha: "after", baseRef: "main", state: "open" });
+
+      const result = await publishTrustedWorkspaceFromSandbox({
+        sourceSandboxId: "source-sandbox",
+        workspaceManifest: twoRepos,
+        sourcePullRequest,
+        ...owner,
+      });
+
+      expect(result.repositories.map((repo) => repo.failureKind)).toEqual([undefined, undefined]);
+      expect(result.repositories[0]).toMatchObject({ pushed: true, pushedHead: "after" });
+      expect(result.repositories[1]).toMatchObject({ pushed: true, pushedHead: "after" });
+    });
+
+    it("still refuses to publish when somebody else pushed to it", async () => {
+      mocks.getPrHead.mockResolvedValue({ headSha: "foreign", baseRef: "main", state: "open" });
+
+      await expect(
+        publishTrustedWorkspaceFromSandbox({
+          sourceSandboxId: "source-sandbox",
+          workspaceManifest: twoRepos,
+          sourcePullRequest,
+          ...owner,
+        }),
+      ).rejects.toThrow(/stale PR\/MR head/);
+    });
+  });
+
   it("rides out a 404 on the ref read that verifies the push", async () => {
     // The push wrote refs/heads/blazebot/AIW-100 milliseconds earlier, so the
     // branch exists; a 404 here is the provider ref API lagging its own write.

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.ts
@@ -483,7 +483,20 @@ export async function publishTrustedWorkspaceFromSandbox(input: {
           baseBranch: input.sourcePullRequest.baseRef,
         }).vcs
       : null;
-    let expectedSourceHead = input.sourcePullRequest?.headSha;
+    // Prepare marks a repository as already pushed exactly when the branch
+    // already carries this workspace's head, which is what a fix agent that
+    // pushed its own commits leaves behind. Seeding from that sha keeps the
+    // assertion below meaningful for the repositories still pending, instead of
+    // measuring them against a head this same run superseded.
+    const preparedSource = input.sourcePullRequest
+      ? prepared.find(
+          (item) =>
+            input.sourcePullRequest &&
+            isSourcePullRequestRepository(input.sourcePullRequest, item.repo),
+        )
+      : undefined;
+    let expectedSourceHead =
+      preparedSource?.result.pushedHead ?? input.sourcePullRequest?.headSha;
 
     for (const item of pending) {
       await runRegistry.registerSandbox(

--- a/apps/worker/src/workflows/source-pull-request.test.ts
+++ b/apps/worker/src/workflows/source-pull-request.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertOpenSourcePullRequest,
+  assertPublishableSourcePullRequest,
+  type SourcePullRequestIdentity,
+} from "./source-pull-request.js";
+
+const source: SourcePullRequestIdentity = {
+  provider: "github",
+  repoPath: "acme/api",
+  prId: 7,
+  headSha: "trigger-head",
+  baseRef: "main",
+};
+
+describe("assertPublishableSourcePullRequest", () => {
+  it("accepts a head that moved after the trigger fired", () => {
+    expect(() =>
+      assertPublishableSourcePullRequest(source, {
+        headSha: "pushed-by-this-run",
+        baseRef: "main",
+        state: "open",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a retargeted pull request", () => {
+    expect(() =>
+      assertPublishableSourcePullRequest(source, {
+        headSha: "trigger-head",
+        baseRef: "develop",
+        state: "open",
+      }),
+    ).toThrow(/stale PR\/MR target/);
+  });
+
+  it("rejects a pull request that is no longer open", () => {
+    expect(() =>
+      assertPublishableSourcePullRequest(source, {
+        headSha: "trigger-head",
+        baseRef: "main",
+        state: "closed",
+      }),
+    ).toThrow(/is closed/);
+  });
+});
+
+describe("assertOpenSourcePullRequest", () => {
+  it("still rejects a head other than the one it was given", () => {
+    expect(() =>
+      assertOpenSourcePullRequest(source, {
+        headSha: "foreign-head",
+        baseRef: "main",
+        state: "open",
+      }),
+    ).toThrow(/stale PR\/MR head/);
+  });
+
+  it("accepts the exact head it was given", () => {
+    expect(() =>
+      assertOpenSourcePullRequest(source, {
+        headSha: "trigger-head",
+        baseRef: "main",
+        state: "open",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/worker/src/workflows/source-pull-request.ts
+++ b/apps/worker/src/workflows/source-pull-request.ts
@@ -13,13 +13,33 @@ export function assertOpenSourcePullRequest(
   input: SourcePullRequestIdentity,
   current: PullRequestHead,
 ): void {
-  const identity = `${input.provider}:${input.repoPath} #${input.prId}`;
   if (current.headSha !== input.headSha) {
     throw new Error(
-      `stale PR/MR head for ${identity}: triggered at ${input.headSha}, ` +
+      `stale PR/MR head for ${sourcePullRequestLabel(input)}: triggered at ${input.headSha}, ` +
         `current head is ${current.headSha}`,
     );
   }
+  assertPublishableSourcePullRequest(input, current);
+}
+
+/**
+ * Target branch and lifecycle only, deliberately without the head comparison.
+ *
+ * A fix agent commits AND pushes from inside the sandbox, so by the time
+ * publication starts the pull request head is routinely this run's own work
+ * rather than the sha recorded when the trigger fired. Comparing the two here
+ * failed every run that actually repaired its checks, with the fix already on
+ * the branch and CI already green. Head staleness is decided where it can be
+ * proven instead: publication accepts a moved remote head only while the
+ * workspace contains it (`merge-base --is-ancestor`) and still fails a foreign
+ * write as remote drift, and the post-push check compares against the exact sha
+ * publication produced.
+ */
+export function assertPublishableSourcePullRequest(
+  input: SourcePullRequestIdentity,
+  current: PullRequestHead,
+): void {
+  const identity = sourcePullRequestLabel(input);
   if (current.baseRef !== input.baseRef) {
     throw new Error(
       `stale PR/MR target for ${identity}: triggered at ${input.baseRef}, ` +
@@ -31,6 +51,10 @@ export function assertOpenSourcePullRequest(
       `source PR/MR ${identity} is ${current.state}; remediation publication requires it to be open`,
     );
   }
+}
+
+function sourcePullRequestLabel(input: SourcePullRequestIdentity): string {
+  return `${input.provider}:${input.repoPath} #${input.prId}`;
 }
 
 export function isSourcePullRequestRepository(

--- a/apps/worker/src/workflows/workspace-publication.test.ts
+++ b/apps/worker/src/workflows/workspace-publication.test.ts
@@ -277,8 +277,12 @@ describe("workspace publication", () => {
     expect(mocks.publish).not.toHaveBeenCalled();
   });
 
-  it("does not publish when the triggering PR identity is stale", async () => {
-    mocks.getPrHead.mockResolvedValue({ headSha: "someone-else", baseRef: "main", state: "open" });
+  it("does not publish when the triggering PR was retargeted", async () => {
+    mocks.getPrHead.mockResolvedValue({
+      headSha: "trigger-head",
+      baseRef: "develop",
+      state: "open",
+    });
     const result = await finalizeWorkspacePublication({
       ...common,
       sandboxId: "sandbox-1",
@@ -294,6 +298,78 @@ describe("workspace publication", () => {
 
     expect(result).toMatchObject({ status: "failed" });
     expect(mocks.publish).not.toHaveBeenCalled();
+  });
+
+  it("does not publish when the triggering PR is no longer open", async () => {
+    mocks.getPrHead.mockResolvedValue({
+      headSha: "trigger-head",
+      baseRef: "main",
+      state: "closed",
+    });
+    const result = await finalizeWorkspacePublication({
+      ...common,
+      sandboxId: "sandbox-1",
+      workspaceManifest: manifest,
+      sourcePullRequest: {
+        provider: "github",
+        repoPath: "acme/api",
+        prId: 7,
+        headSha: "trigger-head",
+        baseRef: "main",
+      },
+    });
+
+    expect(result).toMatchObject({ status: "failed" });
+    expect(mocks.publish).not.toHaveBeenCalled();
+  });
+
+  it("publishes when the triggering PR head is still the one that fired the trigger", async () => {
+    mocks.getPrHead.mockResolvedValue({
+      headSha: "trigger-head",
+      baseRef: "main",
+      state: "open",
+    });
+    const result = await finalizeWorkspacePublication({
+      ...common,
+      sandboxId: "sandbox-1",
+      workspaceManifest: manifest,
+      sourcePullRequest: {
+        provider: "github",
+        repoPath: "acme/api",
+        prId: 7,
+        headSha: "trigger-head",
+        baseRef: "main",
+      },
+    });
+
+    expect(result).toMatchObject({ status: "finalized" });
+    expect(mocks.publish).toHaveBeenCalled();
+  });
+
+  it("publishes when the fix agent already pushed its own work onto the triggering PR", async () => {
+    // The agent commits and pushes from inside the sandbox, which is what makes
+    // CI re-run, so the head at publication time is routinely ahead of the sha
+    // the trigger recorded. Containment is proven inside publication, not here.
+    mocks.getPrHead.mockResolvedValue({
+      headSha: "pushed-by-this-run",
+      baseRef: "main",
+      state: "open",
+    });
+    const result = await finalizeWorkspacePublication({
+      ...common,
+      sandboxId: "sandbox-1",
+      workspaceManifest: manifest,
+      sourcePullRequest: {
+        provider: "github",
+        repoPath: "acme/api",
+        prId: 7,
+        headSha: "trigger-head",
+        baseRef: "main",
+      },
+    });
+
+    expect(result).toMatchObject({ status: "finalized" });
+    expect(mocks.publish).toHaveBeenCalled();
   });
 
   it("verifies the finalized branch before recording intent and ownership", async () => {

--- a/apps/worker/src/workflows/workspace-publication.ts
+++ b/apps/worker/src/workflows/workspace-publication.ts
@@ -22,6 +22,7 @@ import {
 import { isRunControlError } from "./run-control-error.js";
 import {
   assertOpenSourcePullRequest,
+  assertPublishableSourcePullRequest,
   isSourcePullRequestRepository,
   type SourcePullRequestIdentity,
 } from "./source-pull-request.js";
@@ -91,7 +92,7 @@ export async function finalizeWorkspacePublication(input: {
 
   if (input.sourcePullRequest) {
     try {
-      assertOpenSourcePullRequest(
+      assertPublishableSourcePullRequest(
         input.sourcePullRequest,
         await verifySourcePullRequestStep(input.sourcePullRequest),
       );


### PR DESCRIPTION
## Why

Auto-fix on failing PR checks (#321, live on our production as definition 29 and
on the Arthur tenant since 2026.08.8) can never finish a successful run. Every
run that actually repairs the checks dies at `finalize_workspace` with
`stale PR/MR head`, so `post_pr_comment` is unreachable: the fix is on the
branch, CI is green, and nobody is told.

Evidence, `Blazity/aiw-checks-fixture` PR #2, run `wrun_01M0EZGR2CEH4JG480D9N746AN`:
pre-PR checks passed, GitHub CI went green on `0f67cbd7`, run ended red. This is
[AIW-310](https://blazity.atlassian.net/browse/AIW-310).

The cause is structural, not a race. The fix agent commits **and pushes** from
inside the sandbox, which is exactly what makes CI re-run and is the engine of
the whole loop. So by publication time the pull request head is routinely this
run's own work rather than the sha recorded when the trigger fired, and the
pre-push guard compares the two. It was masked until now because the pre-PR
gate threw first on every earlier attempt.

## What changed

**1. Finalize accepts the head this run produced.**
`assertOpenSourcePullRequest` splits into a target-and-lifecycle half
(`assertPublishableSourcePullRequest`) and the full check. Only the pre-push
call site in `finalizeWorkspacePublication` relaxes to the first; the post-push
call site in `openPullRequestsForPublication` stays strict, and it compares
against `pushedHead`, the exact sha publication produced.

A foreign push still fails the run, and it fails where it can be proven rather
than guessed: the trusted publisher already accepts a moved remote head only
while the workspace contains it (`merge-base --is-ancestor`,
`trusted-workspace-publisher.ts:284-306`) and still reports a foreign write as
`remote_drift`. That path has had test coverage since it was written. No new
state, no adapter change.

Second, smaller repair in the same area: with several repositories in the
workspace, the publisher measured the source pull request against the trigger
sha while pushing the *other* repositories, so a multi-repo autofix run would
throw on its own push. It now seeds that expectation from the sha prepare
recorded as pushed.

**2. An unconfigured GitLab webhook secret answers 503, not 401.**
`GITLAB_WEBHOOK_SECRET` is `.optional()` in the schema and the route asserted it
non-null, so an unset variable became the literal string `"undefined"` and every
delivery failed the comparison. "Nobody configured the secret" and "the secret
drifted" were byte-identical 401s. They need different answers, so they get
different statuses.

**3. `runs.diagnose` names a moved pull request.**
It classified this failure as `dependency_unavailable` and advised checking the
AI provider's status page, because the staleness reason arrives wrapped in the
generic provider sentence and the matcher keys off the prefix. A new
`source_pull_request_moved` category matches the reason text, ordered ahead of
the prefix rules.

## Tests

134 passing across the six touched files:

- `source-pull-request.test.ts` (new): the relaxed assert ignores a moved head
  and still rejects a retarget and a closed PR; the strict one still rejects a
  moved head.
- `workspace-publication.test.ts`: finalize publishes on an unchanged head and
  on a head this run pushed; still refuses a retargeted or closed PR; the
  existing post-push `"rejects a stale PR head before recording final ownership"`
  is untouched.
- `trusted-workspace-publisher.test.ts`: a multi-repo run whose source PR the
  agent already pushed publishes the remaining repositories, and still refuses
  when somebody else pushed. Both were verified to fail without the change.
- `gitlab.post.test.ts`: absent secret gives 503 with its own message, wrong
  token still gives 401 `Invalid GitLab webhook token`.
- `run-diagnosis.test.ts`: the real wrapped message classifies as
  `source_pull_request_moved`; the existing `dependency_unavailable` cases are
  unchanged. The MCP contract artifact does not expose the category enum, so
  `contractHash` is unaffected.

`pnpm --filter worker typecheck` clean. `nitro build` succeeds (190 steps, 13
workflows); the one serde warning about `fs`/`path` comes from the `chat`
dependency and predates this branch.

## Not in here

- Rotating the GitLab webhook secret on the fixture project. Only the plain
  `x-gitlab-token` shared secret is implemented, there is no dual-secret window,
  and the stored Vercel value cannot be read back, so it is a manual cutover.
  Tracked separately from this diff.
- HMAC signing for the GitLab hook, and moving provider webhook secrets into the
  dashboard-managed store.
- AIW-309, nothing naming which check command failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GQGB8dGbuMFonpguFa86M


[AIW-310]: https://blazity.atlassian.net/browse/AIW-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ