### PR TITLE
fix(worker): close post-merge reliability gaps

### DIFF
--- a/apps/worker/src/lib/reconcile.test.ts
+++ b/apps/worker/src/lib/reconcile.test.ts
@@ -399,6 +399,56 @@ describe("reconcileRuns owner-CAS recovery", () => {
     },
   );
 
+  it("evicts a terminal manual ticket when the capped AI snapshot omits it but Jira still reports AI", async () => {
+    const manual = entry({ kind: "manual_ticket" });
+    const runRegistry = registry([manual]);
+    const tracker = issueTracker("AI");
+    mockGetRun.mockReturnValue({ status: Promise.resolve("completed") });
+    const onReleased = vi.fn();
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(
+        new Set(),
+        runRegistry,
+        tracker,
+        undefined,
+        onReleased,
+        undefined,
+        mockDb,
+      ),
+    ).resolves.toEqual({ cancelled: 0, cleaned: 1 });
+    expect(mockAssertActiveRunOwnerState).toHaveBeenCalledWith(
+      mockDb,
+      manual,
+      "bound",
+    );
+    expect(tracker.moveTicket).toHaveBeenCalledTimes(1);
+    expect(tracker.moveTicket).toHaveBeenCalledWith("PROJ-1", "Backlog");
+    expect(runRegistry.release).toHaveBeenCalledTimes(1);
+    expect(runRegistry.release).toHaveBeenCalledWith(
+      manual.subjectKey,
+      manual.ownerToken,
+      manual.runId,
+    );
+    expect(onReleased).toHaveBeenCalledTimes(1);
+    expect(onReleased).toHaveBeenCalledWith(manual.subjectKey);
+  });
+
+  it("retains a manual claim omitted from the snapshot when Jira's live read is uncertain", async () => {
+    const manual = entry({ kind: "manual_ticket" });
+    const runRegistry = registry([manual]);
+    const tracker = issueTracker();
+    vi.mocked(tracker.fetchTicket).mockRejectedValue(new Error("Jira unavailable"));
+    const { reconcileRuns } = await import("./reconcile.js");
+
+    await expect(
+      reconcileRuns(new Set(), runRegistry, tracker, undefined, undefined, undefined, mockDb),
+    ).resolves.toEqual({ cancelled: 0, cleaned: 0 });
+    expect(tracker.moveTicket).not.toHaveBeenCalled();
+    expect(runRegistry.release).not.toHaveBeenCalled();
+  });
+
   it("retains a manual claim when stale-snapshot withdrawal cannot be confirmed", async () => {
     const manual = entry({ kind: "manual_ticket" });
     const runRegistry = registry([manual]);

--- a/apps/worker/src/lib/reconcile.ts
+++ b/apps/worker/src/lib/reconcile.ts
@@ -266,7 +266,21 @@ export async function reconcileRuns(
       continue;
     }
     const departure = await verifyTicketLeftAiColumn(ticketKey, issueTracker);
-    if (!departure.left) continue;
+    if (!departure.left) {
+      // The Jira poll is capped, so a manual claim can be absent from its
+      // snapshot even though the authoritative read still finds AI. Reuse the
+      // owner-fenced terminal cleanup; an uncertain read retains the claim.
+      if (entry.kind === "manual_ticket" && departure.trackerStatus !== null) {
+        cleaned += await cleanFinishedManualTicket(
+          boundEntry,
+          runRegistry,
+          issueTracker,
+          onSubjectReleased,
+          db,
+        );
+      }
+      continue;
+    }
     const reviewDestination =
       departure.trackerStatus !== null &&
       (await isAiReviewDestination({

--- a/apps/worker/src/mcp/run-diagnosis.test.ts
+++ b/apps/worker/src/mcp/run-diagnosis.test.ts
@@ -4,6 +4,21 @@ import { diagnoseRun } from "./run-diagnosis.js";
 import { WORKSPACE_GATE_NOT_RECORDED_MESSAGE } from "../workflow-definition/interpreter.js";
 
 describe("diagnoseRun", () => {
+  it("classifies the stable watchdog stalled-engine reason instead of unknown", () => {
+    const result = diagnoseRun({
+      status: "failed",
+      error: {
+        code: "AIW-DIAG-wrun_1-watchdog",
+        message: 'Run engine stalled: step "collectPhase" has been running for 32 minutes',
+      },
+      steps: [],
+    });
+    expect(result.category).toBe("engine_stalled");
+    expect(result.confidence).toBe("low");
+    expect(result.evidenceRefs).toEqual(["AIW-DIAG-wrun_1-watchdog"]);
+    expect(result.nextActions.join(" ")).toMatch(/watchdog|step|worker/i);
+  });
+
   it("hands over the evidence it has even when no rule matched", () => {
     // An unmatched run used to return evidenceRefs: [] unconditionally, so the
     // diagnosis was strictly worse than its neighbours: runs.result showed a
@@ -390,6 +405,31 @@ describe("diagnoseRun", () => {
       evidenceRefs: [],
       nextActions: expect.any(Array),
     });
+  });
+
+  // Real production shape from wrun_01M13WTS2KV1ZX7ZKAFAHM5F7J: the provider
+  // failure was already reduced to this stable, client-safe sentence, but the
+  // diagnosis table had no matching rule and returned unknown. A provider
+  // project spend limit is a dependency failure, not the workflow's own
+  // budget_exhausted category, and needs billing guidance rather than a blind
+  // retry/status-page suggestion.
+  it("classifies the curated provider spend-limit message with billing remediation and preserves its diagnostic evidence", () => {
+    const diagnosticId =
+      "AIW-DIAG-wrun_01M13WTS2KV1ZX7ZKAFAHM5F7J-call_llm-1";
+    const result = diagnoseRun({
+      status: "failed",
+      error: {
+        code: diagnosticId,
+        message:
+          "The AI provider rejected the request: the account has reached its configured spend limit. Raise or remove the spend limit in the provider's billing settings, then rerun.",
+      },
+      steps: [],
+    });
+    expect(result.category).toBe("dependency_unavailable");
+    expect(result.confidence).toBe("low");
+    expect(result.evidenceRefs).toEqual([diagnosticId]);
+    expect(result.nextActions.join(" ")).toMatch(/spend limit|billing/i);
+    expect(result.nextActions.join(" ")).not.toMatch(/status page/i);
   });
 
   // Real shape: PROVIDER_CAUSES rate-limit entry (workflow-definition/

--- a/apps/worker/src/mcp/run-diagnosis.ts
+++ b/apps/worker/src/mcp/run-diagnosis.ts
@@ -48,6 +48,7 @@ export type RunDiagnosisCategory =
   | "source_pull_request_moved"
   | "validation_failed"
   | "budget_exhausted"
+  | "engine_stalled"
   | "engine_error"
   | "step_failed"
   | "unknown";
@@ -141,6 +142,10 @@ const NEXT_ACTIONS: Record<RunDiagnosisCategory, string[]> = {
   budget_exhausted: [
     "The run stopped after exhausting its configured budget, not from a failure.",
     "Raise the workflow's budget limit or narrow the ticket's scope before retrying.",
+  ],
+  engine_stalled: [
+    "The watchdog marked this run failed after a workflow step stopped making progress.",
+    "Inspect the named step and worker or sandbox health before retrying the run.",
   ],
   engine_error: [
     "Check the workflow definition graph for an unresolvable trigger, node, or edge.",
@@ -237,6 +242,10 @@ const SOURCE_PULL_REQUEST_MOVED_KEYWORDS = [
 // stopped by a budget check (workflows/agent.ts:2537-2543).
 const BUDGET_EXHAUSTED_PREFIX = "Run stopped on budget:";
 
+// WATCHDOG_FAILURE_REASON_PREFIX (lib/telemetry/run-telemetry.ts:116), written
+// only by the engine-stall watchdog as a durable failed-run reason.
+const ENGINE_STALLED_PREFIX = "Run engine stalled:";
+
 // fallbackTerminalError's "blocked" lead (lib/overview/sanitize-run-detail.ts:
 // 104-113): the observed face of three silent stop paths that record no
 // statusReason: markRunBlockedOnCancel and sweepOrphanedAwaitingRuns
@@ -264,6 +273,19 @@ const VALIDATION_FAILED_PREFIXES = [
 // rule matches ONLY the sentence it already decided on, never the raw text.
 const DEPENDENCY_AUTH_PREFIX =
   "The AI provider rejected the credentials (authentication failed).";
+
+// Curated provider sentence for an account/project spend-limit rejection
+// (workflow-definition/failure-message.ts:148-151). This is deliberately a
+// whole trusted lead rather than a raw `spend limit` search: runs.diagnose
+// receives the already-sanitized run reason, and only this code-owned sentence
+// is safe to route to billing remediation. It stays distinct from
+// `budget_exhausted`, which describes the workflow's own configured budget.
+const PROVIDER_SPEND_LIMIT_PREFIX =
+  "The AI provider rejected the request: the account has reached its configured spend limit.";
+const PROVIDER_SPEND_LIMIT_ACTIONS = [
+  "Raise or remove the provider project's configured spend limit in billing settings before retrying.",
+  "Confirm the intended provider project/account is selected and that the new limit has propagated before rerunning.",
+] as const;
 
 // The other PROVIDER_CAUSES sentences (workflow-definition/failure-message.ts:
 // 90-113): billing/credit, rate limit, model unavailable, and overloaded. Plus
@@ -391,6 +413,15 @@ const RULES: readonly Rule[] = [
     },
   },
   {
+    category: "engine_stalled",
+    match: (input) => {
+      if (input.status !== "failed") return null;
+      const message = input.error?.message;
+      if (!message || !message.startsWith(ENGINE_STALLED_PREFIX)) return null;
+      return { confidence: "low", evidenceRefs: evidenceFrom(input) };
+    },
+  },
+  {
     category: "cancelled",
     match: (input) => {
       if (input.status !== "blocked") return null;
@@ -474,6 +505,22 @@ const RULES: readonly Rule[] = [
       const message = input.error?.message;
       if (!message || !message.startsWith(DEPENDENCY_AUTH_PREFIX)) return null;
       return { confidence: "low", evidenceRefs: evidenceFrom(input) };
+    },
+  },
+  {
+    // This is a provider dependency failure, but the operator action is
+    // billing remediation rather than a blind retry or a status-page check.
+    // Keep it ahead of the generic dependency_unavailable rule below so the
+    // stable curated spend-limit sentence gets its specific guidance.
+    category: "dependency_unavailable",
+    match: (input) => {
+      const message = input.error?.message;
+      if (!message || !message.startsWith(PROVIDER_SPEND_LIMIT_PREFIX)) return null;
+      return {
+        confidence: "low",
+        evidenceRefs: evidenceFrom(input),
+        nextActions: PROVIDER_SPEND_LIMIT_ACTIONS,
+      };
     },
   },
   {

--- a/apps/worker/src/sandbox/poll-agent.test.ts
+++ b/apps/worker/src/sandbox/poll-agent.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockRunCommand = vi.fn();
 const mockStop = vi.fn();
@@ -137,6 +137,7 @@ describe("checkPhaseDone", () => {
 
 describe("collectPhaseOutput", () => {
   beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
 
   it("prefers stdout and falls back to stderr", async () => {
     mockRunCommand
@@ -146,10 +147,53 @@ describe("collectPhaseOutput", () => {
       collectPhaseOutput("sbx-test-123", "/tmp/stdout", "/tmp/stderr"),
     ).resolves.toBe("error details");
   });
+
+  it("bounds an artifact read that never settles with the deterministic deadline error", async () => {
+    vi.useFakeTimers();
+    mockRunCommand.mockImplementationOnce(() => new Promise(() => {}));
+    let failure: unknown;
+    void collectPhaseOutput("sbx-test-123", "/tmp/stdout", "/tmp/stderr").catch(
+      (error) => {
+        failure = error;
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(failure).toMatchObject({ name: "SandboxDeadlineError", deadlineMs: 60_000 });
+  });
+
+  it("aborts a stdout stream that never settles when the artifact deadline expires", async () => {
+    vi.useFakeTimers();
+    const stdout = vi.fn(({ signal }: { signal: AbortSignal }) =>
+      new Promise<string>((_, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason));
+      }),
+    );
+    mockRunCommand.mockResolvedValueOnce({ ...result(), stdout });
+
+    let failure: unknown;
+    void collectPhaseOutput("sbx-test-123", "/tmp/stdout", "/tmp/stderr").catch(
+      (error) => {
+        failure = error;
+      },
+    );
+
+    for (let i = 0; i < 100 && stdout.mock.calls.length === 0; i += 1) {
+      await vi.advanceTimersByTimeAsync(1);
+    }
+    expect(stdout).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(stdout.mock.calls[0]?.[0].signal.aborted).toBe(true);
+    expect(failure).toMatchObject({ name: "SandboxDeadlineError", deadlineMs: 60_000 });
+  });
 });
 
 describe("collectPhase", () => {
   beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.useRealTimers());
 
   it("returns stdout, stderr, structured output, and exit code independently", async () => {
     mockRunCommand.mockImplementation((_cmd: string, args: string[]) => {
@@ -178,6 +222,74 @@ describe("collectPhase", () => {
       structuredOutput: '{"result":"implemented"}',
       exitCode: 17,
     });
+  });
+
+  it("bounds a Sandbox.get that never settles with the deterministic deadline error", async () => {
+    vi.useFakeTimers();
+    const { Sandbox } = await import("@vercel/sandbox");
+    (Sandbox.get as ReturnType<typeof vi.fn>).mockImplementationOnce(() => new Promise(() => {}));
+    let failure: unknown;
+    void collectPhase("sbx-test-123", {
+      stdout: "/tmp/stdout",
+      stderr: "/tmp/stderr",
+      structuredOutput: null,
+      exitCode: "/tmp/exit-code",
+    }).catch((error) => { failure = error; });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(failure).toMatchObject({ name: "SandboxDeadlineError", deadlineMs: 60_000 });
+    (Sandbox.get as ReturnType<typeof vi.fn>).mockReset().mockImplementation(() => ({
+      sandboxId: "sbx-test-123",
+      status: "running",
+      runCommand: mockRunCommand,
+      stop: mockStop,
+    }));
+  });
+
+  it("bounds an artifact read that never settles with the deterministic deadline error", async () => {
+    vi.useFakeTimers();
+    mockRunCommand.mockImplementationOnce(() => new Promise(() => {}));
+    let failure: unknown;
+    void collectPhase("sbx-test-123", {
+      stdout: "/tmp/stdout",
+      stderr: "/tmp/stderr",
+      structuredOutput: null,
+      exitCode: "/tmp/exit-code",
+    }).catch((error) => { failure = error; });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(failure).toMatchObject({ name: "SandboxDeadlineError", deadlineMs: 60_000 });
+  });
+
+  it("aborts a stdout stream that never settles when the artifact deadline expires", async () => {
+    vi.useFakeTimers();
+    const stdout = vi.fn(({ signal }: { signal: AbortSignal }) =>
+      new Promise<string>((_, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason));
+      }),
+    );
+    mockRunCommand.mockResolvedValueOnce({ ...result(), stdout });
+
+    let failure: unknown;
+    void collectPhase("sbx-test-123", {
+      stdout: "/tmp/stdout",
+      stderr: "/tmp/stderr",
+      structuredOutput: null,
+      exitCode: "/tmp/exit-code",
+    }).catch((error) => { failure = error; });
+
+    for (let i = 0; i < 100 && stdout.mock.calls.length === 0; i += 1) {
+      await vi.advanceTimersByTimeAsync(1);
+    }
+    expect(stdout).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(stdout.mock.calls[0]?.[0].signal.aborted).toBe(true);
+    expect(failure).toMatchObject({ name: "SandboxDeadlineError", deadlineMs: 60_000 });
   });
 
   it("bounds replay-only partial artifact reads", async () => {

--- a/apps/worker/src/sandbox/poll-agent.test.ts
+++ b/apps/worker/src/sandbox/poll-agent.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Sandbox } from "@vercel/sandbox";
 
 const mockRunCommand = vi.fn();
 const mockStop = vi.fn();
@@ -15,6 +16,20 @@ vi.mock("@vercel/sandbox", () => ({
 }));
 
 vi.mock("./credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
+
+const mockSandboxGet = Sandbox.get as unknown as ReturnType<typeof vi.fn>;
+
+function resetSandboxMocks() {
+  vi.clearAllMocks();
+  mockRunCommand.mockReset();
+  mockStop.mockReset();
+  mockSandboxGet.mockReset().mockImplementation(() => ({
+    sandboxId: "sbx-test-123",
+    status: "running",
+    runCommand: mockRunCommand,
+    stop: mockStop,
+  }));
+}
 
 import {
   checkPhaseDone,
@@ -34,7 +49,7 @@ function result(stdout = "", stderr = "", exitCode = 0) {
 }
 
 describe("teardownSandbox", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(resetSandboxMocks);
 
   it("stops the sandbox", async () => {
     await teardownSandbox("sbx-test-123");
@@ -42,8 +57,7 @@ describe("teardownSandbox", () => {
   });
 
   it("does not throw on error", async () => {
-    const { Sandbox } = await import("@vercel/sandbox");
-    (Sandbox.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("gone"));
+    mockSandboxGet.mockRejectedValueOnce(new Error("gone"));
     await expect(teardownSandbox("sbx-test-123")).resolves.not.toThrow();
   });
 
@@ -54,7 +68,7 @@ describe("teardownSandbox", () => {
 });
 
 describe("teardownSandboxes", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(resetSandboxMocks);
 
   it("tears down every distinct id once, de-duplicated", async () => {
     const teardown = vi.fn().mockResolvedValue(undefined);
@@ -77,7 +91,7 @@ describe("teardownSandboxes", () => {
 });
 
 describe("checkPhaseDone", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(resetSandboxMocks);
 
   it("returns true when sentinel file exists", async () => {
     mockRunCommand.mockResolvedValue({ exitCode: 0 });
@@ -90,8 +104,7 @@ describe("checkPhaseDone", () => {
   });
 
   it("returns stopped when the sandbox is unavailable", async () => {
-    const { Sandbox } = await import("@vercel/sandbox");
-    (Sandbox.get as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("gone"));
+    mockSandboxGet.mockRejectedValueOnce(new Error("gone"));
     await expect(checkPhaseDone("sbx-test-123", "/tmp/phase-done")).resolves.toBe("stopped");
   });
 
@@ -120,11 +133,10 @@ describe("checkPhaseDone", () => {
 
   it("hands the deadline signal to the sandbox lookup and the sentinel probe", async () => {
     mockRunCommand.mockResolvedValue({ exitCode: 0 });
-    const { Sandbox } = await import("@vercel/sandbox");
 
     await checkPhaseDone("sbx-test-123", "/tmp/phase-done");
 
-    expect(Sandbox.get).toHaveBeenCalledWith(
+    expect(mockSandboxGet).toHaveBeenCalledWith(
       expect.objectContaining({ sandboxId: "sbx-test-123", signal: expect.any(AbortSignal) }),
     );
     expect(mockRunCommand).toHaveBeenCalledWith(
@@ -136,7 +148,7 @@ describe("checkPhaseDone", () => {
 });
 
 describe("collectPhaseOutput", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(resetSandboxMocks);
   afterEach(() => vi.useRealTimers());
 
   it("prefers stdout and falls back to stderr", async () => {
@@ -192,7 +204,7 @@ describe("collectPhaseOutput", () => {
 });
 
 describe("collectPhase", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(resetSandboxMocks);
   afterEach(() => vi.useRealTimers());
 
   it("returns stdout, stderr, structured output, and exit code independently", async () => {
@@ -226,8 +238,7 @@ describe("collectPhase", () => {
 
   it("bounds a Sandbox.get that never settles with the deterministic deadline error", async () => {
     vi.useFakeTimers();
-    const { Sandbox } = await import("@vercel/sandbox");
-    (Sandbox.get as ReturnType<typeof vi.fn>).mockImplementationOnce(() => new Promise(() => {}));
+    mockSandboxGet.mockImplementationOnce(() => new Promise(() => {}));
     let failure: unknown;
     void collectPhase("sbx-test-123", {
       stdout: "/tmp/stdout",
@@ -240,12 +251,6 @@ describe("collectPhase", () => {
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(failure).toMatchObject({ name: "SandboxDeadlineError", deadlineMs: 60_000 });
-    (Sandbox.get as ReturnType<typeof vi.fn>).mockReset().mockImplementation(() => ({
-      sandboxId: "sbx-test-123",
-      status: "running",
-      runCommand: mockRunCommand,
-      stop: mockStop,
-    }));
   });
 
   it("bounds an artifact read that never settles with the deterministic deadline error", async () => {

--- a/apps/worker/src/sandbox/poll-agent.ts
+++ b/apps/worker/src/sandbox/poll-agent.ts
@@ -70,17 +70,18 @@ export async function collectPhaseOutput(
   stderrFile: string,
 ): Promise<string> {
   "use step";
-  const { Sandbox } = await import("@vercel/sandbox");
+  return withSandboxDeadline(SANDBOX_STEP_DEADLINE_MS, async (signal) => {
+    const { Sandbox } = await import("@vercel/sandbox");
+    const sandbox = await Sandbox.get({ sandboxId, signal, ...getSandboxCredentials() });
 
-  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+    const stdoutResult = await sandbox.runCommand("cat", [outputFile], { signal });
+    const stdout = (await stdoutResult.stdout({ signal })).trim();
 
-  const stdoutResult = await sandbox.runCommand("cat", [outputFile]);
-  const stdout = (await stdoutResult.stdout()).trim();
+    const stderrResult = await sandbox.runCommand("cat", [stderrFile], { signal });
+    const stderr = (await stderrResult.stdout({ signal })).trim();
 
-  const stderrResult = await sandbox.runCommand("cat", [stderrFile]);
-  const stderr = (await stderrResult.stdout()).trim();
-
-  return stdout || stderr;
+    return stdout || stderr;
+  });
 }
 
 /**
@@ -90,24 +91,25 @@ export async function collectPhaseOutput(
 async function collectPhaseArtifacts(
   sandboxId: string,
   paths: Pick<PhaseArtifactPaths, "stdout" | "stderr" | "structuredOutput" | "exitCode">,
+  signal: AbortSignal,
 ): Promise<CollectedPhaseArtifacts> {
   const { Sandbox } = await import("@vercel/sandbox");
-  const sandbox = await Sandbox.get({ sandboxId, ...getSandboxCredentials() });
+  const sandbox = await Sandbox.get({ sandboxId, signal, ...getSandboxCredentials() });
 
-  const stdoutResult = await sandbox.runCommand("cat", [paths.stdout]);
-  const stdoutText = (await stdoutResult.stdout()).trim();
-  const stderrResult = await sandbox.runCommand("cat", [paths.stderr]);
-  const stderrText = (await stderrResult.stdout()).trim();
+  const stdoutResult = await sandbox.runCommand("cat", [paths.stdout], { signal });
+  const stdoutText = (await stdoutResult.stdout({ signal })).trim();
+  const stderrResult = await sandbox.runCommand("cat", [paths.stderr], { signal });
+  const stderrText = (await stderrResult.stdout({ signal })).trim();
 
   let structuredOutput: string | null = null;
   if (paths.structuredOutput) {
-    const result = await sandbox.runCommand("cat", [paths.structuredOutput]);
-    const text = (await result.stdout()).trim();
+    const result = await sandbox.runCommand("cat", [paths.structuredOutput], { signal });
+    const text = (await result.stdout({ signal })).trim();
     structuredOutput = text || null;
   }
 
-  const exitCodeResult = await sandbox.runCommand("cat", [paths.exitCode]);
-  const exitCodeText = (await exitCodeResult.stdout()).trim();
+  const exitCodeResult = await sandbox.runCommand("cat", [paths.exitCode], { signal });
+  const exitCodeText = (await exitCodeResult.stdout({ signal })).trim();
   const parsedExitCode = /^-?\d+$/.test(exitCodeText) ? Number(exitCodeText) : null;
   return {
     stdout: stdoutText,
@@ -122,7 +124,10 @@ export async function collectPhase(
   paths: Pick<PhaseArtifactPaths, "stdout" | "stderr" | "structuredOutput" | "exitCode">,
 ): Promise<CollectedPhaseArtifacts> {
   "use step";
-  return collectPhaseArtifacts(sandboxId, paths);
+  return withSandboxDeadline(
+    SANDBOX_STEP_DEADLINE_MS,
+    (signal) => collectPhaseArtifacts(sandboxId, paths, signal),
+  );
 }
 
 export interface CollectedReplayPhaseDiagnostics

--- a/apps/worker/src/sandbox/stop-ticket-sandboxes.test.ts
+++ b/apps/worker/src/sandbox/stop-ticket-sandboxes.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGet = vi.fn();
 
@@ -36,6 +36,10 @@ describe("stopSandboxesByIds", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("stops every explicitly owned sandbox id without branch discovery", async () => {
     const first = makeSandbox();
     const second = makeSandbox();
@@ -48,8 +52,12 @@ describe("stopSandboxesByIds", () => {
 
     expect(stopped).toBe(2);
     expect(mockGet).toHaveBeenCalledTimes(2);
-    expect(first.stop).toHaveBeenCalledWith({ blocking: true });
-    expect(second.stop).toHaveBeenCalledWith({ blocking: true });
+    expect(first.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ blocking: true, signal: expect.any(AbortSignal) }),
+    );
+    expect(second.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ blocking: true, signal: expect.any(AbortSignal) }),
+    );
   });
 
   it.each(["pending", "stopping", "snapshotting"] as const)(
@@ -60,7 +68,9 @@ describe("stopSandboxesByIds", () => {
 
       const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
       await expect(stopSandboxesByIds([`sbx-${status}`])).resolves.toBe(1);
-      expect(sandbox.stop).toHaveBeenCalledWith({ blocking: true });
+      expect(sandbox.stop).toHaveBeenCalledWith(
+        expect.objectContaining({ blocking: true, signal: expect.any(AbortSignal) }),
+      );
     },
   );
 
@@ -98,7 +108,51 @@ describe("stopSandboxesByIds", () => {
     await expect(
       stopSandboxesByIds(["sbx-child-1", "sbx-child-2"]),
     ).rejects.toThrow("sbx-child-1");
-    expect(first.stop).toHaveBeenCalledWith({ blocking: true });
-    expect(second.stop).toHaveBeenCalledWith({ blocking: true });
+    expect(first.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ blocking: true, signal: expect.any(AbortSignal) }),
+    );
+    expect(second.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ blocking: true, signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("bounds a Sandbox.get call that never settles instead of hanging cleanup", async () => {
+    const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
+    await import("@vercel/sandbox");
+    vi.useFakeTimers();
+    mockGet.mockImplementation(() => new Promise(() => {}));
+    const pending = stopSandboxesByIds(["sbx-never-gets"]);
+    const outcome = pending.then(() => null, (error) => error);
+
+    for (let tick = 0; tick < 100 && mockGet.mock.calls.length === 0; tick += 1) {
+      await vi.advanceTimersByTimeAsync(1);
+    }
+    expect(mockGet).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(outcome).resolves.toMatchObject({
+      message: expect.stringContaining("sbx-never-gets"),
+    });
+  });
+
+  it("bounds a blocking stop that never settles instead of hanging cleanup", async () => {
+    const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
+    await import("@vercel/sandbox");
+    vi.useFakeTimers();
+    const sandbox = makeSandbox();
+    sandbox.stop.mockImplementation(() => new Promise(() => {}));
+    mockGet.mockResolvedValue(sandbox);
+    const pending = stopSandboxesByIds(["sbx-never-stops"]);
+    const outcome = pending.then(() => null, (error) => error);
+
+    for (let tick = 0; tick < 100 && sandbox.stop.mock.calls.length === 0; tick += 1) {
+      await vi.advanceTimersByTimeAsync(1);
+    }
+    expect(sandbox.stop).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(outcome).resolves.toMatchObject({
+      message: expect.stringContaining("sbx-never-stops"),
+    });
   });
 });

--- a/apps/worker/src/sandbox/stop-ticket-sandboxes.ts
+++ b/apps/worker/src/sandbox/stop-ticket-sandboxes.ts
@@ -1,16 +1,20 @@
 import type { Sandbox } from "@vercel/sandbox";
 import { logger } from "../lib/logger.js";
 import { getSandboxCredentials } from "./credentials.js";
+import { SANDBOX_STEP_DEADLINE_MS, withSandboxDeadline } from "./sandbox-deadline.js";
 
 type StoppableSandbox = Pick<Sandbox, "sandboxId" | "status" | "stop">;
 
 /** Block until one known sandbox is terminal, or fail closed if that cannot be confirmed. */
-export async function stopSandboxAndConfirm(sandbox: StoppableSandbox): Promise<boolean> {
+export async function stopSandboxAndConfirm(
+  sandbox: StoppableSandbox,
+  signal?: AbortSignal,
+): Promise<boolean> {
   if (isTerminalStatus(sandbox.status)) return false;
 
   let final: Awaited<ReturnType<StoppableSandbox["stop"]>>;
   try {
-    final = await sandbox.stop({ blocking: true });
+    final = await sandbox.stop({ blocking: true, signal });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
@@ -35,8 +39,13 @@ export async function stopSandboxesByIds(sandboxIds: readonly string[]): Promise
   const results = await Promise.all(
     uniqueIds.map(async (sandboxId): Promise<{ stopped: number; failed: boolean }> => {
       try {
-        const sandbox = await Sandbox.get({ ...credentials, sandboxId });
-        const stopped = await stopSandboxAndConfirm(sandbox);
+        const stopped = await withSandboxDeadline(
+          SANDBOX_STEP_DEADLINE_MS,
+          async (signal) => {
+            const sandbox = await Sandbox.get({ ...credentials, sandboxId, signal });
+            return stopSandboxAndConfirm(sandbox, signal);
+          },
+        );
         return { stopped: stopped ? 1 : 0, failed: false };
       } catch (err) {
         if (isNotFoundError(err)) return { stopped: 0, failed: false };

--- a/apps/worker/src/system-health/probes.test.ts
+++ b/apps/worker/src/system-health/probes.test.ts
@@ -542,7 +542,7 @@ describe("deployment system-health probes", () => {
       }
       if (url.includes("/events?")) {
         return Response.json([
-          { created_at: "2026-08-21T10:00:00.000Z", response_status: 200 },
+          { created_at: new Date().toISOString(), response_status: 200 },
         ]);
       }
       throw new Error(`Unexpected request: ${url}`);


### PR DESCRIPTION
## Scope

Closes the production-audit gaps found while validating merged PRs #280, #347, #352, and #333 on real AWP tickets.

- AWP-124 / #280: reconcile terminal manual ticket runs omitted from the capped Jira snapshot, while retaining the owner on uncertain live reads.
- AWP-125 / #352: bound Sandbox.get, stop, runCommand, and stdout artifact streams with one abortable deadline; classify the stable watchdog reason as engine_stalled with message-derived low confidence.
- AWP-126 / #347: classify the curated Codex spend-limit failure as dependency_unavailable with billing-specific next actions.
- AWP-129 / CI baseline: keep the GitLab concurrency fixture inside the existing seven-day freshness window without changing production health logic.

## Production evidence

- #280: AWP-123, run wrun_01M13WNS43J6ZAEHNDE9V6T0XV. Repeated manual dispatch returned the same run and request IDs, exactly one run was attached, terminal cleanup returned the ticket from Ai to Todo.
- #347: AWP-121, run wrun_01M13WTS2KV1ZX7ZKAFAHM5F7J. The curated spend-limit reason appeared consistently in MCP, dashboard, logs, and Jira; the obsolete PATH warning did not leak.
- #333: AWP-122, run wrun_01M13X5HQR0H8QBC65Y5D572ZS. The durable research report survived later finalize failure and remained visible in dashboard and Jira with evidence, plan, usage, and delivery link.
- #352: healthy sandbox paths completed on AWP-122. No real AWP run with the destructive engine-stalled condition exists, so that edge is covered deterministically in focused tests rather than fabricated on production.

Additional production bugs were split into AWP-127 (verified no-op fails finalize) and AWP-128 (release label false-positive phone redaction).

## Verification

- 144 focused Vitest tests passed across reconciliation, diagnosis, polling, cleanup, and system-health probes.
- Full sandbox directory passed: 465/465 tests.
- Worker TypeScript check passed.
- git diff --check passed.
- Fresh SolAdvisor final review after CI fixes: SHIP.

First CI run exposed two deterministic test-fixture defects: fake-timer/dynamic-import mock leakage in the new stdout deadline tests and an existing hardcoded webhook timestamp that crossed its seven-day cutoff. Both are fixed in the second commit; full suites remain delegated to CI per repository policy.