### PR TITLE
fix(worker): end a review run with zero work items as a clean no-op

### DIFF
--- a/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.test.ts
@@ -1216,11 +1216,11 @@ describe("trusted workspace publisher", () => {
       );
     });
 
-    it("keeps today's no-commit error when the guard summary has zero work items", async () => {
-      // A feed made only of third-party bot threads is exactly what produces
-      // an empty workItems array upstream (selectWorkItems in review-ledger.ts
-      // excludes them before the summary ever reaches this guard), so this
-      // also covers that case at this seam.
+    it("accepts zero commits when the verified feed had zero work items and no writes were declared", async () => {
+      // A re-dispatch on a fully parked PR (every thread awaiting a human) or a
+      // feed made only of third-party and bookkeeping threads: the ledger
+      // looked, found nothing owed, and nobody claimed code changes. Failing
+      // this run red taught operators to ignore the error (prod round C).
       noAgentCommits();
       const result = await publishTrustedWorkspaceFromSandbox({
         sourceSandboxId: "source-sandbox",
@@ -1233,6 +1233,26 @@ describe("trusted workspace publisher", () => {
           rejectedCount: 0,
           truncated: 0,
           declaredWrites: false,
+        },
+      });
+
+      expect(result).toMatchObject({ pushed: true });
+      expect(result.error).toBeUndefined();
+    });
+
+    it("keeps today's no-commit error when the feed had zero work items but the agent declared writes", async () => {
+      noAgentCommits();
+      const result = await publishTrustedWorkspaceFromSandbox({
+        sourceSandboxId: "source-sandbox",
+        workspaceManifest: manifest,
+        ...owner,
+        reviewLedger: {
+          workItems: [],
+          acceptedAliases: [],
+          actionableAliases: [],
+          rejectedCount: 0,
+          truncated: 0,
+          declaredWrites: true,
         },
       });
 

--- a/apps/worker/src/sandbox/trusted-workspace-publisher.ts
+++ b/apps/worker/src/sandbox/trusted-workspace-publisher.ts
@@ -821,6 +821,20 @@ function summarize(
       ) {
         return { pushed: true, repositories };
       }
+      // The other honest no-op: the ledger looked, the verified feed had zero
+      // work items (all threads parked on a human, third-party, or our own
+      // bookkeeping), nothing was accepted and nobody declared code changes.
+      // This is a re-dispatch on a settled PR, not a model wriggling out of
+      // work, and failing it red taught operators to ignore the error.
+      if (
+        reviewLedger.workItems.length === 0 &&
+        reviewLedger.acceptedAliases.length === 0 &&
+        reviewLedger.rejectedCount === 0 &&
+        reviewLedger.truncated === 0 &&
+        !reviewLedger.declaredWrites
+      ) {
+        return { pushed: true, repositories };
+      }
       // With a ledger in hand, the bare legacy line hides which condition
       // refused the zero-commit success; the operator reading the failure note
       // needs the name. A summary with zero work items keeps the legacy line:

--- a/apps/worker/src/workflows/blocks/fix-agent.test.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.test.ts
@@ -385,6 +385,37 @@ describe("fix_agent execute", () => {
       return ctx;
     };
 
+    it("ends as a clean no-op without starting the agent when the feed has zero work items", async () => {
+      // A re-dispatch on a fully parked PR: every thread is waiting on a human,
+      // so the run owes nobody anything. Running the agent anyway ends with the
+      // legacy "made no commits" death at the publish guard (prod round C).
+      const ctx = ledgerCtx();
+      const thread = ctx.reviewLedger!.feed.threads[0]!;
+      thread.awaitingHuman = true;
+      thread.notes.push({
+        author: "ai-workflow",
+        body: "answered <!-- ai-workflow:ledger:d-1 -->",
+        createdAt: "2026-08-21T09:30:00.000Z",
+        isLedgerReply: true,
+      });
+
+      const result = await execute(makeNode("fix_agent"), {}, ctx);
+
+      expect(result.kind).toBe("next");
+      if (result.kind === "next") {
+        expect(result.output?.reviewLedger).toMatchObject({
+          dispositions: [],
+          declaredWrites: false,
+          rejectedCount: 0,
+        });
+      }
+      // The empty verification is stamped so finalize's guard summary can prove
+      // to the publisher that the ledger looked and found nothing owed.
+      expect(ctx.reviewLedger!.verification).toEqual({ accepted: [], rejected: [] });
+      expect(mocks.pollPhaseUntilDone).not.toHaveBeenCalled();
+      expect(mocks.publishTrustedWorkspaceFromSandbox).not.toHaveBeenCalled();
+    });
+
     it("hands the thread feed to the prompt instead of the flat comment list", async () => {
       mocks.parseAgentOutput.mockReturnValue({ result: "implemented", summary: "patched" });
       const ctx = ledgerCtx();

--- a/apps/worker/src/workflows/blocks/fix-agent.ts
+++ b/apps/worker/src/workflows/blocks/fix-agent.ts
@@ -636,6 +636,45 @@ export const execute: BlockExecuteFn = async (
     return executionError("workspace was not attached", { category: "sandbox" });
   }
   const sandboxId = ctx.sandboxId;
+  // A review run whose feed carries zero work items owes nobody anything:
+  // every open thread is parked on a human or is bookkeeping. Starting the
+  // agent anyway ends at the publish guard as "made no commits", so the block
+  // ends here as an honest no-op instead. The empty verification and the
+  // explicit no-writes stamp are what let finalize's guard summary prove to
+  // the publisher that the ledger looked and found nothing owed.
+  // Keyed on ledger presence like every other ledger branch in this block:
+  // only fetch_pr_context on a trigger_pr_review run ever populates it.
+  if (
+    ctx.entry.kind === "pr_trigger" &&
+    ctx.reviewLedger &&
+    selectWorkItems(ctx.reviewLedger.feed).length === 0
+  ) {
+    const ledger = ctx.reviewLedger;
+    ledger.dispositions = [];
+    ledger.verification = { accepted: [], rejected: [] };
+    ledger.researchDeclaresWrites = false;
+    console.log(
+      JSON.stringify({
+        event: "review_ledger",
+        workItems: 0,
+        truncated: ledger.feed.truncated,
+        rejected: 0,
+        accepted: 0,
+        agentSkipped: true,
+      }),
+    );
+    const state = await inspectFixWorkspace(sandboxId);
+    return {
+      kind: "next",
+      output: {
+        status: "fixed",
+        ...workspaceStateFields(sandboxId, state, state),
+        summary:
+          "No open review thread was left for this run to address; the agent was not started and no code was changed.",
+        reviewLedger: buildReviewLedgerDurableState(ledger),
+      },
+    };
+  }
   const runtime =
     ctx.schemaVersion === 2 ? ctx.harnessRuntimes[block.id] : undefined;
   if (ctx.schemaVersion === 2 && !runtime) {


### PR DESCRIPTION
## Problem

Round C of the review-ledger prod e2e (re-dispatch of the review-fix workflow on a PR whose every thread is already parked): run wrun_01M0ZR3A2X1WC0GTYVD9NJMPAD went red at publishPrFixStep with the legacy "Agent reported success but made no commits" and then posted a ledger failure note on the PR. Every no-op re-dispatch on a settled PR both fails and adds noise: with zero work items verifyFixReviewDispositions returns before stamping verification, so the publish guard never sees a ledger summary.

## Change

- fix_agent: when the ledger is present and the feed has zero work items, the block ends as an honest no-op before the agent is even started: it stamps an empty verification and researchDeclaresWrites=false, logs the review_ledger event with agentSkipped, and returns the durable ledger. Finalize then settles nothing and post_pr_comment's existing skip case keeps the PR silent.
- trusted-workspace-publisher: the zero-commit guard accepts a summary proving the ledger looked and found nothing owed (zero work items, zero accepted, zero rejections, zero truncation, no declared writes). A zero-work-items summary with declared writes keeps the legacy error.

## Verification

- apps/worker: pnpm vitest run on fix-agent, trusted-workspace-publisher, finalize-workspace, agent-no-change, review-ledger test files: 216 passed.
- pnpm tsc --noEmit clean.
- Prod re-test of round C on both providers follows after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)