### PR TITLE
feat: verify provider capabilities in System Health

### DIFF
--- a/apps/dashboard/app/api/system-health/handler.test.ts
+++ b/apps/dashboard/app/api/system-health/handler.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { handleSystemHealthScan } from "./handler";
+
+test("active health scan forwards POST with the extended timeout", async () => {
+  const calls: unknown[][] = [];
+  const response = await handleSystemHealthScan(async (...args) => {
+    calls.push(args);
+    return Response.json({ generatedAt: "2026-08-21T12:00:00.000Z" }, { status: 200 });
+  });
+
+  assert.deepEqual(calls, [
+    ["/api/v1/system/health", { method: "POST" }, 15_000],
+  ]);
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+});
+
+test("active health scan preserves worker errors", async () => {
+  const response = await handleSystemHealthScan(async () =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  );
+
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), { error: "Forbidden" });
+});
+
+test("active health scan reports worker timeouts", async () => {
+  const response = await handleSystemHealthScan(async () => {
+    throw new DOMException("timed out", "TimeoutError");
+  });
+
+  assert.equal(response.status, 504);
+  assert.deepEqual(await response.json(), { error: "System health scan timed out" });
+});

--- a/apps/dashboard/app/api/system-health/handler.ts
+++ b/apps/dashboard/app/api/system-health/handler.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+const ACTIVE_SCAN_TIMEOUT_MS = 15_000;
+
+type WorkerProxy = (
+  path: string,
+  init?: RequestInit,
+  timeoutMs?: number,
+) => Promise<Response>;
+
+export async function handleSystemHealthScan(proxy: WorkerProxy) {
+  try {
+    const response = await proxy(
+      "/api/v1/system/health",
+      { method: "POST" },
+      ACTIVE_SCAN_TIMEOUT_MS,
+    );
+    return NextResponse.json(await response.json().catch(() => ({})), {
+      status: response.status,
+      headers: { "cache-control": "no-store" },
+    });
+  } catch (error) {
+    const candidate = error as { name?: unknown; code?: unknown };
+    if (candidate.name === "TimeoutError" || candidate.code === 23) {
+      return NextResponse.json(
+        { error: "System health scan timed out" },
+        { status: 504, headers: { "cache-control": "no-store" } },
+      );
+    }
+    throw error;
+  }
+}

--- a/apps/dashboard/app/api/system-health/route.ts
+++ b/apps/dashboard/app/api/system-health/route.ts
@@ -1,0 +1,6 @@
+import { proxyWorker } from "@/lib/api/proxy";
+import { handleSystemHealthScan } from "./handler";
+
+export async function POST() {
+  return handleSystemHealthScan(proxyWorker);
+}

--- a/apps/dashboard/components/cockpit/screens/health.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/health.test.tsx
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test, { mock } from "node:test";
 import React from "react";
 import { act, create } from "react-test-renderer";
-import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import type { SystemHealthResponse } from "@shared/contracts";
 import { HealthScreen } from "./health";
 
@@ -11,7 +10,18 @@ import { HealthScreen } from "./health";
 
 const data: SystemHealthResponse = {
   generatedAt: "2026-08-20T12:00:00.000Z",
-  summary: { total: 2, live: 1, down: 1, notConfigured: 0, criticalDown: 1 },
+  summary: {
+    total: 2,
+    live: 1,
+    down: 1,
+    notConfigured: 0,
+    criticalDown: 1,
+    checksTotal: 2,
+    checksLive: 1,
+    checksDown: 1,
+    checksUnverified: 0,
+    checksDegraded: 0,
+  },
   integrations: [
     {
       id: "database",
@@ -21,6 +31,15 @@ const data: SystemHealthResponse = {
       critical: true,
       mode: "live",
       ping: { ok: true, latencyMs: 12 },
+      checks: [{
+        id: "connectivity",
+        label: "Connection and query",
+        description: "Verified independently.",
+        critical: true,
+        mode: "live",
+        envVars: ["DATABASE_URL"],
+        evidenceSource: "live-probe",
+      }],
     },
     {
       id: "jira",
@@ -30,6 +49,16 @@ const data: SystemHealthResponse = {
       critical: true,
       mode: "down",
       ping: { ok: false, latencyMs: 40, error: "Jira authentication check failed." },
+      checks: [{
+        id: "api",
+        label: "Account and project",
+        description: "Verified independently.",
+        critical: true,
+        mode: "down",
+        envVars: ["JIRA_API_TOKEN"],
+        evidenceSource: "live-probe",
+        message: "Jira authentication check failed.",
+      }],
     },
   ],
   alerts: [
@@ -52,14 +81,9 @@ function textOf(value: unknown): string {
 }
 
 test("health screen exposes the failed service, fix hint, and safe env names", () => {
-  const router = { refresh() {} };
   let renderer!: ReturnType<typeof create>;
   act(() => {
-    renderer = create(
-      <AppRouterContext.Provider value={router as never}>
-        <HealthScreen data={data} />
-      </AppRouterContext.Provider>,
-    );
+    renderer = create(<HealthScreen data={data} />);
   });
   const text = textOf(renderer.toJSON());
   assert.match(text, /Action required/);
@@ -70,36 +94,73 @@ test("health screen exposes the failed service, fix hint, and safe env names", (
   act(() => renderer.unmount());
 });
 
-test("scan again runs once and recovers when fresh data arrives", () => {
-  let refreshes = 0;
-  const router = { refresh: () => refreshes++ };
-  const tree = (nextData: SystemHealthResponse) => (
-    <AppRouterContext.Provider value={router as never}>
-      <HealthScreen data={nextData} />
-    </AppRouterContext.Provider>
-  );
+test("critical unverified evidence is not presented as operational", () => {
+  const unverified = structuredClone(data);
+  unverified.alerts = [];
+  unverified.summary.criticalDown = 0;
+  unverified.integrations[1]!.mode = "unverified";
+  unverified.integrations[1]!.ping = null;
+  unverified.integrations[1]!.checks![0]!.mode = "unverified";
+
   let renderer!: ReturnType<typeof create>;
   act(() => {
-    renderer = create(tree(data));
+    renderer = create(<HealthScreen data={unverified} />);
+  });
+  const text = textOf(renderer.toJSON());
+  assert.match(text, /Verification incomplete/);
+  assert.doesNotMatch(text, /Operational/);
+  act(() => renderer.unmount());
+});
+
+test("an optional unverified child does not block critical readiness", () => {
+  const optionalWebhook = structuredClone(data);
+  optionalWebhook.alerts = [];
+  optionalWebhook.summary.criticalDown = 0;
+  optionalWebhook.integrations[1]!.mode = "unverified";
+  optionalWebhook.integrations[1]!.ping = null;
+  optionalWebhook.integrations[1]!.checks![0]!.critical = false;
+  optionalWebhook.integrations[1]!.checks![0]!.mode = "unverified";
+
+  let renderer!: ReturnType<typeof create>;
+  act(() => {
+    renderer = create(<HealthScreen data={optionalWebhook} />);
+  });
+  assert.match(textOf(renderer.toJSON()), /Operational/);
+  act(() => renderer.unmount());
+});
+
+test("scan again runs one active scan and renders its fresh result", async (t) => {
+  let resolveFetch!: (response: Response) => void;
+  const pendingResponse = new Promise<Response>((resolve) => {
+    resolveFetch = resolve;
+  });
+  const fetchMock = mock.method(globalThis, "fetch", () => pendingResponse);
+  t.after(() => mock.restoreAll());
+
+  let renderer!: ReturnType<typeof create>;
+  act(() => {
+    renderer = create(<HealthScreen data={data} />);
   });
   const button = renderer.root.findByProps({ children: "Scan again" });
+  let scan!: Promise<void>;
   act(() => {
-    button.props.onClick();
+    scan = button.props.onClick();
     button.props.onClick();
   });
-  assert.equal(refreshes, 1);
+  assert.equal(fetchMock.mock.callCount(), 1);
   assert.equal(
     renderer.root.findByProps({ children: "Scanning…" }).props.disabled,
     true,
   );
 
-  act(() => {
-    renderer.update(
-      tree({
+  await act(async () => {
+    resolveFetch(
+      Response.json({
         ...data,
         generatedAt: "2026-08-20T12:00:01.000Z",
       }),
     );
+    await scan;
   });
   assert.equal(
     renderer.root.findByProps({ children: "Scan again" }).props.disabled,
@@ -108,30 +169,61 @@ test("scan again runs once and recovers when fresh data arrives", () => {
   act(() => renderer.unmount());
 });
 
-test("scan again recovers if a refresh never commits", (t) => {
+test("scan again aborts and recovers when the worker times out", async (t) => {
   mock.timers.enable({ apis: ["setTimeout"] });
-  t.after(() => mock.timers.reset());
+  mock.method(globalThis, "fetch", (...args: Parameters<typeof fetch>) => {
+    const init = args[1];
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => {
+        reject(new DOMException("Aborted", "AbortError"));
+      });
+    });
+  });
+  t.after(() => {
+    mock.restoreAll();
+    mock.timers.reset();
+  });
 
-  const router = { refresh() {} };
   let renderer!: ReturnType<typeof create>;
   act(() => {
-    renderer = create(
-      <AppRouterContext.Provider value={router as never}>
-        <HealthScreen data={data} />
-      </AppRouterContext.Provider>,
-    );
+    renderer = create(<HealthScreen data={data} />);
   });
-  act(() => renderer.root.findByProps({ children: "Scan again" }).props.onClick());
+  let scan!: Promise<void>;
+  act(() => {
+    scan = renderer.root.findByProps({ children: "Scan again" }).props.onClick();
+  });
   assert.equal(
     renderer.root.findByProps({ children: "Scanning…" }).props.disabled,
     true,
   );
 
-  act(() => mock.timers.tick(15_000));
+  await act(async () => {
+    mock.timers.tick(15_000);
+    await scan;
+  });
 
   assert.equal(
     renderer.root.findByProps({ children: "Scan again" }).props.disabled,
     false,
   );
+  assert.match(textOf(renderer.toJSON()), /System health scan timed out/);
+  act(() => renderer.unmount());
+});
+
+test("integration rows expand into independently reported checks", () => {
+  let renderer!: ReturnType<typeof create>;
+  act(() => {
+    renderer = create(<HealthScreen data={data} />);
+  });
+  const button = renderer.root.findByProps({
+    "aria-controls": "health-checks-database",
+  });
+  assert.equal(button.props["aria-expanded"], false);
+
+  act(() => button.props.onClick());
+
+  assert.equal(button.props["aria-expanded"], true);
+  assert.match(textOf(renderer.toJSON()), /Connection and query/);
+  assert.match(textOf(renderer.toJSON()), /Live probe/);
   act(() => renderer.unmount());
 });

--- a/apps/dashboard/components/cockpit/screens/health.tsx
+++ b/apps/dashboard/components/cockpit/screens/health.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
 import type {
+  SystemHealthCheck,
   SystemHealthGroup,
   SystemHealthIntegration,
   SystemHealthMode,
@@ -34,16 +34,17 @@ const GROUPS: Array<{
 const DESCRIPTIONS: Record<string, string> = {
   database: "Stores workflow state, ownership, traces, and dashboard data.",
   jira: "Authenticates the account and checks access to the configured project.",
-  github: "Checks the App installation; the webhook secret is presence-checked.",
-  gitlab: "Authenticates the API token; the webhook secret is presence-checked.",
+  github: "Checks App auth, repository access, webhook configuration, and recent deliveries separately.",
+  gitlab: "Checks API access, projects, webhook configuration, and delivery responses separately.",
   agent: "Authenticates the active provider and checks the configured model when possible.",
   "dashboard-auth": "Presence-checks auth settings; this request already proves session enforcement.",
   sso: "Checks OIDC discovery; client credentials remain presence-checked.",
-  email: "Authenticates Resend; sender configuration remains presence-checked.",
-  slack: "Authenticates the bot token; the channel ID remains presence-checked.",
+  email: "Checks Resend sender readiness and delivery-status webhooks independently.",
+  slack: "Checks bot auth, channel access, and signed slash commands independently.",
   arthur: "Reads the task API used by traces, evaluations, and guardrails.",
   mcp: "Checks that the enabled remote tool contract contains tools.",
   vercel: "Reads the configured project when explicit credentials are available.",
+  "custom-webhooks": "Aggregates active custom endpoints, deliveries, and rejection counters.",
 };
 
 const STATUS: Record<
@@ -59,6 +60,16 @@ const STATUS: Record<
     label: "Down",
     dot: "bg-fail",
     badge: "border-[#F0B8AE] bg-fail-bg text-fail-fg",
+  },
+  degraded: {
+    label: "Degraded",
+    dot: "bg-burnt-orange",
+    badge: "border-orange-300 bg-orange-100 text-[#A23E18]",
+  },
+  unverified: {
+    label: "Unverified",
+    dot: "bg-[#D6A84B]",
+    badge: "border-[#E7D3A1] bg-[#FFF8E7] text-[#7A5714]",
   },
   configured: {
     label: "Configured",
@@ -85,51 +96,87 @@ const STATUS: Record<
 const REFRESH_TIMEOUT_MS = 15_000;
 
 export function HealthScreen({ data }: { data: SystemHealthResponse }) {
-  const router = useRouter();
+  const [currentData, setCurrentData] = useState(data);
   const [refreshing, setRefreshing] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
   const refreshInFlight = useRef(false);
-  const refreshStartedAt = useRef<string | null>(null);
 
   useEffect(() => {
-    if (
-      !refreshInFlight.current ||
-      refreshStartedAt.current === data.generatedAt
-    ) {
-      return;
-    }
-    refreshInFlight.current = false;
-    refreshStartedAt.current = null;
-    setRefreshing(false);
-  }, [data.generatedAt]);
+    setCurrentData(data);
+  }, [data]);
 
-  useEffect(() => {
-    if (!refreshing) return;
-    const timeout = setTimeout(() => {
-      refreshInFlight.current = false;
-      refreshStartedAt.current = null;
-      setRefreshing(false);
-    }, REFRESH_TIMEOUT_MS);
-    return () => clearTimeout(timeout);
-  }, [refreshing]);
-
-  const refresh = () => {
+  const refresh = async () => {
     if (refreshInFlight.current) return;
     refreshInFlight.current = true;
-    refreshStartedAt.current = data.generatedAt;
     setRefreshing(true);
-    router.refresh();
+    setScanError(null);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REFRESH_TIMEOUT_MS);
+    try {
+      const response = await fetch("/api/system-health", {
+        method: "POST",
+        signal: controller.signal,
+      });
+      const body = (await response.json().catch(() => null)) as
+        | SystemHealthResponse
+        | { error?: unknown }
+        | null;
+      if (!response.ok || !body || !("integrations" in body)) {
+        throw new Error(
+          body && "error" in body && typeof body.error === "string"
+            ? body.error
+            : "System health scan failed",
+        );
+      }
+      setCurrentData(body);
+    } catch (error) {
+      setScanError(
+        error instanceof DOMException && error.name === "AbortError"
+          ? "System health scan timed out."
+          : error instanceof Error
+            ? error.message
+            : "System health scan failed.",
+      );
+    } finally {
+      clearTimeout(timeout);
+      refreshInFlight.current = false;
+      setRefreshing(false);
+    }
   };
-  const criticalAlerts = data.alerts.filter((alert) => alert.severity === "critical");
+  const criticalAlerts = currentData.alerts.filter((alert) => alert.severity === "critical");
+  const capabilityChecks = currentData.integrations.flatMap(
+    (integration) => integration.checks ?? [],
+  );
+  const criticalVerificationIncomplete = currentData.integrations.some(
+    (integration) => {
+      if (!integration.critical) return false;
+      const checks = integration.checks ?? [];
+      if (checks.length === 0) {
+        return integration.mode === "unverified" || integration.mode === "degraded";
+      }
+      return checks.some(
+        (check) =>
+          check.critical &&
+          (check.mode === "unverified" || check.mode === "degraded"),
+      );
+    },
+  );
   const overall = criticalAlerts.length > 0
     ? {
         label: "Action required",
         text:
-          data.summary.criticalDown > 0
-            ? `${data.summary.criticalDown} critical ${data.summary.criticalDown === 1 ? "service is" : "services are"} down.`
+          currentData.summary.criticalDown > 0
+            ? `${currentData.summary.criticalDown} critical ${currentData.summary.criticalDown === 1 ? "service is" : "services are"} down.`
             : "Critical deployment configuration is incomplete.",
         className: "border-[#F0B8AE] bg-fail-bg text-fail-fg",
       }
-    : data.alerts.length > 0
+    : criticalVerificationIncomplete
+      ? {
+          label: "Verification incomplete",
+          text: "A critical capability needs fresh successful evidence before this deployment is ready.",
+          className: "border-[#E7D3A1] bg-[#FFF8E7] text-[#7A5714]",
+        }
+      : currentData.alerts.length > 0
       ? {
           label: "Check configuration",
           text: "The execution path is available, but optional setup needs attention.",
@@ -157,10 +204,10 @@ export function HealthScreen({ data }: { data: SystemHealthResponse }) {
         </div>
         <div className="flex shrink-0 items-center gap-3">
           <time
-            dateTime={data.generatedAt}
+            dateTime={currentData.generatedAt}
             className="font-mono text-[10px] leading-4 text-neutral-500"
           >
-            Scanned {formatTime(data.generatedAt)}
+            Scanned {formatTime(currentData.generatedAt)}
           </time>
           <button
             type="button"
@@ -175,7 +222,7 @@ export function HealthScreen({ data }: { data: SystemHealthResponse }) {
 
       <section
         aria-label="Health summary"
-        className="mb-5 grid overflow-hidden rounded-[4px] border border-neutral-200 bg-panel sm:grid-cols-[minmax(280px,1.7fr)_repeat(3,minmax(110px,0.7fr))]"
+        className="mb-5 grid overflow-hidden rounded-[4px] border border-neutral-200 bg-panel sm:grid-cols-[minmax(260px,1.5fr)_repeat(4,minmax(90px,0.65fr))]"
       >
         <div className={`border-b px-4 py-4 sm:border-b-0 sm:border-r ${overall.className}`}>
           <div className="font-display text-[18px] font-semibold tracking-[-0.02em]">
@@ -183,12 +230,47 @@ export function HealthScreen({ data }: { data: SystemHealthResponse }) {
           </div>
           <p className="mt-1 font-body text-[12px] leading-4 opacity-85">{overall.text}</p>
         </div>
-        <SummaryCell label="Live checks" value={data.summary.live} />
-        <SummaryCell label="Down" value={data.summary.down} danger={data.summary.down > 0} />
-        <SummaryCell label="Not configured" value={data.summary.notConfigured} />
+        <SummaryCell
+          label="Live checks"
+          value={
+            currentData.summary.checksLive ??
+            capabilityChecks.filter((check) => check.mode === "live").length
+          }
+        />
+        <SummaryCell
+          label="Down"
+          value={
+            currentData.summary.checksDown ??
+            capabilityChecks.filter((check) => check.mode === "down").length
+          }
+          danger={
+            (currentData.summary.checksDown ??
+              capabilityChecks.filter((check) => check.mode === "down").length) > 0
+          }
+        />
+        <SummaryCell
+          label="Degraded"
+          value={
+            currentData.summary.checksDegraded ??
+            capabilityChecks.filter((check) => check.mode === "degraded").length
+          }
+        />
+        <SummaryCell
+          label="Unverified"
+          value={
+            currentData.summary.checksUnverified ??
+            capabilityChecks.filter((check) => check.mode === "unverified").length
+          }
+        />
       </section>
 
-      {data.alerts.length > 0 && (
+      {scanError && (
+        <div role="alert" className="mb-5 rounded-[4px] border border-[#F0B8AE] bg-fail-bg px-3 py-3 font-body text-[12px] text-fail-fg">
+          {scanError}
+        </div>
+      )}
+
+      {currentData.alerts.length > 0 && (
         <section aria-labelledby="health-alerts" className="mb-5">
           <h2
             id="health-alerts"
@@ -197,9 +279,9 @@ export function HealthScreen({ data }: { data: SystemHealthResponse }) {
             Needs attention
           </h2>
           <div className="grid gap-2">
-            {data.alerts.map((alert) => (
+            {currentData.alerts.map((alert) => (
               <div
-                key={`${alert.integrationId}:${alert.message}`}
+                key={`${alert.integrationId}:${alert.checkId ?? "integration"}:${alert.message}`}
                 role={alert.severity === "critical" ? "alert" : undefined}
                 className={`rounded-[4px] border px-3 py-3 ${
                   alert.severity === "critical"
@@ -221,7 +303,7 @@ export function HealthScreen({ data }: { data: SystemHealthResponse }) {
 
       <div className="grid gap-4">
         {GROUPS.map((group) => {
-          const integrations = data.integrations.filter(
+          const integrations = currentData.integrations.filter(
             (integration) => integration.group === group.id,
           );
           return (
@@ -291,7 +373,9 @@ function HealthRow({
   first: boolean;
   last: boolean;
 }) {
+  const [expanded, setExpanded] = useState(false);
   const status = STATUS[integration.mode];
+  const checks = integration.checks ?? [];
   return (
     <li className={`grid grid-cols-[30px_minmax(0,1fr)] px-4 ${last ? "" : "border-b border-neutral-200"}`}>
       <div className="relative flex justify-center" aria-hidden="true">
@@ -299,8 +383,9 @@ function HealthRow({
         {!last && <span className="absolute bottom-0 h-1/2 w-px bg-neutral-300" />}
         <span className={`relative z-10 mt-[22px] h-2.5 w-2.5 rounded-full ring-4 ring-white ${status.dot}`} />
       </div>
-      <div className="grid min-w-0 gap-3 py-4 sm:grid-cols-[minmax(180px,1fr)_minmax(220px,1.2fr)_auto] sm:items-center">
-        <div className="min-w-0">
+      <div className="min-w-0 py-4">
+        <div className="grid min-w-0 gap-3 sm:grid-cols-[minmax(180px,1fr)_minmax(220px,1.2fr)_auto] sm:items-center">
+          <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <h3 className="font-body text-[13px] font-semibold text-neutral-900">
               {integration.label}
@@ -319,8 +404,8 @@ function HealthRow({
               {integration.ping.latencyMs} ms
             </div>
           )}
-        </div>
-        <div className="flex min-w-0 flex-wrap gap-1.5">
+          </div>
+          <div className="flex min-w-0 flex-wrap gap-1.5">
           {integration.envVars.map((name) => (
             <code
               key={name}
@@ -329,17 +414,92 @@ function HealthRow({
               {name}
             </code>
           ))}
+          </div>
+          <div className="flex items-center gap-2 sm:justify-self-end">
+            <span
+              className={`inline-flex rounded-pill border px-2 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.05em] ${status.badge}`}
+            >
+              {status.label}
+            </span>
+            <button
+              type="button"
+              aria-expanded={expanded}
+              aria-controls={`health-checks-${integration.id}`}
+              onClick={() => setExpanded((value) => !value)}
+              className="rounded-[3px] border border-neutral-200 bg-panel px-2 py-1 font-mono text-[9px] text-neutral-700 hover:bg-app-bg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-mariner"
+            >
+              {expanded ? "Hide checks" : `${checks.length} checks`}
+            </button>
+          </div>
         </div>
-        <div className="sm:justify-self-end">
-          <span
-            className={`inline-flex rounded-pill border px-2 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.05em] ${status.badge}`}
+        {expanded && (
+          <ol
+            id={`health-checks-${integration.id}`}
+            className="mt-3 grid list-none gap-2 border-t border-neutral-200 pt-3"
           >
-            {status.label}
-          </span>
-        </div>
+            {checks.map((check) => (
+              <HealthCheckRow key={check.id} check={check} />
+            ))}
+          </ol>
+        )}
       </div>
     </li>
   );
+}
+
+function HealthCheckRow({ check }: { check: SystemHealthCheck }) {
+  const status = STATUS[check.mode];
+  return (
+    <li className="grid gap-2 rounded-[3px] bg-app-bg px-3 py-2 sm:grid-cols-[minmax(180px,0.9fr)_minmax(220px,1.2fr)_auto] sm:items-start">
+      <div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-body text-[11px] font-semibold text-neutral-900">
+            {check.label}
+          </span>
+          {check.critical && (
+            <span className="font-mono text-[8px] uppercase tracking-[0.07em] text-neutral-500">
+              Required
+            </span>
+          )}
+        </div>
+        <p className="mt-0.5 font-body text-[10px] leading-4 text-neutral-600">
+          {check.message ?? check.description}
+        </p>
+        <div className="mt-1 font-mono text-[9px] text-neutral-500">
+          {evidenceLabel(check)}
+          {check.latencyMs !== undefined ? ` · ${check.latencyMs} ms` : ""}
+          {check.coverage ? ` · ${check.coverage.checked}/${check.coverage.total} checked` : ""}
+        </div>
+      </div>
+      <div className="flex min-w-0 flex-wrap gap-1.5">
+        {check.envVars.map((name) => (
+          <code
+            key={name}
+            className="max-w-full break-all rounded-[3px] bg-panel px-1.5 py-1 font-mono text-[9px] text-neutral-600"
+          >
+            {name}
+          </code>
+        ))}
+      </div>
+      <span className={`inline-flex w-fit rounded-pill border px-2 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.05em] ${status.badge}`}>
+        {status.label}
+      </span>
+    </li>
+  );
+}
+
+function evidenceLabel(check: SystemHealthCheck): string {
+  const source: Record<SystemHealthCheck["evidenceSource"], string> = {
+    "live-probe": "Live probe",
+    "provider-config": "Provider config",
+    "provider-delivery": "Provider delivery",
+    "local-observation": "Observed request",
+    configuration: "Configuration",
+  };
+  const timestamp = check.observedAt ?? check.checkedAt;
+  return timestamp
+    ? `${source[check.evidenceSource]} · ${formatTime(timestamp)}`
+    : source[check.evidenceSource];
 }
 
 function formatTime(value: string): string {

--- a/apps/shared/contracts/api.ts
+++ b/apps/shared/contracts/api.ts
@@ -982,6 +982,8 @@ export interface MemoryDocumentResponse {
 export type SystemHealthMode =
   | "live"
   | "down"
+  | "degraded"
+  | "unverified"
   | "configured"
   | "not-configured"
   | "misconfigured"
@@ -993,6 +995,30 @@ export interface SystemHealthPing {
   ok: boolean;
   latencyMs: number;
   error?: string;
+}
+
+export type SystemHealthEvidenceSource =
+  | "live-probe"
+  | "provider-config"
+  | "provider-delivery"
+  | "local-observation"
+  | "configuration";
+
+export interface SystemHealthCheck {
+  id: string;
+  label: string;
+  description: string;
+  /** A failed required check determines the parent integration status. */
+  critical: boolean;
+  mode: SystemHealthMode;
+  /** Variable NAMES only — values never leave the worker. */
+  envVars: string[];
+  evidenceSource: SystemHealthEvidenceSource;
+  checkedAt?: string;
+  observedAt?: string;
+  latencyMs?: number;
+  message?: string;
+  coverage?: { checked: number; total: number };
 }
 
 export interface SystemHealthIntegration {
@@ -1007,11 +1033,13 @@ export interface SystemHealthIntegration {
   /** Why a partially-set integration counts as misconfigured. */
   configError?: string;
   ping: SystemHealthPing | null;
+  checks: SystemHealthCheck[];
 }
 
 export interface SystemHealthAlert {
   severity: "critical" | "warning";
   integrationId: string;
+  checkId?: string;
   message: string;
   /** What the admin still has to wire, in terms of env var names. */
   fixHint: string;
@@ -1025,6 +1053,11 @@ export interface SystemHealthResponse {
     down: number;
     notConfigured: number;
     criticalDown: number;
+    checksTotal: number;
+    checksLive: number;
+    checksDown: number;
+    checksUnverified: number;
+    checksDegraded: number;
   };
   integrations: SystemHealthIntegration[];
   alerts: SystemHealthAlert[];

--- a/apps/worker/drizzle/0054_curved_mathemanic.sql
+++ b/apps/worker/drizzle/0054_curved_mathemanic.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "system_health_observation_counters" (
+	"integration_id" text NOT NULL,
+	"check_id" text NOT NULL,
+	"scope" text DEFAULT 'deployment' NOT NULL,
+	"window_start" timestamp with time zone NOT NULL,
+	"outcome" text NOT NULL,
+	"reason" text NOT NULL,
+	"count" integer DEFAULT 1 NOT NULL,
+	"last_observed_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "system_health_observation_counters_pk" PRIMARY KEY("integration_id","check_id","scope","window_start","outcome","reason")
+);

--- a/apps/worker/drizzle/meta/0054_snapshot.json
+++ b/apps/worker/drizzle/meta/0054_snapshot.json
@@ -1,0 +1,7339 @@
+{
+  "id": "3bc44933-3502-4f02-98dc-53cf587dd6fa",
+  "prevId": "0454d493-90ce-4ae4-9a67-c3107e3dfc04",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.carry_schema_resync_audit": {
+      "name": "carry_schema_resync_audit",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_index": {
+          "name": "node_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carry_index": {
+          "name": "carry_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_schema": {
+          "name": "before_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk": {
+          "name": "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk",
+          "columns": [
+            "definition_id",
+            "version",
+            "node_index",
+            "carry_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispatch_capacity_queue": {
+      "name": "dispatch_capacity_queue",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_capability_catalogs": {
+      "name": "harness_capability_catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_hash": {
+          "name": "catalog_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "harness_capability_catalogs_scope_unique": {
+          "name": "harness_capability_catalogs_scope_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_capability_catalogs_organization_id_organization_id_fk": {
+          "name": "harness_capability_catalogs_organization_id_organization_id_fk",
+          "tableFrom": "harness_capability_catalogs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_capability_catalogs_provider_check": {
+          "name": "harness_capability_catalogs_provider_check",
+          "value": "\"harness_capability_catalogs\".\"provider\" in ('claude', 'codex')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_content_sha256": {
+          "name": "local_content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifacts_source_kind_check": {
+          "name": "harness_skill_artifacts_source_kind_check",
+          "value": "\"harness_skill_artifacts\".\"source_kind\" in ('github', 'local')"
+        },
+        "harness_skill_artifacts_source_shape_check": {
+          "name": "harness_skill_artifacts_source_shape_check",
+          "value": "(\n        \"harness_skill_artifacts\".\"source_kind\" <> 'github'\n        or (\n          \"harness_skill_artifacts\".\"source_owner\" is not null\n          and \"harness_skill_artifacts\".\"source_repository\" is not null\n          and \"harness_skill_artifacts\".\"source_path\" is not null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is not null\n          and \"harness_skill_artifacts\".\"local_path\" is null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is null\n        )\n      ) and (\n        \"harness_skill_artifacts\".\"source_kind\" <> 'local'\n        or (\n          \"harness_skill_artifacts\".\"local_path\" is not null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is not null\n          and \"harness_skill_artifacts\".\"source_owner\" is null\n          and \"harness_skill_artifacts\".\"source_repository\" is null\n          and \"harness_skill_artifacts\".\"source_path\" is null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is null\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_events": {
+      "name": "mcp_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutation_class": {
+          "name": "mutation_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_refs": {
+          "name": "target_refs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_hash": {
+          "name": "output_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key_hash": {
+          "name": "idempotency_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_version": {
+          "name": "server_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_hash": {
+          "name": "contract_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_audit_events_organization_occurred_at_idx": {
+          "name": "mcp_audit_events_organization_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_audit_events_request_id_idx": {
+          "name": "mcp_audit_events_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_events_organization_id_organization_id_fk": {
+          "name": "mcp_audit_events_organization_id_organization_id_fk",
+          "tableFrom": "mcp_audit_events",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_idempotency_keys": {
+      "name": "mcp_idempotency_keys",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_response": {
+          "name": "safe_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_idempotency_keys_namespace_unique": {
+          "name": "mcp_idempotency_keys_namespace_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_idempotency_keys_expires_at_idx": {
+          "name": "mcp_idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_idempotency_keys_organization_id_organization_id_fk": {
+          "name": "mcp_idempotency_keys_organization_id_organization_id_fk",
+          "tableFrom": "mcp_idempotency_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_idempotency_keys_state_check": {
+          "name": "mcp_idempotency_keys_state_check",
+          "value": "\"mcp_idempotency_keys\".\"state\" in ('started', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_rate_limit_windows": {
+      "name": "mcp_rate_limit_windows",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_rate_limit_windows_expires_at_idx": {
+          "name": "mcp_rate_limit_windows_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_rate_limit_windows_organization_id_organization_id_fk": {
+          "name": "mcp_rate_limit_windows_organization_id_organization_id_fk",
+          "tableFrom": "mcp_rate_limit_windows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_rate_limit_windows_organization_id_actor_subject_client_id_tool_name_window_started_at_pk": {
+          "name": "mcp_rate_limit_windows_organization_id_actor_subject_client_id_tool_name_window_started_at_pk",
+          "columns": [
+            "organization_id",
+            "actor_subject",
+            "client_id",
+            "tool_name",
+            "window_started_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_autofix_attempts": {
+      "name": "pr_autofix_attempts",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_autofix_attempts_pk": {
+          "name": "pr_autofix_attempts_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "provider",
+            "repo_path",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_occurrences": {
+      "name": "schedule_occurrences",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_at": {
+          "name": "occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_count": {
+          "name": "dropped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dropped_count_capped": {
+          "name": "dropped_count_capped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocking_run_id": {
+          "name": "blocking_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedule_occurrences_one_pending_per_schedule_idx": {
+          "name": "schedule_occurrences_one_pending_per_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedule_occurrences\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_occurrences_run_id_idx": {
+          "name": "schedule_occurrences_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_occurrences_schedule_id_workflow_schedules_id_fk": {
+          "name": "schedule_occurrences_schedule_id_workflow_schedules_id_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_occurrences_definition_version_fk": {
+          "name": "schedule_occurrences_definition_version_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedule_occurrences_schedule_id_occurrence_at_pk": {
+          "name": "schedule_occurrences_schedule_id_occurrence_at_pk",
+          "columns": [
+            "schedule_id",
+            "occurrence_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedule_occurrences_outcome_check": {
+          "name": "schedule_occurrences_outcome_check",
+          "value": "\"schedule_occurrences\".\"outcome\" is null or \"schedule_occurrences\".\"outcome\" in ('started', 'skipped_overlap', 'skipped_stale', 'superseded', 'expired', 'cancelled', 'run_cancelled', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.system_health_observation_counters": {
+      "name": "system_health_observation_counters",
+      "schema": "",
+      "columns": {
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployment'"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "system_health_observation_counters_pk": {
+          "name": "system_health_observation_counters_pk",
+          "columns": [
+            "integration_id",
+            "check_id",
+            "scope",
+            "window_start",
+            "outcome",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_rate_limits": {
+      "name": "trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_kind": {
+          "name": "window_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trigger_rate_limits_pk": {
+          "name": "trigger_rate_limits_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "window_kind",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_rejection_counters": {
+      "name": "trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trigger_rejection_counters_definition_id_node_id_day_reason_pk": {
+          "name": "trigger_rejection_counters_definition_id_node_id_day_reason_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "day",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_deliveries": {
+      "name": "webhook_trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "webhook_trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_trigger_deliveries_definition_version_fk": {
+          "name": "webhook_trigger_deliveries_definition_version_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_deliveries_endpoint_id_delivery_id_pk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_delivery_id_pk",
+          "columns": [
+            "endpoint_id",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_endpoints": {
+      "name": "webhook_trigger_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_scheme": {
+          "name": "auth_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hmac_sha256'"
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_timestamp": {
+          "name": "require_timestamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timestamp_header": {
+          "name": "timestamp_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp_tolerance_seconds": {
+          "name": "timestamp_tolerance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_secret_ciphertext": {
+          "name": "previous_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_endpoints_definition_node_idx": {
+          "name": "webhook_trigger_endpoints_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk": {
+          "name": "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "webhook_trigger_endpoints",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhook_trigger_endpoints_auth_scheme_check": {
+          "name": "webhook_trigger_endpoints_auth_scheme_check",
+          "value": "\"webhook_trigger_endpoints\".\"auth_scheme\" in ('hmac_sha256', 'shared_token')"
+        },
+        "webhook_trigger_endpoints_timestamp_tolerance_check": {
+          "name": "webhook_trigger_endpoints_timestamp_tolerance_check",
+          "value": "\"webhook_trigger_endpoints\".\"timestamp_tolerance_seconds\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rate_limits": {
+      "name": "webhook_trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inbox'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_rate_limits",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rejection_counters": {
+      "name": "webhook_trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk": {
+          "name": "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publication_comments": {
+      "name": "workflow_pr_review_publication_comments",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk",
+          "tableFrom": "workflow_pr_review_publication_comments",
+          "tableTo": "workflow_pr_review_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_pr_review_publication_comments_publication_id_content_hash_pk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_content_hash_pk",
+          "columns": [
+            "publication_id",
+            "content_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publication_comments_state_check": {
+          "name": "workflow_pr_review_publication_comments_state_check",
+          "value": "\"workflow_pr_review_publication_comments\".\"state\" in ('pending', 'published')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publications": {
+      "name": "workflow_pr_review_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_comment_count": {
+          "name": "inline_comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summary_fallback_count": {
+          "name": "summary_fallback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_pr_review_publications_content_unique": {
+          "name": "workflow_pr_review_publications_content_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pr_review_publications_run_idx": {
+          "name": "workflow_pr_review_publications_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_pr_review_publications",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publications_state_check": {
+          "name": "workflow_pr_review_publications_state_check",
+          "value": "\"workflow_pr_review_publications\".\"state\" in ('pending', 'published')"
+        },
+        "workflow_pr_review_publications_decision_check": {
+          "name": "workflow_pr_review_publications_decision_check",
+          "value": "\"workflow_pr_review_publications\".\"decision\" in ('approve', 'request_changes')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_external_checks": {
+      "name": "workflow_run_external_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "closure_intent": {
+          "name": "closure_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_external_checks_attempt_unique": {
+          "name": "workflow_run_external_checks_attempt_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_reconcile_idx": {
+          "name": "workflow_run_external_checks_reconcile_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_run_idx": {
+          "name": "workflow_run_external_checks_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_external_checks_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_external_checks_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_external_checks",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_external_checks_state_check": {
+          "name": "workflow_run_external_checks_state_check",
+          "value": "\"workflow_run_external_checks\".\"state\" in ('creating', 'pending', 'closing', 'completed')"
+        },
+        "workflow_run_external_checks_conclusion_check": {
+          "name": "workflow_run_external_checks_conclusion_check",
+          "value": "\"workflow_run_external_checks\".\"conclusion\" is null or \"workflow_run_external_checks\".\"conclusion\" in ('success', 'failure', 'neutral', 'cancelled', 'timed_out', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_started_at": {
+          "name": "entry_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_deadline_at": {
+          "name": "startup_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_startup_watchdog_idx": {
+          "name": "workflow_runs_startup_watchdog_idx",
+          "columns": [
+            {
+              "expression": "startup_deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_runs\".\"entry_started_at\" is null and coalesce(\"workflow_runs\".\"status\", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "overlap_policy": {
+          "name": "overlap_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "catch_up_grace_minutes": {
+          "name": "catch_up_grace_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_watermark_at": {
+          "name": "evaluation_watermark_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_occurrence_at": {
+          "name": "last_started_occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_run_id": {
+          "name": "last_started_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_schedules_definition_node_idx": {
+          "name": "workflow_schedules_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_schedules_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_schedules_overlap_policy_check": {
+          "name": "workflow_schedules_overlap_policy_check",
+          "value": "\"workflow_schedules\".\"overlap_policy\" in ('skip', 'queue', 'allow')"
+        },
+        "workflow_schedules_catch_up_grace_check": {
+          "name": "workflow_schedules_catch_up_grace_check",
+          "value": "\"workflow_schedules\".\"catch_up_grace_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expires_at_idx": {
+          "name": "oauth_access_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_expires_at_idx": {
+          "name": "oauth_refresh_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memory_documents": {
+      "name": "agent_memory_documents",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memory_documents_ticket_key_idx": {
+          "name": "agent_memory_documents_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_documents_updated_at_idx": {
+          "name": "agent_memory_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_memory_documents_subject_key_doc_path_pk": {
+          "name": "agent_memory_documents_subject_key_doc_path_pk",
+          "columns": [
+            "subject_key",
+            "doc_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1787149085071,
       "tag": "0053_pr_autofix_attempts",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1787297195491,
+      "tag": "0054_curved_mathemanic",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -1098,6 +1098,38 @@ export const webhookTriggerRejectionCounters = pgTable(
   (t) => [primaryKey({ columns: [t.endpointId, t.windowStart, t.reason] })],
 );
 
+/** Bounded, payload-free evidence for provider webhook health. One row per
+ * provider/check/outcome/reason/day keeps authentication failures visible to
+ * System Health without turning untrusted requests into an unbounded log. */
+export const systemHealthObservationCounters = pgTable(
+  "system_health_observation_counters",
+  {
+    integrationId: text("integration_id").notNull(),
+    checkId: text("check_id").notNull(),
+    scope: text("scope").notNull().default("deployment"),
+    windowStart: timestamp("window_start", { withTimezone: true }).notNull(),
+    outcome: text("outcome").notNull(),
+    reason: text("reason").notNull(),
+    count: integer("count").notNull().default(1),
+    lastObservedAt: timestamp("last_observed_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    primaryKey({
+      columns: [
+        t.integrationId,
+        t.checkId,
+        t.scope,
+        t.windowStart,
+        t.outcome,
+        t.reason,
+      ],
+      name: "system_health_observation_counters_pk",
+    }),
+  ],
+);
+
 /** Fixed-window start counter per trigger node, shared by every automatic
  * trigger type (ticket, PR, schedule, webhook). The window start is part of
  * the key, so one upsert is the whole rate-limit algorithm and an expired

--- a/apps/worker/src/db/system-health-observations-migration.test.ts
+++ b/apps/worker/src/db/system-health-observations-migration.test.ts
@@ -5,7 +5,7 @@ import { PGlite } from "@electric-sql/pglite";
 
 const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
 
-describe("0055 system health observations migration", () => {
+describe("0054 system health observations migration", () => {
   it("adds the bounded counter without changing existing workflow data", async () => {
     const client = new PGlite();
     const migrations = readdirSync(migrationsDir)
@@ -19,7 +19,7 @@ describe("0055 system health observations migration", () => {
     );
 
     await client.exec(
-      readFileSync(`${migrationsDir}0055_nifty_mongoose.sql`, "utf8"),
+      readFileSync(`${migrationsDir}0054_curved_mathemanic.sql`, "utf8"),
     );
     await client.exec(`
       INSERT INTO system_health_observation_counters

--- a/apps/worker/src/db/system-health-observations-migration.test.ts
+++ b/apps/worker/src/db/system-health-observations-migration.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { PGlite } from "@electric-sql/pglite";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+
+describe("0055 system health observations migration", () => {
+  it("adds the bounded counter without changing existing workflow data", async () => {
+    const client = new PGlite();
+    const migrations = readdirSync(migrationsDir)
+      .filter((file) => file.endsWith(".sql") && file.slice(0, 4) <= "0053")
+      .sort();
+    for (const file of migrations) {
+      await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+    }
+    await client.exec(
+      `INSERT INTO workflow_runs (run_id, status) VALUES ('health-migration-run', 'success')`,
+    );
+
+    await client.exec(
+      readFileSync(`${migrationsDir}0055_nifty_mongoose.sql`, "utf8"),
+    );
+    await client.exec(`
+      INSERT INTO system_health_observation_counters
+        (integration_id, check_id, scope, window_start, outcome, reason, count, last_observed_at)
+      VALUES
+        ('gitlab', 'webhook-delivery', 'deployment', '2026-08-21', 'rejected', 'invalid_token', 2, '2026-08-21T10:00:00Z')
+    `);
+
+    const run = await client.query<{ run_id: string; status: string }>(
+      `SELECT run_id, status FROM workflow_runs WHERE run_id = 'health-migration-run'`,
+    );
+    const counter = await client.query<{ count: number }>(
+      `SELECT count FROM system_health_observation_counters WHERE integration_id = 'gitlab'`,
+    );
+    expect(run.rows).toEqual([{ run_id: "health-migration-run", status: "success" }]);
+    expect(counter.rows).toEqual([{ count: 2 }]);
+  });
+});

--- a/apps/worker/src/routes/api/v1/system/health.post.ts
+++ b/apps/worker/src/routes/api/v1/system/health.post.ts
@@ -1,0 +1,22 @@
+import { createError, defineEventHandler, setResponseHeader } from "h3";
+import type { SystemHealthResponse } from "@shared/contracts";
+import { requireDashboardActor, toHttpError } from "../../../../lib/auth/request-context.js";
+import { canInvite } from "../../../../lib/auth/roles.js";
+import { collectDeploymentSystemHealth } from "../../../../system-health/probes.js";
+
+/** Explicit active scan. Keeping this separate from GET prevents navigation or
+ * server rendering from sending provider test deliveries. */
+export default defineEventHandler(
+  async (event): Promise<SystemHealthResponse | undefined> => {
+    setResponseHeader(event, "Cache-Control", "no-store");
+    try {
+      const actor = await requireDashboardActor(event);
+      if (!canInvite(actor.role)) {
+        throw createError({ statusCode: 403, statusMessage: "Forbidden" });
+      }
+      return await collectDeploymentSystemHealth({ active: true });
+    } catch (error) {
+      toHttpError(error);
+    }
+  },
+);

--- a/apps/worker/src/routes/api/v1/system/health.test.ts
+++ b/apps/worker/src/routes/api/v1/system/health.test.ts
@@ -22,7 +22,8 @@ vi.mock("../../../../system-health/probes.js", () => ({
   collectDeploymentSystemHealth: state.collect,
 }));
 
-const route = (await import("./health.get.js")).default;
+const getRoute = (await import("./health.get.js")).default;
+const postRoute = (await import("./health.post.js")).default;
 
 const fixture: SystemHealthResponse = {
   generatedAt: "2026-08-20T12:00:00.000Z",
@@ -32,6 +33,11 @@ const fixture: SystemHealthResponse = {
     down: 0,
     notConfigured: 0,
     criticalDown: 0,
+    checksTotal: 1,
+    checksLive: 1,
+    checksDown: 0,
+    checksUnverified: 0,
+    checksDegraded: 0,
   },
   integrations: [
     {
@@ -42,15 +48,26 @@ const fixture: SystemHealthResponse = {
       critical: true,
       mode: "live",
       ping: { ok: true, latencyMs: 12 },
+      checks: [
+        {
+          id: "connectivity",
+          label: "Connection and query",
+          description: "Verified independently.",
+          critical: true,
+          mode: "live",
+          envVars: ["DATABASE_URL"],
+          evidenceSource: "live-probe",
+        },
+      ],
     },
   ],
   alerts: [],
 };
 
-function request() {
+function request(route = getRoute, method = "GET") {
   const app = createApp();
   app.use("/", route);
-  return toWebHandler(app)(new Request("http://worker.test/"));
+  return toWebHandler(app)(new Request("http://worker.test/", { method }));
 }
 
 beforeEach(() => {
@@ -76,5 +93,21 @@ describe("GET /api/v1/system/health", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(await response.json()).toEqual(fixture);
     expect(state.collect).toHaveBeenCalledOnce();
+  });
+});
+
+describe("POST /api/v1/system/health", () => {
+  it("keeps active provider tests restricted to owner and admin roles", async () => {
+    state.role = "member";
+    expect((await request(postRoute, "POST")).status).toBe(403);
+    expect(state.collect).not.toHaveBeenCalled();
+  });
+
+  it("runs an explicit active scan without caching", async () => {
+    const response = await request(postRoute, "POST");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual(fixture);
+    expect(state.collect).toHaveBeenCalledWith({ active: true });
   });
 });

--- a/apps/worker/src/routes/cron/poll.get.ts
+++ b/apps/worker/src/routes/cron/poll.get.ts
@@ -50,6 +50,7 @@ import {
 } from "../../schedule-trigger/dispatch-schedule-trigger.js";
 import { reconcilePendingPrChecks } from "../../workflows/pr-external-resources.js";
 import { createWebhookDispatchDeps } from "../webhooks/custom/[endpointId].post.js";
+import { sweepSystemHealthObservations } from "../../system-health/observations.js";
 
 const PENDING_TRIGGER_RECOVERY_SCAN_LIMIT = 20;
 
@@ -211,6 +212,9 @@ export default defineEventHandler(async (event) => {
   );
   await sweepWebhookRejectionCounters(db).catch((err) =>
     logger.warn({ err: (err as Error).message }, "poll_webhook_rejection_sweep_failed"),
+  );
+  await sweepSystemHealthObservations(db).catch((err) =>
+    logger.warn({ err: (err as Error).message }, "poll_health_observation_sweep_failed"),
   );
   await sweepWebhookDeliveries(db).catch((err) =>
     logger.warn({ err: (err as Error).message }, "poll_webhook_delivery_sweep_failed"),

--- a/apps/worker/src/routes/webhooks/github.post.test.ts
+++ b/apps/worker/src/routes/webhooks/github.post.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   getVcsBotLogin: vi.fn(),
   isRepoAllowed: vi.fn(),
   findWorkflowOwnedPullRequestIdentity: vi.fn(),
+  observeProviderWebhook: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({
@@ -35,6 +36,9 @@ vi.mock("../../db/client.js", () => ({ getDb: () => ({}) }));
 vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
   findWorkflowOwnedPullRequestIdentity: (...args: any[]) =>
     mocks.findWorkflowOwnedPullRequestIdentity(...args),
+}));
+vi.mock("../../system-health/provider-webhook-observation.js", () => ({
+  observeProviderWebhook: mocks.observeProviderWebhook,
 }));
 
 const mockDispatchTriggerEvent = vi.fn();
@@ -137,6 +141,11 @@ describe("POST /webhooks/github", () => {
     expect(mocks.isRepoAllowed).not.toHaveBeenCalled();
     expect(mockDispatchTriggerEvent).toHaveBeenCalled();
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+    expect(mocks.observeProviderWebhook).toHaveBeenCalledWith(
+      "github",
+      "accepted",
+      "request_succeeded",
+    );
   });
 
   it("passes a commented review to the dispatcher for snapshot-bound selector evaluation", async () => {
@@ -374,6 +383,16 @@ describe("POST /webhooks/github", () => {
 
     expect(response.status).toBe(503);
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+    expect(mocks.observeProviderWebhook).toHaveBeenCalledWith(
+      "github",
+      "rejected",
+      "handler_failed",
+    );
+    expect(mocks.observeProviderWebhook).not.toHaveBeenCalledWith(
+      "github",
+      "accepted",
+      "request_succeeded",
+    );
   });
 
   it("returns a retryable 503 when dispatch errors", async () => {

--- a/apps/worker/src/routes/webhooks/github.post.ts
+++ b/apps/worker/src/routes/webhooks/github.post.ts
@@ -1,4 +1,10 @@
-import { defineEventHandler, readRawBody, getHeader, createError } from "h3";
+import {
+  defineEventHandler,
+  readRawBody,
+  getHeader,
+  createError,
+  type H3Event,
+} from "h3";
 import { env, getVcsBotLogin } from "../../../env.js";
 import { PostgresRunRegistry } from "../../adapters/run-registry/postgres.js";
 import { getDb } from "../../db/client.js";
@@ -21,22 +27,42 @@ import {
   ticketKeyFromBranch,
 } from "../../lib/workflow-naming.js";
 import { loadPostPrGateConfig } from "../../post-pr-gate/config.js";
+import { observeProviderWebhook } from "../../system-health/provider-webhook-observation.js";
 
 const GATE_ACTIONS = new Set(["opened", "synchronize", "reopened"]);
 
 export default defineEventHandler(async (event) => {
   const rawBody = (await readRawBody(event, "utf8")) ?? "";
 
+  if (!env.GITHUB_WEBHOOK_SECRET) {
+    observeProviderWebhook("github", "rejected", "secret_not_configured");
+    throw createError({
+      statusCode: 503,
+      statusMessage: "GitHub webhook secret is not configured",
+    });
+  }
+
   try {
     verifyGitHubWebhookSignature(
       rawBody,
       getHeader(event, "x-hub-signature-256"),
-      env.GITHUB_WEBHOOK_SECRET!,
+      env.GITHUB_WEBHOOK_SECRET,
     );
   } catch (err) {
+    observeProviderWebhook("github", "rejected", "invalid_signature");
     throw createError({ statusCode: 401, statusMessage: (err as Error).message });
   }
+  try {
+    const result = await handleVerifiedGitHubWebhook(event, rawBody);
+    observeProviderWebhook("github", "accepted", "request_succeeded");
+    return result;
+  } catch (error) {
+    observeProviderWebhook("github", "rejected", "handler_failed");
+    throw error;
+  }
+});
 
+async function handleVerifiedGitHubWebhook(event: H3Event, rawBody: string) {
   const ghEvent = getHeader(event, "x-github-event") ?? "";
   const deliveryId = getHeader(event, "x-github-delivery")?.trim() ?? "";
   if (!deliveryId) {
@@ -164,7 +190,7 @@ export default defineEventHandler(async (event) => {
   }
 
   return { status: "ignored", reason: `event_${ghEvent}` };
-});
+}
 
 /**
  * A rename changes `repository.full_name`, the key every definition repository

--- a/apps/worker/src/routes/webhooks/gitlab.post.test.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   fetch: vi.fn(),
   isRepoAllowed: vi.fn(),
   findWorkflowOwnedPullRequestIdentity: vi.fn(),
+  observeProviderWebhook: vi.fn(),
 }));
 
 global.fetch = mocks.fetch;
@@ -43,6 +44,9 @@ vi.mock("../../db/queries/workflow-owned-branches.js", () => ({
 }));
 vi.mock("../../lib/repo-allowlist.js", () => ({
   isRepoAllowed: (...args: any[]) => mocks.isRepoAllowed(...args),
+}));
+vi.mock("../../system-health/provider-webhook-observation.js", () => ({
+  observeProviderWebhook: mocks.observeProviderWebhook,
 }));
 
 vi.mock("../../adapters/vcs/repository-directory.js", () => ({
@@ -174,6 +178,25 @@ describe("POST /webhooks/gitlab", () => {
       reason: "malformed_payload",
     });
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges the health scan push event without dispatching work", async () => {
+    const response = await makeApp()(
+      makeRequest("{}", "secret", "Push Hook"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "ignored",
+      reason: "not_supported_event",
+    });
+    expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
+    expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+    expect(mocks.observeProviderWebhook).toHaveBeenCalledWith(
+      "gitlab",
+      "accepted",
+      "request_succeeded",
+    );
   });
 
   it("uses webhook-id ahead of all legacy GitLab delivery headers", async () => {
@@ -412,6 +435,11 @@ describe("POST /webhooks/gitlab", () => {
     expect(response.status).toBe(401);
     expect(response.statusText).toBe("Invalid GitLab webhook token");
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+    expect(mocks.observeProviderWebhook).toHaveBeenCalledWith(
+      "gitlab",
+      "rejected",
+      "invalid_token",
+    );
   });
 
   it("answers an unconfigured secret with 503 rather than the mismatch 401", async () => {
@@ -498,6 +526,16 @@ describe("POST /webhooks/gitlab", () => {
 
     expect(response.status).toBe(503);
     expect(mockDispatchPostPrGateWebhook).not.toHaveBeenCalled();
+    expect(mocks.observeProviderWebhook).toHaveBeenCalledWith(
+      "gitlab",
+      "rejected",
+      "handler_failed",
+    );
+    expect(mocks.observeProviderWebhook).not.toHaveBeenCalledWith(
+      "gitlab",
+      "accepted",
+      "request_succeeded",
+    );
   });
 
   it("returns a retryable 503 when dispatch errors", async () => {

--- a/apps/worker/src/routes/webhooks/gitlab.post.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.ts
@@ -1,5 +1,11 @@
 import { createHash } from "node:crypto";
-import { createError, defineEventHandler, getHeader, readRawBody } from "h3";
+import {
+  createError,
+  defineEventHandler,
+  getHeader,
+  readRawBody,
+  type H3Event,
+} from "h3";
 import { env, getConfiguredVcsProviders, getVcsBotLogin } from "../../../env.js";
 import { PostgresRunRegistry } from "../../adapters/run-registry/postgres.js";
 import { createRepositoryDirectoryForProviders } from "../../adapters/vcs/repository-directory.js";
@@ -24,6 +30,7 @@ import {
   workflowPushNormalizationOptions,
 } from "../../lib/workflow-push-suppression.js";
 import { ticketKeyFromBranch } from "../../lib/workflow-naming.js";
+import { observeProviderWebhook } from "../../system-health/provider-webhook-observation.js";
 
 const ALLOWED_ACTIONS = new Set(["opened", "update", "reopened"]);
 
@@ -38,6 +45,7 @@ export default defineEventHandler(async (event) => {
   const gitLabWebhookSecret = env.GITLAB_WEBHOOK_SECRET;
   if (!gitLabWebhookSecret) {
     logger.error({}, "gitlab_webhook_secret_not_configured");
+    observeProviderWebhook("gitlab", "rejected", "secret_not_configured");
     throw createError({
       statusCode: 503,
       statusMessage: "GitLab webhook secret is not configured",
@@ -47,9 +55,20 @@ export default defineEventHandler(async (event) => {
   try {
     verifyGitLabWebhookToken(getHeader(event, "x-gitlab-token"), gitLabWebhookSecret);
   } catch (err) {
+    observeProviderWebhook("gitlab", "rejected", "invalid_token");
     throw createError({ statusCode: 401, statusMessage: (err as Error).message });
   }
+  try {
+    const result = await handleVerifiedGitLabWebhook(event, rawBody);
+    observeProviderWebhook("gitlab", "accepted", "request_succeeded");
+    return result;
+  } catch (error) {
+    observeProviderWebhook("gitlab", "rejected", "handler_failed");
+    throw error;
+  }
+});
 
+async function handleVerifiedGitLabWebhook(event: H3Event, rawBody: string) {
   const gitLabEvent = getHeader(event, "x-gitlab-event");
   if (
     gitLabEvent !== "Merge Request Hook" &&
@@ -162,7 +181,7 @@ export default defineEventHandler(async (event) => {
     return { status: "ignored", reason: "note_ignored" };
   }
   return { status: "ignored", reason: "pipeline_ignored" };
-});
+}
 
 async function dispatchMergeRequestGate(body: any) {
   let normalized;

--- a/apps/worker/src/routes/webhooks/jira.post.test.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.test.ts
@@ -20,6 +20,7 @@ const state = vi.hoisted(() => ({
   hasDurableRunPublication: vi.fn(),
   classifyProtected: vi.fn(),
   listApprovalParked: vi.fn(),
+  observeProviderWebhook: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({ env: state.env }));
@@ -42,6 +43,9 @@ vi.mock("../../db/queries/runs-read.js", () => ({
   isRunRecordedFailed: state.isRunRecordedFailed,
   isRunRecordedSucceeded: state.isRunRecordedSucceeded,
   hasDurableRunPublication: state.hasDurableRunPublication,
+}));
+vi.mock("../../system-health/provider-webhook-observation.js", () => ({
+  observeProviderWebhook: state.observeProviderWebhook,
 }));
 
 const { resetAiReviewDestinationCache } = await import(
@@ -138,6 +142,11 @@ describe("POST /webhooks/jira", () => {
     state.env.JIRA_WEBHOOK_SECRET = undefined;
     const response = await app()(new Request("http://localhost/", { method: "POST", body: "{}" }));
     expect(response.status).toBe(503);
+    expect(state.observeProviderWebhook).toHaveBeenCalledWith(
+      "jira",
+      "rejected",
+      "secret_not_configured",
+    );
   });
 
   it("ignores a status transition authored by the workflow Jira account", async () => {
@@ -152,6 +161,11 @@ describe("POST /webhooks/jira", () => {
     });
     expect(state.cancel).not.toHaveBeenCalled();
     expect(state.dispatch).not.toHaveBeenCalled();
+    expect(state.observeProviderWebhook).toHaveBeenCalledWith(
+      "jira",
+      "accepted",
+      "request_succeeded",
+    );
   });
 
   it("cancels the exact active owner for a human status move", async () => {
@@ -473,6 +487,16 @@ describe("POST /webhooks/jira", () => {
 
     expect(response.status).toBe(503);
     expect(state.cancel).not.toHaveBeenCalled();
+    expect(state.observeProviderWebhook).toHaveBeenCalledWith(
+      "jira",
+      "rejected",
+      "handler_failed",
+    );
+    expect(state.observeProviderWebhook).not.toHaveBeenCalledWith(
+      "jira",
+      "accepted",
+      "request_succeeded",
+    );
   });
 
   it("still cancels a genuine pull-out when the resolved review destination differs", async () => {

--- a/apps/worker/src/routes/webhooks/jira.post.ts
+++ b/apps/worker/src/routes/webhooks/jira.post.ts
@@ -17,6 +17,7 @@ import { cancelRunDetailed } from "../../lib/cancel-run.js";
 import { dispatchTicket } from "../../lib/dispatch.js";
 import { logger } from "../../lib/logger.js";
 import { ticketSubjectKey } from "../../lib/subject-key.js";
+import { observeProviderWebhook } from "../../system-health/provider-webhook-observation.js";
 
 /**
  * Jira webhook handler — triggers the same dispatch logic as the cron poller.
@@ -34,8 +35,27 @@ import { ticketSubjectKey } from "../../lib/subject-key.js";
 export default defineEventHandler(async (event) => {
   const rawBody = (await readRawBody(event, "utf8")) ?? "";
 
-  verifyWebhookAuth(event, rawBody);
+  try {
+    verifyWebhookAuth(event, rawBody);
+  } catch (error) {
+    observeProviderWebhook(
+      "jira",
+      "rejected",
+      env.JIRA_WEBHOOK_SECRET ? "invalid_signature" : "secret_not_configured",
+    );
+    throw error;
+  }
+  try {
+    const result = await handleVerifiedJiraWebhook(rawBody);
+    observeProviderWebhook("jira", "accepted", "request_succeeded");
+    return result;
+  } catch (error) {
+    observeProviderWebhook("jira", "rejected", "handler_failed");
+    throw error;
+  }
+});
 
+async function handleVerifiedJiraWebhook(rawBody: string) {
   const body = rawBody ? JSON.parse(rawBody) : {};
 
   const ticketKey = extractTicketKey(body);
@@ -474,7 +494,7 @@ export default defineEventHandler(async (event) => {
     ticketKey,
     reason: result.reason,
   };
-});
+}
 
 // ---------------------------------------------------------------------------
 // Clarification resume

--- a/apps/worker/src/routes/webhooks/resend.post.test.ts
+++ b/apps/worker/src/routes/webhooks/resend.post.test.ts
@@ -17,6 +17,7 @@ const state = vi.hoisted(() => ({
   env: {
     RESEND_WEBHOOK_SECRET: "MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw" as string | undefined,
   },
+  observeProviderWebhook: vi.fn(),
 }));
 
 vi.mock("../../../env.js", () => ({
@@ -26,12 +27,16 @@ vi.mock("../../../env.js", () => ({
 vi.mock("../../db/client.js", () => ({
   getDb: () => state.db,
 }));
+vi.mock("../../system-health/provider-webhook-observation.js", () => ({
+  observeProviderWebhook: state.observeProviderWebhook,
+}));
 
 const resendHandler = (await import("./resend.post.js")).default;
 
 let db: Db;
 
 beforeEach(async () => {
+  vi.clearAllMocks();
   db = await createTestDb();
   state.db = db;
   state.env.RESEND_WEBHOOK_SECRET = WEBHOOK_SECRET;
@@ -121,6 +126,11 @@ describe("POST /webhooks/resend", () => {
     );
 
     expect(res.status).toBe(401);
+    expect(state.observeProviderWebhook).toHaveBeenCalledWith(
+      "email",
+      "rejected",
+      "invalid_signature",
+    );
   });
 
   it("returns 500 when the webhook secret is not configured", async () => {
@@ -148,6 +158,11 @@ describe("POST /webhooks/resend", () => {
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ status: "ok" });
+    expect(state.observeProviderWebhook).toHaveBeenCalledWith(
+      "email",
+      "accepted",
+      "request_succeeded",
+    );
     await expect(delivery()).resolves.toEqual({
       status: "bounced",
       error: "Mailbox unavailable",

--- a/apps/worker/src/routes/webhooks/resend.post.ts
+++ b/apps/worker/src/routes/webhooks/resend.post.ts
@@ -6,11 +6,13 @@ import {
   applyInviteEmailDeliveryEvent,
   type ResendEmailDeliveryEvent,
 } from "../../lib/email/invite-delivery.js";
+import { observeProviderWebhook } from "../../system-health/provider-webhook-observation.js";
 
 export default defineEventHandler(async (event) => {
   const rawBody = (await readRawBody(event, "utf8")) ?? "";
   const secret = env.RESEND_WEBHOOK_SECRET;
   if (!secret) {
+    observeProviderWebhook("email", "rejected", "secret_not_configured");
     throw createError({
       statusCode: 500,
       statusMessage: "Resend webhook secret is not configured",
@@ -25,11 +27,17 @@ export default defineEventHandler(async (event) => {
       "svix-timestamp": getHeader(event, "svix-timestamp") ?? "",
     });
   } catch {
+    observeProviderWebhook("email", "rejected", "invalid_signature");
     throw createError({ statusCode: 401, statusMessage: "Invalid webhook signature" });
   }
-
-  await applyInviteEmailDeliveryEvent(getDb(), asResendEvent(payload, rawBody));
-  return { status: "ok" };
+  try {
+    await applyInviteEmailDeliveryEvent(getDb(), asResendEvent(payload, rawBody));
+    observeProviderWebhook("email", "accepted", "request_succeeded");
+    return { status: "ok" };
+  } catch (error) {
+    observeProviderWebhook("email", "rejected", "handler_failed");
+    throw error;
+  }
 });
 
 function asResendEvent(

--- a/apps/worker/src/routes/webhooks/slack.post.test.ts
+++ b/apps/worker/src/routes/webhooks/slack.post.test.ts
@@ -4,6 +4,7 @@ import { createHmac } from "node:crypto";
 
 const SIGNING_SECRET = "shhhh-do-not-tell";
 const JIRA_BASE_URL = "https://example.atlassian.net";
+const observeProviderWebhook = vi.hoisted(() => vi.fn());
 
 // Mock env BEFORE importing anything that pulls it in transitively.
 vi.mock("../../../env.js", () => ({
@@ -46,6 +47,9 @@ vi.mock("../../lib/adapters.js", () => ({
 const cancelRunFn = vi.fn();
 vi.mock("../../lib/cancel-run.js", () => ({
   cancelRun: (...args: any[]) => cancelRunFn(...args),
+}));
+vi.mock("../../system-health/provider-webhook-observation.js", () => ({
+  observeProviderWebhook,
 }));
 
 const stopSandboxesByIdsFn = vi.fn();
@@ -131,12 +135,35 @@ describe("POST /webhooks/slack", () => {
       }),
     );
     expect(res.status).toBe(401);
+    expect(observeProviderWebhook).toHaveBeenCalledWith(
+      "slack",
+      "rejected",
+      "invalid_signature",
+    );
   });
 
   it("returns 401 when signature headers are missing", async () => {
     const handler = makeApp();
     const res = await handler(makeRequest(form({ text: "list" }), { signed: false }));
     expect(res.status).toBe(401);
+  });
+
+  it("records a verified request that fails before dispatch", async () => {
+    const res = await makeApp()(
+      makeRequest(form({ command: "/ai-workflow", text: "list", user_id: "U999" })),
+    );
+
+    expect(res.status).toBe(400);
+    expect(observeProviderWebhook).toHaveBeenCalledWith(
+      "slack",
+      "rejected",
+      "handler_failed",
+    );
+    expect(observeProviderWebhook).not.toHaveBeenCalledWith(
+      "slack",
+      "accepted",
+      "request_succeeded",
+    );
   });
 
   it("acks /ai-workflow list within 200 and posts the formatted list to response_url", async () => {
@@ -163,6 +190,11 @@ describe("POST /webhooks/slack", () => {
     const json = await res.json();
     expect(json.response_type).toBe("ephemeral");
     expect(json.text).toContain("Working on");
+    expect(observeProviderWebhook).toHaveBeenCalledWith(
+      "slack",
+      "accepted",
+      "request_succeeded",
+    );
 
     await flushDeferred();
     expect(postedToResponseUrl).toHaveLength(1);

--- a/apps/worker/src/routes/webhooks/slack.post.ts
+++ b/apps/worker/src/routes/webhooks/slack.post.ts
@@ -16,6 +16,7 @@ import {
 } from "../../lib/slack/handlers.js";
 import { postToResponseUrl } from "../../lib/slack/respond.js";
 import { verifySlackSignature } from "../../lib/slack/verify.js";
+import { observeProviderWebhook } from "../../system-health/provider-webhook-observation.js";
 
 /**
  * Slack slash command webhook.
@@ -34,8 +35,27 @@ import { verifySlackSignature } from "../../lib/slack/verify.js";
 export default defineEventHandler(async (event) => {
   const rawBody = (await readRawBody(event, "utf8")) ?? "";
 
-  verifyWebhookAuth(event, rawBody);
+  try {
+    verifyWebhookAuth(event, rawBody);
+  } catch (error) {
+    observeProviderWebhook(
+      "slack",
+      "rejected",
+      env.SLACK_SIGNING_SECRET ? "invalid_signature" : "secret_not_configured",
+    );
+    throw error;
+  }
+  try {
+    const result = await handleVerifiedSlackWebhook(rawBody);
+    observeProviderWebhook("slack", "accepted", "request_succeeded");
+    return result;
+  } catch (error) {
+    observeProviderWebhook("slack", "rejected", "handler_failed");
+    throw error;
+  }
+});
 
+async function handleVerifiedSlackWebhook(rawBody: string) {
   const fields = parseFormBody(rawBody);
   const text = fields.get("text") ?? "";
   const userId = fields.get("user_id") ?? "";
@@ -68,7 +88,7 @@ export default defineEventHandler(async (event) => {
   scheduleHandler(parsed, responseUrl, userId);
 
   return ephemeral(`Working on \`${command} ${text}\`…`);
-});
+}
 
 // ---------------------------------------------------------------------------
 // Auth

--- a/apps/worker/src/system-health/collect.test.ts
+++ b/apps/worker/src/system-health/collect.test.ts
@@ -6,6 +6,7 @@ const baseConfig: SystemHealthConfig = {
   jiraBaseUrl: "https://jira.example",
   jiraApiToken: "jira-secret",
   jiraProjectKey: "TEST",
+  jiraWebhookSecret: "jira-webhook",
   githubAppId: 1,
   githubAppPrivateKey: "private-key",
   githubInstallationId: 2,
@@ -19,87 +20,140 @@ const baseConfig: SystemHealthConfig = {
   mcpEnabled: false,
 };
 
-function clock(...values: number[]) {
-  let index = 0;
-  return () => values[index++] ?? values.at(-1) ?? 0;
-}
-
 describe("collectSystemHealth", () => {
-  it("reports live critical probes and neutral optional integrations", async () => {
+  it("keeps provider capabilities separate and aggregates only their real states", async () => {
     const result = await collectSystemHealth({
       config: baseConfig,
       probes: {
-        database: async () => {},
-        jira: async () => {},
-        github: async () => {},
-        agent: async () => {},
+        "database.connectivity": async () => {},
+        "jira.api": async () => {},
+        "jira.webhook-delivery": async () => ({
+          mode: "unverified",
+          message: "No recent delivery.",
+        }),
+        "github.app-installation": async () => {},
+        "github.repositories": async () => ({ coverage: { checked: 1, total: 2 } }),
+        "github.webhook-delivery": async () => ({
+          mode: "live",
+          observedAt: "2026-08-20T11:59:00.000Z",
+          evidenceSource: "provider-delivery",
+        }),
+        "agent.model": async () => {},
       },
       now: () => new Date("2026-08-20T12:00:00.000Z"),
-      monotonicNow: clock(0, 0, 0, 0, 12, 25, 40, 58),
     });
 
-    expect(result.generatedAt).toBe("2026-08-20T12:00:00.000Z");
-    expect(result.summary).toMatchObject({
-      total: 12,
-      live: 4,
-      down: 0,
-      criticalDown: 0,
-    });
-    expect(result.integrations).toEqual(
+    const github = result.integrations.find((entry) => entry.id === "github");
+    expect(github).toMatchObject({ mode: "live" });
+    expect(github?.checks).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: "database", mode: "live" }),
-        expect.objectContaining({ id: "github", mode: "live" }),
-        expect.objectContaining({ id: "gitlab", mode: "not-configured" }),
-        expect.objectContaining({ id: "slack", mode: "mock" }),
+        expect.objectContaining({ id: "app-installation", mode: "live" }),
+        expect.objectContaining({
+          id: "repositories",
+          mode: "live",
+          coverage: { checked: 1, total: 2 },
+        }),
+        expect.objectContaining({
+          id: "webhook-delivery",
+          mode: "live",
+          evidenceSource: "provider-delivery",
+        }),
       ]),
     );
-    expect(result.alerts).toEqual([]);
+    expect(result.integrations.find((entry) => entry.id === "jira")).toMatchObject({
+      mode: "unverified",
+    });
+    expect(result.summary.checksUnverified).toBeGreaterThan(0);
   });
 
-  it("turns failed probes and partial optional configuration into actionable alerts", async () => {
+  it("makes a broken required webhook visible on the provider and its alert", async () => {
+    const result = await collectSystemHealth({
+      config: baseConfig,
+      probes: {
+        "database.connectivity": async () => {},
+        "jira.api": async () => {},
+        "jira.webhook-delivery": async () => ({ mode: "live" }),
+        "github.app-installation": async () => {},
+        "github.repositories": async () => {},
+        "github.webhook-delivery": async () => ({
+          mode: "down",
+          message: "Latest delivery failed with HTTP 401.",
+        }),
+        "agent.model": async () => {},
+      },
+    });
+
+    expect(result.integrations.find((entry) => entry.id === "github")).toMatchObject({
+      mode: "down",
+    });
+    expect(result.alerts).toContainEqual(
+      expect.objectContaining({
+        severity: "critical",
+        integrationId: "github",
+        checkId: "webhook-delivery",
+        message: expect.stringContaining("HTTP 401"),
+      }),
+    );
+  });
+
+  it("uses degraded for an optional failure without hiding healthy required checks", async () => {
     const result = await collectSystemHealth({
       config: {
         ...baseConfig,
-        slackToken: "slack-secret",
-        ssoIssuer: "https://sso.example",
+        resendApiKey: "resend-key",
+        resendFromEmail: "System <system@example.com>",
+        resendWebhookSecret: "resend-webhook",
       },
       probes: {
-        database: async () => {
-          throw new Error("postgres://user:password@secret-host/db");
-        },
-        jira: async () => {},
-        github: async () => {},
-        agent: async () => {},
-      },
-      monotonicNow: clock(0, 0, 0, 0, 5, 10, 15, 20),
-    });
-
-    expect(result.summary).toMatchObject({ down: 1, criticalDown: 1 });
-    expect(result.integrations).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "database",
+        "email.sender": async () => {},
+        "email.webhook-delivery": async () => ({
           mode: "down",
-          ping: expect.objectContaining({ error: "Health check failed." }),
+          message: "Latest webhook signature was rejected.",
         }),
-        expect.objectContaining({ id: "slack", mode: "misconfigured" }),
-        expect.objectContaining({ id: "sso", mode: "misconfigured" }),
-      ]),
-    );
-    expect(JSON.stringify(result)).not.toContain("secret-host");
-    expect(result.alerts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          severity: "critical",
-          integrationId: "database",
-          fixHint: expect.stringContaining("DATABASE_URL"),
-        }),
-        expect.objectContaining({ severity: "warning", integrationId: "slack" }),
-      ]),
+      },
+    });
+    expect(result.integrations.find((entry) => entry.id === "email")).toMatchObject({
+      mode: "degraded",
+    });
+    expect(result.alerts).toContainEqual(
+      expect.objectContaining({
+        severity: "warning",
+        integrationId: "email",
+        checkId: "webhook-delivery",
+      }),
     );
   });
 
-  it("keeps OAuth-backed agents honest as configured when no safe ping exists", async () => {
+  it("surfaces untrusted rejection evidence as a warning, not a hard outage", async () => {
+    const result = await collectSystemHealth({
+      config: baseConfig,
+      probes: {
+        "jira.api": async () => {},
+        "jira.webhook-delivery": async () => ({
+          mode: "degraded",
+          message: "A recent request was rejected.",
+        }),
+      },
+    });
+
+    expect(
+      result.integrations
+        .find((entry) => entry.id === "jira")
+        ?.checks.find((check) => check.id === "webhook-delivery"),
+    ).toMatchObject({ mode: "degraded" });
+    expect(result.integrations.find((entry) => entry.id === "jira")).toMatchObject({
+      mode: "degraded",
+    });
+    expect(result.alerts).toContainEqual(
+      expect.objectContaining({
+        severity: "warning",
+        integrationId: "jira",
+        checkId: "webhook-delivery",
+      }),
+    );
+  });
+
+  it("keeps OAuth-backed agents unverified when no safe provider probe exists", async () => {
     const result = await collectSystemHealth({
       config: {
         ...baseConfig,
@@ -108,111 +162,135 @@ describe("collectSystemHealth", () => {
         codexOauthToken: "oauth-secret",
         codexModel: "gpt-test",
       },
+      probes: {},
+    });
+    expect(result.integrations.find((entry) => entry.id === "agent")).toMatchObject({
+      mode: "unverified",
+      checks: [expect.objectContaining({ id: "model", mode: "unverified" })],
+    });
+  });
+
+  it("does not treat the default GitLab host as an enabled integration", async () => {
+    const result = await collectSystemHealth({
+      config: {
+        ...baseConfig,
+        gitlabHost: "https://gitlab.com",
+      },
+      probes: {},
+    });
+    expect(result.integrations.find((entry) => entry.id === "gitlab")).toMatchObject({
+      mode: "not-configured",
+    });
+  });
+
+  it("reports orphaned webhook secrets without provider credentials", async () => {
+    const result = await collectSystemHealth({
+      config: {
+        ...baseConfig,
+        githubAppId: undefined,
+        githubAppPrivateKey: undefined,
+        githubInstallationId: undefined,
+        githubWebhookSecret: "orphaned-secret",
+      },
+      probes: {},
+    });
+    expect(result.integrations.find((entry) => entry.id === "github")).toMatchObject({
+      mode: "misconfigured",
+    });
+  });
+
+  it("does not let an inbound-only webhook make Email or Slack look live", async () => {
+    const result = await collectSystemHealth({
+      config: {
+        ...baseConfig,
+        resendWebhookSecret: "orphaned-resend-secret",
+        slackSigningSecret: "orphaned-slack-secret",
+      },
       probes: {
-        database: async () => {},
-        jira: async () => {},
-        github: async () => {},
+        "email.webhook-delivery": async () => ({ mode: "live" }),
+        "slack.webhook-delivery": async () => ({ mode: "live" }),
       },
     });
 
-    expect(result.integrations).toContainEqual(
-      expect.objectContaining({
-        id: "agent",
-        label: "Codex agent",
-        mode: "configured",
-        ping: null,
-      }),
-    );
-  });
-
-  it("classifies every empty and partial configuration without claiming connectivity", async () => {
-    const empty = await collectSystemHealth({
-      config: { agentKind: "claude", mcpEnabled: false },
-      probes: {},
-    });
-    const modes = Object.fromEntries(
-      empty.integrations.map((integration) => [integration.id, integration.mode]),
-    );
-    expect(modes).toEqual({
-      database: "misconfigured",
-      jira: "misconfigured",
-      github: "not-configured",
-      gitlab: "not-configured",
-      agent: "misconfigured",
-      "dashboard-auth": "misconfigured",
-      sso: "not-configured",
-      email: "not-configured",
-      slack: "mock",
-      arthur: "not-configured",
-      mcp: "not-configured",
-      vercel: "not-configured",
-    });
-
-    const partialCases: Array<[string, Partial<SystemHealthConfig>, string]> = [
-      ["jira", { jiraBaseUrl: "https://jira.example", jiraApiToken: "token" }, "misconfigured"],
-      ["github", { githubAppId: 1, githubAppPrivateKey: "key", githubInstallationId: 2 }, "misconfigured"],
-      ["gitlab", { gitlabToken: "token" }, "misconfigured"],
-      ["dashboard-auth", { betterAuthSecret: "secret" }, "misconfigured"],
-      ["sso", { ssoIssuer: "https://sso.example" }, "misconfigured"],
-      ["email", { resendApiKey: "key" }, "misconfigured"],
-      ["email", { resendWebhookSecret: "webhook" }, "misconfigured"],
-      ["slack", { slackToken: "token" }, "misconfigured"],
-      ["arthur", { arthurApiKey: "key" }, "misconfigured"],
-      ["vercel", { vercelToken: "token", vercelTeamId: "team" }, "misconfigured"],
-    ];
-
-    for (const [id, patch, expected] of partialCases) {
-      const result = await collectSystemHealth({
-        config: { agentKind: "claude", mcpEnabled: false, ...patch },
-        probes: {},
-      });
-      expect(result.integrations.find((entry) => entry.id === id)?.mode, id).toBe(expected);
+    for (const integrationId of ["email", "slack"]) {
+      expect(
+        result.integrations.find((entry) => entry.id === integrationId),
+      ).toMatchObject({ mode: "misconfigured" });
+      expect(result.alerts).toContainEqual(
+        expect.objectContaining({
+          severity: "warning",
+          integrationId,
+        }),
+      );
     }
   });
 
-  it("exposes the exact variable names used to determine each integration", async () => {
-    const result = await collectSystemHealth({ config: baseConfig, probes: {} });
-    expect(Object.fromEntries(
-      result.integrations.map((integration) => [integration.id, integration.envVars]),
-    )).toEqual({
-      database: ["DATABASE_URL"],
-      jira: ["JIRA_BASE_URL", "JIRA_API_TOKEN", "JIRA_PROJECT_KEY"],
-      github: ["GITHUB_APP_ID", "GITHUB_APP_PRIVATE_KEY", "GITHUB_INSTALLATION_ID", "GITHUB_WEBHOOK_SECRET"],
-      gitlab: ["GITLAB_TOKEN", "GITLAB_HOST", "GITLAB_WEBHOOK_SECRET"],
-      agent: ["AGENT_KIND", "ANTHROPIC_API_KEY", "CLAUDE_MODEL"],
-      "dashboard-auth": ["BETTER_AUTH_SECRET", "BETTER_AUTH_URL", "DASHBOARD_ORIGIN"],
-      sso: ["SSO_ISSUER", "SSO_ALLOWED_DOMAIN", "SSO_CLIENT_ID", "SSO_CLIENT_SECRET"],
-      email: ["RESEND_API_KEY", "RESEND_FROM_EMAIL", "RESEND_WEBHOOK_SECRET"],
-      slack: ["CHAT_SDK_SLACK_TOKEN", "CHAT_SDK_CHANNEL_ID"],
-      arthur: ["GENAI_ENGINE_API_KEY", "GENAI_ENGINE_TRACE_ENDPOINT"],
-      mcp: ["MCP_ENABLED"],
-      vercel: ["VERCEL_ENV", "VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"],
+  it("still probes independent Slack auth and SSO discovery with partial setup", async () => {
+    const slackAuth = vi.fn(async () => {});
+    const ssoDiscovery = vi.fn(async () => {});
+    const result = await collectSystemHealth({
+      config: {
+        ...baseConfig,
+        slackToken: "slack-token",
+        ssoIssuer: "https://sso.example",
+      },
+      probes: {
+        "slack.bot-auth": slackAuth,
+        "sso.discovery": ssoDiscovery,
+      },
     });
+
+    expect(slackAuth).toHaveBeenCalledOnce();
+    expect(ssoDiscovery).toHaveBeenCalledOnce();
+    expect(
+      result.integrations
+        .find((entry) => entry.id === "slack")
+        ?.checks.find((check) => check.id === "bot-auth"),
+    ).toMatchObject({ mode: "live" });
+    expect(
+      result.integrations
+        .find((entry) => entry.id === "sso")
+        ?.checks.find((check) => check.id === "discovery"),
+    ).toMatchObject({ mode: "live" });
   });
 
-  it("aborts a probe at the bounded timeout", async () => {
+  it("exposes every capability variable name without values", async () => {
+    const result = await collectSystemHealth({ config: baseConfig, probes: {} });
+    expect(result.integrations.find((entry) => entry.id === "jira")?.envVars).toEqual([
+      "JIRA_BASE_URL",
+      "JIRA_API_TOKEN",
+      "JIRA_PROJECT_KEY",
+      "JIRA_WEBHOOK_SECRET",
+    ]);
+    expect(result.integrations.find((entry) => entry.id === "slack")?.envVars).toEqual([
+      "CHAT_SDK_SLACK_TOKEN",
+      "CHAT_SDK_CHANNEL_ID",
+      "SLACK_SIGNING_SECRET",
+      "SLACK_ALLOWED_USER_IDS",
+    ]);
+    expect(JSON.stringify(result)).not.toContain("jira-secret");
+  });
+
+  it("aborts only the timed-out capability and marks it down", async () => {
     vi.useFakeTimers();
     let signal: AbortSignal | undefined;
     const pending = collectSystemHealth({
-      config: { ...baseConfig },
+      config: baseConfig,
       probes: {
-        database: async (probeSignal) => {
+        "database.connectivity": async (probeSignal) => {
           signal = probeSignal;
           await new Promise(() => {});
         },
       },
     });
-
-    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(4_000);
     const result = await pending;
     expect(signal?.aborted).toBe(true);
-    expect(result.integrations).toContainEqual(
-      expect.objectContaining({
-        id: "database",
-        mode: "down",
-        ping: expect.objectContaining({ error: "Health check timed out." }),
-      }),
-    );
+    expect(
+      result.integrations
+        .find((entry) => entry.id === "database")
+        ?.checks.find((check) => check.id === "connectivity"),
+    ).toMatchObject({ mode: "down", message: "Health check timed out." });
   });
 });
 

--- a/apps/worker/src/system-health/collect.ts
+++ b/apps/worker/src/system-health/collect.ts
@@ -1,5 +1,8 @@
 import type {
   SystemHealthAlert,
+  SystemHealthCheck,
+  SystemHealthEvidenceSource,
+  SystemHealthGroup,
   SystemHealthIntegration,
   SystemHealthMode,
   SystemHealthResponse,
@@ -10,6 +13,7 @@ export type SystemHealthConfig = {
   jiraBaseUrl?: string;
   jiraApiToken?: string;
   jiraProjectKey?: string;
+  jiraWebhookSecret?: string;
   githubAppId?: number;
   githubAppPrivateKey?: string;
   githubInstallationId?: number;
@@ -17,6 +21,7 @@ export type SystemHealthConfig = {
   gitlabToken?: string;
   gitlabHost?: string;
   gitlabWebhookSecret?: string;
+  gitlabProjectId?: string;
   agentKind: "claude" | "codex";
   anthropicApiKey?: string;
   anthropicModel?: string;
@@ -35,33 +40,48 @@ export type SystemHealthConfig = {
   resendWebhookSecret?: string;
   slackToken?: string;
   slackChannelId?: string;
+  slackSigningSecret?: string;
+  slackAllowedUserIds?: string;
   arthurApiKey?: string;
   arthurTraceEndpoint?: string;
   mcpEnabled: boolean;
+  webhookTriggerEncryptionKey?: string;
   vercelEnv?: string;
   vercelToken?: string;
   vercelTeamId?: string;
   vercelProjectId?: string;
 };
 
-export type SystemHealthProbeId =
-  | "database"
-  | "jira"
-  | "github"
-  | "gitlab"
-  | "agent"
-  | "sso"
-  | "email"
-  | "slack"
-  | "arthur"
-  | "mcp"
-  | "vercel";
+export type SystemHealthProbeResult = {
+  mode?: Extract<SystemHealthMode, "live" | "down" | "degraded" | "unverified">;
+  message?: string;
+  evidenceSource?: SystemHealthEvidenceSource;
+  observedAt?: string;
+  coverage?: { checked: number; total: number };
+};
 
-export type SystemHealthProbes = Partial<
-  Record<SystemHealthProbeId, (signal: AbortSignal) => Promise<void>>
+export type SystemHealthProbe = (
+  signal: AbortSignal,
+) => Promise<SystemHealthProbeResult | void>;
+
+/** Keys are `${integrationId}.${checkId}` so capabilities can be tested and
+ * timed independently without flattening a provider back into one probe. */
+export type SystemHealthProbes = Partial<Record<string, SystemHealthProbe>>;
+
+const PROBE_TIMEOUT_MS = 4_000;
+
+type CheckBase = Omit<
+  SystemHealthCheck,
+  "checkedAt" | "observedAt" | "latencyMs" | "coverage"
 >;
 
-const PROBE_TIMEOUT_MS = 5_000;
+type IntegrationDefinition = {
+  id: string;
+  label: string;
+  group: SystemHealthGroup;
+  critical: boolean;
+  checks: CheckBase[];
+};
 
 export async function collectSystemHealth(input: {
   config: SystemHealthConfig;
@@ -71,257 +91,57 @@ export async function collectSystemHealth(input: {
 }): Promise<SystemHealthResponse> {
   const now = input.now ?? (() => new Date());
   const monotonicNow = input.monotonicNow ?? (() => performance.now());
-  const { config, probes } = input;
+  const generatedAt = now().toISOString();
+  const definitions = healthDefinitions(input.config);
 
-  const githubMode = groupedMode([
-    config.githubAppId,
-    config.githubAppPrivateKey,
-    config.githubInstallationId,
-    config.githubWebhookSecret,
-  ]);
-  const gitlabMode = groupedMode([
-    config.gitlabToken,
-    config.gitlabWebhookSecret,
-  ]);
-  const jiraMode: SystemHealthMode =
-    config.jiraBaseUrl && config.jiraApiToken && config.jiraProjectKey
-      ? "configured"
-      : "misconfigured";
-  const ssoMode = groupedMode([
-    config.ssoIssuer,
-    config.ssoAllowedDomain,
-    config.ssoClientId,
-    config.ssoClientSecret,
-  ]);
-  const emailBaseMode = groupedMode([config.resendApiKey, config.resendFromEmail]);
-  const emailMode: SystemHealthMode =
-    config.resendWebhookSecret && emailBaseMode !== "configured"
-      ? "misconfigured"
-      : emailBaseMode;
-  const slackMode = groupedMode([config.slackToken, config.slackChannelId], "mock");
-  const arthurMode = groupedMode([
-    config.arthurApiKey,
-    config.arthurTraceEndpoint,
-  ]);
-  const authMode = groupedMode([
-    config.betterAuthSecret,
-    config.betterAuthUrl,
-    config.dashboardOrigin,
-  ], "misconfigured");
-  const vercelCredentials = groupedMode([
-    config.vercelToken,
-    config.vercelTeamId,
-    config.vercelProjectId,
-  ]);
-  const vercelMode: SystemHealthMode = config.vercelEnv
-    ? "configured"
-    : vercelCredentials;
-  const agentConfigured =
-    config.agentKind === "claude"
-      ? Boolean(config.anthropicApiKey && config.anthropicModel)
-      : Boolean((config.codexApiKey || config.codexOauthToken) && config.codexModel);
+  const integrations = await Promise.all(
+    definitions.map(async (definition): Promise<SystemHealthIntegration> => {
+      const checks = await Promise.all(
+        definition.checks.map((check) =>
+          probedCheck(
+            check,
+            input.probes[`${definition.id}.${check.id}`],
+            monotonicNow,
+            generatedAt,
+          ),
+        ),
+      );
+      const mode = integrationMode(checks);
+      const pingCheck = checks.find(
+        (check) =>
+          check.latencyMs !== undefined &&
+          (check.mode === "live" || check.mode === "down"),
+      );
+      return {
+        id: definition.id,
+        label: definition.label,
+        group: definition.group,
+        critical: definition.critical,
+        envVars: [...new Set(checks.flatMap((check) => check.envVars))],
+        mode,
+        configError: checks
+          .filter((check) => check.mode === "misconfigured")
+          .map((check) => check.message)
+          .filter((message): message is string => Boolean(message))
+          .join(" ") || undefined,
+        ping: pingCheck
+          ? {
+              ok: pingCheck.mode === "live",
+              latencyMs: pingCheck.latencyMs ?? 0,
+              ...(pingCheck.mode === "down" && pingCheck.message
+                ? { error: pingCheck.message }
+                : {}),
+            }
+          : null,
+        checks,
+      };
+    }),
+  );
 
-  const integrations = await Promise.all([
-    probedIntegration(
-      {
-        id: "database",
-        label: "Database",
-        group: "core",
-        envVars: ["DATABASE_URL"],
-        critical: true,
-        mode: config.databaseUrl ? "configured" : "misconfigured",
-        configError: config.databaseUrl ? undefined : "DATABASE_URL is missing.",
-      },
-      probes.database,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "jira",
-        label: "Jira",
-        group: "core",
-        envVars: ["JIRA_BASE_URL", "JIRA_API_TOKEN", "JIRA_PROJECT_KEY"],
-        critical: true,
-        mode: jiraMode,
-        configError:
-          jiraMode === "configured"
-            ? undefined
-            : "Jira URL, API token, and project key are required.",
-      },
-      probes.jira,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "github",
-        label: "GitHub",
-        group: "core",
-        envVars: [
-          "GITHUB_APP_ID",
-          "GITHUB_APP_PRIVATE_KEY",
-          "GITHUB_INSTALLATION_ID",
-          "GITHUB_WEBHOOK_SECRET",
-        ],
-        critical: true,
-        mode: githubMode,
-        configError:
-          githubMode === "misconfigured"
-            ? "GitHub App credentials and webhook secret must be configured together."
-            : undefined,
-      },
-      probes.github,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "gitlab",
-        label: "GitLab",
-        group: "core",
-        envVars: ["GITLAB_TOKEN", "GITLAB_HOST", "GITLAB_WEBHOOK_SECRET"],
-        critical: true,
-        mode: gitlabMode,
-        configError:
-          gitlabMode === "misconfigured"
-            ? "GitLab token and webhook secret must be configured together."
-            : undefined,
-      },
-      probes.gitlab,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "agent",
-        label: config.agentKind === "claude" ? "Claude agent" : "Codex agent",
-        group: "core",
-        envVars:
-          config.agentKind === "claude"
-            ? ["AGENT_KIND", "ANTHROPIC_API_KEY", "CLAUDE_MODEL"]
-            : ["AGENT_KIND", "CODEX_API_KEY", "CODEX_CHATGPT_OAUTH_TOKEN", "CODEX_MODEL"],
-        critical: true,
-        mode: agentConfigured ? "configured" : "misconfigured",
-        configError: agentConfigured
-          ? undefined
-          : `Credentials and a model are required for the active ${config.agentKind} agent.`,
-      },
-      probes.agent,
-      monotonicNow,
-    ),
-    Promise.resolve(
-      configuredIntegration({
-        id: "dashboard-auth",
-        label: "Dashboard authentication",
-        group: "auth-email",
-        envVars: ["BETTER_AUTH_SECRET", "BETTER_AUTH_URL", "DASHBOARD_ORIGIN"],
-        critical: true,
-        mode: authMode,
-        configError:
-          authMode === "misconfigured"
-            ? "Dashboard authentication settings are incomplete."
-            : undefined,
-      }),
-    ),
-    probedIntegration(
-      {
-        id: "sso",
-        label: "Single sign-on",
-        group: "auth-email",
-        envVars: [
-          "SSO_ISSUER",
-          "SSO_ALLOWED_DOMAIN",
-          "SSO_CLIENT_ID",
-          "SSO_CLIENT_SECRET",
-        ],
-        critical: false,
-        mode: ssoMode,
-        configError:
-          ssoMode === "misconfigured"
-            ? "SSO requires issuer, domain, client ID, and client secret together."
-            : undefined,
-      },
-      probes.sso,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "email",
-        label: "Email delivery",
-        group: "auth-email",
-        envVars: ["RESEND_API_KEY", "RESEND_FROM_EMAIL", "RESEND_WEBHOOK_SECRET"],
-        critical: false,
-        mode: emailMode,
-        configError:
-          emailMode === "misconfigured"
-            ? "Email delivery requires RESEND_API_KEY and RESEND_FROM_EMAIL together."
-            : undefined,
-      },
-      probes.email,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "slack",
-        label: "Slack notifications",
-        group: "platform",
-        envVars: ["CHAT_SDK_SLACK_TOKEN", "CHAT_SDK_CHANNEL_ID"],
-        critical: false,
-        mode: slackMode,
-        configError:
-          slackMode === "misconfigured"
-            ? "Slack requires a token and channel ID together."
-            : undefined,
-      },
-      probes.slack,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "arthur",
-        label: "Arthur AI Engine",
-        group: "platform",
-        envVars: ["GENAI_ENGINE_API_KEY", "GENAI_ENGINE_TRACE_ENDPOINT"],
-        critical: false,
-        mode: arthurMode,
-        configError:
-          arthurMode === "misconfigured"
-            ? "Arthur requires an API key and trace endpoint together."
-            : undefined,
-      },
-      probes.arthur,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "mcp",
-        label: "Remote MCP",
-        group: "platform",
-        envVars: ["MCP_ENABLED"],
-        critical: false,
-        mode: config.mcpEnabled ? "configured" : "not-configured",
-      },
-      probes.mcp,
-      monotonicNow,
-    ),
-    probedIntegration(
-      {
-        id: "vercel",
-        label: "Vercel deployment",
-        group: "platform",
-        envVars: ["VERCEL_ENV", "VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"],
-        critical: false,
-        mode: vercelMode,
-        configError:
-          vercelMode === "misconfigured"
-            ? "Vercel credentials require token, team ID, and project ID together."
-            : undefined,
-      },
-      probes.vercel,
-      monotonicNow,
-    ),
-  ]);
-
-  const alerts = integrations.flatMap(alertForIntegration);
+  const checks = integrations.flatMap((integration) => integration.checks);
+  const alerts = integrations.flatMap(alertsForIntegration);
   return {
-    generatedAt: now().toISOString(),
+    generatedAt,
     summary: {
       total: integrations.length,
       live: integrations.filter((entry) => entry.mode === "live").length,
@@ -330,31 +150,260 @@ export async function collectSystemHealth(input: {
         (entry) => entry.mode === "not-configured",
       ).length,
       criticalDown: integrations.filter(
-        (entry) => entry.mode === "down" && entry.critical,
+        (entry) =>
+          entry.critical &&
+          (entry.mode === "down" || entry.mode === "misconfigured"),
       ).length,
+      checksTotal: checks.length,
+      checksLive: checks.filter((check) => check.mode === "live").length,
+      checksDown: checks.filter((check) => check.mode === "down").length,
+      checksUnverified: checks.filter((check) => check.mode === "unverified").length,
+      checksDegraded: checks.filter((check) => check.mode === "degraded").length,
     },
     integrations,
     alerts,
   };
 }
 
-type IntegrationBase = Omit<SystemHealthIntegration, "ping">;
+function healthDefinitions(config: SystemHealthConfig): IntegrationDefinition[] {
+  const githubCredentialsMode = groupedMode([
+    config.githubAppId,
+    config.githubAppPrivateKey,
+    config.githubInstallationId,
+  ]);
+  const githubAppMode =
+    githubCredentialsMode === "not-configured" && config.githubWebhookSecret
+      ? "misconfigured"
+      : githubCredentialsMode;
+  const gitlabApiMode: SystemHealthMode = config.gitlabToken
+    ? "configured"
+    : config.gitlabProjectId || config.gitlabWebhookSecret
+      ? "misconfigured"
+      : "not-configured";
+  const jiraApiMode = requiredMode([
+    config.jiraBaseUrl,
+    config.jiraApiToken,
+    config.jiraProjectKey,
+  ]);
+  const authMode = requiredMode([
+    config.betterAuthSecret,
+    config.betterAuthUrl,
+    config.dashboardOrigin,
+  ]);
+  const ssoLoginMode = groupedMode([
+    config.ssoIssuer,
+    config.ssoAllowedDomain,
+    config.ssoClientId,
+    config.ssoClientSecret,
+  ]);
+  const ssoDiscoveryMode: SystemHealthMode = config.ssoIssuer
+    ? "configured"
+    : ssoLoginMode === "not-configured"
+      ? "not-configured"
+      : "misconfigured";
+  const emailCredentialsMode = groupedMode([
+    config.resendApiKey,
+    config.resendFromEmail,
+  ]);
+  const emailMode =
+    config.resendWebhookSecret && emailCredentialsMode === "not-configured"
+      ? "misconfigured"
+      : emailCredentialsMode;
+  const slackHasAnyConfig = Boolean(
+    config.slackToken || config.slackChannelId || config.slackSigningSecret,
+  );
+  const slackBotMode: SystemHealthMode = config.slackToken
+    ? "configured"
+    : slackHasAnyConfig
+      ? "misconfigured"
+      : "mock";
+  const slackChannelMode: SystemHealthMode =
+    config.slackToken && config.slackChannelId
+      ? "configured"
+      : slackHasAnyConfig
+        ? "misconfigured"
+        : "mock";
+  const arthurMode = groupedMode([config.arthurApiKey, config.arthurTraceEndpoint]);
+  const vercelCredentials = groupedMode([
+    config.vercelToken,
+    config.vercelTeamId,
+    config.vercelProjectId,
+  ]);
+  const vercelMode: SystemHealthMode = config.vercelEnv
+    ? "configured"
+    : vercelCredentials;
+  const agentMode: SystemHealthMode =
+    config.agentKind === "claude"
+      ? requiredMode([config.anthropicApiKey, config.anthropicModel])
+      : requiredMode([
+          config.codexApiKey || config.codexOauthToken,
+          config.codexModel,
+        ]);
 
-function configuredIntegration(base: IntegrationBase): SystemHealthIntegration {
-  return { ...base, ping: null };
+  return [
+    integration("database", "Database", "core", true, [
+      configured("configuration", "Configuration", ["DATABASE_URL"], config.databaseUrl),
+      checked("connectivity", "Connection and query", ["DATABASE_URL"], config.databaseUrl ? "configured" : "misconfigured", true),
+    ]),
+    integration("jira", "Jira", "core", true, [
+      checked("api", "Account, project and statuses", ["JIRA_BASE_URL", "JIRA_API_TOKEN", "JIRA_PROJECT_KEY"], jiraApiMode, true),
+      checked("webhook-delivery", "Signed webhook delivery", ["JIRA_WEBHOOK_SECRET"], optionalValueMode(config.jiraWebhookSecret), false, "local-observation"),
+    ]),
+    integration("github", "GitHub", "core", true, [
+      checked("app-installation", "App installation", ["GITHUB_APP_ID", "GITHUB_APP_PRIVATE_KEY", "GITHUB_INSTALLATION_ID"], githubAppMode, true),
+      checked("repositories", "Repository access", ["GITHUB_APP_ID", "GITHUB_APP_PRIVATE_KEY", "GITHUB_INSTALLATION_ID"], githubAppMode, true),
+      checked("webhook-delivery", "App webhook delivery", ["GITHUB_WEBHOOK_SECRET"], dependentOptionalMode(githubAppMode, config.githubWebhookSecret), true, "provider-delivery"),
+    ]),
+    integration("gitlab", "GitLab", "core", true, [
+      checked("api", "API identity", ["GITLAB_TOKEN", "GITLAB_HOST"], gitlabApiMode, true),
+      checked("repositories", "Repository access", ["GITLAB_TOKEN", "GITLAB_HOST", "GITLAB_PROJECT_ID"], gitlabApiMode, true),
+      checked("webhook-delivery", "Project webhook delivery", ["GITLAB_WEBHOOK_SECRET"], dependentOptionalMode(gitlabApiMode, config.gitlabWebhookSecret), true, "provider-delivery"),
+    ]),
+    integration("agent", config.agentKind === "claude" ? "Claude agent" : "Codex agent", "core", true, [
+      checked("model", "Credentials and configured model", config.agentKind === "claude" ? ["AGENT_KIND", "ANTHROPIC_API_KEY", "CLAUDE_MODEL"] : ["AGENT_KIND", "CODEX_API_KEY", "CODEX_CHATGPT_OAUTH_TOKEN", "CODEX_MODEL"], agentMode, true),
+    ]),
+    integration("dashboard-auth", "Dashboard authentication", "auth-email", true, [
+      configured("configuration", "URL, origin and session secret", ["BETTER_AUTH_SECRET", "BETTER_AUTH_URL", "DASHBOARD_ORIGIN"], authMode === "configured", authMode),
+      fixed("session", "Protected session enforcement", "live", true, "This protected request has an authorized admin session."),
+    ]),
+    integration("sso", "Single sign-on", "auth-email", false, [
+      checked("discovery", "OIDC discovery and issuer", ["SSO_ISSUER"], ssoDiscoveryMode, true),
+      checked("login-start", "Authorization redirect", ["SSO_CLIENT_ID", "SSO_CLIENT_SECRET", "SSO_ALLOWED_DOMAIN"], ssoLoginMode, false),
+    ]),
+    integration("email", "Email delivery", "auth-email", false, [
+      checked("sender", "API and sender domain", ["RESEND_API_KEY", "RESEND_FROM_EMAIL"], emailMode, true),
+      checked("webhook-delivery", "Delivery-status webhook", ["RESEND_WEBHOOK_SECRET"], optionalValueMode(config.resendWebhookSecret), false, "provider-delivery"),
+    ]),
+    integration("slack", "Slack", "platform", false, [
+      checked("bot-auth", "Bot authentication", ["CHAT_SDK_SLACK_TOKEN"], slackBotMode, true),
+      checked("channel", "Configured channel access", ["CHAT_SDK_SLACK_TOKEN", "CHAT_SDK_CHANNEL_ID"], slackChannelMode, true),
+      checked("webhook-delivery", "Signed slash command", ["SLACK_SIGNING_SECRET", "SLACK_ALLOWED_USER_IDS"], optionalValueMode(config.slackSigningSecret), false, "local-observation"),
+    ]),
+    integration("arthur", "Arthur AI Engine", "platform", false, [
+      checked("api", "Task API", ["GENAI_ENGINE_API_KEY", "GENAI_ENGINE_TRACE_ENDPOINT"], arthurMode, true),
+      unverified("trace-ingestion", "Trace ingestion", ["GENAI_ENGINE_API_KEY", "GENAI_ENGINE_TRACE_ENDPOINT"], arthurMode, false, "A read-only scan cannot safely create a production trace."),
+    ]),
+    integration("mcp", "Remote MCP", "platform", false, [
+      checked("contract", "Published tool contract", ["MCP_ENABLED"], config.mcpEnabled ? "configured" : "not-configured", true),
+      unverified("authenticated-transport", "Authenticated tool transport", ["MCP_ENABLED", "BETTER_AUTH_URL"], config.mcpEnabled ? "configured" : "not-configured", false, "No operator OAuth token is available to the server-side scan."),
+    ]),
+    integration("vercel", "Vercel deployment", "platform", false, [
+      checked("project", "Project access", ["VERCEL_ENV", "VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"], vercelMode, true),
+      checked("production-deployment", "Production deployment", ["VERCEL_ENV", "VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"], vercelMode, false),
+    ]),
+    integration("custom-webhooks", "Custom webhooks", "platform", false, [
+      checked("aggregate", "Endpoint and delivery aggregate", ["WEBHOOK_TRIGGER_ENCRYPTION_KEY"], config.webhookTriggerEncryptionKey ? "configured" : "not-configured", false, "local-observation"),
+    ]),
+  ];
 }
 
-async function probedIntegration(
-  base: IntegrationBase,
-  probe: ((signal: AbortSignal) => Promise<void>) | undefined,
+function integration(
+  id: string,
+  label: string,
+  group: SystemHealthGroup,
+  critical: boolean,
+  checks: CheckBase[],
+): IntegrationDefinition {
+  return { id, label, group, critical, checks };
+}
+
+function configured(
+  id: string,
+  label: string,
+  envVars: string[],
+  value: unknown,
+  explicitMode?: SystemHealthMode,
+): CheckBase {
+  const mode = explicitMode ?? (value ? "configured" : "misconfigured");
+  return {
+    id,
+    label,
+    description: "Required deployment configuration is present.",
+    critical: true,
+    mode,
+    envVars,
+    evidenceSource: "configuration",
+    ...(mode === "misconfigured"
+      ? { message: `${label} configuration is incomplete.` }
+      : {}),
+  };
+}
+
+function checked(
+  id: string,
+  label: string,
+  envVars: string[],
+  mode: SystemHealthMode,
+  critical: boolean,
+  evidenceSource: SystemHealthEvidenceSource = "live-probe",
+): CheckBase {
+  return {
+    id,
+    label,
+    description: "Verified independently from other provider capabilities.",
+    critical,
+    mode,
+    envVars,
+    evidenceSource,
+    ...(mode === "misconfigured"
+      ? { message: `${label} configuration is incomplete.` }
+      : {}),
+  };
+}
+
+function fixed(
+  id: string,
+  label: string,
+  mode: SystemHealthMode,
+  critical: boolean,
+  message: string,
+): CheckBase {
+  return {
+    id,
+    label,
+    description: "Verified by the current protected request.",
+    critical,
+    mode,
+    envVars: [],
+    evidenceSource: "live-probe",
+    message,
+  };
+}
+
+function unverified(
+  id: string,
+  label: string,
+  envVars: string[],
+  mode: SystemHealthMode,
+  critical: boolean,
+  message: string,
+): CheckBase {
+  const base = checked(id, label, envVars, mode, critical, "configuration");
+  return mode === "configured" ? { ...base, mode: "unverified", message } : base;
+}
+
+async function probedCheck(
+  base: CheckBase,
+  probe: SystemHealthProbe | undefined,
   monotonicNow: () => number,
-): Promise<SystemHealthIntegration> {
-  if (base.mode !== "configured" || !probe) return configuredIntegration(base);
+  checkedAt: string,
+): Promise<SystemHealthCheck> {
+  if (base.mode !== "configured") return base;
+  if (!probe) {
+    return base.evidenceSource === "configuration"
+      ? base
+      : {
+          ...base,
+          mode: "unverified",
+          message: base.message ?? "Configured, but no end-to-end evidence is available.",
+        };
+  }
+
   const startedAt = monotonicNow();
   const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    await Promise.race([
+    const result = await Promise.race([
       probe(controller.signal),
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
@@ -363,30 +412,54 @@ async function probedIntegration(
         }, PROBE_TIMEOUT_MS);
       }),
     ]);
+    const details = result ?? {};
     return {
       ...base,
-      mode: "live",
-      ping: {
-        ok: true,
-        latencyMs: Math.max(0, Math.round(monotonicNow() - startedAt)),
-      },
+      mode: details.mode ?? "live",
+      checkedAt,
+      latencyMs: Math.max(0, Math.round(monotonicNow() - startedAt)),
+      evidenceSource: details.evidenceSource ?? base.evidenceSource,
+      ...(details.message ? { message: details.message } : {}),
+      ...(details.observedAt ? { observedAt: details.observedAt } : {}),
+      ...(details.coverage ? { coverage: details.coverage } : {}),
     };
   } catch (error) {
     return {
       ...base,
       mode: "down",
-      ping: {
-        ok: false,
-        latencyMs: Math.max(0, Math.round(monotonicNow() - startedAt)),
-        error:
-          error instanceof PublicHealthProbeError
-            ? error.message
-            : "Health check failed.",
-      },
+      checkedAt,
+      latencyMs: Math.max(0, Math.round(monotonicNow() - startedAt)),
+      message:
+        error instanceof PublicHealthProbeError
+          ? error.message
+          : "Health check failed.",
     };
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+function integrationMode(checks: SystemHealthCheck[]): SystemHealthMode {
+  if (checks.some((check) => check.critical && check.mode === "down")) return "down";
+  if (checks.some((check) => check.critical && check.mode === "misconfigured")) {
+    return "misconfigured";
+  }
+  if (
+    checks.some(
+      (check) =>
+        !check.critical &&
+        (check.mode === "down" || check.mode === "misconfigured"),
+    )
+  ) {
+    return "degraded";
+  }
+  if (checks.some((check) => check.mode === "degraded")) return "degraded";
+  if (checks.some((check) => check.mode === "unverified")) return "unverified";
+  if (checks.some((check) => check.mode === "live")) return "live";
+  if (checks.every((check) => check.mode === "not-configured")) return "not-configured";
+  if (checks.every((check) => check.mode === "mock")) return "mock";
+  if (checks.some((check) => check.mode === "configured")) return "configured";
+  return checks[0]?.mode ?? "not-configured";
 }
 
 function groupedMode(
@@ -394,30 +467,54 @@ function groupedMode(
   emptyMode: Extract<SystemHealthMode, "not-configured" | "misconfigured" | "mock"> =
     "not-configured",
 ): SystemHealthMode {
-  const configured = values.filter(Boolean).length;
-  if (configured === 0) return emptyMode;
-  return configured === values.length ? "configured" : "misconfigured";
+  const count = values.filter(Boolean).length;
+  if (count === 0) return emptyMode;
+  return count === values.length ? "configured" : "misconfigured";
 }
 
-function alertForIntegration(
+function requiredMode(values: unknown[]): SystemHealthMode {
+  return values.every(Boolean) ? "configured" : "misconfigured";
+}
+
+function optionalValueMode(value: unknown): SystemHealthMode {
+  return value ? "configured" : "not-configured";
+}
+
+function dependentOptionalMode(
+  parentMode: SystemHealthMode,
+  value: unknown,
+): SystemHealthMode {
+  if (parentMode === "not-configured") return "not-configured";
+  if (parentMode === "misconfigured") return "misconfigured";
+  return value ? "configured" : "misconfigured";
+}
+
+function alertsForIntegration(
   integration: SystemHealthIntegration,
 ): SystemHealthAlert[] {
-  if (integration.mode !== "down" && integration.mode !== "misconfigured") {
-    return [];
-  }
-  const severity = integration.critical ? "critical" : "warning";
-  const detail =
-    integration.mode === "down"
-      ? integration.ping?.error ?? "Health check failed."
-      : integration.configError ?? "Configuration is incomplete.";
-  return [
-    {
-      severity,
-      integrationId: integration.id,
-      message: `${integration.label}: ${detail}`,
-      fixHint: `Check ${integration.envVars.join(", ")} and the provider setup.`,
-    },
-  ];
+  return integration.checks.flatMap((check) => {
+    if (
+      check.mode !== "down" &&
+      check.mode !== "degraded" &&
+      check.mode !== "misconfigured"
+    ) {
+      return [];
+    }
+    return [
+      {
+        severity:
+          check.mode !== "degraded" && integration.critical && check.critical
+            ? "critical" as const
+            : "warning" as const,
+        integrationId: integration.id,
+        checkId: check.id,
+        message: `${integration.label} / ${check.label}: ${check.message ?? "Health check failed."}`,
+        fixHint: check.envVars.length > 0
+          ? `Check ${check.envVars.join(", ")} and this provider capability.`
+          : "Check this provider capability.",
+      },
+    ];
+  });
 }
 
 export class PublicHealthProbeError extends Error {}

--- a/apps/worker/src/system-health/observations.test.ts
+++ b/apps/worker/src/system-health/observations.test.ts
@@ -1,0 +1,94 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Db } from "../db/client.js";
+import { createTestDb } from "../db/test-db.js";
+import {
+  getLatestSystemHealthObservations,
+  recordSystemHealthObservation,
+  sweepSystemHealthObservations,
+  systemHealthObservationScope,
+} from "./observations.js";
+
+let db: Db;
+
+beforeAll(async () => {
+  db = await createTestDb();
+}, 60_000);
+
+describe("system health observations", () => {
+  it("binds evidence to a one-way fingerprint of the configured secret", () => {
+    const scope = systemHealthObservationScope("rotated-secret");
+    expect(scope).toMatch(/^deployment:[a-f0-9]{64}$/);
+    expect(scope).not.toContain("rotated-secret");
+    expect(systemHealthObservationScope("other-secret")).not.toBe(scope);
+  });
+
+  it("only returns evidence for the requested configuration scope", async () => {
+    await recordSystemHealthObservation(db, {
+      integrationId: "scoped-provider",
+      checkId: "webhook-delivery",
+      scope: systemHealthObservationScope("old-secret"),
+      outcome: "accepted",
+      reason: "request_succeeded",
+    });
+
+    expect(
+      await getLatestSystemHealthObservations(
+        db,
+        "scoped-provider",
+        "webhook-delivery",
+        systemHealthObservationScope("new-secret"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("bounds writes by provider, outcome, reason, and UTC day", async () => {
+    const first = new Date("2026-08-20T01:00:00.000Z");
+    const second = new Date("2026-08-20T23:00:00.000Z");
+    await recordSystemHealthObservation(db, {
+      integrationId: "test-provider",
+      checkId: "webhook-delivery",
+      outcome: "accepted",
+      reason: "signature_valid",
+    }, first);
+    await recordSystemHealthObservation(db, {
+      integrationId: "test-provider",
+      checkId: "webhook-delivery",
+      outcome: "accepted",
+      reason: "signature_valid",
+    }, second);
+
+    expect(
+      await getLatestSystemHealthObservations(
+        db,
+        "test-provider",
+        "webhook-delivery",
+      ),
+    ).toEqual([
+      {
+        outcome: "accepted",
+        reason: "signature_valid",
+        count: 2,
+        observedAt: second,
+      },
+    ]);
+  });
+
+  it("sweeps observations older than the 30-day retention window", async () => {
+    await recordSystemHealthObservation(db, {
+      integrationId: "expired-provider",
+      checkId: "webhook-delivery",
+      outcome: "rejected",
+      reason: "invalid_signature",
+    }, new Date("2026-07-01T12:00:00.000Z"));
+
+    await sweepSystemHealthObservations(db, new Date("2026-08-21T12:00:00.000Z"));
+
+    expect(
+      await getLatestSystemHealthObservations(
+        db,
+        "expired-provider",
+        "webhook-delivery",
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/worker/src/system-health/observations.ts
+++ b/apps/worker/src/system-health/observations.ts
@@ -1,0 +1,108 @@
+import { createHash } from "node:crypto";
+import { and, desc, eq, lt, sql } from "drizzle-orm";
+import type { Db } from "../db/client.js";
+import { systemHealthObservationCounters } from "../db/schema.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RETENTION_DAYS = 30;
+
+export type SystemHealthObservationOutcome = "accepted" | "rejected";
+
+export type SystemHealthObservation = {
+  outcome: SystemHealthObservationOutcome;
+  reason: string;
+  count: number;
+  observedAt: Date;
+};
+
+export function systemHealthObservationWindowStart(now: Date = new Date()): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+export function systemHealthObservationScope(secret: string | undefined): string {
+  if (!secret) return "deployment:unconfigured";
+  return `deployment:${createHash("sha256").update(secret).digest("hex")}`;
+}
+
+export async function recordSystemHealthObservation(
+  db: Db,
+  input: {
+    integrationId: string;
+    checkId: string;
+    scope?: string;
+    outcome: SystemHealthObservationOutcome;
+    reason: string;
+  },
+  now: Date = new Date(),
+): Promise<void> {
+  await db
+    .insert(systemHealthObservationCounters)
+    .values({
+      integrationId: input.integrationId,
+      checkId: input.checkId,
+      scope: input.scope ?? "deployment",
+      windowStart: systemHealthObservationWindowStart(now),
+      outcome: input.outcome,
+      reason: input.reason,
+      count: 1,
+      lastObservedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        systemHealthObservationCounters.integrationId,
+        systemHealthObservationCounters.checkId,
+        systemHealthObservationCounters.scope,
+        systemHealthObservationCounters.windowStart,
+        systemHealthObservationCounters.outcome,
+        systemHealthObservationCounters.reason,
+      ],
+      set: {
+        count: sql`${systemHealthObservationCounters.count} + 1`,
+        lastObservedAt: now,
+      },
+    });
+}
+
+export async function getLatestSystemHealthObservations(
+  db: Db,
+  integrationId: string,
+  checkId: string,
+  scope?: string,
+): Promise<SystemHealthObservation[]> {
+  const rows = await db
+    .select({
+      outcome: systemHealthObservationCounters.outcome,
+      reason: systemHealthObservationCounters.reason,
+      count: systemHealthObservationCounters.count,
+      observedAt: systemHealthObservationCounters.lastObservedAt,
+    })
+    .from(systemHealthObservationCounters)
+    .where(
+      and(
+        eq(systemHealthObservationCounters.integrationId, integrationId),
+        eq(systemHealthObservationCounters.checkId, checkId),
+        ...(scope ? [eq(systemHealthObservationCounters.scope, scope)] : []),
+      ),
+    )
+    .orderBy(desc(systemHealthObservationCounters.lastObservedAt));
+  return rows.filter(
+    (row): row is SystemHealthObservation =>
+      row.outcome === "accepted" || row.outcome === "rejected",
+  );
+}
+
+export async function sweepSystemHealthObservations(
+  db: Db,
+  now: Date = new Date(),
+): Promise<void> {
+  await db
+    .delete(systemHealthObservationCounters)
+    .where(
+      lt(
+        systemHealthObservationCounters.windowStart,
+        new Date(
+          systemHealthObservationWindowStart(now).getTime() - RETENTION_DAYS * DAY_MS,
+        ),
+      ),
+    );
+}

--- a/apps/worker/src/system-health/probes.test.ts
+++ b/apps/worker/src/system-health/probes.test.ts
@@ -6,6 +6,7 @@ const environment = vi.hoisted(() => ({
   JIRA_BASE_URL: "https://jira.example",
   JIRA_API_TOKEN: "jira-token",
   JIRA_PROJECT_KEY: "AIW",
+  JIRA_WEBHOOK_SECRET: "jira-webhook",
   GITHUB_APP_ID: 11,
   GITHUB_APP_PRIVATE_KEY: "github-key",
   GITHUB_INSTALLATION_ID: 22,
@@ -13,6 +14,7 @@ const environment = vi.hoisted(() => ({
   GITLAB_TOKEN: "gitlab-token",
   GITLAB_HOST: "https://gitlab.example",
   GITLAB_WEBHOOK_SECRET: "gitlab-webhook",
+  GITLAB_PROJECT_ID: "group/project",
   AGENT_KIND: "codex" as const,
   ANTHROPIC_API_KEY: "anthropic-key",
   CLAUDE_MODEL: "claude-test",
@@ -31,9 +33,12 @@ const environment = vi.hoisted(() => ({
   RESEND_WEBHOOK_SECRET: "resend-webhook",
   CHAT_SDK_SLACK_TOKEN: "slack-token",
   CHAT_SDK_CHANNEL_ID: "C123",
+  SLACK_SIGNING_SECRET: "slack-signing",
+  SLACK_ALLOWED_USER_IDS: "U1,U2",
   GENAI_ENGINE_API_KEY: "arthur-key",
   GENAI_ENGINE_TRACE_ENDPOINT: "https://arthur.example/api/v1/traces",
   MCP_ENABLED: true,
+  WEBHOOK_TRIGGER_ENCRYPTION_KEY: "a".repeat(64),
   VERCEL_ENV: undefined,
   VERCEL_TOKEN: "vercel-token",
   VERCEL_TEAM_ID: "team-id",
@@ -41,30 +46,52 @@ const environment = vi.hoisted(() => ({
 }));
 
 vi.mock("../../env.js", () => ({ env: environment }));
+const getLatestSystemHealthObservations = vi.hoisted(() =>
+  vi.fn().mockResolvedValue([]),
+);
+vi.mock("../db/client.js", () => ({ getDb: () => ({}) }));
+vi.mock("./observations.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./observations.js")>()),
+  getLatestSystemHealthObservations,
+}));
 vi.mock("../mcp/contract-artifact.js", () => ({
-  MCP_CONTRACT_ARTIFACT: { tools: [{ name: "system.capabilities" }] },
+  MCP_CONTRACT_ARTIFACT: {
+    contractHash: "hash",
+    tools: [{ name: "system.capabilities" }],
+  },
 }));
 const getInstallation = vi.hoisted(() => vi.fn().mockResolvedValue({ data: {} }));
+const listReposAccessibleToInstallation = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ data: { total_count: 3, repositories: [{}] } }),
+);
 vi.mock("../lib/github-auth.js", () => ({
-  buildOctokit: () => ({ apps: { getInstallation } }),
+  buildOctokit: () => ({
+    apps: { getInstallation, listReposAccessibleToInstallation },
+  }),
+}));
+vi.mock("@octokit/auth-app", () => ({
+  createAppAuth: () => async () => ({ token: "app-jwt" }),
 }));
 
 const { configFromEnvironment, probesForEnvironment } = await import("./probes.js");
-
 const fetchMock = vi.fn();
 vi.stubGlobal("fetch", fetchMock);
 
 describe("deployment system-health probes", () => {
   beforeEach(() => {
     fetchMock.mockReset();
+    getInstallation.mockClear();
+    listReposAccessibleToInstallation.mockClear();
+    getLatestSystemHealthObservations.mockReset().mockResolvedValue([]);
   });
 
-  it("maps every health variable from the validated runtime environment", () => {
+  it("maps credentials for every independently checked capability", () => {
     expect(configFromEnvironment()).toEqual({
       databaseUrl: environment.DATABASE_URL,
       jiraBaseUrl: environment.JIRA_BASE_URL,
       jiraApiToken: environment.JIRA_API_TOKEN,
       jiraProjectKey: environment.JIRA_PROJECT_KEY,
+      jiraWebhookSecret: environment.JIRA_WEBHOOK_SECRET,
       githubAppId: environment.GITHUB_APP_ID,
       githubAppPrivateKey: environment.GITHUB_APP_PRIVATE_KEY,
       githubInstallationId: environment.GITHUB_INSTALLATION_ID,
@@ -72,6 +99,7 @@ describe("deployment system-health probes", () => {
       gitlabToken: environment.GITLAB_TOKEN,
       gitlabHost: environment.GITLAB_HOST,
       gitlabWebhookSecret: environment.GITLAB_WEBHOOK_SECRET,
+      gitlabProjectId: environment.GITLAB_PROJECT_ID,
       agentKind: environment.AGENT_KIND,
       anthropicApiKey: environment.ANTHROPIC_API_KEY,
       anthropicModel: environment.CLAUDE_MODEL,
@@ -90,9 +118,12 @@ describe("deployment system-health probes", () => {
       resendWebhookSecret: environment.RESEND_WEBHOOK_SECRET,
       slackToken: environment.CHAT_SDK_SLACK_TOKEN,
       slackChannelId: environment.CHAT_SDK_CHANNEL_ID,
+      slackSigningSecret: environment.SLACK_SIGNING_SECRET,
+      slackAllowedUserIds: environment.SLACK_ALLOWED_USER_IDS,
       arthurApiKey: environment.GENAI_ENGINE_API_KEY,
       arthurTraceEndpoint: environment.GENAI_ENGINE_TRACE_ENDPOINT,
       mcpEnabled: environment.MCP_ENABLED,
+      webhookTriggerEncryptionKey: environment.WEBHOOK_TRIGGER_ENCRYPTION_KEY,
       vercelEnv: environment.VERCEL_ENV,
       vercelToken: environment.VERCEL_TOKEN,
       vercelTeamId: environment.VERCEL_TEAM_ID,
@@ -100,83 +131,358 @@ describe("deployment system-health probes", () => {
     });
   });
 
-  it("uses read-only provider endpoints with bounded abort signals", async () => {
+  it("uses separate read-only endpoints for provider capabilities", async () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (url.includes("openid-configuration")) {
-        return new Response(JSON.stringify({ issuer: environment.SSO_ISSUER }));
+        return new Response(JSON.stringify({
+          issuer: environment.SSO_ISSUER,
+          authorization_endpoint: `${environment.SSO_ISSUER}/authorize`,
+        }));
       }
-      if (url.includes("slack.com")) {
-        return new Response(JSON.stringify({ ok: true }));
+      if (url.includes("api.resend.com/domains")) {
+        return new Response(JSON.stringify({
+          data: [{ name: "example.com", status: "verified" }],
+        }));
+      }
+      if (url.includes("slack.com")) return new Response(JSON.stringify({ ok: true }));
+      if (url.includes("/v6/deployments")) {
+        return new Response(JSON.stringify({ deployments: [{ readyState: "READY" }] }));
       }
       return new Response(JSON.stringify({}));
     });
 
-    const config = configFromEnvironment();
-    const probes = probesForEnvironment(config);
-    const controller = new AbortController();
-    for (const id of ["github", "sso", "email", "slack", "arthur", "mcp", "vercel", "agent"] as const) {
-      await expect(probes[id]?.(controller.signal), id).resolves.toBeUndefined();
+    const probes = probesForEnvironment(configFromEnvironment());
+    const signal = new AbortController().signal;
+    for (const id of [
+      "github.app-installation",
+      "github.repositories",
+      "sso.discovery",
+      "email.sender",
+      "slack.bot-auth",
+      "slack.channel",
+      "arthur.api",
+      "mcp.contract",
+      "vercel.project",
+      "vercel.production-deployment",
+      "agent.model",
+    ]) {
+      expect(probes[id], id).toBeTypeOf("function");
+      await expect(probes[id]!(signal), id).resolves.not.toBeInstanceOf(Error);
     }
-    expect(getInstallation).toHaveBeenCalledWith({
-      installation_id: environment.GITHUB_INSTALLATION_ID,
-      request: { signal: controller.signal },
-    });
-
-    const calls = fetchMock.mock.calls.map(([url, init]) => ({
-      url: String(url),
-      authorization: (init?.headers as Record<string, string> | undefined)?.Authorization,
-      method: init?.method ?? "GET",
-      signal: init?.signal,
-    }));
-    expect(calls).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        url: "https://sso.example/.well-known/openid-configuration",
-        signal: controller.signal,
-      }),
-      expect.objectContaining({
-        url: "https://api.resend.com/domains",
-        authorization: "Bearer resend-key",
-      }),
-      expect.objectContaining({
-        url: "https://slack.com/api/auth.test",
-        authorization: "Bearer slack-token",
-        method: "POST",
-      }),
-      expect.objectContaining({
-        url: "https://arthur.example/api/v2/tasks?page_size=1",
-        authorization: "Bearer arthur-key",
-      }),
-      expect.objectContaining({
-        url: "https://api.vercel.com/v9/projects/project%2Fid?teamId=team-id",
-        authorization: "Bearer vercel-token",
-      }),
-      expect.objectContaining({
-        url: "https://api.openai.com/v1/models/gpt-test",
-        authorization: "Bearer openai-key",
-      }),
-    ]));
+    expect(getInstallation).toHaveBeenCalledOnce();
+    expect(listReposAccessibleToInstallation).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual(
+      expect.arrayContaining([
+        "https://sso.example/.well-known/openid-configuration",
+        "https://api.resend.com/domains",
+        "https://slack.com/api/auth.test",
+        "https://slack.com/api/conversations.info",
+      ]),
+    );
   });
 
-  it("does not create probes for presence-only credential modes", () => {
+  it("keeps OAuth-only agent modes unverified by omitting a fake probe", () => {
     const config: SystemHealthConfig = {
       agentKind: "codex",
       codexOauthToken: "oauth-token",
       codexModel: "gpt-test",
       mcpEnabled: false,
-      vercelEnv: "production",
     };
-    const probes = probesForEnvironment(config);
-    expect(probes.agent).toBeUndefined();
-    expect(probes.vercel).toBeUndefined();
-    expect(probes.mcp).toBeUndefined();
+    expect(probesForEnvironment(config)["agent.model"]).toBeUndefined();
   });
 
-  it("accepts a valid send-only Resend key without requiring full account access", async () => {
-    fetchMock.mockResolvedValueOnce(new Response(
-      JSON.stringify({ name: "restricted_api_key" }),
-      { status: 401, headers: { "Content-Type": "application/json" } },
-    ));
-    const probe = probesForEnvironment(configFromEnvironment()).email;
-    await expect(probe?.(new AbortController().signal)).resolves.toBeUndefined();
+  it("reports a GitHub App that omits handled webhook events", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("/app")) {
+        return Response.json({ events: ["pull_request"] });
+      }
+      if (url.includes("/hook/config")) {
+        return Response.json({
+          url: "https://worker.example/webhooks/github",
+          insecure_ssl: "0",
+        });
+      }
+      if (url.includes("/hook/deliveries")) return Response.json([]);
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    await expect(
+      probesForEnvironment(configFromEnvironment())["github.webhook-delivery"]?.(
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(/missing required webhook events/);
+  });
+
+  it("does not reuse a successful GitHub delivery from an old webhook secret", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("/app")) {
+        return Response.json({
+          events: [
+            "check_run",
+            "issue_comment",
+            "pull_request",
+            "pull_request_review",
+            "pull_request_review_comment",
+          ],
+        });
+      }
+      if (url.includes("/hook/config")) {
+        return Response.json({
+          url: "https://worker.example/webhooks/github",
+          insecure_ssl: "0",
+        });
+      }
+      if (url.includes("/hook/deliveries")) {
+        return Response.json([
+          { delivered_at: new Date().toISOString(), status_code: 200 },
+        ]);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    const result = await probesForEnvironment(configFromEnvironment())[
+      "github.webhook-delivery"
+    ]?.(new AbortController().signal);
+
+    expect(result).toMatchObject({
+      mode: "unverified",
+      message: expect.stringContaining("current webhook secret"),
+    });
+    expect(getLatestSystemHealthObservations).toHaveBeenCalledWith(
+      expect.anything(),
+      "github",
+      "webhook-delivery",
+      expect.stringMatching(/^deployment:[a-f0-9]{64}$/),
+    );
+  });
+
+  it("accepts GitHub delivery evidence tied to the current webhook secret", async () => {
+    getLatestSystemHealthObservations.mockResolvedValueOnce([
+      {
+        outcome: "accepted",
+        reason: "request_succeeded",
+        count: 1,
+        observedAt: new Date(),
+      },
+    ]);
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("/app")) {
+        return Response.json({
+          events: [
+            "check_run",
+            "issue_comment",
+            "pull_request",
+            "pull_request_review",
+            "pull_request_review_comment",
+          ],
+        });
+      }
+      if (url.includes("/hook/config")) {
+        return Response.json({
+          url: "https://worker.example/webhooks/github",
+          insecure_ssl: "0",
+        });
+      }
+      if (url.includes("/hook/deliveries")) {
+        return Response.json([
+          { delivered_at: new Date().toISOString(), status_code: 200 },
+        ]);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    const result = await probesForEnvironment(configFromEnvironment())[
+      "github.webhook-delivery"
+    ]?.(new AbortController().signal);
+
+    expect(result).toMatchObject({ mode: "live" });
+  });
+
+  it("accepts a restricted send-only Resend key as unverified, not down", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ name: "restricted_api_key" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const result = await probesForEnvironment(configFromEnvironment())["email.sender"]?.(
+      new AbortController().signal,
+    );
+    expect(result).toMatchObject({ mode: "unverified" });
+  });
+
+  it("does not mark a malformed Resend domain response as verified", async () => {
+    fetchMock.mockResolvedValueOnce(Response.json({}));
+
+    await expect(
+      probesForEnvironment(configFromEnvironment())["email.sender"]?.(
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(/sender-domain verification data/);
+  });
+
+  it("reports a Resend webhook that omits handled delivery events", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({
+        data: [
+          {
+            endpoint: "https://worker.example/webhooks/resend",
+            status: "enabled",
+            events: ["email.delivered"],
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      probesForEnvironment(configFromEnvironment())["email.webhook-delivery"]?.(
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(/missing required events/);
+  });
+
+  it("bounds active GitLab webhook inspection to four concurrent projects", async () => {
+    let activeHookLists = 0;
+    let maxActiveHookLists = 0;
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes("/projects?")) {
+        return new Response(
+          JSON.stringify(
+            Array.from({ length: 5 }, (_, index) => ({
+              id: index + 1,
+              path_with_namespace: `group/project-${index + 1}`,
+            })),
+          ),
+          { headers: { "x-total": "5" } },
+        );
+      }
+      if (/\/projects\/\d+\/hooks$/.test(url)) {
+        activeHookLists += 1;
+        maxActiveHookLists = Math.max(maxActiveHookLists, activeHookLists);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        activeHookLists -= 1;
+        return Response.json([
+          {
+            id: 10,
+            url: "https://worker.example/webhooks/gitlab",
+            enable_ssl_verification: true,
+            merge_requests_events: true,
+            pipeline_events: true,
+            note_events: true,
+            token_present: true,
+          },
+        ]);
+      }
+      if (url.includes("/test/push_events")) {
+        expect(init?.method).toBe("POST");
+        return new Response(null, { status: 204 });
+      }
+      if (url.includes("/events?")) {
+        return Response.json([
+          { created_at: "2026-08-21T10:00:00.000Z", response_status: 200 },
+        ]);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const config = { ...configFromEnvironment(), gitlabProjectId: undefined };
+
+    const result = await probesForEnvironment(config, { active: true })[
+      "gitlab.webhook-delivery"
+    ]?.(new AbortController().signal);
+
+    expect(maxActiveHookLists).toBe(4);
+    expect(
+      fetchMock.mock.calls.filter(([url]) =>
+        String(url).includes("/test/push_events"),
+      ),
+    ).toHaveLength(4);
+    expect(result).toMatchObject({
+      mode: "unverified",
+      coverage: { checked: 5, total: 5 },
+    });
+  });
+
+  it("treats a rate-limited active GitLab test as unverified", async () => {
+    fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes("/projects/group%2Fproject") && !url.includes("/hooks")) {
+        return Response.json({ id: 1, path_with_namespace: "group/project" });
+      }
+      if (url.endsWith("/projects/1/hooks")) {
+        return Response.json([
+          {
+            id: 10,
+            url: "https://worker.example/webhooks/gitlab",
+            enable_ssl_verification: true,
+            merge_requests_events: true,
+            pipeline_events: true,
+            note_events: true,
+            token_present: true,
+          },
+        ]);
+      }
+      if (url.includes("/test/push_events")) {
+        expect(init?.method).toBe("POST");
+        return new Response(null, { status: 429 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+
+    const result = await probesForEnvironment(configFromEnvironment(), { active: true })[
+      "gitlab.webhook-delivery"
+    ]?.(new AbortController().signal);
+
+    expect(result).toMatchObject({
+      mode: "unverified",
+      message: expect.stringContaining("rate-limited"),
+    });
+  });
+
+  it("keeps a checked GitLab webhook failure visible with partial coverage", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("/projects?")) {
+        return new Response(
+          JSON.stringify([
+            { id: 1, path_with_namespace: "group/broken" },
+            { id: 2, path_with_namespace: "group/healthy" },
+          ]),
+          { headers: { "x-total": "30" } },
+        );
+      }
+      if (/\/projects\/\d+\/hooks$/.test(url)) {
+        return Response.json([
+          {
+            id: 10,
+            url: "https://worker.example/webhooks/gitlab",
+            enable_ssl_verification: true,
+            merge_requests_events: true,
+            pipeline_events: true,
+            note_events: true,
+            token_present: true,
+          },
+        ]);
+      }
+      if (url.includes("/projects/1/") && url.includes("/events?")) {
+        return Response.json([
+          { created_at: "2026-08-21T09:00:00.000Z", response_status: 302 },
+        ]);
+      }
+      if (url.includes("/events?")) {
+        return Response.json([
+          { created_at: "2026-08-21T10:00:00.000Z", response_status: 200 },
+        ]);
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const config = { ...configFromEnvironment(), gitlabProjectId: undefined };
+
+    const result = await probesForEnvironment(config)["gitlab.webhook-delivery"]?.(
+      new AbortController().signal,
+    );
+
+    expect(result).toMatchObject({
+      mode: "down",
+      coverage: { checked: 2, total: 30 },
+      message: expect.stringContaining("HTTP 302"),
+    });
   });
 });

--- a/apps/worker/src/system-health/probes.test.ts
+++ b/apps/worker/src/system-health/probes.test.ts
@@ -323,6 +323,27 @@ describe("deployment system-health probes", () => {
     expect(result).toMatchObject({ mode: "live" });
   });
 
+  it("points a handler failure at the worker, not at the provider", async () => {
+    getLatestSystemHealthObservations.mockResolvedValueOnce([
+      {
+        outcome: "rejected",
+        reason: "handler_failed",
+        count: 1,
+        observedAt: new Date(),
+      },
+    ]);
+
+    const result = await probesForEnvironment(configFromEnvironment())[
+      "jira.webhook-delivery"
+    ]?.(new AbortController().signal);
+
+    expect(result).toMatchObject({
+      mode: "degraded",
+      message: expect.stringContaining("worker handler failed"),
+    });
+    expect(result?.message).not.toContain("unsolicited traffic");
+  });
+
   it("accepts a restricted send-only Resend key as unverified, not down", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ name: "restricted_api_key" }), {

--- a/apps/worker/src/system-health/probes.test.ts
+++ b/apps/worker/src/system-health/probes.test.ts
@@ -191,6 +191,31 @@ describe("deployment system-health probes", () => {
     expect(probesForEnvironment(config)["agent.model"]).toBeUndefined();
   });
 
+  it("does not mark GitHub repository access live when the installation is empty", async () => {
+    listReposAccessibleToInstallation.mockResolvedValueOnce({
+      data: { total_count: 0, repositories: [] },
+    });
+
+    await expect(
+      probesForEnvironment(configFromEnvironment())["github.repositories"]?.(
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(/no accessible repositories/);
+  });
+
+  it("does not mark GitLab repository access live when the token sees no projects", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("[]", { headers: { "x-total": "0" } }),
+    );
+    const config = { ...configFromEnvironment(), gitlabProjectId: undefined };
+
+    await expect(
+      probesForEnvironment(config)["gitlab.repositories"]?.(
+        new AbortController().signal,
+      ),
+    ).rejects.toThrow(/no accessible projects/);
+  });
+
   it("reports a GitHub App that omits handled webhook events", async () => {
     fetchMock.mockImplementation(async (url: string) => {
       if (url.endsWith("/app")) {

--- a/apps/worker/src/system-health/probes.ts
+++ b/apps/worker/src/system-health/probes.ts
@@ -151,17 +151,22 @@ export function probesForEnvironment(
       }
     };
     probes["github.repositories"] = async (signal) => {
-      try {
-        const response = await buildOctokit(auth).apps.listReposAccessibleToInstallation({
+      const response = await buildOctokit(auth).apps
+        .listReposAccessibleToInstallation({
           per_page: 1,
           request: { signal },
+        })
+        .catch(() => {
+          throw new PublicHealthProbeError("GitHub repository access failed.");
         });
-        return {
-          coverage: { checked: response.data.repositories.length, total: response.data.total_count },
-        };
-      } catch {
-        throw new PublicHealthProbeError("GitHub repository access failed.");
+      if (response.data.total_count === 0) {
+        throw new PublicHealthProbeError(
+          "GitHub App installation has no accessible repositories.",
+        );
       }
+      return {
+        coverage: { checked: response.data.repositories.length, total: response.data.total_count },
+      };
     };
     probes["github.webhook-delivery"] = (signal) =>
       githubWebhookResult(config, signal);
@@ -176,6 +181,11 @@ export function probesForEnvironment(
     };
     probes["gitlab.repositories"] = async (signal) => {
       const projects = await gitlabProjects(config, signal);
+      if (projects.total === 0) {
+        throw new PublicHealthProbeError(
+          "GitLab token has no accessible projects.",
+        );
+      }
       return { coverage: { checked: projects.projects.length, total: projects.total } };
     };
     probes["gitlab.webhook-delivery"] = (signal) =>

--- a/apps/worker/src/system-health/probes.ts
+++ b/apps/worker/src/system-health/probes.ts
@@ -290,19 +290,23 @@ function classifyObservations(
       message: "Configured, but no signed delivery was observed in the last 7 days.",
     };
   }
-  return latest.outcome === "accepted"
-    ? {
-        mode: "live",
-        evidenceSource: "local-observation",
-        observedAt: latest.observedAt.toISOString(),
-        message: "A recent request passed signature verification.",
-      }
-    : {
-        mode: "degraded",
-        evidenceSource: "local-observation",
-        observedAt: latest.observedAt.toISOString(),
-        message: `A recent request was rejected (${latest.reason}); this may be provider drift or unsolicited traffic.`,
-      };
+  if (latest.outcome === "accepted") {
+    return {
+      mode: "live",
+      evidenceSource: "local-observation",
+      observedAt: latest.observedAt.toISOString(),
+      message: "A recent request passed signature verification.",
+    };
+  }
+  return {
+    mode: "degraded",
+    evidenceSource: "local-observation",
+    observedAt: latest.observedAt.toISOString(),
+    message:
+      latest.reason === "handler_failed"
+        ? "A recent request passed signature verification but the worker handler failed; check the worker logs."
+        : `A recent request was rejected (${latest.reason}); this may be provider drift or unsolicited traffic.`,
+  };
 }
 
 async function githubWebhookResult(

--- a/apps/worker/src/system-health/probes.ts
+++ b/apps/worker/src/system-health/probes.ts
@@ -1,22 +1,55 @@
-import { sql } from "drizzle-orm";
+import { createAppAuth } from "@octokit/auth-app";
+import { and, desc, eq, gte, isNull, sql } from "drizzle-orm";
 import type { SystemHealthResponse } from "@shared/contracts";
 import { env } from "../../env.js";
 import { JiraAdapter } from "../adapters/issue-tracker/jira.js";
 import { getDb } from "../db/client.js";
+import {
+  webhookTriggerDeliveries,
+  webhookTriggerEndpoints,
+  webhookTriggerRejectionCounters,
+} from "../db/schema.js";
 import { buildOctokit } from "../lib/github-auth.js";
 import { MCP_CONTRACT_ARTIFACT } from "../mcp/contract-artifact.js";
 import {
   collectSystemHealth,
   PublicHealthProbeError,
   type SystemHealthConfig,
+  type SystemHealthProbeResult,
   type SystemHealthProbes,
 } from "./collect.js";
+import {
+  getLatestSystemHealthObservations,
+  systemHealthObservationScope,
+} from "./observations.js";
 
-export function collectDeploymentSystemHealth(): Promise<SystemHealthResponse> {
+const GITHUB_DELIVERY_FRESH_MS = 3 * 24 * 60 * 60 * 1000;
+const LOCAL_OBSERVATION_FRESH_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_GITLAB_HEALTH_PROJECTS = 25;
+const MAX_ACTIVE_GITLAB_WEBHOOK_TESTS = 4;
+const REQUIRED_GITHUB_WEBHOOK_EVENTS = [
+  "check_run",
+  "issue_comment",
+  "pull_request",
+  "pull_request_review",
+  "pull_request_review_comment",
+] as const;
+const REQUIRED_RESEND_WEBHOOK_EVENTS = [
+  "email.sent",
+  "email.delivered",
+  "email.bounced",
+  "email.complained",
+  "email.failed",
+  "email.suppressed",
+] as const;
+
+export function collectDeploymentSystemHealth(options: {
+  active?: boolean;
+} = {}): Promise<SystemHealthResponse> {
   const config = configFromEnvironment();
   return collectSystemHealth({
     config,
-    probes: probesForEnvironment(config),
+    probes: probesForEnvironment(config, options),
   });
 }
 
@@ -26,6 +59,7 @@ export function configFromEnvironment(): SystemHealthConfig {
     jiraBaseUrl: env.JIRA_BASE_URL,
     jiraApiToken: env.JIRA_API_TOKEN,
     jiraProjectKey: env.JIRA_PROJECT_KEY,
+    jiraWebhookSecret: env.JIRA_WEBHOOK_SECRET,
     githubAppId: env.GITHUB_APP_ID,
     githubAppPrivateKey: env.GITHUB_APP_PRIVATE_KEY,
     githubInstallationId: env.GITHUB_INSTALLATION_ID,
@@ -33,6 +67,7 @@ export function configFromEnvironment(): SystemHealthConfig {
     gitlabToken: env.GITLAB_TOKEN,
     gitlabHost: env.GITLAB_HOST,
     gitlabWebhookSecret: env.GITLAB_WEBHOOK_SECRET,
+    gitlabProjectId: env.GITLAB_PROJECT_ID,
     agentKind: env.AGENT_KIND,
     anthropicApiKey: env.ANTHROPIC_API_KEY,
     anthropicModel: env.CLAUDE_MODEL,
@@ -51,9 +86,12 @@ export function configFromEnvironment(): SystemHealthConfig {
     resendWebhookSecret: env.RESEND_WEBHOOK_SECRET,
     slackToken: env.CHAT_SDK_SLACK_TOKEN,
     slackChannelId: env.CHAT_SDK_CHANNEL_ID,
+    slackSigningSecret: env.SLACK_SIGNING_SECRET,
+    slackAllowedUserIds: env.SLACK_ALLOWED_USER_IDS,
     arthurApiKey: env.GENAI_ENGINE_API_KEY,
     arthurTraceEndpoint: env.GENAI_ENGINE_TRACE_ENDPOINT,
     mcpEnabled: env.MCP_ENABLED,
+    webhookTriggerEncryptionKey: env.WEBHOOK_TRIGGER_ENCRYPTION_KEY,
     vercelEnv: env.VERCEL_ENV,
     vercelToken: env.VERCEL_TOKEN,
     vercelTeamId: env.VERCEL_TEAM_ID,
@@ -63,16 +101,17 @@ export function configFromEnvironment(): SystemHealthConfig {
 
 export function probesForEnvironment(
   config: SystemHealthConfig,
+  options: { active?: boolean } = {},
 ): SystemHealthProbes {
-  return {
-    database: async () => {
+  const probes: SystemHealthProbes = {
+    "database.connectivity": async () => {
       try {
         await getDb().execute(sql.raw("select 1"));
       } catch {
         throw new PublicHealthProbeError("Database did not respond.");
       }
     },
-    jira: async (signal) => {
+    "jira.api": async (signal) => {
       if (!config.jiraBaseUrl || !config.jiraApiToken || !config.jiraProjectKey) return;
       try {
         const adapter = new JiraAdapter({
@@ -83,166 +122,748 @@ export function probesForEnvironment(
         await adapter.getCurrentUserAccountId(signal);
         await adapter.listStatuses(signal);
       } catch {
-        throw new PublicHealthProbeError("Jira authentication check failed.");
+        throw new PublicHealthProbeError("Jira account or project access failed.");
       }
     },
-    ...(config.githubAppId &&
-    config.githubAppPrivateKey &&
-    config.githubInstallationId
-      ? {
-          github: async (signal) => {
-            try {
-              await buildOctokit({
-                appId: config.githubAppId!,
-                privateKeyBase64: config.githubAppPrivateKey!,
-                installationId: config.githubInstallationId!,
-              }).apps.getInstallation({
-                installation_id: config.githubInstallationId!,
-                request: { signal },
-              });
-            } catch {
-              throw new PublicHealthProbeError("GitHub App authentication failed.");
-            }
-          },
-        }
-      : {}),
-    ...(config.gitlabToken
-      ? {
-          gitlab: async (signal) => {
-            const response = await fetch(
-              `${(config.gitlabHost ?? "https://gitlab.com").replace(/\/+$/, "")}/api/v4/user`,
-              {
-                headers: { "PRIVATE-TOKEN": config.gitlabToken! },
-                signal,
-              },
-            ).catch(() => null);
-            if (!response?.ok) {
-              throw new PublicHealthProbeError("GitLab authentication failed.");
-            }
-          },
-        }
-      : {}),
-    ...(config.ssoIssuer
-      ? {
-          sso: async (signal) => {
-            const issuer = config.ssoIssuer!.replace(/\/+$/, "");
-            const response = await fetch(
-              `${issuer}/.well-known/openid-configuration`,
-              { signal },
-            ).catch(() => null);
-            const metadata = response?.ok
-              ? ((await response.json().catch(() => null)) as {
-                  issuer?: unknown;
-                } | null)
-              : null;
-            if (!metadata || metadata.issuer !== config.ssoIssuer) {
-              throw new PublicHealthProbeError("SSO discovery check failed.");
-            }
-          },
-        }
-      : {}),
-    ...(config.resendApiKey
-      ? {
-          email: async (signal) => {
-            const response = await fetch("https://api.resend.com/domains", {
-              headers: { Authorization: `Bearer ${config.resendApiKey}` },
-              signal,
-            }).catch(() => null);
-            if (response?.ok) return;
-            const error = response
-              ? ((await response.json().catch(() => null)) as {
-                  name?: unknown;
-                } | null)
-              : null;
-            if (response?.status === 401 && error?.name === "restricted_api_key") {
-              return;
-            }
-            throw new PublicHealthProbeError("Resend authentication failed.");
-          },
-        }
-      : {}),
-    ...(config.slackToken
-      ? {
-          slack: async (signal) => {
-            const response = await fetch("https://slack.com/api/auth.test", {
-              method: "POST",
-              headers: { Authorization: `Bearer ${config.slackToken}` },
-              signal,
-            }).catch(() => null);
-            const result = response?.ok
-              ? ((await response.json().catch(() => null)) as {
-                  ok?: unknown;
-                } | null)
-              : null;
-            if (result?.ok !== true) {
-              throw new PublicHealthProbeError("Slack authentication failed.");
-            }
-          },
-        }
-      : {}),
-    ...(config.arthurApiKey && config.arthurTraceEndpoint
-      ? {
-          arthur: async (signal) => {
-            const baseUrl = config.arthurTraceEndpoint!
-              .replace(/\/api\/v1\/traces\/?$/, "")
-              .replace(/\/+$/, "");
-            const response = await fetch(`${baseUrl}/api/v2/tasks?page_size=1`, {
-              headers: {
-                Authorization: `Bearer ${config.arthurApiKey}`,
-                "ngrok-skip-browser-warning": "true",
-              },
-              signal,
-            }).catch(() => null);
-            if (!response?.ok) {
-              throw new PublicHealthProbeError("Arthur authentication failed.");
-            }
-          },
-        }
-      : {}),
-    ...(config.mcpEnabled
-      ? {
-          mcp: async () => {
-            if (MCP_CONTRACT_ARTIFACT.tools.length === 0) {
-              throw new PublicHealthProbeError("MCP contract has no tools.");
-            }
-          },
-        }
-      : {}),
-    ...(config.vercelToken && config.vercelTeamId && config.vercelProjectId
-      ? {
-          vercel: async (signal) => {
-            const projectId = encodeURIComponent(config.vercelProjectId!);
-            const teamId = encodeURIComponent(config.vercelTeamId!);
-            const response = await fetch(
-              `https://api.vercel.com/v9/projects/${projectId}?teamId=${teamId}`,
-              {
-                headers: { Authorization: `Bearer ${config.vercelToken}` },
-                signal,
-              },
-            ).catch(() => null);
-            if (!response?.ok) {
-              throw new PublicHealthProbeError("Vercel project check failed.");
-            }
-          },
-        }
-      : {}),
-    ...agentProbe(config),
+    "jira.webhook-delivery": () =>
+      observedWebhookResult("jira", config.jiraWebhookSecret),
+    "email.webhook-delivery": async (signal) =>
+      resendWebhookResult(config, signal),
+    "slack.webhook-delivery": () =>
+      observedWebhookResult("slack", config.slackSigningSecret),
+    "custom-webhooks.aggregate": () => customWebhookAggregate(),
+  };
+
+  if (config.githubAppId && config.githubAppPrivateKey && config.githubInstallationId) {
+    const auth = {
+      appId: config.githubAppId,
+      privateKeyBase64: config.githubAppPrivateKey,
+      installationId: config.githubInstallationId,
+    };
+    probes["github.app-installation"] = async (signal) => {
+      try {
+        await buildOctokit(auth).apps.getInstallation({
+          installation_id: config.githubInstallationId!,
+          request: { signal },
+        });
+      } catch {
+        throw new PublicHealthProbeError("GitHub App installation check failed.");
+      }
+    };
+    probes["github.repositories"] = async (signal) => {
+      try {
+        const response = await buildOctokit(auth).apps.listReposAccessibleToInstallation({
+          per_page: 1,
+          request: { signal },
+        });
+        return {
+          coverage: { checked: response.data.repositories.length, total: response.data.total_count },
+        };
+      } catch {
+        throw new PublicHealthProbeError("GitHub repository access failed.");
+      }
+    };
+    probes["github.webhook-delivery"] = (signal) =>
+      githubWebhookResult(config, signal);
+  }
+
+  if (config.gitlabToken) {
+    probes["gitlab.api"] = async (signal) => {
+      const response = await gitlabFetch(config, "/user", signal);
+      if (!response.ok) {
+        throw new PublicHealthProbeError("GitLab authentication failed.");
+      }
+    };
+    probes["gitlab.repositories"] = async (signal) => {
+      const projects = await gitlabProjects(config, signal);
+      return { coverage: { checked: projects.projects.length, total: projects.total } };
+    };
+    probes["gitlab.webhook-delivery"] = (signal) =>
+      gitlabWebhookResult(config, signal, Boolean(options.active));
+  }
+
+  if (config.ssoIssuer) {
+    probes["sso.discovery"] = async (signal) => {
+      const issuer = config.ssoIssuer!.replace(/\/+$/, "");
+      const response = await fetch(`${issuer}/.well-known/openid-configuration`, {
+        signal,
+      }).catch(() => null);
+      const metadata = response?.ok
+        ? ((await response.json().catch(() => null)) as {
+            issuer?: unknown;
+            authorization_endpoint?: unknown;
+          } | null)
+        : null;
+      if (
+        !metadata ||
+        metadata.issuer !== config.ssoIssuer ||
+        typeof metadata.authorization_endpoint !== "string"
+      ) {
+        throw new PublicHealthProbeError("SSO discovery or issuer check failed.");
+      }
+    };
+  }
+
+  if (config.resendApiKey) {
+    probes["email.sender"] = (signal) => resendSenderResult(config, signal);
+  }
+
+  if (config.slackToken) {
+    probes["slack.bot-auth"] = (signal) => slackApiResult(config, "auth.test", {}, signal);
+    probes["slack.channel"] = (signal) =>
+      slackApiResult(
+        config,
+        "conversations.info",
+        { channel: config.slackChannelId ?? "" },
+        signal,
+      );
+  }
+
+  if (config.arthurApiKey && config.arthurTraceEndpoint) {
+    probes["arthur.api"] = async (signal) => {
+      const baseUrl = config.arthurTraceEndpoint!
+        .replace(/\/api\/v1\/traces\/?$/, "")
+        .replace(/\/+$/, "");
+      const response = await fetch(`${baseUrl}/api/v2/tasks?page_size=1`, {
+        headers: {
+          Authorization: `Bearer ${config.arthurApiKey}`,
+          "ngrok-skip-browser-warning": "true",
+        },
+        signal,
+      }).catch(() => null);
+      if (!response?.ok) {
+        throw new PublicHealthProbeError("Arthur task API authentication failed.");
+      }
+    };
+  }
+
+  if (config.mcpEnabled) {
+    probes["mcp.contract"] = async () => {
+      if (MCP_CONTRACT_ARTIFACT.tools.length === 0) {
+        throw new PublicHealthProbeError("MCP contract has no tools.");
+      }
+    };
+  }
+
+  if (config.vercelToken && config.vercelTeamId && config.vercelProjectId) {
+    probes["vercel.project"] = (signal) => vercelProjectResult(config, signal);
+    probes["vercel.production-deployment"] = (signal) =>
+      vercelDeploymentResult(config, signal);
+  }
+
+  Object.assign(probes, agentProbes(config));
+  return probes;
+}
+
+async function observedWebhookResult(
+  integrationId: "jira" | "slack",
+  secret: string | undefined,
+): Promise<SystemHealthProbeResult> {
+  const observations = await getLatestSystemHealthObservations(
+    getDb(),
+    integrationId,
+    "webhook-delivery",
+    systemHealthObservationScope(secret),
+  );
+  return classifyObservations(observations);
+}
+
+function classifyObservations(
+  observations: Awaited<ReturnType<typeof getLatestSystemHealthObservations>>,
+  now: Date = new Date(),
+): SystemHealthProbeResult {
+  const latest = observations[0];
+  if (!latest || now.getTime() - latest.observedAt.getTime() > LOCAL_OBSERVATION_FRESH_MS) {
+    return {
+      mode: "unverified",
+      evidenceSource: "local-observation",
+      message: "Configured, but no signed delivery was observed in the last 7 days.",
+    };
+  }
+  return latest.outcome === "accepted"
+    ? {
+        mode: "live",
+        evidenceSource: "local-observation",
+        observedAt: latest.observedAt.toISOString(),
+        message: "A recent request passed signature verification.",
+      }
+    : {
+        mode: "degraded",
+        evidenceSource: "local-observation",
+        observedAt: latest.observedAt.toISOString(),
+        message: `A recent request was rejected (${latest.reason}); this may be provider drift or unsolicited traffic.`,
+      };
+}
+
+async function githubWebhookResult(
+  config: SystemHealthConfig,
+  signal: AbortSignal,
+): Promise<SystemHealthProbeResult> {
+  const appId = config.githubAppId!;
+  const privateKey = Buffer.from(config.githubAppPrivateKey!, "base64").toString("utf8");
+  const appAuth = createAppAuth({ appId, privateKey });
+  const authentication = await appAuth({ type: "app" });
+  const headers = {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${authentication.token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const [appResponse, configResponse, deliveriesResponse] = await Promise.all([
+    fetch("https://api.github.com/app", { headers, signal }),
+    fetch("https://api.github.com/app/hook/config", { headers, signal }),
+    fetch("https://api.github.com/app/hook/deliveries?per_page=1", { headers, signal }),
+  ]);
+  if (!appResponse.ok || !configResponse.ok || !deliveriesResponse.ok) {
+    throw new PublicHealthProbeError("GitHub App webhook API check failed.");
+  }
+  const app = (await appResponse.json()) as { events?: string[] };
+  const appEvents = new Set(app.events ?? []);
+  const missingEvents = REQUIRED_GITHUB_WEBHOOK_EVENTS.filter(
+    (event) => !appEvents.has(event),
+  );
+  if (missingEvents.length > 0) {
+    throw new PublicHealthProbeError(
+      `The GitHub App is missing required webhook events: ${missingEvents.join(", ")}.`,
+    );
+  }
+  const hook = (await configResponse.json()) as { url?: unknown; insecure_ssl?: unknown };
+  const expectedUrl = providerWebhookUrl(config, "github");
+  if (typeof hook.url !== "string" || normalizeUrl(hook.url) !== expectedUrl) {
+    throw new PublicHealthProbeError("GitHub App webhook URL does not match this worker.");
+  }
+  if (String(hook.insecure_ssl) === "1") {
+    throw new PublicHealthProbeError("GitHub App webhook disables TLS verification.");
+  }
+  const deliveries = (await deliveriesResponse.json()) as Array<{
+    delivered_at?: string;
+    status_code?: number;
+  }>;
+  const latest = deliveries[0];
+  if (!latest?.delivered_at) {
+    return { mode: "unverified", message: "Webhook is configured, but has no recent delivery." };
+  }
+  const observedAt = new Date(latest.delivered_at);
+  if (Date.now() - observedAt.getTime() > GITHUB_DELIVERY_FRESH_MS) {
+    return { mode: "unverified", observedAt: observedAt.toISOString(), message: "No GitHub App delivery was observed in the last 3 days." };
+  }
+  const ok =
+    typeof latest.status_code === "number" &&
+    latest.status_code >= 200 &&
+    latest.status_code < 300;
+  if (
+    ok &&
+    !(await hasFreshAcceptedObservation(
+      "github",
+      config.githubWebhookSecret,
+    ))
+  ) {
+    return {
+      mode: "unverified",
+      observedAt: observedAt.toISOString(),
+      evidenceSource: "provider-delivery",
+      message:
+        "GitHub reports a successful delivery, but none was accepted with the current webhook secret.",
+    };
+  }
+  return {
+    mode: ok ? "live" : "down",
+    observedAt: observedAt.toISOString(),
+    evidenceSource: "provider-delivery",
+    message: ok
+      ? `Latest GitHub delivery returned ${latest.status_code}.`
+      : `Latest GitHub delivery failed with HTTP ${latest.status_code ?? "unknown"}.`,
   };
 }
 
-function agentProbe(
+type GitLabProject = { id: number; path_with_namespace?: string };
+
+async function gitlabProjects(
   config: SystemHealthConfig,
-): Pick<SystemHealthProbes, "agent"> {
+  signal: AbortSignal,
+): Promise<{ projects: GitLabProject[]; total: number }> {
+  if (config.gitlabProjectId) {
+    const response = await gitlabFetch(
+      config,
+      `/projects/${encodeURIComponent(config.gitlabProjectId)}`,
+      signal,
+    );
+    if (!response.ok) throw new PublicHealthProbeError("Configured GitLab project is unavailable.");
+    return { projects: [(await response.json()) as GitLabProject], total: 1 };
+  }
+  const response = await gitlabFetch(
+    config,
+    `/projects?membership=true&simple=true&per_page=${MAX_GITLAB_HEALTH_PROJECTS}&page=1`,
+    signal,
+  );
+  if (!response.ok) throw new PublicHealthProbeError("GitLab repository listing failed.");
+  const projects = (await response.json()) as GitLabProject[];
+  const total = Number(response.headers.get("x-total") ?? projects.length);
+  return { projects, total: Number.isFinite(total) ? total : projects.length };
+}
+
+async function gitlabWebhookResult(
+  config: SystemHealthConfig,
+  signal: AbortSignal,
+  active: boolean,
+): Promise<SystemHealthProbeResult> {
+  const projectResult = await gitlabProjects(config, signal);
+  const expectedUrl = providerWebhookUrl(config, "gitlab");
+  let checked = 0;
+  let newest: { observedAt: Date; status: number } | null = null;
+  let newestFailure: { observedAt: Date; status: number } | null = null;
+  let activeEvidenceMissing = false;
+  let activeRateLimited = false;
+  let activeDeliveryVerified = false;
+  let activeTests = 0;
+  for (let offset = 0; offset < projectResult.projects.length; offset += 4) {
+    const batch = projectResult.projects.slice(offset, offset + 4);
+    const results = await Promise.all(
+      batch.map((project, batchIndex) =>
+        inspectGitLabWebhook(
+          config,
+          project,
+          expectedUrl,
+          signal,
+          active && offset + batchIndex < MAX_ACTIVE_GITLAB_WEBHOOK_TESTS,
+        ),
+      ),
+    );
+    const permissionFailure = results.find((result) => result.permissionDenied);
+    if (permissionFailure) {
+      return {
+        mode: "unverified",
+        message: "The token cannot inspect project webhooks; Maintainer access is required.",
+        coverage: { checked, total: projectResult.total },
+      };
+    }
+    checked += results.length;
+    for (const result of results) {
+      activeEvidenceMissing ||= Boolean(result.activeEvidenceMissing);
+      activeRateLimited ||= Boolean(result.activeRateLimited);
+      activeTests += result.activeTested ? 1 : 0;
+      activeDeliveryVerified ||= Boolean(
+        result.activeTested &&
+          result.delivery &&
+          result.delivery.status >= 200 &&
+          result.delivery.status < 300,
+      );
+      if (result.delivery && (!newest || result.delivery.observedAt > newest.observedAt)) {
+        newest = result.delivery;
+      }
+      if (
+        result.delivery?.status !== undefined &&
+        (result.delivery.status < 200 || result.delivery.status >= 300) &&
+        (!newestFailure || result.delivery.observedAt > newestFailure.observedAt)
+      ) {
+        newestFailure = result.delivery;
+      }
+    }
+  }
+  const coverage = { checked, total: projectResult.total };
   if (
-    config.agentKind === "claude" &&
-    config.anthropicApiKey &&
-    config.anthropicModel
+    newestFailure &&
+    Date.now() - newestFailure.observedAt.getTime() <= LOCAL_OBSERVATION_FRESH_MS
   ) {
-    // OAuth-style Claude credentials are consumed by the CLI, not the public
-    // Models API. Presence is the honest readiness signal for that mode.
+    return {
+      mode: "down",
+      observedAt: newestFailure.observedAt.toISOString(),
+      evidenceSource: "provider-delivery",
+      coverage,
+      message: `A checked GitLab webhook's latest delivery failed with HTTP ${newestFailure.status}.`,
+    };
+  }
+  if (activeRateLimited) {
+    return {
+      mode: "unverified",
+      coverage,
+      message: "GitLab rate-limited the active webhook test; try again later.",
+    };
+  }
+  if (projectResult.total > checked) {
+    return {
+      mode: "unverified",
+      coverage,
+      message: `Checked ${checked} of ${projectResult.total} GitLab projects; coverage is partial.`,
+    };
+  }
+  if (activeEvidenceMissing && (!newest || newest.status < 400)) {
+    return {
+      mode: "unverified",
+      coverage,
+      message: "GitLab accepted the test request, but its delivery result was not available yet.",
+    };
+  }
+  if (active && activeTests < checked) {
+    return {
+      mode: "unverified",
+      coverage,
+      message: `Actively tested ${activeTests} of ${checked} GitLab webhooks; the scan limits test deliveries to ${MAX_ACTIVE_GITLAB_WEBHOOK_TESTS}.`,
+    };
+  }
+  if (!newest) {
+    const local = await getLatestSystemHealthObservations(
+      getDb(),
+      "gitlab",
+      "webhook-delivery",
+      systemHealthObservationScope(config.gitlabWebhookSecret),
+    );
+    return { ...classifyObservations(local), coverage };
+  }
+  if (Date.now() - newest.observedAt.getTime() > LOCAL_OBSERVATION_FRESH_MS) {
+    return {
+      mode: "unverified",
+      observedAt: newest.observedAt.toISOString(),
+      evidenceSource: "provider-delivery",
+      coverage,
+      message: "No GitLab webhook delivery was observed in the last 7 days.",
+    };
+  }
+  const ok = newest.status >= 200 && newest.status < 300;
+  if (
+    ok &&
+    !activeDeliveryVerified &&
+    !(await hasFreshAcceptedObservation(
+      "gitlab",
+      config.gitlabWebhookSecret,
+    ))
+  ) {
+    return {
+      mode: "unverified",
+      observedAt: newest.observedAt.toISOString(),
+      evidenceSource: "provider-delivery",
+      coverage,
+      message:
+        "GitLab reports a successful delivery, but none was accepted with the current webhook secret.",
+    };
+  }
+  return {
+    mode: ok ? "live" : "down",
+    observedAt: newest.observedAt.toISOString(),
+    evidenceSource: "provider-delivery",
+    coverage,
+    message: ok
+      ? `Latest GitLab delivery returned ${newest.status}.`
+      : `Latest GitLab delivery failed with HTTP ${newest.status}.`,
+  };
+}
+
+async function inspectGitLabWebhook(
+  config: SystemHealthConfig,
+  project: GitLabProject,
+  expectedUrl: string,
+  signal: AbortSignal,
+  active: boolean,
+): Promise<{
+  permissionDenied?: true;
+  activeEvidenceMissing?: true;
+  activeRateLimited?: true;
+  activeTested?: true;
+  delivery?: { observedAt: Date; status: number };
+}> {
+  const hooksResponse = await gitlabFetch(config, `/projects/${project.id}/hooks`, signal);
+  if (hooksResponse.status === 401) {
+    throw new PublicHealthProbeError("GitLab webhook credentials were rejected.");
+  }
+  if (hooksResponse.status === 403) return { permissionDenied: true };
+  if (!hooksResponse.ok) {
+    throw new PublicHealthProbeError("GitLab webhook listing failed.");
+  }
+  const hooks = (await hooksResponse.json()) as Array<{
+    id: number;
+    url?: string;
+    enable_ssl_verification?: boolean;
+    merge_requests_events?: boolean;
+    pipeline_events?: boolean;
+    note_events?: boolean;
+    token_present?: boolean;
+  }>;
+  const hook = hooks.find((candidate) => normalizeUrl(candidate.url ?? "") === expectedUrl);
+  if (!hook) {
+    throw new PublicHealthProbeError(
+      `GitLab webhook is missing for ${project.path_with_namespace ?? project.id}.`,
+    );
+  }
+  if (hook.enable_ssl_verification === false) {
+    throw new PublicHealthProbeError("A GitLab webhook disables TLS verification.");
+  }
+  if (!hook.merge_requests_events || !hook.pipeline_events || !hook.note_events) {
+    throw new PublicHealthProbeError("A GitLab webhook is missing required event subscriptions.");
+  }
+  if (hook.token_present === false) {
+    throw new PublicHealthProbeError("A GitLab webhook has no secret token.");
+  }
+  const activeStartedAt = active ? Date.now() : null;
+  if (active) {
+    const testResponse = await gitlabFetch(
+      config,
+      `/projects/${project.id}/hooks/${hook.id}/test/push_events`,
+      signal,
+      { method: "POST" },
+    );
+    if (testResponse.status === 429) {
+      return { activeTested: true, activeRateLimited: true };
+    }
+    if (!testResponse.ok) {
+      throw new PublicHealthProbeError(
+        `GitLab webhook test failed with HTTP ${testResponse.status}.`,
+      );
+    }
+  }
+  const eventsResponse = await gitlabFetch(
+    config,
+    `/projects/${project.id}/hooks/${hook.id}/events?per_page=1&page=1`,
+    signal,
+  );
+  if (!eventsResponse.ok) {
+    return active
+      ? { activeTested: true, activeEvidenceMissing: true }
+      : {};
+  }
+  const events = (await eventsResponse.json()) as Array<{
+    created_at?: string;
+    response_status?: string | number;
+  }>;
+  const event = events[0];
+  const observedAt = event?.created_at ? new Date(event.created_at) : null;
+  const status = Number(event?.response_status);
+  if (!observedAt || !Number.isFinite(status)) {
+    return active
+      ? { activeTested: true, activeEvidenceMissing: true }
+      : {};
+  }
+  if (
+    activeStartedAt !== null &&
+    observedAt.getTime() < activeStartedAt - 5_000
+  ) {
+    return { activeTested: true, activeEvidenceMissing: true };
+  }
+  return {
+    ...(active ? { activeTested: true as const } : {}),
+    delivery: { observedAt, status },
+  };
+}
+
+async function resendSenderResult(
+  config: SystemHealthConfig,
+  signal: AbortSignal,
+): Promise<SystemHealthProbeResult | void> {
+  const response = await resendFetch(config, "/domains", signal);
+  if (response.ok) {
+    const body = (await response.json().catch(() => null)) as {
+      data?: Array<{ name?: string; status?: string }>;
+    } | null;
+    const senderDomain = emailDomain(config.resendFromEmail);
+    if (senderDomain) {
+      if (!Array.isArray(body?.data)) {
+        throw new PublicHealthProbeError(
+          "Resend did not return sender-domain verification data.",
+        );
+      }
+      const domain = body.data.find((candidate) => candidate.name === senderDomain);
+      if (!domain || domain.status !== "verified") {
+        throw new PublicHealthProbeError("Resend sender domain is not verified.");
+      }
+    }
+    return;
+  }
+  const error = (await response.json().catch(() => null)) as { name?: unknown } | null;
+  if (response.status === 401 && error?.name === "restricted_api_key") {
+    return {
+      mode: "unverified",
+      message: "The send-only key works, but cannot verify the sender domain.",
+    };
+  }
+  throw new PublicHealthProbeError("Resend authentication failed.");
+}
+
+async function resendWebhookResult(
+  config: SystemHealthConfig,
+  signal: AbortSignal,
+): Promise<SystemHealthProbeResult> {
+  if (!config.resendApiKey) {
+    return observedWebhookFallback("email", config.resendWebhookSecret);
+  }
+  const response = await resendFetch(config, "/webhooks", signal);
+  if (response.ok) {
+    const body = (await response.json()) as {
+      data?: Array<{ endpoint?: string; status?: string; events?: string[] }>;
+    };
+    const expectedUrl = providerWebhookUrl(config, "resend");
+    const hook = body.data?.find(
+      (candidate) => normalizeUrl(candidate.endpoint ?? "") === expectedUrl,
+    );
+    if (!hook || hook.status !== "enabled") {
+      throw new PublicHealthProbeError("The Resend webhook endpoint is missing or disabled.");
+    }
+    const events = new Set(hook.events ?? []);
+    const missingEvents = REQUIRED_RESEND_WEBHOOK_EVENTS.filter(
+      (event) => !events.has(event),
+    );
+    if (missingEvents.length > 0) {
+      throw new PublicHealthProbeError(
+        `The Resend webhook is missing required events: ${missingEvents.join(", ")}.`,
+      );
+    }
+    return observedWebhookFallback("email", config.resendWebhookSecret);
+  }
+  if (response.status === 401) {
+    return {
+      mode: "unverified",
+      message: "The Resend key cannot inspect webhook configuration.",
+    };
+  }
+  throw new PublicHealthProbeError("Resend webhook configuration check failed.");
+}
+
+async function observedWebhookFallback(
+  integrationId: "email",
+  secret: string | undefined,
+): Promise<SystemHealthProbeResult> {
+  return classifyObservations(
+    await getLatestSystemHealthObservations(
+      getDb(),
+      integrationId,
+      "webhook-delivery",
+      systemHealthObservationScope(secret),
+    ),
+  );
+}
+
+async function hasFreshAcceptedObservation(
+  integrationId: "github" | "gitlab",
+  secret: string | undefined,
+): Promise<boolean> {
+  const observations = await getLatestSystemHealthObservations(
+    getDb(),
+    integrationId,
+    "webhook-delivery",
+    systemHealthObservationScope(secret),
+  );
+  const latest = observations[0];
+  return Boolean(
+    latest?.outcome === "accepted" &&
+      Date.now() - latest.observedAt.getTime() <= LOCAL_OBSERVATION_FRESH_MS,
+  );
+}
+
+async function slackApiResult(
+  config: SystemHealthConfig,
+  method: string,
+  body: Record<string, string>,
+  signal: AbortSignal,
+): Promise<void> {
+  const response = await fetch(`https://slack.com/api/${method}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.slackToken}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams(body),
+    signal,
+  }).catch(() => null);
+  const result = response?.ok
+    ? ((await response.json().catch(() => null)) as { ok?: unknown } | null)
+    : null;
+  if (result?.ok !== true) {
+    throw new PublicHealthProbeError(
+      method === "auth.test"
+        ? "Slack authentication failed."
+        : "Slack channel is unavailable to the bot.",
+    );
+  }
+}
+
+async function customWebhookAggregate(): Promise<SystemHealthProbeResult> {
+  const db = getDb();
+  const endpoints = await db
+    .select({ id: webhookTriggerEndpoints.id, revokedAt: webhookTriggerEndpoints.revokedAt })
+    .from(webhookTriggerEndpoints);
+  const active = endpoints.filter((endpoint) => !endpoint.revokedAt);
+  if (active.length === 0) {
+    return {
+      mode: "unverified",
+      message: "No active custom webhook endpoint exists.",
+      coverage: { checked: 0, total: endpoints.length },
+    };
+  }
+  const latestDelivery = await db
+    .select({ createdAt: webhookTriggerDeliveries.createdAt })
+    .from(webhookTriggerDeliveries)
+    .innerJoin(
+      webhookTriggerEndpoints,
+      eq(webhookTriggerDeliveries.endpointId, webhookTriggerEndpoints.id),
+    )
+    .where(isNull(webhookTriggerEndpoints.revokedAt))
+    .orderBy(desc(webhookTriggerDeliveries.createdAt))
+    .limit(1);
+  const rejection = await db
+    .select({ count: webhookTriggerRejectionCounters.count })
+    .from(webhookTriggerRejectionCounters)
+    .innerJoin(
+      webhookTriggerEndpoints,
+      eq(webhookTriggerRejectionCounters.endpointId, webhookTriggerEndpoints.id),
+    )
+    .where(
+      and(
+        isNull(webhookTriggerEndpoints.revokedAt),
+        gte(webhookTriggerRejectionCounters.windowStart, utcDayStart()),
+      ),
+    )
+    .limit(1)
+    .catch(() => [] as Array<{ count: number }>);
+  const observedAt = latestDelivery[0]?.createdAt;
+  const deliveryIsFresh = Boolean(
+    observedAt && Date.now() - observedAt.getTime() <= LOCAL_OBSERVATION_FRESH_MS,
+  );
+  return {
+    mode: rejection.length > 0 ? "down" : deliveryIsFresh ? "live" : "unverified",
+    ...(observedAt ? { observedAt: observedAt.toISOString() } : {}),
+    coverage: { checked: active.length, total: endpoints.length },
+    message: rejection.length > 0
+      ? "An active custom endpoint rejected a request today."
+      : deliveryIsFresh
+        ? "Custom endpoints accepted a delivery in the last 7 days."
+        : "Custom endpoints are active but have no recent delivery evidence.",
+  };
+}
+
+function utcDayStart(now: Date = new Date()): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+async function vercelProjectResult(
+  config: SystemHealthConfig,
+  signal: AbortSignal,
+): Promise<void> {
+  const response = await vercelFetch(
+    config,
+    `/v9/projects/${encodeURIComponent(config.vercelProjectId!)}`,
+    signal,
+  );
+  if (!response.ok) throw new PublicHealthProbeError("Vercel project check failed.");
+}
+
+async function vercelDeploymentResult(
+  config: SystemHealthConfig,
+  signal: AbortSignal,
+): Promise<void> {
+  const response = await vercelFetch(
+    config,
+    `/v6/deployments?projectId=${encodeURIComponent(config.vercelProjectId!)}&target=production&limit=1`,
+    signal,
+  );
+  if (!response.ok) throw new PublicHealthProbeError("Vercel deployment lookup failed.");
+  const body = (await response.json()) as { deployments?: Array<{ readyState?: string }> };
+  if (body.deployments?.[0]?.readyState !== "READY") {
+    throw new PublicHealthProbeError("Latest Vercel production deployment is not READY.");
+  }
+}
+
+function agentProbes(config: SystemHealthConfig): SystemHealthProbes {
+  if (config.agentKind === "claude" && config.anthropicApiKey && config.anthropicModel) {
     if (config.anthropicApiKey.startsWith("sk-ant-oat")) return {};
     return {
-      agent: async (signal) => {
+      "agent.model": async (signal) => {
         const response = await fetch("https://api.anthropic.com/v1/models", {
           headers: {
             "x-api-key": config.anthropicApiKey!,
@@ -250,9 +871,7 @@ function agentProbe(
           },
           signal,
         }).catch(() => null);
-        if (!response?.ok) {
-          throw new PublicHealthProbeError("Anthropic authentication failed.");
-        }
+        if (!response?.ok) throw new PublicHealthProbeError("Anthropic authentication failed.");
         const body = (await response.json().catch(() => null)) as {
           data?: Array<{ id?: unknown }>;
         } | null;
@@ -264,19 +883,69 @@ function agentProbe(
   }
   if (config.agentKind === "codex" && config.codexApiKey && config.codexModel) {
     return {
-      agent: async (signal) => {
+      "agent.model": async (signal) => {
         const response = await fetch(
           `https://api.openai.com/v1/models/${encodeURIComponent(config.codexModel!)}`,
-          {
-            headers: { Authorization: `Bearer ${config.codexApiKey}` },
-            signal,
-          },
+          { headers: { Authorization: `Bearer ${config.codexApiKey}` }, signal },
         ).catch(() => null);
-        if (!response?.ok) {
-          throw new PublicHealthProbeError("OpenAI authentication failed.");
-        }
+        if (!response?.ok) throw new PublicHealthProbeError("OpenAI authentication failed.");
       },
     };
   }
   return {};
+}
+
+function gitlabFetch(
+  config: SystemHealthConfig,
+  path: string,
+  signal: AbortSignal,
+  init: RequestInit = {},
+): Promise<Response> {
+  const host = (config.gitlabHost ?? "https://gitlab.com").replace(/\/+$/, "");
+  return fetch(`${host}/api/v4${path}`, {
+    ...init,
+    headers: { ...init.headers, "PRIVATE-TOKEN": config.gitlabToken! },
+    signal,
+  });
+}
+
+function resendFetch(
+  config: SystemHealthConfig,
+  path: string,
+  signal: AbortSignal,
+): Promise<Response> {
+  return fetch(`https://api.resend.com${path}`, {
+    headers: { Authorization: `Bearer ${config.resendApiKey}` },
+    signal,
+  });
+}
+
+function vercelFetch(
+  config: SystemHealthConfig,
+  path: string,
+  signal: AbortSignal,
+): Promise<Response> {
+  const joiner = path.includes("?") ? "&" : "?";
+  return fetch(`https://api.vercel.com${path}${joiner}teamId=${encodeURIComponent(config.vercelTeamId!)}`, {
+    headers: { Authorization: `Bearer ${config.vercelToken}` },
+    signal,
+  });
+}
+
+function providerWebhookUrl(
+  config: SystemHealthConfig,
+  provider: "github" | "gitlab" | "resend",
+): string {
+  const base = (config.betterAuthUrl ?? "").replace(/\/+$/, "");
+  return normalizeUrl(`${base}/webhooks/${provider}`);
+}
+
+function normalizeUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function emailDomain(value: string | undefined): string | null {
+  const address = value?.match(/<([^>]+)>/)?.[1] ?? value;
+  const domain = address?.split("@").at(-1)?.trim().toLowerCase();
+  return domain || null;
 }

--- a/apps/worker/src/system-health/provider-webhook-observation.test.ts
+++ b/apps/worker/src/system-health/provider-webhook-observation.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  record: vi.fn<() => Promise<void>>(),
+  waitUntil: vi.fn(),
+}));
+
+vi.mock("@vercel/functions", () => ({ waitUntil: state.waitUntil }));
+vi.mock("../../env.js", () => ({
+  env: {
+    GITHUB_WEBHOOK_SECRET: "github-secret",
+    GITLAB_WEBHOOK_SECRET: "gitlab-secret",
+    JIRA_WEBHOOK_SECRET: "jira-secret",
+    SLACK_SIGNING_SECRET: "slack-secret",
+    RESEND_WEBHOOK_SECRET: "resend-secret",
+  },
+}));
+vi.mock("./observations.js", () => ({
+  recordSystemHealthObservation: state.record,
+  systemHealthObservationScope: (secret: string | undefined) =>
+    `scope:${secret ?? "unconfigured"}`,
+}));
+vi.mock("../db/client.js", () => ({ getDb: () => ({}) }));
+
+const { observeProviderWebhook } = await import("./provider-webhook-observation.js");
+
+describe("provider webhook health observations", () => {
+  beforeEach(() => {
+    state.record.mockReset().mockResolvedValue();
+    state.waitUntil.mockReset();
+  });
+
+  it("defers the database write outside the webhook response path", () => {
+    expect(
+      observeProviderWebhook("github", "accepted", "deferred-test"),
+    ).toBeUndefined();
+    expect(state.record).toHaveBeenCalledOnce();
+    expect(state.record).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: "scope:github-secret" }),
+    );
+    expect(state.waitUntil).toHaveBeenCalledOnce();
+  });
+
+  it("samples repeated unauthenticated failures instead of amplifying writes", () => {
+    observeProviderWebhook("gitlab", "rejected", "throttle-test");
+    observeProviderWebhook("gitlab", "rejected", "throttle-test");
+
+    expect(state.record).toHaveBeenCalledOnce();
+    expect(state.waitUntil).toHaveBeenCalledOnce();
+  });
+
+  it("never changes the provider response when persistence is unavailable", () => {
+    state.record.mockImplementationOnce(() => {
+      throw new Error("database unavailable");
+    });
+
+    expect(() =>
+      observeProviderWebhook("slack", "rejected", "failure-test"),
+    ).not.toThrow();
+    expect(state.waitUntil).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/system-health/provider-webhook-observation.ts
+++ b/apps/worker/src/system-health/provider-webhook-observation.ts
@@ -1,0 +1,77 @@
+import { waitUntil } from "@vercel/functions";
+import { env } from "../../env.js";
+import { getDb } from "../db/client.js";
+import { logger } from "../lib/logger.js";
+import {
+  recordSystemHealthObservation,
+  systemHealthObservationScope,
+  type SystemHealthObservationOutcome,
+} from "./observations.js";
+
+const OBSERVATION_WRITE_INTERVAL_MS = 60_000;
+const lastScheduledAt = new Map<string, number>();
+
+export function observeProviderWebhook(
+  integrationId: "github" | "gitlab" | "jira" | "slack" | "email",
+  outcome: SystemHealthObservationOutcome,
+  reason: string,
+): void {
+  const scope = systemHealthObservationScope(providerWebhookSecret(integrationId));
+  const key = `${integrationId}:${scope}:${outcome}:${reason}`;
+  const now = Date.now();
+  const previous = lastScheduledAt.get(key);
+  if (previous !== undefined && now - previous < OBSERVATION_WRITE_INTERVAL_MS) return;
+  lastScheduledAt.set(key, now);
+
+  let write: Promise<void>;
+  try {
+    write = recordSystemHealthObservation(getDb(), {
+      integrationId,
+      checkId: "webhook-delivery",
+      scope,
+      outcome,
+      reason,
+    });
+  } catch (error) {
+    logWriteFailure(integrationId, outcome, reason, error);
+    return;
+  }
+  write = write.catch((error) => {
+    logWriteFailure(integrationId, outcome, reason, error);
+  });
+  waitUntil(write);
+}
+
+function providerWebhookSecret(
+  integrationId: "github" | "gitlab" | "jira" | "slack" | "email",
+): string | undefined {
+  switch (integrationId) {
+    case "github":
+      return env.GITHUB_WEBHOOK_SECRET;
+    case "gitlab":
+      return env.GITLAB_WEBHOOK_SECRET;
+    case "jira":
+      return env.JIRA_WEBHOOK_SECRET;
+    case "slack":
+      return env.SLACK_SIGNING_SECRET;
+    case "email":
+      return env.RESEND_WEBHOOK_SECRET;
+  }
+}
+
+function logWriteFailure(
+  integrationId: string,
+  outcome: SystemHealthObservationOutcome,
+  reason: string,
+  error: unknown,
+): void {
+  logger.warn(
+    {
+      integrationId,
+      outcome,
+      reason,
+      error: error instanceof Error ? error.message : String(error),
+    },
+    "system_health_observation_write_failed",
+  );
+}

--- a/docs/GITHUB-APP-SETUP.md
+++ b/docs/GITHUB-APP-SETUP.md
@@ -84,15 +84,17 @@ Leave everything on **No access**.
 
 ## 5. Subscribe to events
 
-Under **Subscribe to events**, enable these three:
+Under **Subscribe to events**, enable these five:
 
 - **Pull request**: fires the `pull_request` event on `opened` / `synchronize` / `reopened` / `closed`. Drives the `trigger_pr_created` workflow trigger and the post-PR gate. The deployment filters to the actions it cares about; subscribing to the umbrella event is required.
 - **Check run**: fires the `check_run` event when a CI check completes. Drives the `trigger_pr_checks_failed` workflow trigger (re-run the fix flow when a bot PR's checks fail). Needs the `Checks` permission, which is already read & write from step 4.
 - **Pull request review**: fires the `pull_request_review` event when a human submits a review. Drives the `trigger_pr_review` workflow trigger (react to "request changes" reviews on a bot PR). Needs the `Pull requests` permission, which is already read & write from step 4.
+- **Pull request review comment**: fires the `pull_request_review_comment` event for inline review-thread comments and replies. Lets the agent read and react to line-level PR feedback. Needs the `Pull requests` permission, which is already read & write from step 4.
+- **Issue comment**: fires the `issue_comment` event for general comments on a pull request. Lets the agent read and react to PR conversation comments outside review threads. Needs the `Issues` permission, which is already read & write from step 4.
 
 Leave every other event unchecked.
 
-> Adding **Check run** and **Pull request review** needs no permission change: `Checks` and `Pull requests` are already read & write (step 4). Event-only changes do not require re-accepting the installation; if GitHub still flags the install as "pending" (step 9), a repo admin accepts it before the new events start delivering.
+> Adding **Check run**, **Pull request review**, **Pull request review comment**, and **Issue comment** needs no permission change: `Checks`, `Pull requests`, and `Issues` are already configured in step 4. Event-only changes do not require re-accepting the installation; if GitHub still flags the install as "pending" (step 9), a repo admin accepts it before the new events start delivering.
 
 ## 6. Choose installation scope
 


### PR DESCRIPTION
## Summary

- split System Health providers into independently verified capabilities
- verify webhook configuration, subscriptions, current-secret delivery evidence, and bounded active GitLab transport
- surface degraded/unverified states in the dashboard without false-green readiness
- record bounded payload-free webhook outcomes with 30-day retention
- require GitHub PR comment events so agents receive conversation and inline review feedback

## Safety

- secret values never leave the worker; stored observation scope is a one-way SHA-256 fingerprint
- GitLab active scan uses an unsupported push event that is acknowledged before any workflow dispatch
- active project tests are capped at 4, provider inspection concurrency is capped at 4, and every check has a 4s timeout
- migration is additive and verified against the prior schema

## Verification

- worker full suite: 6012 passed, 0 failed
- clean targeted worker suite: 139 passed, 0 failed
- dashboard health/proxy suite: 9 passed, 0 failed
- worker and dashboard typechecks passed
- Drizzle check and migration regression test passed

## Rollout

Deploy the additive DB migration first. If dashboard and worker are promoted independently, deploy dashboard before worker so the UI understands the new degraded/unverified modes.