### PR TITLE
docs(release): record the Artur 2026.08.9 release rehearsal

### DIFF
--- a/docs/releases/artur/rehearsals/2026.08.9.json
+++ b/docs/releases/artur/rehearsals/2026.08.9.json
@@ -1,0 +1,11 @@
+{
+  "version": "2026.08.9",
+  "sourceCommit": "089650f4348496d8aeee613acaed9e2e69a0014c",
+  "runId": "wrun_01M0FHTMY7K5RGFWAX8H0DSFBG",
+  "runUrl": "https://ai-workflow-app-dashboard.vercel.app/trace/wrun_01M0FHTMY7K5RGFWAX8H0DSFBG",
+  "repository": "Blazity/aiw-checks-fixture",
+  "checksDurationSec": 1492,
+  "outcome": "success",
+  "recordedAt": "2026-08-20T12:53:50Z",
+  "recordedBy": "filip.maszota@blazity.com"
+}


### PR DESCRIPTION
Records the production rehearsal for the 2026.08.9 release at the pinned source commit 089650f4348496d8aeee613acaed9e2e69a0014c.

Run wrun_01M0FHTMY7K5RGFWAX8H0DSFBG on our production (AWP-104, Blazity/aiw-checks-fixture): checks phase 1492 s, open pull request node green, outcome success. Validated with release-notes validate-rehearsal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)