### PR TITLE
fix(worker): recover stalled workflow steps

### DIFF
--- a/apps/worker/src/lib/cancel-run.test.ts
+++ b/apps/worker/src/lib/cancel-run.test.ts
@@ -213,6 +213,31 @@ describe("cancelRun", () => {
     });
   });
 
+  it("runs an explicit final fence before releasing the cancelling owner", async () => {
+    const runRegistry = registry();
+    const beforeRelease = vi.fn().mockResolvedValue(undefined);
+
+    await expect(cancelRunDetailed(
+      "PROJ-1",
+      { ownerToken: "owner-a", runId: "run-1" },
+      runRegistry,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      beforeRelease,
+    )).resolves.toMatchObject({ cancelled: true, released: true });
+
+    expect(beforeRelease).toHaveBeenCalledWith(expect.objectContaining({
+      subjectKey: "ticket:jira:PROJ-1",
+      ownerToken: "owner-a",
+      runId: "run-1",
+    }));
+    expect(beforeRelease.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(runRegistry.releaseCancellation).mock.invocationCallOrder[0],
+    );
+  });
+
   it("records the cancellation reason best-effort after a confirmed cancel", async () => {
     const runRegistry = registry();
     await expect(cancelRun(

--- a/apps/worker/src/lib/cancel-run.ts
+++ b/apps/worker/src/lib/cancel-run.ts
@@ -23,6 +23,12 @@ export interface ObservedRunClaim {
 
 export type CancelRunTarget = string | ObservedRunClaim;
 
+export type CancelBeforeRelease = (owner: {
+  subjectKey: string;
+  ownerToken: string;
+  runId: string | null;
+}) => Promise<void>;
+
 /**
  * Result of a cancellation attempt. `alreadyTerminal` distinguishes a run
  * that was genuinely still in flight and got cancelled by this call from one
@@ -102,6 +108,7 @@ export async function cancelRunDetailed(
   targetColumn?: IssueTrackerMoveTarget,
   onReleased?: (subjectKey: string) => Promise<void> | void,
   reason?: string,
+  beforeRelease?: CancelBeforeRelease,
 ): Promise<CancelRunResult> {
   const subjectKey = ticketSubjectKey("jira", ticketKey);
   const confirmTicketMove = issueTracker && targetColumn
@@ -125,7 +132,7 @@ export async function cancelRunDetailed(
     target,
     runRegistry,
     onReleased,
-    confirmTicketMove,
+    beforeRelease ?? confirmTicketMove,
     reason,
   );
 }

--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -4,7 +4,10 @@ import type {
   FailedTicketMeta,
   RunRegistryAdapter,
 } from "../adapters/run-registry/types.js";
-import type { IssueTrackerAdapter } from "../adapters/issue-tracker/types.js";
+import {
+  IssueTrackerNotFoundError,
+  type IssueTrackerAdapter,
+} from "../adapters/issue-tracker/types.js";
 import type { Db } from "../db/client.js";
 
 vi.mock("../../env.js", () => ({
@@ -26,6 +29,7 @@ const mockHasDurableRunPublication = vi.fn();
 const mockDb = {} as Db;
 const mockStopSandboxesByIds = vi.fn();
 const mockListWorkflowSteps = vi.fn();
+const mockReconcileStalledRun = vi.hoisted(() => vi.fn().mockResolvedValue(false));
 const mockAssertActiveRunOwnerState = vi.hoisted(() => vi.fn());
 vi.mock("workflow/api", () => ({ getRun: (...args: any[]) => mockGetRun(...args) }));
 vi.mock("workflow/runtime", () => ({
@@ -51,6 +55,9 @@ vi.mock("./run-start-lifecycle.js", () => ({
 }));
 vi.mock("../sandbox/stop-ticket-sandboxes.js", () => ({
   stopSandboxesByIds: (...args: any[]) => mockStopSandboxesByIds(...args),
+}));
+vi.mock("./run-stall-watchdog.js", () => ({
+  reconcileStalledRun: (...args: any[]) => mockReconcileStalledRun(...args),
 }));
 vi.mock("./active-run-owner.js", () => ({
   assertActiveRunOwnerState: (...args: any[]) => mockAssertActiveRunOwnerState(...args),
@@ -468,6 +475,32 @@ describe("reconcileRuns owner-CAS recovery", () => {
     expect(mockGetRun).not.toHaveBeenCalled();
     expect(mockCancelRunDetailed).not.toHaveBeenCalled();
     expect(runRegistry.release).not.toHaveBeenCalled();
+    expect(mockReconcileStalledRun).not.toHaveBeenCalled();
+  });
+
+  it("runs the stall watchdog before terminal cleanup for a bound answered clarification", async () => {
+    const answered = entry();
+    const runRegistry = registry([answered]);
+    const onReleased = vi.fn();
+    mockReconcileStalledRun.mockResolvedValueOnce(true);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        issueTracker("Review"),
+        undefined,
+        onReleased,
+        new Set(),
+        mockDb,
+        new Set([answered.subjectKey]),
+      ),
+    ).resolves.toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockReconcileStalledRun).toHaveBeenCalledWith(
+      expect.objectContaining({ entry: answered, db: mockDb }),
+    );
+    expect(runRegistry.release).not.toHaveBeenCalled();
   });
 
   it("terminal-cleans an answered same-run clarification instead of retaining it forever", async () => {
@@ -675,6 +708,80 @@ describe("reconcileRuns owner-CAS recovery", () => {
     );
   });
 
+  it("warns when a closing claim fails to converge again instead of staying silent", async () => {
+    const closing = entry({ state: "cancelling" });
+    const runRegistry = registry([closing]);
+    const tracker = issueTracker("AI");
+    mockCancelRunDetailed.mockResolvedValue({ cancelled: false, released: false, tornDown: true });
+    const { logger } = await import("./logger.js");
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(new Set(["PROJ-1"]), runRegistry, tracker),
+    ).toEqual({ cancelled: 0, cleaned: 0 });
+    expect(warn).toHaveBeenCalledWith(
+      { subjectKey: closing.subjectKey, ticketKey: "PROJ-1", runId: "run-1", tornDown: true },
+      "reconcile_cancelling_claim_unconverged",
+    );
+    warn.mockRestore();
+  });
+
+  it("settles a bound run the stall watchdog reports dead before any column logic runs", async () => {
+    const bound = entry({ state: "bound" });
+    const runRegistry = registry([bound]);
+    const tracker = issueTracker("AI");
+    const onReleased = vi.fn();
+    mockReconcileStalledRun.mockResolvedValueOnce(true);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    expect(
+      await reconcileRuns(
+        new Set(["PROJ-1"]),
+        runRegistry,
+        tracker,
+        undefined,
+        onReleased,
+        undefined,
+        mockDb,
+      ),
+    ).toEqual({ cancelled: 1, cleaned: 0 });
+    expect(mockReconcileStalledRun).toHaveBeenCalledWith({
+      entry: bound,
+      runRegistry,
+      db: mockDb,
+      issueTracker: tracker,
+      moveTarget: "Backlog",
+      onSubjectReleased: onReleased,
+    });
+    expect(mockGetRun).not.toHaveBeenCalled();
+    expect(mockCancelRunDetailed).not.toHaveBeenCalled();
+  });
+
+  it("offers Backlog to the watchdog even when the snapshot says the ticket left AI", async () => {
+    const bound = entry({ state: "bound" });
+    const runRegistry = registry([bound]);
+    mockReconcileStalledRun.mockResolvedValueOnce(true);
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await reconcileRuns(new Set(), runRegistry, issueTracker("Done"), undefined, undefined, undefined, mockDb);
+
+    expect(mockReconcileStalledRun).toHaveBeenCalledWith(
+      expect.objectContaining({ moveTarget: "Backlog" }),
+    );
+  });
+
+  it("runs the stall watchdog only with a database to settle the run in", async () => {
+    const bound = entry({ state: "bound" });
+    const runRegistry = registry([bound]);
+    mockGetRun.mockReturnValue({ status: Promise.resolve("running") });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await reconcileRuns(new Set(["PROJ-1"]), runRegistry, issueTracker("AI"));
+
+    expect(mockReconcileStalledRun).not.toHaveBeenCalled();
+  });
+
   it("retries a closing ticket claim and confirms Backlog before it can be released", async () => {
     const closing = entry({ state: "cancelling" });
     const runRegistry = registry([closing]);
@@ -701,6 +808,7 @@ describe("reconcileRuns owner-CAS recovery", () => {
       "Backlog",
       onReleased,
       "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
+      expect.any(Function),
     );
   });
 
@@ -723,7 +831,185 @@ describe("reconcileRuns owner-CAS recovery", () => {
       undefined,
       onReleased,
       "Orphaned run cancelled by reconciler: ticket no longer in the AI column",
+      expect.any(Function),
     );
+  });
+
+  it("rechecks a closing ticket before release when AI moved to Review", async () => {
+    const closing = entry({ state: "cancelling" });
+    const runRegistry = registry([closing]);
+    const tracker = issueTracker("AI");
+    const fetchTicket = vi.mocked(tracker.fetchTicket);
+    const ticket = {
+      id: "ticket-id",
+      identifier: "PROJ-1",
+      title: "Ticket",
+      description: "",
+      acceptanceCriteria: "",
+      comments: [],
+      labels: [],
+      trackerStatus: "AI",
+      attachments: [],
+    };
+    fetchTicket
+      .mockReset()
+      .mockResolvedValueOnce(ticket)
+      .mockResolvedValueOnce({ ...ticket, trackerStatus: "Review" });
+    mockCancelRunDetailed
+      .mockReset()
+      .mockImplementationOnce(async (...args: any[]) => {
+        const fence = args[7] as (owner: {
+          subjectKey: string;
+          ownerToken: string;
+          runId: string | null;
+        }) => Promise<void>;
+        await fence({
+          subjectKey: closing.subjectKey,
+          ownerToken: closing.ownerToken,
+          runId: closing.runId,
+        });
+        return { cancelled: true, released: true };
+      });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(["PROJ-1"]),
+        runRegistry,
+        tracker,
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
+    ).resolves.toEqual({ cancelled: 1, cleaned: 0 });
+
+    expect(fetchTicket).toHaveBeenCalledTimes(2);
+    expect(tracker.moveTicket).not.toHaveBeenCalled();
+    expect(mockAssertActiveRunOwnerState).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        subjectKey: closing.subjectKey,
+        ownerToken: closing.ownerToken,
+        runId: closing.runId,
+      }),
+      "cancelling",
+    );
+  });
+
+  it("withdraws a closing ticket that moved from Review back to AI before release", async () => {
+    const closing = entry({ state: "cancelling" });
+    const runRegistry = registry([closing]);
+    const tracker = issueTracker("Review");
+    const fetchTicket = vi.mocked(tracker.fetchTicket);
+    const ticket = {
+      id: "ticket-id",
+      identifier: "PROJ-1",
+      title: "Ticket",
+      description: "",
+      acceptanceCriteria: "",
+      comments: [],
+      labels: [],
+      trackerStatus: "Review",
+      attachments: [],
+    };
+    fetchTicket
+      .mockReset()
+      .mockResolvedValueOnce(ticket)
+      .mockResolvedValueOnce({ ...ticket, trackerStatus: "AI" });
+    mockCancelRunDetailed
+      .mockReset()
+      .mockImplementationOnce(async (...args: any[]) => {
+        const fence = args[7] as (owner: {
+          subjectKey: string;
+          ownerToken: string;
+          runId: string | null;
+        }) => Promise<void>;
+        await fence({
+          subjectKey: closing.subjectKey,
+          ownerToken: closing.ownerToken,
+          runId: closing.runId,
+        });
+        return { cancelled: true, released: true };
+      });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        tracker,
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
+    ).resolves.toEqual({ cancelled: 1, cleaned: 0 });
+
+    expect(fetchTicket).toHaveBeenCalledTimes(2);
+    expect(tracker.moveTicket).toHaveBeenCalledWith("PROJ-1", "Backlog");
+    expect(mockAssertActiveRunOwnerState).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        subjectKey: closing.subjectKey,
+        ownerToken: closing.ownerToken,
+        runId: closing.runId,
+      }),
+      "cancelling",
+    );
+  });
+
+  it("releases a closing claim after the ticket is confirmed deleted", async () => {
+    const closing = entry({ state: "cancelling" });
+    const runRegistry = registry([closing]);
+    const tracker = issueTracker("AI");
+    vi.mocked(tracker.fetchTicket)
+      .mockReset()
+      .mockRejectedValue(new IssueTrackerNotFoundError("Jira issue", "PROJ-1"));
+    mockCancelRunDetailed
+      .mockReset()
+      .mockImplementationOnce(async (...args: any[]) => {
+        const fence = args[7] as (owner: {
+          subjectKey: string;
+          ownerToken: string;
+          runId: string | null;
+        }) => Promise<void>;
+        await fence({
+          subjectKey: closing.subjectKey,
+          ownerToken: closing.ownerToken,
+          runId: closing.runId,
+        });
+        return { cancelled: true, released: true };
+      });
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        tracker,
+        undefined,
+        undefined,
+        undefined,
+        mockDb,
+      ),
+    ).resolves.toEqual({ cancelled: 1, cleaned: 0 });
+
+    expect(vi.mocked(tracker.fetchTicket)).toHaveBeenCalledTimes(2);
+    expect(tracker.moveTicket).not.toHaveBeenCalled();
+    expect(mockAssertActiveRunOwnerState).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        subjectKey: closing.subjectKey,
+        ownerToken: closing.ownerToken,
+        runId: closing.runId,
+      }),
+      "cancelling",
+    );
+    await expect(mockCancelRunDetailed.mock.results[0]?.value).resolves.toEqual({
+      cancelled: true,
+      released: true,
+    });
   });
 
   it("retries a closing ticketless claim without Jira mutation", async () => {

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -24,6 +24,7 @@ import type {
 import type { Db } from "../db/client.js";
 import { confirmWorkflowStepsDrained } from "./workflow-step-drain.js";
 import { reconcileStartupWatchdog } from "./run-start-lifecycle.js";
+import { reconcileStalledRun } from "./run-stall-watchdog.js";
 import { ticketSubjectKey } from "./subject-key.js";
 import { withdrawTicketFromAiForRun } from "./ticket-transition.js";
 
@@ -94,6 +95,7 @@ export async function reconcileRuns(
         runRegistry,
         issueTracker,
         onSubjectReleased,
+        db,
       );
       if (result.cancelled) {
         if (result.alreadyTerminal) {
@@ -109,6 +111,19 @@ export async function reconcileRuns(
           );
         }
         cancelled++;
+      } else {
+        // Convergence failed again. Until 2026-08-21 this was silent, which is
+        // how a claim wedged in "cancelling" (its run's last step never
+        // drained) stayed invisible while its ticket was undispatchable.
+        logger.warn(
+          {
+            subjectKey: entry.subjectKey,
+            ticketKey: entry.ticketKey ?? "",
+            runId: entry.runId,
+            tornDown: result.tornDown === true,
+          },
+          "reconcile_cancelling_claim_unconverged",
+        );
       }
       continue;
     }
@@ -126,7 +141,10 @@ export async function reconcileRuns(
     // Once answered, that Workflow may keep running while the ticket remains
     // outside AI. Reconcile only terminal cleanup: cleanFinishedRun retains the
     // exact owner until the whole Workflow and every durable step have drained.
-    if (terminalReconciliationSubjects?.has(entry.subjectKey)) {
+    if (
+      terminalReconciliationSubjects?.has(entry.subjectKey) &&
+      entry.state !== "bound"
+    ) {
       if (entry.runId) {
         cleaned += await cleanFinishedRun(
           { ...entry, runId: entry.runId },
@@ -157,6 +175,57 @@ export async function reconcileRuns(
       entry.ticketKey !== null;
     const ticketStillInAiColumn =
       followsTicketColumn && aiColumnTickets.has(entry.ticketKey as string);
+
+    // A bound run whose engine died (its newest step has been "running" longer
+    // than any invocation can live) looks exactly like a healthy in-progress
+    // run to every branch below. Settle it here, before the column logic, so it
+    // cannot sit in RUNNING with a live claim until someone notices.
+    if (db && entry.state === "bound") {
+      const backlogTarget: IssueTrackerMoveTarget = env.JIRA_BACKLOG_TRANSITION_ID
+        ? { name: env.COLUMN_BACKLOG, transitionId: env.JIRA_BACKLOG_TRANSITION_ID }
+        : env.COLUMN_BACKLOG;
+      const stalled = await reconcileStalledRun({
+        entry: boundEntry,
+        runRegistry,
+        db,
+        issueTracker,
+        // The snapshot only drives ordinary terminal/stuck cleanup. The stall
+        // watchdog must receive the configured safe target for every ticket
+        // claim so its live Jira read can distinguish AI from a destination
+        // selected after this poll snapshot was taken.
+        moveTarget: followsTicketColumn ? backlogTarget : undefined,
+        onSubjectReleased,
+      }).catch((error) => {
+        logger.warn(
+          {
+            subjectKey: entry.subjectKey,
+            runId: entry.runId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "stall_watchdog_reconciliation_failed",
+        );
+        return false;
+      });
+      if (stalled) {
+        cancelled++;
+        continue;
+      }
+    }
+
+    // Answered clarifications normally run outside AI and use terminal-only
+    // cleanup, but a bound Workflow can still be stalled. Let the watchdog
+    // inspect it before releasing the exact owner; true parked claims were
+    // skipped above and never enter this path.
+    if (terminalReconciliationSubjects?.has(entry.subjectKey)) {
+      cleaned += await cleanFinishedRun(
+        boundEntry,
+        runRegistry,
+        issueTracker,
+        onSubjectReleased,
+        db,
+      );
+      continue;
+    }
 
     if (!followsTicketColumn) {
       cleaned += await cleanFinishedRun(
@@ -318,6 +387,7 @@ async function retryCancellingClaim(
   runRegistry: RunRegistryAdapter,
   issueTracker?: IssueTrackerAdapter,
   onSubjectReleased?: SubjectReleasedCallback,
+  db?: Db,
 ): Promise<CancelRunResult> {
   const target = { ownerToken: entry.ownerToken, runId: entry.runId };
   const reason = entry.runId
@@ -348,9 +418,29 @@ async function retryCancellingClaim(
     );
     return { cancelled: false, released: false };
   }
+  const ticketKey = entry.ticketKey;
   const backlogTarget = env.JIRA_BACKLOG_TRANSITION_ID
     ? { name: env.COLUMN_BACKLOG, transitionId: env.JIRA_BACKLOG_TRANSITION_ID }
     : env.COLUMN_BACKLOG;
+  const finalFence = async (owner: {
+    subjectKey: string;
+    ownerToken: string;
+    runId: string | null;
+  }) => {
+    const transitionDb = db ?? (await import("../db/client.js")).getDb();
+    await withdrawTicketFromAiForRun({
+      db: transitionDb,
+      issueTracker: issueTracker!,
+      ticketKey,
+      aiColumn: env.COLUMN_AI,
+      // The first read is only a snapshot. Keep Backlog available to the final
+      // owner fence so a ticket that moved Review -> AI before release is
+      // withdrawn instead of becoming dispatchable while this run still owns it.
+      target: backlogTarget,
+      owner,
+      requiredOwnerState: "cancelling",
+    });
+  };
   return cancelRunDetailed(
     entry.ticketKey,
     target,
@@ -359,6 +449,7 @@ async function retryCancellingClaim(
     inAiColumn ? backlogTarget : undefined,
     onSubjectReleased,
     reason,
+    finalFence,
   );
 }
 

--- a/apps/worker/src/lib/run-stall-watchdog.test.ts
+++ b/apps/worker/src/lib/run-stall-watchdog.test.ts
@@ -1,0 +1,664 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunRegistryAdapter } from "../adapters/run-registry/types.js";
+import { IssueTrackerNotFoundError } from "../adapters/issue-tracker/types.js";
+import type { IssueTrackerAdapter } from "../adapters/issue-tracker/types.js";
+import type { Db } from "../db/client.js";
+import { workflowRuns } from "../db/schema.js";
+import { createTestDb } from "../db/test-db.js";
+import * as runTelemetry from "./telemetry/run-telemetry.js";
+
+vi.mock("../../env.js", () => ({
+  env: { COLUMN_AI: "AI" },
+}));
+
+const mocks = vi.hoisted(() => ({
+  hostedStatus: "running" as string,
+  statusError: null as Error | null,
+  listSteps: vi.fn(),
+  cancelRunDetailed: vi.fn(),
+  cancelSubjectRunDetailed: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+const assertOwner = vi.hoisted(() => vi.fn());
+
+vi.mock("workflow/api", () => ({
+  getRun: () => ({
+    get status() {
+      return mocks.statusError
+        ? Promise.reject(mocks.statusError)
+        : Promise.resolve(mocks.hostedStatus);
+    },
+  }),
+}));
+vi.mock("workflow/runtime", () => ({
+  getWorld: () => ({ steps: { list: mocks.listSteps } }),
+}));
+vi.mock("./cancel-run.js", () => ({
+  cancelRunDetailed: (...args: unknown[]) => mocks.cancelRunDetailed(...args),
+  cancelSubjectRunDetailed: (...args: unknown[]) =>
+    mocks.cancelSubjectRunDetailed(...args),
+}));
+vi.mock("./logger.js", () => ({
+  logger: { warn: mocks.warn, info: mocks.info, error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock("./active-run-owner.js", () => ({
+  assertActiveRunOwnerState: assertOwner,
+}));
+
+const { findStalledStep, reconcileStalledRun, STALLED_STEP_AFTER_MS } =
+  await import("./run-stall-watchdog.js");
+
+// UP-4765 (2026-08-21): checkPhaseDone created 11:57:54, three attempts each
+// killed at 800 s, nothing after it. The cron looked at 12:30.
+const now = Date.parse("2026-08-21T12:30:00.000Z");
+const stepCreatedAt = new Date("2026-08-21T11:57:54.679Z");
+
+const entry = {
+  subjectKey: "ticket:jira:UP-4765",
+  ticketKey: "UP-4765",
+  ownerToken: "owner-a",
+  kind: "ticket" as const,
+  runId: "wrun_stalled",
+  state: "bound" as const,
+  createdAt: now - 60 * 60_000,
+  updatedAt: now - 60 * 60_000,
+};
+const registry = {} as RunRegistryAdapter;
+
+function page(data: unknown[]) {
+  return { data, cursor: null, hasMore: false };
+}
+
+function step(overrides: Record<string, unknown> = {}) {
+  return {
+    stepId: "step_01M0J1WXT6K5Q6Q9T3DJED252E",
+    stepName: "step//./src/sandbox/poll-agent//checkPhaseDone",
+    status: "running",
+    attempt: 3,
+    createdAt: stepCreatedAt,
+    startedAt: new Date("2026-08-21T11:57:54.845Z"),
+    updatedAt: new Date("2026-08-21T12:16:01.903Z"),
+    ...overrides,
+  };
+}
+
+let db: Db;
+
+async function runRow() {
+  const [row] = await db
+    .select({
+      status: workflowRuns.status,
+      statusReason: workflowRuns.statusReason,
+      completedAt: workflowRuns.completedAt,
+    })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, entry.runId));
+  return row;
+}
+
+function tracker(status = "AI"): IssueTrackerAdapter {
+  return {
+    fetchTicket: vi.fn().mockResolvedValue({
+      id: "ticket-id",
+      identifier: "UP-4765",
+      title: "Ticket",
+      description: "",
+      acceptanceCriteria: "",
+      comments: [],
+      labels: [],
+      trackerStatus: status,
+      attachments: [],
+    }),
+    moveTicket: vi.fn(),
+    postComment: vi.fn(),
+    searchTickets: vi.fn(),
+  };
+}
+
+let issueTracker: IssueTrackerAdapter;
+
+beforeEach(async () => {
+  db = await createTestDb();
+  await db.insert(workflowRuns).values({
+    runId: entry.runId,
+    status: "running",
+    subjectKey: entry.subjectKey,
+    ticketKey: entry.ticketKey,
+  });
+  issueTracker = tracker();
+  mocks.hostedStatus = "running";
+  mocks.statusError = null;
+  mocks.listSteps.mockReset().mockResolvedValue(page([step()]));
+  mocks.cancelRunDetailed
+    .mockReset()
+    .mockResolvedValue({ cancelled: false, released: false, tornDown: true });
+  mocks.cancelSubjectRunDetailed
+    .mockReset()
+    .mockResolvedValue({ cancelled: true, released: true, tornDown: true });
+  assertOwner.mockReset().mockResolvedValue(undefined);
+  mocks.warn.mockReset();
+  mocks.info.mockReset();
+});
+
+function warned(): string[] {
+  return mocks.warn.mock.calls.map((call) => call[1] as string);
+}
+
+function executeFinalFence() {
+  mocks.cancelRunDetailed.mockImplementationOnce(async (...args: unknown[]) => {
+    const fence = args[7];
+    if (typeof fence !== "function") throw new Error("missing final fence");
+    try {
+      await fence({
+        subjectKey: entry.subjectKey,
+        ownerToken: entry.ownerToken,
+        runId: entry.runId,
+      });
+      return { cancelled: true, released: true, tornDown: true };
+    } catch {
+      return { cancelled: false, released: false, tornDown: true };
+    }
+  });
+}
+
+describe("findStalledStep", () => {
+  it("asks for the newest step only", async () => {
+    await findStalledStep(entry.runId, now);
+    expect(mocks.listSteps).toHaveBeenCalledWith({
+      runId: entry.runId,
+      resolveData: "none",
+      pagination: { limit: 1, sortOrder: "desc" },
+    });
+  });
+
+  it("reports the newest step when it has been running past the ceiling", async () => {
+    await expect(findStalledStep(entry.runId, now)).resolves.toEqual({
+      stepId: "step_01M0J1WXT6K5Q6Q9T3DJED252E",
+      stepName: "step//./src/sandbox/poll-agent//checkPhaseDone",
+      attempt: 3,
+      createdAt: stepCreatedAt,
+    });
+  });
+
+  it("ignores a running step still inside the ceiling", async () => {
+    mocks.listSteps.mockResolvedValue(
+      page([step({ createdAt: new Date(now - STALLED_STEP_AFTER_MS) })]),
+    );
+    await expect(findStalledStep(entry.runId, now)).resolves.toBeNull();
+  });
+
+  it("ignores a run whose newest step completed (between steps is not a stall)", async () => {
+    mocks.listSteps.mockResolvedValue(page([step({ status: "completed" })]));
+    await expect(findStalledStep(entry.runId, now)).resolves.toBeNull();
+  });
+
+  it("ignores a run with no steps yet", async () => {
+    mocks.listSteps.mockResolvedValue(page([]));
+    await expect(findStalledStep(entry.runId, now)).resolves.toBeNull();
+  });
+
+  it("ignores a stalled step with incomplete metadata", async () => {
+    mocks.listSteps.mockResolvedValue(page([step({ attempt: undefined })]));
+    await expect(findStalledStep(entry.runId, now)).resolves.toBeNull();
+  });
+});
+
+describe("reconcileStalledRun", () => {
+  it("does nothing for a claim that is not bound", async () => {
+    await expect(
+      reconcileStalledRun({
+        entry: { ...entry, state: "parking" },
+        runRegistry: registry,
+        db,
+        now,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mocks.listSteps).not.toHaveBeenCalled();
+    expect((await runRow()).status).toBe("running");
+  });
+
+  it("fails the run with a reason and cancels it through the ticket path", async () => {
+    const onReleased = vi.fn();
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        onSubjectReleased: onReleased,
+        now,
+      }),
+    ).resolves.toBe(true);
+
+    const row = await runRow();
+    expect(row.status).toBe("failed");
+    expect(row.statusReason).toContain('step "checkPhaseDone"');
+    expect(row.statusReason).toContain("32 minutes");
+    expect(row.statusReason).toContain("attempt 3");
+    expect(row.completedAt).not.toBeNull();
+    expect(mocks.cancelRunDetailed).toHaveBeenCalledWith(
+      "UP-4765",
+      { ownerToken: "owner-a", runId: "wrun_stalled" },
+      registry,
+      issueTracker,
+      "Backlog",
+      onReleased,
+      row.statusReason,
+      expect.any(Function),
+    );
+    expect(mocks.cancelSubjectRunDetailed).not.toHaveBeenCalled();
+    expect(warned()).toEqual(
+      expect.arrayContaining([
+        "stall_watchdog_detected_dead_engine",
+        "stall_watchdog_cancelled_stalled_run",
+      ]),
+    );
+  });
+
+  it("preserves a live Review/Done destination despite a requested Backlog move", async () => {
+    issueTracker = tracker("Review");
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(true);
+
+    expect(mocks.cancelRunDetailed).toHaveBeenCalledWith(
+      "UP-4765",
+      expect.anything(),
+      registry,
+      issueTracker,
+      "Backlog",
+      undefined,
+      expect.stringContaining("Run engine stalled"),
+      expect.any(Function),
+    );
+    expect(mocks.info.mock.calls.map((call) => call[1] as string)).toContain(
+      "stall_watchdog_preserved_ticket_destination",
+    );
+  });
+
+  it("preserves AI to Review between the initial read and the final fence", async () => {
+    const fetchTicket = vi.fn()
+      .mockResolvedValueOnce({ trackerStatus: "AI" })
+      .mockResolvedValueOnce({ trackerStatus: "Review" });
+    const moveTicket = vi.fn();
+    issueTracker = {
+      fetchTicket,
+      moveTicket,
+      postComment: vi.fn(),
+      searchTickets: vi.fn(),
+    } as unknown as IssueTrackerAdapter;
+    executeFinalFence();
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(true);
+
+    expect(fetchTicket).toHaveBeenCalledTimes(2);
+    expect(moveTicket).not.toHaveBeenCalled();
+    expect(assertOwner).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        subjectKey: entry.subjectKey,
+        ownerToken: entry.ownerToken,
+        runId: entry.runId,
+      }),
+      "cancelling",
+    );
+  });
+
+  it("evicts Review to AI before releasing the torn-down owner", async () => {
+    const fetchTicket = vi.fn()
+      .mockResolvedValueOnce({ trackerStatus: "Review" })
+      .mockResolvedValueOnce({ trackerStatus: "AI" });
+    const moveTicket = vi.fn();
+    issueTracker = {
+      fetchTicket,
+      moveTicket,
+      postComment: vi.fn(),
+      searchTickets: vi.fn(),
+    } as unknown as IssueTrackerAdapter;
+    executeFinalFence();
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(true);
+
+    expect(fetchTicket).toHaveBeenCalledTimes(2);
+    expect(moveTicket).toHaveBeenCalledWith("UP-4765", "Backlog");
+    expect((await runRow()).status).toBe("failed");
+    await expect(mocks.cancelRunDetailed.mock.results[0]?.value).resolves.toEqual({
+      cancelled: true,
+      released: true,
+      tornDown: true,
+    });
+  });
+
+  it("retains the torn-down owner when the final Jira read is unavailable", async () => {
+    const fetchTicket = vi.fn()
+      .mockResolvedValueOnce({ trackerStatus: "AI" })
+      .mockRejectedValueOnce(new Error("jira read lost"));
+    const moveTicket = vi.fn();
+    issueTracker = {
+      fetchTicket,
+      moveTicket,
+      postComment: vi.fn(),
+      searchTickets: vi.fn(),
+    } as unknown as IssueTrackerAdapter;
+    executeFinalFence();
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(true);
+
+    expect(fetchTicket).toHaveBeenCalledTimes(2);
+    expect(moveTicket).not.toHaveBeenCalled();
+    expect((await runRow()).status).toBe("failed");
+    await expect(mocks.cancelRunDetailed.mock.results[0]?.value).resolves.toEqual({
+      cancelled: false,
+      released: false,
+      tornDown: true,
+    });
+  });
+
+  it("retains the owner when watchdog failure persistence throws", async () => {
+    const persist = vi
+      .spyOn(runTelemetry, "markRunFailedByWatchdog")
+      .mockRejectedValueOnce(new Error("database unavailable"));
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mocks.cancelRunDetailed).not.toHaveBeenCalled();
+    expect((await runRow()).status).toBe("running");
+    expect(warned()).toContain("stall_watchdog_status_write_failed");
+    persist.mockRestore();
+  });
+
+  it("retains the owner when a Jira ticket has no live tracker", async () => {
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mocks.cancelRunDetailed).not.toHaveBeenCalled();
+    expect((await runRow()).status).toBe("running");
+    expect(warned()).toContain("stall_watchdog_ticket_tracker_missing");
+  });
+
+  it("retains the owner when a live Jira read fails", async () => {
+    vi.mocked(issueTracker.fetchTicket).mockRejectedValueOnce(new Error("jira 503"));
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mocks.cancelRunDetailed).not.toHaveBeenCalled();
+    expect((await runRow()).status).toBe("running");
+    expect(warned()).toContain("stall_watchdog_ticket_state_unreachable");
+  });
+
+  it.each(["typed error", "error code"])(
+    "settles a deleted Jira ticket when the initial read returns a %s",
+    async (notFoundShape) => {
+      const notFound = notFoundShape === "typed error"
+        ? new IssueTrackerNotFoundError("Jira issue", entry.ticketKey!)
+        : Object.assign(new Error("gone"), { code: "NOT_FOUND" });
+      const fetchTicket = vi.fn().mockRejectedValue(notFound);
+      const moveTicket = vi.fn();
+      issueTracker = {
+        fetchTicket,
+        moveTicket,
+        postComment: vi.fn(),
+        searchTickets: vi.fn(),
+      } as unknown as IssueTrackerAdapter;
+      executeFinalFence();
+
+      await expect(
+        reconcileStalledRun({
+          entry,
+          runRegistry: registry,
+          db,
+          issueTracker,
+          moveTarget: "Backlog",
+          now,
+        }),
+      ).resolves.toBe(true);
+
+      expect((await runRow()).status).toBe("failed");
+      expect(mocks.cancelRunDetailed).toHaveBeenCalledWith(
+        entry.ticketKey,
+        expect.anything(),
+        registry,
+        issueTracker,
+        "Backlog",
+        undefined,
+        expect.stringContaining("Run engine stalled"),
+        expect.any(Function),
+      );
+      expect(fetchTicket).toHaveBeenCalledTimes(2);
+      expect(moveTicket).not.toHaveBeenCalled();
+      expect(assertOwner).toHaveBeenCalledWith(
+        db,
+        expect.objectContaining({
+          subjectKey: entry.subjectKey,
+          ownerToken: entry.ownerToken,
+          runId: entry.runId,
+        }),
+        "cancelling",
+      );
+    },
+  );
+
+  it("retains the owner when a live AI ticket has no safe move target", async () => {
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        now,
+      }),
+    ).resolves.toBe(false);
+
+    expect(issueTracker.fetchTicket).not.toHaveBeenCalled();
+    expect(mocks.cancelRunDetailed).not.toHaveBeenCalled();
+    expect((await runRow()).status).toBe("running");
+    expect(warned()).toContain("stall_watchdog_ticket_move_target_missing");
+  });
+
+  it("cancels a ticketless subject on its own subject key", async () => {
+    const prEntry = {
+      ...entry,
+      subjectKey: "pr:github:acme/app#9",
+      ticketKey: null,
+      kind: "pr_trigger" as const,
+    };
+    await db
+      .update(workflowRuns)
+      .set({ subjectKey: prEntry.subjectKey, ticketKey: null })
+      .where(eq(workflowRuns.runId, entry.runId));
+
+    await expect(
+      reconcileStalledRun({ entry: prEntry, runRegistry: registry, db, now }),
+    ).resolves.toBe(true);
+
+    expect(mocks.cancelSubjectRunDetailed).toHaveBeenCalledWith(
+      "pr:github:acme/app#9",
+      { ownerToken: "owner-a", runId: "wrun_stalled" },
+      registry,
+      undefined,
+      expect.stringContaining("Run engine stalled"),
+    );
+    expect(mocks.cancelRunDetailed).not.toHaveBeenCalled();
+  });
+
+  it("leaves a run alone while its newest step is inside the ceiling", async () => {
+    mocks.listSteps.mockResolvedValue(
+      page([step({ createdAt: new Date(now - 5 * 60_000) })]),
+    );
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        now,
+      }),
+    ).resolves.toBe(false);
+
+    expect((await runRow()).status).toBe("running");
+    expect(mocks.cancelRunDetailed).not.toHaveBeenCalled();
+    expect(mocks.cancelSubjectRunDetailed).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when Workflow already reports the run terminal", async () => {
+    mocks.hostedStatus = "cancelled";
+
+    await expect(
+      reconcileStalledRun({ entry, runRegistry: registry, db, now }),
+    ).resolves.toBe(false);
+
+    expect(mocks.listSteps).not.toHaveBeenCalled();
+    expect((await runRow()).status).toBe("running");
+  });
+
+  it("retains the owner when the run status is unreachable", async () => {
+    mocks.statusError = new Error("workflow api 503");
+
+    await expect(
+      reconcileStalledRun({ entry, runRegistry: registry, db, now }),
+    ).resolves.toBe(false);
+
+    expect(warned()).toContain("stall_watchdog_run_status_unreachable");
+    expect((await runRow()).status).toBe("running");
+  });
+
+  it("retains the owner when the step list is unreachable", async () => {
+    mocks.listSteps.mockRejectedValue(new Error("steps api 503"));
+
+    await expect(
+      reconcileStalledRun({ entry, runRegistry: registry, db, now }),
+    ).resolves.toBe(false);
+
+    expect(warned()).toContain("stall_watchdog_steps_unreachable");
+    expect((await runRow()).status).toBe("running");
+  });
+
+  it("reports no action when the cancel never began, keeping the failed status for the retry", async () => {
+    mocks.cancelRunDetailed.mockResolvedValue({ cancelled: false, released: false });
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(false);
+
+    expect(warned()).toContain("stall_watchdog_cancel_unconfirmed");
+    expect((await runRow()).status).toBe("failed");
+  });
+
+  it("retries cancellation when the prior watchdog failure has a later elapsed-minute reason", async () => {
+    mocks.cancelRunDetailed
+      .mockReset()
+      .mockResolvedValueOnce({ cancelled: false, released: false })
+      .mockResolvedValueOnce({ cancelled: true, released: true, tornDown: true });
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now,
+      }),
+    ).resolves.toBe(false);
+    const firstReason = (await runRow()).statusReason;
+
+    await expect(
+      reconcileStalledRun({
+        entry,
+        runRegistry: registry,
+        db,
+        issueTracker,
+        moveTarget: "Backlog",
+        now: now + 60_000,
+      }),
+    ).resolves.toBe(true);
+
+    const secondReason = (await runRow()).statusReason;
+    expect(firstReason).toContain("32 minutes");
+    expect(secondReason).toBe(firstReason);
+    expect(mocks.cancelRunDetailed).toHaveBeenCalledTimes(2);
+  });
+
+  it("never overwrites a run that already settled on its own", async () => {
+    await db
+      .update(workflowRuns)
+      .set({ status: "success" })
+      .where(eq(workflowRuns.runId, entry.runId));
+
+    await reconcileStalledRun({ entry, runRegistry: registry, db, now });
+
+    expect((await runRow()).status).toBe("success");
+    expect(mocks.cancelRunDetailed).not.toHaveBeenCalled();
+  });
+});

--- a/apps/worker/src/lib/run-stall-watchdog.ts
+++ b/apps/worker/src/lib/run-stall-watchdog.ts
@@ -1,0 +1,318 @@
+import { getRun } from "workflow/api";
+import { env } from "../../env.js";
+import {
+  IssueTrackerNotFoundError,
+  type IssueTrackerAdapter,
+  type IssueTrackerMoveTarget,
+} from "../adapters/issue-tracker/types.js";
+import type {
+  ActiveRunEntry,
+  RunRegistryAdapter,
+} from "../adapters/run-registry/types.js";
+import type { Db } from "../db/client.js";
+import {
+  cancelRunDetailed,
+  cancelSubjectRunDetailed,
+  type CancelRunResult,
+} from "./cancel-run.js";
+import { logger } from "./logger.js";
+import { ticketSubjectKey } from "./subject-key.js";
+import { withdrawTicketFromAiForRun } from "./ticket-transition.js";
+import {
+  markRunFailedByWatchdog,
+  WATCHDOG_FAILURE_REASON_PREFIX,
+} from "./telemetry/run-telemetry.js";
+
+/**
+ * A step still "running" this long after it was created has outlived every
+ * invocation the platform allows. The deployed step function's maxDuration is
+ * "max" (800 s on Pro, 900 s on Enterprise), and when the invocation is killed
+ * at that ceiling the queue redelivers the same message after its visibility
+ * timeout (about five minutes), which starts a new attempt of the SAME step:
+ * the step's createdAt does not move. Twenty minutes is therefore past one
+ * full kill-and-redeliver cycle, and a healthy step never gets anywhere near
+ * it (poll ticks sleep 30 s; nothing else may legally run that long).
+ *
+ * Anchoring on the newest step's createdAt, not on "any recent event", is
+ * deliberate: the redelivery writes a fresh step_started every cycle, so an
+ * event-recency rule would see activity in a run whose engine is dead.
+ */
+export const STALLED_STEP_AFTER_MS = 20 * 60_000;
+
+export interface StalledStep {
+  stepId: string;
+  stepName: string;
+  attempt: number;
+  createdAt: Date;
+}
+
+function toMs(value: Date | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * The newest step of the run, when it is "running" and older than
+ * STALLED_STEP_AFTER_MS. A run waiting on a hook or between steps has no
+ * running step and is never reported: only a handler the event log believes
+ * is executing, past the point where any handler could be, counts.
+ */
+export async function findStalledStep(
+  runId: string,
+  now: number = Date.now(),
+): Promise<StalledStep | null> {
+  const { getWorld } = await import("workflow/runtime");
+  const page = await getWorld().steps.list({
+    runId,
+    resolveData: "none",
+    pagination: { limit: 1, sortOrder: "desc" },
+  });
+  const newest = page.data[0];
+  if (!newest || newest.status !== "running") return null;
+  if (
+    typeof newest.stepId !== "string" ||
+    typeof newest.stepName !== "string" ||
+    typeof newest.attempt !== "number" ||
+    !Number.isFinite(newest.attempt)
+  ) {
+    return null;
+  }
+  const createdAt = toMs(newest.createdAt);
+  if (createdAt === null || now - createdAt <= STALLED_STEP_AFTER_MS) return null;
+  return {
+    stepId: newest.stepId,
+    stepName: newest.stepName,
+    attempt: newest.attempt,
+    createdAt: new Date(createdAt),
+  };
+}
+
+export function stalledRunReason(stalled: StalledStep, now: number): string {
+  const minutes = Math.max(1, Math.round((now - stalled.createdAt.getTime()) / 60_000));
+  const name = stalled.stepName.split("//").pop() || stalled.stepName;
+  return (
+    `${WATCHDOG_FAILURE_REASON_PREFIX} step "${name}" has been running for ${minutes} minutes ` +
+    `(attempt ${stalled.attempt}) with no later step recorded, longer than any ` +
+    `function invocation can live. The stall watchdog cancelled the run.`
+  );
+}
+
+/**
+ * A Backlog target may be used only after a live Jira read. The poll route's
+ * aiColumnTickets set is a snapshot taken before this reconciliation pass; a
+ * workflow can have moved the ticket to Review/Done in the meantime. In that
+ * case cancellation preserves the selected destination. Confirmed absence is
+ * also safe; every other unavailable live read fails closed.
+ */
+type TicketMoveDecision =
+  | { safe: true; moveTarget?: IssueTrackerMoveTarget }
+  | { safe: false };
+
+async function safeTicketMoveTarget(input: {
+  ticketKey: string;
+  issueTracker?: IssueTrackerAdapter;
+  moveTarget?: IssueTrackerMoveTarget;
+  context: { subjectKey: string; runId: string };
+}): Promise<TicketMoveDecision> {
+  if (!input.issueTracker) {
+    logger.warn(input.context, "stall_watchdog_ticket_tracker_missing");
+    return { safe: false };
+  }
+  if (!input.moveTarget) {
+    logger.warn(
+      { ...input.context, ticketKey: input.ticketKey },
+      "stall_watchdog_ticket_move_target_missing",
+    );
+    return { safe: false };
+  }
+  try {
+    const ticket = await input.issueTracker.fetchTicket(input.ticketKey);
+    const inAi =
+      ticket.trackerStatus.trim().toLowerCase() === env.COLUMN_AI.trim().toLowerCase();
+    if (!inAi) {
+      logger.info(
+        {
+          ...input.context,
+          ticketKey: input.ticketKey,
+          liveStatus: ticket.trackerStatus,
+        },
+        "stall_watchdog_preserved_ticket_destination",
+      );
+    }
+    // Keep the safe target available even when this first read is outside AI.
+    // The exact cancelling-owner fence reads Jira again: it preserves an
+    // unchanged Review/Done destination, but can still evict Review -> AI.
+    return { safe: true, moveTarget: input.moveTarget };
+  } catch (error) {
+    if (isIssueTrackerNotFound(error)) {
+      logger.info(
+        { ...input.context, ticketKey: input.ticketKey },
+        "stall_watchdog_ticket_absent",
+      );
+      // The ticket cannot still be in AI, but preserve the configured target
+      // for the exact cancelling-owner fence. That fence must still verify
+      // ownership before allowing cancellation to release the claim.
+      return { safe: true, moveTarget: input.moveTarget };
+    }
+    logger.warn(
+      {
+        ...input.context,
+        ticketKey: input.ticketKey,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "stall_watchdog_ticket_state_unreachable",
+    );
+    return { safe: false };
+  }
+}
+
+function isIssueTrackerNotFound(error: unknown): boolean {
+  if (error instanceof IssueTrackerNotFoundError) return true;
+  if (!error || typeof error !== "object") return false;
+  return (error as { code?: unknown }).code === "NOT_FOUND";
+}
+
+/**
+ * Settles a bound run whose engine is dead: the Workflow run still reports
+ * "running", but its newest step has been "running" longer than any invocation
+ * can live (see STALLED_STEP_AFTER_MS). Nothing else ever ends such a run: the
+ * workflow body never reaches its own finally, the claim stays, the ticket is
+ * undispatchable, and the dashboard shows a healthy run (UP-4765, 2026-08-21).
+ *
+ * Order of operations: a Jira ticket is live-read first so a failed lookup can
+ * never release a claim while the ticket remains in AI; then the "failed"
+ * status and reason are written before cancellation so the outcome is durable
+ * whatever the cancel confirms. Cancellation uses the same machinery the
+ * reconciler uses for orphans (moving an AI ticket to Backlog, so discovery
+ * does not re-dispatch it). Returns true when the run was torn down, in which
+ * case the caller must not treat the entry as healthy any further this tick.
+ */
+export async function reconcileStalledRun(input: {
+  entry: ActiveRunEntry & { runId: string };
+  runRegistry: RunRegistryAdapter;
+  db: Db;
+  issueTracker?: IssueTrackerAdapter;
+  moveTarget?: IssueTrackerMoveTarget;
+  onSubjectReleased?: (subjectKey: string) => Promise<void> | void;
+  now?: number;
+}): Promise<boolean> {
+  const { entry, runRegistry, db } = input;
+  const now = input.now ?? Date.now();
+  const context = { subjectKey: entry.subjectKey, runId: entry.runId };
+
+  // Only a bound claim represents a run the reconciler owns and can safely
+  // settle. Reservations/parking are handled by their own recovery paths.
+  if (entry.state !== "bound") return false;
+
+  let status: string;
+  try {
+    status = await getRun(entry.runId).status;
+  } catch (error) {
+    logger.warn(
+      { ...context, error: error instanceof Error ? error.message : String(error) },
+      "stall_watchdog_run_status_unreachable",
+    );
+    return false;
+  }
+  if (status !== "running") return false;
+
+  let stalled: StalledStep | null;
+  try {
+    stalled = await findStalledStep(entry.runId, now);
+  } catch (error) {
+    logger.warn(
+      { ...context, error: error instanceof Error ? error.message : String(error) },
+      "stall_watchdog_steps_unreachable",
+    );
+    return false;
+  }
+  if (!stalled) return false;
+
+  const reason = stalledRunReason(stalled, now);
+  logger.warn(
+    {
+      ...context,
+      stepId: stalled.stepId,
+      stepName: stalled.stepName,
+      attempt: stalled.attempt,
+      stepCreatedAt: stalled.createdAt.toISOString(),
+      stalledForMs: now - stalled.createdAt.getTime(),
+    },
+    "stall_watchdog_detected_dead_engine",
+  );
+
+  const target = { ownerToken: entry.ownerToken, runId: entry.runId };
+  const ticketKey = entry.ticketKey;
+  const followsJiraTicket =
+    ticketKey !== null && entry.subjectKey === ticketSubjectKey("jira", ticketKey);
+  let moveTarget = input.moveTarget;
+  if (followsJiraTicket) {
+    const decision = await safeTicketMoveTarget({
+      ticketKey,
+      issueTracker: input.issueTracker,
+      moveTarget: input.moveTarget,
+      context,
+    });
+    if (!decision.safe) return false;
+    moveTarget = decision.moveTarget;
+  }
+
+  let statusPersisted: boolean;
+  try {
+    statusPersisted = await markRunFailedByWatchdog(db, entry.runId, reason);
+  } catch (error) {
+    logger.warn(
+      { ...context, error: error instanceof Error ? error.message : String(error) },
+      "stall_watchdog_status_write_failed",
+    );
+    return false;
+  }
+  if (!statusPersisted) {
+    logger.warn(context, "stall_watchdog_status_write_unconfirmed");
+    return false;
+  }
+
+  const result: CancelRunResult =
+    followsJiraTicket
+      ? await cancelRunDetailed(
+          ticketKey,
+          target,
+          runRegistry,
+          input.issueTracker,
+          moveTarget,
+          input.onSubjectReleased,
+          reason,
+          async (owner) => {
+            await withdrawTicketFromAiForRun({
+              db,
+              issueTracker: input.issueTracker!,
+              ticketKey,
+              aiColumn: env.COLUMN_AI,
+              target: moveTarget,
+              owner,
+              requiredOwnerState: "cancelling",
+            });
+          },
+        )
+      : await cancelSubjectRunDetailed(
+          entry.subjectKey,
+          target,
+          runRegistry,
+          input.onSubjectReleased,
+          reason,
+        );
+  if (!result.cancelled && !result.tornDown) {
+    logger.warn(context, "stall_watchdog_cancel_unconfirmed");
+    return false;
+  }
+  logger.warn(
+    {
+      ...context,
+      released: result.released,
+      alreadyTerminal: result.alreadyTerminal === true,
+    },
+    "stall_watchdog_cancelled_stalled_run",
+  );
+  return true;
+}

--- a/apps/worker/src/lib/telemetry/run-telemetry.test.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.test.ts
@@ -19,6 +19,7 @@ import {
   markRunAwaiting,
   markRunBlockedOnCancel,
   markRunBlockedByOperator,
+  markRunFailedByWatchdog,
   markRunFailedOnSelfMove,
   markRunResumed,
   markRunSucceededOnSelfMove,
@@ -576,6 +577,121 @@ describe("markRunFailedOnSelfMove", () => {
   it("is a no-op for a missing run", async () => {
     await markRunFailedOnSelfMove(db, "wrun_missing");
     expect(await row("wrun_missing")).toBeUndefined();
+  });
+});
+
+describe("markRunFailedByWatchdog", () => {
+  const reason =
+    'Run engine stalled: step "checkPhaseDone" has been running for 32 minutes';
+
+  it("settles an in-flight run with the watchdog reason and completion fields", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_watchdog_running",
+      subjectKey: "ticket:jira:PROJ-1",
+      workflowId: "wf_agent",
+      workflowName: "Agent",
+      status: "running",
+      startedAt: new Date("2026-06-15T10:00:05Z"),
+    });
+
+    await expect(markRunFailedByWatchdog(db, "wrun_watchdog_running", reason)).resolves.toBe(true);
+
+    const r = await row("wrun_watchdog_running");
+    expect(r.status).toBe("failed");
+    expect(r.statusReason).toBe(reason);
+    expect(r.completedAt).not.toBeNull();
+    expect(r.durationSec).not.toBeNull();
+  });
+
+  it("never overwrites a terminal outcome", async () => {
+    for (const status of ["success", "failed", "blocked"] as const) {
+      const runId = `wrun_watchdog_${status}`;
+      await db.insert(workflowRuns).values({
+        runId,
+        subjectKey: "ticket:jira:PROJ-1",
+        workflowId: "wf_agent",
+        workflowName: "Agent",
+        status,
+        statusReason: "original reason",
+      });
+      await expect(markRunFailedByWatchdog(db, runId, reason)).resolves.toBe(false);
+      const r = await row(runId);
+      expect(r.status).toBe(status);
+      expect(r.statusReason).toBe("original reason");
+    }
+  });
+
+  it("creates and confirms a missing run row", async () => {
+    await expect(markRunFailedByWatchdog(db, "wrun_watchdog_missing", reason)).resolves.toBe(true);
+    const r = await row("wrun_watchdog_missing");
+    expect(r.status).toBe("failed");
+    expect(r.statusReason).toBe(reason);
+  });
+
+  it("treats an identical watchdog failure as an idempotent success", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_watchdog_retry",
+      status: "running",
+      statusReason: null,
+    });
+
+    await expect(markRunFailedByWatchdog(db, "wrun_watchdog_retry", reason)).resolves.toBe(true);
+    await expect(markRunFailedByWatchdog(db, "wrun_watchdog_retry", reason)).resolves.toBe(true);
+    expect((await row("wrun_watchdog_retry")).statusReason).toBe(reason);
+  });
+
+  it("keeps an earlier watchdog reason when a later retry has more elapsed minutes", async () => {
+    await db.insert(workflowRuns).values({
+      runId: "wrun_watchdog_later_minute",
+      status: "failed",
+      statusReason: reason,
+    });
+    const laterReason =
+      'Run engine stalled: step "checkPhaseDone" has been running for 33 minutes';
+
+    await expect(
+      markRunFailedByWatchdog(db, "wrun_watchdog_later_minute", laterReason),
+    ).resolves.toBe(true);
+
+    const r = await row("wrun_watchdog_later_minute");
+    expect(r.status).toBe("failed");
+    expect(r.statusReason).toBe(reason);
+  });
+
+  it("preserves watchdog failure and reason when late workflow usage arrives", async () => {
+    await markRunFailedByWatchdog(db, "wrun_watchdog_late_usage", reason);
+
+    await recordRunUsage(
+      db,
+      usage({
+        runId: "wrun_watchdog_late_usage",
+        status: "success",
+        statusReason: "late workflow finalizer reason",
+      }),
+    );
+
+    const r = await row("wrun_watchdog_late_usage");
+    expect(r.status).toBe("failed");
+    expect(r.statusReason).toBe(reason);
+  });
+
+  it("allows a later workflow outcome to replace an ordinary failure", async () => {
+    await recordRunUsage(
+      db,
+      usage({
+        runId: "wrun_ordinary_late_usage",
+        status: "failed",
+        statusReason: "phase failed",
+      }),
+    );
+    await recordRunUsage(
+      db,
+      usage({ runId: "wrun_ordinary_late_usage", status: "success" }),
+    );
+
+    const r = await row("wrun_ordinary_late_usage");
+    expect(r.status).toBe("success");
+    expect(r.statusReason).toBe("phase failed");
   });
 });
 

--- a/apps/worker/src/lib/telemetry/run-telemetry.ts
+++ b/apps/worker/src/lib/telemetry/run-telemetry.ts
@@ -108,6 +108,13 @@ export interface RunUsage {
   harnessManifests?: HarnessRunManifestRecord[];
 }
 
+/**
+ * A watchdog failure is durable authority even if the workflow's late finally
+ * arrives after reconciliation. Keep this discriminator narrow so ordinary
+ * workflow failures remain owned by recordRunUsage.
+ */
+export const WATCHDOG_FAILURE_REASON_PREFIX = "Run engine stalled:";
+
 /** `coalesce(excluded.<col>, "workflow_runs"."<col>")` — take the incoming
  * value when present, otherwise keep what's already stored. */
 function keepIfNull(column: { name: string }, existing: unknown) {
@@ -224,10 +231,21 @@ export async function recordRunUsage(db: Db, usage: RunUsage): Promise<void> {
         // The workflow knows the real outcome; overwrite the cron's in-flight
         // "running". completedAt keeps a precise cron-recorded value if present,
         // else stamps now(); durationSec is filled from a known start.
-        status: sql`excluded.status`,
-        // Never erase a recorded reason with a later re-record that has none
-        // (same COALESCE rule as steps).
-        statusReason: keepIfNull(workflowRuns.statusReason, workflowRuns.statusReason),
+        status: sql`case
+          when ${workflowRuns.status} = 'failed'
+            and ${workflowRuns.statusReason} like ${`${WATCHDOG_FAILURE_REASON_PREFIX}%`}
+          then 'failed'
+          else excluded.status
+        end`,
+        // The watchdog outcome and its explanation are one durable decision;
+        // a late workflow finally must not keep the status while replacing
+        // the reason with a secondary cancellation/finalization message.
+        statusReason: sql`case
+          when ${workflowRuns.status} = 'failed'
+            and ${workflowRuns.statusReason} like ${`${WATCHDOG_FAILURE_REASON_PREFIX}%`}
+          then ${workflowRuns.statusReason}
+          else coalesce(excluded.status_reason, ${workflowRuns.statusReason})
+        end`,
         workflowId: sql`excluded.workflow_id`,
         workflowName: sql`excluded.workflow_name`,
         subjectKey: sql`excluded.subject_key`,
@@ -597,6 +615,77 @@ export async function markRunBlockedByOperator(
         inArray(workflowRuns.status, ["awaiting", "running"]),
       ),
     );
+}
+
+/**
+ * Settles a run the stall watchdog found dead (lib/run-stall-watchdog.ts) as
+ * "failed" with the reason, in one write, BEFORE the watchdog cancels the
+ * Workflow run. The cancel path's own writers never overwrite a terminal
+ * status (markRunBlockedByOperator is guarded on awaiting/running and the
+ * cancel reason only fills an empty statusReason), so writing first makes the
+ * outcome durable whatever the cancel manages to confirm. A missing row is
+ * created with only the watchdog-owned fields; an existing identical watchdog
+ * outcome is an idempotent success, even if a later cron computes a different
+ * elapsed-minute detail; the first watchdog reason remains untouched. Other
+ * terminal outcomes are not clobbered and return false so the watchdog retains
+ * the claim.
+ */
+export async function markRunFailedByWatchdog(
+  db: Db,
+  runId: string,
+  reason: string,
+): Promise<boolean> {
+  const updated = await db
+    .update(workflowRuns)
+    .set({
+      status: "failed",
+      statusReason: reason,
+      completedAt: sql`coalesce(${workflowRuns.completedAt}, now())`,
+      durationSec: durationFromStart(),
+      updatedAt: sql`now()`,
+    })
+    .where(
+      and(
+        eq(workflowRuns.runId, runId),
+        or(
+          isNull(workflowRuns.status),
+          inArray(workflowRuns.status, ["awaiting", "running"]),
+        ),
+      ),
+    )
+    .returning({
+      status: workflowRuns.status,
+      statusReason: workflowRuns.statusReason,
+    });
+  if (updated.length > 0) return true;
+
+  const inserted = await db
+    .insert(workflowRuns)
+    .values({
+      runId,
+      status: "failed",
+      statusReason: reason,
+      completedAt: sql`now()`,
+    })
+    .onConflictDoNothing({ target: workflowRuns.runId })
+    .returning({
+      status: workflowRuns.status,
+      statusReason: workflowRuns.statusReason,
+    });
+  if (inserted.length > 0) return true;
+
+  const [existing] = await db
+    .select({
+      status: workflowRuns.status,
+      statusReason: workflowRuns.statusReason,
+    })
+    .from(workflowRuns)
+    .where(eq(workflowRuns.runId, runId));
+  return (
+    existing?.status === "failed" &&
+    typeof existing.statusReason === "string" &&
+    existing.statusReason.startsWith(WATCHDOG_FAILURE_REASON_PREFIX)
+  );
 }
 
 /**

--- a/apps/worker/src/lib/ticket-transition.test.ts
+++ b/apps/worker/src/lib/ticket-transition.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IssueTrackerNotFoundError } from "../adapters/issue-tracker/types.js";
 import type { IssueTrackerAdapter } from "../adapters/issue-tracker/types.js";
 
 const assertOwner = vi.hoisted(() => vi.fn());
@@ -135,6 +136,31 @@ describe("withdrawTicketFromAiForRun", () => {
     expect(assertOwner).toHaveBeenCalledWith(db, owner, "bound");
     expect(issueTracker.moveTicket).not.toHaveBeenCalled();
   });
+
+  it.each(["typed error", "error code"])(
+    "treats a deleted ticket as outside AI while still fencing the %s",
+    async (notFoundShape) => {
+      const notFound = notFoundShape === "typed error"
+        ? new IssueTrackerNotFoundError("Jira issue", "AIW-101")
+        : Object.assign(new Error("gone"), { code: "NOT_FOUND" });
+      const issueTracker = tracker(vi.fn().mockRejectedValue(notFound));
+
+      await expect(
+        withdrawTicketFromAiForRun({
+          db,
+          issueTracker,
+          ticketKey: "AIW-101",
+          aiColumn: "AI",
+          target: "Backlog",
+          owner,
+          requiredOwnerState: "cancelling",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(assertOwner).toHaveBeenCalledWith(db, owner, "cancelling");
+      expect(issueTracker.moveTicket).not.toHaveBeenCalled();
+    },
+  );
 
   it("accepts an ambiguous move when a fresh read confirms the ticket left AI", async () => {
     const fetchTicket = vi.fn()

--- a/apps/worker/src/lib/ticket-transition.ts
+++ b/apps/worker/src/lib/ticket-transition.ts
@@ -1,3 +1,4 @@
+import { IssueTrackerNotFoundError } from "../adapters/issue-tracker/types.js";
 import type {
   IssueTrackerAdapter,
   IssueTrackerMoveTarget,
@@ -39,23 +40,47 @@ export async function moveTicketForRun(input: {
  * subject. A manual dispatch uses the AI column only as execution state, so
  * releasing that owner while the ticket is still there would let the default
  * pickup path claim it as new work.
+ *
+ * Conditionally withdraw a ticket from AI while an exact run owner still holds
+ * it. The live read happens inside the cancellation before-release fence, so a
+ * workflow move to Review/Done is preserved and a move back to AI is safely
+ * evicted before the owner is released. An ambiguous move is successful only
+ * when a fresh read proves the ticket left AI; otherwise the original error is
+ * propagated and cancellation retains the owner.
  */
 export async function withdrawTicketFromAiForRun(input: {
   db: Db;
   issueTracker: Pick<IssueTrackerAdapter, "fetchTicket" | "moveTicket">;
   ticketKey: string;
   aiColumn: IssueTrackerMoveTarget;
-  target: IssueTrackerMoveTarget;
+  target?: IssueTrackerMoveTarget;
   owner: TicketTransitionOwner;
   requiredOwnerState: "bound" | "cancelling";
 }): Promise<void> {
-  const current = await input.issueTracker.fetchTicket(input.ticketKey);
+  let current: TicketContent;
+  try {
+    current = await input.issueTracker.fetchTicket(input.ticketKey);
+  } catch (error) {
+    if (!isIssueTrackerNotFound(error)) throw error;
+    // A deleted ticket is already outside AI. Still fence the release against
+    // the exact cancelling owner; absence alone must never authorize another
+    // run's claim to be released.
+    await assertActiveRunOwnerState(
+      input.db,
+      input.owner,
+      input.requiredOwnerState,
+    );
+    return;
+  }
   await assertActiveRunOwnerState(
     input.db,
     input.owner,
     input.requiredOwnerState,
   );
   if (!ticketMatchesMoveTarget(current, input.aiColumn)) return;
+  if (!input.target) {
+    throw new Error("Cannot withdraw an AI ticket without a safe move target");
+  }
 
   try {
     await input.issueTracker.moveTicket(input.ticketKey, input.target);
@@ -63,7 +88,15 @@ export async function withdrawTicketFromAiForRun(input: {
     try {
       const afterError = await input.issueTracker.fetchTicket(input.ticketKey);
       if (!ticketMatchesMoveTarget(afterError, input.aiColumn)) return;
-    } catch {
+    } catch (readError) {
+      if (isIssueTrackerNotFound(readError)) {
+        await assertActiveRunOwnerState(
+          input.db,
+          input.owner,
+          input.requiredOwnerState,
+        );
+        return;
+      }
       // Preserve the original mutation error.
     }
     throw error;
@@ -112,6 +145,12 @@ export async function moveTicket(input: {
     throw error;
   }
   return { statusBefore, alreadyAtTarget: false };
+}
+
+function isIssueTrackerNotFound(error: unknown): boolean {
+  if (error instanceof IssueTrackerNotFoundError) return true;
+  if (!error || typeof error !== "object") return false;
+  return (error as { code?: unknown }).code === "NOT_FOUND";
 }
 
 export function ticketMatchesMoveTarget(

--- a/apps/worker/src/lib/workflow-step-drain.test.ts
+++ b/apps/worker/src/lib/workflow-step-drain.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listSteps: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("workflow/runtime", () => ({
+  getWorld: () => ({ steps: { list: mocks.listSteps } }),
+}));
+vi.mock("./logger.js", () => ({
+  logger: { warn: mocks.warn, info: mocks.info, error: vi.fn(), debug: vi.fn() },
+}));
+
+const { confirmWorkflowStepsDrained, DEAD_STEP_AFTER_MS, isDeadRunningStep } =
+  await import("./workflow-step-drain.js");
+
+// The UP-4765 shape (2026-08-21): one checkPhaseDone whose invocation hung
+// until the 800 s kill, redelivered twice more into the same hang, then the
+// operator cancelled the run. The step stayed "running" in the event log.
+const stepCreatedAt = new Date("2026-08-21T11:57:54.679Z");
+const firstAttemptAt = new Date("2026-08-21T11:57:54.845Z");
+const runCancelledAt = new Date("2026-08-21T12:48:34.490Z");
+
+function page(data: unknown[]) {
+  return { data, cursor: null, hasMore: false };
+}
+
+function hungStep(overrides: Record<string, unknown> = {}) {
+  return {
+    stepId: "step_01M0J1WXT6K5Q6Q9T3DJED252E",
+    stepName: "step//./src/sandbox/poll-agent//checkPhaseDone",
+    status: "running",
+    attempt: 3,
+    createdAt: stepCreatedAt,
+    startedAt: firstAttemptAt,
+    updatedAt: runCancelledAt,
+    ...overrides,
+  };
+}
+
+describe("confirmWorkflowStepsDrained", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.listSteps.mockReset();
+    mocks.warn.mockReset();
+    mocks.info.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps a freshly cancelled run pending while its last attempt could still be executing", async () => {
+    vi.setSystemTime(new Date(runCancelledAt.getTime() + 60_000));
+    mocks.listSteps.mockResolvedValue(page([hungStep()]));
+
+    await expect(confirmWorkflowStepsDrained("ticket:jira:UP-4765", "wrun_1")).resolves.toBe(false);
+    expect(mocks.info).toHaveBeenCalledWith(
+      { subjectKey: "ticket:jira:UP-4765", runId: "wrun_1" },
+      "workflow_step_drain_pending",
+    );
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps a step just past the Enterprise ceiling pending", async () => {
+    vi.setSystemTime(new Date(runCancelledAt.getTime() + 900_000 + 1));
+    mocks.listSteps.mockResolvedValue(page([hungStep()]));
+
+    await expect(confirmWorkflowStepsDrained("ticket:jira:UP-4765", "wrun_1")).resolves.toBe(false);
+    expect(mocks.info).toHaveBeenCalledWith(
+      { subjectKey: "ticket:jira:UP-4765", runId: "wrun_1" },
+      "workflow_step_drain_pending",
+    );
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("treats a running step past the safety margin as drained", async () => {
+    vi.setSystemTime(new Date(runCancelledAt.getTime() + DEAD_STEP_AFTER_MS + 1_000));
+    mocks.listSteps.mockResolvedValue(page([hungStep()]));
+
+    await expect(confirmWorkflowStepsDrained("ticket:jira:UP-4765", "wrun_1")).resolves.toBe(true);
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subjectKey: "ticket:jira:UP-4765",
+        runId: "wrun_1",
+        steps: [
+          expect.objectContaining({
+            stepId: "step_01M0J1WXT6K5Q6Q9T3DJED252E",
+            attempt: 3,
+          }),
+        ],
+      }),
+      "workflow_step_drain_ignored_dead_steps",
+    );
+  });
+
+  it("measures the ceiling from the later of startedAt and updatedAt", async () => {
+    // startedAt is the first attempt, long dead; updatedAt was bumped by the
+    // cancel, so an attempt started just before it could still be alive.
+    vi.setSystemTime(new Date(runCancelledAt.getTime() + DEAD_STEP_AFTER_MS - 1_000));
+    mocks.listSteps.mockResolvedValue(page([hungStep()]));
+
+    await expect(confirmWorkflowStepsDrained("ticket:jira:UP-4765", "wrun_1")).resolves.toBe(false);
+  });
+
+  it("keeps a running step without timestamps live", async () => {
+    vi.setSystemTime(new Date("2030-01-01T00:00:00.000Z"));
+    mocks.listSteps.mockResolvedValue(page([{ status: "running" }]));
+
+    await expect(confirmWorkflowStepsDrained("subject", "wrun_1")).resolves.toBe(false);
+  });
+
+  it("keeps a running step with an invalid timestamp live", async () => {
+    vi.setSystemTime(new Date("2030-01-01T00:00:00.000Z"));
+    mocks.listSteps.mockResolvedValue(
+      page([hungStep({ updatedAt: "not-a-timestamp" })]),
+    );
+
+    await expect(confirmWorkflowStepsDrained("subject", "wrun_1")).resolves.toBe(false);
+  });
+
+  it("still drains a run with only completed steps", async () => {
+    vi.setSystemTime(runCancelledAt);
+    mocks.listSteps.mockResolvedValue(
+      page([hungStep({ status: "completed", completedAt: firstAttemptAt })]),
+    );
+
+    await expect(confirmWorkflowStepsDrained("subject", "wrun_1")).resolves.toBe(true);
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("isDeadRunningStep", () => {
+  it("never reports a non-running step", () => {
+    expect(
+      isDeadRunningStep(
+        hungStep({ status: "completed" }),
+        runCancelledAt.getTime() + 10 * DEAD_STEP_AFTER_MS,
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts ISO strings as well as Date instances", () => {
+    const now = runCancelledAt.getTime() + DEAD_STEP_AFTER_MS + 1;
+    expect(
+      isDeadRunningStep(
+        hungStep({
+          startedAt: firstAttemptAt.toISOString(),
+          updatedAt: runCancelledAt.toISOString(),
+        }),
+        now,
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/worker/src/lib/workflow-step-drain.ts
+++ b/apps/worker/src/lib/workflow-step-drain.ts
@@ -1,9 +1,63 @@
 import { logger } from "./logger.js";
 
 /**
+ * Longest a single step invocation can stay alive on Vercel. The deployed step
+ * function ships maxDuration "max", which resolves to 800 s on Pro and 900 s
+ * on Enterprise, and the runtime kills the invocation at that ceiling ("Task
+ * timed out after 800 seconds", 504). Twenty minutes leaves a real margin
+ * beyond the larger figure for clock skew between the platform and event log.
+ */
+export const DEAD_STEP_AFTER_MS = 20 * 60_000;
+
+interface DrainStep {
+  stepId?: string;
+  stepName?: string;
+  status: string;
+  attempt?: number;
+  startedAt?: Date | string | null;
+  updatedAt?: Date | string | null;
+}
+
+function toMs(value: Date | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * A "running" step proves a live handler only while an invocation could still
+ * be executing it. Callers ask once the Workflow run is terminal (cancelled,
+ * failed, completed): from then on a queue redelivery of the step message is
+ * rejected on RunExpired before any user code runs, so the only handler that
+ * can still be alive is one that started before the run went terminal, and it
+ * dies at the function ceiling at the latest. A step whose last recorded
+ * activity (the later of startedAt and updatedAt; the terminal transition
+ * itself bumps updatedAt) is older than DEAD_STEP_AFTER_MS therefore has no
+ * handler left anywhere.
+ *
+ * Without this rule a step whose invocation hung until the kill stays
+ * "running" in the event log forever, every drain reports pending, and the
+ * claim it blocks never releases (UP-4765, 2026-08-21: three redeliveries of
+ * one checkPhaseDone each died at 800 s, the cancel confirmed the run but the
+ * ticket stayed undispatchable). A step without timestamps stays live: that is
+ * the conservative reading.
+ */
+export function isDeadRunningStep(step: DrainStep, now: number = Date.now()): boolean {
+  if (step.status !== "running") return false;
+  const startedAt = toMs(step.startedAt);
+  const updatedAt = toMs(step.updatedAt);
+  // Treat incomplete or malformed metadata as live. The watchdog must fail
+  // closed rather than release an owner on a timestamp it cannot trust.
+  if (startedAt === null || updatedAt === null) return false;
+  const last = Math.max(startedAt, updatedAt);
+  return now - last > DEAD_STEP_AFTER_MS;
+}
+
+/**
  * A terminal Workflow run may still have a step handler executing. Do not
  * release or park the application owner until every durable step page proves
- * that no handler remains in `running`.
+ * that no handler remains in `running`, where a step that outlived the
+ * function ceiling no longer counts (see isDeadRunningStep).
  */
 export async function confirmWorkflowStepsDrained(
   subjectKey: string,
@@ -19,7 +73,25 @@ export async function confirmWorkflowStepsDrained(
         resolveData: "none",
         pagination: { limit: 100, ...(cursor ? { cursor } : {}) },
       });
-      if (page.data.some((step) => step.status === "running")) {
+      const running = page.data.filter((step) => step.status === "running");
+      const dead = running.filter((step) => isDeadRunningStep(step));
+      if (dead.length > 0) {
+        logger.warn(
+          {
+            subjectKey,
+            runId,
+            steps: dead.map((step) => ({
+              stepId: step.stepId,
+              stepName: step.stepName,
+              attempt: step.attempt,
+              startedAt: step.startedAt,
+              updatedAt: step.updatedAt,
+            })),
+          },
+          "workflow_step_drain_ignored_dead_steps",
+        );
+      }
+      if (running.length > dead.length) {
         logger.info({ subjectKey, runId }, "workflow_step_drain_pending");
         return false;
       }

--- a/apps/worker/src/sandbox/poll-agent.test.ts
+++ b/apps/worker/src/sandbox/poll-agent.test.ts
@@ -46,6 +46,11 @@ describe("teardownSandbox", () => {
     (Sandbox.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("gone"));
     await expect(teardownSandbox("sbx-test-123")).resolves.not.toThrow();
   });
+
+  it("gives up on a sandbox that never answers the stop", async () => {
+    mockStop.mockImplementationOnce(() => new Promise(() => {}));
+    await expect(teardownSandbox("sbx-test-123", 25)).resolves.toBeUndefined();
+  });
 });
 
 describe("teardownSandboxes", () => {
@@ -88,6 +93,45 @@ describe("checkPhaseDone", () => {
     const { Sandbox } = await import("@vercel/sandbox");
     (Sandbox.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("gone"));
     await expect(checkPhaseDone("sbx-test-123", "/tmp/phase-done")).resolves.toBe("stopped");
+  });
+
+  it("reports stopped when the sandbox API never answers, instead of hanging the step", async () => {
+    // Before the deadline existed this promise never settled: the step's
+    // invocation lived until the platform killed it at maxDuration (800 s)
+    // and the queue redelivered the same message into the same hang, three
+    // times over, while the run sat in RUNNING (UP-4765, 2026-08-21).
+    mockRunCommand.mockImplementation(
+      (_cmd: string, _args: string[], opts: { signal: AbortSignal }) =>
+        new Promise((_, reject) => {
+          opts.signal.addEventListener("abort", () => reject(opts.signal.reason));
+        }),
+    );
+    await expect(
+      checkPhaseDone("sbx-test-123", "/tmp/phase-done", 25),
+    ).resolves.toBe("stopped");
+  });
+
+  it("reports stopped even when the sandbox client ignores the abort signal", async () => {
+    mockRunCommand.mockImplementation(() => new Promise(() => {}));
+    await expect(
+      checkPhaseDone("sbx-test-123", "/tmp/phase-done", 25),
+    ).resolves.toBe("stopped");
+  });
+
+  it("hands the deadline signal to the sandbox lookup and the sentinel probe", async () => {
+    mockRunCommand.mockResolvedValue({ exitCode: 0 });
+    const { Sandbox } = await import("@vercel/sandbox");
+
+    await checkPhaseDone("sbx-test-123", "/tmp/phase-done");
+
+    expect(Sandbox.get).toHaveBeenCalledWith(
+      expect.objectContaining({ sandboxId: "sbx-test-123", signal: expect.any(AbortSignal) }),
+    );
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      "test",
+      ["-f", "/tmp/phase-done"],
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 });
 

--- a/apps/worker/src/sandbox/poll-agent.ts
+++ b/apps/worker/src/sandbox/poll-agent.ts
@@ -7,26 +7,55 @@ import {
 import { configuredReplaySecrets } from "../run-observability/configured-secrets.js";
 import { sanitizeReplayValue } from "../run-observability/sanitizer.js";
 import type { ReplaySanitizationMetadata } from "@shared/contracts";
+import {
+  SANDBOX_STEP_DEADLINE_MS,
+  SandboxDeadlineError,
+  withSandboxDeadline,
+} from "./sandbox-deadline.js";
 
 /**
  * Generalized sentinel check — works with any sentinel file path.
+ *
+ * Every sandbox round trip is bounded by `deadlineMs` (see sandbox-deadline.ts
+ * for why): a sandbox that stops answering reads as "stopped" after one
+ * deadline instead of holding the step's invocation open until the platform
+ * kills it, which the queue then redelivers into the same hang. The poll loop
+ * already treats "stopped" as "abandon the phase" (tunable through
+ * stoppedObservations), so the outcome is a failed phase with a reason, not a
+ * run wedged in RUNNING.
  */
 export async function checkPhaseDone(
   sandboxId: string,
   sentinelFile: string,
+  deadlineMs: number = SANDBOX_STEP_DEADLINE_MS,
 ): Promise<boolean | "stopped"> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
   try {
-    const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+    return await withSandboxDeadline(deadlineMs, async (signal) => {
+      const sandbox = await Sandbox.get({
+        sandboxId,
+        signal,
+        ...getSandboxCredentials(),
+      });
 
-    if (sandbox.status !== "running") {
-      return "stopped";
+      if (sandbox.status !== "running") {
+        return "stopped" as const;
+      }
+
+      const result = await sandbox.runCommand("test", ["-f", sentinelFile], {
+        signal,
+      });
+      return result.exitCode === 0;
+    });
+  } catch (error) {
+    if (error instanceof SandboxDeadlineError) {
+      const { logger } = await import("../lib/logger.js");
+      logger.warn(
+        { sandboxId, sentinelFile, deadlineMs },
+        "sandbox_phase_check_deadline_exceeded",
+      );
     }
-
-    const result = await sandbox.runCommand("test", ["-f", sentinelFile]);
-    return result.exitCode === 0;
-  } catch {
     return "stopped";
   }
 }
@@ -222,14 +251,25 @@ export async function collectPhaseReplayDiagnostics(
 /**
  * Reconnects to a sandbox and stops it.
  */
-export async function teardownSandbox(sandboxId: string): Promise<void> {
+export async function teardownSandbox(
+  sandboxId: string,
+  deadlineMs: number = SANDBOX_STEP_DEADLINE_MS,
+): Promise<void> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
   try {
-    const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
-    await sandbox.stop();
+    await withSandboxDeadline(deadlineMs, async (signal) => {
+      const sandbox = await Sandbox.get({
+        sandboxId,
+        signal,
+        ...getSandboxCredentials(),
+      });
+      await sandbox.stop({ signal });
+    });
   } catch {
-    // Teardown failures are non-critical (sandbox may have already stopped)
+    // Teardown failures are non-critical (sandbox may have already stopped).
+    // A deadline lands here too: the run must not hang on a sandbox that no
+    // longer answers, and the cancel/reconcile paths stop sandboxes by id.
   }
 }
 

--- a/apps/worker/src/sandbox/sandbox-deadline.ts
+++ b/apps/worker/src/sandbox/sandbox-deadline.ts
@@ -1,0 +1,52 @@
+/**
+ * Bound on one sandbox API round trip made from inside a Workflow step.
+ *
+ * The @vercel/sandbox client has no timeout of its own (its undici dispatcher
+ * even disables the body timeout so long log streams can flow), so a call
+ * that never gets an answer holds the step's function invocation open until
+ * the platform kills it at the deployed ceiling (maxDuration "max": 800 s on
+ * Pro). Production hit exactly that on 2026-08-21 (run
+ * wrun_01M0J1WX7HECNWK3J8G6SBH56X): one checkPhaseDone tick hung on the
+ * sandbox, the queue redelivered the same step message after every kill, and
+ * each redelivery hung again, so the run sat in RUNNING with a live claim
+ * while nothing advanced. See docs/plans/2026-08-21-step-invocation-800s-incident.md.
+ *
+ * Sixty seconds is two poll ticks, far above a healthy round trip (hundreds
+ * of milliseconds) and far below the 300 s default function limit, so a
+ * deployment that does not raise maxDuration still answers before it is
+ * killed. Keep it under whatever the deployed step function allows.
+ */
+export const SANDBOX_STEP_DEADLINE_MS = 60_000;
+
+export class SandboxDeadlineError extends Error {
+  constructor(readonly deadlineMs: number) {
+    super(`Sandbox API call exceeded ${deadlineMs}ms`);
+    this.name = "SandboxDeadlineError";
+  }
+}
+
+/**
+ * Runs `call` with an AbortSignal that fires after `deadlineMs`, and rejects
+ * with SandboxDeadlineError at the same moment whether or not the callee
+ * honours the signal. The race is the belt to the signal's braces: a client
+ * that ignores `signal` still cannot keep the invocation alive.
+ */
+export async function withSandboxDeadline<T>(
+  deadlineMs: number,
+  call: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const error = new SandboxDeadlineError(deadlineMs);
+      controller.abort(error);
+      reject(error);
+    }, deadlineMs);
+  });
+  try {
+    return await Promise.race([call(controller.signal), expired]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/worker/src/workflows/blocks/poll-phase.test.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.test.ts
@@ -123,9 +123,18 @@ describe("pollPhaseUntilDone", () => {
     });
 
     expect(mocks.delay).toHaveBeenCalledWith(5_000);
-    expect(mocks.sandboxGet).toHaveBeenCalledWith({ sandboxId: "sbx-1" });
-    expect(mocks.getCommand).toHaveBeenCalledWith("cmd-9");
+    expect(mocks.sandboxGet).toHaveBeenCalledWith(
+      expect.objectContaining({ sandboxId: "sbx-1", signal: expect.any(AbortSignal) }),
+    );
+    expect(mocks.getCommand).toHaveBeenCalledWith(
+      "cmd-9",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(mocks.kill).toHaveBeenCalledOnce();
+    expect(mocks.kill).toHaveBeenCalledWith(
+      undefined,
+      { abortSignal: expect.any(AbortSignal) },
+    );
     expect(mocks.checkPhaseDone).toHaveBeenCalledWith("sbx-1", "/tmp/done");
   });
 
@@ -149,7 +158,10 @@ describe("pollPhaseUntilDone", () => {
       },
     });
 
-    expect(mocks.getCommand).toHaveBeenCalledWith("cmd-0");
+    expect(mocks.getCommand).toHaveBeenCalledWith(
+      "cmd-0",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(mocks.kill).toHaveBeenCalledOnce();
     expect(mocks.delay).not.toHaveBeenCalled();
     expect(mocks.checkPhaseDone).not.toHaveBeenCalled();
@@ -206,6 +218,21 @@ describe("pollPhaseUntilDone", () => {
     expect(mocks.kill).toHaveBeenCalledOnce();
   });
 
+  it("gives up on a sandbox that never answers the stop instead of holding the invocation open", async () => {
+    // Without the deadline this never settled: the step invocation lived
+    // until the platform killed it at maxDuration (UP-4765, 2026-08-21).
+    mocks.sandboxGet.mockImplementationOnce(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise((_, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason));
+        }),
+    );
+    const { stopPhaseCommand } = await import("./poll-phase.js");
+
+    await expect(stopPhaseCommand("sbx-1", "cmd-1", 20)).resolves.toBeUndefined();
+    expect(mocks.getCommand).not.toHaveBeenCalled();
+  });
+
   it("kills the exact detached command before returning false at the normal phase cap", async () => {
     const observeBudget = vi.fn().mockResolvedValue(ok(60_000));
     mocks.checkPhaseDone.mockResolvedValue(false);
@@ -214,7 +241,10 @@ describe("pollPhaseUntilDone", () => {
       pollPhaseUntilDone("sbx-1", "/tmp/done", 0.0001, "cmd-normal-cap", observeBudget),
     ).resolves.toBe(false);
 
-    expect(mocks.getCommand).toHaveBeenCalledWith("cmd-normal-cap");
+    expect(mocks.getCommand).toHaveBeenCalledWith(
+      "cmd-normal-cap",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(mocks.kill).toHaveBeenCalledOnce();
   });
 
@@ -239,7 +269,10 @@ describe("pollPhaseUntilDone", () => {
       reason: "another block failed",
     } satisfies Partial<V2InvocationCancelledError>);
 
-    expect(mocks.getCommand).toHaveBeenCalledWith("cmd-cancelled");
+    expect(mocks.getCommand).toHaveBeenCalledWith(
+      "cmd-cancelled",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(mocks.kill).toHaveBeenCalledOnce();
     expect(mocks.checkPhaseDone).not.toHaveBeenCalled();
   });

--- a/apps/worker/src/workflows/blocks/poll-phase.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.ts
@@ -263,14 +263,30 @@ export async function pollPhaseUntilDone(
 export async function stopPhaseCommand(
   sandboxId: string,
   commandId: string,
+  deadlineMs?: number,
 ): Promise<void> {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
   const { getSandboxCredentials } = await import("../../sandbox/credentials.js");
+  const { SANDBOX_STEP_DEADLINE_MS, withSandboxDeadline } = await import(
+    "../../sandbox/sandbox-deadline.js"
+  );
   try {
-    const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
-    const command = await sandbox.getCommand(commandId);
-    await command.kill();
+    // Bounded like checkPhaseDone (see sandbox-deadline.ts): a sandbox that
+    // stopped answering must not turn the stop into an invocation that lives
+    // until the platform kills it.
+    await withSandboxDeadline(
+      deadlineMs ?? SANDBOX_STEP_DEADLINE_MS,
+      async (signal) => {
+        const sandbox = await Sandbox.get({
+          sandboxId,
+          signal,
+          ...getSandboxCredentials(),
+        });
+        const command = await sandbox.getCommand(commandId, { signal });
+        await command.kill(undefined, { abortSignal: signal });
+      },
+    );
   } catch {
     // The command or sandbox may already have stopped. Terminal teardown remains
     // responsible for the sandbox itself; budget handling must stay deterministic.

--- a/docs/plans/2026-08-21-step-invocation-800s-incident.md
+++ b/docs/plans/2026-08-21-step-invocation-800s-incident.md
@@ -1,0 +1,66 @@
+# Incydent: inwokacje /step umieraja na suficie 800 s, run wisi w RUNNING
+
+Handoff dla agenta, ktory ma to zdiagnozowac do konca i naprawic. Stan wiedzy na 2026-08-21 ~15:20 CEST. Autor: sesja diagnostyczna Filipa (Claude), na zywym incydencie u Arthura.
+
+## Co sie stalo (fakty, zweryfikowane)
+
+Prod Arthura, projekt Vercel `ai-workflow-arthur` (prj_2NOaSKdixAgcsee1FbO1Xr8eceVS, team team_IAWwMMQ7tpVzbfjdtAV6MLSi), release 2026.08.8, deployment przypiety do runa: `dpl_EKy97z2kS7MvvHdkR2Q4U9HAuKN2`.
+
+- Run `wrun_01M0J1WX7HECNWK3J8G6SBH56X` (ticket UP-4765, def 1 "Ticket workflow" v10, harness Codex gpt-5.6-sol reasoning high): trigger 11:39:31Z, prepare ok (78.7 s), planning ok (254.8 s), implementation wystartowala 11:45:31Z.
+- `get_runtime_errors` dla projektu: grupa **"Vercel Runtime Timeout Error: Task timed out after 800 seconds"**, route `/.well-known/workflow/v1/step`, status 504. Dwa wystapienia w trakcie tego runa: **11:57:54Z** (inwokacja startowala ~11:44:34, jeszcze w fazie planningu) i **12:16:00Z** (start ~12:02:40). Licznik grupy za 7 dni: **count=5, first=2026-08-18T13:08:40Z**, wiec bilo juz wczesniej i to nie jest jednorazowy przypadek.
+- Po 12:16 silnik zamilkl calkowicie (zero wywolan `/flow` i `/step` w logach runtime, tylko polling dashboardu). Run wisial w RUNNING z attempt "running", 0 retries, bez zadnego sladu porazki, az do recznego cancel o 12:49:15Z. Dashboard i MCP pokazywaly zdrowy "running", `runs_diagnose` mowil "wait for the run to finish".
+- Pierwsze wystapienie z 18.08 13:08 naklada sie czasowo na run `wrun_01M0AEZD66CEPZENMXXQ07S1GC` (UP-4847), ktory skonczyl jako failed i jest sklasyfikowany jako budget_exhausted. Czyli wczesniejsze trafienia maskowaly sie jako "budget", nikt nie widzial timeoutu.
+
+## Co zostalo WYKLUCZONE (nie badac ponownie)
+
+1. **Release / zmiana kodu.** Run byl przypiety do deploymentu z 18.08; na tym samym deploymencie dzien wczesniej przechodzily sukcesy (UP-4091, 306-513 s). Limit 800 s nie wystepuje nigdzie w repo (grep po `maxDuration` w apps/worker), to per-projektowe ustawienie funkcji Vercela.
+2. **Podniesienie limitu.** 800 s to maksimum planu Pro na Fluid Compute (default 300). Enterprise daje 900 s. Slepa uliczka.
+3. **Teoria "implementation czeka jedna dluga inwokacja".** NIEPRAWDA dla tego kodu i tego wydania. Faza agenta jest detached od lipca: `writeAndStartPhase` odpala wrapper przez `sandbox.runCommand({detached: true})` i oddaje commandId (apps/worker/src/workflows/agent.ts:1451-1530, commit a015cf6f/218765bd, lipiec), a czekanie robi `pollPhaseUntilDone` (agent.ts:5153 dla implementation, 4798 research, 5401 review) tickami po maks 30 s (PHASE_POLL_TICK_MAX_MS, apps/worker/src/workflows/blocks/poll-phase.ts:15). Kazdy tick to osobny step (`delayPhasePollStep`, poll-delay.ts:54-57). To wszystko JEST w wydaniu 2026.08.8. Uwaga: wczesniejsza komunikacja na Slacku podawala te teorie jako przyczyne; jest do sprostowania.
+
+## Zagadka do rozwiazania
+
+Skoro kazdy step w petli poll jest krotki (sleep <=30 s, odczyt sentinela, odczyt budzetu), to CO trzymalo inwokacje `/step` przy zyciu przez 800 s? Hipotezy, uszeregowane:
+
+1. **Runtime WDK przetwarza kolejne stepy w jednej, dlugozyjacej inwokacji** (batching/reuse kolejki). Jedna inwokacja obsluguje tick za tickiem przez caly czas fazy i w koncu wpada w sufit funkcji, ginie w polowie ticku, kolejka redelivery podnosi nastepna inwokacje (stad druga smierc 12:16), az retry sie koncza i silnik milknie. Pasuje do: ciagla aktywnosc silnika 11:44 do 11:57 zakonczona 504; incydent checkow z 19.08, gdzie inwokacja zyla 358631 ms na trasie z limitem 300 s (pamiec projektu: pre-pr-checks-300s-invocation-ceiling, "dwie rozne sygnatury tego samego wyscigu"). Falsyfikacja: w logach runtime deploymentu EKy97 policzyc czas zycia requestow na `/step` (requestId + duration) w oknie 11:44-12:16; jesli pojedynczy requestId zyje setki sekund obejmujac wiele tickow, hipoteza potwierdzona.
+2. **Wywolanie API sandboxa w stepie wisi bez timeoutu.** `checkPhaseDone` (apps/worker/src/sandbox/poll-agent.ts) lub `Sandbox.get`/`observeBudget` zawisa na sieci; kod przewiduje bledy (zwraca "stopped"), ale nie przewiduje wiszacego promise, wiec step zyje do sufitu funkcji. Falsyfikacja: te same logi; jesli inwokacja, ktora zginela, obsluzyla dokladnie JEDEN step i jej jedyna aktywnosc to wywolanie sandbox API, potwierdzone. Fix: AbortSignal/timeout na kazde wywolanie @vercel/sandbox w stepach petli.
+3. **Sciezka harness (Codex) omija poll w wydaniu 2026.08.8.** Malo prawdopodobne (writeAndStartPhase jest wspolne dla kind i runtime), ale weryfikowac na zrodle TAGU wydania, nie na lokalnym mainie: `git show artur-v2026.08.8:...` w repo zrodlowym po pinie sourceCommit z release-manifest.json.
+
+## Drugi defekt (osobny fix, rownie wazny)
+
+Po smierci inwokacji **run nie ma zadnego watchdoga**: zostaje w RUNNING na zawsze, uzytkownik widzi zdrowy run, `runs_diagnose` kaze czekac. To znana rodzina (pamiec: prod-runs-stuck-running-leak). Do tego cancel przy martwym silniku zostawia claim w stanie "cancelling", ktory zwalnia dopiero `reconcileRuns` na `/cron/poll` (apps/worker/src/lib/cancel-run.ts:261-264, apps/worker/src/lib/reconcile.ts:90-96), a ten cron chodzi u Arthura **co 15 minut** (apps/worker/vercel.json:5), wiec ticket jest niedispatchowalny do kwadransa po cancelu. Pozadane: (a) watchdog wykrywajacy runy z aktywnym claimem bez zadnej aktywnosci silnika przez N minut i przenoszacy je w terminal failed z czytelnym powodem, (b) rozwazyc release claimu synchronicznie w cancel, gdy teardown potwierdzony.
+
+## Trzeci defekt: claim po cancelu zakleszcza sie w "cancelling" (potwierdzone na zywo 13:00-13:05Z)
+
+Po recznym cancelu wedgniętego runa claim subjectu NIE schodzi. Sciezka potwierdzenia cancelu wymaga `confirmWorkflowStepsDrained` (apps/worker/src/lib/cancel-run.ts:520); stepy runa z martwym silnikiem nigdy sie nie drainuja, wiec kazdy cancel konczy jako tornDown-only i zostawia claim w "cancelling". `reconcileRuns` na cronie ponawia to samo co 15 minut i przy niepowodzeniu NIE loguje nic (apps/worker/src/lib/reconcile.ts:97-111 loguje tylko sukces), wiec zakleszczenie jest niewidoczne. Skutek: subject (ticket) trwale niedispatchowalny, preflight wiecznie zwraca `active_run` (manual-dispatch/service.ts:53 blokuje na samym istnieniu wpisu w registry, niezaleznie od stanu). Zweryfikowane: cancel 12:49:15Z, tick crona 13:00Z, preflight 13:03Z nadal `active_run`, zero logow reconcile.
+
+Reczny unblock na produkcji (Neon Arthura): `DELETE FROM active_runs WHERE subject_key = 'ticket:jira:UP-4765';` (tabela active_runs, klucz glowny subject_key; powiazane wiersze sandboxow maja FK na subject_key+owner_token). Pozadany fix: sciezka cancel/reconcile, ktora po potwierdzonym teardownie i terminalnym statusie WDK runa (cancelled) zwalnia claim bez czekania na drain stepow, plus log warn przy kazdej nieudanej probie konwergencji.
+
+## Prior art i narzedzia
+
+- Wzorzec detached + poll i jego koszty: poll-delay.ts (caly komentarz, wazny), poll-phase.ts, PR #318 (e94f5d7c) "run pre-PR checks detached so they survive the invocation ceiling".
+- Stanowisko reprodukcyjne checkow: repo aiw-checks-fixture (pamiec projektu: aiw-checks-fixture-repro-harness) z pokretlem czasu trwania; nadaje sie do wymuszenia dlugiej fazy bez palenia kredytow Codexa.
+- Diagnostyka Vercela: `get_runtime_errors` (pre-agregowane, nie timeoutuje) najpierw; `get_runtime_logs` TYLKO waskie okna albo scope po deploymentId, szerokie zapytania timeoutuja; group_by requestPath do tanich przegladow. Sanitized LOGS obserwacji nie istnieja dla trwajacego attemptu.
+- Dowody o prodzie Arthura wylacznie z prawdziwych zrodel (MCP arthur-prod po auth, dashboard, logi Vercela); lokalny port 43111 to atrapa.
+
+## Ograniczenia robocze
+
+- Zadnych pelnych suit lokalnie; szeroka weryfikacja przez CI. `pnpm build` w apps/worker odpala migracje DB, nie uruchamiac. neon-http nie ma transakcji (zadnych db.transaction() w sciezkach zapisu workera). Stepy WDK: unikalne nazwy, zadnych odczepionych lancuchow stepow (AIW-251), inputy stepow serializuja sie do event logu, wiec nie przepychac przez nie duzych obiektow.
+- Fix trafi do Arthura dopiero przez release (procedura artur-release); do tego czasu doraznie u Arthura mozna zdjac codex-execution z reasoning high, zeby skrocic fazy.
+
+## Definicja ukonczenia
+
+1. Zidentyfikowana i udowodniona (logami lub reprodukcja na fixture) dokladna przyczyna 800-sekundowych inwokacji na `/step`.
+2. Fix + test, ktory reprodukowal problem przed fixem.
+3. Watchdog na runy z martwym silnikiem (terminal failed + powod), z testem.
+4. Wpis w docs/qa lub w tym pliku z dowodami weryfikacji.
+
+---
+
+## Wynik diagnozy (2026-08-21, ~15:30 CEST)
+
+Zagadka rozwiązana, dowody i naprawy w `docs/qa/2026-08-21-step-invocation-800s-root-cause.md`. W skrócie:
+
+- Hipoteza 1 (batching stepów w jednej inwokacji) jest fałszywa: `@workflow/core` 4.8.0 + `@vercel/queue` 0.3.1 w trybie push obsługują jedną wiadomość na inwokację.
+- Hipoteza 2 potwierdzona event logiem WDK: step `checkPhaseDone` (`step_01M0J1WXT6K5Q6Q9T3DJED252E`, utworzony 11:57:54.679Z) zawisł na API sandboxa i był dostarczany trzy razy (`step_started` 11:57:54, 12:16:01, 12:34:09), za każdym razem do sufitu 800 s. Znaczniki czasu 504 w logach Vercela to czas STARTU requestu, stąd błędne "11:44:34, w planningu" powyżej.
+- Naprawy: deadline 60 s na wywołania sandboxa w `checkPhaseDone`/`stopPhaseCommand`/`teardownSandbox` (`sandbox/sandbox-deadline.ts`), watchdog martwego silnika w reconcile (`lib/run-stall-watchdog.ts`, próg 20 min od `createdAt` najnowszego running stepu, `status=failed` + powód + cancel), drain ignorujący stepy starsze niż sufit inwokacji (`lib/workflow-step-drain.ts`, 20 min) plus log warn przy niekonwergującym claimie `cancelling`.
+- Otwarte: dlaczego sandbox przestał odpowiadać (nowy log `sandbox_phase_check_deadline_exceeded` poda `sandboxId` przy następnym razie).

--- a/docs/qa/2026-08-21-step-invocation-800s-root-cause.md
+++ b/docs/qa/2026-08-21-step-invocation-800s-root-cause.md
@@ -1,0 +1,47 @@
+# Inwokacje /step umierające na suficie 800 s: przyczyna, naprawa, dowody
+
+Data: 2026-08-21. Dotyczy prod Arthura (projekt `prj_2NOaSKdixAgcsee1FbO1Xr8eceVS`, deployment `dpl_EKy97z2kS7MvvHdkR2Q4U9HAuKN2`, wydanie 2026.08.8), run `wrun_01M0J1WX7HECNWK3J8G6SBH56X` (UP-4765). Kontynuacja handoffu `docs/plans/2026-08-21-step-invocation-800s-incident.md`.
+
+## Werdykt
+
+Jedna inwokacja `/.well-known/workflow/v1/step` = jeden step WDK (handler `@workflow/core` 4.8.0 `runtime/step-handler.js`, dostawa push przez Vercel Queues, `@vercel/queue` 0.3.1 `consumeMessage`, jedna wiadomość na callback). Hipoteza "runtime przetwarza wiele stepów w jednej inwokacji" jest **fałszywa**.
+
+Przyczyną jest **hipoteza 2**: step `checkPhaseDone` (`apps/worker/src/sandbox/poll-agent.ts`) woła `Sandbox.get` i `sandbox.runCommand("test", ["-f", sentinel])` bez żadnego limitu czasu. Klient `@vercel/sandbox` 1.8.1 nie ma własnego timeoutu (`base-client.js` ustawia wręcz `bodyTimeout: 0`). Gdy sandbox przestał odpowiadać, promise nigdy się nie rozstrzygnął, inwokacja żyła do sufitu funkcji (800 s), Vercel ją zabił (504), kolejka po upływie visibility timeout (300 s, odnawiany co 60 s, stąd ~287 s po zgonie) dostarczyła **tę samą wiadomość** ponownie, nowy attempt tego samego stepu zawisł identycznie. Trzy cykle po ~18 min, potem ręczny cancel.
+
+## Dowody
+
+1. Event log WDK runa (CLI `workflow inspect steps|events -r wrun_01M0J1WX7HECNWK3J8G6SBH56X -b vercel` z `WORKFLOW_VERCEL_PROJECT`/`TEAM` Arthura, cwd poza repo, żeby CLI nie podmieniło projektu na `.vercel/` z repo):
+
+   | step | stepName | status | attempt | createdAt | step_started |
+   |---|---|---|---|---|---|
+   | `step_01M0J1WXT6K5Q6Q9T3DJED252E` | `sandbox/poll-agent//checkPhaseDone` | running | 3 | 11:57:54.679Z | 11:57:54.859Z, 12:16:01.903Z, 12:34:09.270Z |
+
+   Wszystkie 99 wcześniejszych stepów pętli poll (readRunBudgetClockStep ×2, delayPhasePollStep, readRunBudgetClockStep ×2, checkPhaseDone; 6 na tick co ~32 s) są `completed`, poprzednie `checkPhaseDone` kończyły się w 200-300 ms. `run_cancelled` 12:48:33.151Z.
+
+2. Runtime logi Vercela (`get_runtime_logs`, scope po deploymentId): 504 "Task timed out after 800 seconds" o 11:57:54, 12:16:00, 12:34:07. Te znaczniki czasu to **czas startu** requestu (pokrywają się co do sekundy ze `step_started` trzech attemptów), nie czas zgonu. Wniosek handoffu "inwokacja startowała ~11:44:34, w fazie planningu" był artefaktem odejmowania 800 s od czasu startu. Czwarta dostawa 12:52:14 (= zgon trzeciego attemptu 12:47:29 + ~287 s) dostała 200: run był już cancelled, handler odrzucił wiadomość na RunExpired, po czym `/flow` 200 o 12:52:16.
+
+3. Logi `level=warning|error` dla deploymentu w oknie 11:50-12:50 zawierają wyłącznie te trzy 504; żadnego logu aplikacji ze stepu (kod nie logował przed zawisem).
+
+4. Kod: `poll-agent.ts` `checkPhaseDone` przed zmianą: brak `signal`, brak wyścigu z timerem; `@vercel/sandbox/dist/api-client/base-client.js:22` `bodyTimeout: 0`; `api-client.js:175` `wait: "true"` (long poll na zakończenie komendy).
+
+## Nierozstrzygnięte
+
+Dlaczego sandbox przestał odpowiadać o 11:57:54 (ok. 18 min od `prepare`, 12,4 min fazy implementation na Codex gpt-5.6-sol high). Kandydaci: VM przeciążony (CPU/RAM przez Codexa), zawieszenie po stronie API sandboxów. Id sandboxa zniknął razem z ręcznie usuniętym wierszem `active_runs`; do sprawdzenia w panelu Sandboxes Vercela przy następnym wystąpieniu (log `sandbox_phase_check_deadline_exceeded` poda `sandboxId`).
+
+## Naprawy (branch `wip/run-analysis-report`, niezacommitowane na 21.08 15:30)
+
+1. **Deadline na wywołania sandboxa w stepach pętli** (`apps/worker/src/sandbox/sandbox-deadline.ts`, `SANDBOX_STEP_DEADLINE_MS = 60_000`, `withSandboxDeadline` = AbortSignal + `Promise.race` z timerem, więc działa także gdy klient zignoruje sygnał). Objęte: `checkPhaseDone` (zwraca `"stopped"` + log warn `sandbox_phase_check_deadline_exceeded`), `stopPhaseCommand` (`poll-phase.ts`), `teardownSandbox`. Pętla poll traktuje `"stopped"` jak dotąd (`stoppedObservations`), więc wedgnięty sandbox kończy się porażką fazy z powodem, nie runem w RUNNING.
+2. **Watchdog martwego silnika** (`apps/worker/src/lib/run-stall-watchdog.ts`, wpięty w `reconcileRuns` dla claimów `bound` gdy jest `db`): jeśli WDK mówi `running`, a najnowszy step runa jest `running` dłużej niż `STALLED_STEP_AFTER_MS` (20 min, czyli więcej niż pełny cykl 800 s + redelivery), run dostaje `status=failed` z czytelnym `statusReason` (`markRunFailedByWatchdog`, guard na in-flight), potem cancel przez `cancelRunDetailed` (ticket w AI ląduje w Backlogu, żeby discovery go nie zdispatchowało) lub `cancelSubjectRunDetailed`. Kotwica to `createdAt` najnowszego stepu, bo redelivery pisze nowe `step_started` co cykl i reguła "ostatnie zdarzenie" widziałaby aktywność.
+3. **Drain stepów ignoruje martwe stepy** (`apps/worker/src/lib/workflow-step-drain.ts`, `DEAD_STEP_AFTER_MS = 20 min`): running step, którego `max(startedAt, updatedAt)` jest starsze niż sufit inwokacji, nie blokuje zwolnienia claimu (warunek wstępny: run terminalny, co spełniają wszyscy trzej wywołujący). Dwudziestominutowy próg zostawia realny margines ponad Enterprise 900 s; dokładnie 900 s nadal jest pending. Log warn `workflow_step_drain_ignored_dead_steps`. Dodatkowo `reconcileRuns` loguje warn `reconcile_cancelling_claim_unconverged` przy każdej nieudanej konwergencji claimu `cancelling` (wcześniej cisza).
+
+## Weryfikacja
+
+- `pnpm --filter worker exec tsc --noEmit`: exit 0.
+- `vitest run` na 7 plikach: `sandbox/poll-agent.test.ts`, `workflows/blocks/poll-phase.test.ts`, `lib/workflow-step-drain.test.ts`, `lib/run-stall-watchdog.test.ts`, `lib/reconcile.test.ts`, `lib/cancel-run.test.ts`, `lib/run-start-lifecycle.test.ts`: 132 testy zielone (po dostosowaniu asercji `getCommand`/`Sandbox.get` w poll-phase.test do nowego argumentu `signal`).
+- Reprodukcja przed fixem: `git stash` samego `poll-agent.ts` i `vitest run src/sandbox/poll-agent.test.ts --testTimeout=3000` daje `× checkPhaseDone > reports stopped even when the sandbox client ignores the abort signal (Test timed out in 3000ms)` oraz `× teardownSandbox > gives up on a sandbox that never answers the stop (Test timed out)`; po `stash pop` oba zielone w ~25 ms.
+- Szerokie suity wyłącznie przez CI (zasada repo).
+
+## Do zrobienia po stronie operacyjnej
+
+- Fix trafia do Arthura dopiero przez wydanie (`artur-release`). Do tego czasu wedgnięty run: `runs_cancel`, a claim zakleszczony w `cancelling` zwalnia dopiero cron `/cron/poll` (u Arthura co 15 min) po wejściu fixu 3; ręcznie: `DELETE FROM active_runs WHERE subject_key = 'ticket:jira:<KEY>'`.
+- Sprostowanie na Slacku: przyczyną nie był brak wzorca detached+poll (jest od lipca), tylko brak limitu czasu na pojedynczym wywołaniu sandboxa w ticku poll.


### PR DESCRIPTION
## Summary

- Bound sandbox round trips and poll-phase teardown so a never-settling client cannot hold a workflow invocation to the platform ceiling.
- Add a newest-running-step stall watchdog with guarded failure telemetry, cancellation, exact-owner Jira withdrawal, and dead-step drain handling.
- Preserve workflow-selected Jira destinations and retain claims when live state, ownership, or durable status cannot be confirmed.

## Verification

- CI: `pnpm --filter worker build:shared`
- CI: focused Vitest coverage for poll-agent, poll-phase, workflow-step-drain, run-stall-watchdog, reconcile, cancel-run, ticket-transition, run-start-lifecycle, and telemetry
- CI: `pnpm --filter worker typecheck`
- Publication check: `git diff --check origin/main...HEAD` passed

## Dependencies

- #280 manual-dispatch ownership behavior is already in `main`.
- #347 provider-error behavior is already in `main`.
- No merge or rebase is required for this watchdog-only diff.