### PR TITLE
fix(worker): report what the auto-fix changed in the pull request comment

### DIFF
--- a/apps/worker/drizzle/0056_autofix_comment_binding.sql
+++ b/apps/worker/drizzle/0056_autofix_comment_binding.sql
@@ -1,0 +1,98 @@
+-- Makes an already deployed auto-fix workflow say WHAT it fixed.
+--
+-- The "review-fix-after-pr" template closed every successful run with one fixed
+-- sentence, "Automated fix pushed. Please re-review.", so a reviewer returning
+-- to the pull request learned nothing: not what was failing, not what changed,
+-- not what was verified. The fix agent already reports that (fix_agent output
+-- `summary`); it was simply never wired to the comment. The template now binds
+-- the comment body to it, but a definition that is already deployed froze a copy
+-- of the graph when it was saved and never reads the template again, so without
+-- this migration the fix reaches only workflows created from here on.
+--
+-- Schema version 2 gets no {{variable}} substitution at all
+-- (substituteNodePromptParamsForSchema returns v2 nodes unchanged, and
+-- v2NonAgentPromptPlaceholderIssue rejects braces in v2 non-agent params), so an
+-- input binding is the only mechanism that can carry the summary into the body.
+--
+-- Guard: a definition JSON carries no authorship marker, so a version is
+-- rewritten only when it still has the platform's auto-fix shape AND nobody has
+-- customized the two things being changed:
+--   * a fix_agent node with id "fix" and a post_pr_comment node with id
+--     "comment",
+--   * the comment body byte-matching the platform sentence and carrying no body
+--     binding yet,
+--   * the backbone edges fix -> checks -> finalize -> comment, which is what
+--     makes "steps.fix.output.summary" reachable from the comment. A rewired
+--     graph would take an unreachable reference and start failing validation,
+--     which is the AIW-245 failure mode, so a rewired graph is skipped instead.
+-- A customer who edited either the comment body or the wiring keeps their graph
+-- byte for byte.
+--
+-- No audit table, unlike 0051: there the overwritten value was one of several
+-- unknown shapes, so the pre-image had to be recorded. Here the guard pins the
+-- pre-image exactly (that sentence, and no binding), so an operator reverts by
+-- removing inputs.body and restoring the sentence, with nothing to look up.
+--
+-- Idempotent by construction: after the rewrite the comment node HAS a body
+-- binding, so it no longer matches the guard and a second run changes nothing.
+--
+-- Every stored version is corrected, not just the deployed one, the same way
+-- 0051 does it, so a rollback to an earlier version does not walk back into the
+-- silent comment. One statement, no explicit transaction (neon-http has none),
+-- and every jsonb_array_elements is guarded against a non-array so one malformed
+-- row cannot abort the migration.
+UPDATE "workflow_definition_versions" AS "v"
+SET "definition" = jsonb_set(
+  "v"."definition",
+  '{nodes}',
+  COALESCE((
+    SELECT jsonb_agg("rewritten_node" ORDER BY "node_ord")
+    FROM (
+      SELECT
+        CASE
+          WHEN "node"->>'id' = 'comment'
+           AND "node"->>'type' = 'post_pr_comment'
+           AND "node"->'configuration'->>'body' = $aiw_autofix_comment$Automated fix pushed. Please re-review.$aiw_autofix_comment$
+           AND "node"->'inputs'->'body' IS NULL
+          THEN jsonb_set(
+                 "node",
+                 '{inputs}',
+                 COALESCE("node"->'inputs', '{}'::jsonb)
+                   || $aiw_autofix_comment${"body":{"kind":"reference","reference":"steps.fix.output.summary"}}$aiw_autofix_comment$::jsonb
+               )
+          WHEN "node"->>'id' = 'fix'
+           AND "node"->>'type' = 'fix_agent'
+           AND jsonb_typeof("node"->'configuration') = 'object'
+           AND "node"->'configuration'->>'instructions' = $aiw_autofix_comment$Resolve the fetched pull-request review feedback or failing checks, verify the fix, and commit the resulting changes.$aiw_autofix_comment$
+          THEN jsonb_set(
+                 "node",
+                 '{configuration,instructions}',
+                 to_jsonb($aiw_autofix_comment$Resolve the fetched pull-request review feedback or failing checks, verify the fix, and commit the resulting changes. Your summary is posted as a comment on the pull request, so write it for the reviewer: name what was failing, what you changed and where, and how you verified it.$aiw_autofix_comment$::text)
+               )
+          ELSE "node"
+        END AS "rewritten_node",
+        "node_ord"
+      FROM jsonb_array_elements(
+        CASE WHEN jsonb_typeof("v"."definition"->'nodes') = 'array' THEN "v"."definition"->'nodes' ELSE '[]'::jsonb END
+      ) WITH ORDINALITY AS "n"("node", "node_ord")
+    ) AS "nodes"
+  ), "v"."definition"->'nodes')
+)
+WHERE jsonb_typeof("v"."definition"->'nodes') = 'array'
+  AND jsonb_typeof("v"."definition"->'edges') = 'array'
+  AND "v"."definition"->'edges' @> '[{"from":"fix","to":"checks"}]'::jsonb
+  AND "v"."definition"->'edges' @> '[{"from":"checks","to":"finalize"}]'::jsonb
+  AND "v"."definition"->'edges' @> '[{"from":"finalize","to":"comment"}]'::jsonb
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements("v"."definition"->'nodes') AS "n"("node")
+    WHERE "node"->>'id' = 'fix' AND "node"->>'type' = 'fix_agent'
+  )
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements("v"."definition"->'nodes') AS "n"("node")
+    WHERE "node"->>'id' = 'comment'
+      AND "node"->>'type' = 'post_pr_comment'
+      AND "node"->'configuration'->>'body' = $aiw_autofix_comment$Automated fix pushed. Please re-review.$aiw_autofix_comment$
+      AND "node"->'inputs'->'body' IS NULL
+  );

--- a/apps/worker/drizzle/meta/0056_snapshot.json
+++ b/apps/worker/drizzle/meta/0056_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "3bc44933-3502-4f02-98dc-53cf587dd6fa",
-  "prevId": "0454d493-90ce-4ae4-9a67-c3107e3dfc04",
+  "id": "8c1d5f42-3b76-4a90-9e58-2d4f7a61c0b3",
+  "prevId": "fb2f529c-1201-437b-90ac-af7ee8966a8e",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -2540,6 +2540,38 @@
           ]
         }
       },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_health_scans": {
+      "name": "system_health_scans",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'deployment'"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1787307064716,
       "tag": "0055_system_health_scans",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1787310664716,
+      "tag": "0056_autofix_comment_binding",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/src/workflow-definition/autofix-comment-binding.test.ts
+++ b/apps/worker/src/workflow-definition/autofix-comment-binding.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, expect, it } from "vitest";
+import type { WorkflowDefinitionV2 } from "@shared/contracts";
+import type { WorkflowBlockRegistryContext } from "./block-registry.js";
+import { workflowDefinitionTemplate } from "./templates.js";
+import { validateWorkflowDefinitionCandidate } from "./validation.js";
+
+const migrationsDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+const migrationFiles = readdirSync(migrationsDir)
+  .filter((file) => file.endsWith(".sql"))
+  .sort();
+
+const registryContext: WorkflowBlockRegistryContext = {
+  agentProviders: { claude: true, codex: true },
+  llmProviders: { claude: true, codex: true },
+  defaultAgent: { provider: "claude", model: "claude-test" },
+  vcsProviders: ["github", "gitlab"],
+  vcsBotIdentities: ["github", "gitlab"],
+  slackConfigured: true,
+  arthurConfigured: true,
+  webhookTriggerConfigured: true,
+};
+
+const OLD_INSTRUCTIONS =
+  "Resolve the fetched pull-request review feedback or failing checks, verify the fix, and commit the resulting changes.";
+const AUTOFIX_COMMENT_MIGRATION = "0056_autofix_comment_binding";
+
+async function migrateThrough(lastPrefix: string): Promise<PGlite> {
+  const client = new PGlite();
+  for (const file of migrationFiles) {
+    if (file.slice(0, 4) > lastPrefix) break;
+    await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+  }
+  return client;
+}
+
+async function applyAutofixCommentBinding(client: PGlite): Promise<void> {
+  const file = migrationFiles.find((name) => name.startsWith(AUTOFIX_COMMENT_MIGRATION));
+  if (!file) throw new Error(`${AUTOFIX_COMMENT_MIGRATION} migration not found`);
+  await client.exec(readFileSync(`${migrationsDir}${file}`, "utf8"));
+}
+
+async function deployDefinition(
+  client: PGlite,
+  name: string,
+  definition: unknown,
+): Promise<number> {
+  const created = await client.query<{ id: number }>(
+    `INSERT INTO workflow_definitions (name, enabled, trigger_types, created_by_id, created_by_label)
+     VALUES ($1, false, '{}', 'u_admin', 'Admin') RETURNING id`,
+    [name],
+  );
+  const id = created.rows[0]!.id;
+  await client.query(
+    `INSERT INTO workflow_definition_versions (definition_id, version, definition, created_by_id, created_by_label)
+     VALUES ($1, 1, $2, 'u_admin', 'Admin')`,
+    [id, JSON.stringify(definition)],
+  );
+  await client.query(`UPDATE workflow_definitions SET deployed_version = 1 WHERE id = $1`, [id]);
+  return id;
+}
+
+async function readStoredDefinition(client: PGlite, id: number): Promise<unknown> {
+  const rows = await client.query<{ definition: unknown }>(
+    `SELECT definition FROM workflow_definition_versions WHERE definition_id = $1 AND version = 1`,
+    [id],
+  );
+  return rows.rows[0]!.definition;
+}
+
+function currentFixTemplate(): WorkflowDefinitionV2 {
+  const template = workflowDefinitionTemplate("review-fix-after-pr", {
+    includeReview: true,
+    provider: "claude",
+  });
+  if (!template || template.definition.schemaVersion !== 2) {
+    throw new Error("The Fix template must use schema version 2");
+  }
+  return template.definition;
+}
+
+/** What the same template produced before the summary was wired into the
+ *  comment, which is what every definition deployed until now still stores. */
+function deployedBeforeTheFix(): WorkflowDefinitionV2 {
+  const definition = JSON.parse(JSON.stringify(currentFixTemplate())) as WorkflowDefinitionV2;
+  for (const node of definition.nodes) {
+    if (node.id === "comment") node.inputs = {};
+    if (node.id === "fix") node.configuration.instructions = OLD_INSTRUCTIONS;
+  }
+  return definition;
+}
+
+describe("0056 auto-fix comment binding", () => {
+  it("brings a definition deployed before the fix up to the current template", async () => {
+    const client = await migrateThrough("0055");
+    const before = deployedBeforeTheFix();
+    const id = await deployDefinition(client, "PR checks failed autofix", before);
+
+    await applyAutofixCommentBinding(client);
+
+    const after = await readStoredDefinition(client, id);
+    expect(after).toEqual(currentFixTemplate());
+    expect(
+      validateWorkflowDefinitionCandidate(after, registryContext).response.valid,
+    ).toBe(true);
+  });
+
+  it("changes nothing on a second application", async () => {
+    const client = await migrateThrough("0055");
+    const id = await deployDefinition(client, "PR checks failed autofix", deployedBeforeTheFix());
+
+    await applyAutofixCommentBinding(client);
+    const once = await readStoredDefinition(client, id);
+    await applyAutofixCommentBinding(client);
+    const twice = await readStoredDefinition(client, id);
+
+    expect(twice).toEqual(once);
+  });
+
+  it("leaves a customized comment body byte for byte", async () => {
+    const client = await migrateThrough("0055");
+    const customized = deployedBeforeTheFix();
+    customized.nodes.find((node) => node.id === "comment")!.configuration.body =
+      "Our bot pushed a fix.";
+    const id = await deployDefinition(client, "Customized autofix", customized);
+
+    await applyAutofixCommentBinding(client);
+
+    // The instructions are left alone too: a graph whose comment somebody edited
+    // is not ours to rewrite, in either place.
+    expect(await readStoredDefinition(client, id)).toEqual(customized);
+  });
+
+  it("leaves a rewired graph alone rather than binding an unreachable reference", async () => {
+    const client = await migrateThrough("0055");
+    const rewired = deployedBeforeTheFix();
+    // The pre-PR checks node is gone, so fix no longer reaches comment through
+    // the backbone the guard recognizes.
+    rewired.nodes = rewired.nodes.filter((node) => node.id !== "checks");
+    rewired.edges = rewired.edges
+      .filter((edge) => edge.to !== "checks" && edge.from !== "checks")
+      .concat([{ id: "rewired-fix-out-finalize", from: "fix", to: "finalize" }]);
+    const id = await deployDefinition(client, "Rewired autofix", rewired);
+
+    await applyAutofixCommentBinding(client);
+
+    expect(await readStoredDefinition(client, id)).toEqual(rewired);
+  });
+
+  it("corrects every stored version, not only the deployed one", async () => {
+    const client = await migrateThrough("0055");
+    const id = await deployDefinition(client, "PR checks failed autofix", deployedBeforeTheFix());
+    await client.query(
+      `INSERT INTO workflow_definition_versions (definition_id, version, definition, created_by_id, created_by_label)
+       VALUES ($1, 2, $2, 'u_admin', 'Admin')`,
+      [id, JSON.stringify(deployedBeforeTheFix())],
+    );
+
+    await applyAutofixCommentBinding(client);
+
+    const rows = await client.query<{ version: number; definition: unknown }>(
+      `SELECT version, definition FROM workflow_definition_versions
+       WHERE definition_id = $1 ORDER BY version`,
+      [id],
+    );
+    expect(rows.rows.map((row) => row.version)).toEqual([1, 2]);
+    for (const row of rows.rows) expect(row.definition).toEqual(currentFixTemplate());
+  });
+});

--- a/apps/worker/src/workflow-definition/default-v2.test.ts
+++ b/apps/worker/src/workflow-definition/default-v2.test.ts
@@ -214,6 +214,27 @@ describe("v2 built-in authoring definitions", () => {
       ?.configuration.instructions).toContain("Resolve the fetched pull-request");
   });
 
+  it("posts what the fix agent changed rather than a fixed sentence", () => {
+    const fix = workflowDefinitionTemplate("review-fix-after-pr", {
+      includeReview: true,
+      provider: "claude",
+    })!.definition;
+    if (fix.schemaVersion !== 2) {
+      throw new Error("The Fix template must use schema version 2");
+    }
+
+    const comment = fix.nodes.find((node) => node.type === "post_pr_comment")!;
+    expect(comment.inputs.body).toEqual({
+      kind: "reference",
+      reference: "steps.fix.output.summary",
+    });
+    // The authored body survives as the fallback for an agent that reports no
+    // summary, so the pull request is never left without a comment.
+    expect(comment.configuration.body).toBe("Automated fix pushed. Please re-review.");
+    expect(fix.nodes.find((node) => node.type === "fix_agent")
+      ?.configuration.instructions).toContain("posted as a comment on the pull request");
+  });
+
   it.each(["claude", "codex"] as const)(
     "builds every %s template as a structurally deployable v2 graph",
     (provider) => {

--- a/apps/worker/src/workflow-definition/templates.ts
+++ b/apps/worker/src/workflow-definition/templates.ts
@@ -220,7 +220,8 @@ function reviewFixAfterPrDefinition(
       configuration: {
         ...builtinHarnessProfileConfiguration(provider, profileReference),
         instructions:
-          "Resolve the fetched pull-request review feedback or failing checks, verify the fix, and commit the resulting changes.",
+          "Resolve the fetched pull-request review feedback or failing checks, verify the fix, and commit the resulting changes. " +
+          "Your summary is posted as a comment on the pull request, so write it for the reviewer: name what was failing, what you changed and where, and how you verified it.",
       },
     },
     {
@@ -244,8 +245,18 @@ function reviewFixAfterPrDefinition(
       column: 6,
       row: 0,
       configuration: {
+        // Fallback only. It is what gets posted when the fix agent reports no
+        // summary, which is the one case where we have nothing to say beyond
+        // that a fix landed.
         body: "Automated fix pushed. Please re-review.",
         target: "all",
+      },
+      inputs: {
+        // The reviewer is told what was fixed, not just that something was.
+        body: {
+          kind: "reference",
+          reference: "steps.fix.output.summary" as WorkflowDataReferenceV2,
+        },
       },
     },
   ];

--- a/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.test.ts
@@ -194,6 +194,35 @@ describe("post_pr_comment execute", () => {
     expect(postPRComment).toHaveBeenCalledWith(7, marked("Bound"));
   });
 
+  it("falls back to the authored body when the binding resolves to nothing", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: null });
+    mockFreshVcs(postPRComment);
+
+    await execute(
+      makeNode("post_pr_comment", { body: "Automated fix pushed." }),
+      {},
+      makeCtx({ publication: publication() }),
+      { body: "   " },
+    );
+
+    expect(postPRComment).toHaveBeenCalledWith(7, marked("Automated fix pushed."));
+  });
+
+  it("still rejects an empty binding with no authored body to fall back to", async () => {
+    const postPRComment = vi.fn().mockResolvedValue({ url: null });
+    mockFreshVcs(postPRComment);
+
+    const result = await execute(
+      makeNode("post_pr_comment", { body: "" }),
+      {},
+      makeCtx({ publication: publication() }),
+      { body: "" },
+    );
+
+    expect(result.kind).toBe("execution_error");
+    expect(postPRComment).not.toHaveBeenCalled();
+  });
+
   it("comments every PR when target is all", async () => {
     const postPRComment = vi.fn().mockResolvedValue({ url: null });
     mockFreshVcs(postPRComment);

--- a/apps/worker/src/workflows/blocks/post-pr-comment.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.ts
@@ -52,8 +52,10 @@ async function blockPostPrCommentStep(
   const comments: PostPrCommentsResult["comments"] = [];
   const errors: string[] = [];
 
-  // The body is {{variable}}-substituted before it gets here, so it can carry
-  // {{change_summary}} or any agent block's output.
+  // On schema version 1 the body is {{variable}}-substituted before it gets
+  // here, so it can carry {{change_summary}} or any agent block's output. v2
+  // gets no substitution at all and carries the same thing through a binding on
+  // the body input.
   const scrubbed = scrubForPublication(body);
   // Every comment we post carries the marker so that even a misconfigured bot
   // login cannot let our own comments re-trigger the workflow (AIW-140).

--- a/apps/worker/src/workflows/blocks/post-pr-comment.ts
+++ b/apps/worker/src/workflows/blocks/post-pr-comment.ts
@@ -130,12 +130,16 @@ export const execute: BlockExecuteFn = async (
   ctx,
   resolvedInputs = {},
 ): Promise<BlockExecutionResult> => {
-  const body =
-    typeof resolvedInputs.body === "string"
-      ? resolvedInputs.body.trim()
-      : typeof block.params.body === "string"
-        ? block.params.body.trim()
-        : "";
+  // A bound body wins over the authored one, but a binding that resolves to
+  // nothing falls back to it instead of failing the run. The auto-fix graph
+  // binds this to the fix agent's summary so the comment says what was fixed,
+  // and an agent that reports no summary must still leave the pull request with
+  // a comment saying a fix was pushed.
+  const boundBody =
+    typeof resolvedInputs.body === "string" ? resolvedInputs.body.trim() : "";
+  const authoredBody =
+    typeof block.params.body === "string" ? block.params.body.trim() : "";
+  const body = boundBody.length > 0 ? boundBody : authoredBody;
   if (body.length === 0) {
     return executionError("post_pr_comment requires a body", {
       category: "binding",


### PR DESCRIPTION
## What

The auto-fix workflow closed every successful run with the same sentence:

> Automated fix pushed. Please re-review.

A reviewer coming back to a pull request learned nothing from it: not what was
failing, not what changed, not what was verified. The fix agent already produces
that account (`fix_agent` output `summary`), it was simply never used.

## How

- The `comment` node of the `review-fix-after-pr` template now binds its `body`
  to `steps.fix.output.summary`, so the comment carries the agent's own report of
  the change. Schema version 2 blocks get no `{{variable}}` substitution
  (`substituteNodePromptParamsForSchema` returns v2 nodes unchanged, and
  `v2NonAgentPromptPlaceholderIssue` rejects braces in v2 non-agent params), so an
  input binding is the only mechanism available here.
- The fix agent's instructions now say the summary is posted on the pull request,
  so it is written for a reviewer.
- `post_pr_comment` falls back to the authored body when a binding resolves to
  blank, instead of failing the run. Without that, an agent that reports no
  summary would end the run on `post_pr_comment requires a body` with the fix
  already pushed, which is the failure mode AIW-310 was about.

The authored body stays in the node as that fallback, so a pull request is never
left without a comment.

## Verification

- `apps/worker`: `vitest run src/workflows/blocks/post-pr-comment.test.ts src/workflow-definition/default-v2.test.ts` -> 38 passed.
- The existing "builds every %s template as a structurally deployable v2 graph"
  case runs the deployment validator over the new binding.
- `pnpm --filter worker typecheck` clean.



## Reaching workflows that are already deployed

A deployed definition froze a copy of the graph when it was saved and never reads
the template again, so the template change alone would only reach workflows
created from here on. Migration `0054_autofix_comment_binding` adds the same
binding and the same instructions to stored versions, guarded so that it can only
touch a graph that is still the platform's auto-fix shape:

- a `fix_agent` node with id `fix` and a `post_pr_comment` node with id `comment`,
- the comment body byte-matching the platform sentence, with no body binding yet,
- the backbone edges `fix -> checks -> finalize -> comment`, which is what makes
  `steps.fix.output.summary` reachable from the comment. A rewired graph would
  otherwise get an unreachable reference and start failing validation, the
  AIW-245 failure mode, so a rewired graph is skipped instead.

No audit table, unlike `0051`: there the overwritten value was one of several
unknown shapes. Here the guard pins the pre-image exactly, so reverting is
"remove `inputs.body`, restore the sentence" with nothing to look up. It is
idempotent by construction, since after the rewrite the node no longer matches
its own guard.

`apps/worker`: `vitest run src/workflow-definition/autofix-comment-binding.test.ts` -> 5 passed,
including that a definition deployed before the fix comes out byte-identical to
what the template produces now, and that a customized or rewired graph is left
alone. `carry-schema-drift.test.ts` (8 passed) walks every migration file, so the
new one applies cleanly in sequence.
