### PR TITLE
refactor(system-health): drop the Vercel deployment row

### DIFF
--- a/apps/dashboard/components/cockpit/screens/health.test.tsx
+++ b/apps/dashboard/components/cockpit/screens/health.test.tsx
@@ -11,12 +11,12 @@ import { HealthScreen } from "./health";
 const data: SystemHealthResponse = {
   generatedAt: "2026-08-20T12:00:00.000Z",
   summary: {
-    total: 3,
+    total: 2,
     live: 1,
     down: 1,
     notConfigured: 0,
     criticalDown: 1,
-    checksTotal: 6,
+    checksTotal: 4,
     checksLive: 3,
     checksDown: 1,
     checksDegraded: 0,
@@ -30,15 +30,26 @@ const data: SystemHealthResponse = {
       critical: true,
       mode: "live",
       ping: { ok: true, latencyMs: 12 },
-      checks: [{
-        id: "connectivity",
-        label: "Connection and query",
-        description: "Verified independently.",
-        critical: true,
-        mode: "live",
-        envVars: ["DATABASE_URL"],
-        evidenceSource: "live-probe",
-      }],
+      checks: [
+        {
+          id: "connectivity",
+          label: "Connection and query",
+          description: "Verified independently.",
+          critical: true,
+          mode: "live",
+          envVars: ["DATABASE_URL"],
+          evidenceSource: "live-probe",
+        },
+        {
+          id: "migrations",
+          label: "Schema migrations",
+          description: "Verified independently.",
+          critical: true,
+          mode: "live",
+          envVars: ["DATABASE_URL"],
+          evidenceSource: "live-probe",
+        },
+      ],
     },
     {
       id: "github",
@@ -67,35 +78,6 @@ const data: SystemHealthResponse = {
           envVars: ["GITHUB_WEBHOOK_SECRET"],
           evidenceSource: "provider-delivery",
           message: "Latest GitHub delivery failed with HTTP 401.",
-        },
-      ],
-    },
-    {
-      id: "vercel",
-      label: "Vercel deployment",
-      group: "platform",
-      envVars: ["VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"],
-      critical: false,
-      mode: "live",
-      ping: { ok: true, latencyMs: 80 },
-      checks: [
-        {
-          id: "project",
-          label: "Project access",
-          description: "Verified independently.",
-          critical: true,
-          mode: "live",
-          envVars: ["VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"],
-          evidenceSource: "live-probe",
-        },
-        {
-          id: "production-deployment",
-          label: "Production deployment",
-          description: "Verified independently.",
-          critical: false,
-          mode: "live",
-          envVars: ["VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"],
-          evidenceSource: "live-probe",
         },
       ],
     },
@@ -272,13 +254,12 @@ test("checks that all need the same variables leave them on the provider row", (
     renderer = create(<HealthScreen initialData={data} />);
   });
   const button = renderer.root.findByProps({
-    "aria-controls": "health-checks-vercel",
+    "aria-controls": "health-checks-database",
   });
   act(() => button.props.onClick());
 
   const text = textOf(renderer.toJSON());
-  assert.match(text, /Production deployment/);
-  assert.equal(count(text, "VERCEL_TOKEN"), 1);
-  assert.equal(count(text, "VERCEL_PROJECT_ID"), 1);
+  assert.match(text, /Schema migrations/);
+  assert.equal(count(text, "DATABASE_URL"), 1);
   act(() => renderer.unmount());
 });

--- a/apps/dashboard/components/cockpit/screens/health.tsx
+++ b/apps/dashboard/components/cockpit/screens/health.tsx
@@ -27,7 +27,7 @@ const GROUPS: Array<{
   {
     id: "platform",
     label: "Platform extensions",
-    description: "Optional integrations that add notifications, traces, remote tools, and hosting context.",
+    description: "Optional integrations that add notifications, traces, and remote tools.",
   },
 ];
 
@@ -43,7 +43,6 @@ const DESCRIPTIONS: Record<string, string> = {
   slack: "Checks bot auth, channel access, and recent slash-command signatures.",
   arthur: "Reads the task API used by traces, evaluations, and guardrails.",
   mcp: "Checks that the enabled remote tool contract contains tools.",
-  vercel: "Reads the configured project and its latest production deployment.",
   "custom-webhooks": "Aggregates active custom endpoints, deliveries, and rejection counters.",
 };
 

--- a/apps/worker/src/system-health/collect.test.ts
+++ b/apps/worker/src/system-health/collect.test.ts
@@ -198,7 +198,6 @@ describe("collectSystemHealth", () => {
       ]),
     );
     expect(checks).toContainEqual({ id: "sso.client", mode: "configured" });
-    expect(checks).toContainEqual({ id: "vercel.project", mode: "not-configured" });
     expect(JSON.stringify(result)).not.toContain("unverified");
   });
 

--- a/apps/worker/src/system-health/collect.ts
+++ b/apps/worker/src/system-health/collect.ts
@@ -45,9 +45,6 @@ export type SystemHealthConfig = {
   arthurTraceEndpoint?: string;
   mcpEnabled: boolean;
   webhookTriggerEncryptionKey?: string;
-  vercelToken?: string;
-  vercelTeamId?: string;
-  vercelProjectId?: string;
 };
 
 export type SystemHealthProbeResult = {
@@ -229,11 +226,6 @@ function healthDefinitions(config: SystemHealthConfig): IntegrationDefinition[] 
         ? "misconfigured"
         : "mock";
   const arthurMode = groupedMode([config.arthurApiKey, config.arthurTraceEndpoint]);
-  const vercelMode = groupedMode([
-    config.vercelToken,
-    config.vercelTeamId,
-    config.vercelProjectId,
-  ]);
   const agentMode: SystemHealthMode =
     config.agentKind === "claude"
       ? requiredMode([config.anthropicApiKey, config.anthropicModel])
@@ -286,10 +278,6 @@ function healthDefinitions(config: SystemHealthConfig): IntegrationDefinition[] 
     ]),
     integration("mcp", "Remote MCP", "platform", false, [
       checked("contract", "Published tool contract", ["MCP_ENABLED"], config.mcpEnabled ? "configured" : "not-configured", true),
-    ]),
-    integration("vercel", "Vercel deployment", "platform", false, [
-      checked("project", "Project access", ["VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"], vercelMode, true),
-      checked("production-deployment", "Production deployment", ["VERCEL_TOKEN", "VERCEL_TEAM_ID", "VERCEL_PROJECT_ID"], vercelMode, false),
     ]),
     integration("custom-webhooks", "Custom webhooks", "platform", false, [
       checked("aggregate", "Endpoint and delivery aggregate", ["WEBHOOK_TRIGGER_ENCRYPTION_KEY"], config.webhookTriggerEncryptionKey ? "configured" : "not-configured", false, "local-observation"),

--- a/apps/worker/src/system-health/probes.test.ts
+++ b/apps/worker/src/system-health/probes.test.ts
@@ -39,9 +39,6 @@ const environment = vi.hoisted(() => ({
   GENAI_ENGINE_TRACE_ENDPOINT: "https://arthur.example/api/v1/traces",
   MCP_ENABLED: true,
   WEBHOOK_TRIGGER_ENCRYPTION_KEY: "a".repeat(64),
-  VERCEL_TOKEN: "vercel-token",
-  VERCEL_TEAM_ID: "team-id",
-  VERCEL_PROJECT_ID: "project/id",
 }));
 
 vi.mock("../../env.js", () => ({ env: environment }));
@@ -147,9 +144,6 @@ describe("deployment system-health probes", () => {
       arthurTraceEndpoint: environment.GENAI_ENGINE_TRACE_ENDPOINT,
       mcpEnabled: environment.MCP_ENABLED,
       webhookTriggerEncryptionKey: environment.WEBHOOK_TRIGGER_ENCRYPTION_KEY,
-      vercelToken: environment.VERCEL_TOKEN,
-      vercelTeamId: environment.VERCEL_TEAM_ID,
-      vercelProjectId: environment.VERCEL_PROJECT_ID,
     });
   });
 
@@ -184,8 +178,6 @@ describe("deployment system-health probes", () => {
       "slack.channel",
       "arthur.api",
       "mcp.contract",
-      "vercel.project",
-      "vercel.production-deployment",
       "agent.model",
     ]) {
       expect(probes[id], id).toBeTypeOf("function");

--- a/apps/worker/src/system-health/probes.ts
+++ b/apps/worker/src/system-health/probes.ts
@@ -94,9 +94,6 @@ export function configFromEnvironment(): SystemHealthConfig {
     arthurTraceEndpoint: env.GENAI_ENGINE_TRACE_ENDPOINT,
     mcpEnabled: env.MCP_ENABLED,
     webhookTriggerEncryptionKey: env.WEBHOOK_TRIGGER_ENCRYPTION_KEY,
-    vercelToken: env.VERCEL_TOKEN,
-    vercelTeamId: env.VERCEL_TEAM_ID,
-    vercelProjectId: env.VERCEL_PROJECT_ID,
   };
 }
 
@@ -249,12 +246,6 @@ export function probesForEnvironment(config: SystemHealthConfig): SystemHealthPr
         throw new PublicHealthProbeError("MCP contract has no tools.");
       }
     };
-  }
-
-  if (config.vercelToken && config.vercelTeamId && config.vercelProjectId) {
-    probes["vercel.project"] = (signal) => vercelProjectResult(config, signal);
-    probes["vercel.production-deployment"] = (signal) =>
-      vercelDeploymentResult(config, signal);
   }
 
   Object.assign(probes, agentProbes(config));
@@ -811,34 +802,6 @@ function utcDayStart(now: Date = new Date()): Date {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 }
 
-async function vercelProjectResult(
-  config: SystemHealthConfig,
-  signal: AbortSignal,
-): Promise<void> {
-  const response = await vercelFetch(
-    config,
-    `/v9/projects/${encodeURIComponent(config.vercelProjectId!)}`,
-    signal,
-  );
-  if (!response.ok) throw new PublicHealthProbeError("Vercel project check failed.");
-}
-
-async function vercelDeploymentResult(
-  config: SystemHealthConfig,
-  signal: AbortSignal,
-): Promise<void> {
-  const response = await vercelFetch(
-    config,
-    `/v6/deployments?projectId=${encodeURIComponent(config.vercelProjectId!)}&target=production&limit=1`,
-    signal,
-  );
-  if (!response.ok) throw new PublicHealthProbeError("Vercel deployment lookup failed.");
-  const body = (await response.json()) as { deployments?: Array<{ readyState?: string }> };
-  if (body.deployments?.[0]?.readyState !== "READY") {
-    throw new PublicHealthProbeError("Latest Vercel production deployment is not READY.");
-  }
-}
-
 function agentProbes(config: SystemHealthConfig): SystemHealthProbes {
   if (config.agentKind === "claude" && config.anthropicApiKey && config.anthropicModel) {
     if (config.anthropicApiKey.startsWith("sk-ant-oat")) return {};
@@ -896,18 +859,6 @@ function resendFetch(
 ): Promise<Response> {
   return fetch(`https://api.resend.com${path}`, {
     headers: { Authorization: `Bearer ${config.resendApiKey}` },
-    signal,
-  });
-}
-
-function vercelFetch(
-  config: SystemHealthConfig,
-  path: string,
-  signal: AbortSignal,
-): Promise<Response> {
-  const joiner = path.includes("?") ? "&" : "?";
-  return fetch(`https://api.vercel.com${path}${joiner}teamId=${encodeURIComponent(config.vercelTeamId!)}`, {
-    headers: { Authorization: `Bearer ${config.vercelToken}` },
     signal,
   });
 }


### PR DESCRIPTION
## Summary
- remove the optional "Vercel deployment" integration from System Health: its two probes asked the Vercel API, from inside a running deployment, whether that deployment is READY, and prod has no VERCEL_* variables, so the row only ever said "needs configuration"
- `VERCEL_TOKEN/TEAM_ID/PROJECT_ID` stay in env.ts: the sandbox credentials helper and the MCP secret redaction still read them

## Test plan
- [x] worker: collect.test.ts (12), probes.test.ts (19), typecheck
- [x] dashboard: health.test.tsx (6), typecheck
- [ ] prod: Scan again shows no Vercel row under Platform extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)