### PR TITLE
fix(system-health): verify Slack delivery for real and name the failing Jira call

### DIFF
--- a/apps/dashboard/components/cockpit/screens/health.tsx
+++ b/apps/dashboard/components/cockpit/screens/health.tsx
@@ -40,7 +40,7 @@ const DESCRIPTIONS: Record<string, string> = {
   "dashboard-auth": "Presence-checks auth settings; this request already proves session enforcement.",
   sso: "Checks OIDC discovery; client credentials are presence-checked.",
   email: "Checks Resend sender readiness and the delivery-status webhook registration.",
-  slack: "Checks bot auth, channel access, and recent slash-command signatures.",
+  slack: "Checks bot auth, real message delivery to the configured channel, and recent slash-command signatures.",
   arthur: "Reads the task API used by traces, evaluations, and guardrails.",
   mcp: "Checks that the enabled remote tool contract contains tools.",
   "custom-webhooks": "Aggregates active custom endpoints, deliveries, and rejection counters.",

--- a/apps/worker/src/system-health/collect.ts
+++ b/apps/worker/src/system-health/collect.ts
@@ -270,7 +270,7 @@ function healthDefinitions(config: SystemHealthConfig): IntegrationDefinition[] 
     ]),
     integration("slack", "Slack", "platform", false, [
       checked("bot-auth", "Bot authentication", ["CHAT_SDK_SLACK_TOKEN"], slackBotMode, true),
-      checked("channel", "Configured channel access", ["CHAT_SDK_SLACK_TOKEN", "CHAT_SDK_CHANNEL_ID"], slackChannelMode, true),
+      checked("channel", "Configured channel delivery", ["CHAT_SDK_SLACK_TOKEN", "CHAT_SDK_CHANNEL_ID"], slackChannelMode, true),
       checked("webhook-delivery", "Slash command signature", ["SLACK_SIGNING_SECRET", "SLACK_ALLOWED_USER_IDS"], optionalValueMode(config.slackSigningSecret), false, "local-observation"),
     ]),
     integration("arthur", "Arthur AI Engine", "platform", false, [

--- a/apps/worker/src/system-health/probes.test.ts
+++ b/apps/worker/src/system-health/probes.test.ts
@@ -160,7 +160,9 @@ describe("deployment system-health probes", () => {
           data: [{ name: "example.com", status: "verified" }],
         }));
       }
-      if (url.includes("slack.com")) return new Response(JSON.stringify({ ok: true }));
+      if (url.includes("slack.com")) {
+        return new Response(JSON.stringify({ ok: true, scheduled_message_id: "Q0123" }));
+      }
       if (url.includes("/v6/deployments")) {
         return new Response(JSON.stringify({ deployments: [{ readyState: "READY" }] }));
       }
@@ -190,9 +192,59 @@ describe("deployment system-health probes", () => {
         "https://sso.example/.well-known/openid-configuration",
         "https://api.resend.com/domains",
         "https://slack.com/api/auth.test",
-        "https://slack.com/api/conversations.info",
+        "https://slack.com/api/chat.scheduleMessage",
+        "https://slack.com/api/chat.deleteScheduledMessage",
       ]),
     );
+  });
+
+  it("verifies Slack delivery end to end and deletes the scheduled probe", async () => {
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith("chat.scheduleMessage")) {
+        return Response.json({ ok: true, scheduled_message_id: "Q0123" });
+      }
+      if (url.endsWith("chat.deleteScheduledMessage")) return Response.json({ ok: true });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    const probes = probesForEnvironment(configFromEnvironment());
+    const result = await probes["slack.channel"]!(new AbortController().signal);
+    expect(result).toMatchObject({ mode: "live" });
+    const deletion = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("chat.deleteScheduledMessage"),
+    );
+    expect(String(deletion?.[1]?.body)).toContain("scheduled_message_id=Q0123");
+  });
+
+  it("reports the Slack error when the bot cannot deliver to the channel", async () => {
+    fetchMock.mockImplementation(async () =>
+      Response.json({ ok: false, error: "channel_not_found" }),
+    );
+    const probes = probesForEnvironment(configFromEnvironment());
+    await expect(probes["slack.channel"]!(new AbortController().signal)).rejects.toThrow(
+      "Slack bot cannot deliver to the configured channel (channel_not_found).",
+    );
+  });
+
+  it("names the Jira call that failed instead of one blended error", async () => {
+    const signal = new AbortController().signal;
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("/_edge/tenant_info")) return Response.json({ cloudId: "cloud-1" });
+      if (url.includes("/rest/api/3/myself")) return new Response(null, { status: 401 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    await expect(
+      probesForEnvironment(configFromEnvironment())["jira.api"]!(signal),
+    ).rejects.toThrow("Jira authentication failed: the base URL or API token was not accepted.");
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes("/_edge/tenant_info")) return Response.json({ cloudId: "cloud-1" });
+      if (url.includes("/rest/api/3/myself")) return Response.json({ accountId: "acc-1" });
+      if (url.includes("/statuses")) return new Response(null, { status: 404 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    await expect(
+      probesForEnvironment(configFromEnvironment())["jira.api"]!(signal),
+    ).rejects.toThrow("Jira authenticated, but the configured project is not accessible");
   });
 
   it("omits a fake probe for OAuth-only agent tokens instead of inventing a result", () => {

--- a/apps/worker/src/system-health/probes.ts
+++ b/apps/worker/src/system-health/probes.ts
@@ -108,16 +108,27 @@ export function probesForEnvironment(config: SystemHealthConfig): SystemHealthPr
     },
     "jira.api": async (signal) => {
       if (!config.jiraBaseUrl || !config.jiraApiToken || !config.jiraProjectKey) return;
+      const adapter = new JiraAdapter({
+        baseUrl: config.jiraBaseUrl,
+        apiToken: config.jiraApiToken,
+        projectKey: config.jiraProjectKey,
+      });
+      // Two separate errors on purpose: a deployment where runs flow through
+      // webhooks can hide a stale project key for weeks, and one blended
+      // message made that undiagnosable from the Health screen.
       try {
-        const adapter = new JiraAdapter({
-          baseUrl: config.jiraBaseUrl,
-          apiToken: config.jiraApiToken,
-          projectKey: config.jiraProjectKey,
-        });
         await adapter.getCurrentUserAccountId(signal);
+      } catch {
+        throw new PublicHealthProbeError(
+          "Jira authentication failed: the base URL or API token was not accepted.",
+        );
+      }
+      try {
         await adapter.listStatuses(signal);
       } catch {
-        throw new PublicHealthProbeError("Jira account or project access failed.");
+        throw new PublicHealthProbeError(
+          "Jira authenticated, but the configured project is not accessible; check JIRA_PROJECT_KEY and the token account's access to that project.",
+        );
       }
     },
     "jira.webhook-delivery": (signal) => jiraWebhookResult(config, signal),
@@ -212,14 +223,13 @@ export function probesForEnvironment(config: SystemHealthConfig): SystemHealthPr
   }
 
   if (config.slackToken) {
-    probes["slack.bot-auth"] = (signal) => slackApiResult(config, "auth.test", {}, signal);
-    probes["slack.channel"] = (signal) =>
-      slackApiResult(
-        config,
-        "conversations.info",
-        { channel: config.slackChannelId ?? "" },
-        signal,
-      );
+    probes["slack.bot-auth"] = async (signal) => {
+      const result = await slackApi(config, "auth.test", {}, signal);
+      if (result?.ok !== true) {
+        throw new PublicHealthProbeError("Slack authentication failed.");
+      }
+    };
+    probes["slack.channel"] = (signal) => slackChannelDeliveryResult(config, signal);
   }
 
   if (config.arthurApiKey && config.arthurTraceEndpoint) {
@@ -717,12 +727,13 @@ async function resendWebhookResult(
   throw new PublicHealthProbeError("Resend webhook configuration check failed.");
 }
 
-async function slackApiResult(
+/** One Slack Web API call; null when Slack is unreachable or answers junk. */
+async function slackApi(
   config: SystemHealthConfig,
   method: string,
   body: Record<string, string>,
   signal: AbortSignal,
-): Promise<void> {
+): Promise<Record<string, unknown> | null> {
   const response = await fetch(`https://slack.com/api/${method}`, {
     method: "POST",
     headers: {
@@ -732,16 +743,59 @@ async function slackApiResult(
     body: new URLSearchParams(body),
     signal,
   }).catch(() => null);
-  const result = response?.ok
-    ? ((await response.json().catch(() => null)) as { ok?: unknown } | null)
-    : null;
-  if (result?.ok !== true) {
+  if (!response?.ok) return null;
+  return (await response.json().catch(() => null)) as Record<string, unknown> | null;
+}
+
+/** Sixty days: far enough that a leaked probe is obvious in the scheduled
+ * queue, well inside Slack's 120-day scheduling ceiling. */
+const SLACK_PROBE_DELAY_SECONDS = 60 * 24 * 60 * 60;
+
+/** Proves the bot can deliver to the configured channel the same way real
+ * notifications do: schedule a message far in the future, then delete it
+ * before it can ever post. `conversations.info` asked the wrong question,
+ * needing read scopes and channel visibility that posting never requires, so
+ * a Slack Connect channel showed "unavailable" while messages flowed fine. */
+async function slackChannelDeliveryResult(
+  config: SystemHealthConfig,
+  signal: AbortSignal,
+): Promise<SystemHealthProbeResult> {
+  const channel = config.slackChannelId ?? "";
+  const postAt = Math.floor(Date.now() / 1000) + SLACK_PROBE_DELAY_SECONDS;
+  const scheduled = await slackApi(
+    config,
+    "chat.scheduleMessage",
+    {
+      channel,
+      post_at: String(postAt),
+      text: "System health delivery probe. Deleting this scheduled message failed; it is safe to ignore.",
+    },
+    signal,
+  );
+  if (scheduled?.ok !== true) {
+    const reason =
+      typeof scheduled?.error === "string" ? scheduled.error : "no response";
     throw new PublicHealthProbeError(
-      method === "auth.test"
-        ? "Slack authentication failed."
-        : "Slack channel is unavailable to the bot.",
+      `Slack bot cannot deliver to the configured channel (${reason}).`,
     );
   }
+  const scheduledMessageId =
+    typeof scheduled.scheduled_message_id === "string"
+      ? scheduled.scheduled_message_id
+      : null;
+  if (scheduledMessageId) {
+    await slackApi(
+      config,
+      "chat.deleteScheduledMessage",
+      { channel, scheduled_message_id: scheduledMessageId },
+      signal,
+    );
+  }
+  return {
+    mode: "live",
+    message:
+      "Delivery verified: a probe message was scheduled in the channel and deleted before sending.",
+  };
 }
 
 async function customWebhookAggregate(): Promise<SystemHealthProbeResult> {


### PR DESCRIPTION
## Summary
- the Slack channel check asked the wrong question: `conversations.info` needs read scopes and channel visibility that posting never requires, so a Slack Connect channel showed "unavailable" while the bot delivered messages fine (seen on the Arthur tenant today)
- the probe now proves delivery the way real notifications do: `chat.scheduleMessage` 60 days ahead, then `chat.deleteScheduledMessage` immediately, so nothing visible is ever posted; failure surfaces Slack's own error code ("channel_not_found", "missing_scope", ...)
- the Jira probe no longer blends two calls into one error: authentication (`/myself`) and project access (`/project/<key>/statuses`) fail with distinct messages, because a webhook-driven deployment can hide a stale JIRA_PROJECT_KEY for weeks (also seen on Arthur: webhook LIVE, API DOWN in 110 ms)

## Test plan
- [x] worker: probes.test.ts (22, three new), collect.test.ts (12), typecheck
- [x] dashboard typecheck (copy change only)
- [ ] prod: Scan shows Slack channel check verified via scheduled-message delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)