### PR TITLE
fix(mcp): include issuer in OAuth consent redirects

### DIFF
--- a/apps/worker/src/routes/mcp-auth/consent.post.test.ts
+++ b/apps/worker/src/routes/mcp-auth/consent.post.test.ts
@@ -110,7 +110,9 @@ describe("MCP consent POST", () => {
     const { response } = await renderThenApprove();
 
     expect(response.status).toBe(302);
-    expect(response.headers.get("location")).toBe(`${REDIRECT_URI}?code=the-code&state=probe`);
+    expect(response.headers.get("location")).toBe(
+      `${REDIRECT_URI}?code=the-code&state=probe&iss=https%3A%2F%2Fworker.example.com%2Fapi%2Fauth`,
+    );
     expect(state.authHandler).toHaveBeenCalledOnce();
     const request = state.authHandler.mock.calls[0]?.[0] as Request;
     expect(request.url).toBe("https://worker.example.com/api/auth/oauth2/consent");

--- a/apps/worker/src/routes/mcp-auth/consent.post.ts
+++ b/apps/worker/src/routes/mcp-auth/consent.post.ts
@@ -145,6 +145,13 @@ export default defineEventHandler(async (event) => {
       statusMessage: "Authorization server rejected the consent",
     });
   }
+  // The advertised RFC 9207 support makes `iss` mandatory. Enforce that
+  // contract at the final browser boundary even if the provider omits it.
+  const redirect = new URL(location ?? String(result.url));
+  redirect.searchParams.set(
+    "iss",
+    `${env.BETTER_AUTH_URL.replace(/\/$/, "")}/api/auth`,
+  );
   setResponseHeader(event, "set-cookie", clearOAuthFlowCookie());
-  return sendRedirect(event, location ?? String(result.url), 302);
+  return sendRedirect(event, redirect.href, 302);
 });


### PR DESCRIPTION
## What

The MCP authorization server advertises `authorization_response_iss_parameter_supported: true`, but the final consent redirect back to the OAuth client never carried the RFC 9207 `iss` parameter. Strict clients (Codex CLI) validate this and abort the login with an authorization error, while lenient clients (Claude Code) happened to work by reusing previously issued tokens.

## How

`consent.post.ts` now force-appends `iss=<BETTER_AUTH_URL>/api/auth` to the final 302 redirect, enforcing the advertised contract at the browser boundary even when the underlying provider omits it. If the provider ever starts emitting `iss` itself, `searchParams.set` overwrites it with the same value, so nothing double-appends.

## Verification

- `consent.post.test.ts` updated: the redirect assertion now requires the encoded `iss` parameter.
- `pnpm --filter worker test src/routes/mcp-auth/`: 3 files, 21 tests passed.
- `pnpm --filter worker typecheck` clean.
- Root cause and fix were reproduced against production behavior with the Codex CLI login flow (login failed strictly on the missing `iss`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)