### PR TITLE
test(worker): bind sandbox mock statically

### DIFF
--- a/apps/worker/src/sandbox/poll-agent.test.ts
+++ b/apps/worker/src/sandbox/poll-agent.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Sandbox } from "@vercel/sandbox";
 
 const mockRunCommand = vi.fn();
 const mockStop = vi.fn();
@@ -16,7 +17,6 @@ vi.mock("@vercel/sandbox", () => ({
 
 vi.mock("./credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
 
-const { Sandbox } = await import("@vercel/sandbox");
 const mockSandboxGet = Sandbox.get as unknown as ReturnType<typeof vi.fn>;
 
 function resetSandboxMocks() {


### PR DESCRIPTION
Follow-up to #354 / AWP-125.

Main CI run 33173321742 showed that the top-level dynamic test import introduced in #354 could still lose the Vitest mock boundary under the full suite: one timeout test never reached its stdout spy and the following replay test reached the real Vercel Sandbox OIDC path.

This surgical test-only patch restores the static `Sandbox` import while retaining #354's deferred rejection/drain cleanup. Vitest hoists `vi.mock`, so runtime dynamic imports in `poll-agent.ts` resolve against the statically established mocked module.

Verification:
- `poll-agent.test.ts`: 21/21, repeated 20/20 sequentially (420 tests)
- worker TypeScript: pass
- `git diff --check`: pass
- task-scoped Sol profile exactness check: pass
- fresh Sol/High audit: SHIP

No production runtime file changes.