### PR TITLE
fix(worker): gate review ledger failure note behind the flag

### DIFF
--- a/apps/worker/src/workflows/agent-no-change.test.ts
+++ b/apps/worker/src/workflows/agent-no-change.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResearchResult } from "../sandbox/agents/types.js";
 import type {
@@ -920,5 +922,39 @@ describe("postReviewLedgerFailureNoteStep", () => {
     });
 
     expect(postedBody()).toContain("pushed `def456`");
+  });
+});
+
+/**
+ * Source tripwire, deliberately narrow.
+ *
+ * postReviewLedgerFailureNoteOnFailureExit is a closure inside
+ * agentWorkflowBody, which is not exported, so no test can invoke it to prove
+ * that a flag-off run posts no failure note. What follows therefore asserts
+ * ONLY that a REVIEW_LEDGER_ENABLED reference still sits on the lines above
+ * the postReviewLedgerFailureNoteStep call. It cannot tell a live guard from a
+ * dead local, and it cannot see work hoisted above the guard. It catches one
+ * thing: the flag check being deleted or moved below the call, which would
+ * post a ledger-failure note on a run with the flag off (prod: run
+ * wrun_01M0Z24PJ92043J4Z4BZE7PZSK on MR !11). Treat a failure as "go read the
+ * call site", not as a behavioral regression.
+ */
+describe("postReviewLedgerFailureNoteOnFailureExit flag gate", () => {
+  const agentLines = readFileSync(
+    fileURLToPath(new URL("./agent.ts", import.meta.url)),
+    "utf8",
+  ).split("\n");
+
+  it("still checks REVIEW_LEDGER_ENABLED before posting a failure note on a failed trigger_pr_review run", () => {
+    const index = agentLines.findIndex((line) =>
+      line.includes("postReviewLedgerFailureNoteStep({"),
+    );
+    expect(index, "postReviewLedgerFailureNoteStep is no longer called in agent.ts").toBeGreaterThan(-1);
+
+    const window = agentLines.slice(Math.max(0, index - 20), index);
+    expect(
+      window.some((line) => line.includes("env.REVIEW_LEDGER_ENABLED")),
+      "no REVIEW_LEDGER_ENABLED reference guards postReviewLedgerFailureNoteStep, so a flag-off run still posts the failure note",
+    ).toBe(true);
   });
 });

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -5289,6 +5289,12 @@ async function agentWorkflowBody(
         ) {
           return;
         }
+        // Flag off must reproduce byte-for-byte pre-ledger behavior, and the
+        // pre-ledger run never posted a failure note on this path.
+        const { env } = await import("../../env.js");
+        if (!env.REVIEW_LEDGER_ENABLED) {
+          return;
+        }
         const ledger = ctx.reviewLedger;
         const workItems = ledger ? selectWorkItems(ledger.feed) : [];
         await postReviewLedgerFailureNoteStep({


### PR DESCRIPTION
## Summary

- The review ledger feature is gated by `REVIEW_LEDGER_ENABLED` (default off). The flag contract is: flag off means byte-for-byte pre-ledger behavior.
- Production evidence: run `wrun_01M0Z24PJ92043J4Z4BZE7PZSK` (2026-08-26) posted a ledger-failure note (marker `ai-workflow:ledger-failure:...`) on GitLab MR `filipmaszota3/ai-workflow-integration-test!11` for a failed `trigger_pr_review` run, even though the flag was off. This breaks the flag-off contract.
- Root cause: in `apps/worker/src/workflows/agent.ts`, the closure `postReviewLedgerFailureNoteOnFailureExit` only gated on `ctx.entry.kind === "pr_trigger"` and `ctx.entry.triggerType === "trigger_pr_review"`, never on the flag itself.
- Fix: the closure now reads `REVIEW_LEDGER_ENABLED` via the same dynamic `env.js` import idiom used elsewhere in this file (e.g. `fetchAttachments`) and returns early when the flag is disabled, before any note is posted.

## Test plan

- [x] `pnpm tsc --noEmit` in `apps/worker` passes clean
- [x] `pnpm vitest run src/workflows/agent-no-change.test.ts` passes (42 tests), including a new source-tripwire test `postReviewLedgerFailureNoteOnFailureExit flag gate > still checks REVIEW_LEDGER_ENABLED before posting a failure note on a failed trigger_pr_review run` (the gating closure lives inside the non-exported `agentWorkflowBody`, so this asserts the guard still sits above the call site, mirroring the existing `ENABLE_REPO_MEMORY` tripwire pattern in `agent-repo-memory-gating.test.ts`)
- [x] Confirmed the new test fails without the fix (verified via `git stash` on `agent.ts`) and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)