### PR TITLE
feat: add durable run analysis reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     # `pnpm run test` alone measured 16:52, 17:52, 17:55 and 18:58 across four
-    # branches on one day, so a 20 minute job left one to three minutes for
+    # branches on one day, so a 35 minute job left too little headroom for
     # everything else and cancelled mid-step whenever a runner was slow. A
     # cancelled check reads as neither red nor green, which is worse than a
     # failure: it is easy to merge past. The suite's cost is dominated by
     # per-file database setup rather than test count, so this ceiling has to
     # cover that until the database fixture is shared.
-    timeout-minutes: 35
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
+++ b/apps/dashboard/app/(cockpit)/cockpit-shell.test.tsx
@@ -168,6 +168,7 @@ function makeDetail(status: Run["status"]): RunDetailResponse {
       deploymentId: null,
     },
     steps: [],
+    analysisReport: null,
     clarification: null,
   };
 }

--- a/apps/dashboard/components/cockpit/screens/run-analysis-report.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/run-analysis-report.test.tsx
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { RunAnalysisReport } from "@shared/contracts";
+import { RunAnalysisReportCard } from "./run-analysis-report";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const base: RunAnalysisReport = {
+  version: 1,
+  runId: "run-report",
+  sourceResearchRunId: "run-report",
+  researchRevision: 1,
+  stage: "published",
+  researchCompletedAt: "2026-08-20T00:00:00.000Z",
+  repositories: [{ provider: "github", repoPath: "acme/api", defaultBranch: "main", researchBranch: "arthur/AWT-1", researchBaseSha: "abcdef123456", access: "write", rationale: "ticket" }],
+  expansionRounds: 1,
+  repositoryRequests: [],
+  writeRepositories: [{ provider: "github", repoPath: "acme/api", rationale: "ticket" }],
+  evidenceStatus: "captured",
+  evidence: ["github:acme/api src/index.ts: checked"],
+  planMarkdown: "# Plan\n\nImplement the change.",
+  noChangeNeeded: false,
+  resolutionEvidence: [],
+  publication: { prs: [{ provider: "github", repoPath: "acme/api", id: 1, url: "https://github.com/acme/api/pull/1" }], changeSummary: "Implemented the change." },
+  usage: {
+    research: {
+      capturedAt: "2026-08-20T00:00:00.000Z",
+      costUsd: 1.2,
+      costKnown: false,
+      tokensInput: null,
+      tokensCached: null,
+      tokensOutput: null,
+      phases: {
+        research: {
+          costUsd: 1.2,
+          tokens: { input: 100, cachedInput: 25, output: 50 },
+          durationMs: 1200,
+          numTurns: 2,
+          model: "gpt-5.6",
+        },
+      },
+    },
+    publication: null,
+    final: null,
+  },
+  jira: {
+    research: { state: "posted", attemptedAt: "2026-08-20T00:00:00.000Z", commentUrl: "https://jira.example/comment/1", error: null },
+    pullRequest: { state: "failed", attemptedAt: "2026-08-20T00:00:00.000Z", commentUrl: null, error: "Jira unavailable" },
+  },
+  sanitization: { redactions: { token: 1 }, truncated: false, originalBytes: 1, storedBytes: 1, unavailable: false, unavailableReason: null },
+};
+
+test("renders the complete report with accessible disclosures and delivery state", () => {
+  const html = renderToStaticMarkup(<RunAnalysisReportCard report={base} runStatus="success" currentRunId="run-report" />);
+  assert.match(html, /Analysis report/);
+  assert.match(html, /PR\/MR published/);
+  assert.match(html, /aria-expanded="true"/);
+  assert.match(html, /Some report content was redacted/);
+  assert.match(html, /Automatic retries exhausted/);
+  assert.match(html, /\$1\.20\+/);
+  assert.match(html, /gpt-5\.6/);
+  assert.match(html, /100 in \/ 25 cached \/ 50 out/);
+  assert.match(html, /1200ms \/ 2 turns/);
+  assert.match(html, /https:\/\/jira\.example\/comment\/1/);
+  assert.match(html, /base: main/);
+  assert.doesNotMatch(html, /overflow-x-hidden/); // code blocks retain a bounded local scroller
+});
+
+test("distinguishes missing evidence and hides runs without a report", () => {
+  const notRetained = renderToStaticMarkup(<RunAnalysisReportCard report={{ ...base, stage: "research_complete", evidenceStatus: "not_retained", evidence: [], publication: null }} runStatus="success" currentRunId="run-report" />);
+  assert.match(notRetained, /Source evidence was not retained/);
+  const missing = renderToStaticMarkup(<RunAnalysisReportCard report={null} runStatus="failed" currentRunId="legacy" />);
+  assert.equal(missing, "");
+  const active = renderToStaticMarkup(<RunAnalysisReportCard report={null} runStatus="running" currentRunId="live" />);
+  assert.equal(active, "");
+});

--- a/apps/dashboard/components/cockpit/screens/run-analysis-report.tsx
+++ b/apps/dashboard/components/cockpit/screens/run-analysis-report.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import type {
+  RunAnalysisPhaseUsage,
+  RunAnalysisReport,
+  RunAnalysisUsageSnapshot,
+  RunStatus,
+} from "@shared/contracts";
+import { CkCard, CkChip } from "@/components/ui";
+import { PromptPreview } from "@/components/cockpit/prompt-library/prompt-preview";
+import { runHref } from "@/lib/run-href";
+
+function stageLabel(stage: RunAnalysisReport["stage"]): string {
+  if (stage === "published") return "PR/MR published";
+  if (stage === "no_change") return "No change needed";
+  return "Research complete";
+}
+
+function stageTone(stage: RunAnalysisReport["stage"]): "success" | "warn" | "mariner" {
+  return stage === "published" ? "success" : stage === "no_change" ? "warn" : "mariner";
+}
+
+function costLabel(snapshot: RunAnalysisUsageSnapshot | null): string {
+  if (!snapshot) return "Not reached";
+  return `$${snapshot.costUsd.toFixed(2)}${snapshot.costKnown ? "" : "+"}`;
+}
+
+function phaseCostLabel(phase: RunAnalysisPhaseUsage): string {
+  return phase.costUsd === null ? "Unknown" : `$${phase.costUsd.toFixed(2)}`;
+}
+
+function tokenLabel(tokens: RunAnalysisPhaseUsage["tokens"]): string {
+  if (!tokens) return "Unknown";
+  return `${tokens.input} in / ${tokens.cachedInput} cached / ${tokens.output} out`;
+}
+
+function deliveryLabel(delivery: RunAnalysisReport["jira"]["research"]): string {
+  if (delivery.state === "posted") return "Posted";
+  if (delivery.state === "failed") return delivery.error ? `Failed: ${delivery.error}` : "Failed";
+  if (delivery.state === "pending") return "Pending";
+  return "Not applicable";
+}
+
+function DeliveryStatus({
+  label,
+  delivery,
+}: {
+  label: string;
+  delivery: RunAnalysisReport["jira"]["research"];
+}) {
+  return (
+    <span>
+      {label}: {delivery.commentUrl ? (
+        <a
+          href={delivery.commentUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-mariner underline-offset-2 hover:underline"
+        >
+          {deliveryLabel(delivery)} ↗
+        </a>
+      ) : deliveryLabel(delivery)}
+    </span>
+  );
+}
+
+function Disclosure({ title, children, defaultOpen = false }: { title: string; children: React.ReactNode; defaultOpen?: boolean }) {
+  const [open, setOpen] = React.useState(defaultOpen);
+  return (
+    <div className="border-t border-neutral-200 pt-3">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center justify-between gap-3 border-0 bg-transparent p-0 text-left font-mono text-[11px] uppercase tracking-[0.04em] text-neutral-800"
+      >
+        <span>{title}</span>
+        <span aria-hidden="true">{open ? "−" : "+"}</span>
+      </button>
+      {open && <div className="mt-3 min-w-0">{children}</div>}
+    </div>
+  );
+}
+
+function UsageTable({ report }: { report: RunAnalysisReport }) {
+  const rows: Array<[string, RunAnalysisUsageSnapshot | null]> = [
+    ["Research", report.usage.research],
+    ["Publication", report.usage.publication],
+    ["Final", report.usage.final],
+  ];
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[720px] border-collapse font-mono text-[11px]">
+        <thead><tr className="text-left text-neutral-500"><th className="pb-2 pr-3 font-normal">Snapshot / phase</th><th className="pb-2 pr-3 font-normal">Cost</th><th className="pb-2 pr-3 font-normal">Tokens</th><th className="pb-2 pr-3 font-normal">Model</th><th className="pb-2 font-normal">Duration / turns</th></tr></thead>
+        <tbody>
+          {rows.map(([name, snapshot]) => (
+            <React.Fragment key={name}>
+              <tr className="border-t border-neutral-200 align-top">
+                <td className="py-2 pr-3 font-medium text-neutral-900">{name}</td>
+                <td className="py-2 pr-3 text-neutral-800">{costLabel(snapshot)}</td>
+                <td className="py-2 pr-3 text-neutral-700">{snapshot?.tokensInput === null || !snapshot ? "Unknown" : `${snapshot.tokensInput} in / ${snapshot.tokensCached ?? 0} cached / ${snapshot.tokensOutput ?? 0} out`}</td>
+                <td className="py-2 pr-3 text-neutral-500">{snapshot ? `Captured ${new Date(snapshot.capturedAt).toLocaleString()}` : "—"}</td>
+                <td className="py-2 text-neutral-500">—</td>
+              </tr>
+              {snapshot ? Object.entries(snapshot.phases).map(([phaseName, phase]) => (
+                <tr key={`${name}:${phaseName}`} className="border-t border-neutral-100 align-top">
+                  <td className="py-2 pr-3 pl-3 text-neutral-700">↳ {phaseName}</td>
+                  <td className="py-2 pr-3 text-neutral-700">{phaseCostLabel(phase)}</td>
+                  <td className="py-2 pr-3 text-neutral-700">{tokenLabel(phase.tokens)}</td>
+                  <td className="py-2 pr-3 text-neutral-700">{phase.model ?? "Unknown"}</td>
+                  <td className="py-2 text-neutral-700">{phase.durationMs}ms / {phase.numTurns} turns</td>
+                </tr>
+              )) : null}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function RunAnalysisReportCard({ report, runStatus: _runStatus, currentRunId }: { report: RunAnalysisReport | null; runStatus: RunStatus; currentRunId: string }) {
+  if (!report) return null;
+  const finalOrPublication = report.usage.final ?? report.usage.publication ?? report.usage.research;
+  const sourceDiffers = report.sourceResearchRunId !== currentRunId;
+  return (
+    <CkCard eyebrow="Run analysis" title="Analysis report" action={<CkChip tone={stageTone(report.stage)}>{stageLabel(report.stage)}</CkChip>}>
+      <div className="flex min-w-0 flex-col gap-4 font-body text-[13px]">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-neutral-600">
+          <span>Captured {new Date(report.researchCompletedAt).toLocaleString()}</span>
+          {sourceDiffers && <Link href={runHref({ id: report.sourceResearchRunId, ticket: "" })} className="text-mariner underline-offset-2 hover:underline">Source research run: {report.sourceResearchRunId}</Link>}
+        </div>
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+          <Metric label="Repositories inspected" value={report.repositories.length} />
+          <Metric label="Evidence items" value={report.evidenceStatus === "not_retained" ? "—" : report.evidence.length} />
+          <Metric label="Expansion rounds" value={report.expansionRounds} />
+          <Metric label="Current cost" value={costLabel(finalOrPublication)} />
+        </div>
+        {report.sanitization.truncated || Object.keys(report.sanitization.redactions).length > 0 ? (
+          <div role="status" className="rounded-[3px] border border-[#F0D9A8] bg-[#FFF9E8] px-3 py-2 text-[12px] text-[#6E5200]">Some report content was redacted or truncated for safety.</div>
+        ) : null}
+        {report.evidenceStatus === "not_retained" && <div className="rounded-[3px] border border-neutral-200 bg-app-bg px-3 py-2 text-[12px] text-neutral-700">Source evidence was not retained.</div>}
+        <div className="min-w-0 overflow-hidden">
+          <h3 className="m-0 mb-2 font-mono text-[10px] uppercase tracking-[0.05em] text-neutral-500">Repositories analyzed</h3>
+          <div className="flex min-w-0 flex-col gap-2">
+            {report.repositories.map((repo) => <div key={`${repo.provider}:${repo.repoPath}`} className="grid min-w-0 gap-1 rounded-[3px] border border-neutral-200 bg-off-white p-2 md:grid-cols-[1.3fr_.5fr_1fr_1.4fr] md:items-start"><span className="break-all font-mono text-[11px] text-neutral-900">{repo.provider}:{repo.repoPath}</span><span className="font-mono text-[10px] uppercase text-neutral-600">{repo.access}</span><span className="break-all font-mono text-[10px] text-neutral-600">{repo.researchBranch}@{repo.researchBaseSha ? repo.researchBaseSha.slice(0, 8) : "unknown SHA"}<span className="block text-neutral-500">base: {repo.defaultBranch}</span></span><span className="break-words text-[12px] text-neutral-700">{repo.rationale}</span></div>)}
+          </div>
+        </div>
+        <Disclosure title="What was checked" defaultOpen={report.evidenceStatus === "captured"}>
+          {report.evidenceStatus === "not_retained" ? <p className="m-0 text-neutral-600">Source evidence was not retained.</p> : report.evidence.length > 0 ? <ol className="m-0 flex list-decimal flex-col gap-1 pl-5 text-neutral-800">{report.evidence.map((item, index) => <li key={index} className="break-words">{item}</li>)}</ol> : <p className="m-0 text-neutral-600">No evidence items were captured.</p>}
+        </Disclosure>
+        <Disclosure title="Decisions">
+          <div className="flex flex-col gap-2 text-neutral-800">
+            <p className="m-0">Expansion rounds: {report.expansionRounds}</p>
+            <DecisionList title="Requests" items={report.repositoryRequests} />
+            <DecisionList title="Write repositories" items={report.writeRepositories} />
+            {report.resolutionEvidence.length > 0 && <p className="m-0 break-words">Resolution evidence: {report.resolutionEvidence.join(" · ")}</p>}
+          </div>
+        </Disclosure>
+        <Disclosure title="Implementation plan" defaultOpen>
+          <div className="min-w-0 overflow-hidden"><PromptPreview body={report.planMarkdown || "No implementation plan was retained."} /></div>
+        </Disclosure>
+        <div className="border-t border-neutral-200 pt-3"><h3 className="m-0 mb-2 font-mono text-[10px] uppercase tracking-[0.05em] text-neutral-500">Usage</h3><UsageTable report={report} /></div>
+        {report.publication && <div className="border-t border-neutral-200 pt-3"><h3 className="m-0 mb-2 font-mono text-[10px] uppercase tracking-[0.05em] text-neutral-500">Published</h3><div className="flex flex-col gap-2"><div className="flex flex-wrap gap-2">{report.publication.prs.map((pr) => <a key={`${pr.provider}:${pr.repoPath}:${pr.id}`} href={pr.url} target="_blank" rel="noreferrer" className="max-w-full break-all text-mariner underline-offset-2 hover:underline">{pr.provider}:{pr.repoPath} #{pr.id} ↗</a>)}</div><p className="m-0 whitespace-pre-wrap break-words text-neutral-800">{report.publication.changeSummary}</p></div></div>}
+        <div className="border-t border-neutral-200 pt-3"><h3 className="m-0 mb-2 font-mono text-[10px] uppercase tracking-[0.05em] text-neutral-500">Jira delivery</h3><div className="grid gap-1 font-mono text-[11px] text-neutral-700 md:grid-cols-2"><DeliveryStatus label="Research" delivery={report.jira.research} /><DeliveryStatus label="PR/MR" delivery={report.jira.pullRequest} /></div>{(report.jira.research.state === "failed" || report.jira.pullRequest.state === "failed") && <p className="m-0 mt-2 text-[12px] text-fail-fg">Automatic retries exhausted; code delivery was not blocked.</p>}</div>
+      </div>
+    </CkCard>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: React.ReactNode }) {
+  return <div className="min-w-0 rounded-[3px] border border-neutral-200 bg-off-white px-2.5 py-2"><div className="font-mono text-[9px] uppercase tracking-[0.04em] text-neutral-500">{label}</div><div className="mt-1 break-words font-display text-lg text-neutral-900">{value}</div></div>;
+}
+
+function DecisionList({
+  title,
+  items,
+}: {
+  title: string;
+  items: RunAnalysisReport["repositoryRequests"];
+}) {
+  if (items.length === 0) return <p className="m-0">{title}: none</p>;
+  return (
+    <div>
+      <p className="m-0">{title}:</p>
+      <ul className="m-0 mt-1 flex list-disc flex-col gap-1 pl-5">
+        {items.map((item) => (
+          <li key={`${item.provider}:${item.repoPath}`} className="break-words">
+            <span className="font-mono">{item.provider}:{item.repoPath}</span> — {item.rationale}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/dashboard/components/cockpit/screens/trace-replay.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace-replay.test.tsx
@@ -52,6 +52,7 @@ const detail: RunDetailResponse = {
       error: { message: "Review failed" },
     },
   ],
+  analysisReport: null,
   clarification: null,
 };
 

--- a/apps/dashboard/components/cockpit/screens/trace.tsx
+++ b/apps/dashboard/components/cockpit/screens/trace.tsx
@@ -17,6 +17,7 @@ import { runModelLabel } from "@/lib/run-model";
 import { runPullRequests } from "@/lib/run-prs";
 import { hasActiveRun, useRunRefresh } from "@/lib/use-run-refresh";
 import { RunRefreshControl } from "@/components/cockpit/run-refresh-control";
+import { RunAnalysisReportCard } from "./run-analysis-report";
 import { SPAN_KIND_COLOR } from "@/lib/theme";
 import { pullRequestRef, pullRequestRepoLabels } from "@shared/contracts";
 import type { Span, SpanKind, SpanStatus } from "@/lib/types";
@@ -482,6 +483,12 @@ export function TraceDetail({
           runStatus={run.status}
         />
       )}
+
+      <RunAnalysisReportCard
+        report={shownData.analysisReport ?? null}
+        runStatus={run.status}
+        currentRunId={run.id}
+      />
 
       {hasReplay || replayPending ? (
         <WorkflowReplay

--- a/apps/dashboard/lib/api/fallbacks.test.ts
+++ b/apps/dashboard/lib/api/fallbacks.test.ts
@@ -1,0 +1,7 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runDetailFallback } from "./fallbacks";
+
+test("run detail fallback carries a nullable analysis report", () => {
+  assert.equal(runDetailFallback("now").analysisReport, null);
+});

--- a/apps/dashboard/lib/api/fallbacks.ts
+++ b/apps/dashboard/lib/api/fallbacks.ts
@@ -37,7 +37,7 @@ export function recentRunsFallback(now: string): RunsResponse {
 }
 
 export function runDetailFallback(now: string): RunDetailResponse {
-  return { generatedAt: now, available: false, run: null, steps: [] };
+  return { generatedAt: now, available: false, run: null, steps: [], analysisReport: null };
 }
 
 export function runReplayFallback(): WorkflowRunReplayResponse {

--- a/apps/shared/contracts/api.ts
+++ b/apps/shared/contracts/api.ts
@@ -24,6 +24,7 @@ import type {
   WebhookAuthScheme,
 } from "./domain.js";
 import type { PromptSlotDefinition } from "./prompt-slots.js";
+import type { RunAnalysisReport } from "./run-analysis.js";
 
 export interface ErrorEnvelope {
   error: { code: string; message: string; details?: unknown };
@@ -161,6 +162,7 @@ export interface RunDetailResponse {
   available: boolean;
   run: RunDetail | null;
   steps: RunStep[];
+  analysisReport: RunAnalysisReport | null;
   clarification?: ClarificationRequest | null;
 }
 

--- a/apps/shared/contracts/index.ts
+++ b/apps/shared/contracts/index.ts
@@ -12,3 +12,4 @@ export * from "./default-agent-prompt-references.js";
 export * from "./workflow-value-compatibility.js";
 export * from "./review-result.js";
 export * from "./repository-scripts.js";
+export * from "./run-analysis.js";

--- a/apps/shared/contracts/run-analysis.ts
+++ b/apps/shared/contracts/run-analysis.ts
@@ -1,0 +1,84 @@
+import type { RunPullRequest } from "./domain.js";
+import type { ReplaySanitizationMetadata } from "./run-replay.js";
+
+export type RunAnalysisStage =
+  | "research_complete"
+  | "published"
+  | "no_change";
+
+export interface RunAnalysisRepository {
+  provider: "github" | "gitlab";
+  repoPath: string;
+  defaultBranch: string;
+  researchBranch: string;
+  researchBaseSha: string | null;
+  access: "read" | "write";
+  rationale: string;
+}
+
+export interface RunAnalysisRepositoryRequest {
+  provider: "github" | "gitlab";
+  repoPath: string;
+  rationale: string;
+}
+
+export interface RunAnalysisPhaseUsage {
+  costUsd: number | null;
+  tokens: {
+    input: number;
+    cachedInput: number;
+    output: number;
+  } | null;
+  durationMs: number;
+  numTurns: number;
+  model: string | null;
+}
+
+export interface RunAnalysisUsageSnapshot {
+  capturedAt: string;
+  costUsd: number;
+  costKnown: boolean;
+  tokensInput: number | null;
+  tokensCached: number | null;
+  tokensOutput: number | null;
+  phases: Record<string, RunAnalysisPhaseUsage>;
+}
+
+export interface RunAnalysisCommentDelivery {
+  state: "not_applicable" | "pending" | "posted" | "failed";
+  attemptedAt: string | null;
+  commentUrl: string | null;
+  error: string | null;
+}
+
+export interface RunAnalysisReport {
+  version: 1;
+  runId: string;
+  sourceResearchRunId: string;
+  researchRevision: number;
+  stage: RunAnalysisStage;
+  researchCompletedAt: string;
+  repositories: RunAnalysisRepository[];
+  expansionRounds: number;
+  repositoryRequests: RunAnalysisRepositoryRequest[];
+  writeRepositories: RunAnalysisRepositoryRequest[];
+  evidenceStatus: "captured" | "not_retained";
+  evidence: string[];
+  planMarkdown: string;
+  noChangeNeeded: boolean;
+  resolutionEvidence: string[];
+  publication: {
+    prs: RunPullRequest[];
+    changeSummary: string;
+  } | null;
+  usage: {
+    research: RunAnalysisUsageSnapshot;
+    publication: RunAnalysisUsageSnapshot | null;
+    final: RunAnalysisUsageSnapshot | null;
+  };
+  jira: {
+    research: RunAnalysisCommentDelivery;
+    pullRequest: RunAnalysisCommentDelivery;
+  };
+  sanitization: ReplaySanitizationMetadata;
+}

--- a/apps/worker/drizzle/0057_run_analysis_report.sql
+++ b/apps/worker/drizzle/0057_run_analysis_report.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflow_runs" ADD COLUMN "analysis_report" jsonb;

--- a/apps/worker/drizzle/meta/0057_snapshot.json
+++ b/apps/worker/drizzle/meta/0057_snapshot.json
@@ -1,0 +1,7377 @@
+{
+  "id": "ebec03fc-96b4-409e-bc5d-de17cf2d950b",
+  "prevId": "8c1d5f42-3b76-4a90-9e58-2d4f7a61c0b3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.carry_schema_resync_audit": {
+      "name": "carry_schema_resync_audit",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_index": {
+          "name": "node_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carry_index": {
+          "name": "carry_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_schema": {
+          "name": "before_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk": {
+          "name": "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk",
+          "columns": [
+            "definition_id",
+            "version",
+            "node_index",
+            "carry_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispatch_capacity_queue": {
+      "name": "dispatch_capacity_queue",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_capability_catalogs": {
+      "name": "harness_capability_catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_hash": {
+          "name": "catalog_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "harness_capability_catalogs_scope_unique": {
+          "name": "harness_capability_catalogs_scope_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_capability_catalogs_organization_id_organization_id_fk": {
+          "name": "harness_capability_catalogs_organization_id_organization_id_fk",
+          "tableFrom": "harness_capability_catalogs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_capability_catalogs_provider_check": {
+          "name": "harness_capability_catalogs_provider_check",
+          "value": "\"harness_capability_catalogs\".\"provider\" in ('claude', 'codex')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_content_sha256": {
+          "name": "local_content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifacts_source_kind_check": {
+          "name": "harness_skill_artifacts_source_kind_check",
+          "value": "\"harness_skill_artifacts\".\"source_kind\" in ('github', 'local')"
+        },
+        "harness_skill_artifacts_source_shape_check": {
+          "name": "harness_skill_artifacts_source_shape_check",
+          "value": "(\n        \"harness_skill_artifacts\".\"source_kind\" <> 'github'\n        or (\n          \"harness_skill_artifacts\".\"source_owner\" is not null\n          and \"harness_skill_artifacts\".\"source_repository\" is not null\n          and \"harness_skill_artifacts\".\"source_path\" is not null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is not null\n          and \"harness_skill_artifacts\".\"local_path\" is null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is null\n        )\n      ) and (\n        \"harness_skill_artifacts\".\"source_kind\" <> 'local'\n        or (\n          \"harness_skill_artifacts\".\"local_path\" is not null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is not null\n          and \"harness_skill_artifacts\".\"source_owner\" is null\n          and \"harness_skill_artifacts\".\"source_repository\" is null\n          and \"harness_skill_artifacts\".\"source_path\" is null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is null\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_events": {
+      "name": "mcp_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutation_class": {
+          "name": "mutation_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_refs": {
+          "name": "target_refs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_hash": {
+          "name": "output_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key_hash": {
+          "name": "idempotency_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_version": {
+          "name": "server_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_hash": {
+          "name": "contract_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_audit_events_organization_occurred_at_idx": {
+          "name": "mcp_audit_events_organization_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_audit_events_request_id_idx": {
+          "name": "mcp_audit_events_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_events_organization_id_organization_id_fk": {
+          "name": "mcp_audit_events_organization_id_organization_id_fk",
+          "tableFrom": "mcp_audit_events",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_idempotency_keys": {
+      "name": "mcp_idempotency_keys",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_response": {
+          "name": "safe_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_idempotency_keys_namespace_unique": {
+          "name": "mcp_idempotency_keys_namespace_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_idempotency_keys_expires_at_idx": {
+          "name": "mcp_idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_idempotency_keys_organization_id_organization_id_fk": {
+          "name": "mcp_idempotency_keys_organization_id_organization_id_fk",
+          "tableFrom": "mcp_idempotency_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_idempotency_keys_state_check": {
+          "name": "mcp_idempotency_keys_state_check",
+          "value": "\"mcp_idempotency_keys\".\"state\" in ('started', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_rate_limit_windows": {
+      "name": "mcp_rate_limit_windows",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_rate_limit_windows_expires_at_idx": {
+          "name": "mcp_rate_limit_windows_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_rate_limit_windows_organization_id_organization_id_fk": {
+          "name": "mcp_rate_limit_windows_organization_id_organization_id_fk",
+          "tableFrom": "mcp_rate_limit_windows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_rate_limit_windows_organization_id_actor_subject_client_id_tool_name_window_started_at_pk": {
+          "name": "mcp_rate_limit_windows_organization_id_actor_subject_client_id_tool_name_window_started_at_pk",
+          "columns": [
+            "organization_id",
+            "actor_subject",
+            "client_id",
+            "tool_name",
+            "window_started_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_autofix_attempts": {
+      "name": "pr_autofix_attempts",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_autofix_attempts_pk": {
+          "name": "pr_autofix_attempts_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "provider",
+            "repo_path",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_occurrences": {
+      "name": "schedule_occurrences",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_at": {
+          "name": "occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_count": {
+          "name": "dropped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dropped_count_capped": {
+          "name": "dropped_count_capped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocking_run_id": {
+          "name": "blocking_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedule_occurrences_one_pending_per_schedule_idx": {
+          "name": "schedule_occurrences_one_pending_per_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedule_occurrences\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_occurrences_run_id_idx": {
+          "name": "schedule_occurrences_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_occurrences_schedule_id_workflow_schedules_id_fk": {
+          "name": "schedule_occurrences_schedule_id_workflow_schedules_id_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_occurrences_definition_version_fk": {
+          "name": "schedule_occurrences_definition_version_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedule_occurrences_schedule_id_occurrence_at_pk": {
+          "name": "schedule_occurrences_schedule_id_occurrence_at_pk",
+          "columns": [
+            "schedule_id",
+            "occurrence_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedule_occurrences_outcome_check": {
+          "name": "schedule_occurrences_outcome_check",
+          "value": "\"schedule_occurrences\".\"outcome\" is null or \"schedule_occurrences\".\"outcome\" in ('started', 'skipped_overlap', 'skipped_stale', 'superseded', 'expired', 'cancelled', 'run_cancelled', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.system_health_observation_counters": {
+      "name": "system_health_observation_counters",
+      "schema": "",
+      "columns": {
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployment'"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "system_health_observation_counters_pk": {
+          "name": "system_health_observation_counters_pk",
+          "columns": [
+            "integration_id",
+            "check_id",
+            "scope",
+            "window_start",
+            "outcome",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_health_scans": {
+      "name": "system_health_scans",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'deployment'"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_rate_limits": {
+      "name": "trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_kind": {
+          "name": "window_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trigger_rate_limits_pk": {
+          "name": "trigger_rate_limits_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "window_kind",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_rejection_counters": {
+      "name": "trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trigger_rejection_counters_definition_id_node_id_day_reason_pk": {
+          "name": "trigger_rejection_counters_definition_id_node_id_day_reason_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "day",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_deliveries": {
+      "name": "webhook_trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "webhook_trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_trigger_deliveries_definition_version_fk": {
+          "name": "webhook_trigger_deliveries_definition_version_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_deliveries_endpoint_id_delivery_id_pk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_delivery_id_pk",
+          "columns": [
+            "endpoint_id",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_endpoints": {
+      "name": "webhook_trigger_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_scheme": {
+          "name": "auth_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hmac_sha256'"
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_timestamp": {
+          "name": "require_timestamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timestamp_header": {
+          "name": "timestamp_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp_tolerance_seconds": {
+          "name": "timestamp_tolerance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_secret_ciphertext": {
+          "name": "previous_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_endpoints_definition_node_idx": {
+          "name": "webhook_trigger_endpoints_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk": {
+          "name": "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "webhook_trigger_endpoints",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhook_trigger_endpoints_auth_scheme_check": {
+          "name": "webhook_trigger_endpoints_auth_scheme_check",
+          "value": "\"webhook_trigger_endpoints\".\"auth_scheme\" in ('hmac_sha256', 'shared_token')"
+        },
+        "webhook_trigger_endpoints_timestamp_tolerance_check": {
+          "name": "webhook_trigger_endpoints_timestamp_tolerance_check",
+          "value": "\"webhook_trigger_endpoints\".\"timestamp_tolerance_seconds\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rate_limits": {
+      "name": "webhook_trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inbox'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_rate_limits",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rejection_counters": {
+      "name": "webhook_trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk": {
+          "name": "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publication_comments": {
+      "name": "workflow_pr_review_publication_comments",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk",
+          "tableFrom": "workflow_pr_review_publication_comments",
+          "tableTo": "workflow_pr_review_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_pr_review_publication_comments_publication_id_content_hash_pk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_content_hash_pk",
+          "columns": [
+            "publication_id",
+            "content_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publication_comments_state_check": {
+          "name": "workflow_pr_review_publication_comments_state_check",
+          "value": "\"workflow_pr_review_publication_comments\".\"state\" in ('pending', 'published')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publications": {
+      "name": "workflow_pr_review_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_comment_count": {
+          "name": "inline_comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summary_fallback_count": {
+          "name": "summary_fallback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_pr_review_publications_content_unique": {
+          "name": "workflow_pr_review_publications_content_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pr_review_publications_run_idx": {
+          "name": "workflow_pr_review_publications_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_pr_review_publications",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publications_state_check": {
+          "name": "workflow_pr_review_publications_state_check",
+          "value": "\"workflow_pr_review_publications\".\"state\" in ('pending', 'published')"
+        },
+        "workflow_pr_review_publications_decision_check": {
+          "name": "workflow_pr_review_publications_decision_check",
+          "value": "\"workflow_pr_review_publications\".\"decision\" in ('approve', 'request_changes')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_external_checks": {
+      "name": "workflow_run_external_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "closure_intent": {
+          "name": "closure_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_external_checks_attempt_unique": {
+          "name": "workflow_run_external_checks_attempt_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_reconcile_idx": {
+          "name": "workflow_run_external_checks_reconcile_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_run_idx": {
+          "name": "workflow_run_external_checks_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_external_checks_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_external_checks_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_external_checks",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_external_checks_state_check": {
+          "name": "workflow_run_external_checks_state_check",
+          "value": "\"workflow_run_external_checks\".\"state\" in ('creating', 'pending', 'closing', 'completed')"
+        },
+        "workflow_run_external_checks_conclusion_check": {
+          "name": "workflow_run_external_checks_conclusion_check",
+          "value": "\"workflow_run_external_checks\".\"conclusion\" is null or \"workflow_run_external_checks\".\"conclusion\" in ('success', 'failure', 'neutral', 'cancelled', 'timed_out', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_started_at": {
+          "name": "entry_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_deadline_at": {
+          "name": "startup_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_report": {
+          "name": "analysis_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_startup_watchdog_idx": {
+          "name": "workflow_runs_startup_watchdog_idx",
+          "columns": [
+            {
+              "expression": "startup_deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_runs\".\"entry_started_at\" is null and coalesce(\"workflow_runs\".\"status\", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "overlap_policy": {
+          "name": "overlap_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "catch_up_grace_minutes": {
+          "name": "catch_up_grace_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_watermark_at": {
+          "name": "evaluation_watermark_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_occurrence_at": {
+          "name": "last_started_occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_run_id": {
+          "name": "last_started_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_schedules_definition_node_idx": {
+          "name": "workflow_schedules_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_schedules_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_schedules_overlap_policy_check": {
+          "name": "workflow_schedules_overlap_policy_check",
+          "value": "\"workflow_schedules\".\"overlap_policy\" in ('skip', 'queue', 'allow')"
+        },
+        "workflow_schedules_catch_up_grace_check": {
+          "name": "workflow_schedules_catch_up_grace_check",
+          "value": "\"workflow_schedules\".\"catch_up_grace_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expires_at_idx": {
+          "name": "oauth_access_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_expires_at_idx": {
+          "name": "oauth_refresh_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memory_documents": {
+      "name": "agent_memory_documents",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memory_documents_ticket_key_idx": {
+          "name": "agent_memory_documents_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_documents_updated_at_idx": {
+          "name": "agent_memory_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_memory_documents_subject_key_doc_path_pk": {
+          "name": "agent_memory_documents_subject_key_doc_path_pk",
+          "columns": [
+            "subject_key",
+            "doc_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1787310664716,
       "tag": "0056_autofix_comment_binding",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1787827772268,
+      "tag": "0057_run_analysis_report",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/adapters/issue-tracker/jira.test.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.test.ts
@@ -841,6 +841,62 @@ describe("JiraAdapter", () => {
     });
   });
 
+  describe("findCommentByMarker", () => {
+    it("scans paginated comments and returns the matching deep link", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            startAt: 0,
+            maxResults: 1,
+            total: 2,
+            comments: [{ id: "1", body: { content: [{ content: [{ text: "unrelated" }] }] } }],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            startAt: 1,
+            maxResults: 1,
+            total: 2,
+            comments: [{
+              id: "2",
+              body: { content: [{ content: [{ text: "Arthur report: run-1:research" }] }] },
+            }],
+          }),
+        });
+
+      await expect(
+        jiraAdapter().findCommentByMarker("PROJ-1", "Arthur report: run-1:research"),
+      ).resolves.toBe(
+        "https://test.atlassian.net/browse/PROJ-1?focusedCommentId=2",
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch.mock.calls[1]![0]).toBe(
+        `${API_BASE}/rest/api/3/issue/PROJ-1/comment?startAt=1&maxResults=100`,
+      );
+    });
+
+    it("matches the marker as a complete line", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          startAt: 0,
+          maxResults: 100,
+          total: 1,
+          comments: [{
+            id: "1",
+            body: { content: [{ content: [{ text: "prefix Arthur report: run-1:research suffix" }] }] },
+          }],
+        }),
+      });
+
+      await expect(
+        jiraAdapter().findCommentByMarker("PROJ-1", "Arthur report: run-1:research"),
+      ).resolves.toBeNull();
+    });
+  });
+
   describe("createTicket", () => {
     it("creates in the configured project with an ADF description and returns a browse url", async () => {
       mockFetch.mockResolvedValueOnce({

--- a/apps/worker/src/adapters/issue-tracker/jira.ts
+++ b/apps/worker/src/adapters/issue-tracker/jira.ts
@@ -31,6 +31,7 @@ type JiraTransition = {
 };
 
 const STATUS_DISCOVERY_TIMEOUT_MS = 5000;
+const COMMENT_PAGE_SIZE = 100;
 
 export class JiraAdapter implements IssueTrackerAdapter {
   private tenantOrigin: string;
@@ -208,6 +209,33 @@ export class JiraAdapter implements IssueTrackerAdapter {
     const commentId = typeof data?.id === "string" ? data.id : null;
     if (!commentId) return null;
     return `${this.tenantOrigin}/browse/${encodeURIComponent(id)}?focusedCommentId=${encodeURIComponent(commentId)}`;
+  }
+
+  async findCommentByMarker(id: string, marker: string): Promise<string | null> {
+    let startAt = 0;
+    while (true) {
+      const data = await this.request(
+        `/rest/api/3/issue/${encodeURIComponent(id)}/comment?startAt=${startAt}&maxResults=${COMMENT_PAGE_SIZE}`,
+      );
+      const comments = Array.isArray(data?.comments) ? data.comments : [];
+      for (const comment of comments) {
+        const body = extractAdfText(comment?.body);
+        const hasMarker = body
+          .split(/\r?\n/u)
+          .some((line) => line.trim() === marker);
+        if (!hasMarker) continue;
+        const commentId = comment?.id == null ? "" : String(comment.id);
+        return commentId
+          ? `${this.tenantOrigin}/browse/${encodeURIComponent(id)}?focusedCommentId=${encodeURIComponent(commentId)}`
+          : `${this.tenantOrigin}/browse/${encodeURIComponent(id)}`;
+      }
+
+      const total = Number(data?.total);
+      if (comments.length === 0 || !Number.isFinite(total) || startAt + comments.length >= total) {
+        return null;
+      }
+      startAt += comments.length;
+    }
   }
 
   async createTicket(input: {

--- a/apps/worker/src/adapters/issue-tracker/types.ts
+++ b/apps/worker/src/adapters/issue-tracker/types.ts
@@ -106,6 +106,16 @@ export interface IssueTrackerAdapter {
     options?: { signal?: AbortSignal },
   ): Promise<string | null>;
   /**
+   * Finds a previously published comment containing `marker` as an exact line.
+   * Providers that expose paginated comments should scan every page so a retry
+   * cannot duplicate an older side effect that fell outside fetchTicket's
+   * embedded comment window.
+   */
+  findCommentByMarker?(
+    id: string,
+    marker: string,
+  ): Promise<string | null>;
+  /**
    * Create a ticket in the adapter's configured project. Optional — the platform's own
    * work never creates tickets (it reacts to ones people file), so an implementation
    * without this is complete; callers must handle its absence.

--- a/apps/worker/src/approvals/dispatch.test.ts
+++ b/apps/worker/src/approvals/dispatch.test.ts
@@ -194,6 +194,7 @@ describe("dispatchPlanApproved owner reservation", () => {
         ownerToken: expect.stringMatching(/^owner:/),
         definitionId: 7,
         definitionVersion: 4,
+        approvedPlan: expect.objectContaining({ sourceRunId: "run-produced" }),
       }),
     ]);
     const reservation = vi.mocked(registry.reserve).mock.calls[0]![0];

--- a/apps/worker/src/approvals/dispatch.ts
+++ b/apps/worker/src/approvals/dispatch.ts
@@ -125,6 +125,7 @@ export async function dispatchPlanApproved(input: {
           definitionVersion: pinned.version,
           approvedPlan: {
             markdown: approval.plan.markdown,
+            sourceRunId: approval.runId,
             assumptions: approval.assumptions ?? undefined,
             repositoryScope: approval.repositoryScope ?? undefined,
           },

--- a/apps/worker/src/db/queries/run-detail-read.test.ts
+++ b/apps/worker/src/db/queries/run-detail-read.test.ts
@@ -4,6 +4,7 @@ import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
 import type { HarnessRunManifestRecord } from "@shared/contracts";
 import { fetchRunDetailFromDb, fetchRunRefs } from "./run-detail-read.js";
+import { buildResearchAnalysisReport } from "../../run-analysis/report.js";
 
 /** Minimal fixture: attributeRunModel only reads `.nodeId` / `.manifest.model.id`. */
 function harnessManifest(nodeId: string, modelId: string): HarnessRunManifestRecord {
@@ -24,6 +25,19 @@ const base = { jiraBaseUrl: JIRA };
 describe("fetchRunDetailFromDb", () => {
   it("returns null for an unknown run id", async () => {
     expect(await fetchRunDetailFromDb({ db, runId: "nope", ...base })).toBeNull();
+  });
+
+  it("round-trips a valid report and treats legacy JSON as null", async () => {
+    const report = buildResearchAnalysisReport({
+      runId: "r-report",
+      researchResult: { body: "# Plan" },
+      usage: { costUsd: 0, costKnown: true, tokensInput: 0, tokensCached: 0, tokensOutput: 0, phases: {} },
+    });
+    await db.insert(workflowRuns).values({ runId: "r-report", analysisReport: report, startedAt: new Date() });
+    const result = await fetchRunDetailFromDb({ db, runId: "r-report", ...base });
+    expect(result?.analysisReport).toEqual(report);
+    await db.insert(workflowRuns).values({ runId: "r-legacy", startedAt: new Date() });
+    expect((await fetchRunDetailFromDb({ db, runId: "r-legacy", ...base }))?.analysisReport).toBeNull();
   });
 
   it("rebuilds the header from the persisted row", async () => {

--- a/apps/worker/src/db/queries/run-detail-read.ts
+++ b/apps/worker/src/db/queries/run-detail-read.ts
@@ -1,10 +1,11 @@
 import { eq } from "drizzle-orm";
-import type { RunDetail, RunPullRequest, RunStep } from "@shared/contracts";
+import type { RunAnalysisReport, RunDetail, RunPullRequest, RunStep } from "@shared/contracts";
 import type { Db } from "../client.js";
 import { workflowRuns } from "../schema.js";
 import { coerceStatus } from "./runs-read.js";
 import { attributeRunModel } from "../../lib/overview/attribute-run-model.js";
 import { sanitizeRunSteps } from "../../lib/overview/sanitize-run-detail.js";
+import { parseStoredRunAnalysisReport } from "../../run-analysis/report.js";
 
 /**
  * Postgres fallback for the single-run trace. The Vercel Workflow step waterfall
@@ -91,7 +92,7 @@ export interface FetchRunDetailFromDbOptions {
 
 export async function fetchRunDetailFromDb(
   opts: FetchRunDetailFromDbOptions,
-): Promise<{ run: RunDetail; steps: RunStep[]; hasRealSteps: boolean } | null> {
+): Promise<{ run: RunDetail; steps: RunStep[]; hasRealSteps: boolean; analysisReport: RunAnalysisReport | null } | null> {
   const { db, runId, jiraBaseUrl } = opts;
   const tenantOrigin = jiraBaseUrl.replace(/\/+$/, "");
 
@@ -139,9 +140,9 @@ export async function fetchRunDetailFromDb(
     const steps = TERMINAL.has(run.status)
       ? normalizeFinishedSteps(safePersisted, run.completedAt)
       : safePersisted;
-    return { run, steps, hasRealSteps: true };
+    return { run, steps, hasRealSteps: true, analysisReport: parseStoredRunAnalysisReport(row.analysisReport) };
   }
-  return { run, steps: phasesToSteps(row.phases, base), hasRealSteps: false };
+  return { run, steps: phasesToSteps(row.phases, base), hasRealSteps: false, analysisReport: parseStoredRunAnalysisReport(row.analysisReport) };
 }
 
 /**

--- a/apps/worker/src/db/run-analysis-report-migration.test.ts
+++ b/apps/worker/src/db/run-analysis-report-migration.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { PGlite } from "@electric-sql/pglite";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+
+async function migrateThrough(lastPrefix: string): Promise<PGlite> {
+  const client = new PGlite();
+  const files = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith(".sql") && file.slice(0, 4) <= lastPrefix)
+    .sort();
+  for (const file of files) await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+  return client;
+}
+
+describe("0057 run analysis report migration", () => {
+  it("preserves existing runs and leaves the new report nullable", async () => {
+    const client = await migrateThrough("0056");
+    await client.exec(`INSERT INTO workflow_runs (run_id, status) VALUES ('legacy-report-run', 'success')`);
+    await client.exec(readFileSync(`${migrationsDir}0057_run_analysis_report.sql`, "utf8"));
+    const rows = await client.query<{ run_id: string; status: string; analysis_report: unknown }>(
+      `SELECT run_id, status, analysis_report FROM workflow_runs WHERE run_id = 'legacy-report-run'`,
+    );
+    expect(rows.rows).toEqual([{ run_id: "legacy-report-run", status: "success", analysis_report: null }]);
+  });
+
+  it("round-trips a version-1 report on a fresh schema", async () => {
+    const client = await migrateThrough("0057");
+    const report = {
+      version: 1,
+      runId: "report-run",
+      sourceResearchRunId: "report-run",
+      researchRevision: 1,
+      stage: "research_complete",
+      researchCompletedAt: "2026-08-20T00:00:00.000Z",
+      repositories: [],
+      expansionRounds: 0,
+      repositoryRequests: [],
+      writeRepositories: [],
+      evidenceStatus: "captured",
+      evidence: [],
+      planMarkdown: "# Plan",
+      noChangeNeeded: false,
+      resolutionEvidence: [],
+      publication: null,
+      usage: {
+        research: {
+          capturedAt: "2026-08-20T00:00:00.000Z",
+          costUsd: 0,
+          costKnown: true,
+          tokensInput: 0,
+          tokensCached: 0,
+          tokensOutput: 0,
+          phases: {},
+        },
+        publication: null,
+        final: null,
+      },
+      jira: {
+        research: { state: "pending", attemptedAt: null, commentUrl: null, error: null },
+        pullRequest: { state: "not_applicable", attemptedAt: null, commentUrl: null, error: null },
+      },
+      sanitization: {
+        redactions: {},
+        truncated: false,
+        originalBytes: 8,
+        storedBytes: 8,
+        unavailable: false,
+        unavailableReason: null,
+      },
+    };
+    await client.query(`INSERT INTO workflow_runs (run_id, analysis_report) VALUES ($1, $2::jsonb)`, ["report-run", JSON.stringify(report)]);
+    const rows = await client.query<{ analysis_report: typeof report }>(
+      `SELECT analysis_report FROM workflow_runs WHERE run_id = 'report-run'`,
+    );
+    expect(rows.rows[0]?.analysis_report).toEqual(report);
+  });
+});

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -31,6 +31,7 @@ import type {
   ReplaySanitizedEnvelope,
   ResolvedPromptReference,
   RunPullRequest,
+  RunAnalysisReport,
   SystemHealthResponse,
   WorkflowDefinitionLayoutInput,
   WorkflowReplayGraphSnapshot,
@@ -499,6 +500,8 @@ export const workflowRuns = pgTable("workflow_runs", {
   phases: jsonb("phases"),
   /** Full RunStep[] trace waterfall, captured on completion (workflow-owned). */
   steps: jsonb("steps"),
+  /** Sanitized durable planning/research summary (workflow-owned). */
+  analysisReport: jsonb("analysis_report").$type<RunAnalysisReport>(),
   /** Structured terminal budget cause; null for non-budget exits. */
   budgetFailure: jsonb("budget_failure").$type<WorkflowRunBudgetFailure>(),
 

--- a/apps/worker/src/routes/api/v1/runs/[runId].get.ts
+++ b/apps/worker/src/routes/api/v1/runs/[runId].get.ts
@@ -21,6 +21,7 @@ const EMPTY: Omit<RunDetailResponse, "generatedAt"> = {
   available: false,
   run: null,
   steps: [],
+  analysisReport: null,
 };
 
 export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
@@ -54,6 +55,12 @@ export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
       runId,
       jiraBaseUrl: env.JIRA_BASE_URL,
     }).catch(() => null);
+    let analysisReport = dbDetail?.analysisReport ?? null;
+    if (!analysisReport) {
+      analysisReport = await (await import("../../../../run-analysis/store.js"))
+        .getRunAnalysisReport(getDb(), runId)
+        .catch(() => null);
+    }
 
     const result = await resolveRunDetail({
       dbDetail,
@@ -103,6 +110,7 @@ export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
       available: true,
       run: safe.run,
       steps: safe.steps,
+      analysisReport: analysisReport ?? null,
       clarification,
     };
   } catch (err) {
@@ -124,6 +132,7 @@ export default defineEventHandler(async (event): Promise<RunDetailResponse> => {
           available: true,
           run: safe.run,
           steps: safe.steps,
+          analysisReport: fallback.analysisReport ?? null,
           clarification,
         };
       }

--- a/apps/worker/src/routes/api/v1/runs/run-detail.test.ts
+++ b/apps/worker/src/routes/api/v1/runs/run-detail.test.ts
@@ -1,0 +1,94 @@
+import { createApp, createError, createRouter, toWebHandler } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunAnalysisReport, RunDetail, RunStep } from "@shared/contracts";
+
+const state = vi.hoisted(() => ({
+  actor: true,
+  dbDetail: null as { run: RunDetail; steps: RunStep[]; hasRealSteps: boolean; analysisReport: RunAnalysisReport | null } | null,
+  worldResult: null as { run: RunDetail; steps: RunStep[] } | null,
+  resolveError: null as Error | null,
+  storedReport: null as RunAnalysisReport | null,
+}));
+
+vi.mock("../../../../../env.js", () => ({ env: { JIRA_BASE_URL: "https://jira.example", DASHBOARD_ORIGIN: "https://dash.example" } }));
+vi.mock("../../../../db/client.js", () => ({ getDb: () => ({}) }));
+vi.mock("../../../../lib/auth/request-context.js", () => ({
+  requireDashboardActor: vi.fn(async () => {
+    if (!state.actor) throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    return { organizationId: "org", role: "member" };
+  }),
+  toHttpError: (error: unknown) => { throw error; },
+}));
+vi.mock("../../../../db/queries/run-detail-read.js", () => ({
+  fetchRunDetailFromDb: vi.fn(async () => state.dbDetail),
+  fetchRunRefs: vi.fn(async () => null),
+}));
+vi.mock("../../../../lib/overview/resolve-run-detail.js", () => ({
+  resolveRunDetail: vi.fn(async () => {
+    if (state.resolveError) throw state.resolveError;
+    return state.worldResult;
+  }),
+}));
+vi.mock("../../../../lib/overview/collect-run-detail.js", () => ({ collectRunDetail: vi.fn() }));
+vi.mock("../../../../clarifications/store.js", () => ({ getClarificationForRun: vi.fn(async () => null), serializeClarification: vi.fn() }));
+vi.mock("../../../../run-analysis/store.js", () => ({ getRunAnalysisReport: vi.fn(async () => state.storedReport) }));
+
+const route = (await import("./[runId].get.js")).default;
+
+function handler() {
+  const app = createApp();
+  const router = createRouter();
+  router.get("/runs/:runId", route);
+  app.use(router);
+  return toWebHandler(app);
+}
+
+const run = (status: RunDetail["status"] = "running"): RunDetail => ({
+  id: "run-1", workflow: "wf_agent", workflowName: "Agent", status,
+  ticket: "AWT-1", ticketTitle: "Ticket", ticketUrl: "https://jira.example/browse/AWT-1",
+  prNumber: null, prUrl: null, prs: null, model: null,
+  createdAt: "2026-08-20T00:00:00.000Z", startedAt: "2026-08-20T00:00:00.000Z", completedAt: null,
+  durationSec: null, error: null, deploymentId: null,
+});
+
+const report = { version: 1, runId: "run-1", sourceResearchRunId: "run-1", researchRevision: 1, stage: "research_complete", researchCompletedAt: "2026-08-20T00:00:00.000Z", repositories: [], expansionRounds: 0, repositoryRequests: [], writeRepositories: [], evidenceStatus: "captured", evidence: [], planMarkdown: "plan", noChangeNeeded: false, resolutionEvidence: [], publication: null, usage: { research: { capturedAt: "now", costUsd: 0, costKnown: true, tokensInput: 0, tokensCached: 0, tokensOutput: 0, phases: {} }, publication: null, final: null }, jira: { research: { state: "pending", attemptedAt: null, commentUrl: null, error: null }, pullRequest: { state: "not_applicable", attemptedAt: null, commentUrl: null, error: null } }, sanitization: { redactions: {}, truncated: false, originalBytes: 1, storedBytes: 1, unavailable: false, unavailableReason: null } } as unknown as RunAnalysisReport;
+
+beforeEach(() => {
+  state.actor = true;
+  state.dbDetail = { run: run("running"), steps: [], hasRealSteps: false, analysisReport: report };
+  state.worldResult = { run: run("running"), steps: [] };
+  state.resolveError = null;
+  state.storedReport = report;
+});
+
+describe("run detail analysis report API", () => {
+  it("returns the DB report alongside live world steps and keeps the response private", async () => {
+    const response = await handler()(new Request("http://worker.test/runs/run-1"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect((await response.json()).analysisReport.runId).toBe("run-1");
+  });
+
+  it("uses the DB-only fallback when the world fails", async () => {
+    state.resolveError = new Error("world unavailable");
+    const response = await handler()(new Request("http://worker.test/runs/run-1"));
+    expect(response.status).toBe(200);
+    expect((await response.json()).analysisReport).toEqual(report);
+  });
+
+  it("returns a null report for an unknown run", async () => {
+    state.dbDetail = null;
+    state.worldResult = null;
+    state.storedReport = null;
+    const response = await handler()(new Request("http://worker.test/runs/missing"));
+    expect(response.status).toBe(200);
+    expect((await response.json()).analysisReport).toBeNull();
+  });
+
+  it("rejects unauthenticated requests before reading the report", async () => {
+    state.actor = false;
+    const response = await handler()(new Request("http://worker.test/runs/run-1"));
+    expect(response.status).toBe(401);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+  });
+});

--- a/apps/worker/src/run-analysis/report.test.ts
+++ b/apps/worker/src/run-analysis/report.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import {
+  analysisCommentMarker,
+  buildApprovedPlanAnalysisReport,
+  buildResearchAnalysisReport,
+  formatPublishedAnalysisComment,
+  formatResearchAnalysisComment,
+  hasAnalysisComment,
+  parseStoredRunAnalysisReport,
+  usageSnapshot,
+  withAnalysisDelivery,
+  withAnalysisPublication,
+} from "./report.js";
+
+const usage = {
+  costUsd: 1.23,
+  costKnown: false,
+  tokensInput: null,
+  tokensCached: null,
+  tokensOutput: null,
+  phases: {
+    research: {
+      costUsd: null,
+      tokens: null,
+      durationMs: 12,
+      numTurns: 1,
+      model: "gpt-5.6",
+    },
+  },
+};
+
+describe("run analysis report", () => {
+  it("maps trusted repository metadata and sanitizes model content", () => {
+    const report = buildResearchAnalysisReport({
+      runId: "run-1",
+      capturedAt: "2026-08-20T00:00:00.000Z",
+      workspaceManifest: {
+        repositories: [{
+          provider: "github",
+          repoPath: "acme/api",
+          defaultBranch: "main",
+          branchName: "arthur/AWT-1",
+          researchBaseSha: "abcdef123456",
+          access: "read",
+        }],
+      },
+      selectedRepositories: [{
+        provider: "github",
+        repoPath: "acme/api",
+        selectedRationale: "Read ai-workflow/memory/AWT-1.md before checking the ticket code.",
+      }],
+      researchResult: {
+        body: "# Plan\nsecret-token sk-1234567890123456 /vercel/sandbox/private\n```text\nRead blazebot/memory/AWT-1.md.\n```",
+        repositoryEvidence: Array.from({ length: 60 }, (_, i) => `github:acme/api src/file-${i}.ts: finding`),
+      },
+      usage,
+    });
+    expect(report.repositories[0]).toMatchObject({
+      provider: "github",
+      repoPath: "acme/api",
+      access: "read",
+      researchBaseSha: "abcdef123456",
+    });
+    expect(report.evidence).toHaveLength(50);
+    expect(report.planMarkdown).not.toContain("/vercel/sandbox");
+    expect(report.planMarkdown).not.toContain("blazebot/memory/AWT-1.md");
+    expect(report.repositories[0]?.rationale).not.toContain("ai-workflow/memory/AWT-1.md");
+    expect(report.sanitization.redactions).toBeTruthy();
+    expect(report.usage.research.costKnown).toBe(false);
+  });
+
+  it("keeps deterministic markers and bounded UTF-8 Jira comments", () => {
+    const report = buildResearchAnalysisReport({
+      runId: "run-unicode",
+      capturedAt: "2026-08-20T00:00:00.000Z",
+      researchResult: {
+        body: "# Plan\n" + "é".repeat(40_000),
+        repositoryEvidence: ["github:acme/api src/index.ts: checked"],
+      },
+      usage,
+    });
+    const comment = formatResearchAnalysisComment(report, "https://dashboard.example/runs/run-unicode");
+    expect(new TextEncoder().encode(comment).length).toBeLessThanOrEqual(20_000);
+    expect(comment).toContain(analysisCommentMarker("run-unicode", "research"));
+    expect(hasAnalysisComment({ comments: [{ body: comment }] }, analysisCommentMarker("run-unicode", "research"))).toBe(true);
+    expect(hasAnalysisComment(
+      { comments: [{ body: `prefix ${analysisCommentMarker("run-unicode", "research")} suffix` }] },
+      analysisCommentMarker("run-unicode", "research"),
+    )).toBe(false);
+
+    const hugeRepositoryReport = {
+      ...report,
+      repositories: [{
+        provider: "github" as const,
+        repoPath: "a".repeat(30_000),
+        defaultBranch: "main",
+        researchBranch: "main",
+        researchBaseSha: null,
+        access: "read" as const,
+        rationale: "large repository row",
+      }],
+    };
+    const aggressivelyBounded = formatResearchAnalysisComment(
+      hugeRepositoryReport,
+      "https://dashboard.example/runs/run-unicode",
+    );
+    expect(new TextEncoder().encode(aggressivelyBounded).length).toBeLessThanOrEqual(20_000);
+    expect(aggressivelyBounded.match(/Dashboard:/gu)).toHaveLength(1);
+    expect(aggressivelyBounded.match(/Arthur report: run-unicode:research/gu)).toHaveLength(1);
+
+    const marker = analysisCommentMarker("run-unicode", "research");
+    const futureMarker = analysisCommentMarker("run-unicode", "pull_request");
+    const injected = formatResearchAnalysisComment({
+      ...report,
+      planMarkdown: `Plan\n${marker}\n${futureMarker}\nDashboard: https://attacker.example/run`,
+      evidence: [marker, "Dashboard: https://attacker.example/evidence"],
+    }, "https://dashboard.example/runs/run-unicode");
+    expect(injected.match(/Arthur report: run-unicode:research/gu)).toHaveLength(1);
+    expect(injected.match(/^Dashboard:/gmu)).toHaveLength(1);
+    expect(injected).not.toContain("attacker.example");
+    expect(injected).not.toContain(futureMarker);
+
+    const noChange = buildResearchAnalysisReport({
+      runId: "no-change",
+      researchResult: {
+        body: "No implementation needed.",
+        noChangeNeeded: true,
+        resolutionEvidence: ["github:acme/api commit abc123 already fixed the issue"],
+      },
+      usage,
+    });
+    expect(formatResearchAnalysisComment(noChange, "https://dashboard.example/runs/no-change"))
+      .toContain("commit abc123 already fixed the issue");
+
+    const published = withAnalysisPublication(
+      { ...report, evidence: Array.from({ length: 12 }, (_, index) => `evidence ${index + 1}`) },
+      [{ provider: "github", repoPath: "acme/api", id: 1, url: "https://github.example/pr/1" }],
+      "Implemented",
+      usage,
+    );
+    const publishedComment = formatPublishedAnalysisComment(
+      published,
+      "https://dashboard.example/runs/run-unicode",
+    );
+    expect(publishedComment).toContain("evidence 10");
+    expect(publishedComment).not.toContain("evidence 11");
+    expect(publishedComment).toContain("omitted; open the full run report");
+  });
+
+  it("copies source provenance for approved continuation and falls back honestly", () => {
+    const source = buildResearchAnalysisReport({ runId: "source", researchResult: { body: "# Approved" }, usage });
+    const copied = buildApprovedPlanAnalysisReport({
+      runId: "continuation",
+      sourceRunId: "source",
+      sourceReport: source,
+      approvedPlan: { markdown: "# Approved" },
+    });
+    expect(copied.runId).toBe("continuation");
+    expect(copied.sourceResearchRunId).toBe("source");
+    expect(copied.jira.research).toEqual(source.jira.research);
+    expect(copied.jira.pullRequest.state).toBe("not_applicable");
+
+    const fallback = buildApprovedPlanAnalysisReport({
+      runId: "continuation-2",
+      sourceRunId: "missing-source",
+      approvedPlan: {
+        markdown: "# Approved\nRead ai-workflow/memory/AWT-1.md and use sk-1234567890123456.",
+        repositoryScope: {
+          repositories: [{
+            provider: "github",
+            repoPath: "acme/api",
+            defaultBranch: "main",
+            researchBranch: "arthur/AWT-1",
+            researchBaseSha: "abcdef",
+            access: "write",
+            rationale: "Chosen from blazebot/memory/AWT-1.md with sk-1234567890123456",
+          }],
+        },
+      },
+    });
+    expect(fallback.evidenceStatus).toBe("not_retained");
+    expect(fallback.sourceResearchRunId).toBe("missing-source");
+    expect(fallback.planMarkdown).not.toContain("ai-workflow/memory/AWT-1.md");
+    expect(fallback.planMarkdown).not.toContain("sk-1234567890123456");
+    expect(fallback.repositories[0]?.rationale).not.toContain("blazebot/memory/AWT-1.md");
+    expect(fallback.repositories[0]?.rationale).not.toContain("sk-1234567890123456");
+  });
+
+  it("marks Jira delivery not applicable for ticketless planning runs", () => {
+    const report = buildResearchAnalysisReport({
+      runId: "ticketless",
+      jiraApplicable: false,
+      researchResult: { body: "Plan" },
+      usage,
+    });
+    expect(report.jira.research.state).toBe("not_applicable");
+  });
+
+  it("does not mutate publication or delivery inputs and rejects malformed storage", () => {
+    const report = buildResearchAnalysisReport({ runId: "run-2", researchResult: { body: "plan" }, usage });
+    const published = withAnalysisPublication(report, [{ provider: "github", repoPath: "acme/api", id: 1, url: "https://github.com/acme/api/pull/1" }], `Implemented ${"x".repeat(80_000)}`, usage);
+    const delivered = withAnalysisDelivery(published, "pull_request", { state: "posted", attemptedAt: "now", commentUrl: "url", error: null });
+    expect(report.publication).toBeNull();
+    expect(new TextEncoder().encode(JSON.stringify({
+      planMarkdown: published.planMarkdown,
+      evidence: published.evidence,
+      resolutionEvidence: published.resolutionEvidence,
+      repositoryRequests: published.repositoryRequests,
+      writeRepositories: published.writeRepositories,
+      rationales: published.repositories.map((repository) => repository.rationale),
+      changeSummary: published.publication?.changeSummary,
+    })).length).toBeLessThanOrEqual(64 * 1024);
+    expect(delivered.jira.pullRequest.state).toBe("posted");
+    expect(parseStoredRunAnalysisReport({ version: 2 })).toBeNull();
+    expect(parseStoredRunAnalysisReport({
+      ...delivered,
+      repositories: [{}],
+    })).toBeNull();
+    expect(parseStoredRunAnalysisReport({
+      ...delivered,
+      usage: {
+        ...delivered.usage,
+        research: {
+          ...delivered.usage.research,
+          phases: { research: { costUsd: "not-a-number" } },
+        },
+      },
+    })).toBeNull();
+    expect(formatPublishedAnalysisComment(delivered, "https://dashboard.example/runs/run-2")).toContain("pull_request");
+  });
+
+  it("maps unknown usage values without inventing tokens", () => {
+    const snapshot = usageSnapshot({ ...usage, tokensInput: null, tokensCached: null, tokensOutput: null }, "now");
+    expect(snapshot.tokensInput).toBeNull();
+    expect(snapshot.costKnown).toBe(false);
+  });
+});

--- a/apps/worker/src/run-analysis/report.test.ts
+++ b/apps/worker/src/run-analysis/report.test.ts
@@ -69,6 +69,40 @@ describe("run analysis report", () => {
     expect(report.usage.research.costKnown).toBe(false);
   });
 
+  it("keeps the trusted research branch separate from a later promoted branch", () => {
+    const prePromotionManifest = {
+      repositories: [{
+        provider: "github" as const,
+        repoPath: "acme/api",
+        defaultBranch: "main",
+        branchName: "main",
+        researchBaseSha: "abcdef123456",
+        access: "write" as const,
+      }],
+    };
+    const promotedManifest = {
+      repositories: [{
+        ...prePromotionManifest.repositories[0],
+        branchName: "arthur/AWT-1",
+      }],
+    };
+    const prePromotion = buildResearchAnalysisReport({
+      runId: "pre-promotion",
+      workspaceManifest: prePromotionManifest,
+      researchResult: { body: "Plan" },
+      usage,
+    });
+    const afterPromotion = buildResearchAnalysisReport({
+      runId: "after-promotion",
+      workspaceManifest: promotedManifest,
+      researchResult: { body: "Plan" },
+      usage,
+    });
+
+    expect(prePromotion.repositories[0]?.researchBranch).toBe("main");
+    expect(afterPromotion.repositories[0]?.researchBranch).toBe("arthur/AWT-1");
+  });
+
   it("keeps deterministic markers and bounded UTF-8 Jira comments", () => {
     const report = buildResearchAnalysisReport({
       runId: "run-unicode",
@@ -131,6 +165,20 @@ describe("run analysis report", () => {
     });
     expect(formatResearchAnalysisComment(noChange, "https://dashboard.example/runs/no-change"))
       .toContain("commit abc123 already fixed the issue");
+
+    const ledgerNoChange = buildResearchAnalysisReport({
+      runId: "ledger-no-change",
+      researchResult: {
+        body: "Every review thread was answered without code changes.",
+        noChangeNeeded: false,
+      },
+      noChangeNeededOverride: true,
+      usage,
+    });
+    expect(ledgerNoChange).toMatchObject({
+      stage: "no_change",
+      noChangeNeeded: true,
+    });
 
     const published = withAnalysisPublication(
       { ...report, evidence: Array.from({ length: 12 }, (_, index) => `evidence ${index + 1}`) },
@@ -227,6 +275,68 @@ describe("run analysis report", () => {
       },
     })).toBeNull();
     expect(formatPublishedAnalysisComment(delivered, "https://dashboard.example/runs/run-2")).toContain("pull_request");
+  });
+
+  it("bounds an already-large authored bundle after JSON escaping the summary", () => {
+    const repositories = Array.from({ length: 8 }, (_, index) => ({
+      provider: "github" as const,
+      repoPath: `acme/repository-${index}`,
+      defaultBranch: "main",
+      branchName: "main",
+      researchBaseSha: "abcdef1234567890",
+      access: "write" as const,
+      selectedRationale: `Repository rationale ${"r".repeat(650)}`,
+    }));
+    const requests = repositories.map((repository) => ({
+      provider: repository.provider,
+      repoPath: repository.repoPath,
+      rationale: `Request rationale ${"q".repeat(350)}`,
+    }));
+    const large = buildResearchAnalysisReport({
+      runId: "large-publication",
+      workspaceManifest: { repositories },
+      researchResult: {
+        body: `# Plan\n${"P".repeat(14_000)}`,
+        repositoryEvidence: Array.from(
+          { length: 50 },
+          (_, index) => `Evidence ${index} ${"E".repeat(500)}`,
+        ),
+        resolutionEvidence: Array.from(
+          { length: 10 },
+          (_, index) => `Resolution ${index} ${"R".repeat(450)}`,
+        ),
+      },
+      repositoryRequests: requests,
+      writeRepositories: requests,
+      usage,
+    });
+    const authoredBundle = (report: typeof large, changeSummary: string) => ({
+      planMarkdown: report.planMarkdown,
+      evidence: report.evidence,
+      resolutionEvidence: report.resolutionEvidence,
+      repositoryRequests: report.repositoryRequests,
+      writeRepositories: report.writeRepositories,
+      rationales: report.repositories.map((repository) => repository.rationale),
+      changeSummary,
+    });
+    const existingBytes = new TextEncoder().encode(
+      JSON.stringify(authoredBundle(large, "")),
+    ).length;
+    expect(existingBytes).toBeGreaterThan(48 * 1024);
+
+    const escapeHeavySummary = ['"', "\\", "\n"].join("").repeat(30_000);
+    const published = withAnalysisPublication(large, [], escapeHeavySummary, usage);
+    const combinedBytes = new TextEncoder().encode(
+      JSON.stringify(
+        authoredBundle(published, published.publication?.changeSummary ?? ""),
+      ),
+    ).length;
+
+    expect(combinedBytes).toBeLessThanOrEqual(64 * 1024);
+    expect(published.publication?.changeSummary).toContain(
+      "omitted; open the full run report",
+    );
+    expect(published.sanitization.truncated).toBe(true);
   });
 
   it("maps unknown usage values without inventing tokens", () => {

--- a/apps/worker/src/run-analysis/report.ts
+++ b/apps/worker/src/run-analysis/report.ts
@@ -69,6 +69,7 @@ interface AnalysisInputBase {
   usage?: RunAnalysisUsageSnapshot | UsageTotals;
   researchUsage?: RunAnalysisUsageSnapshot | UsageTotals;
   researchTotals?: UsageTotals;
+  noChangeNeededOverride?: boolean;
   phaseUsages?: Record<string, PhaseUsage | null>;
   phaseModels?: Record<string, string>;
   priceLookup?: PriceLookup;
@@ -367,6 +368,7 @@ function emptyDelivery(state: RunAnalysisCommentDelivery["state"] = "pending"): 
 
 export function buildResearchAnalysisReport(input: BuildResearchAnalysisReportInput): RunAnalysisReport {
   const result = input.researchResult ?? input.result ?? input.research ?? {};
+  const noChangeNeeded = input.noChangeNeededOverride ?? result.noChangeNeeded === true;
   const capturedAt = nowIso(input.capturedAt);
   const plan = limitUtf8(safeModelText(result.body ?? result.plan ?? ""), 16 * 1024);
   const requests = safeRequestList(
@@ -401,7 +403,7 @@ export function buildResearchAnalysisReport(input: BuildResearchAnalysisReportIn
       Number.isInteger(input.researchRevision) && Number(input.researchRevision) > 0
         ? Number(input.researchRevision)
         : 1,
-    stage: result.noChangeNeeded ? "no_change" : "research_complete",
+    stage: noChangeNeeded ? "no_change" : "research_complete",
     researchCompletedAt: input.researchCompletedAt ?? capturedAt,
     repositories,
     expansionRounds: input.expansionRounds ?? input.repositoryExpansion?.rounds ?? 0,
@@ -410,7 +412,7 @@ export function buildResearchAnalysisReport(input: BuildResearchAnalysisReportIn
     evidenceStatus: "captured",
     evidence: (value.evidence as string[]) ?? evidence,
     planMarkdown: typeof value.planMarkdown === "string" ? value.planMarkdown : plan,
-    noChangeNeeded: result.noChangeNeeded === true,
+    noChangeNeeded,
     resolutionEvidence: (value.resolutionEvidence as string[]) ?? resolutionEvidence,
     publication: null,
     usage: { research: usage, publication: null, final: null },
@@ -500,15 +502,58 @@ export function withAnalysisPublication(
     writeRepositories: report.writeRepositories,
     rationales: report.repositories.map((repository) => repository.rationale),
   };
-  const existingBytes = utf8Bytes(JSON.stringify(existingAgentBundle));
-  const summaryBudget = Math.max(
-    0,
-    Math.min(24 * 1024, REPORT_MAX_BYTES - existingBytes - 64),
-  );
-  const safe = sanitizeBundle({
-    changeSummary: limitUtf8(safeSummary, summaryBudget),
+  const summaryEnvelope = sanitizeReplayValue(safeSummary, {
+    secrets: configuredReplaySecrets(),
+    // Leave enough room for JSON escaping (including control characters) and
+    // sanitizer metadata before the publication bundle applies its exact
+    // combined-byte bound.
+    maxBytes: Math.max(REPORT_MAX_BYTES, utf8Bytes(safeSummary) * 8 + 4 * 1024),
   });
-  const nextSummary = typeof safe.value.changeSummary === "string" ? safe.value.changeSummary : "";
+  if (
+    summaryEnvelope.metadata.unavailable ||
+    typeof summaryEnvelope.value !== "string"
+  ) {
+    throw new Error("run analysis publication summary could not be safely retained");
+  }
+  const sanitizedSummary = summaryEnvelope.value;
+  const authoredBundle = (summary: string): Record<string, unknown> => ({
+    ...existingAgentBundle,
+    changeSummary: summary,
+  });
+  const bundleBytes = (summary: string): number =>
+    utf8Bytes(JSON.stringify(authoredBundle(summary)));
+  let nextSummary = sanitizedSummary;
+  let summaryTruncated = summaryEnvelope.metadata.truncated;
+  if (bundleBytes(nextSummary) > REPORT_MAX_BYTES) {
+    const omissionMarker = `\n${OMITTED}`;
+    const markerOnly = omissionMarker;
+    if (bundleBytes(markerOnly) <= REPORT_MAX_BYTES) {
+      let low = 0;
+      let high = utf8Bytes(sanitizedSummary);
+      let best = markerOnly;
+      while (low <= high) {
+        const middle = Math.floor((low + high) / 2);
+        const candidate = `${sliceUtf8(sanitizedSummary, middle, "head")}${omissionMarker}`;
+        if (bundleBytes(candidate) <= REPORT_MAX_BYTES) {
+          best = candidate;
+          low = middle + 1;
+        } else {
+          high = middle - 1;
+        }
+      }
+      nextSummary = best;
+    } else if (bundleBytes("") <= REPORT_MAX_BYTES) {
+      nextSummary = "";
+    } else {
+      throw new Error("run analysis publication bundle exceeds its storage bound");
+    }
+    summaryTruncated = true;
+  }
+  const summaryMetadata: ReplaySanitizationMetadata = {
+    ...summaryEnvelope.metadata,
+    truncated: summaryTruncated,
+    storedBytes: utf8Bytes(JSON.stringify(nextSummary)),
+  };
   return {
     ...report,
     stage: "published",
@@ -522,7 +567,7 @@ export function withAnalysisPublication(
       changeSummary: nextSummary,
     },
     usage: { ...report.usage, publication: usageSnapshot(usage, nowIso()) },
-    sanitization: aggregateMetadata(report.sanitization, safe.metadata),
+    sanitization: aggregateMetadata(report.sanitization, summaryMetadata),
   };
 }
 

--- a/apps/worker/src/run-analysis/report.ts
+++ b/apps/worker/src/run-analysis/report.ts
@@ -1,0 +1,799 @@
+import type {
+  RunAnalysisCommentDelivery,
+  RunAnalysisPhaseUsage,
+  RunAnalysisReport,
+  RunAnalysisRepository,
+  RunAnalysisRepositoryRequest,
+  RunAnalysisUsageSnapshot,
+  RunPullRequest,
+  ReplaySanitizationMetadata,
+} from "@shared/contracts";
+import type { PhaseUsage } from "../sandbox/agents/types.js";
+import type { PriceLookup, UsageTotals } from "../sandbox/usage.js";
+import { configuredReplaySecrets } from "../run-observability/configured-secrets.js";
+import { sanitizeReplayValue } from "../run-observability/sanitizer.js";
+import { scrubForPublication } from "../lib/publication-scrub.js";
+
+const REPORT_MAX_BYTES = 64 * 1024;
+const COMMENT_MAX_BYTES = 20_000;
+const OMITTED = "… omitted; open the full run report";
+
+type Provider = "github" | "gitlab";
+
+interface ManifestRepository {
+  provider: Provider;
+  repoPath: string;
+  defaultBranch?: string;
+  branchName?: string;
+  researchBranch?: string;
+  researchBaseSha?: string | null;
+  access?: "read" | "write";
+  selectedRationale?: string;
+  rationale?: string;
+}
+
+interface AnalysisInputBase {
+  runId: string;
+  sourceResearchRunId?: string;
+  researchRevision?: number;
+  researchCompletedAt?: string;
+  capturedAt?: string;
+  workspaceManifest?: { repositories?: ManifestRepository[] } | null;
+  manifest?: { repositories?: ManifestRepository[] } | null;
+  repositories?: ManifestRepository[];
+  selectedRepositories?: Array<{
+    provider: Provider;
+    repoPath: string;
+    selectedRationale?: string;
+    rationale?: string;
+    defaultBranch?: string;
+  }>;
+  repositoryExpansion?: {
+    rounds?: number;
+    priorRequests?: Array<RunAnalysisRepositoryRequest>;
+  };
+  expansionRounds?: number;
+  repositoryRequests?: RunAnalysisRepositoryRequest[];
+  writeRepositories?: RunAnalysisRepositoryRequest[];
+  researchResult?: {
+    body?: string;
+    plan?: string;
+    repositoryEvidence?: string[];
+    resolutionEvidence?: string[];
+    noChangeNeeded?: boolean;
+    repositories?: RunAnalysisRepositoryRequest[];
+    writeRepositories?: RunAnalysisRepositoryRequest[];
+  };
+  result?: AnalysisInputBase["researchResult"];
+  research?: AnalysisInputBase["researchResult"];
+  usage?: RunAnalysisUsageSnapshot | UsageTotals;
+  researchUsage?: RunAnalysisUsageSnapshot | UsageTotals;
+  researchTotals?: UsageTotals;
+  phaseUsages?: Record<string, PhaseUsage | null>;
+  phaseModels?: Record<string, string>;
+  priceLookup?: PriceLookup;
+  model?: string;
+  jiraApplicable?: boolean;
+}
+
+export interface BuildResearchAnalysisReportInput extends AnalysisInputBase {}
+
+export interface BuildApprovedPlanAnalysisReportInput {
+  runId: string;
+  sourceRunId?: string | null;
+  sourceReport?: unknown | null;
+  report?: unknown | null;
+  approvedPlan: {
+    markdown: string;
+    sourceRunId?: string;
+    repositoryScope?: {
+      repositories: Array<{
+        provider: Provider;
+        repoPath: string;
+        defaultBranch: string;
+        researchBranch: string;
+        researchBaseSha: string;
+        access: "read" | "write";
+        rationale: string;
+      }>;
+    };
+  };
+  capturedAt?: string;
+}
+
+function nowIso(value?: string): string {
+  return value ?? new Date().toISOString();
+}
+
+function utf8Bytes(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function safeModelText(value: unknown): string {
+  if (typeof value !== "string") return "";
+  // The replay sanitizer handles credentials and token-shaped values. These
+  // explicit markers are not credentials, but are private implementation
+  // paths/session bookkeeping that must never enter the report surface.
+  return scrubForPublication(value
+    .replace(/\b(?:ai-workflow|blazebot)\/memory\/[^\s)`\]]+/gi, "[omitted memory path]")
+    .replace(/(?:\/vercel\/sandbox|\/tmp\/attachments|\/workspace\/)[^\s)`]*/gi, "[omitted private path]")
+    .replace(/\b(?:session|memory)[_-][A-Za-z0-9-]+\b/gi, "[omitted session reference]")
+    .replace(/\bsession\s+memory(?:\s+(?:text|document|bookkeeping))?\b/gi, "[omitted session reference]"));
+}
+
+function safeModelList(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return values
+    .filter((value): value is string => typeof value === "string")
+    .map(safeModelText)
+    .filter((value) => value.trim().length > 0)
+    .slice(0, 50);
+}
+
+function limitUtf8(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return "";
+  if (utf8Bytes(value) <= maxBytes) return value;
+  const marker = `\n${OMITTED}`;
+  if (utf8Bytes(marker) >= maxBytes) return sliceUtf8(OMITTED, maxBytes, "head");
+  const budget = Math.max(0, maxBytes - utf8Bytes(marker));
+  return `${sliceUtf8(value, budget, "head")}${marker}`;
+}
+
+function boundModelList(values: string[], maxBytes: number): string[] {
+  const output: string[] = [];
+  let used = 2;
+  for (const value of values) {
+    const item = limitUtf8(value, 1_200);
+    const next = used + utf8Bytes(item) + 1;
+    if (next > maxBytes) {
+      output.push(OMITTED);
+      break;
+    }
+    output.push(item);
+    used = next;
+  }
+  return output;
+}
+
+function safeRequestList(values: unknown): RunAnalysisRepositoryRequest[] {
+  if (!Array.isArray(values)) return [];
+  const requests = values
+    .filter((value): value is Record<string, unknown> => !!value && typeof value === "object")
+    .map((value): RunAnalysisRepositoryRequest => ({
+      provider: value.provider === "gitlab" ? "gitlab" : "github",
+      repoPath: typeof value.repoPath === "string" ? limitUtf8(safeModelText(value.repoPath), 512) : "unknown",
+      rationale: limitUtf8(safeModelText(value.rationale), 1_200),
+    }))
+    .filter((value) => value.repoPath !== "unknown" && value.rationale.length > 0)
+    .slice(0, 8);
+  let used = 2;
+  const bounded: RunAnalysisRepositoryRequest[] = [];
+  for (const request of requests) {
+    const next = used + utf8Bytes(JSON.stringify(request)) + 1;
+    if (next > 8 * 1024) break;
+    bounded.push(request);
+    used = next;
+  }
+  return bounded;
+}
+
+function matchingRationale(
+  repo: ManifestRepository,
+  selected: BuildResearchAnalysisReportInput["selectedRepositories"],
+): string {
+  const match = selected?.find(
+    (candidate) => candidate.provider === repo.provider && candidate.repoPath === repo.repoPath,
+  );
+  return safeModelText(
+    repo.selectedRationale ?? repo.rationale ?? match?.selectedRationale ?? match?.rationale ?? "Selected by the workflow planner.",
+  );
+}
+
+function mapRepositories(input: BuildResearchAnalysisReportInput): RunAnalysisRepository[] {
+  const manifest = input.workspaceManifest ?? input.manifest;
+  const repos = manifest?.repositories ?? input.repositories ?? [];
+  return repos
+    .filter((repo): repo is ManifestRepository => !!repo && typeof repo.repoPath === "string")
+    .map((repo) => ({
+      provider: repo.provider === "gitlab" ? "gitlab" : "github",
+      repoPath: repo.repoPath,
+      defaultBranch: repo.defaultBranch ?? "unknown",
+      researchBranch: repo.researchBranch ?? repo.branchName ?? repo.defaultBranch ?? "unknown",
+      researchBaseSha: typeof repo.researchBaseSha === "string" ? repo.researchBaseSha : null,
+      access: repo.access === "read" ? "read" : "write",
+      rationale: matchingRationale(repo, input.selectedRepositories),
+    }));
+}
+
+function aggregateMetadata(
+  first: ReplaySanitizationMetadata,
+  second: ReplaySanitizationMetadata,
+): ReplaySanitizationMetadata {
+  const redactions = { ...first.redactions };
+  for (const [key, count] of Object.entries(second.redactions)) {
+    redactions[key as keyof typeof redactions] =
+      (redactions[key as keyof typeof redactions] ?? 0) + (count ?? 0);
+  }
+  return {
+    redactions,
+    truncated: first.truncated || second.truncated,
+    originalBytes: first.originalBytes + second.originalBytes,
+    storedBytes: first.storedBytes + second.storedBytes,
+    unavailable: first.unavailable || second.unavailable,
+    unavailableReason: first.unavailableReason ?? second.unavailableReason,
+  };
+}
+
+function sanitizeBundle(bundle: Record<string, unknown>): {
+  value: Record<string, unknown>;
+  metadata: ReplaySanitizationMetadata;
+} {
+  const envelope = sanitizeReplayValue(bundle, {
+    secrets: configuredReplaySecrets(),
+    maxBytes: REPORT_MAX_BYTES,
+  });
+  if (
+    envelope.metadata.unavailable ||
+    envelope.value === null ||
+    typeof envelope.value !== "object" ||
+    Array.isArray(envelope.value)
+  ) {
+    throw new Error("run analysis report content could not be safely retained");
+  }
+  return { value: envelope.value as Record<string, unknown>, metadata: envelope.metadata };
+}
+
+function phaseUsage(value: unknown): RunAnalysisPhaseUsage | null {
+  if (!value || typeof value !== "object") return null;
+  const phase = value as Record<string, unknown>;
+  const tokens = phase.tokens;
+  return {
+    costUsd: typeof phase.costUsd === "number" ? phase.costUsd : null,
+    tokens:
+      tokens && typeof tokens === "object"
+        ? {
+            input: Number((tokens as Record<string, unknown>).input) || 0,
+            cachedInput: Number((tokens as Record<string, unknown>).cachedInput ?? (tokens as Record<string, unknown>).cached_input) || 0,
+            output: Number((tokens as Record<string, unknown>).output) || 0,
+          }
+        : null,
+    durationMs: Number(phase.durationMs ?? phase.duration_ms) || 0,
+    numTurns: Number(phase.numTurns ?? phase.num_turns) || 0,
+    model: typeof phase.model === "string" ? phase.model : null,
+  };
+}
+
+/** Convert worker usage totals into the public report snapshot without making
+ * unknown tokens/cost look like zero. */
+export function usageSnapshot(
+  totals: UsageTotals | RunAnalysisUsageSnapshot,
+  capturedAt: string,
+): RunAnalysisUsageSnapshot {
+  if ("capturedAt" in totals && "costKnown" in totals) {
+    return {
+      capturedAt,
+      costUsd: totals.costUsd,
+      costKnown: totals.costKnown,
+      tokensInput: totals.tokensInput,
+      tokensCached: totals.tokensCached,
+      tokensOutput: totals.tokensOutput,
+      phases: Object.fromEntries(
+        Object.entries(totals.phases ?? {}).map(([name, value]) => [name, phaseUsage(value) ?? {
+          costUsd: null,
+          tokens: null,
+          durationMs: 0,
+          numTurns: 0,
+          model: null,
+        }]),
+      ),
+    };
+  }
+  return {
+    capturedAt,
+    costUsd: Number(totals.costUsd) || 0,
+    costKnown: totals.costKnown !== false,
+    tokensInput: totals.tokensInput ?? null,
+    tokensCached: totals.tokensCached ?? null,
+    tokensOutput: totals.tokensOutput ?? null,
+    phases: Object.fromEntries(
+      Object.entries(totals.phases ?? {}).map(([name, value]) => [name, phaseUsage(value) ?? {
+        costUsd: null,
+        tokens: null,
+        durationMs: 0,
+        numTurns: 0,
+        model: null,
+      }]),
+    ),
+  };
+}
+
+function fallbackUsage(input: BuildResearchAnalysisReportInput, capturedAt: string): RunAnalysisUsageSnapshot {
+  if (input.researchTotals) return usageSnapshot(input.researchTotals, capturedAt);
+  if (input.researchUsage && "costUsd" in input.researchUsage) {
+    return usageSnapshot(input.researchUsage, capturedAt);
+  }
+  if (input.usage && "costUsd" in input.usage) {
+    return usageSnapshot(input.usage, capturedAt);
+  }
+  if (input.phaseUsages) {
+    // Importing computeUsageTotals here would make this pure module depend on a
+    // workflow singleton. The worker passes totals in production; this fallback
+    // keeps tests and older callers honest, with unknown phases retained.
+    const phases = Object.fromEntries(
+      Object.entries(input.phaseUsages).map(([name, value]) => [name, value ? {
+        costUsd: value.cost_usd,
+        tokens: value.tokens ? {
+          input: value.tokens.input,
+          cachedInput: value.tokens.cached_input,
+          output: value.tokens.output,
+        } : null,
+        durationMs: value.duration_ms,
+        numTurns: value.num_turns,
+        model: input.phaseModels?.[name] ?? input.model ?? null,
+      } : {
+        costUsd: null,
+        tokens: null,
+        durationMs: 0,
+        numTurns: 0,
+        model: input.phaseModels?.[name] ?? input.model ?? null,
+      }]),
+    );
+    const values = Object.values(phases) as Array<RunAnalysisPhaseUsage>;
+    const known = values.every((value) => value.costUsd !== null);
+    return {
+      capturedAt,
+      costUsd: values.reduce((sum, value) => sum + (value.costUsd ?? 0), 0),
+      costKnown: known,
+      tokensInput: values.every((value) => value.tokens !== null) ? values.reduce((sum, value) => sum + (value.tokens?.input ?? 0), 0) : null,
+      tokensCached: values.every((value) => value.tokens !== null) ? values.reduce((sum, value) => sum + (value.tokens?.cachedInput ?? 0), 0) : null,
+      tokensOutput: values.every((value) => value.tokens !== null) ? values.reduce((sum, value) => sum + (value.tokens?.output ?? 0), 0) : null,
+      phases: phases as Record<string, RunAnalysisPhaseUsage>,
+    };
+  }
+  return {
+    capturedAt,
+    costUsd: 0,
+    costKnown: false,
+    tokensInput: null,
+    tokensCached: null,
+    tokensOutput: null,
+    phases: {},
+  };
+}
+
+function emptyDelivery(state: RunAnalysisCommentDelivery["state"] = "pending"): RunAnalysisCommentDelivery {
+  return { state, attemptedAt: null, commentUrl: null, error: null };
+}
+
+export function buildResearchAnalysisReport(input: BuildResearchAnalysisReportInput): RunAnalysisReport {
+  const result = input.researchResult ?? input.result ?? input.research ?? {};
+  const capturedAt = nowIso(input.capturedAt);
+  const plan = limitUtf8(safeModelText(result.body ?? result.plan ?? ""), 16 * 1024);
+  const requests = safeRequestList(
+    input.repositoryRequests ?? input.repositoryExpansion?.priorRequests ?? result.repositories,
+  );
+  const writes = safeRequestList(input.writeRepositories ?? result.writeRepositories);
+  const evidence = boundModelList(safeModelList(result.repositoryEvidence), 18 * 1024);
+  const resolutionEvidence = boundModelList(safeModelList(result.resolutionEvidence), 6 * 1024);
+  const sourceRepositories = mapRepositories(input);
+  const sanitized = sanitizeBundle({
+    planMarkdown: plan,
+    evidence,
+    resolutionEvidence,
+    repositoryRequests: requests,
+    writeRepositories: writes,
+    rationales: sourceRepositories.map((repo) => limitUtf8(repo.rationale, 768)).slice(0, 8),
+  });
+  const value = sanitized.value;
+  const usage = fallbackUsage(input, capturedAt);
+  const repositories = sourceRepositories.map((repository, index) => ({
+    ...repository,
+    rationale:
+      Array.isArray(value.rationales) && typeof value.rationales[index] === "string"
+        ? value.rationales[index] as string
+        : "Selection rationale was not retained.",
+  }));
+  return {
+    version: 1,
+    runId: input.runId,
+    sourceResearchRunId: input.sourceResearchRunId ?? input.runId,
+    researchRevision:
+      Number.isInteger(input.researchRevision) && Number(input.researchRevision) > 0
+        ? Number(input.researchRevision)
+        : 1,
+    stage: result.noChangeNeeded ? "no_change" : "research_complete",
+    researchCompletedAt: input.researchCompletedAt ?? capturedAt,
+    repositories,
+    expansionRounds: input.expansionRounds ?? input.repositoryExpansion?.rounds ?? 0,
+    repositoryRequests: (value.repositoryRequests as RunAnalysisRepositoryRequest[]) ?? requests,
+    writeRepositories: (value.writeRepositories as RunAnalysisRepositoryRequest[]) ?? writes,
+    evidenceStatus: "captured",
+    evidence: (value.evidence as string[]) ?? evidence,
+    planMarkdown: typeof value.planMarkdown === "string" ? value.planMarkdown : plan,
+    noChangeNeeded: result.noChangeNeeded === true,
+    resolutionEvidence: (value.resolutionEvidence as string[]) ?? resolutionEvidence,
+    publication: null,
+    usage: { research: usage, publication: null, final: null },
+    jira: {
+      research: emptyDelivery(input.jiraApplicable === false ? "not_applicable" : "pending"),
+      pullRequest: emptyDelivery("not_applicable"),
+    },
+    sanitization: sanitized.metadata,
+  };
+}
+
+function scopeRepositories(scope: BuildApprovedPlanAnalysisReportInput["approvedPlan"]["repositoryScope"]): RunAnalysisRepository[] {
+  return (scope?.repositories ?? []).map((repo) => ({
+    provider: repo.provider,
+    repoPath: repo.repoPath,
+    defaultBranch: repo.defaultBranch,
+    researchBranch: repo.researchBranch,
+    researchBaseSha: repo.researchBaseSha ?? null,
+    access: repo.access,
+    rationale: limitUtf8(safeModelText(repo.rationale), 1_200),
+  }));
+}
+
+export function buildApprovedPlanAnalysisReport(input: BuildApprovedPlanAnalysisReportInput): RunAnalysisReport {
+  const source = parseStoredRunAnalysisReport(input.sourceReport ?? input.report);
+  if (source) {
+    return {
+      ...source,
+      runId: input.runId,
+      sourceResearchRunId: source.sourceResearchRunId || source.runId,
+      publication: null,
+      usage: { ...source.usage, publication: null, final: null },
+      jira: { research: source.jira.research, pullRequest: emptyDelivery("not_applicable") },
+    };
+  }
+  const capturedAt = nowIso(input.capturedAt);
+  const sourceScope = scopeRepositories(input.approvedPlan.repositoryScope);
+  const approvedMarkdown = limitUtf8(safeModelText(input.approvedPlan.markdown), 24 * 1024);
+  const sanitized = sanitizeBundle({
+    planMarkdown: approvedMarkdown,
+    rationales: sourceScope.map((repository) => repository.rationale),
+  });
+  const scope = sourceScope.map((repository, index) => ({
+    ...repository,
+    rationale:
+      Array.isArray(sanitized.value.rationales) &&
+      typeof sanitized.value.rationales[index] === "string"
+        ? sanitized.value.rationales[index] as string
+        : "Selection rationale was not retained.",
+  }));
+  return {
+    version: 1,
+    runId: input.runId,
+    sourceResearchRunId: input.sourceRunId ?? input.approvedPlan.sourceRunId ?? input.runId,
+    researchRevision: 1,
+    stage: "research_complete",
+    researchCompletedAt: capturedAt,
+    repositories: scope,
+    expansionRounds: 0,
+    repositoryRequests: [],
+    writeRepositories: scope.filter((repo) => repo.access === "write").map(({ provider, repoPath, rationale }) => ({ provider, repoPath, rationale })),
+    evidenceStatus: "not_retained",
+    evidence: [],
+    planMarkdown: typeof sanitized.value.planMarkdown === "string" ? sanitized.value.planMarkdown : approvedMarkdown,
+    noChangeNeeded: false,
+    resolutionEvidence: [],
+    publication: null,
+    usage: { research: usageSnapshot({ costUsd: 0, costKnown: false, tokensInput: null, tokensCached: null, tokensOutput: null, phases: {} }, capturedAt), publication: null, final: null },
+    jira: { research: emptyDelivery("not_applicable"), pullRequest: emptyDelivery("not_applicable") },
+    sanitization: sanitized.metadata,
+  };
+}
+
+export function withAnalysisPublication(
+  report: RunAnalysisReport,
+  publication: { prs: RunPullRequest[] } | RunPullRequest[],
+  changeSummary: string,
+  usage: RunAnalysisUsageSnapshot | UsageTotals,
+): RunAnalysisReport {
+  const prs = Array.isArray(publication) ? publication : publication.prs;
+  const safeSummary = safeModelText(changeSummary);
+  const existingAgentBundle = {
+    planMarkdown: report.planMarkdown,
+    evidence: report.evidence,
+    resolutionEvidence: report.resolutionEvidence,
+    repositoryRequests: report.repositoryRequests,
+    writeRepositories: report.writeRepositories,
+    rationales: report.repositories.map((repository) => repository.rationale),
+  };
+  const existingBytes = utf8Bytes(JSON.stringify(existingAgentBundle));
+  const summaryBudget = Math.max(
+    0,
+    Math.min(24 * 1024, REPORT_MAX_BYTES - existingBytes - 64),
+  );
+  const safe = sanitizeBundle({
+    changeSummary: limitUtf8(safeSummary, summaryBudget),
+  });
+  const nextSummary = typeof safe.value.changeSummary === "string" ? safe.value.changeSummary : "";
+  return {
+    ...report,
+    stage: "published",
+    publication: {
+      prs: prs.map((pr) => ({
+        provider: pr.provider,
+        repoPath: pr.repoPath,
+        id: pr.id,
+        url: pr.url,
+      })),
+      changeSummary: nextSummary,
+    },
+    usage: { ...report.usage, publication: usageSnapshot(usage, nowIso()) },
+    sanitization: aggregateMetadata(report.sanitization, safe.metadata),
+  };
+}
+
+export function withAnalysisDelivery(
+  report: RunAnalysisReport,
+  stage: "research_complete" | "published" | "no_change" | "research" | "pull_request",
+  delivery: RunAnalysisCommentDelivery,
+): RunAnalysisReport {
+  const slot = stage === "published" || stage === "pull_request" ? "pullRequest" : "research";
+  return { ...report, jira: { ...report.jira, [slot]: { ...delivery } } };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function validRepository(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    ["github", "gitlab"].includes(String(value.provider)) &&
+    typeof value.repoPath === "string" &&
+    typeof value.defaultBranch === "string" &&
+    typeof value.researchBranch === "string" &&
+    isNullableString(value.researchBaseSha) &&
+    ["read", "write"].includes(String(value.access)) &&
+    typeof value.rationale === "string"
+  );
+}
+
+function validRepositoryRequest(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    ["github", "gitlab"].includes(String(value.provider)) &&
+    typeof value.repoPath === "string" &&
+    typeof value.rationale === "string"
+  );
+}
+
+function validPhaseUsage(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const tokens = value.tokens;
+  return (
+    (value.costUsd === null || isFiniteNumber(value.costUsd)) &&
+    (tokens === null || (
+      isRecord(tokens) &&
+      isFiniteNumber(tokens.input) &&
+      isFiniteNumber(tokens.cachedInput) &&
+      isFiniteNumber(tokens.output)
+    )) &&
+    isFiniteNumber(value.durationMs) &&
+    isFiniteNumber(value.numTurns) &&
+    isNullableString(value.model)
+  );
+}
+
+function validUsage(value: unknown): boolean {
+  if (!isRecord(value) || !isRecord(value.phases)) return false;
+  return (
+    typeof value.capturedAt === "string" &&
+    isFiniteNumber(value.costUsd) &&
+    typeof value.costKnown === "boolean" &&
+    (value.tokensInput === null || isFiniteNumber(value.tokensInput)) &&
+    (value.tokensCached === null || isFiniteNumber(value.tokensCached)) &&
+    (value.tokensOutput === null || isFiniteNumber(value.tokensOutput)) &&
+    Object.values(value.phases).every(validPhaseUsage)
+  );
+}
+
+function validDelivery(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    ["not_applicable", "pending", "posted", "failed"].includes(String(value.state)) &&
+    isNullableString(value.attemptedAt) &&
+    isNullableString(value.commentUrl) &&
+    isNullableString(value.error)
+  );
+}
+
+function validPullRequest(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    ["github", "gitlab"].includes(String(value.provider)) &&
+    typeof value.repoPath === "string" &&
+    isFiniteNumber(value.id) &&
+    typeof value.url === "string" &&
+    (value.headSha === undefined || typeof value.headSha === "string")
+  );
+}
+
+function validPublication(value: unknown): boolean {
+  if (value === null) return true;
+  return (
+    isRecord(value) &&
+    Array.isArray(value.prs) &&
+    value.prs.every(validPullRequest) &&
+    typeof value.changeSummary === "string"
+  );
+}
+
+function validSanitization(value: unknown): boolean {
+  if (!isRecord(value) || !isRecord(value.redactions)) return false;
+  return (
+    Object.values(value.redactions).every(isFiniteNumber) &&
+    typeof value.truncated === "boolean" &&
+    isFiniteNumber(value.originalBytes) &&
+    isFiniteNumber(value.storedBytes) &&
+    typeof value.unavailable === "boolean" &&
+    [null, "serialization", "traversal_limit", "size_limit"].includes(
+      value.unavailableReason as null | string,
+    )
+  );
+}
+
+export function parseStoredRunAnalysisReport(value: unknown): RunAnalysisReport | null {
+  if (!isRecord(value) || value.version !== 1) return null;
+  if (
+    typeof value.runId !== "string" ||
+    typeof value.sourceResearchRunId !== "string" ||
+    !isFiniteNumber(value.researchRevision) ||
+    !Number.isInteger(value.researchRevision) ||
+    value.researchRevision < 1 ||
+    !["research_complete", "published", "no_change"].includes(String(value.stage)) ||
+    typeof value.researchCompletedAt !== "string" ||
+    !Array.isArray(value.repositories) ||
+    !value.repositories.every(validRepository) ||
+    !isFiniteNumber(value.expansionRounds) ||
+    !Array.isArray(value.repositoryRequests) ||
+    !value.repositoryRequests.every(validRepositoryRequest) ||
+    !Array.isArray(value.writeRepositories) ||
+    !value.writeRepositories.every(validRepositoryRequest) ||
+    !["captured", "not_retained"].includes(String(value.evidenceStatus)) ||
+    !isStringArray(value.evidence) ||
+    typeof value.planMarkdown !== "string" ||
+    typeof value.noChangeNeeded !== "boolean" ||
+    !isStringArray(value.resolutionEvidence) ||
+    !validPublication(value.publication) ||
+    !isRecord(value.usage) ||
+    !isRecord(value.jira) ||
+    !validSanitization(value.sanitization)
+  ) return null;
+  const usage = value.usage as Record<string, unknown>;
+  const jira = value.jira as Record<string, unknown>;
+  if (!validDelivery(jira.research) || !validDelivery(jira.pullRequest)) return null;
+  if (!validUsage(usage.research)) return null;
+  if (usage.publication !== null && !validUsage(usage.publication)) return null;
+  if (usage.final !== null && !validUsage(usage.final)) return null;
+  return value as unknown as RunAnalysisReport;
+}
+
+export function analysisCommentMarker(runId: string, stage: "research" | "pull_request"): string {
+  return `Arthur report: ${runId}:${stage}`;
+}
+
+export function hasAnalysisComment(ticket: unknown, marker: string): boolean {
+  const comments = isRecord(ticket) && Array.isArray(ticket.comments) ? ticket.comments : Array.isArray(ticket) ? ticket : [];
+  return comments.some((comment) => {
+    const body = typeof comment === "string"
+      ? comment
+      : isRecord(comment) && typeof comment.body === "string"
+        ? comment.body
+        : "";
+    return body.split(/\r?\n/u).some((line) => line.trim() === marker);
+  });
+}
+
+function costLabel(snapshot: RunAnalysisUsageSnapshot): string {
+  return `$${snapshot.costUsd.toFixed(2)}${snapshot.costKnown ? "" : "+"}`;
+}
+
+function usageLines(snapshot: RunAnalysisUsageSnapshot): string[] {
+  const tokens = snapshot.tokensInput === null ? "tokens unknown" : `${snapshot.tokensInput} in / ${snapshot.tokensOutput ?? 0} out`;
+  const phaseLines = Object.entries(snapshot.phases).map(([name, phase]) =>
+    `- ${name}: ${costLabel({ ...snapshot, costUsd: phase.costUsd ?? 0, costKnown: phase.costUsd !== null })} · ${phase.durationMs}ms · ${phase.model ?? "model unknown"}`,
+  );
+  return [`Total: ${costLabel(snapshot)} · ${tokens}`, ...phaseLines];
+}
+
+function repositoryLines(report: RunAnalysisReport): string[] {
+  return report.repositories.length > 0
+    ? report.repositories.map((repo) => `- ${repo.provider}:${repo.repoPath} · ${repo.access} · ${repo.researchBranch}@${repo.researchBaseSha ? repo.researchBaseSha.slice(0, 8) : "unknown SHA"} · ${repo.rationale}`)
+    : ["- No repository manifest was retained."];
+}
+
+function sliceUtf8(value: string, maxBytes: number, direction: "head" | "tail"): string {
+  const chars = Array.from(value);
+  const selected: string[] = [];
+  let bytes = 0;
+  const source = direction === "head" ? chars : chars.reverse();
+  for (const char of source) {
+    const width = utf8Bytes(char);
+    if (bytes + width > maxBytes) break;
+    selected.push(char);
+    bytes += width;
+  }
+  return direction === "head" ? selected.join("") : selected.reverse().join("");
+}
+
+function scrubComment(text: string): string {
+  return scrubForPublication(text);
+}
+
+function withoutReservedCommentLines(value: string, marker: string): string {
+  return value
+    .split("\n")
+    .map((line) => line
+      .replaceAll(marker, "")
+      .replace(/Arthur report:\s+[^\s]+:(?:research|pull_request)/giu, "")
+      .replace(/Dashboard:\s+\S+/giu, ""))
+    .filter((line) => line.trim().length > 0)
+    .join("\n");
+}
+
+export function formatResearchAnalysisComment(report: RunAnalysisReport, dashboardUrl: string): string {
+  const marker = analysisCommentMarker(report.runId, "research");
+  const sections = [
+    `Arthur research complete\nRun: ${report.runId}`,
+    `Repositories analyzed\n${repositoryLines(report).join("\n")}`,
+    `What was checked\n${report.evidenceStatus === "not_retained" ? "Source evidence was not retained." : report.evidence.length > 0 ? report.evidence.map((item, i) => `${i + 1}. ${item}`).join("\n") : "No evidence items were captured."}`,
+    ...(report.noChangeNeeded
+      ? [`Resolution evidence\n${report.resolutionEvidence.length > 0 ? report.resolutionEvidence.map((item, i) => `${i + 1}. ${item}`).join("\n") : "No resolution evidence was captured."}`]
+      : []),
+    `Decisions\nExpansion rounds: ${report.expansionRounds}\nRequests: ${report.repositoryRequests.map((request) => `${request.provider}:${request.repoPath}`).join(", ") || "none"}\nWrite repositories: ${report.writeRepositories.map((request) => `${request.provider}:${request.repoPath}`).join(", ") || "none"}`,
+    `Implementation plan\n${report.planMarkdown || "No implementation plan was retained."}`,
+    `Usage so far\n${usageLines(report.usage.research).join("\n")}`,
+  ];
+  return scrubComment(fitFormattedComment(sections, dashboardUrl, marker));
+}
+
+export function formatPublishedAnalysisComment(report: RunAnalysisReport, dashboardUrl: string): string {
+  const marker = analysisCommentMarker(report.runId, "pull_request");
+  const publication = report.publication;
+  const sections = [
+    `Arthur pull requests ready\n${publication?.prs.map((pr) => `- ${pr.provider}:${pr.repoPath} ${pr.url}`).join("\n") || "No pull requests were published."}`,
+    `Implemented\n${publication?.changeSummary || "No implementation summary was retained."}`,
+    `Repositories\n${repositoryLines(report).join("\n")}`,
+    `Evidence\n${report.evidence.slice(0, 10).map((item) => `- ${item}`).join("\n") || "No evidence items were captured."}${report.evidence.length > 10 ? `\n- ${OMITTED}` : ""}`,
+    `Implementation plan\n${report.planMarkdown || "No implementation plan was retained."}`,
+    `Usage at publication\n${usageLines(report.usage.publication ?? report.usage.research).join("\n")}`,
+  ];
+  return scrubComment(fitFormattedComment(sections, dashboardUrl, marker));
+}
+
+function fitFormattedComment(sections: string[], dashboardUrl: string, marker: string): string {
+  const reserved = [`Dashboard: ${dashboardUrl}`, marker];
+  const mutable = sections.map((section) => withoutReservedCommentLines(section, marker));
+  let body = [...mutable, ...reserved].join("\n\n");
+  if (utf8Bytes(body) <= COMMENT_MAX_BYTES) return body;
+  for (let index = 0; index < mutable.length; index += 1) {
+    const section = mutable[index]!;
+    if (!/(What was checked|Resolution evidence|Evidence|Implementation plan|Implemented)/.test(section)) continue;
+    const lines = section.split("\n");
+    mutable[index] = `${lines[0]}\n${OMITTED}`;
+    body = [...mutable, ...reserved].join("\n\n");
+    if (utf8Bytes(body) <= COMMENT_MAX_BYTES) return body;
+  }
+  const usage = mutable.find((section) => section.startsWith("Usage")) ?? "";
+  const tail = `${usage}\n\nDashboard: ${dashboardUrl}\n\n${marker}`;
+  const separator = `\n\n${OMITTED}\n\n`;
+  const budget = COMMENT_MAX_BYTES - utf8Bytes(tail) - utf8Bytes(separator);
+  const heading = sliceUtf8(mutable[0] ?? "Arthur report", Math.max(0, budget), "head");
+  return `${heading}${separator}${tail}`;
+}

--- a/apps/worker/src/run-analysis/store.test.ts
+++ b/apps/worker/src/run-analysis/store.test.ts
@@ -1,0 +1,94 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { RunAnalysisReport } from "@shared/contracts";
+import { createTestDb } from "../db/test-db.js";
+import type { Db } from "../db/client.js";
+import { workflowRuns } from "../db/schema.js";
+import {
+  buildResearchAnalysisReport,
+  usageSnapshot,
+  withAnalysisDelivery,
+  withAnalysisPublication,
+} from "./report.js";
+import { finalizeRunAnalysisUsage, getRunAnalysisReport, recordRunAnalysisReport } from "./store.js";
+
+let db: Db;
+beforeAll(async () => { db = await createTestDb(); }, 60_000);
+beforeEach(async () => { await db.delete(workflowRuns); });
+
+function report(): RunAnalysisReport {
+  return buildResearchAnalysisReport({ runId: "store-run", researchResult: { body: "# Plan" }, usage: { costUsd: 1, costKnown: true, tokensInput: 1, tokensCached: 0, tokensOutput: 1, phases: {} } });
+}
+
+describe("run analysis report store", () => {
+  it("upserts a report and parses the JSONB value", async () => {
+    const value = report();
+    await recordRunAnalysisReport(db, value);
+    expect(await getRunAnalysisReport(db, value.runId)).toEqual(value);
+    await recordRunAnalysisReport(db, value);
+    expect((await getRunAnalysisReport(db, value.runId))?.jira.research.state).toBe("pending");
+  });
+
+  it("finalizes only the final usage slot", async () => {
+    const value = report();
+    await recordRunAnalysisReport(db, value);
+    await finalizeRunAnalysisUsage(db, value.runId, { ...value.usage.research, capturedAt: "final" });
+    const stored = await getRunAnalysisReport(db, value.runId);
+    expect(stored?.usage.final?.capturedAt).toBe("final");
+    expect(stored?.usage.research.capturedAt).toBe(value.usage.research.capturedAt);
+  });
+
+  it("never lets a stale replay erase forward lifecycle state", async () => {
+    const pending = report();
+    const posted = withAnalysisDelivery(pending, "research", {
+      state: "posted",
+      attemptedAt: "2026-08-20T00:01:00.000Z",
+      commentUrl: "https://jira.example/comment/1",
+      error: null,
+    });
+    const published = withAnalysisPublication(
+      posted,
+      [{ provider: "github", repoPath: "acme/api", id: 1, url: "https://github.example/pr/1" }],
+      "Implemented",
+      usageSnapshot({ costUsd: 2, costKnown: true, tokensInput: 2, tokensCached: 0, tokensOutput: 2, phases: {} }, "2026-08-20T00:02:00.000Z"),
+    );
+    await recordRunAnalysisReport(db, published);
+    await finalizeRunAnalysisUsage(db, pending.runId, {
+      ...pending.usage.research,
+      capturedAt: "2026-08-20T00:03:00.000Z",
+    });
+    const revised = buildResearchAnalysisReport({
+      runId: pending.runId,
+      researchRevision: 2,
+      researchCompletedAt: "2026-08-20T00:04:00.000Z",
+      researchResult: {
+        body: "# Revised plan",
+        repositoryEvidence: ["newer evidence"],
+      },
+      usage: {
+        costUsd: 3,
+        costKnown: true,
+        tokensInput: 3,
+        tokensCached: 0,
+        tokensOutput: 3,
+        phases: {},
+      },
+    });
+    await recordRunAnalysisReport(db, revised);
+    await recordRunAnalysisReport(db, pending);
+
+    const stored = await getRunAnalysisReport(db, pending.runId);
+    expect(stored?.researchRevision).toBe(2);
+    expect(stored?.planMarkdown).toBe("# Revised plan");
+    expect(stored?.evidence).toEqual(["newer evidence"]);
+    expect(stored?.usage.research.costUsd).toBe(3);
+    expect(stored?.stage).toBe("published");
+    expect(stored?.publication?.prs).toHaveLength(1);
+    expect(stored?.jira.research.state).toBe("posted");
+    expect(stored?.usage.publication).not.toBeNull();
+    expect(stored?.usage.final?.capturedAt).toBe("2026-08-20T00:03:00.000Z");
+  });
+
+  it("returns null for absent and malformed values", async () => {
+    expect(await getRunAnalysisReport(db, "absent")).toBeNull();
+  });
+});

--- a/apps/worker/src/run-analysis/store.test.ts
+++ b/apps/worker/src/run-analysis/store.test.ts
@@ -28,6 +28,30 @@ describe("run analysis report store", () => {
     expect((await getRunAnalysisReport(db, value.runId))?.jira.research.state).toBe("pending");
   });
 
+  it("persists through a driver without interactive transaction support", async () => {
+    const noTransactionDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property === "transaction") {
+          return async () => {
+            throw new Error("No transactions support in neon-http driver");
+          };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const value = report();
+
+    await db.insert(workflowRuns).values({
+      runId: value.runId,
+      workflowId: "wf_agent",
+      workflowName: "Agent",
+      analysisReport: null,
+    });
+    await expect(recordRunAnalysisReport(noTransactionDb, value)).resolves.toBeUndefined();
+    await expect(recordRunAnalysisReport(noTransactionDb, value)).resolves.toBeUndefined();
+    expect(await getRunAnalysisReport(db, value.runId)).toEqual(value);
+  });
+
   it("finalizes only the final usage slot", async () => {
     const value = report();
     await recordRunAnalysisReport(db, value);

--- a/apps/worker/src/run-analysis/store.ts
+++ b/apps/worker/src/run-analysis/store.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import type { RunAnalysisReport, RunAnalysisUsageSnapshot } from "@shared/contracts";
 import type { Db } from "../db/client.js";
 import { workflowRuns } from "../db/schema.js";
@@ -16,6 +16,12 @@ const deliveryRank = {
   failed: 2,
   posted: 3,
 } as const;
+
+const MAX_REPORT_WRITE_ATTEMPTS = 8;
+
+function jsonbValue(value: unknown) {
+  return sql`${JSON.stringify(value ?? null)}::jsonb`;
+}
 
 function newerDelivery(
   current: RunAnalysisReport["jira"]["research"],
@@ -70,11 +76,11 @@ export async function recordRunAnalysisReport(
   db: Db,
   report: RunAnalysisReport,
 ): Promise<void> {
-  await db.transaction(async (tx) => {
-    // The advisory transaction lock also serializes the first insert, where no
-    // workflow_runs row exists yet for SELECT ... FOR UPDATE to lock.
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${report.runId}, 0))`);
-    const [row] = await tx
+  // neon-http does not support interactive transactions. Compare-and-swap the
+  // exact JSONB snapshot that was merged so a concurrent writer cannot be
+  // overwritten; a conflicting insert follows the same retry path.
+  for (let attempt = 0; attempt < MAX_REPORT_WRITE_ATTEMPTS; attempt += 1) {
+    const [row] = await db
       .select({ analysisReport: workflowRuns.analysisReport })
       .from(workflowRuns)
       .where(eq(workflowRuns.runId, report.runId))
@@ -83,7 +89,25 @@ export async function recordRunAnalysisReport(
       parseStoredRunAnalysisReport(row?.analysisReport),
       report,
     );
-    await tx
+    if (row) {
+      const snapshotCondition = row.analysisReport === null
+        ? isNull(workflowRuns.analysisReport)
+        : sql`${workflowRuns.analysisReport} is not distinct from ${jsonbValue(row.analysisReport)}`;
+      const [updated] = await db
+        .update(workflowRuns)
+        .set({ analysisReport: merged, updatedAt: sql`now()` })
+        .where(
+          and(
+            eq(workflowRuns.runId, report.runId),
+            snapshotCondition,
+          ),
+        )
+        .returning({ runId: workflowRuns.runId });
+      if (updated) return;
+      continue;
+    }
+
+    const [inserted] = await db
       .insert(workflowRuns)
       .values({
         runId: report.runId,
@@ -91,14 +115,14 @@ export async function recordRunAnalysisReport(
         workflowName: "Agent",
         analysisReport: merged,
       })
-      .onConflictDoUpdate({
-        target: workflowRuns.runId,
-        set: {
-          analysisReport: merged,
-          updatedAt: sql`now()`,
-        },
-      });
-  });
+      .onConflictDoNothing({ target: workflowRuns.runId })
+      .returning({ runId: workflowRuns.runId });
+    if (inserted) return;
+  }
+
+  throw new Error(
+    `Could not persist run analysis report for ${report.runId} after ${MAX_REPORT_WRITE_ATTEMPTS} attempts`,
+  );
 }
 
 /** Read JSONB through the structural parser; callers never trust a cast from

--- a/apps/worker/src/run-analysis/store.ts
+++ b/apps/worker/src/run-analysis/store.ts
@@ -1,0 +1,133 @@
+import { eq, sql } from "drizzle-orm";
+import type { RunAnalysisReport, RunAnalysisUsageSnapshot } from "@shared/contracts";
+import type { Db } from "../db/client.js";
+import { workflowRuns } from "../db/schema.js";
+import { parseStoredRunAnalysisReport } from "./report.js";
+
+const stageRank = {
+  research_complete: 1,
+  no_change: 2,
+  published: 3,
+} as const;
+
+const deliveryRank = {
+  not_applicable: 0,
+  pending: 1,
+  failed: 2,
+  posted: 3,
+} as const;
+
+function newerDelivery(
+  current: RunAnalysisReport["jira"]["research"],
+  incoming: RunAnalysisReport["jira"]["research"],
+): RunAnalysisReport["jira"]["research"] {
+  return deliveryRank[incoming.state] >= deliveryRank[current.state]
+    ? incoming
+    : current;
+}
+
+/** Merge only forward-moving lifecycle slots so a durable replay of an older
+ * snapshot cannot erase publication, delivery, or final-usage state. */
+export function mergeRunAnalysisReports(
+  current: RunAnalysisReport | null,
+  incoming: RunAnalysisReport,
+): RunAnalysisReport {
+  if (!current || current.runId !== incoming.runId) return incoming;
+  const researchBase = incoming.researchRevision >= current.researchRevision
+    ? incoming
+    : current;
+  const incomingSanitizationIsNewer =
+    incoming.researchRevision > current.researchRevision ||
+    incoming.sanitization.originalBytes > current.sanitization.originalBytes ||
+    (incoming.sanitization.originalBytes === current.sanitization.originalBytes &&
+      incoming.sanitization.storedBytes >= current.sanitization.storedBytes);
+  return {
+    ...researchBase,
+    stage:
+      stageRank[incoming.stage] >= stageRank[current.stage]
+        ? incoming.stage
+        : current.stage,
+    publication: incoming.publication ?? current.publication,
+    usage: {
+      research: researchBase.usage.research,
+      publication: incoming.usage.publication ?? current.usage.publication,
+      final: incoming.usage.final ?? current.usage.final,
+    },
+    jira: {
+      research: newerDelivery(current.jira.research, incoming.jira.research),
+      pullRequest: newerDelivery(current.jira.pullRequest, incoming.jira.pullRequest),
+    },
+    sanitization: incomingSanitizationIsNewer
+      ? incoming.sanitization
+      : current.sanitization,
+  };
+}
+
+/** Persist one report without claiming ownership of any other workflow_runs
+ * columns. The insert identity mirrors the agent telemetry writer so research
+ * can be recorded before a cron snapshot or terminal usage write exists. */
+export async function recordRunAnalysisReport(
+  db: Db,
+  report: RunAnalysisReport,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    // The advisory transaction lock also serializes the first insert, where no
+    // workflow_runs row exists yet for SELECT ... FOR UPDATE to lock.
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${report.runId}, 0))`);
+    const [row] = await tx
+      .select({ analysisReport: workflowRuns.analysisReport })
+      .from(workflowRuns)
+      .where(eq(workflowRuns.runId, report.runId))
+      .limit(1);
+    const merged = mergeRunAnalysisReports(
+      parseStoredRunAnalysisReport(row?.analysisReport),
+      report,
+    );
+    await tx
+      .insert(workflowRuns)
+      .values({
+        runId: report.runId,
+        workflowId: "wf_agent",
+        workflowName: "Agent",
+        analysisReport: merged,
+      })
+      .onConflictDoUpdate({
+        target: workflowRuns.runId,
+        set: {
+          analysisReport: merged,
+          updatedAt: sql`now()`,
+        },
+      });
+  });
+}
+
+/** Read JSONB through the structural parser; callers never trust a cast from
+ * the database because legacy/corrupt rows must behave like a missing report. */
+export async function getRunAnalysisReport(
+  db: Db,
+  runId: string,
+): Promise<RunAnalysisReport | null> {
+  const [row] = await db
+    .select({ analysisReport: workflowRuns.analysisReport })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, runId))
+    .limit(1);
+  return parseStoredRunAnalysisReport(row?.analysisReport);
+}
+
+/** Add the authoritative terminal usage snapshot after recordRunUsage. This
+ * intentionally updates only the nested final slot and leaves Jira delivery
+ * plus earlier research/publication snapshots untouched. */
+export async function finalizeRunAnalysisUsage(
+  db: Db,
+  runId: string,
+  finalUsage: RunAnalysisUsageSnapshot,
+): Promise<void> {
+  const current = await getRunAnalysisReport(db, runId);
+  if (!current) return;
+  const next: RunAnalysisReport = {
+    ...current,
+    usage: { ...current.usage, final: finalUsage },
+  };
+  await recordRunAnalysisReport(db, next);
+}

--- a/apps/worker/src/sandbox/agents/types.ts
+++ b/apps/worker/src/sandbox/agents/types.ts
@@ -274,7 +274,9 @@ export const researchOutputSchema = z.object({
   suggestedAnswers: z.array(z.string()).nullish(),
   repositories: z.array(researchRepositorySchema).max(3).nullish(),
   writeRepositories: z.array(researchRepositorySchema).max(8).nullish(),
-  repositoryEvidence: z.array(z.string()).max(50).nullish(),
+  repositoryEvidence: z.array(z.string()).max(50).nullish().describe(
+    "Up to 50 ordered facts. Each item names the exact provider:repoPath, file/symbol/commit/PR or ticket fact checked, and the relevant finding.",
+  ),
   noChangeNeeded: z.boolean().nullish(),
   resolutionEvidence: z.array(z.string()).max(50).nullish(),
   reviewThreads: reviewThreadsFieldSchema,
@@ -352,6 +354,8 @@ export const RESEARCH_SCHEMA = JSON.stringify({
         { type: "array", maxItems: 50, items: { type: "string" } },
         { type: "null" },
       ],
+      description:
+        "Each item names the exact provider:repoPath, file/symbol/commit/PR or ticket fact checked, and the relevant finding.",
     },
     noChangeNeeded: { type: ["boolean", "null"] },
     resolutionEvidence: {

--- a/apps/worker/src/sandbox/context.ts
+++ b/apps/worker/src/sandbox/context.ts
@@ -151,8 +151,11 @@ This protocol extends and overrides any older Output Format instructions above.
   ask where that logic lives.
 - When returning \`status: "completed"\`, set \`writeRepositories\` to the exact
   attached repositories the implementation must modify, and include concise
-  \`repositoryEvidence\`. A code-changing plan must declare at least one write
-  repository.
+  \`repositoryEvidence\`. Every evidence item must name the exact
+  \`provider:repoPath\`, the file, symbol, commit, PR, or ticket fact checked,
+  and the relevant finding (for example: \`github:acme/api src/auth.ts:42 —
+  token refresh is delegated to SessionStore\`). A code-changing plan must
+  declare at least one write repository.
 - Set fields that do not apply to \`null\`, as required by the structured schema.
 - Research is read-only: do not modify files, create commits, or change branches.
 `;

--- a/apps/worker/src/workflows/agent-input.test.ts
+++ b/apps/worker/src/workflows/agent-input.test.ts
@@ -161,6 +161,7 @@ describe("clarification origin entries", () => {
       definitionVersion: 9,
       approvedPlan: {
         markdown: "Implement the approved plan.",
+        sourceRunId: "run-produced",
         assumptions: ["flagged"],
         repositoryScope: {
           repositories: [

--- a/apps/worker/src/workflows/agent-input.ts
+++ b/apps/worker/src/workflows/agent-input.ts
@@ -176,6 +176,8 @@ export type AgentWorkflowInput =
       definitionVersion?: number;
       approvedPlan: {
         markdown: string;
+        /** Run that produced the approved research plan, when available. */
+        sourceRunId?: string;
         assumptions?: string[];
         repositoryScope?: ApprovedRepositoryScope;
       };
@@ -228,6 +230,7 @@ export type ClarificationOriginEntry =
       definitionVersion?: number;
       approvedPlan: {
         markdown: string;
+        sourceRunId?: string;
         assumptions?: string[];
         repositoryScope?: ApprovedRepositoryScope;
       };

--- a/apps/worker/src/workflows/agent-no-change.test.ts
+++ b/apps/worker/src/workflows/agent-no-change.test.ts
@@ -958,3 +958,28 @@ describe("postReviewLedgerFailureNoteOnFailureExit flag gate", () => {
     ).toBe(true);
   });
 });
+
+describe("planning analysis report provenance", () => {
+  const agentLines = readFileSync(
+    fileURLToPath(new URL("./agent.ts", import.meta.url)),
+    "utf8",
+  ).split("\n");
+
+  it("captures the research manifest before write-scope promotion", () => {
+    const snapshotIndex = agentLines.findIndex((line) =>
+      line.includes("const researchWorkspaceManifest = ctx.workspaceManifest;"),
+    );
+    const promotionIndex = agentLines.findIndex(
+      (line, index) =>
+        index > snapshotIndex &&
+        line.includes("const promotion = await promoteWorkspaceWrites("),
+    );
+    const reportIndex = agentLines.findIndex((line) =>
+      line.includes("workspaceManifest: researchWorkspaceManifest,"),
+    );
+
+    expect(snapshotIndex, "research manifest snapshot is missing").toBeGreaterThan(-1);
+    expect(promotionIndex, "planning promotion is missing").toBeGreaterThan(snapshotIndex);
+    expect(reportIndex, "report does not use the pre-promotion manifest").toBeGreaterThan(promotionIndex);
+  });
+});

--- a/apps/worker/src/workflows/agent-provider-fences.test.ts
+++ b/apps/worker/src/workflows/agent-provider-fences.test.ts
@@ -3,9 +3,14 @@ import { ActiveRunOwnerError } from "../lib/run-control-errors.js";
 
 const mocks = vi.hoisted(() => ({
   assertActiveRunOwner: vi.fn(),
+  fetchTicket: vi.fn(),
+  findCommentByMarker: vi.fn(),
+  info: vi.fn(),
+  getRunAnalysisReport: vi.fn(),
   moveTicket: vi.fn(),
   notifyForTicket: vi.fn(),
   postComment: vi.fn(),
+  recordRunAnalysisReport: vi.fn(),
   reconcileClarificationPickupState: vi.fn(),
   resolveAwaitingRunsForTicket: vi.fn(),
   supersedePendingForTicket: vi.fn(),
@@ -21,6 +26,8 @@ vi.mock("../lib/active-run-owner.js", () => ({
 vi.mock("../lib/adapters.js", () => ({
   createAdapters: () => ({
     issueTracker: {
+      fetchTicket: mocks.fetchTicket,
+      findCommentByMarker: mocks.findCommentByMarker,
       postComment: mocks.postComment,
       updateLabels: mocks.updateLabels,
     },
@@ -43,7 +50,11 @@ vi.mock("../lib/ticket-label-mutation.js", () => ({
   updateTicketLabelsForRun: (...args: any[]) =>
     mocks.updateTicketLabels(...args),
 }));
-vi.mock("../lib/logger.js", () => ({ logger: { warn: mocks.warn } }));
+vi.mock("../lib/logger.js", () => ({ logger: { info: mocks.info, warn: mocks.warn } }));
+vi.mock("../run-analysis/store.js", () => ({
+  getRunAnalysisReport: (...args: any[]) => mocks.getRunAnalysisReport(...args),
+  recordRunAnalysisReport: (...args: any[]) => mocks.recordRunAnalysisReport(...args),
+}));
 vi.mock("../../env.js", () => ({
   env: { DASHBOARD_ORIGIN: "https://dashboard.example.com" },
 }));
@@ -53,13 +64,17 @@ import {
   clarificationExitDisposition,
   notifyTicket,
   notifyTicketBestEffort,
+  loadApprovedPlanAnalysisReportBestEffort,
   parkForClarificationStep,
   postPickupCommentStep,
   postPrLinksComment,
+  postRunAnalysisCommentStep,
   postTicketComment,
+  recordRunAnalysisReportBestEffort,
   reconcileClarificationsOnPickup,
 } from "./agent.js";
 import { runControlErrorCases } from "./blocks/test-support.js";
+import { buildResearchAnalysisReport } from "../run-analysis/report.js";
 
 const owner = {
   subjectKey: "ticket:jira:AWT-1",
@@ -67,13 +82,31 @@ const owner = {
   runId: "run-1",
 };
 
+const analysisReport = buildResearchAnalysisReport({
+  runId: "run-1",
+  capturedAt: "2026-08-20T00:00:00.000Z",
+  researchResult: { body: "Implement the ticket." },
+  usage: {
+    costUsd: 0.25,
+    costKnown: true,
+    tokensInput: 10,
+    tokensCached: 0,
+    tokensOutput: 5,
+    phases: {},
+  },
+});
+
 describe("agent provider side-effect fences", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.assertActiveRunOwner.mockResolvedValue(undefined);
+    mocks.fetchTicket.mockResolvedValue({ comments: [] });
+    mocks.findCommentByMarker.mockResolvedValue(null);
+    mocks.getRunAnalysisReport.mockResolvedValue(null);
     mocks.moveTicket.mockResolvedValue(undefined);
     mocks.notifyForTicket.mockResolvedValue(undefined);
     mocks.postComment.mockResolvedValue(null);
+    mocks.recordRunAnalysisReport.mockResolvedValue(undefined);
     mocks.reconcileClarificationPickupState.mockResolvedValue({
       superseded: 0,
       resolvedAwaiting: 0,
@@ -126,6 +159,77 @@ describe("agent provider side-effect fences", () => {
     }
   });
 
+  it("posts one analysis comment and recovers a replay from the paginated marker lookup", async () => {
+    mocks.postComment.mockResolvedValueOnce("https://jira.example/comment/1");
+
+    await expect(
+      postRunAnalysisCommentStep("AWT-1", analysisReport, "research", owner),
+    ).resolves.toMatchObject({
+      state: "posted",
+      commentUrl: "https://jira.example/comment/1",
+    });
+    expect(mocks.findCommentByMarker).toHaveBeenCalledWith(
+      "AWT-1",
+      "Arthur report: run-1:research",
+    );
+    expect(mocks.postComment).toHaveBeenCalledOnce();
+    expect(mocks.assertActiveRunOwner).toHaveBeenCalledTimes(2);
+
+    vi.clearAllMocks();
+    mocks.assertActiveRunOwner.mockResolvedValue(undefined);
+    mocks.findCommentByMarker.mockResolvedValue(
+      "https://jira.example/comment/1",
+    );
+
+    await expect(
+      postRunAnalysisCommentStep("AWT-1", analysisReport, "research", owner),
+    ).resolves.toMatchObject({
+      state: "posted",
+      commentUrl: "https://jira.example/comment/1",
+    });
+    expect(mocks.postComment).not.toHaveBeenCalled();
+    expect(mocks.info).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: "run-1", stage: "research" }),
+      "run_analysis_comment_skipped_duplicate",
+    );
+  });
+
+  it("keeps report persistence and approved-report loading best-effort", async () => {
+    mocks.recordRunAnalysisReport.mockRejectedValue(new Error("database unavailable"));
+    await expect(recordRunAnalysisReportBestEffort(analysisReport)).resolves.toBe(false);
+
+    mocks.getRunAnalysisReport.mockRejectedValue(new Error("database unavailable"));
+    await expect(loadApprovedPlanAnalysisReportBestEffort(
+      "continuation",
+      "source",
+      {
+        kind: "plan_approved",
+        subjectKey: "ticket:jira:AWT-1",
+        ticketKey: "AWT-1",
+        ownerToken: "owner:test",
+        definitionId: 1,
+        approvedPlan: { markdown: "Approved", sourceRunId: "source" },
+        approval: {
+          approvalRequestId: "approval-1",
+          approver: "reviewer@example.com",
+          approvedAt: "2026-08-20T00:00:00.000Z",
+        },
+      },
+    )).resolves.toBeNull();
+  });
+
+  it("rechecks ownership after marker lookup and before posting Jira", async () => {
+    mocks.assertActiveRunOwner
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new ActiveRunOwnerError("owner changed"));
+
+    await expect(
+      postRunAnalysisCommentStep("AWT-1", analysisReport, "research", owner),
+    ).rejects.toThrow("owner changed");
+    expect(mocks.findCommentByMarker).toHaveBeenCalledOnce();
+    expect(mocks.postComment).not.toHaveBeenCalled();
+  });
+
   it("prevents stale Jira comments and Slack notifications after cancellation", async () => {
     mocks.assertActiveRunOwner.mockRejectedValue(
       new Error("Provider mutation requires the exact active run owner."),
@@ -161,6 +265,9 @@ describe("agent provider side-effect fences", () => {
         ),
       ).rejects.toBe(error);
       await expect(postPickupCommentStep("AWT-1", owner)).rejects.toBe(error);
+      await expect(
+        postRunAnalysisCommentStep("AWT-1", analysisReport, "research", owner),
+      ).rejects.toBe(error);
 
       expect(mocks.postComment).not.toHaveBeenCalled();
     },

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -140,6 +140,17 @@ import type { HumanDecision } from "../lib/human-decisions-memory.js";
 import type { WorkspacePublicationResult } from "./workspace-publication.js";
 import { publicationPrsForTelemetry } from "./publication-prs-for-telemetry.js";
 import {
+  analysisCommentMarker,
+  buildApprovedPlanAnalysisReport,
+  buildResearchAnalysisReport,
+  formatPublishedAnalysisComment,
+  formatResearchAnalysisComment,
+  hasAnalysisComment,
+  usageSnapshot,
+  withAnalysisDelivery,
+  withAnalysisPublication,
+} from "../run-analysis/report.js";
+import {
   invalidateWorkspaceGate,
   recordSuccessfulWorkspaceGate,
 } from "./workspace-gate.js";
@@ -245,6 +256,7 @@ import type {
   ReplaySanitizedEnvelope,
   ResolvedPromptReference,
   RunPullRequest,
+  RunAnalysisReport,
   TransformConfiguration,
   VcsProviderKind,
   WorkflowBlockType,
@@ -2005,6 +2017,166 @@ export async function postPrLinksComment(
   }
 }
 postPrLinksComment.maxRetries = 0;
+
+/** Durable report writer kept as a workflow step so a replay/cold resume can
+ * safely retry the database boundary without importing the DB client into the
+ * workflow bundle. */
+export async function recordRunAnalysisReportStep(report: RunAnalysisReport): Promise<void> {
+  "use step";
+  const { getDb } = await import("../db/client.js");
+  const { logger } = await import("../lib/logger.js");
+  const { recordRunAnalysisReport } = await import("../run-analysis/store.js");
+  await recordRunAnalysisReport(getDb(), report);
+  logger.info({ runId: report.runId, stage: report.stage }, "run_analysis_report_recorded");
+}
+recordRunAnalysisReportStep.maxRetries = 2;
+
+export async function recordRunAnalysisReportBestEffort(report: RunAnalysisReport): Promise<boolean> {
+  try {
+    await recordRunAnalysisReportStep(report);
+    return true;
+  } catch (error) {
+    console.warn(
+      `[agent] run analysis report persistence failed: ${safeRunAnalysisReportError(error)}`,
+    );
+    return false;
+  }
+}
+
+async function loadApprovedPlanAnalysisReportStep(
+  runId: string,
+  sourceRunId: string | undefined,
+  approvedPlan: AgentWorkflowInput & { kind: "plan_approved" },
+): Promise<RunAnalysisReport> {
+  "use step";
+  const { getDb } = await import("../db/client.js");
+  const { getRunAnalysisReport } = await import("../run-analysis/store.js");
+  const source = sourceRunId ? await getRunAnalysisReport(getDb(), sourceRunId) : null;
+  return buildApprovedPlanAnalysisReport({
+    runId,
+    sourceRunId: sourceRunId ?? null,
+    sourceReport: source,
+    approvedPlan: approvedPlan.approvedPlan,
+  });
+}
+loadApprovedPlanAnalysisReportStep.maxRetries = 2;
+
+export async function loadApprovedPlanAnalysisReportBestEffort(
+  runId: string,
+  sourceRunId: string | undefined,
+  approvedPlan: AgentWorkflowInput & { kind: "plan_approved" },
+): Promise<RunAnalysisReport | null> {
+  try {
+    return await loadApprovedPlanAnalysisReportStep(runId, sourceRunId, approvedPlan);
+  } catch (error) {
+    console.warn(
+      `[agent] approved run analysis report unavailable: ${safeRunAnalysisReportError(error)}`,
+    );
+    return null;
+  }
+}
+
+function buildResearchAnalysisReportBestEffort(
+  input: Parameters<typeof buildResearchAnalysisReport>[0],
+): RunAnalysisReport | null {
+  try {
+    return buildResearchAnalysisReport(input);
+  } catch (error) {
+    console.warn(
+      `[agent] research analysis report unavailable: ${safeRunAnalysisReportError(error)}`,
+    );
+    return null;
+  }
+}
+
+/** Fetch-before-post makes a lost POST response idempotent: a retry sees the
+ * marker and returns a posted delivery instead of creating a duplicate. */
+export async function postRunAnalysisCommentStep(
+  ticketKey: string,
+  report: RunAnalysisReport,
+  stage: "research" | "pull_request",
+  owner: ActiveRunOwner,
+): Promise<import("@shared/contracts").RunAnalysisCommentDelivery> {
+  "use step";
+  const { getDb } = await import("../db/client.js");
+  const { assertActiveRunOwner } = await import("../lib/active-run-owner.js");
+  const { createAdapters } = await import("../lib/adapters.js");
+  const { env } = await import("../../env.js");
+  const { issueTracker } = createAdapters();
+  await assertActiveRunOwner(getDb(), owner);
+  const attemptedAt = new Date().toISOString();
+  const marker = analysisCommentMarker(report.runId, stage);
+  let existingCommentUrl: string | null | undefined;
+  if (issueTracker.findCommentByMarker) {
+    existingCommentUrl =
+      (await issueTracker.findCommentByMarker(ticketKey, marker)) ?? undefined;
+  } else {
+    existingCommentUrl = hasAnalysisComment(
+      await issueTracker.fetchTicket(ticketKey),
+      marker,
+    )
+      ? null
+      : undefined;
+  }
+  if (existingCommentUrl !== undefined) {
+    const { logger } = await import("../lib/logger.js");
+    logger.info({ runId: report.runId, stage, ticketKey }, "run_analysis_comment_skipped_duplicate");
+    return { state: "posted", attemptedAt, commentUrl: existingCommentUrl, error: null };
+  }
+  const dashboardUrl = ticketRunUrl(env.DASHBOARD_ORIGIN, ticketKey, report.runId);
+  const body = stage === "research"
+    ? formatResearchAnalysisComment(report, dashboardUrl)
+    : formatPublishedAnalysisComment(report, dashboardUrl);
+  await assertActiveRunOwner(getDb(), owner);
+  const commentUrl = await issueTracker.postComment(ticketKey, body);
+  const { logger } = await import("../lib/logger.js");
+  logger.info({ runId: report.runId, stage, ticketKey }, "run_analysis_comment_posted");
+  return { state: "posted", attemptedAt, commentUrl, error: null };
+}
+postRunAnalysisCommentStep.maxRetries = 2;
+
+export async function recordRunAnalysisCommentFailureStep(
+  runId: string,
+  stage: "research" | "pull_request",
+  error: string,
+): Promise<void> {
+  "use step";
+  const { logger } = await import("../lib/logger.js");
+  logger.warn({ runId, stage, error }, "run_analysis_comment_failed");
+}
+recordRunAnalysisCommentFailureStep.maxRetries = 0;
+
+async function recordRunAnalysisCommentFailureBestEffort(
+  runId: string,
+  stage: "research" | "pull_request",
+  error: string,
+): Promise<void> {
+  try {
+    await recordRunAnalysisCommentFailureStep(runId, stage, error);
+  } catch (loggingError) {
+    console.warn(
+      `[agent] run analysis comment failure logging failed: ${safeRunAnalysisReportError(loggingError)}`,
+    );
+  }
+}
+
+function safeRunAnalysisDeliveryError(error: unknown): string {
+  return safeRunAnalysisError(error, "Jira analysis report delivery failed.");
+}
+
+function safeRunAnalysisReportError(error: unknown): string {
+  return safeRunAnalysisError(error, "Run analysis report capture failed.");
+}
+
+function safeRunAnalysisError(error: unknown, fallback: string): string {
+  const envelope = sanitizeReplayValue(errorMessage(error), {
+    secrets: configuredReplaySecrets(),
+    maxBytes: 2 * 1024,
+  });
+  return !envelope.metadata.unavailable && typeof envelope.value === "string"
+    ? envelope.value
+    : fallback;
+}
 
 /** Posts the comment and hands back the tracker's deep link to it when the
  *  provider exposes one, so callers can point a notification at the comment.
@@ -3946,6 +4118,7 @@ export async function recordRunTelemetryStep(payload: {
   "use step";
   const { getDb } = await import("../db/client.js");
   const { recordRunUsage } = await import("../lib/telemetry/run-telemetry.js");
+  const { finalizeRunAnalysisUsage } = await import("../run-analysis/store.js");
   const { getWorld } = await import("workflow/runtime");
   const collectRunDetailMod = await import(
     "../lib/overview/collect-run-detail.js"
@@ -3994,6 +4167,19 @@ export async function recordRunTelemetryStep(payload: {
     prs: payload.prs,
     harnessManifests: payload.harnessManifests,
   });
+  try {
+    await finalizeRunAnalysisUsage(
+      getDb(),
+      payload.runId,
+      usageSnapshot(payload.totals, new Date().toISOString()),
+    );
+  } catch (error) {
+    console.error(
+      "run_analysis_final_usage_failed",
+      payload.runId,
+      redactDiagnosticText(errorMessage(error)),
+    );
+  }
 }
 recordRunTelemetryStep.maxRetries = 0;
 
@@ -4958,6 +5144,13 @@ async function agentWorkflowBody(
       attempt: 1,
     };
 
+    const initialAnalysisReport =
+      entry.kind === "plan_approved"
+        ? await loadApprovedPlanAnalysisReportBestEffort(workflowRunId, entry.approvedPlan.sourceRunId, entry)
+        : null;
+    if (initialAnalysisReport) {
+      await recordRunAnalysisReportBestEffort(initialAnalysisReport);
+    }
     const ctx: EngineCtx = {
       runId: workflowRunId,
       schemaVersion: plan.schemaVersion,
@@ -4995,6 +5188,8 @@ async function agentWorkflowBody(
         entry.kind === "plan_approved"
           ? entry.approvedPlan.markdown
           : "",
+      analysisReport: initialAnalysisReport,
+      analysisRevision: initialAnalysisReport?.researchRevision ?? 0,
       publication: null,
       prePrGate: null,
       runDefaultKind,
@@ -6274,17 +6469,67 @@ async function agentWorkflowBody(
               );
             }
             if (noChangeAction === "no_change") {
+              const researchTotals = computeUsageTotals(
+                runPhaseUsages,
+                priceLookup,
+                activeModel,
+                runPhaseModels,
+              );
+              ctx.analysisRevision += 1;
+              ctx.analysisReport = buildResearchAnalysisReportBestEffort({
+                runId: workflowRunId,
+                researchRevision: ctx.analysisRevision,
+                workspaceManifest: ctx.workspaceManifest,
+                selectedRepositories: ctx.selectedRepositories,
+                repositoryExpansion: ctx.repositoryExpansion,
+                researchResult: research,
+                usage: researchTotals,
+                jiraApplicable: Boolean(entry.ticketKey),
+              });
+              const analysisReportPersisted = ctx.analysisReport
+                ? await recordRunAnalysisReportBestEffort(ctx.analysisReport)
+                : false;
               // Ticket-bound side effects only, exactly like the terminate
               // dispatch: an uncorrelated entry has no ticket to comment on,
               // move, or notify about.
               if (entry.ticketKey) {
-                const evidenceCommentUrl = await postTicketComment(
-                  ticket.identifier,
-                  ledgerGate?.kind === "no_change"
-                    ? ledgerGate.comment
-                    : buildResolutionEvidenceComment(research),
-                  transitionOwner,
-                );
+                let evidenceCommentUrl: string | null = null;
+                if (ctx.analysisReport && analysisReportPersisted) {
+                  let delivery: import("@shared/contracts").RunAnalysisCommentDelivery;
+                  try {
+                    delivery = await postRunAnalysisCommentStep(
+                      ticket.identifier,
+                      ctx.analysisReport,
+                      "research",
+                      transitionOwner,
+                    );
+                  } catch (error) {
+                    if (isRunControlError(error)) throw error;
+                    const deliveryError = safeRunAnalysisDeliveryError(error);
+                    await recordRunAnalysisCommentFailureBestEffort(
+                      ctx.analysisReport.runId,
+                      "research",
+                      deliveryError,
+                    );
+                    delivery = {
+                      state: "failed",
+                      attemptedAt: new Date().toISOString(),
+                      commentUrl: null,
+                      error: deliveryError,
+                    };
+                  }
+                  ctx.analysisReport = withAnalysisDelivery(ctx.analysisReport, "no_change", delivery);
+                  await recordRunAnalysisReportBestEffort(ctx.analysisReport);
+                  evidenceCommentUrl = delivery.commentUrl;
+                } else {
+                  evidenceCommentUrl = await postTicketComment(
+                    ticket.identifier,
+                    ledgerGate?.kind === "no_change"
+                      ? ledgerGate.comment
+                      : buildResolutionEvidenceComment(research),
+                    transitionOwner,
+                  );
+                }
                 // terminal_success skips the downstream cone, so the graph's own
                 // update_ticket_status node never runs. Dispatch has no
                 // post-success dedup: a ticket left in the AI column would be
@@ -6359,6 +6604,53 @@ async function agentWorkflowBody(
               if (promotion) return promotion;
             }
             ctx.researchPlanMarkdown = research.body;
+            const researchTotals = computeUsageTotals(
+              runPhaseUsages,
+              priceLookup,
+              activeModel,
+              runPhaseModels,
+            );
+            ctx.analysisRevision += 1;
+            ctx.analysisReport = buildResearchAnalysisReportBestEffort({
+              runId: workflowRunId,
+              researchRevision: ctx.analysisRevision,
+              workspaceManifest: ctx.workspaceManifest,
+              selectedRepositories: ctx.selectedRepositories,
+              repositoryExpansion: ctx.repositoryExpansion,
+              researchResult: research,
+              usage: researchTotals,
+              jiraApplicable: Boolean(entry.ticketKey),
+            });
+            const analysisReportPersisted = ctx.analysisReport
+              ? await recordRunAnalysisReportBestEffort(ctx.analysisReport)
+              : false;
+            if (entry.ticketKey && ctx.analysisReport && analysisReportPersisted) {
+              let delivery: import("@shared/contracts").RunAnalysisCommentDelivery;
+              try {
+                delivery = await postRunAnalysisCommentStep(
+                  ticket.identifier,
+                  ctx.analysisReport,
+                  "research",
+                  transitionOwner,
+                );
+              } catch (error) {
+                if (isRunControlError(error)) throw error;
+                const deliveryError = safeRunAnalysisDeliveryError(error);
+                await recordRunAnalysisCommentFailureBestEffort(
+                  ctx.analysisReport.runId,
+                  "research",
+                  deliveryError,
+                );
+                delivery = {
+                  state: "failed",
+                  attemptedAt: new Date().toISOString(),
+                  commentUrl: null,
+                  error: deliveryError,
+                };
+              }
+              ctx.analysisReport = withAnalysisDelivery(ctx.analysisReport, "research_complete", delivery);
+              await recordRunAnalysisReportBestEffort(ctx.analysisReport);
+            }
             return {
               kind: "next",
               output: {
@@ -6991,7 +7283,53 @@ async function agentWorkflowBody(
               );
             }
 
-            if (publication.prs.some((pr) => pr.isNew)) {
+            const hasNewPublication = publication.prs.some((pr) => pr.isNew);
+            let publicationReport: RunAnalysisReport | null = null;
+            let publicationReportPersisted = false;
+            if (ctx.analysisReport) {
+              try {
+                publicationReport = withAnalysisPublication(
+                  ctx.analysisReport,
+                  publication,
+                  ctx.changeSummary,
+                  computeUsageTotals(runPhaseUsages, priceLookup, activeModel, runPhaseModels),
+                );
+                ctx.analysisReport = publicationReport;
+                publicationReportPersisted = await recordRunAnalysisReportBestEffort(publicationReport);
+              } catch (error) {
+                console.warn(
+                  `[agent] publication analysis report unavailable: ${safeRunAnalysisReportError(error)}`,
+                );
+              }
+              if (publicationReport && publicationReportPersisted && hasNewPublication && entry.ticketKey) {
+                let delivery: import("@shared/contracts").RunAnalysisCommentDelivery;
+                try {
+                  delivery = await postRunAnalysisCommentStep(
+                    ticket.identifier,
+                    publicationReport,
+                    "pull_request",
+                    transitionOwner,
+                  );
+                } catch (error) {
+                  if (isRunControlError(error)) throw error;
+                  const deliveryError = safeRunAnalysisDeliveryError(error);
+                  await recordRunAnalysisCommentFailureBestEffort(
+                    publicationReport.runId,
+                    "pull_request",
+                    deliveryError,
+                  );
+                  delivery = {
+                    state: "failed",
+                    attemptedAt: new Date().toISOString(),
+                    commentUrl: null,
+                    error: deliveryError,
+                  };
+                }
+                ctx.analysisReport = withAnalysisDelivery(publicationReport, "published", delivery);
+                await recordRunAnalysisReportBestEffort(ctx.analysisReport);
+              }
+            }
+            if ((!publicationReport || !publicationReportPersisted) && hasNewPublication) {
               await postPrLinksComment(ticket.identifier, publication.prs, transitionOwner);
             }
 

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -6485,6 +6485,7 @@ async function agentWorkflowBody(
                 researchResult: research,
                 usage: researchTotals,
                 jiraApplicable: Boolean(entry.ticketKey),
+                noChangeNeededOverride: true,
               });
               const analysisReportPersisted = ctx.analysisReport
                 ? await recordRunAnalysisReportBestEffort(ctx.analysisReport)
@@ -6589,6 +6590,7 @@ async function agentWorkflowBody(
             }
 
             ctx.researchWriteRepositories = research.writeRepositories ?? [];
+            const researchWorkspaceManifest = ctx.workspaceManifest;
             if (
               shouldPromoteResearchWriteScope({
                 definitionNodes: ctx.definitionNodes,
@@ -6614,7 +6616,7 @@ async function agentWorkflowBody(
             ctx.analysisReport = buildResearchAnalysisReportBestEffort({
               runId: workflowRunId,
               researchRevision: ctx.analysisRevision,
-              workspaceManifest: ctx.workspaceManifest,
+              workspaceManifest: researchWorkspaceManifest,
               selectedRepositories: ctx.selectedRepositories,
               repositoryExpansion: ctx.repositoryExpansion,
               researchResult: research,

--- a/apps/worker/src/workflows/blocks/test-support.ts
+++ b/apps/worker/src/workflows/blocks/test-support.ts
@@ -171,6 +171,7 @@ export function makeCtx(overrides: Partial<EngineCtx> = {}): EngineCtx {
     researchWriteRepositories: [],
     preSandboxAdditions: { research: [], implementation: [], review: [] },
     researchPlanMarkdown: "",
+    analysisRevision: 0,
     publication: null,
     prePrGate: null,
     runDefaultKind: "claude",

--- a/apps/worker/src/workflows/blocks/types.ts
+++ b/apps/worker/src/workflows/blocks/types.ts
@@ -2,6 +2,7 @@ import type {
   WorkflowDefinitionNode,
   WorkflowDefinitionV2Node,
   WorkflowRepositoryScope,
+  RunAnalysisReport,
 } from "@shared/contracts";
 import type {
   BlockExecutionContext,
@@ -190,6 +191,10 @@ export interface EngineCtx {
   };
   /** Markdown plan produced by planning_agent; empty string before it runs. */
   researchPlanMarkdown: string;
+  /** Sanitized durable research/report state; null for workflows without planning. */
+  analysisReport?: RunAnalysisReport | null;
+  /** Monotonic planning result revision used to reject stale durable replays. */
+  analysisRevision: number;
   /** Result of finalize_workspace / open_pr; null before publication. */
   publication: WorkspacePublicationResult | null;
   /**

--- a/docs/plans/2026-08-20-run-analysis-report.md
+++ b/docs/plans/2026-08-20-run-analysis-report.md
@@ -1,0 +1,640 @@
+# Run analysis report: dashboard and Jira delivery plan
+
+Status: implemented and verified. Written 2026-08-20 from the requirements
+captured in Kimi session `session_071099c1-f449-4508-9654-32db45bf5d43` and
+implemented from `main` at `0b41be7f`.
+
+## 1. Outcome
+
+After the planning/research phase, a user can see what the bot actually
+analyzed without reading worker logs or guessing from the final PR:
+
+- the repositories it inspected and why each was selected;
+- the exact branch and base SHA inspected in each repository;
+- the concrete files, symbols, commits, PRs, or ticket facts used as evidence;
+- repository-expansion requests and the final read/write scope;
+- the implementation plan;
+- cost, tokens, model, duration, and turns by phase;
+- the final PRs/MRs and implementation summary, when publication occurs;
+- whether Jira received the research and PR-stage reports.
+
+The full report is durable on the run trace. Jira receives two bounded analysis
+comments containing views of the same report:
+
+1. immediately after research completes;
+2. in the existing PR-ready comment when a new PR/MR is published.
+
+The report is an audit summary, not hidden reasoning. It must never contain
+chain-of-thought, raw stdout/stderr, complete file contents, secrets, sandbox
+paths, or session-memory bookkeeping.
+
+## 2. Product decisions already made
+
+The Kimi session asked and answered the three product questions that change the
+implementation:
+
+| Question | Decision |
+| --- | --- |
+| Where is the report visible? | Dashboard and Jira |
+| What does it contain? | Repository analysis, evidence, decisions, plan, and costs |
+| When is Jira updated? | After research and when the PR/MR is created |
+
+Recommended UX decisions:
+
+- The dashboard is the source of truth and retains the complete safe report.
+- Jira contains the same sections but applies a hard comment-size bound. If a
+  plan or evidence list does not fit, the comment says exactly what was omitted
+  and links to the run trace; it never silently truncates.
+- A cost whose price is incomplete is displayed as a lower bound (`$1.23+`),
+  never as an exact value or `$0.00`.
+- Reports are captured only when a `planning_agent` produces or reuses a plan.
+  Workflows without a planning phase keep their current behavior and do not
+  receive a fabricated empty report.
+- Existing runs are not backfilled. Their trace says that analysis capture was
+  not available for that run.
+
+## 3. Existing seams to reuse
+
+Do not build a second observability pipeline. The required facts already exist
+at the following points:
+
+- `apps/worker/src/workflows/agent.ts`, `case "planning_agent"` receives the
+  successful `ResearchResult` and assigns `ctx.researchPlanMarkdown`.
+- `ResearchResult.repositoryEvidence` and `resolutionEvidence` are parsed in
+  `apps/worker/src/sandbox/agents/types.ts` but are not persisted today.
+- `ctx.selectedRepositories`, `ctx.repositoryExpansion`, and
+  `ctx.researchWriteRepositories` retain repository-selection decisions.
+- `ctx.workspaceManifest` contains the trusted branch, access mode, and
+  `researchBaseSha` for every attached repository.
+- `computeUsageTotals()` in `apps/worker/src/sandbox/usage.ts` already applies
+  the correct pricing and unknown-cost rules.
+- `recordRunUsage()` in
+  `apps/worker/src/lib/telemetry/run-telemetry.ts` owns durable per-run cost,
+  tokens, phases, and final lifecycle.
+- `IssueTrackerAdapter.postComment()` and `JiraAdapter.postComment()` already
+  publish Jira comments and return a deep link when available.
+- `postPrLinksComment()` in `apps/worker/src/workflows/agent.ts` is the current
+  PR-ready Jira comment. Replace that successful-publication call with the
+  PR-stage report instead of posting a third Jira comment.
+- `RunDetailResponse` feeds both the standalone trace and ticket split view.
+  Extending it avoids a second endpoint and an extra browser request.
+- `PromptPreview`, `CkCard`, `CkChip`, and the trace layout already provide the
+  dashboard primitives needed for the report.
+- `sanitizeReplayValue()`, `configuredReplaySecrets()`, and
+  `scrubForPublication()` are the existing output-safety boundaries.
+
+## 4. Data contract
+
+Add `apps/shared/contracts/run-analysis.ts`, export it from
+`apps/shared/contracts/index.ts`, and place the following public DTOs there.
+That file may import `RunPullRequest` from `domain.ts` and
+`ReplaySanitizationMetadata` from `run-replay.ts` without creating the circular
+dependency that putting these DTOs in `domain.ts` would cause. Keep the report
+versioned because it is persisted JSON, but implement only version `1`.
+
+```ts
+export type RunAnalysisStage =
+  | "research_complete"
+  | "published"
+  | "no_change";
+
+export interface RunAnalysisRepository {
+  provider: "github" | "gitlab";
+  repoPath: string;
+  defaultBranch: string;
+  researchBranch: string;
+  researchBaseSha: string | null;
+  access: "read" | "write";
+  rationale: string;
+}
+
+export interface RunAnalysisRepositoryRequest {
+  provider: "github" | "gitlab";
+  repoPath: string;
+  rationale: string;
+}
+
+export interface RunAnalysisPhaseUsage {
+  costUsd: number | null;
+  tokens: {
+    input: number;
+    cachedInput: number;
+    output: number;
+  } | null;
+  durationMs: number;
+  numTurns: number;
+  model: string | null;
+}
+
+export interface RunAnalysisUsageSnapshot {
+  capturedAt: string;
+  costUsd: number;
+  costKnown: boolean;
+  tokensInput: number | null;
+  tokensCached: number | null;
+  tokensOutput: number | null;
+  phases: Record<string, RunAnalysisPhaseUsage>;
+}
+
+export interface RunAnalysisCommentDelivery {
+  state: "not_applicable" | "pending" | "posted" | "failed";
+  attemptedAt: string | null;
+  commentUrl: string | null;
+  error: string | null;
+}
+
+export interface RunAnalysisReport {
+  version: 1;
+  runId: string;
+  sourceResearchRunId: string;
+  stage: RunAnalysisStage;
+  researchCompletedAt: string;
+  repositories: RunAnalysisRepository[];
+  expansionRounds: number;
+  repositoryRequests: RunAnalysisRepositoryRequest[];
+  writeRepositories: RunAnalysisRepositoryRequest[];
+  evidenceStatus: "captured" | "not_retained";
+  evidence: string[];
+  planMarkdown: string;
+  noChangeNeeded: boolean;
+  resolutionEvidence: string[];
+  publication: {
+    prs: RunPullRequest[];
+    changeSummary: string;
+  } | null;
+  usage: {
+    research: RunAnalysisUsageSnapshot;
+    publication: RunAnalysisUsageSnapshot | null;
+    final: RunAnalysisUsageSnapshot | null;
+  };
+  jira: {
+    research: RunAnalysisCommentDelivery;
+    pullRequest: RunAnalysisCommentDelivery;
+  };
+  sanitization: ReplaySanitizationMetadata;
+}
+```
+
+Add `analysisReport: RunAnalysisReport | null` to `RunDetailResponse` in
+`apps/shared/contracts/api.ts`. Every response path and dashboard fallback must
+return the key. During a rolling deploy, the dashboard must still read a missing
+key as `null` with `data.analysisReport ?? null`.
+
+Contract rules:
+
+- `runId` is the run currently displayed.
+- `sourceResearchRunId` equals `runId` for an ordinary run. An approved-plan run
+  points it at the earlier run that produced the approved plan.
+- `researchBaseSha` is nullable only for a legacy/V1 workspace that genuinely
+  did not capture it. Never replace an unknown SHA with the current HEAD.
+- Evidence stays an ordered list of safe, human-readable facts. Do not parse
+  model prose into guessed paths after the fact.
+- `evidenceStatus: "not_retained"` is used only when an approved-plan run can
+  recover the approved plan/scope but its source report is unavailable; an
+  empty captured evidence list is not mislabeled as lost data.
+- `usage.research`, `usage.publication`, and `usage.final` are distinct snapshots;
+  later costs must not rewrite what Jira reported earlier.
+- Unknown tokens stay `null`. Unknown cost is represented by
+  `costKnown: false` plus the priced lower bound in `costUsd`.
+- The shipped templates produce one logical plan per run. If a custom graph
+  executes another successful planning node later, the durable dashboard report
+  advances to the latest plan, while the already-posted research Jira comment
+  remains an explicitly timestamped point-in-time snapshot. The PR-stage comment
+  carries the latest plan. Editing old Jira comments is outside this slice.
+
+## 5. Persistence and migration
+
+Use one nullable JSONB column on the existing run row.
+
+1. In `apps/worker/src/db/schema.ts`, add:
+
+   ```ts
+   analysisReport: jsonb("analysis_report").$type<RunAnalysisReport>(),
+   ```
+
+   Place it beside `phases`/`steps`, because the agent workflow owns it just as
+   it owns usage and the durable trace.
+
+2. Generate migration `0057_run_analysis_report.sql` with:
+
+   ```sh
+   pnpm --filter worker db:generate -- --name run_analysis_report
+   ```
+
+   The migration must only add the nullable column. No default, index, table,
+   trigger, or historical backfill is needed.
+
+3. Add
+   `apps/worker/src/db/run-analysis-report-migration.test.ts`. Migrate through
+   `0056`, insert an existing `workflow_runs` row, apply `0057`, and assert that
+   the row survives with `analysis_report IS NULL`. Also migrate a fresh DB
+   through `0057` and round-trip one version-1 JSON value.
+
+4. Add `apps/worker/src/run-analysis/store.ts`:
+
+   - `recordRunAnalysisReport(db, report)` upserts by `run_id` and owns only
+     `analysis_report` plus `updated_at`. Its insert path sets the minimal run
+     identity (`runId`, `workflowId: "wf_agent"`, `workflowName: "Agent"`) so it
+     works before cron or terminal telemetry has written the row.
+   - `getRunAnalysisReport(db, runId)` returns and version-checks the stored
+     report for the approved-plan continuation and returns `null` for an absent
+     or unsupported version.
+   - `finalizeRunAnalysisUsage(db, runId, finalUsage)` reads the current report,
+     returns when none exists, and replaces only `usage.final`. This is called
+     after `recordRunUsage()` in terminal telemetry, when no workflow writer can
+     still race it.
+   - Repeating either function with the same data is a no-op in meaning and
+     cannot erase Jira delivery state or an earlier usage snapshot.
+
+Do not create a separate analysis-event table. The feature renders one bounded
+summary per run and does not query individual evidence items across runs.
+
+## 6. Build and sanitize the report
+
+Create `apps/worker/src/run-analysis/report.ts` as a pure module with focused
+tests in `report.test.ts`.
+
+Required functions:
+
+- `buildResearchAnalysisReport(input)` builds the version-1 report after a
+  successful research result.
+- `buildApprovedPlanAnalysisReport(input)` copies the source report for a
+  `plan_approved` run, changes `runId`, preserves `sourceResearchRunId`, resets
+  publication/final usage, and does not claim that research ran twice. If the
+  source report is unavailable, build a smaller honest report from
+  `approvedPlan.markdown` and `approvedPlan.repositoryScope`; evidence is empty
+  and the UI says it was not retained.
+- `withAnalysisPublication(report, publication, changeSummary, usage)` returns
+  the `published` version without mutating its input.
+- `withAnalysisDelivery(report, stage, delivery)` updates only the selected Jira
+  delivery slot.
+- `parseStoredRunAnalysisReport(value)` accepts version 1 with the required
+  structural fields and returns `null` for corrupt or unsupported JSON; neither
+  the API nor an approved continuation trusts a cast from JSONB.
+- `usageSnapshot(totals, capturedAt)` maps `UsageTotals` without changing null
+  or lower-bound semantics.
+- `formatResearchAnalysisComment(report, dashboardUrl)` and
+  `formatPublishedAnalysisComment(report, dashboardUrl)` produce Jira text.
+- `analysisCommentMarker(runId, stage)` returns a deterministic visible marker,
+  for example `Arthur report: <runId>:research` or
+  `Arthur report: <runId>:pull_request`.
+- `hasAnalysisComment(ticket, marker)` performs an exact marker search over
+  fetched ticket comments.
+
+Repository mapping must come from trusted server state:
+
+- iterate `ctx.workspaceManifest.repositories`, not model output;
+- take provider, repo path, branch, access, and `researchBaseSha` from the
+  manifest;
+- take selection rationale from the matching `ctx.selectedRepositories` entry;
+- compare against `ctx.researchWriteRepositories` only to expose the planner's
+  requested write set, never to grant access.
+
+Improve evidence quality without changing the structured-output shape:
+
+- in `apps/worker/src/sandbox/context.ts`, strengthen the Repository Access
+  Protocol: every `repositoryEvidence` item must name the exact
+  `provider:repo`, file/symbol/commit/PR checked, and the relevant finding;
+- in `apps/worker/src/sandbox/agents/types.ts`, add the same description to the
+  Zod/manual JSON schema;
+- retain the existing `string[]` field and maximum of 50 entries, so Claude and
+  Codex protocol compatibility is unchanged.
+
+Safety boundary:
+
+- server-authored provider/repository/branch/SHA fields pass through unchanged;
+- send only the model-authored bundle (plan, evidence, resolution evidence,
+  rationales, and implementation change summary) through
+  `sanitizeReplayValue()` using
+  `configuredReplaySecrets()`;
+- reject an unavailable or structurally invalid sanitized bundle rather than
+  storing the raw fallback;
+- persist the returned `ReplaySanitizationMetadata` and display when content was
+  redacted or truncated;
+- run Jira text through `scrubForPublication()` after formatting;
+- cap the durable agent-authored bundle at 64 KiB and each Jira comment at
+  20,000 UTF-8 bytes. A bounded Jira comment keeps all headings, repository
+  rows, totals, and the dashboard link; it shortens evidence/plan content with
+  an explicit `… omitted; open the full run report` note.
+
+Tests must cover configured secrets, token/JWT-like values, sandbox paths,
+session-memory text, Unicode byte limits, unknown cost, missing SHA, 50 evidence
+items, and deterministic output for identical input.
+
+## 7. Capture the report in the workflow
+
+Make surgical changes in `apps/worker/src/workflows/agent.ts` and
+`apps/worker/src/workflows/blocks/types.ts`.
+
+### 7.1 Workflow state
+
+Add `analysisReport: RunAnalysisReport | null` to `EngineCtx` and initialize it
+to `null`. Add two workflow step wrappers in `agent.ts`:
+
+- `recordRunAnalysisReportStep(report)` dynamically imports the DB/store module
+  and persists the report;
+- `postRunAnalysisCommentStep(ticketKey, report, stage, owner)`
+  enforces `assertActiveRunOwner`, fetches the ticket, skips when the marker
+  already exists, builds the URL with the existing
+  `ticketRunUrl(env.DASHBOARD_ORIGIN, ticketKey, report.runId)`, then calls
+  `issueTracker.postComment()`.
+
+The comment step returns `RunAnalysisCommentDelivery`. Give it two retries. A
+retry first fetches the ticket and recognizes a comment whose POST succeeded but
+whose response was lost. After the retry budget, the caller records a sanitized
+`failed` delivery and continues the run; reporting must not block code delivery.
+Run-control/ownership errors still rethrow.
+
+### 7.2 Ordinary research completion
+
+Inside `case "planning_agent"`, after a completed research result has passed
+repository-expansion, clarification, failure, and false-no-change checks:
+
+1. assign `ctx.researchPlanMarkdown` and the final write set as today;
+2. compute the research usage snapshot from `runPhaseUsages` and
+   `runPhaseModels` with the already-resolved `priceLookup`;
+3. build `ctx.analysisReport` from the final manifest, repository state, research
+   result, and usage;
+4. persist it before any external comment;
+5. for ticket-backed runs, publish the research Jira comment, apply the returned
+   delivery state, and persist again;
+6. return the existing planning block output unchanged.
+
+Persist-before-publish guarantees that a Jira link never points to a report that
+does not exist. A crash after Jira publication is resolved by the deterministic
+marker when the step replays.
+
+### 7.3 No-change completion
+
+The existing `no_change_needed` branch currently posts
+`buildResolutionEvidenceComment()` and exits before downstream blocks. Replace
+that standalone evidence comment with the research analysis comment:
+
+- set `stage: "no_change"`;
+- include the plan/body and `resolutionEvidence`;
+- set `publication: null` and PR delivery to `not_applicable`;
+- retain the current ticket move and notification behavior.
+
+This produces one Jira report, not the old evidence comment plus a new duplicate.
+
+### 7.4 Approved-plan continuation
+
+An approval creates a new workflow run. Preserve the research provenance across
+that boundary:
+
+- add optional `sourceRunId?: string` to the `approvedPlan` payload in
+  `apps/worker/src/workflows/agent-input.ts`;
+- set it from `approval.runId` in
+  `apps/worker/src/approvals/dispatch.ts`;
+- load that run's report during approved-run setup and initialize
+  `ctx.analysisReport` through `buildApprovedPlanAnalysisReport()`;
+- persist the cloned/fallback report under the new run ID before implementation
+  starts;
+- do not repost the research Jira comment; copy its delivery state;
+- show both run IDs in the dashboard when they differ.
+
+Update the existing input/dispatch tests so older serialized input without the
+field remains readable by treating it as optional at normalization boundaries.
+
+### 7.5 PR/MR publication
+
+In `case "open_pr"`, after `publication.status === "published"`:
+
+1. keep the current telemetry PR assignment;
+2. if `ctx.analysisReport` exists, add PRs, `ctx.changeSummary`, and the
+   publication usage snapshot, then persist;
+3. when at least one PR is new, publish the PR-stage analysis comment;
+4. apply/persist its delivery result;
+5. skip the existing `postPrLinksComment()` success call because the new comment
+   already includes every PR/MR link;
+6. if no analysis report exists, retain `postPrLinksComment()` exactly as the
+   compatibility fallback.
+
+Keep the existing partial-publication failure comment unchanged. A failed
+publication does not claim `stage: "published"`.
+
+### 7.6 Final usage
+
+In `recordRunTelemetryStep()`, call `finalizeRunAnalysisUsage()` after
+`recordRunUsage()`. Use the same authoritative `totals` passed to terminal
+telemetry, including repo-memory distillation. This makes dashboard totals match
+the cost screen while preserving the earlier research/publication snapshots.
+
+If report finalization fails, log `run_analysis_final_usage_failed` and preserve
+the run outcome. Do not retry or rewrite the report from raw workflow state in
+the terminal path.
+
+## 8. Jira comment specification
+
+Both comments use plain text/markdown compatible with the existing Jira ADF
+conversion. Do not add an HTML renderer or provider-specific rich-text model.
+
+Research comment sections, in order:
+
+1. `Arthur research complete` plus the run dashboard URL;
+2. `Repositories analyzed` with provider/path, read/write, branch@short-SHA, and
+   rationale;
+3. `What was checked` with ordered evidence;
+4. `Decisions` with expansion count/requests and final write repositories;
+5. `Implementation plan`;
+6. `Usage so far` with total and per-phase cost/tokens/duration/model;
+7. the deterministic marker.
+
+PR-stage comment sections, in order:
+
+1. `Arthur pull requests ready` plus all PR/MR links;
+2. `Implemented` using the scrubbed `ctx.changeSummary`;
+3. a compact repository/evidence summary and the complete plan while it fits;
+4. `Usage at publication`;
+5. the dashboard URL for the full/final report;
+6. the deterministic marker.
+
+Idempotency assertions:
+
+- retrying a stage with the same run ID creates zero additional comments;
+- a research marker never suppresses the PR-stage marker;
+- two different runs for the same ticket do not suppress one another;
+- an approved-plan run does not repost its source run's research comment;
+- a lost `postComment()` response is recovered by refetching and matching the
+  marker.
+
+## 9. Run-detail API
+
+Extend the existing read path; do not add `/analysis`.
+
+1. Update `RunDetailParts` and `fetchRunDetailFromDb()` in
+   `apps/worker/src/db/queries/run-detail-read.ts` to return the stored report.
+2. The route `apps/worker/src/routes/api/v1/runs/[runId].get.ts` must attach that
+   report whether the step waterfall comes from Postgres or the live Workflow
+   world. The report always comes from Postgres.
+3. Add `analysisReport: null` to `EMPTY`, both successful response branches,
+   and `runDetailFallback()`.
+4. Keep `Cache-Control: private, no-store`; the report contains private repo
+   names and sanitized analysis and must not enter a shared cache.
+5. Do not expose raw workflow observations, artifact logs, workspace paths, or
+   ticket comments through this field.
+
+Add assertions to:
+
+- `apps/worker/src/db/queries/run-detail-read.test.ts` for report round-trip and
+  legacy null;
+- new `apps/worker/src/routes/api/v1/runs/run-detail.test.ts` for DB report +
+  live world steps, DB-only fallback, unknown run, and auth/no-store behavior;
+- `apps/dashboard/lib/api/fallbacks` tests for the nullable fallback.
+
+## 10. Dashboard UX
+
+Create
+`apps/dashboard/components/cockpit/screens/run-analysis-report.tsx` and render it
+from `TraceDetail` in `trace.tsx` after the error/clarification cards and before
+workflow replay or the legacy step timeline.
+
+The component is one `CkCard` titled `Analysis report` with:
+
+- a stage chip (`Research complete`, `No change needed`, or `PR/MR published`),
+  capture time, and source-research-run link when it differs from the current
+  run;
+- four top-line values: repositories inspected, evidence items, expansion
+  rounds, and final/current cost;
+- a responsive repository table showing repository, access, research ref, and
+  selection reason;
+- expandable sections for `What was checked`, `Decisions`, and
+  `Implementation plan`;
+- an explicit `Source evidence was not retained` state when
+  `evidenceStatus === "not_retained"`, distinct from a captured empty list;
+- plan rendering through the existing read-only `PromptPreview` rather than a
+  new markdown dependency;
+- a usage table with Research, Publication, and Final columns. Missing snapshots
+  render `Not reached`, and unknown cost renders a lower-bound label;
+- PR/MR links and the implementation summary when published;
+- small delivery indicators for the two analysis comments, including a safe
+  failure message and `Automatic retries exhausted` copy when exhausted;
+- a visible warning when sanitization redacted or truncated content.
+
+For a null report:
+
+- hide the card while a planning-capable run is still before research;
+- for a terminal historical run, show one compact line above the trace:
+  `Analysis report was not captured for this run.`;
+- do not show the historical message for workflows whose definition has no
+  planning phase unless that distinction is already available in the response.
+  If it is not available, prefer hiding the card over guessing.
+
+Responsive/accessibility requirements:
+
+- repository rows stack below the desktop breakpoint;
+- expand/collapse controls are real buttons with `aria-expanded`;
+- no horizontal page overflow from plan code blocks, SHAs, or repo paths;
+- stage and delivery status use text in addition to color;
+- keyboard focus follows existing cockpit focus styles.
+
+Add component coverage in
+`apps/dashboard/components/cockpit/screens/run-analysis-report.test.tsx` and one
+integration assertion in the existing `trace-replay.test.tsx` for placement.
+Cover full, research only, no-change, approved-source, unknown cost,
+redacted/truncated, Jira failure, mobile markup, and null report cases.
+
+## 11. Verification order
+
+Run focused proof first:
+
+```sh
+pnpm --filter worker build:shared
+
+pnpm --filter worker exec vitest run \
+  src/run-analysis/report.test.ts \
+  src/run-analysis/store.test.ts \
+  src/db/run-analysis-report-migration.test.ts \
+  src/db/queries/run-detail-read.test.ts \
+  src/lib/telemetry/run-telemetry.test.ts
+
+pnpm --filter ai-workflow-dashboard test
+pnpm --filter worker typecheck
+pnpm --filter ai-workflow-dashboard typecheck
+```
+
+Then run repository gates:
+
+```sh
+pnpm test
+pnpm typecheck
+pnpm build
+```
+
+Preview smoke test with one disposable Jira ticket:
+
+1. Start a ticket-backed run with two selected repositories.
+2. Verify the research comment appears once and links to a dashboard report
+   that already exists.
+3. Verify repository paths, branch/SHA, rationale, evidence, plan, and research
+   costs agree with the run.
+4. Let the run publish a PR/MR; verify the existing PR-ready comment is replaced
+   by one PR-stage analysis comment, not supplemented by a third analysis
+   comment.
+5. Replay/retry both publication steps and verify comment counts do not change.
+6. Verify final dashboard cost matches `workflow_runs.cost_usd`, including the
+   lower-bound presentation when `cost_known = false`.
+7. Put a fake configured secret in model-authored evidence and verify it appears
+   nowhere in Postgres API output, dashboard HTML, or Jira.
+
+## 12. Acceptance criteria
+
+- [ ] A ticket-backed planning run persists a report immediately after research,
+      before implementation begins.
+- [ ] The report names every inspected repository with provider, access,
+      rationale, research branch, and real captured SHA (or explicit unknown).
+- [ ] Evidence identifies concrete checked locations/findings and is capped at
+      50 safe entries.
+- [ ] The dashboard shows evidence, decisions, full safe plan, repository scope,
+      PRs, change summary, and research/publication/final usage snapshots.
+- [ ] Jira receives exactly one research report and exactly one PR-stage report
+      for a successful new-PR run. Pickup, clarification, and failure comments
+      remain separate existing behavior and are not counted as analysis reports.
+- [ ] The PR-stage report replaces the current PR-links-only success comment;
+      it does not create a third comment.
+- [ ] A no-change run receives one research/no-change report and no PR-stage
+      comment.
+- [ ] Plan approval preserves the source research run and does not repost the
+      research comment.
+- [ ] Comment replay, worker retry, and a lost POST response do not create
+      duplicates.
+- [ ] Jira failure is visible in the dashboard but never changes the code-delivery
+      outcome.
+- [ ] Unknown tokens/cost remain unknown and are never rendered as zero/exact.
+- [ ] Raw logs, chain-of-thought, secrets, sandbox paths, and session-memory
+      bookkeeping are absent from storage and both user surfaces.
+- [ ] Old runs and workflows without planning continue to render and execute
+      unchanged.
+- [ ] The migration is nullable, reversible at the application layer, and needs
+      no backfill.
+
+## 13. Explicit non-goals and stop condition
+
+Do not include in this feature:
+
+- raw agent stdout/stderr or downloadable research transcripts;
+- chain-of-thought or a request to make models reveal it;
+- a new run-analysis page, search index, event store, export format, or admin
+  configuration;
+- editing or approving the plan from the report card;
+- cross-run/ticket analytics over evidence;
+- report backfill for historical runs;
+- Slack delivery or changes to PR body templates;
+- reports fabricated for workflows that never ran a planning agent.
+
+Stop when all acceptance criteria pass and the preview smoke proves exactly two
+idempotent analysis-report comments in Jira. Additional report filters, exports,
+analytics, and customizable templates require separate product decisions.
+
+## 14. Rollout and rollback
+
+1. Apply migration `0057` first; it is additive and does not affect old workers.
+2. Deploy worker and dashboard in the same release. A new worker is compatible
+   with the old dashboard; the new dashboard treats a temporarily missing field
+   as null during rolling deployment.
+3. Watch existing structured logs plus:
+   `run_analysis_report_recorded`, `run_analysis_comment_posted`,
+   `run_analysis_comment_skipped_duplicate`, and
+   `run_analysis_comment_failed`. Do not add a metrics service for this slice.
+4. Roll back by reverting the writer/API/UI. Leave the nullable column in place;
+   dropping it is unnecessary and would destroy recoverable reports.


### PR DESCRIPTION
## Summary

- Persist a versioned, sanitized run analysis report with replay-monotonic PostgreSQL updates.
- Expose the report through the run-detail API and Dashboard trace.
- Publish bounded, idempotent Jira research and pull-request report comments with ownership and persistence guards.
- Preserve provider error diagnostics from current main while adding report capture and final usage integration.

## Migration

- Current-main metadata generates `0057_run_analysis_report`.
- SQL is additive only: `ALTER TABLE "workflow_runs" ADD COLUMN "analysis_report" jsonb;`
- Migration coverage preserves legacy rows with NULL reports and round-trips a version-1 report on a fresh schema.

## Verification

- `pnpm --filter worker build:shared` — passed.
- Focused report/API/workflow worker tests — 8 files, 179 passed.
- Focused provider-diagnostic preservation tests — 7 files, 306 passed.
- Focused Dashboard report/trace/fallback/cockpit tests — 28 passed.
- `pnpm --filter worker run typecheck` — passed.
- `pnpm --filter ai-workflow-dashboard run typecheck` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Full repository suites were not run locally.

## Verification gap

A live disposable Jira/Postgres migration and comment-replay smoke remains pending. The plan documents the bounded smoke: one disposable ticket, exactly one research marker and one pull-request marker, retry/idempotency checks, final usage, and secret-scrub verification.