### PR TITLE
docs(release): record the Artur 2026.08.11 release rehearsal

### DIFF
--- a/docs/releases/artur/rehearsals/2026.08.11.json
+++ b/docs/releases/artur/rehearsals/2026.08.11.json
@@ -1,0 +1,11 @@
+{
+  "version": "2026.08.11",
+  "sourceCommit": "c33d84e2e7b38f32b38f080d4e97eaaa00bb6b74",
+  "runId": "wrun_01M0J0DVBFB1B9MDSYG1TAPQ6Q",
+  "runUrl": "https://ai-workflow-app-dashboard.vercel.app/trace/wrun_01M0J0DVBFB1B9MDSYG1TAPQ6Q",
+  "repository": "Blazity/aiw-checks-fixture",
+  "checksDurationSec": 636,
+  "outcome": "success",
+  "recordedAt": "2026-08-21T11:29:34Z",
+  "recordedBy": "filip.maszota@blazity.com"
+}


### PR DESCRIPTION
Evidence for the 2026.08.11 release gate.

One end-to-end run on our own production, against a repository whose pre-PR
checks really run past the 300 second invocation ceiling.

| | |
|---|---|
| Run | [`wrun_01M0J0DVBFB1B9MDSYG1TAPQ6Q`](https://ai-workflow-app-dashboard.vercel.app/trace/wrun_01M0J0DVBFB1B9MDSYG1TAPQ6Q) |
| Definition | 30 "Release rehearsal", version 2, `builtin-claude` / `claude-opus-4-6` |
| Source commit | `c33d84e2e7b38f32b38f080d4e97eaaa00bb6b74`, the pin in #340 |
| Deployment | `ai-workflow-9v170kt77`, built from that commit, alias `ai-workflow-app-eight` |
| Repository | `Blazity/aiw-checks-fixture` |
| Outcome | `success`, 945 s total |
| Pull request opened | [aiw-checks-fixture#8](https://github.com/Blazity/aiw-checks-fixture/pull/8), head `ee181854` |

Node by node: `trigger` fired, `prepare` ok 16 s, `planning` ready 105 s,
`implementation` implemented 101 s, **`checks` ok 636 114 ms**, `finalize`
finalized 14 s, `open-pr` ok 14 s, `status` ok 9 s.

The checks figure is the one the gate exists for: 636 seconds is twice the
300 second floor, so this rehearsal did cross the invocation boundary that the
client outage came from.
