### PR TITLE
[AIW-313] Add credential-free source build gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,10 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    # `pnpm run test` alone measured 16:52, 17:52, 17:55 and 18:58 across four
-    # branches on one day, so a 35 minute job left too little headroom for
-    # everything else and cancelled mid-step whenever a runner was slow. A
-    # cancelled check reads as neither red nor green, which is worse than a
-    # failure: it is easy to merge past. The suite's cost is dominated by
-    # per-file database setup rather than test count, so this ceiling has to
-    # cover that until the database fixture is shared.
-    timeout-minutes: 40
+    # The full job has already approached 36 minutes without the production
+    # bundle below. Keep enough headroom for slow runners so the source gate
+    # reports a real verdict instead of being cancelled mid-step.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -56,6 +52,7 @@ jobs:
       - run: pnpm run test
       - run: pnpm run test:release-notes
       - run: pnpm run test:ci
+      - run: pnpm run build:ci
       # Durable-workflow tests. They need their own Workflow SDK builder config,
       # so vitest.config.ts cannot pick them up alongside the rest of the suite.
       - run: pnpm run test:workflow-sdk

--- a/SETUP.md
+++ b/SETUP.md
@@ -467,7 +467,7 @@ If anything stalls, jump to [troubleshooting](#13-troubleshooting).
 
 Four workflows ship in `.github/workflows/`:
 
-- **`ci.yml`** — runs on pull requests against `main`/`dev` and on `merge_group` events. The `ci` job runs typecheck + unit tests with no secrets. The merge-queue path additionally runs `e2e-orchestration → e2e-capacity → e2e-agent` against the same `e2e` GitHub environment.
+- **`ci.yml`** — runs on pull requests against `main`/`dev`, pushes to `main`, manual dispatches, and `merge_group` events. The `ci` job runs typecheck, unit tests, and a credential-free production build. The merge-queue path additionally runs `e2e-orchestration → e2e-capacity → e2e-agent` against the same `e2e` GitHub environment.
 - **`e2e.yml`** — manual `workflow_dispatch` with two inputs:
   - `tier`: `orchestration` | `capacity` | `agent` | `all` (default `all`).
   - `agent`: `claude` | `codex` — passed as `E2E_AGENT_KIND`, only consumed by the `agent` tier.
@@ -482,6 +482,17 @@ Four workflows ship in `.github/workflows/`:
   synchronizes the complete pinned application snapshot into a pull request in
   `Blazity/ai-workflow-arthur`. It preserves only that repository's `.github/`
   directory and `renovate.json`; it does not call Vercel.
+
+Run the source-build gate locally without deployment credentials or external
+service/database writes:
+
+```bash
+pnpm run build:ci
+```
+
+It builds the worker and dashboard and runs the committed worker validators,
+without database migrations or auth-user seeding. The regular `pnpm build`
+remains the deployment-oriented entry point and preserves those setup steps.
 
 The E2E jobs need the production env
 vars exposed as GitHub Actions secrets in the `e2e` environment (Repo Settings

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "pnpm build:shared && rm -rf .nitro/workflow && nitro dev",
     "build": "pnpm build:shared && pnpm validate:pre-sandbox && pnpm validate:local-skills && pnpm db:migrate && pnpm seed:auth-user && rm -rf .nitro/workflow && NODE_OPTIONS=--max-old-space-size=8192 nitro build",
+    "build:ci": "pnpm build:shared && pnpm validate:pre-sandbox && pnpm validate:local-skills && pnpm mcp:contract:check && rm -rf .nitro/workflow && NODE_OPTIONS=--max-old-space-size=8192 nitro build",
     "preview": "nitro preview",
     "test": "pnpm build:shared && vitest run",
     "test:workflow-sdk": "pnpm build:shared && vitest run --config vitest.run-control-workflow.config.ts",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev:dashboard": "pnpm --filter ai-workflow-dashboard dev",
     "dev:all": "pnpm --parallel -r run dev",
     "build": "pnpm -r build",
+    "build:ci": "pnpm --filter worker build:ci && NEXT_TELEMETRY_DISABLED=1 pnpm --filter ai-workflow-dashboard build",
     "typecheck": "pnpm typecheck:release-notes && pnpm -r typecheck",
     "typecheck:release-notes": "tsc -p scripts/release-notes/tsconfig.json",
     "test": "pnpm -r test",

--- a/scripts/ci/ci-workflow.test.ts
+++ b/scripts/ci/ci-workflow.test.ts
@@ -3,6 +3,18 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { parse } from "yaml";
 
+type PackageJson = {
+  scripts: Record<string, string>;
+};
+
+function commands(script: string): string[] {
+  return script.split(" && ");
+}
+
+async function readPackageJson(path: string): Promise<PackageJson> {
+  return JSON.parse(await readFile(path, "utf8")) as PackageJson;
+}
+
 test("main pushes run CI in a non-canceling concurrency group", async () => {
   const source = await readFile(".github/workflows/ci.yml", "utf8");
   const workflow = parse(source) as {
@@ -16,4 +28,122 @@ test("main pushes run CI in a non-canceling concurrency group", async () => {
     workflow.concurrency.group,
     /github\.event_name == 'push' && github\.sha/,
   );
+});
+
+test("CI preserves every authoritative source trigger", async () => {
+  const source = await readFile(".github/workflows/ci.yml", "utf8");
+  const workflow = parse(source) as {
+    on: Record<string, unknown> & {
+      pull_request: { branches: string[] };
+      push: { branches: string[] };
+    };
+  };
+
+  assert.deepEqual(Object.keys(workflow.on).sort(), [
+    "merge_group",
+    "pull_request",
+    "push",
+    "workflow_dispatch",
+  ]);
+  assert.deepEqual(workflow.on.pull_request, { branches: ["main", "dev"] });
+  assert.deepEqual(workflow.on.push, { branches: ["main"] });
+});
+
+test("the CI job runs the no-secret production build after its contract tests", async () => {
+  const source = await readFile(".github/workflows/ci.yml", "utf8");
+  const workflow = parse(source) as {
+    jobs: {
+      ci: {
+        "continue-on-error"?: boolean;
+        env?: Record<string, string>;
+        environment?: unknown;
+        if?: string;
+        "timeout-minutes": number;
+        steps: Array<{
+          "continue-on-error"?: boolean;
+          env?: Record<string, string>;
+          if?: string;
+          run?: string;
+          uses?: string;
+        }>;
+      };
+    };
+  };
+  const runSteps = workflow.jobs.ci.steps.filter(
+    (step): step is { if?: string; run: string } => typeof step.run === "string",
+  );
+
+  assert.deepEqual(
+    runSteps.map((step) => step.run),
+    [
+      "pnpm install --frozen-lockfile",
+      "pnpm run typecheck",
+      "pnpm run test",
+      "pnpm run test:release-notes",
+      "pnpm run test:ci",
+      "pnpm run build:ci",
+      "pnpm run test:workflow-sdk",
+    ],
+  );
+  assert.equal(workflow.jobs.ci.if, undefined);
+  assert.equal(workflow.jobs.ci["continue-on-error"], undefined);
+  assert.equal(workflow.jobs.ci["timeout-minutes"], 60);
+  assert.equal(
+    workflow.jobs.ci.steps.every(
+      (step) => step.if === undefined && step["continue-on-error"] === undefined,
+    ),
+    true,
+  );
+  assert.equal(runSteps[5]?.env, undefined);
+  assert.equal(workflow.jobs.ci.environment, undefined);
+  assert.equal(workflow.jobs.ci.env, undefined);
+  assert.doesNotMatch(JSON.stringify(workflow.jobs.ci), /\$\{\{[^}]*\bsecrets\b/);
+});
+
+test("the source build covers worker and dashboard without deployment side effects", async () => {
+  const rootPackage = await readPackageJson("package.json");
+  const workerPackage = await readPackageJson("apps/worker/package.json");
+  const dashboardPackage = await readPackageJson("apps/dashboard/package.json");
+
+  assert.deepEqual(commands(rootPackage.scripts["build:ci"]), [
+    "pnpm --filter worker build:ci",
+    "NEXT_TELEMETRY_DISABLED=1 pnpm --filter ai-workflow-dashboard build",
+  ]);
+  assert.deepEqual(commands(workerPackage.scripts["build:ci"]), [
+    "pnpm build:shared",
+    "pnpm validate:pre-sandbox",
+    "pnpm validate:local-skills",
+    "pnpm mcp:contract:check",
+    "rm -rf .nitro/workflow",
+    "NODE_OPTIONS=--max-old-space-size=8192 nitro build",
+  ]);
+  assert.equal(dashboardPackage.scripts.build, "pnpm build:shared && next build");
+  assert.doesNotMatch(workerPackage.scripts["build:ci"], /db:migrate/);
+  assert.doesNotMatch(workerPackage.scripts["build:ci"], /seed:auth-user/);
+});
+
+test("the source build uses the validator entrypoints and preserves deployment setup order", async () => {
+  const workerPackage = await readPackageJson("apps/worker/package.json");
+
+  assert.equal(
+    workerPackage.scripts["validate:pre-sandbox"],
+    "tsx scripts/validate-pre-sandbox-config.ts",
+  );
+  assert.equal(
+    workerPackage.scripts["validate:local-skills"],
+    "tsx scripts/validate-local-skills.ts",
+  );
+  assert.equal(
+    workerPackage.scripts["mcp:contract:check"],
+    "tsx scripts/generate-mcp-contract.ts --check",
+  );
+  assert.deepEqual(commands(workerPackage.scripts.build), [
+    "pnpm build:shared",
+    "pnpm validate:pre-sandbox",
+    "pnpm validate:local-skills",
+    "pnpm db:migrate",
+    "pnpm seed:auth-user",
+    "rm -rf .nitro/workflow",
+    "NODE_OPTIONS=--max-old-space-size=8192 nitro build",
+  ]);
 });


### PR DESCRIPTION
## Cel

Dodaje do głównego CI credential-free build gate dla workera i dashboardu. Gate buduje kod źródłowy bez migracji bazy, seedowania użytkownika ani sekretów aplikacyjnych.

## Dokładny zakres

- base main: 172de9c6ce6fde1d7949d3034477e78b72972f47
- head: 23c231344058abb45bcbcd0dbfdcd7eb682a10c7
- 1 commit, 5 plików
- CI timeout: 60 minut
- build:ci uruchamiany po test:ci
- test kontraktowy blokuje migrację DB i seed auth w tej ścieżce
- SETUP.md dokumentuje zakres i granice gate

## Focused local evidence

Zgodnie z polityką repo nie uruchamiano pełnego suite lokalnie; pełny Node 24 suite należy do exact-SHA CI PR.

- typecheck: PASS
- test:ci: 5/5 PASS
- test:release-notes: 57/57 PASS
- test:workflow-sdk: 4/4 pliki, 27/27 PASS
- build:ci: PASS; walidatory, worker Nitro i dashboard 44 strony
- git diff --check: PASS
- wszystkie workflow YAML parsują się: PASS

## Jawne granice

- G2 / branch protection pozostaje odłożone decyzją właściciela i nie jest przedstawiane jako aktywne.
- Secret-bearing E2E nie zostało uruchomione: audyt wykrył globalne kasowanie active_runs i brak powiązania deploymentu z tested SHA. Blokery są zapisane w AIW-316, AIW-317, AIW-318 i AIW-320.
- Ten PR nie wdraża zmian runtime ani DB i nie powinien być mergowany przed terminalnie zielonym exact-SHA CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added a credential-free production build check to the continuous integration process.
  * CI now validates both the worker and dashboard builds before workflow tests run.
  * Increased the CI job timeout to support longer builds.
  * Added automated checks for workflow triggers, build ordering, validation steps, and secret-free execution.

* **Documentation**
  * Documented the new source-build verification process and how it differs from deployment builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->