### PR TITLE
test(worker): await sandbox import readiness (AIW-314)

### DIFF
--- a/apps/worker/src/sandbox/poll-agent.test.ts
+++ b/apps/worker/src/sandbox/poll-agent.test.ts
@@ -283,9 +283,7 @@ describe("collectPhaseOutput", () => {
       collectPhaseOutput("sbx-test-123", "/tmp/stdout", "/tmp/stderr"),
     );
 
-    for (let i = 0; i < 100 && mockRunCommand.mock.calls.length === 0; i += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
+    await vi.dynamicImportSettled();
     expectCurrentArtifactRead();
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -303,9 +301,7 @@ describe("collectPhaseOutput", () => {
       collectPhaseOutput("sbx-test-123", "/tmp/stdout", "/tmp/stderr"),
     );
 
-    for (let i = 0; i < 100 && stdout.mock.calls.length === 0; i += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
+    await vi.dynamicImportSettled();
     const deadlineSignal = expectCurrentArtifactRead(stdout);
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -355,9 +351,7 @@ describe("collectPhase", () => {
       collectPhase("sbx-test-123", phasePaths),
     );
 
-    for (let i = 0; i < 100 && mockSandboxGet.mock.calls.length === 0; i += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
+    await vi.dynamicImportSettled();
     expectCurrentSandboxGet();
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -373,9 +367,7 @@ describe("collectPhase", () => {
       collectPhase("sbx-test-123", phasePaths),
     );
 
-    for (let i = 0; i < 100 && mockRunCommand.mock.calls.length === 0; i += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
+    await vi.dynamicImportSettled();
     expectCurrentArtifactRead();
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -393,9 +385,7 @@ describe("collectPhase", () => {
       collectPhase("sbx-test-123", phasePaths),
     );
 
-    for (let i = 0; i < 100 && stdout.mock.calls.length === 0; i += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
+    await vi.dynamicImportSettled();
     const deadlineSignal = expectCurrentArtifactRead(stdout);
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -421,18 +411,14 @@ describe("collectPhase", () => {
       collectPhase("sbx-test-123", phasePaths),
     );
 
-    for (let i = 0; i < 100 && mockSandboxGet.mock.calls.length === 0; i += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
+    await vi.dynamicImportSettled();
     const deadlineSignal = expectCurrentSandboxGet();
 
     await vi.advanceTimersByTimeAsync(60_000);
     const error = await failure;
 
     pendingSandboxGet.resolve(delayedSandbox);
-    for (let i = 0; i < 100 && stdout.mock.calls.length === 0; i += 1) {
-      await vi.advanceTimersByTimeAsync(1);
-    }
+    await vi.dynamicImportSettled();
     expect(expectCurrentArtifactRead(stdout)).toBe(deadlineSignal);
     await drainFixturePromises();
     expect(await results()).toMatchObject([{


### PR DESCRIPTION
## Summary

- replace seven bounded fake-timer readiness loops with Vitest's dynamic-import settlement barrier
- keep exact Sandbox.get, runCommand, stdout, shared AbortSignal, and 60-second deadline assertions unchanged
- preserve the existing tracked-promise drain and fake-timer cleanup

Jira: https://blazity.atlassian.net/browse/AIW-314

## Why

Exact-SHA CI run 33842519310 failed before the deadline behavior was exercised: `collectPhase()` was still waiting for its dynamic `@vercel/sandbox` import, while the test stopped after an arbitrary 100 fake-timer ticks and asserted that `Sandbox.get` had already run. Under full-suite load it had not, producing the recurring zero-call flake.

The production deadline implementation is unchanged. `vi.dynamicImportSettled()` is the Vitest-provided barrier for waiting until dynamic imports and the following synchronous work have settled.

## Testing

Base: `main@172de9c6ce6fde1d7949d3034477e78b72972f47`

Candidate: `ac7fa33ee471118099cd0eee50ae948fbb298abc`

- original authoritative RED: GitHub Actions run 33842519310, worker 6696/6697
- exact named test before the patch: focused PASS, confirming the failure is load-dependent
- `poll-agent.test.ts`: 22/22
- eight parallel shuffled containing-file runs: 176/176
- `poll-agent.test.ts` + `stop-ticket-sandboxes.test.ts`: 34/34
- `stop-ticket-sandboxes.test.ts`: 12/12
- worker typecheck: PASS
- `git diff --check`: PASS
- two independent read-only reviews: ship, no blockers/minors

The attempt to download exact local Node 24.20.0 did not complete and was terminated; Node 24 proof is therefore delegated to exact-SHA GitHub CI. No broad/full suite was run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test synchronization for sandbox polling and late stdout-abort scenarios.
  * Replaced repeated timer polling with more reliable asynchronous settling.
  * No production behavior or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->