### PR TITLE
[AIW-319] Drain stop sandbox deadline fixtures

### DIFF
--- a/apps/worker/src/sandbox/stop-ticket-sandboxes.test.ts
+++ b/apps/worker/src/sandbox/stop-ticket-sandboxes.test.ts
@@ -1,6 +1,59 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGet = vi.fn();
+const trackedFixturePromises = new Set<Promise<void>>();
+const fixtureCleanups = new Set<() => void>();
+
+function trackFixturePromise<T>(promise: Promise<T>): Promise<T> {
+  trackedFixturePromises.add(promise.then(() => undefined, () => undefined));
+  return promise;
+}
+
+function captureFailure<T>(promise: Promise<T>) {
+  return trackFixturePromise(promise).catch((error) => error);
+}
+
+function createDeferred<T>() {
+  let done = false;
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = trackFixturePromise(
+    new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    }),
+  );
+  let cleanup!: () => void;
+  const settle = (action: () => void) => {
+    if (done) return;
+    done = true;
+    fixtureCleanups.delete(cleanup);
+    action();
+  };
+  cleanup = () => settle(() => reject(new Error("test cleanup")));
+  fixtureCleanups.add(cleanup);
+  return {
+    promise,
+    resolve: (value: T) => settle(() => resolve(value)),
+  };
+}
+
+async function drainFixturePromises() {
+  for (;;) {
+    const tracked = [...trackedFixturePromises];
+    await Promise.all(tracked);
+    await Promise.resolve();
+    if (tracked.length === trackedFixturePromises.size) return;
+  }
+}
+
+async function cleanupFixtures() {
+  for (const cleanup of [...fixtureCleanups]) cleanup();
+  if (vi.isFakeTimers()) await vi.runAllTimersAsync();
+  await drainFixturePromises();
+  trackedFixturePromises.clear();
+  fixtureCleanups.clear();
+}
 
 vi.mock("@vercel/sandbox", () => ({
   Sandbox: {
@@ -11,6 +64,8 @@ vi.mock("@vercel/sandbox", () => ({
 vi.mock("./credentials.js", () => ({
   getSandboxCredentials: vi.fn(() => ({})),
 }));
+
+import { stopSandboxesByIds } from "./stop-ticket-sandboxes.js";
 
 type SandboxStatus =
   | "aborted"
@@ -31,13 +86,90 @@ function makeSandbox(
   };
 }
 
+async function expectStalledGetDeadline(sandboxId: string) {
+  const stalledGet = createDeferred<ReturnType<typeof makeSandbox>>();
+  const getStarted = createDeferred<{ signal: AbortSignal }>();
+  mockGet.mockClear();
+  mockGet.mockImplementation((options: { signal: AbortSignal }) => {
+    getStarted.resolve(options);
+    return stalledGet.promise;
+  });
+
+  const failure = captureFailure(stopSandboxesByIds([sandboxId]));
+  const { signal } = await getStarted.promise;
+
+  expect(mockGet).toHaveBeenCalledTimes(1);
+  expect(mockGet).toHaveBeenCalledWith(
+    expect.objectContaining({ sandboxId, signal }),
+  );
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  const error = await failure;
+
+  expect(signal.aborted).toBe(true);
+  expect(error).toMatchObject({
+    message: expect.stringContaining(sandboxId),
+  });
+
+  const terminalSandbox = makeSandbox("stopped");
+  stalledGet.resolve(terminalSandbox);
+  await drainFixturePromises();
+  expect(terminalSandbox.stop).not.toHaveBeenCalled();
+}
+
+async function expectStalledStopDeadline(sandboxId: string) {
+  const stalledStop = createDeferred<{ status: SandboxStatus }>();
+  const stopStarted = createDeferred<{
+    blocking: boolean;
+    signal: AbortSignal;
+  }>();
+  const sandbox = makeSandbox();
+  sandbox.stop.mockImplementation((options) => {
+    stopStarted.resolve(options);
+    return stalledStop.promise;
+  });
+  mockGet.mockClear();
+  mockGet.mockResolvedValue(sandbox);
+
+  const failure = captureFailure(stopSandboxesByIds([sandboxId]));
+  const options = await stopStarted.promise;
+
+  expect(mockGet).toHaveBeenCalledTimes(1);
+  expect(mockGet).toHaveBeenCalledWith(
+    expect.objectContaining({ sandboxId, signal: options.signal }),
+  );
+  expect(sandbox.stop).toHaveBeenCalledTimes(1);
+  expect(sandbox.stop).toHaveBeenCalledWith({
+    blocking: true,
+    signal: options.signal,
+  });
+
+  await vi.advanceTimersByTimeAsync(60_000);
+  const error = await failure;
+
+  expect(options.signal.aborted).toBe(true);
+  expect(error).toMatchObject({
+    message: expect.stringContaining(sandboxId),
+  });
+
+  stalledStop.resolve({ status: "stopped" });
+  await drainFixturePromises();
+}
+
 describe("stopSandboxesByIds", () => {
   beforeEach(() => {
+    if (trackedFixturePromises.size !== 0 || fixtureCleanups.size !== 0) {
+      throw new Error("sandbox fixtures must be drained before mock reset");
+    }
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
+  afterEach(async () => {
+    try {
+      await cleanupFixtures();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("stops every explicitly owned sandbox id without branch discovery", async () => {
@@ -47,7 +179,6 @@ describe("stopSandboxesByIds", () => {
       sandboxId === "sbx-child-1" ? first : second,
     );
 
-    const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
     const stopped = await stopSandboxesByIds(["sbx-child-1", "sbx-child-2"]);
 
     expect(stopped).toBe(2);
@@ -66,7 +197,6 @@ describe("stopSandboxesByIds", () => {
       const sandbox = makeSandbox(status);
       mockGet.mockResolvedValue(sandbox);
 
-      const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
       await expect(stopSandboxesByIds([`sbx-${status}`])).resolves.toBe(1);
       expect(sandbox.stop).toHaveBeenCalledWith(
         expect.objectContaining({ blocking: true, signal: expect.any(AbortSignal) }),
@@ -80,7 +210,6 @@ describe("stopSandboxesByIds", () => {
       const sandbox = makeSandbox(status);
       mockGet.mockResolvedValue(sandbox);
 
-      const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
       await expect(stopSandboxesByIds([`sbx-${status}`])).resolves.toBe(0);
       expect(sandbox.stop).not.toHaveBeenCalled();
     },
@@ -90,7 +219,6 @@ describe("stopSandboxesByIds", () => {
     const sandbox = makeSandbox("running", "stopping");
     mockGet.mockResolvedValue(sandbox);
 
-    const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
     await expect(stopSandboxesByIds(["sbx-unconfirmed"])).rejects.toThrow(
       "sbx-unconfirmed",
     );
@@ -104,7 +232,6 @@ describe("stopSandboxesByIds", () => {
       sandboxId === "sbx-child-1" ? first : second,
     );
 
-    const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
     await expect(
       stopSandboxesByIds(["sbx-child-1", "sbx-child-2"]),
     ).rejects.toThrow("sbx-child-1");
@@ -117,42 +244,32 @@ describe("stopSandboxesByIds", () => {
   });
 
   it("bounds a Sandbox.get call that never settles instead of hanging cleanup", async () => {
-    const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
-    await import("@vercel/sandbox");
     vi.useFakeTimers();
-    mockGet.mockImplementation(() => new Promise(() => {}));
-    const pending = stopSandboxesByIds(["sbx-never-gets"]);
-    const outcome = pending.then(() => null, (error) => error);
-
-    for (let tick = 0; tick < 100 && mockGet.mock.calls.length === 0; tick += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
-    expect(mockGet).toHaveBeenCalledOnce();
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    await expect(outcome).resolves.toMatchObject({
-      message: expect.stringContaining("sbx-never-gets"),
-    });
+    await expectStalledGetDeadline("sbx-never-gets");
   });
 
   it("bounds a blocking stop that never settles instead of hanging cleanup", async () => {
-    const { stopSandboxesByIds } = await import("./stop-ticket-sandboxes.js");
-    await import("@vercel/sandbox");
     vi.useFakeTimers();
+    await expectStalledStopDeadline("sbx-never-stops");
+  });
+
+  it("drains both deadline branches before the next cleanup uses fresh mocks", async () => {
+    vi.useFakeTimers();
+    await expectStalledGetDeadline("sbx-sequential-get");
+    await expectStalledStopDeadline("sbx-sequential-stop");
+
     const sandbox = makeSandbox();
-    sandbox.stop.mockImplementation(() => new Promise(() => {}));
+    mockGet.mockClear();
     mockGet.mockResolvedValue(sandbox);
-    const pending = stopSandboxesByIds(["sbx-never-stops"]);
-    const outcome = pending.then(() => null, (error) => error);
 
-    for (let tick = 0; tick < 100 && sandbox.stop.mock.calls.length === 0; tick += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
-    expect(sandbox.stop).toHaveBeenCalledOnce();
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    await expect(outcome).resolves.toMatchObject({
-      message: expect.stringContaining("sbx-never-stops"),
-    });
+    await expect(stopSandboxesByIds(["sbx-next-cleanup"])).resolves.toBe(1);
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sandboxId: "sbx-next-cleanup",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(sandbox.stop).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Track and drain every deadline fixture promise, including cleanup after failed assertions.
- Start fake-clock deadline advancement only after the current Sandbox.get or blocking stop seam has been reached.
- Prove abort-signal propagation, settle the losing async branch, and add a sequential stalled-get → stalled-stop → fresh-cleanup regression.

## Why

Source-main run 33198152628 exposed a second fixture-start race in stop-ticket-sandboxes.test.ts. The race is intermittent: post-merge main run 33204644312 passed, but the earlier exact failure remains reproducible evidence that the irreversible test promises can corrupt a full-suite run.

## Scope

Test-only. Exactly one file changes:

- apps/worker/src/sandbox/stop-ticket-sandboxes.test.ts

No product behavior or production source is changed.

## Exact commits

- base main: 6187e88ef70a73ab1cc942d950f10ba5edb586e3
- head: d0e8935aa41faf989aba1a01bff60af125bf7c41
- test blob: a68a314133cd9e79cb140a0d0b6021f9a17e7e07

## Focused evidence

- Node 25: 12/12 PASS
- Node 24: 12/12 PASS
- shuffled seeds 1-10 on Node 25 and Node 24: 20/20 runs PASS
- poll-agent plus stop-ticket-sandboxes on Node 25 and Node 24: 34/34 tests per runtime PASS
- sequential regression on Node 25 and Node 24: PASS
- worker typecheck: PASS
- git diff --check: PASS
- independent exact-diff review: ACCEPT, 0 blockers
- focused evidence remains exact after rebase: old and squash-merged base trees are identical, and the test blob is unchanged

Full local suites were intentionally not duplicated; the full gate belongs to this PR CI.

Jira: https://blazity.atlassian.net/browse/AIW-319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved sandbox timeout test reliability and determinism.
  * Added coverage for stalled retrieval and stop operations, including abort behavior after the timeout period.
  * Added validation that late responses do not trigger unintended sandbox stops.
  * Ensured sequential timeout scenarios complete cleanly with isolated test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->