### PR TITLE
fix(worker): comment on the head an autofix run published, not the trigger sha (AIW-310)

### DIFF
--- a/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
@@ -253,6 +253,86 @@ describe("post_pr_comment execute", () => {
     expect(result.kind).toBe("next");
   });
 
+  function finalizedWithoutPr(pushedHead: string): WorkspacePublicationResult {
+    // What a remediation graph really produces: the branch was finalized, but no
+    // pull request was opened because the pull request already existed.
+    return {
+      status: "finalized",
+      prs: [],
+      repositories: [
+        {
+          provider: "github",
+          repoPath: "acme/api",
+          branchName: "blazebot/awt-1",
+          defaultBranch: "main",
+          expectedHead: "abc123",
+          pushedHead,
+        },
+      ],
+    };
+  }
+
+  function prTriggerEntry() {
+    return {
+      kind: "pr_trigger" as const,
+      triggerType: "trigger_pr_checks_failed" as const,
+      subjectKey: "ticket:jira:AWT-1",
+      ticketKey: "AWT-1",
+      ownerToken: "owner:test",
+      definitionId: 1,
+      definitionVersion: 1,
+      scope: "workflow_owned" as const,
+      pr: makePrPayload(),
+    };
+  }
+
+  it("comments on the head this run published, not the sha the trigger recorded", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: "https://pr/comment" });
+    mocks.createRepositoryVCS.mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "pushed-by-this-run", baseRef: "main", state: "open" }),
+      postPRComment,
+    });
+
+    const result = await execute(
+      makeNode("post_pr_comment", { body: "Automated fix pushed." }),
+      {},
+      makeCtx({
+        entry: prTriggerEntry(),
+        publication: finalizedWithoutPr("pushed-by-this-run"),
+      }),
+    );
+
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("Automated fix pushed."));
+    expect(result.kind).toBe("next");
+  });
+
+  it("still refuses to comment when somebody else moved the head", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: "https://pr/comment" });
+    mocks.createRepositoryVCS.mockReturnValue({
+      getPRHead: vi
+        .fn()
+        .mockResolvedValue({ headSha: "someone-else", baseRef: "main", state: "open" }),
+      postPRComment,
+    });
+
+    const result = await execute(
+      makeNode("post_pr_comment", { body: "Automated fix pushed." }),
+      {},
+      makeCtx({
+        entry: prTriggerEntry(),
+        publication: finalizedWithoutPr("pushed-by-this-run"),
+      }),
+    );
+
+    expect(postPRComment).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      kind: "execution_error",
+      error: expect.objectContaining({ message: expect.stringContaining("stale PR/MR head") }),
+    });
+  });
+
   it.each([
     {
       current: { headSha: "new-head", baseRef: "main", state: "open" as const },

--- a/apps/worker/src/workflows/blocks/post-pr-comment.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.ts
@@ -166,13 +166,28 @@ export const execute: BlockExecuteFn = async (
       });
     }
   } else if (ctx.entry.kind === "pr_trigger") {
+    // Publication reports `prs` only when it opened one, so a graph that
+    // remediates an existing pull request always lands here rather than in the
+    // branch above. Its head is still this run's own work: a fix agent commits
+    // AND pushes from inside the sandbox, which is what makes CI re-run. Taking
+    // the sha the trigger recorded would compare the comment against a head this
+    // same run superseded and refuse to post on every successful fix. Publication
+    // already proved that head is ours, so prefer what it finalized, and keep the
+    // trigger sha for a run that published nothing. A foreign push still fails
+    // the comparison below and still stops the comment.
+    const finalized = ctx.publication?.repositories.find(
+      (repository) =>
+        ctx.entry.kind === "pr_trigger" &&
+        repository.provider === ctx.entry.pr.provider &&
+        repository.repoPath === ctx.entry.pr.repoPath,
+    );
     prs = [
       {
         provider: ctx.entry.pr.provider,
         repoPath: ctx.entry.pr.repoPath,
         baseBranch: ctx.entry.pr.baseRef,
         prId: ctx.entry.pr.prNumber,
-        expectedHead: ctx.entry.pr.headSha,
+        expectedHead: finalized?.pushedHead ?? ctx.entry.pr.headSha,
         expectedState: ctx.entry.triggerType === "trigger_pr_merged" ? "merged" : "open",
       },
     ];


### PR DESCRIPTION
## Why

Second site of the same defect as #324, found by running the fixed build on
production. Run `wrun_01M0F7NJA7DCK8QB1XCKCTXKGA` (definition 29,
`Blazity/aiw-checks-fixture` PR #2) got all the way through `finalize_workspace`
and then died one node later:

```
AIW-DIAG-wrun_01M0F7NJA7DCK8QB1XCKCTXKGA-comment-1
(github:Blazity/aiw-checks-fixture#2: stale PR/MR head for
 github:Blazity/aiw-checks-fixture #2: expected <trigger sha>, current head is <pushed sha>)
```

`post_pr_comment` builds its target from `ctx.publication.prs` when publication
opened a pull request, and otherwise from the `pr_trigger` entry payload. A
remediation graph never opens a pull request, because the pull request already
exists, so `finalizeWorkspacePublication` returns `status: "finalized"` with
`prs: []` by type. The fallback is therefore not an edge case here: it is the
only branch that ever runs, and it compared the live head against the sha the
trigger recorded, which the fix agent had already superseded by pushing.

Net effect on production: the comment could never be posted on a run that
actually fixed anything. The pull request silently received the fix with nobody
told about it.

## What changed

One expression. When the run has a publication for the pull request's own
repository, take the head that publication finalized (`pushedHead`) instead of
the trigger sha. That is exactly what the `ctx.publication.prs` branch above
already does. A run that published nothing still has only the trigger sha to go
on, so it keeps using it.

The guard itself is unchanged and still does its job: a head somebody else moved
does not match `pushedHead` either, so the bot still refuses to announce
"Automated fix pushed" on a pull request that changed under it.

## Tests

`apps/worker/src/workflows/blocks/post-pr-comment.test.ts`, 23 passing:

- new: publication finalized `pushed-by-this-run` with `prs: []`, live head is
  `pushed-by-this-run`, trigger sha is `abc123` -> the comment is posted.
  Verified to fail without the change, with the exact production message.
- new: same publication, live head is `someone-else` -> no comment, and the
  execution error still says `stale PR/MR head`.
- the existing `it.each` stale-target and stale-lifecycle cases are untouched.

`pnpm --filter worker typecheck` clean.

## Note

Definition 29 on our production is `deployedVersion: 2` and its graph is
trigger -> prepare -> fetch-context -> fix -> checks -> finalize -> comment,
with no node that opens a pull request. Any graph of that shape hits this path,
which includes the built-in `review-fix-after-pr` template that ships to
tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GQGB8dGbuMFonpguFa86M
