### PR TITLE
docs(release): record the Artur 2026.08.10 release rehearsal

### DIFF
--- a/docs/releases/artur/rehearsals/2026.08.10.json
+++ b/docs/releases/artur/rehearsals/2026.08.10.json
@@ -1,0 +1,11 @@
+{
+  "version": "2026.08.10",
+  "sourceCommit": "e84fd311db94087a35d4b432f1c4ae52efd371aa",
+  "runId": "wrun_01M0HESCG6MKS59CVK5HVX3J8S",
+  "runUrl": "https://ai-workflow-app-dashboard.vercel.app/trace/wrun_01M0HESCG6MKS59CVK5HVX3J8S",
+  "repository": "Blazity/aiw-checks-fixture",
+  "checksDurationSec": 637,
+  "outcome": "success",
+  "recordedAt": "2026-08-21T06:30:00Z",
+  "recordedBy": "filip.maszota@blazity.com"
+}


### PR DESCRIPTION
Rehearsal evidence for 2026.08.10, required by `sync-artur-release` before it touches the client repository.

Run `wrun_01M0HESCG6MKS59CVK5HVX3J8S`, definition 30 (`Release rehearsal 2026.08.8`) v2, ticket AWP-106, against `Blazity/aiw-checks-fixture`. Production ran a deployment built from `e84fd311db94087a35d4b432f1c4ae52efd371aa`, the commit this release pins.

Every node green, including the two the gate cares about:

| node | outcome | duration |
|---|---|---|
| planning | ready | 102 580 ms |
| implementation | implemented | 139 063 ms |
| checks | ok | **637 924 ms** |
| finalize | finalized | 17 493 ms |
| open-pr | ok | 16 454 ms |
| status | ok | 10 714 ms |

The checks phase ran for 637 s against real commands (`uv sync`, black, isort, autoflake, mypy, pytest, yarn install, yarn check, yarn test, and a slow pytest), so it crossed the 300 s invocation boundary the floor exists to exercise. It opened [fixture PR #6](https://github.com/Blazity/aiw-checks-fixture/pull/6).

Recorded `checksDurationSec` is floored to a whole second, as the schema requires.