### PR TITLE
feat(dashboard): add system health diagnostics

### DIFF
--- a/apps/dashboard/app/(cockpit)/cockpit-shell.tsx
+++ b/apps/dashboard/app/(cockpit)/cockpit-shell.tsx
@@ -58,6 +58,7 @@ const TITLE_FOR_SCREEN: Record<string, string> = {
   editor: "Workflow editor",
   profiles: "Harness profiles",
   checks: "Pre-PR checks",
+  health: "System health",
   users: "Users",
   trace: "Run trace",
   ticket: "Ticket runs",

--- a/apps/dashboard/app/(cockpit)/health/page.tsx
+++ b/apps/dashboard/app/(cockpit)/health/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+import { HealthData } from "@/app/health-data";
+import { HealthSkeleton } from "@/app/health-skeleton";
+
+export default function HealthPage() {
+  return (
+    <Suspense fallback={<HealthSkeleton />}>
+      <HealthData />
+    </Suspense>
+  );
+}

--- a/apps/dashboard/app/health-data.tsx
+++ b/apps/dashboard/app/health-data.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+import type { SystemHealthResponse } from "@shared/contracts";
+import { getJSON } from "@/lib/api/server";
+import { requireSession } from "@/lib/auth/session";
+import { HealthScreen } from "@/components/cockpit/screens/health";
+
+export async function HealthData() {
+  const session = await requireSession();
+  if (!session.canManageUsers) redirect("/");
+  const data = await getJSON<SystemHealthResponse>("/api/v1/system/health");
+  return <HealthScreen data={data} />;
+}

--- a/apps/dashboard/app/health-skeleton.tsx
+++ b/apps/dashboard/app/health-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Block } from "./skeleton-block";
+
+export function HealthSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-[1120px] px-4 pb-10 pt-5 lg:px-6 lg:pt-6">
+      <div className="mb-5 flex items-end justify-between border-b border-neutral-300 pb-5">
+        <div className="space-y-2">
+          <Block className="h-3 w-36" />
+          <Block className="h-8 w-52" />
+          <Block className="h-4 w-[480px] max-w-full" />
+        </div>
+        <Block className="h-8 w-24" />
+      </div>
+      <Block className="mb-5 h-[92px]" />
+      <div className="grid gap-4">
+        <Block className="h-[330px]" />
+        <Block className="h-[220px]" />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/components/cockpit/chrome.test.ts
+++ b/apps/dashboard/components/cockpit/chrome.test.ts
@@ -3,16 +3,18 @@ import test from "node:test";
 
 import { cockpitNavItems } from "./chrome";
 
-test("Harness Profiles is always discoverable while user management remains role-gated", () => {
+test("Harness Profiles is always discoverable while administration remains role-gated", () => {
   const memberIds = cockpitNavItems({ canManageUsers: false }).map(
     (item) => item.id,
   );
   assert.ok(memberIds.includes("profiles"));
+  assert.ok(!memberIds.includes("health"));
   assert.ok(!memberIds.includes("users"));
 
   const adminIds = cockpitNavItems({ canManageUsers: true }).map(
     (item) => item.id,
   );
   assert.ok(adminIds.includes("profiles"));
+  assert.ok(adminIds.includes("health"));
   assert.ok(adminIds.includes("users"));
 });

--- a/apps/dashboard/components/cockpit/chrome.tsx
+++ b/apps/dashboard/components/cockpit/chrome.tsx
@@ -14,13 +14,14 @@ const NAV = [
   { id: "editor", label: "Workflow editor", glyph: "▷", group: "flow" },
   { id: "profiles", label: "Harness profiles", glyph: "⌘", group: "flow" },
   { id: "checks", label: "Pre-PR checks", glyph: "☑", group: "flow" },
+  { id: "health", label: "System health", glyph: "＋", group: "team" },
   { id: "users", label: "Users", glyph: "U", group: "team" },
 ];
 
 const NAV_GROUPS = [
   { id: "obs", label: "Observability" },
   { id: "flow", label: "Workflow" },
-  { id: "team", label: "Users" },
+  { id: "team", label: "Administration" },
 ];
 
 export const MOBILE_MORE_NAV_IDS = [
@@ -31,6 +32,7 @@ export const MOBILE_MORE_NAV_IDS = [
   "cost",
   "profiles",
   "checks",
+  "health",
   "users",
 ] as const;
 
@@ -44,7 +46,8 @@ export function cockpitNavItems({
   canManageUsers: boolean;
 }) {
   return NAV.filter(
-    (item) => item.id !== "users" || canManageUsers,
+    (item) =>
+      (item.id !== "users" && item.id !== "health") || canManageUsers,
   );
 }
 

--- a/apps/dashboard/components/cockpit/screens/health.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/health.test.tsx
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { act, create } from "react-test-renderer";
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import type { SystemHealthResponse } from "@shared/contracts";
+import { HealthScreen } from "./health";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const data: SystemHealthResponse = {
+  generatedAt: "2026-08-20T12:00:00.000Z",
+  summary: { total: 2, live: 1, down: 1, notConfigured: 0, criticalDown: 1 },
+  integrations: [
+    {
+      id: "database",
+      label: "Database",
+      group: "core",
+      envVars: ["DATABASE_URL"],
+      critical: true,
+      mode: "live",
+      ping: { ok: true, latencyMs: 12 },
+    },
+    {
+      id: "jira",
+      label: "Jira",
+      group: "core",
+      envVars: ["JIRA_API_TOKEN"],
+      critical: true,
+      mode: "down",
+      ping: { ok: false, latencyMs: 40, error: "Jira authentication check failed." },
+    },
+  ],
+  alerts: [
+    {
+      severity: "critical",
+      integrationId: "jira",
+      message: "Jira: Jira authentication check failed.",
+      fixHint: "Check JIRA_API_TOKEN and the provider setup.",
+    },
+  ],
+};
+
+function textOf(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  if (Array.isArray(value)) return value.map(textOf).join(" ");
+  if (value && typeof value === "object" && "children" in value) {
+    return textOf((value as { children?: unknown }).children);
+  }
+  return "";
+}
+
+test("health screen exposes the failed service, fix hint, and safe env names", () => {
+  const router = { refresh() {} };
+  let renderer!: ReturnType<typeof create>;
+  act(() => {
+    renderer = create(
+      <AppRouterContext.Provider value={router as never}>
+        <HealthScreen data={data} />
+      </AppRouterContext.Provider>,
+    );
+  });
+  const text = textOf(renderer.toJSON());
+  assert.match(text, /Action required/);
+  assert.match(text, /Jira authentication check failed/);
+  assert.match(text, /JIRA_API_TOKEN/);
+  assert.match(text, /DATABASE_URL/);
+  assert.doesNotMatch(text, /secret-value/);
+  act(() => renderer.unmount());
+});
+
+test("scan again refreshes the server data", () => {
+  let refreshes = 0;
+  const router = { refresh: () => refreshes++ };
+  let renderer!: ReturnType<typeof create>;
+  act(() => {
+    renderer = create(
+      <AppRouterContext.Provider value={router as never}>
+        <HealthScreen data={{ ...data, alerts: [], summary: { ...data.summary, down: 0, criticalDown: 0 } }} />
+      </AppRouterContext.Provider>,
+    );
+  });
+  const button = renderer.root.findByProps({ children: "Scan again" });
+  act(() => button.props.onClick());
+  assert.equal(refreshes, 1);
+  act(() => renderer.unmount());
+});

--- a/apps/dashboard/components/cockpit/screens/health.tsx
+++ b/apps/dashboard/components/cockpit/screens/health.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import type {
+  SystemHealthGroup,
+  SystemHealthIntegration,
+  SystemHealthMode,
+  SystemHealthResponse,
+} from "@shared/contracts";
+
+const GROUPS: Array<{
+  id: SystemHealthGroup;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "core",
+    label: "Execution path",
+    description: "Services every workflow depends on while it researches and publishes changes.",
+  },
+  {
+    id: "auth-email",
+    label: "Access & email",
+    description: "Human access to the dashboard and optional account delivery channels.",
+  },
+  {
+    id: "platform",
+    label: "Platform extensions",
+    description: "Optional integrations that add notifications, traces, remote tools, and hosting context.",
+  },
+];
+
+const DESCRIPTIONS: Record<string, string> = {
+  database: "Stores workflow state, ownership, traces, and dashboard data.",
+  jira: "Authenticates the account and checks access to the configured project.",
+  github: "Checks the App installation; the webhook secret is presence-checked.",
+  gitlab: "Authenticates the API token; the webhook secret is presence-checked.",
+  agent: "Authenticates the active provider and checks the configured model when possible.",
+  "dashboard-auth": "Presence-checks auth settings; this request already proves session enforcement.",
+  sso: "Checks OIDC discovery; client credentials remain presence-checked.",
+  email: "Authenticates Resend; sender configuration remains presence-checked.",
+  slack: "Authenticates the bot token; the channel ID remains presence-checked.",
+  arthur: "Reads the task API used by traces, evaluations, and guardrails.",
+  mcp: "Checks that the enabled remote tool contract contains tools.",
+  vercel: "Reads the configured project when explicit credentials are available.",
+};
+
+const STATUS: Record<
+  SystemHealthMode,
+  { label: string; dot: string; badge: string }
+> = {
+  live: {
+    label: "Live",
+    dot: "bg-success",
+    badge: "border-[#B8DDAA] bg-success-bg text-success-fg",
+  },
+  down: {
+    label: "Down",
+    dot: "bg-fail",
+    badge: "border-[#F0B8AE] bg-fail-bg text-fail-fg",
+  },
+  configured: {
+    label: "Configured",
+    dot: "bg-mariner",
+    badge: "border-mariner-300 bg-mariner-100 text-mariner",
+  },
+  "not-configured": {
+    label: "Not configured",
+    dot: "bg-neutral-400",
+    badge: "border-neutral-200 bg-app-bg text-neutral-600",
+  },
+  misconfigured: {
+    label: "Needs configuration",
+    dot: "bg-burnt-orange",
+    badge: "border-orange-300 bg-orange-100 text-[#A23E18]",
+  },
+  mock: {
+    label: "Mock mode",
+    dot: "bg-neutral-500",
+    badge: "border-neutral-300 bg-neutral-100 text-neutral-700",
+  },
+};
+
+export function HealthScreen({ data }: { data: SystemHealthResponse }) {
+  const router = useRouter();
+  const [refreshing, startRefresh] = useTransition();
+  const criticalAlerts = data.alerts.filter((alert) => alert.severity === "critical");
+  const overall = criticalAlerts.length > 0
+    ? {
+        label: "Action required",
+        text:
+          data.summary.criticalDown > 0
+            ? `${data.summary.criticalDown} critical ${data.summary.criticalDown === 1 ? "service is" : "services are"} down.`
+            : "Critical deployment configuration is incomplete.",
+        className: "border-[#F0B8AE] bg-fail-bg text-fail-fg",
+      }
+    : data.alerts.length > 0
+      ? {
+          label: "Check configuration",
+          text: "The execution path is available, but optional setup needs attention.",
+          className: "border-orange-300 bg-orange-100 text-[#A23E18]",
+        }
+      : {
+          label: "Operational",
+          text: "No critical issue was detected in this scan.",
+          className: "border-[#B8DDAA] bg-success-bg text-success-fg",
+        };
+
+  return (
+    <div className="mx-auto w-full max-w-[1120px] px-4 pb-10 pt-5 lg:px-6 lg:pt-6">
+      <header className="mb-5 flex flex-col gap-4 border-b border-neutral-300 pb-5 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.09em] text-neutral-500">
+            Deployment diagnostic
+          </div>
+          <h1 className="font-display text-[25px] font-semibold leading-tight tracking-[-0.025em] text-neutral-900">
+            System health
+          </h1>
+          <p className="mt-1 max-w-[650px] font-body text-[13px] leading-5 text-neutral-600">
+            Live connectivity for the execution path, plus configuration readiness for optional services. Secret values never appear here.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <time
+            dateTime={data.generatedAt}
+            className="font-mono text-[10px] leading-4 text-neutral-500"
+          >
+            Scanned {formatTime(data.generatedAt)}
+          </time>
+          <button
+            type="button"
+            disabled={refreshing}
+            onClick={() => startRefresh(() => router.refresh())}
+            className="appearance-none rounded-[3px] border border-neutral-300 bg-panel px-3 py-2 font-body text-[12px] font-semibold text-neutral-800 transition-colors duration-[120ms] hover:border-neutral-400 hover:bg-app-bg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-mariner disabled:cursor-wait disabled:opacity-60"
+          >
+            {refreshing ? "Scanning…" : "Scan again"}
+          </button>
+        </div>
+      </header>
+
+      <section
+        aria-label="Health summary"
+        className="mb-5 grid overflow-hidden rounded-[4px] border border-neutral-200 bg-panel sm:grid-cols-[minmax(280px,1.7fr)_repeat(3,minmax(110px,0.7fr))]"
+      >
+        <div className={`border-b px-4 py-4 sm:border-b-0 sm:border-r ${overall.className}`}>
+          <div className="font-display text-[18px] font-semibold tracking-[-0.02em]">
+            {overall.label}
+          </div>
+          <p className="mt-1 font-body text-[12px] leading-4 opacity-85">{overall.text}</p>
+        </div>
+        <SummaryCell label="Live checks" value={data.summary.live} />
+        <SummaryCell label="Down" value={data.summary.down} danger={data.summary.down > 0} />
+        <SummaryCell label="Not configured" value={data.summary.notConfigured} />
+      </section>
+
+      {data.alerts.length > 0 && (
+        <section aria-labelledby="health-alerts" className="mb-5">
+          <h2
+            id="health-alerts"
+            className="mb-2 font-mono text-[10px] uppercase tracking-[0.08em] text-neutral-600"
+          >
+            Needs attention
+          </h2>
+          <div className="grid gap-2">
+            {data.alerts.map((alert) => (
+              <div
+                key={`${alert.integrationId}:${alert.message}`}
+                role={alert.severity === "critical" ? "alert" : undefined}
+                className={`rounded-[4px] border px-3 py-3 ${
+                  alert.severity === "critical"
+                    ? "border-[#F0B8AE] bg-fail-bg"
+                    : "border-orange-300 bg-orange-100"
+                }`}
+              >
+                <div className="font-body text-[12px] font-semibold text-neutral-900">
+                  {alert.message}
+                </div>
+                <div className="mt-1 font-mono text-[10px] leading-4 text-neutral-700">
+                  {alert.fixHint}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <div className="grid gap-4">
+        {GROUPS.map((group) => {
+          const integrations = data.integrations.filter(
+            (integration) => integration.group === group.id,
+          );
+          return (
+            <section
+              key={group.id}
+              aria-labelledby={`health-group-${group.id}`}
+              className="overflow-hidden rounded-[4px] border border-neutral-200 bg-panel"
+            >
+              <div className="border-b border-neutral-200 bg-neutral-100 px-4 py-3">
+                <h2
+                  id={`health-group-${group.id}`}
+                  className="font-display text-[15px] font-semibold tracking-[-0.01em] text-neutral-900"
+                >
+                  {group.label}
+                </h2>
+                <p className="mt-0.5 font-body text-[11px] leading-4 text-neutral-600">
+                  {group.description}
+                </p>
+              </div>
+              <ol className="m-0 list-none p-0">
+                {integrations.map((integration, index) => (
+                  <HealthRow
+                    key={integration.id}
+                    integration={integration}
+                    first={index === 0}
+                    last={index === integrations.length - 1}
+                  />
+                ))}
+              </ol>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SummaryCell({
+  label,
+  value,
+  danger = false,
+}: {
+  label: string;
+  value: number;
+  danger?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3 last:border-b-0 sm:block sm:border-b-0 sm:border-r sm:last:border-r-0">
+      <div className="font-mono text-[9px] uppercase tracking-[0.07em] text-neutral-500">
+        {label}
+      </div>
+      <div
+        className={`font-display text-[20px] font-semibold tracking-[-0.02em] ${danger ? "text-fail" : "text-neutral-900"}`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function HealthRow({
+  integration,
+  first,
+  last,
+}: {
+  integration: SystemHealthIntegration;
+  first: boolean;
+  last: boolean;
+}) {
+  const status = STATUS[integration.mode];
+  return (
+    <li className={`grid grid-cols-[30px_minmax(0,1fr)] px-4 ${last ? "" : "border-b border-neutral-200"}`}>
+      <div className="relative flex justify-center" aria-hidden="true">
+        {!first && <span className="absolute top-0 h-1/2 w-px bg-neutral-300" />}
+        {!last && <span className="absolute bottom-0 h-1/2 w-px bg-neutral-300" />}
+        <span className={`relative z-10 mt-[22px] h-2.5 w-2.5 rounded-full ring-4 ring-white ${status.dot}`} />
+      </div>
+      <div className="grid min-w-0 gap-3 py-4 sm:grid-cols-[minmax(180px,1fr)_minmax(220px,1.2fr)_auto] sm:items-center">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="font-body text-[13px] font-semibold text-neutral-900">
+              {integration.label}
+            </h3>
+            {integration.critical && (
+              <span className="font-mono text-[8px] uppercase tracking-[0.07em] text-neutral-500">
+                Critical
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 font-body text-[11px] leading-4 text-neutral-600">
+            {DESCRIPTIONS[integration.id] ?? "Deployment integration."}
+          </p>
+          {integration.ping && (
+            <div className="mt-1 font-mono text-[9px] text-neutral-500">
+              {integration.ping.latencyMs} ms
+            </div>
+          )}
+        </div>
+        <div className="flex min-w-0 flex-wrap gap-1.5">
+          {integration.envVars.map((name) => (
+            <code
+              key={name}
+              className="max-w-full break-all rounded-[3px] bg-app-bg px-1.5 py-1 font-mono text-[9px] text-neutral-600"
+            >
+              {name}
+            </code>
+          ))}
+        </div>
+        <div className="sm:justify-self-end">
+          <span
+            className={`inline-flex rounded-pill border px-2 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.05em] ${status.badge}`}
+          >
+            {status.label}
+          </span>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function formatTime(value: string): string {
+  return new Intl.DateTimeFormat("en", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(new Date(value));
+}

--- a/apps/shared/contracts/api.ts
+++ b/apps/shared/contracts/api.ts
@@ -971,3 +971,61 @@ export interface MemoryDocumentDto {
 export interface MemoryDocumentResponse {
   document: MemoryDocumentDto;
 }
+
+/* ── System health (dashboard Health screen) ─────────────────────────────── */
+
+/**
+ * `live` / `down` describe entries with a real ping; `configured` /
+ * `not-configured` / `misconfigured` describe presence-only entries; `mock`
+ * means the system deliberately runs a no-op adapter (Slack without a token).
+ */
+export type SystemHealthMode =
+  | "live"
+  | "down"
+  | "configured"
+  | "not-configured"
+  | "misconfigured"
+  | "mock";
+
+export type SystemHealthGroup = "core" | "auth-email" | "platform";
+
+export interface SystemHealthPing {
+  ok: boolean;
+  latencyMs: number;
+  error?: string;
+}
+
+export interface SystemHealthIntegration {
+  id: string;
+  label: string;
+  group: SystemHealthGroup;
+  /** Variable NAMES only — values never leave the worker. */
+  envVars: string[];
+  /** A failure blocks the workflow itself (issue tracker, VCS, agent, DB). */
+  critical: boolean;
+  mode: SystemHealthMode;
+  /** Why a partially-set integration counts as misconfigured. */
+  configError?: string;
+  ping: SystemHealthPing | null;
+}
+
+export interface SystemHealthAlert {
+  severity: "critical" | "warning";
+  integrationId: string;
+  message: string;
+  /** What the admin still has to wire, in terms of env var names. */
+  fixHint: string;
+}
+
+export interface SystemHealthResponse {
+  generatedAt: string;
+  summary: {
+    total: number;
+    live: number;
+    down: number;
+    notConfigured: number;
+    criticalDown: number;
+  };
+  integrations: SystemHealthIntegration[];
+  alerts: SystemHealthAlert[];
+}

--- a/apps/worker/src/adapters/issue-tracker/jira.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.ts
@@ -170,10 +170,10 @@ export class JiraAdapter implements IssueTrackerAdapter {
     return { id: statusId, name: statusName };
   }
 
-  async listStatuses(): Promise<Array<{ id: string; name: string }>> {
+  async listStatuses(signal?: AbortSignal): Promise<Array<{ id: string; name: string }>> {
     const groups = await this.request(
       `/rest/api/3/project/${encodeURIComponent(this.projectKey)}/statuses`,
-      { signal: AbortSignal.timeout(STATUS_DISCOVERY_TIMEOUT_MS) },
+      { signal: signal ?? AbortSignal.timeout(STATUS_DISCOVERY_TIMEOUT_MS) },
     );
     const seen = new Set<string>();
     const statuses: Array<{ id: string; name: string }> = [];
@@ -362,9 +362,9 @@ export class JiraAdapter implements IssueTrackerAdapter {
     });
   }
 
-  async getCurrentUserAccountId(): Promise<string> {
+  async getCurrentUserAccountId(signal?: AbortSignal): Promise<string> {
     if (!this.selfAccountIdPromise) {
-      this.selfAccountIdPromise = this.request(`/rest/api/3/myself`)
+      this.selfAccountIdPromise = this.request(`/rest/api/3/myself`, { signal })
         .then((data: any) => {
           const accountId = data?.accountId;
           if (typeof accountId !== "string" || accountId === "") {

--- a/apps/worker/src/routes/api/v1/system/health.get.ts
+++ b/apps/worker/src/routes/api/v1/system/health.get.ts
@@ -1,0 +1,20 @@
+import { createError, defineEventHandler, setResponseHeader } from "h3";
+import type { SystemHealthResponse } from "@shared/contracts";
+import { requireDashboardActor, toHttpError } from "../../../../lib/auth/request-context.js";
+import { canInvite } from "../../../../lib/auth/roles.js";
+import { collectDeploymentSystemHealth } from "../../../../system-health/probes.js";
+
+export default defineEventHandler(
+  async (event): Promise<SystemHealthResponse | undefined> => {
+    setResponseHeader(event, "Cache-Control", "no-store");
+    try {
+      const actor = await requireDashboardActor(event);
+      if (!canInvite(actor.role)) {
+        throw createError({ statusCode: 403, statusMessage: "Forbidden" });
+      }
+      return await collectDeploymentSystemHealth();
+    } catch (error) {
+      toHttpError(error);
+    }
+  },
+);

--- a/apps/worker/src/routes/api/v1/system/health.test.ts
+++ b/apps/worker/src/routes/api/v1/system/health.test.ts
@@ -1,0 +1,80 @@
+import { createError, createApp, toWebHandler } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SystemHealthResponse } from "@shared/contracts";
+
+const state = vi.hoisted(() => ({
+  role: "admin" as "owner" | "admin" | "member" | null,
+  collect: vi.fn(),
+}));
+
+vi.mock("../../../../lib/auth/request-context.js", () => ({
+  requireDashboardActor: vi.fn(async () => {
+    if (state.role === null) {
+      throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+    return { role: state.role };
+  }),
+  toHttpError: (error: unknown) => {
+    throw error;
+  },
+}));
+vi.mock("../../../../system-health/probes.js", () => ({
+  collectDeploymentSystemHealth: state.collect,
+}));
+
+const route = (await import("./health.get.js")).default;
+
+const fixture: SystemHealthResponse = {
+  generatedAt: "2026-08-20T12:00:00.000Z",
+  summary: {
+    total: 1,
+    live: 1,
+    down: 0,
+    notConfigured: 0,
+    criticalDown: 0,
+  },
+  integrations: [
+    {
+      id: "database",
+      label: "Database",
+      group: "core",
+      envVars: ["DATABASE_URL"],
+      critical: true,
+      mode: "live",
+      ping: { ok: true, latencyMs: 12 },
+    },
+  ],
+  alerts: [],
+};
+
+function request() {
+  const app = createApp();
+  app.use("/", route);
+  return toWebHandler(app)(new Request("http://worker.test/"));
+}
+
+beforeEach(() => {
+  state.role = "admin";
+  state.collect.mockReset().mockResolvedValue(fixture);
+});
+
+describe("GET /api/v1/system/health", () => {
+  it("requires a dashboard session", async () => {
+    state.role = null;
+    expect((await request()).status).toBe(401);
+  });
+
+  it("keeps deployment diagnostics restricted to owner and admin roles", async () => {
+    state.role = "member";
+    expect((await request()).status).toBe(403);
+    expect(state.collect).not.toHaveBeenCalled();
+  });
+
+  it("returns fresh diagnostics without caching", async () => {
+    const response = await request();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual(fixture);
+    expect(state.collect).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/worker/src/system-health/collect.test.ts
+++ b/apps/worker/src/system-health/collect.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { collectSystemHealth, type SystemHealthConfig } from "./collect.js";
+
+const baseConfig: SystemHealthConfig = {
+  databaseUrl: "postgres://fixture/db",
+  jiraBaseUrl: "https://jira.example",
+  jiraApiToken: "jira-secret",
+  jiraProjectKey: "TEST",
+  githubAppId: 1,
+  githubAppPrivateKey: "private-key",
+  githubInstallationId: 2,
+  githubWebhookSecret: "webhook-secret",
+  agentKind: "claude",
+  anthropicApiKey: "anthropic-secret",
+  anthropicModel: "claude-test",
+  betterAuthSecret: "auth-secret",
+  betterAuthUrl: "https://worker.example",
+  dashboardOrigin: "https://dashboard.example",
+  mcpEnabled: false,
+};
+
+function clock(...values: number[]) {
+  let index = 0;
+  return () => values[index++] ?? values.at(-1) ?? 0;
+}
+
+describe("collectSystemHealth", () => {
+  it("reports live critical probes and neutral optional integrations", async () => {
+    const result = await collectSystemHealth({
+      config: baseConfig,
+      probes: {
+        database: async () => {},
+        jira: async () => {},
+        github: async () => {},
+        agent: async () => {},
+      },
+      now: () => new Date("2026-08-20T12:00:00.000Z"),
+      monotonicNow: clock(0, 0, 0, 0, 12, 25, 40, 58),
+    });
+
+    expect(result.generatedAt).toBe("2026-08-20T12:00:00.000Z");
+    expect(result.summary).toMatchObject({
+      total: 12,
+      live: 4,
+      down: 0,
+      criticalDown: 0,
+    });
+    expect(result.integrations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "database", mode: "live" }),
+        expect.objectContaining({ id: "github", mode: "live" }),
+        expect.objectContaining({ id: "gitlab", mode: "not-configured" }),
+        expect.objectContaining({ id: "slack", mode: "mock" }),
+      ]),
+    );
+    expect(result.alerts).toEqual([]);
+  });
+
+  it("turns failed probes and partial optional configuration into actionable alerts", async () => {
+    const result = await collectSystemHealth({
+      config: {
+        ...baseConfig,
+        slackToken: "slack-secret",
+        ssoIssuer: "https://sso.example",
+      },
+      probes: {
+        database: async () => {
+          throw new Error("postgres://user:password@secret-host/db");
+        },
+        jira: async () => {},
+        github: async () => {},
+        agent: async () => {},
+      },
+      monotonicNow: clock(0, 0, 0, 0, 5, 10, 15, 20),
+    });
+
+    expect(result.summary).toMatchObject({ down: 1, criticalDown: 1 });
+    expect(result.integrations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "database",
+          mode: "down",
+          ping: expect.objectContaining({ error: "Health check failed." }),
+        }),
+        expect.objectContaining({ id: "slack", mode: "misconfigured" }),
+        expect.objectContaining({ id: "sso", mode: "misconfigured" }),
+      ]),
+    );
+    expect(JSON.stringify(result)).not.toContain("secret-host");
+    expect(result.alerts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "critical",
+          integrationId: "database",
+          fixHint: expect.stringContaining("DATABASE_URL"),
+        }),
+        expect.objectContaining({ severity: "warning", integrationId: "slack" }),
+      ]),
+    );
+  });
+
+  it("keeps OAuth-backed agents honest as configured when no safe ping exists", async () => {
+    const result = await collectSystemHealth({
+      config: {
+        ...baseConfig,
+        agentKind: "codex",
+        anthropicApiKey: undefined,
+        codexOauthToken: "oauth-secret",
+        codexModel: "gpt-test",
+      },
+      probes: {
+        database: async () => {},
+        jira: async () => {},
+        github: async () => {},
+      },
+    });
+
+    expect(result.integrations).toContainEqual(
+      expect.objectContaining({
+        id: "agent",
+        label: "Codex agent",
+        mode: "configured",
+        ping: null,
+      }),
+    );
+  });
+
+  it("classifies every empty and partial configuration without claiming connectivity", async () => {
+    const empty = await collectSystemHealth({
+      config: { agentKind: "claude", mcpEnabled: false },
+      probes: {},
+    });
+    const modes = Object.fromEntries(
+      empty.integrations.map((integration) => [integration.id, integration.mode]),
+    );
+    expect(modes).toEqual({
+      database: "misconfigured",
+      jira: "misconfigured",
+      github: "not-configured",
+      gitlab: "not-configured",
+      agent: "misconfigured",
+      "dashboard-auth": "misconfigured",
+      sso: "not-configured",
+      email: "not-configured",
+      slack: "mock",
+      arthur: "not-configured",
+      mcp: "not-configured",
+      vercel: "not-configured",
+    });
+
+    const partialCases: Array<[string, Partial<SystemHealthConfig>, string]> = [
+      ["jira", { jiraBaseUrl: "https://jira.example", jiraApiToken: "token" }, "misconfigured"],
+      ["github", { githubAppId: 1, githubAppPrivateKey: "key", githubInstallationId: 2 }, "misconfigured"],
+      ["gitlab", { gitlabToken: "token" }, "misconfigured"],
+      ["dashboard-auth", { betterAuthSecret: "secret" }, "misconfigured"],
+      ["sso", { ssoIssuer: "https://sso.example" }, "misconfigured"],
+      ["email", { resendApiKey: "key" }, "misconfigured"],
+      ["email", { resendWebhookSecret: "webhook" }, "misconfigured"],
+      ["slack", { slackToken: "token" }, "misconfigured"],
+      ["arthur", { arthurApiKey: "key" }, "misconfigured"],
+      ["vercel", { vercelToken: "token", vercelTeamId: "team" }, "misconfigured"],
+    ];
+
+    for (const [id, patch, expected] of partialCases) {
+      const result = await collectSystemHealth({
+        config: { agentKind: "claude", mcpEnabled: false, ...patch },
+        probes: {},
+      });
+      expect(result.integrations.find((entry) => entry.id === id)?.mode, id).toBe(expected);
+    }
+  });
+
+  it("exposes the exact variable names used to determine each integration", async () => {
+    const result = await collectSystemHealth({ config: baseConfig, probes: {} });
+    expect(Object.fromEntries(
+      result.integrations.map((integration) => [integration.id, integration.envVars]),
+    )).toEqual({
+      database: ["DATABASE_URL"],
+      jira: ["JIRA_BASE_URL", "JIRA_API_TOKEN", "JIRA_PROJECT_KEY"],
+      github: ["GITHUB_APP_ID", "GITHUB_APP_PRIVATE_KEY", "GITHUB_INSTALLATION_ID", "GITHUB_WEBHOOK_SECRET"],
+      gitlab: ["GITLAB_TOKEN", "GITLAB_HOST", "GITLAB_WEBHOOK_SECRET"],
+      agent: ["AGENT_KIND", "ANTHROPIC_API_KEY", "CLAUDE_MODEL"],
+      "dashboard-auth": ["BETTER_AUTH_SECRET", "BETTER_AUTH_URL", "DASHBOARD_ORIGIN"],
+      sso: ["SSO_ISSUER", "SSO_ALLOWED_DOMAIN", "SSO_CLIENT_ID", "SSO_CLIENT_SECRET"],
+      email: ["RESEND_API_KEY", "RESEND_FROM_EMAIL", "RESEND_WEBHOOK_SECRET"],
+      slack: ["CHAT_SDK_SLACK_TOKEN", "CHAT_SDK_CHANNEL_ID"],
+      arthur: ["GENAI_ENGINE_API_KEY", "GENAI_ENGINE_TRACE_ENDPOINT"],
+      mcp: ["MCP_ENABLED"],
+      vercel: ["VERCEL_ENV", "VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"],
+    });
+  });
+
+  it("aborts a probe at the bounded timeout", async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    const pending = collectSystemHealth({
+      config: { ...baseConfig },
+      probes: {
+        database: async (probeSignal) => {
+          signal = probeSignal;
+          await new Promise(() => {});
+        },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await pending;
+    expect(signal?.aborted).toBe(true);
+    expect(result.integrations).toContainEqual(
+      expect.objectContaining({
+        id: "database",
+        mode: "down",
+        ping: expect.objectContaining({ error: "Health check timed out." }),
+      }),
+    );
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});

--- a/apps/worker/src/system-health/collect.ts
+++ b/apps/worker/src/system-health/collect.ts
@@ -1,0 +1,423 @@
+import type {
+  SystemHealthAlert,
+  SystemHealthIntegration,
+  SystemHealthMode,
+  SystemHealthResponse,
+} from "@shared/contracts";
+
+export type SystemHealthConfig = {
+  databaseUrl?: string;
+  jiraBaseUrl?: string;
+  jiraApiToken?: string;
+  jiraProjectKey?: string;
+  githubAppId?: number;
+  githubAppPrivateKey?: string;
+  githubInstallationId?: number;
+  githubWebhookSecret?: string;
+  gitlabToken?: string;
+  gitlabHost?: string;
+  gitlabWebhookSecret?: string;
+  agentKind: "claude" | "codex";
+  anthropicApiKey?: string;
+  anthropicModel?: string;
+  codexApiKey?: string;
+  codexOauthToken?: string;
+  codexModel?: string;
+  betterAuthSecret?: string;
+  betterAuthUrl?: string;
+  dashboardOrigin?: string;
+  ssoIssuer?: string;
+  ssoAllowedDomain?: string;
+  ssoClientId?: string;
+  ssoClientSecret?: string;
+  resendApiKey?: string;
+  resendFromEmail?: string;
+  resendWebhookSecret?: string;
+  slackToken?: string;
+  slackChannelId?: string;
+  arthurApiKey?: string;
+  arthurTraceEndpoint?: string;
+  mcpEnabled: boolean;
+  vercelEnv?: string;
+  vercelToken?: string;
+  vercelTeamId?: string;
+  vercelProjectId?: string;
+};
+
+export type SystemHealthProbeId =
+  | "database"
+  | "jira"
+  | "github"
+  | "gitlab"
+  | "agent"
+  | "sso"
+  | "email"
+  | "slack"
+  | "arthur"
+  | "mcp"
+  | "vercel";
+
+export type SystemHealthProbes = Partial<
+  Record<SystemHealthProbeId, (signal: AbortSignal) => Promise<void>>
+>;
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+export async function collectSystemHealth(input: {
+  config: SystemHealthConfig;
+  probes: SystemHealthProbes;
+  now?: () => Date;
+  monotonicNow?: () => number;
+}): Promise<SystemHealthResponse> {
+  const now = input.now ?? (() => new Date());
+  const monotonicNow = input.monotonicNow ?? (() => performance.now());
+  const { config, probes } = input;
+
+  const githubMode = groupedMode([
+    config.githubAppId,
+    config.githubAppPrivateKey,
+    config.githubInstallationId,
+    config.githubWebhookSecret,
+  ]);
+  const gitlabMode = groupedMode([
+    config.gitlabToken,
+    config.gitlabWebhookSecret,
+  ]);
+  const jiraMode: SystemHealthMode =
+    config.jiraBaseUrl && config.jiraApiToken && config.jiraProjectKey
+      ? "configured"
+      : "misconfigured";
+  const ssoMode = groupedMode([
+    config.ssoIssuer,
+    config.ssoAllowedDomain,
+    config.ssoClientId,
+    config.ssoClientSecret,
+  ]);
+  const emailBaseMode = groupedMode([config.resendApiKey, config.resendFromEmail]);
+  const emailMode: SystemHealthMode =
+    config.resendWebhookSecret && emailBaseMode !== "configured"
+      ? "misconfigured"
+      : emailBaseMode;
+  const slackMode = groupedMode([config.slackToken, config.slackChannelId], "mock");
+  const arthurMode = groupedMode([
+    config.arthurApiKey,
+    config.arthurTraceEndpoint,
+  ]);
+  const authMode = groupedMode([
+    config.betterAuthSecret,
+    config.betterAuthUrl,
+    config.dashboardOrigin,
+  ], "misconfigured");
+  const vercelCredentials = groupedMode([
+    config.vercelToken,
+    config.vercelTeamId,
+    config.vercelProjectId,
+  ]);
+  const vercelMode: SystemHealthMode = config.vercelEnv
+    ? "configured"
+    : vercelCredentials;
+  const agentConfigured =
+    config.agentKind === "claude"
+      ? Boolean(config.anthropicApiKey && config.anthropicModel)
+      : Boolean((config.codexApiKey || config.codexOauthToken) && config.codexModel);
+
+  const integrations = await Promise.all([
+    probedIntegration(
+      {
+        id: "database",
+        label: "Database",
+        group: "core",
+        envVars: ["DATABASE_URL"],
+        critical: true,
+        mode: config.databaseUrl ? "configured" : "misconfigured",
+        configError: config.databaseUrl ? undefined : "DATABASE_URL is missing.",
+      },
+      probes.database,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "jira",
+        label: "Jira",
+        group: "core",
+        envVars: ["JIRA_BASE_URL", "JIRA_API_TOKEN", "JIRA_PROJECT_KEY"],
+        critical: true,
+        mode: jiraMode,
+        configError:
+          jiraMode === "configured"
+            ? undefined
+            : "Jira URL, API token, and project key are required.",
+      },
+      probes.jira,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "github",
+        label: "GitHub",
+        group: "core",
+        envVars: [
+          "GITHUB_APP_ID",
+          "GITHUB_APP_PRIVATE_KEY",
+          "GITHUB_INSTALLATION_ID",
+          "GITHUB_WEBHOOK_SECRET",
+        ],
+        critical: true,
+        mode: githubMode,
+        configError:
+          githubMode === "misconfigured"
+            ? "GitHub App credentials and webhook secret must be configured together."
+            : undefined,
+      },
+      probes.github,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "gitlab",
+        label: "GitLab",
+        group: "core",
+        envVars: ["GITLAB_TOKEN", "GITLAB_HOST", "GITLAB_WEBHOOK_SECRET"],
+        critical: true,
+        mode: gitlabMode,
+        configError:
+          gitlabMode === "misconfigured"
+            ? "GitLab token and webhook secret must be configured together."
+            : undefined,
+      },
+      probes.gitlab,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "agent",
+        label: config.agentKind === "claude" ? "Claude agent" : "Codex agent",
+        group: "core",
+        envVars:
+          config.agentKind === "claude"
+            ? ["AGENT_KIND", "ANTHROPIC_API_KEY", "CLAUDE_MODEL"]
+            : ["AGENT_KIND", "CODEX_API_KEY", "CODEX_CHATGPT_OAUTH_TOKEN", "CODEX_MODEL"],
+        critical: true,
+        mode: agentConfigured ? "configured" : "misconfigured",
+        configError: agentConfigured
+          ? undefined
+          : `Credentials and a model are required for the active ${config.agentKind} agent.`,
+      },
+      probes.agent,
+      monotonicNow,
+    ),
+    Promise.resolve(
+      configuredIntegration({
+        id: "dashboard-auth",
+        label: "Dashboard authentication",
+        group: "auth-email",
+        envVars: ["BETTER_AUTH_SECRET", "BETTER_AUTH_URL", "DASHBOARD_ORIGIN"],
+        critical: true,
+        mode: authMode,
+        configError:
+          authMode === "misconfigured"
+            ? "Dashboard authentication settings are incomplete."
+            : undefined,
+      }),
+    ),
+    probedIntegration(
+      {
+        id: "sso",
+        label: "Single sign-on",
+        group: "auth-email",
+        envVars: [
+          "SSO_ISSUER",
+          "SSO_ALLOWED_DOMAIN",
+          "SSO_CLIENT_ID",
+          "SSO_CLIENT_SECRET",
+        ],
+        critical: false,
+        mode: ssoMode,
+        configError:
+          ssoMode === "misconfigured"
+            ? "SSO requires issuer, domain, client ID, and client secret together."
+            : undefined,
+      },
+      probes.sso,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "email",
+        label: "Email delivery",
+        group: "auth-email",
+        envVars: ["RESEND_API_KEY", "RESEND_FROM_EMAIL", "RESEND_WEBHOOK_SECRET"],
+        critical: false,
+        mode: emailMode,
+        configError:
+          emailMode === "misconfigured"
+            ? "Email delivery requires RESEND_API_KEY and RESEND_FROM_EMAIL together."
+            : undefined,
+      },
+      probes.email,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "slack",
+        label: "Slack notifications",
+        group: "platform",
+        envVars: ["CHAT_SDK_SLACK_TOKEN", "CHAT_SDK_CHANNEL_ID"],
+        critical: false,
+        mode: slackMode,
+        configError:
+          slackMode === "misconfigured"
+            ? "Slack requires a token and channel ID together."
+            : undefined,
+      },
+      probes.slack,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "arthur",
+        label: "Arthur AI Engine",
+        group: "platform",
+        envVars: ["GENAI_ENGINE_API_KEY", "GENAI_ENGINE_TRACE_ENDPOINT"],
+        critical: false,
+        mode: arthurMode,
+        configError:
+          arthurMode === "misconfigured"
+            ? "Arthur requires an API key and trace endpoint together."
+            : undefined,
+      },
+      probes.arthur,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "mcp",
+        label: "Remote MCP",
+        group: "platform",
+        envVars: ["MCP_ENABLED"],
+        critical: false,
+        mode: config.mcpEnabled ? "configured" : "not-configured",
+      },
+      probes.mcp,
+      monotonicNow,
+    ),
+    probedIntegration(
+      {
+        id: "vercel",
+        label: "Vercel deployment",
+        group: "platform",
+        envVars: ["VERCEL_ENV", "VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"],
+        critical: false,
+        mode: vercelMode,
+        configError:
+          vercelMode === "misconfigured"
+            ? "Vercel credentials require token, team ID, and project ID together."
+            : undefined,
+      },
+      probes.vercel,
+      monotonicNow,
+    ),
+  ]);
+
+  const alerts = integrations.flatMap(alertForIntegration);
+  return {
+    generatedAt: now().toISOString(),
+    summary: {
+      total: integrations.length,
+      live: integrations.filter((entry) => entry.mode === "live").length,
+      down: integrations.filter((entry) => entry.mode === "down").length,
+      notConfigured: integrations.filter(
+        (entry) => entry.mode === "not-configured",
+      ).length,
+      criticalDown: integrations.filter(
+        (entry) => entry.mode === "down" && entry.critical,
+      ).length,
+    },
+    integrations,
+    alerts,
+  };
+}
+
+type IntegrationBase = Omit<SystemHealthIntegration, "ping">;
+
+function configuredIntegration(base: IntegrationBase): SystemHealthIntegration {
+  return { ...base, ping: null };
+}
+
+async function probedIntegration(
+  base: IntegrationBase,
+  probe: ((signal: AbortSignal) => Promise<void>) | undefined,
+  monotonicNow: () => number,
+): Promise<SystemHealthIntegration> {
+  if (base.mode !== "configured" || !probe) return configuredIntegration(base);
+  const startedAt = monotonicNow();
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      probe(controller.signal),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          controller.abort();
+          reject(new PublicHealthProbeError("Health check timed out."));
+        }, PROBE_TIMEOUT_MS);
+      }),
+    ]);
+    return {
+      ...base,
+      mode: "live",
+      ping: {
+        ok: true,
+        latencyMs: Math.max(0, Math.round(monotonicNow() - startedAt)),
+      },
+    };
+  } catch (error) {
+    return {
+      ...base,
+      mode: "down",
+      ping: {
+        ok: false,
+        latencyMs: Math.max(0, Math.round(monotonicNow() - startedAt)),
+        error:
+          error instanceof PublicHealthProbeError
+            ? error.message
+            : "Health check failed.",
+      },
+    };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function groupedMode(
+  values: unknown[],
+  emptyMode: Extract<SystemHealthMode, "not-configured" | "misconfigured" | "mock"> =
+    "not-configured",
+): SystemHealthMode {
+  const configured = values.filter(Boolean).length;
+  if (configured === 0) return emptyMode;
+  return configured === values.length ? "configured" : "misconfigured";
+}
+
+function alertForIntegration(
+  integration: SystemHealthIntegration,
+): SystemHealthAlert[] {
+  if (integration.mode !== "down" && integration.mode !== "misconfigured") {
+    return [];
+  }
+  const severity = integration.critical ? "critical" : "warning";
+  const detail =
+    integration.mode === "down"
+      ? integration.ping?.error ?? "Health check failed."
+      : integration.configError ?? "Configuration is incomplete.";
+  return [
+    {
+      severity,
+      integrationId: integration.id,
+      message: `${integration.label}: ${detail}`,
+      fixHint: `Check ${integration.envVars.join(", ")} and the provider setup.`,
+    },
+  ];
+}
+
+export class PublicHealthProbeError extends Error {}

--- a/apps/worker/src/system-health/probes.test.ts
+++ b/apps/worker/src/system-health/probes.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SystemHealthConfig } from "./collect.js";
+
+const environment = vi.hoisted(() => ({
+  DATABASE_URL: "postgres://db.example/workflow",
+  JIRA_BASE_URL: "https://jira.example",
+  JIRA_API_TOKEN: "jira-token",
+  JIRA_PROJECT_KEY: "AIW",
+  GITHUB_APP_ID: 11,
+  GITHUB_APP_PRIVATE_KEY: "github-key",
+  GITHUB_INSTALLATION_ID: 22,
+  GITHUB_WEBHOOK_SECRET: "github-webhook",
+  GITLAB_TOKEN: "gitlab-token",
+  GITLAB_HOST: "https://gitlab.example",
+  GITLAB_WEBHOOK_SECRET: "gitlab-webhook",
+  AGENT_KIND: "codex" as const,
+  ANTHROPIC_API_KEY: "anthropic-key",
+  CLAUDE_MODEL: "claude-test",
+  CODEX_API_KEY: "openai-key",
+  CODEX_CHATGPT_OAUTH_TOKEN: "codex-oauth",
+  CODEX_MODEL: "gpt-test",
+  BETTER_AUTH_SECRET: "auth-secret",
+  BETTER_AUTH_URL: "https://worker.example",
+  DASHBOARD_ORIGIN: "https://dashboard.example",
+  SSO_ISSUER: "https://sso.example",
+  SSO_ALLOWED_DOMAIN: "example.com",
+  SSO_CLIENT_ID: "sso-client",
+  SSO_CLIENT_SECRET: "sso-secret",
+  RESEND_API_KEY: "resend-key",
+  RESEND_FROM_EMAIL: "AI Workflow <system@example.com>",
+  RESEND_WEBHOOK_SECRET: "resend-webhook",
+  CHAT_SDK_SLACK_TOKEN: "slack-token",
+  CHAT_SDK_CHANNEL_ID: "C123",
+  GENAI_ENGINE_API_KEY: "arthur-key",
+  GENAI_ENGINE_TRACE_ENDPOINT: "https://arthur.example/api/v1/traces",
+  MCP_ENABLED: true,
+  VERCEL_ENV: undefined,
+  VERCEL_TOKEN: "vercel-token",
+  VERCEL_TEAM_ID: "team-id",
+  VERCEL_PROJECT_ID: "project/id",
+}));
+
+vi.mock("../../env.js", () => ({ env: environment }));
+vi.mock("../mcp/contract-artifact.js", () => ({
+  MCP_CONTRACT_ARTIFACT: { tools: [{ name: "system.capabilities" }] },
+}));
+const getInstallation = vi.hoisted(() => vi.fn().mockResolvedValue({ data: {} }));
+vi.mock("../lib/github-auth.js", () => ({
+  buildOctokit: () => ({ apps: { getInstallation } }),
+}));
+
+const { configFromEnvironment, probesForEnvironment } = await import("./probes.js");
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+describe("deployment system-health probes", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("maps every health variable from the validated runtime environment", () => {
+    expect(configFromEnvironment()).toEqual({
+      databaseUrl: environment.DATABASE_URL,
+      jiraBaseUrl: environment.JIRA_BASE_URL,
+      jiraApiToken: environment.JIRA_API_TOKEN,
+      jiraProjectKey: environment.JIRA_PROJECT_KEY,
+      githubAppId: environment.GITHUB_APP_ID,
+      githubAppPrivateKey: environment.GITHUB_APP_PRIVATE_KEY,
+      githubInstallationId: environment.GITHUB_INSTALLATION_ID,
+      githubWebhookSecret: environment.GITHUB_WEBHOOK_SECRET,
+      gitlabToken: environment.GITLAB_TOKEN,
+      gitlabHost: environment.GITLAB_HOST,
+      gitlabWebhookSecret: environment.GITLAB_WEBHOOK_SECRET,
+      agentKind: environment.AGENT_KIND,
+      anthropicApiKey: environment.ANTHROPIC_API_KEY,
+      anthropicModel: environment.CLAUDE_MODEL,
+      codexApiKey: environment.CODEX_API_KEY,
+      codexOauthToken: environment.CODEX_CHATGPT_OAUTH_TOKEN,
+      codexModel: environment.CODEX_MODEL,
+      betterAuthSecret: environment.BETTER_AUTH_SECRET,
+      betterAuthUrl: environment.BETTER_AUTH_URL,
+      dashboardOrigin: environment.DASHBOARD_ORIGIN,
+      ssoIssuer: environment.SSO_ISSUER,
+      ssoAllowedDomain: environment.SSO_ALLOWED_DOMAIN,
+      ssoClientId: environment.SSO_CLIENT_ID,
+      ssoClientSecret: environment.SSO_CLIENT_SECRET,
+      resendApiKey: environment.RESEND_API_KEY,
+      resendFromEmail: environment.RESEND_FROM_EMAIL,
+      resendWebhookSecret: environment.RESEND_WEBHOOK_SECRET,
+      slackToken: environment.CHAT_SDK_SLACK_TOKEN,
+      slackChannelId: environment.CHAT_SDK_CHANNEL_ID,
+      arthurApiKey: environment.GENAI_ENGINE_API_KEY,
+      arthurTraceEndpoint: environment.GENAI_ENGINE_TRACE_ENDPOINT,
+      mcpEnabled: environment.MCP_ENABLED,
+      vercelEnv: environment.VERCEL_ENV,
+      vercelToken: environment.VERCEL_TOKEN,
+      vercelTeamId: environment.VERCEL_TEAM_ID,
+      vercelProjectId: environment.VERCEL_PROJECT_ID,
+    });
+  });
+
+  it("uses read-only provider endpoints with bounded abort signals", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("openid-configuration")) {
+        return new Response(JSON.stringify({ issuer: environment.SSO_ISSUER }));
+      }
+      if (url.includes("slack.com")) {
+        return new Response(JSON.stringify({ ok: true }));
+      }
+      return new Response(JSON.stringify({}));
+    });
+
+    const config = configFromEnvironment();
+    const probes = probesForEnvironment(config);
+    const controller = new AbortController();
+    for (const id of ["github", "sso", "email", "slack", "arthur", "mcp", "vercel", "agent"] as const) {
+      await expect(probes[id]?.(controller.signal), id).resolves.toBeUndefined();
+    }
+    expect(getInstallation).toHaveBeenCalledWith({
+      installation_id: environment.GITHUB_INSTALLATION_ID,
+      request: { signal: controller.signal },
+    });
+
+    const calls = fetchMock.mock.calls.map(([url, init]) => ({
+      url: String(url),
+      authorization: (init?.headers as Record<string, string> | undefined)?.Authorization,
+      method: init?.method ?? "GET",
+      signal: init?.signal,
+    }));
+    expect(calls).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        url: "https://sso.example/.well-known/openid-configuration",
+        signal: controller.signal,
+      }),
+      expect.objectContaining({
+        url: "https://api.resend.com/domains",
+        authorization: "Bearer resend-key",
+      }),
+      expect.objectContaining({
+        url: "https://slack.com/api/auth.test",
+        authorization: "Bearer slack-token",
+        method: "POST",
+      }),
+      expect.objectContaining({
+        url: "https://arthur.example/api/v2/tasks?page_size=1",
+        authorization: "Bearer arthur-key",
+      }),
+      expect.objectContaining({
+        url: "https://api.vercel.com/v9/projects/project%2Fid?teamId=team-id",
+        authorization: "Bearer vercel-token",
+      }),
+      expect.objectContaining({
+        url: "https://api.openai.com/v1/models/gpt-test",
+        authorization: "Bearer openai-key",
+      }),
+    ]));
+  });
+
+  it("does not create probes for presence-only credential modes", () => {
+    const config: SystemHealthConfig = {
+      agentKind: "codex",
+      codexOauthToken: "oauth-token",
+      codexModel: "gpt-test",
+      mcpEnabled: false,
+      vercelEnv: "production",
+    };
+    const probes = probesForEnvironment(config);
+    expect(probes.agent).toBeUndefined();
+    expect(probes.vercel).toBeUndefined();
+    expect(probes.mcp).toBeUndefined();
+  });
+
+  it("accepts a valid send-only Resend key without requiring full account access", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(
+      JSON.stringify({ name: "restricted_api_key" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    ));
+    const probe = probesForEnvironment(configFromEnvironment()).email;
+    await expect(probe?.(new AbortController().signal)).resolves.toBeUndefined();
+  });
+});

--- a/apps/worker/src/system-health/probes.ts
+++ b/apps/worker/src/system-health/probes.ts
@@ -1,0 +1,282 @@
+import { sql } from "drizzle-orm";
+import type { SystemHealthResponse } from "@shared/contracts";
+import { env } from "../../env.js";
+import { JiraAdapter } from "../adapters/issue-tracker/jira.js";
+import { getDb } from "../db/client.js";
+import { buildOctokit } from "../lib/github-auth.js";
+import { MCP_CONTRACT_ARTIFACT } from "../mcp/contract-artifact.js";
+import {
+  collectSystemHealth,
+  PublicHealthProbeError,
+  type SystemHealthConfig,
+  type SystemHealthProbes,
+} from "./collect.js";
+
+export function collectDeploymentSystemHealth(): Promise<SystemHealthResponse> {
+  const config = configFromEnvironment();
+  return collectSystemHealth({
+    config,
+    probes: probesForEnvironment(config),
+  });
+}
+
+export function configFromEnvironment(): SystemHealthConfig {
+  return {
+    databaseUrl: env.DATABASE_URL,
+    jiraBaseUrl: env.JIRA_BASE_URL,
+    jiraApiToken: env.JIRA_API_TOKEN,
+    jiraProjectKey: env.JIRA_PROJECT_KEY,
+    githubAppId: env.GITHUB_APP_ID,
+    githubAppPrivateKey: env.GITHUB_APP_PRIVATE_KEY,
+    githubInstallationId: env.GITHUB_INSTALLATION_ID,
+    githubWebhookSecret: env.GITHUB_WEBHOOK_SECRET,
+    gitlabToken: env.GITLAB_TOKEN,
+    gitlabHost: env.GITLAB_HOST,
+    gitlabWebhookSecret: env.GITLAB_WEBHOOK_SECRET,
+    agentKind: env.AGENT_KIND,
+    anthropicApiKey: env.ANTHROPIC_API_KEY,
+    anthropicModel: env.CLAUDE_MODEL,
+    codexApiKey: env.CODEX_API_KEY,
+    codexOauthToken: env.CODEX_CHATGPT_OAUTH_TOKEN,
+    codexModel: env.CODEX_MODEL,
+    betterAuthSecret: env.BETTER_AUTH_SECRET,
+    betterAuthUrl: env.BETTER_AUTH_URL,
+    dashboardOrigin: env.DASHBOARD_ORIGIN,
+    ssoIssuer: env.SSO_ISSUER,
+    ssoAllowedDomain: env.SSO_ALLOWED_DOMAIN,
+    ssoClientId: env.SSO_CLIENT_ID,
+    ssoClientSecret: env.SSO_CLIENT_SECRET,
+    resendApiKey: env.RESEND_API_KEY,
+    resendFromEmail: env.RESEND_FROM_EMAIL,
+    resendWebhookSecret: env.RESEND_WEBHOOK_SECRET,
+    slackToken: env.CHAT_SDK_SLACK_TOKEN,
+    slackChannelId: env.CHAT_SDK_CHANNEL_ID,
+    arthurApiKey: env.GENAI_ENGINE_API_KEY,
+    arthurTraceEndpoint: env.GENAI_ENGINE_TRACE_ENDPOINT,
+    mcpEnabled: env.MCP_ENABLED,
+    vercelEnv: env.VERCEL_ENV,
+    vercelToken: env.VERCEL_TOKEN,
+    vercelTeamId: env.VERCEL_TEAM_ID,
+    vercelProjectId: env.VERCEL_PROJECT_ID,
+  };
+}
+
+export function probesForEnvironment(
+  config: SystemHealthConfig,
+): SystemHealthProbes {
+  return {
+    database: async () => {
+      try {
+        await getDb().execute(sql.raw("select 1"));
+      } catch {
+        throw new PublicHealthProbeError("Database did not respond.");
+      }
+    },
+    jira: async (signal) => {
+      if (!config.jiraBaseUrl || !config.jiraApiToken || !config.jiraProjectKey) return;
+      try {
+        const adapter = new JiraAdapter({
+          baseUrl: config.jiraBaseUrl,
+          apiToken: config.jiraApiToken,
+          projectKey: config.jiraProjectKey,
+        });
+        await adapter.getCurrentUserAccountId(signal);
+        await adapter.listStatuses(signal);
+      } catch {
+        throw new PublicHealthProbeError("Jira authentication check failed.");
+      }
+    },
+    ...(config.githubAppId &&
+    config.githubAppPrivateKey &&
+    config.githubInstallationId
+      ? {
+          github: async (signal) => {
+            try {
+              await buildOctokit({
+                appId: config.githubAppId!,
+                privateKeyBase64: config.githubAppPrivateKey!,
+                installationId: config.githubInstallationId!,
+              }).apps.getInstallation({
+                installation_id: config.githubInstallationId!,
+                request: { signal },
+              });
+            } catch {
+              throw new PublicHealthProbeError("GitHub App authentication failed.");
+            }
+          },
+        }
+      : {}),
+    ...(config.gitlabToken
+      ? {
+          gitlab: async (signal) => {
+            const response = await fetch(
+              `${(config.gitlabHost ?? "https://gitlab.com").replace(/\/+$/, "")}/api/v4/user`,
+              {
+                headers: { "PRIVATE-TOKEN": config.gitlabToken! },
+                signal,
+              },
+            ).catch(() => null);
+            if (!response?.ok) {
+              throw new PublicHealthProbeError("GitLab authentication failed.");
+            }
+          },
+        }
+      : {}),
+    ...(config.ssoIssuer
+      ? {
+          sso: async (signal) => {
+            const issuer = config.ssoIssuer!.replace(/\/+$/, "");
+            const response = await fetch(
+              `${issuer}/.well-known/openid-configuration`,
+              { signal },
+            ).catch(() => null);
+            const metadata = response?.ok
+              ? ((await response.json().catch(() => null)) as {
+                  issuer?: unknown;
+                } | null)
+              : null;
+            if (!metadata || metadata.issuer !== config.ssoIssuer) {
+              throw new PublicHealthProbeError("SSO discovery check failed.");
+            }
+          },
+        }
+      : {}),
+    ...(config.resendApiKey
+      ? {
+          email: async (signal) => {
+            const response = await fetch("https://api.resend.com/domains", {
+              headers: { Authorization: `Bearer ${config.resendApiKey}` },
+              signal,
+            }).catch(() => null);
+            if (response?.ok) return;
+            const error = response
+              ? ((await response.json().catch(() => null)) as {
+                  name?: unknown;
+                } | null)
+              : null;
+            if (response?.status === 401 && error?.name === "restricted_api_key") {
+              return;
+            }
+            throw new PublicHealthProbeError("Resend authentication failed.");
+          },
+        }
+      : {}),
+    ...(config.slackToken
+      ? {
+          slack: async (signal) => {
+            const response = await fetch("https://slack.com/api/auth.test", {
+              method: "POST",
+              headers: { Authorization: `Bearer ${config.slackToken}` },
+              signal,
+            }).catch(() => null);
+            const result = response?.ok
+              ? ((await response.json().catch(() => null)) as {
+                  ok?: unknown;
+                } | null)
+              : null;
+            if (result?.ok !== true) {
+              throw new PublicHealthProbeError("Slack authentication failed.");
+            }
+          },
+        }
+      : {}),
+    ...(config.arthurApiKey && config.arthurTraceEndpoint
+      ? {
+          arthur: async (signal) => {
+            const baseUrl = config.arthurTraceEndpoint!
+              .replace(/\/api\/v1\/traces\/?$/, "")
+              .replace(/\/+$/, "");
+            const response = await fetch(`${baseUrl}/api/v2/tasks?page_size=1`, {
+              headers: {
+                Authorization: `Bearer ${config.arthurApiKey}`,
+                "ngrok-skip-browser-warning": "true",
+              },
+              signal,
+            }).catch(() => null);
+            if (!response?.ok) {
+              throw new PublicHealthProbeError("Arthur authentication failed.");
+            }
+          },
+        }
+      : {}),
+    ...(config.mcpEnabled
+      ? {
+          mcp: async () => {
+            if (MCP_CONTRACT_ARTIFACT.tools.length === 0) {
+              throw new PublicHealthProbeError("MCP contract has no tools.");
+            }
+          },
+        }
+      : {}),
+    ...(config.vercelToken && config.vercelTeamId && config.vercelProjectId
+      ? {
+          vercel: async (signal) => {
+            const projectId = encodeURIComponent(config.vercelProjectId!);
+            const teamId = encodeURIComponent(config.vercelTeamId!);
+            const response = await fetch(
+              `https://api.vercel.com/v9/projects/${projectId}?teamId=${teamId}`,
+              {
+                headers: { Authorization: `Bearer ${config.vercelToken}` },
+                signal,
+              },
+            ).catch(() => null);
+            if (!response?.ok) {
+              throw new PublicHealthProbeError("Vercel project check failed.");
+            }
+          },
+        }
+      : {}),
+    ...agentProbe(config),
+  };
+}
+
+function agentProbe(
+  config: SystemHealthConfig,
+): Pick<SystemHealthProbes, "agent"> {
+  if (
+    config.agentKind === "claude" &&
+    config.anthropicApiKey &&
+    config.anthropicModel
+  ) {
+    // OAuth-style Claude credentials are consumed by the CLI, not the public
+    // Models API. Presence is the honest readiness signal for that mode.
+    if (config.anthropicApiKey.startsWith("sk-ant-oat")) return {};
+    return {
+      agent: async (signal) => {
+        const response = await fetch("https://api.anthropic.com/v1/models", {
+          headers: {
+            "x-api-key": config.anthropicApiKey!,
+            "anthropic-version": "2023-06-01",
+          },
+          signal,
+        }).catch(() => null);
+        if (!response?.ok) {
+          throw new PublicHealthProbeError("Anthropic authentication failed.");
+        }
+        const body = (await response.json().catch(() => null)) as {
+          data?: Array<{ id?: unknown }>;
+        } | null;
+        if (!body?.data?.some((model) => model.id === config.anthropicModel)) {
+          throw new PublicHealthProbeError("Configured Claude model is unavailable.");
+        }
+      },
+    };
+  }
+  if (config.agentKind === "codex" && config.codexApiKey && config.codexModel) {
+    return {
+      agent: async (signal) => {
+        const response = await fetch(
+          `https://api.openai.com/v1/models/${encodeURIComponent(config.codexModel!)}`,
+          {
+            headers: { Authorization: `Bearer ${config.codexApiKey}` },
+            signal,
+          },
+        ).catch(() => null);
+        if (!response?.ok) {
+          throw new PublicHealthProbeError("OpenAI authentication failed.");
+        }
+      },
+    };
+  }
+  return {};
+}


### PR DESCRIPTION
## Summary
- add an owner/admin-only System health screen to the cockpit
- classify configuration without exposing values and run bounded, read-only probes for DB, Jira project access, GitHub installation, GitLab, active agent model, SSO, Resend, Slack, Arthur, MCP, and Vercel
- surface actionable alerts, latency, manual refresh, and responsive desktop/mobile diagnostics

## Safety
- secret values never leave the worker; only environment variable names are returned
- provider errors are replaced with fixed public messages
- probes run in parallel with a 5-second abort boundary and the response is no-store
- member access is blocked in navigation, page data, and worker API

## Verification
- focused Health worker tests: 13 passed during review
- dashboard regression suite: 809 passed during review
- final authoritative gates: PR CI and PR preview browser test

## Browser QA after preview
- admin desktop and mobile layout
- manual Scan again refresh
- member access denial
- live/configured/not-configured/down states and safe alert copy