### PR TITLE
test(worker): pin the clock in the webhook rate limit tests

### DIFF
--- a/apps/worker/src/webhook-trigger/dispatch-webhook-trigger.test.ts
+++ b/apps/worker/src/webhook-trigger/dispatch-webhook-trigger.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import type { Db } from "../db/client.js";
 import {
@@ -277,6 +277,19 @@ describe("webhook delivery dispatch", () => {
 
 describe("webhook trigger rate limit", () => {
   const perMinute = { max: 1, windowKind: "minute" as const };
+
+  // The limit floors the clock into fixed windows, so two dispatches that
+  // straddle a minute boundary land in different windows and the second one is
+  // legitimately allowed: on the real clock these tests fail whenever they run
+  // across :00. Pin the clock mid-window. Only Date is faked, because faking
+  // the timers as well would stall the awaits these tests are built on.
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["Date"], now: new Date("2026-04-01T10:30:30.000Z") });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("rejects the delivery terminally once the node limit is spent and tallies it", async () => {
     const resolveTriggerRateLimit = vi.fn(async () => perMinute);


### PR DESCRIPTION
## What broke

`dispatch-webhook-trigger.test.ts > webhook trigger rate limit` fails on `main` whenever the run crosses a minute boundary. From the failing job:

```
14:44:54.734Z  delivery d-1 dispatched
14:45:00.020Z  delivery d-2 dispatched
AssertionError: expected { result: 'error', reason: 'AIW-DIAG-ingest-...' }
                to deeply equal { result: 'rejected', reason: 'rate_limited' }
```

## Why

`checkAndIncrementTriggerRate` floors the clock into fixed windows (`trigger-rate-limit.ts`), and `consumeWebhookRateLimit` passes `new Date()`. With `windowKind: "minute"` and `max: 1`, two dispatches on opposite sides of `:00` land in two different windows, so the second one is legitimately allowed. It then calls `startWorkflow`, which returns the mock's `run-1`, a run id the first delivery already bound to subject `T-1`, so `commitHostedStart` refuses and the dispatcher reports `error` instead of `rate_limited`.

That is correct production behaviour. The test was the thing assuming a window can never roll.

## The change

Pin `Date` mid-window for that describe block. Only `Date` is faked, not the timers, because the tests are built on real awaits. This also covers `counts the refused start too`, which asserts a single counter row with `count: 4` and would split into two rows across the same boundary.

No production code changes.