### PR TITLE
fix(worker): unify review ledger work item predicate across prompt, verifier and guard

### DIFF
--- a/apps/worker/src/adapters/vcs/github.ts
+++ b/apps/worker/src/adapters/vcs/github.ts
@@ -30,7 +30,6 @@ import type {
   PostRunFailureNoteInput,
 } from "./types.js";
 import {
-  isReviewLedgerWorkItem,
   readReviewFindingDigest,
   reviewFallbackBullet,
   REVIEW_LEDGER_MAX_CONTEXT_THREADS,
@@ -41,6 +40,7 @@ import {
   hasReviewLedgerFailureMarker,
   isReopenedLedgerThread,
   isReviewLedgerNote,
+  isReviewLedgerWorkItem,
   markReviewLedgerReplyResolved,
   markReviewLedgerReplyStale,
   readAnyReviewLedgerMarker,

--- a/apps/worker/src/adapters/vcs/gitlab.ts
+++ b/apps/worker/src/adapters/vcs/gitlab.ts
@@ -26,7 +26,6 @@ import type {
   PostRunFailureNoteInput,
 } from "./types.js";
 import {
-  isReviewLedgerWorkItem,
   readReviewFindingDigest,
   reviewFallbackBullet,
   REVIEW_LEDGER_MAX_CONTEXT_THREADS,
@@ -39,6 +38,7 @@ import {
   hasReviewLedgerFailureMarker,
   isReopenedLedgerThread,
   isReviewLedgerNote,
+  isReviewLedgerWorkItem,
   markReviewLedgerReplyResolved,
   markReviewLedgerReplyStale,
   readAnyReviewLedgerMarker,

--- a/apps/worker/src/adapters/vcs/types.ts
+++ b/apps/worker/src/adapters/vcs/types.ts
@@ -120,23 +120,10 @@ export interface ReviewThreadFeed {
   snapshotAt: string; // ISO 8601, when the feed was read
 }
 
-/**
- * Is this thread the agent's to answer? Three kinds of thread are carried as
- * background instead:
- *
- * - one already answered by us, which is waiting on a person, not on the agent;
- * - one opened by a third-party reviewer, which the ledger never replies to;
- * - one of our own general notes ("automated fix pushed", a run summary), which
- *   is bookkeeping rather than review feedback. Our own *inline* thread is a
- *   real finding from the review pass and stays work.
- */
-export function isReviewLedgerWorkItem(
-  thread: Pick<ReviewThread, "awaitingHuman" | "source" | "filePath">,
-): boolean {
-  if (thread.awaitingHuman) return false;
-  if (thread.source === "third_party") return false;
-  return !(thread.source === "bot" && thread.filePath === undefined);
-}
+// The work-item predicate itself lives in lib/vcs-bot-identity.ts: this module
+// imports node:crypto for the finding digest, so a value export from here would
+// drag Node into the workflow bundle the moment the ledger's pure logic needed
+// the predicate.
 
 export const REVIEW_LEDGER_MAX_WORK_ITEMS = 20;
 

--- a/apps/worker/src/lib/vcs-bot-identity.ts
+++ b/apps/worker/src/lib/vcs-bot-identity.ts
@@ -98,6 +98,30 @@ export function readAnyReviewLedgerMarker(body: string): string | null {
  * thread, so an id comparison would let it back in as a work item and the next
  * run would answer our own apology.
  */
+/**
+ * Is this thread the agent's to answer? Three kinds of thread are carried as
+ * background instead:
+ *
+ * - one already answered by us, which is waiting on a person, not on the agent;
+ * - one opened by a third-party reviewer, which the ledger never replies to;
+ * - one of our own general notes ("automated fix pushed", a run summary), which
+ *   is bookkeeping rather than review feedback. Our own *inline* thread is a
+ *   real finding from the review pass and stays work.
+ *
+ * Lives here rather than next to the ReviewThread type: adapters/vcs/types.ts
+ * imports node:crypto, and this predicate is also needed by the workflow
+ * bundle, where Node modules are refused at build time.
+ */
+export function isReviewLedgerWorkItem(thread: {
+  awaitingHuman: boolean;
+  source: "human" | "bot" | "third_party";
+  filePath?: string | undefined;
+}): boolean {
+  if (thread.awaitingHuman) return false;
+  if (thread.source === "third_party") return false;
+  return !(thread.source === "bot" && thread.filePath === undefined);
+}
+
 export function isReviewLedgerNote(body: string): boolean {
   return /<!-- ai-workflow:ledger(?:-stale|-resolved|-failure)?:[^\s]+ -->/.test(body);
 }

--- a/apps/worker/src/sandbox/context.test.ts
+++ b/apps/worker/src/sandbox/context.test.ts
@@ -1061,20 +1061,22 @@ describe("review ledger prompt section", () => {
     expect(result).toContain("### T1 (human) in `src/auth/session.ts` line 42");
     expect(result).toContain("alice: This drops the null check we discussed.");
     expect(result).toContain("bob: Agreed, please restore it.");
-    expect(result).toContain("### T2 (our bot), general comment");
-    expect(result).toContain("ai-workflow: The migration number collides with 0044.");
   });
 
-  it("keeps threads awaiting a human and third-party bot threads out of the answer list", () => {
+  it("keeps threads awaiting a human, third-party bots, and our own general notes out of the answer list", () => {
     const result = research();
     const contextHeading = result.indexOf("### Context only: do not disposition these");
 
     expect(contextHeading).toBeGreaterThan(-1);
     expect(result).toContain("T3 (human) in `src/db/schema.ts`: waiting on a human reply");
     expect(result).toContain("T4 (another vendor's bot): not answered by this workflow");
-    // Both must sit inside the context block, after the answerable work items.
+    // Our own general note is bookkeeping, shown with its full body but never
+    // offered to the model as something to disposition.
+    expect(result).toContain("#### T2 (our bot): not answered by this workflow");
+    expect(result).toContain("ai-workflow: The migration number collides with 0044.");
+    // Context threads sit inside the context block, after the answerable work items.
     expect(result.indexOf("### T1 (human)")).toBeLessThan(contextHeading);
-    expect(result.indexOf("### T2 (our bot)")).toBeLessThan(contextHeading);
+    expect(result.indexOf("#### T2 (our bot)")).toBeGreaterThan(contextHeading);
   });
 
   it("states the disposition contract including the now-versus-this-run rule", () => {

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
@@ -1240,7 +1240,7 @@ describe("trusted workspace publisher", () => {
       expect(result.error).toBe("Agent reported success but made no commits");
     });
 
-    it("keeps today's no-commit error when verification rejected a disposition", async () => {
+    it("names the rejection count when verification rejected a disposition", async () => {
       noAgentCommits();
       const result = await publishTrustedWorkspaceFromSandbox({
         sourceSandboxId: "source-sandbox",
@@ -1257,10 +1257,12 @@ describe("trusted workspace publisher", () => {
       });
 
       expect(result.pushed).toBe(false);
-      expect(result.error).toBe("Agent reported success but made no commits");
+      expect(result.error).toBe(
+        "Agent reported success but made no commits (review ledger: no verified disposition for T1; verification rejected 1 disposition)",
+      );
     });
 
-    it("keeps today's no-commit error when the feed was truncated", async () => {
+    it("names the truncation when the feed was truncated", async () => {
       // The guard must not vouch for a snapshot it knows is incomplete.
       noAgentCommits();
       const result = await publishTrustedWorkspaceFromSandbox({
@@ -1278,10 +1280,12 @@ describe("trusted workspace publisher", () => {
       });
 
       expect(result.pushed).toBe(false);
-      expect(result.error).toBe("Agent reported success but made no commits");
+      expect(result.error).toBe(
+        "Agent reported success but made no commits (review ledger: the feed dropped 1 work item)",
+      );
     });
 
-    it("keeps today's no-commit error when the agent declared it intended to write code", async () => {
+    it("names the declared writes when the agent declared it intended to write code", async () => {
       noAgentCommits();
       const result = await publishTrustedWorkspaceFromSandbox({
         sourceSandboxId: "source-sandbox",
@@ -1298,10 +1302,12 @@ describe("trusted workspace publisher", () => {
       });
 
       expect(result.pushed).toBe(false);
-      expect(result.error).toBe("Agent reported success but made no commits");
+      expect(result.error).toBe(
+        "Agent reported success but made no commits (review ledger: the agent declared code changes)",
+      );
     });
 
-    it("keeps today's no-commit error when a work item was never covered by verification", async () => {
+    it("names the uncovered aliases when a work item was never covered by verification", async () => {
       noAgentCommits();
       const result = await publishTrustedWorkspaceFromSandbox({
         sourceSandboxId: "source-sandbox",
@@ -1322,7 +1328,9 @@ describe("trusted workspace publisher", () => {
       });
 
       expect(result.pushed).toBe(false);
-      expect(result.error).toBe("Agent reported success but made no commits");
+      expect(result.error).toBe(
+        "Agent reported success but made no commits (review ledger: no verified disposition for T2)",
+      );
     });
   });
 });

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.ts
@@ -821,6 +821,40 @@ function summarize(
       ) {
         return { pushed: true, repositories };
       }
+      // With a ledger in hand, the bare legacy line hides which condition
+      // refused the zero-commit success; the operator reading the failure note
+      // needs the name. A summary with zero work items keeps the legacy line:
+      // that run owed nothing to the ledger, so its no-commit failure means the
+      // same thing it meant before the ledger existed.
+      if (reviewLedger.workItems.length > 0) {
+        const reasons: string[] = [];
+        const uncovered = reviewLedger.workItems.filter(
+          (item) => !reviewLedger.acceptedAliases.includes(item.alias),
+        );
+        if (uncovered.length > 0) {
+          reasons.push(
+            `no verified disposition for ${uncovered.map((item) => item.alias).join(", ")}`,
+          );
+        }
+        if (reviewLedger.rejectedCount > 0) {
+          reasons.push(
+            `verification rejected ${reviewLedger.rejectedCount} disposition${reviewLedger.rejectedCount === 1 ? "" : "s"}`,
+          );
+        }
+        if (reviewLedger.truncated > 0) {
+          reasons.push(
+            `the feed dropped ${reviewLedger.truncated} work item${reviewLedger.truncated === 1 ? "" : "s"}`,
+          );
+        }
+        if (reviewLedger.declaredWrites) {
+          reasons.push("the agent declared code changes");
+        }
+        return {
+          pushed: false,
+          repositories,
+          error: `Agent reported success but made no commits (review ledger: ${reasons.join("; ")})`,
+        };
+      }
     }
     return { pushed: false, repositories, error: "Agent reported success but made no commits" };
   }

--- a/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
+++ b/apps/worker/src/workflows/blocks/fetch-pr-context.test.ts
@@ -265,11 +265,11 @@ describe("fetch_pr_context execute", () => {
         verification: null,
       });
       expect(result.kind).toBe("next");
-      // Work items exclude the third-party thread and the one awaiting a human,
-      // so the source counters have to be read off the whole feed to stay
-      // informative in the trace.
+      // Work items exclude the third-party thread, the one awaiting a human,
+      // and our own general bot note (bookkeeping), so the source counters have
+      // to be read off the whole feed to stay informative in the trace.
       expect(result.kind === "next" && result.output?.reviewThreads).toEqual({
-        workItems: 2,
+        workItems: 1,
         awaitingHuman: 1,
         bySource: { human: 2, bot: 1, third_party: 1 },
         truncated: 2,

--- a/apps/worker/src/workflows/review-ledger.test.ts
+++ b/apps/worker/src/workflows/review-ledger.test.ts
@@ -44,16 +44,25 @@ const feed = (threads: ReviewThread[]): ReviewThreadFeed => ({
 });
 
 describe("selectWorkItems", () => {
-  it("keeps threads that wait on us and drops awaitingHuman and third party ones", () => {
+  it("keeps threads that wait on us and drops awaitingHuman, third party, and bot bookkeeping ones", () => {
     const items = selectWorkItems(
       feed([
         thread({ threadId: "th-1", alias: "T1" }),
         thread({ threadId: "th-2", alias: "T2", awaitingHuman: true }),
         thread({ threadId: "th-3", alias: "T3", source: "third_party" }),
+        // Our own general note (a run summary) is bookkeeping, not review
+        // feedback; our own inline thread is a real finding and stays work.
         thread({ threadId: "th-4", alias: "T4", source: "bot" }),
+        thread({
+          threadId: "th-5",
+          alias: "T5",
+          source: "bot",
+          filePath: "src/a.ts",
+          line: 7,
+        }),
       ]),
     );
-    expect(items.map((item) => item.alias)).toEqual(["T1", "T4"]);
+    expect(items.map((item) => item.alias)).toEqual(["T1", "T5"]);
   });
 });
 
@@ -1126,6 +1135,10 @@ describe("buildReviewLedgerGuardSummary", () => {
         thread({ threadId: "th-1", alias: "T1", filePath: "src/a.ts", line: 42 }),
         thread({ threadId: "th-2", alias: "T2" }),
         thread({ threadId: "th-3", alias: "T3", source: "third_party" }),
+        // Our own general note (a run summary): bookkeeping, never a work item,
+        // so coversEveryWorkItem in the publish guard must not demand a
+        // disposition for it.
+        thread({ threadId: "th-4", alias: "T4", source: "bot" }),
       ],
       truncated: 2,
       contextTruncated: 0,

--- a/apps/worker/src/workflows/review-ledger.ts
+++ b/apps/worker/src/workflows/review-ledger.ts
@@ -9,8 +9,7 @@ import type {
   ReviewThreadFeed,
   ReviewThreadTarget,
 } from "../adapters/vcs/types.js";
-import { isReviewLedgerWorkItem } from "../adapters/vcs/types.js";
-import { reviewLedgerMarker } from "../lib/vcs-bot-identity.js";
+import { isReviewLedgerWorkItem, reviewLedgerMarker } from "../lib/vcs-bot-identity.js";
 
 /**
  * Pure review ledger logic: which unresolved threads are work items, whether

--- a/apps/worker/src/workflows/review-ledger.ts
+++ b/apps/worker/src/workflows/review-ledger.ts
@@ -9,6 +9,7 @@ import type {
   ReviewThreadFeed,
   ReviewThreadTarget,
 } from "../adapters/vcs/types.js";
+import { isReviewLedgerWorkItem } from "../adapters/vcs/types.js";
 import { reviewLedgerMarker } from "../lib/vcs-bot-identity.js";
 
 /**
@@ -20,14 +21,14 @@ import { reviewLedgerMarker } from "../lib/vcs-bot-identity.js";
  */
 
 /**
- * Work items are the threads still waiting on us. A thread whose last note is
- * our own ledger reply waits on a human, and a third party bot thread is
- * context only in v1 (we do not answer other vendors' bots).
+ * Work items are the threads still waiting on us. Delegates to the adapters'
+ * own predicate so the prompt, the verifier, the failure note and the feed's
+ * work/context split can never disagree about what the agent owes an answer
+ * to: that drift is exactly what once made the publish guard demand a
+ * disposition for the bot's own run-summary note.
  */
 export function selectWorkItems(feed: ReviewThreadFeed): ReviewThread[] {
-  return feed.threads.filter(
-    (thread) => !thread.awaitingHuman && thread.source !== "third_party",
-  );
+  return feed.threads.filter((thread) => isReviewLedgerWorkItem(thread));
 }
 
 // Inline evidence has to sit near the commented line, so a model cannot point
@@ -594,7 +595,7 @@ export function buildReviewLedgerGuardSummaryFromDurable(
 ): ReviewLedgerGuardSummary {
   return {
     workItems: durable.feedLite
-      .filter((entry) => !entry.awaitingHuman && entry.source !== "third_party")
+      .filter((entry) => isReviewLedgerWorkItem(entry))
       .map(toGuardWorkItem),
     acceptedAliases: durable.dispositions.map((disposition) => disposition.alias),
     actionableAliases: durable.dispositions


### PR DESCRIPTION
## Problem

Round B of the review-ledger prod e2e failed identically on GitLab and GitHub: a run whose review threads were all question / out_of_scope died at publishPrFixStep with the legacy error "Agent reported success but made no commits" instead of ending as a clean no-change run, and left every thread unanswered.

Root cause: two work-item predicates drifted apart. The adapters split the feed with isReviewLedgerWorkItem, which treats the bot's own general notes (run summaries) as bookkeeping, while selectWorkItems and the publish-guard summary filter still used the older awaitingHuman/third_party-only predicate. The previous run's summary comment therefore re-entered the next run as an answerable work item: the prompt asked the model to disposition it, the model reasonably skipped it, verification rejected it as "no disposition", and the publish guard refused the zero-commit success. Evidence: the failure notes name non-contiguous aliases (GitLab "T1, T2, T4", GitHub "T1, T2, T3, T6"), exactly the context-positioned bot threads counted by the stale predicate.

## Change

- selectWorkItems delegates to isReviewLedgerWorkItem, so the prompt, the verifier, the failure note and the feed split can no longer disagree.
- The guard summary built from the durable projection uses the same predicate.
- When a ledger summary is present and the zero-commit conditions fail, the publisher error now names the reason (uncovered aliases, rejections, truncation, declared writes) instead of the bare legacy line. Runs with zero work items keep the legacy message.

## Verification

- apps/worker: pnpm vitest run on review-ledger, trusted-workspace-publisher, context, agent-no-change, fetch-pr-context, gitlab, github, fix-agent test files: 413 passed.
- pnpm tsc --noEmit clean.
- Prod re-test of round B on both providers follows after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)