### PR TITLE
fix(test): isolate Workflow SDK Vitest storage and bundles per invocation (AIW-327)

### DIFF
--- a/apps/worker/src/test-support/workflow-vitest-isolation-global-setup.ts
+++ b/apps/worker/src/test-support/workflow-vitest-isolation-global-setup.ts
@@ -1,0 +1,9 @@
+import {
+  cleanupWorkflowVitestIsolation,
+  readWorkflowVitestIsolationFromEnvironment,
+} from "./workflow-vitest-isolation.js";
+
+export function setup(): () => Promise<void> {
+  const isolation = readWorkflowVitestIsolationFromEnvironment();
+  return () => cleanupWorkflowVitestIsolation(isolation);
+}

--- a/apps/worker/src/test-support/workflow-vitest-isolation.test.ts
+++ b/apps/worker/src/test-support/workflow-vitest-isolation.test.ts
@@ -1,0 +1,187 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  cleanupWorkflowVitestIsolation,
+  type WorkflowVitestIsolation,
+} from "./workflow-vitest-isolation.js";
+
+const execFileAsync = promisify(execFile);
+const workerRoot = join(import.meta.dirname, "../..");
+const artifactRoot = join(workerRoot, ".workflow-vitest");
+const helperUrl = pathToFileURL(
+  join(import.meta.dirname, "workflow-vitest-isolation.ts"),
+).href;
+
+const allocated: WorkflowVitestIsolation[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    allocated.splice(0).map((isolation) =>
+      cleanupWorkflowVitestIsolation(isolation).catch(() => undefined),
+    ),
+  );
+});
+
+describe("workflow Vitest isolation", () => {
+  it("keeps concurrent invocations with the same pool tag fully isolated", async () => {
+    const [first, second] = await Promise.all([
+      allocateInChild("run-control"),
+      allocateInChild("run-control"),
+    ]);
+    allocated.push(first.isolation, second.isolation);
+
+    expect(first.poolId).toBe("1");
+    expect(second.poolId).toBe("1");
+    expect(first.isolation.invocationRoot).not.toBe(
+      second.isolation.invocationRoot,
+    );
+    expect(first.isolation.dataDir).not.toBe(second.isolation.dataDir);
+    expect(first.isolation.outDir).not.toBe(second.isolation.outDir);
+
+    for (const { invocationRoot, dataDir, outDir } of [
+      first.isolation,
+      second.isolation,
+    ]) {
+      expect(dirname(invocationRoot)).toBe(artifactRoot);
+      expect(basename(invocationRoot)).toMatch(/^run-control-[A-Za-z0-9]{6}$/);
+      expect(dirname(dataDir)).toBe(invocationRoot);
+      expect(dirname(outDir)).toBe(invocationRoot);
+    }
+
+    const secondDataMarker = join(second.isolation.dataDir, "survives.txt");
+    const secondBundleMarker = join(second.isolation.outDir, "survives.txt");
+    await Promise.all([
+      writeFile(join(first.isolation.dataDir, "owned.txt"), "first"),
+      writeFile(secondDataMarker, "second"),
+      writeFile(secondBundleMarker, "second"),
+    ]);
+
+    await cleanupWorkflowVitestIsolation(first.isolation);
+    allocated.shift();
+
+    await expect(stat(first.isolation.invocationRoot)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(stat(secondDataMarker)).resolves.toMatchObject({
+      size: 6,
+    });
+    await expect(stat(secondBundleMarker)).resolves.toMatchObject({
+      size: 6,
+    });
+    expect((await stat(workerRoot)).isDirectory()).toBe(true);
+  });
+
+  it("refuses cleanup outside the exact owned suite leaf", async () => {
+    const { isolation } = await allocateInChild("divergence");
+    allocated.push(isolation);
+
+    const outsideRoot = await mkdtemp(join(artifactRoot, "outside-"));
+
+    try {
+      await expect(
+        cleanupWorkflowVitestIsolation({
+          ...isolation,
+          invocationRoot: outsideRoot,
+          dataDir: join(outsideRoot, "data"),
+          outDir: join(outsideRoot, "bundles"),
+        }),
+      ).rejects.toThrow(/refusing workflow Vitest cleanup/i);
+      expect((await stat(outsideRoot)).isDirectory()).toBe(true);
+      expect((await stat(workerRoot)).isDirectory()).toBe(true);
+    } finally {
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    "vitest.run-control-workflow.config.ts",
+    "vitest.workflow-divergence.config.ts",
+  ])("preserves the Workflow SDK setup when loading %s", async (config) => {
+    const result = await inspectConfigInChild(config);
+
+    expect(result.poolId).toBe("1");
+    expect(result.unchanged).toBe(true);
+    expect(result.globalSetup).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/@workflow\/vitest\/dist\/global-setup\.js$/),
+        join(
+          workerRoot,
+          "src/test-support/workflow-vitest-isolation-global-setup.ts",
+        ),
+      ]),
+    );
+    expect(result.cleaned).toBe(true);
+  });
+});
+
+async function allocateInChild(suite: string): Promise<{
+  isolation: WorkflowVitestIsolation;
+  poolId: string | undefined;
+}> {
+  const script = [
+    `import { createWorkflowVitestIsolation } from ${JSON.stringify(helperUrl)};`,
+    `const before = process.env.VITEST_POOL_ID;`,
+    `const isolation = createWorkflowVitestIsolation(${JSON.stringify(suite)});`,
+    `console.log(JSON.stringify({ isolation, poolId: process.env.VITEST_POOL_ID, unchanged: process.env.VITEST_POOL_ID === before }));`,
+  ].join("\n");
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script],
+    {
+      cwd: workerRoot,
+      env: { ...process.env, VITEST_POOL_ID: "1" },
+    },
+  );
+  const result = JSON.parse(stdout.trim()) as {
+    isolation: WorkflowVitestIsolation;
+    poolId: string | undefined;
+    unchanged: boolean;
+  };
+  expect(result.unchanged).toBe(true);
+  return result;
+}
+
+async function inspectConfigInChild(config: string): Promise<{
+  globalSetup: string[];
+  poolId: string | undefined;
+  unchanged: boolean;
+  cleaned: boolean;
+}> {
+  const script = [
+    `import { access } from "node:fs/promises";`,
+    `import { resolveConfig } from "vitest/node";`,
+    `import { pathToFileURL } from "node:url";`,
+    `import { cleanupWorkflowVitestIsolation, readWorkflowVitestIsolationFromEnvironment, workflowVitestIsolationGlobalSetup } from ${JSON.stringify(helperUrl)};`,
+    `const before = process.env.VITEST_POOL_ID;`,
+    `let isolation;`,
+    `try {`,
+    `  const { vitestConfig } = await resolveConfig({ root: ${JSON.stringify(workerRoot)}, config: ${JSON.stringify(config)} });`,
+    `  isolation = readWorkflowVitestIsolationFromEnvironment();`,
+    `  const { setup } = await import(pathToFileURL(workflowVitestIsolationGlobalSetup).href);`,
+    `  await setup()();`,
+    `  const cleaned = await access(isolation.invocationRoot).then(() => false, () => true);`,
+    `  console.log(JSON.stringify({ globalSetup: vitestConfig.globalSetup, poolId: process.env.VITEST_POOL_ID, unchanged: process.env.VITEST_POOL_ID === before, cleaned }));`,
+    `} catch (error) {`,
+    `  if (isolation) await cleanupWorkflowVitestIsolation(isolation).catch(() => undefined);`,
+    `  throw error;`,
+    `}`,
+  ].join("\n");
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script],
+    {
+      cwd: workerRoot,
+      env: { ...process.env, VITEST_POOL_ID: "1" },
+    },
+  );
+  return JSON.parse(stdout.trim()) as {
+    globalSetup: string[];
+    poolId: string | undefined;
+    unchanged: boolean;
+    cleaned: boolean;
+  };
+}

--- a/apps/worker/src/test-support/workflow-vitest-isolation.ts
+++ b/apps/worker/src/test-support/workflow-vitest-isolation.ts
@@ -1,0 +1,207 @@
+import { randomUUID } from "node:crypto";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { lstat, readFile, realpath, rm } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const isolationEnvironmentKey = "AI_WORKFLOW_VITEST_ISOLATION";
+const ownerFileName = ".workflow-vitest-owner.json";
+const workflowVitestWorkerRoot = resolve(
+  fileURLToPath(new URL("../../", import.meta.url)),
+);
+
+export const workflowVitestIsolationGlobalSetup = fileURLToPath(
+  new URL("./workflow-vitest-isolation-global-setup.ts", import.meta.url),
+);
+
+export interface WorkflowVitestIsolation {
+  workerRoot: string;
+  suite: string;
+  invocationRoot: string;
+  dataDir: string;
+  outDir: string;
+  ownerToken: string;
+}
+
+export function createWorkflowVitestIsolation(
+  suite: string,
+): WorkflowVitestIsolation {
+  assertSuiteName(suite);
+
+  const artifactRoot = join(workflowVitestWorkerRoot, ".workflow-vitest");
+  mkdirSync(artifactRoot, { recursive: true });
+
+  const artifactRootStat = lstatSync(artifactRoot);
+  if (!artifactRootStat.isDirectory() || artifactRootStat.isSymbolicLink()) {
+    throw new Error(
+      `Refusing workflow Vitest allocation in unsafe artifact root: ${artifactRoot}`,
+    );
+  }
+  if (realpathSync(artifactRoot) !== artifactRoot) {
+    throw new Error(
+      `Refusing workflow Vitest allocation outside the worker artifact root: ${artifactRoot}`,
+    );
+  }
+
+  const invocationRoot = mkdtempSync(join(artifactRoot, `${suite}-`));
+  const isolation: WorkflowVitestIsolation = {
+    workerRoot: workflowVitestWorkerRoot,
+    suite,
+    invocationRoot,
+    dataDir: join(invocationRoot, "data"),
+    outDir: join(invocationRoot, "bundles"),
+    ownerToken: randomUUID(),
+  };
+
+  mkdirSync(isolation.dataDir);
+  mkdirSync(isolation.outDir);
+  writeFileSync(
+    join(invocationRoot, ownerFileName),
+    JSON.stringify({ suite, ownerToken: isolation.ownerToken }),
+    { encoding: "utf8", flag: "wx", mode: 0o600 },
+  );
+  process.env[isolationEnvironmentKey] = JSON.stringify(isolation);
+
+  return isolation;
+}
+
+export function readWorkflowVitestIsolationFromEnvironment(): WorkflowVitestIsolation {
+  const serialized = process.env[isolationEnvironmentKey];
+  if (!serialized) {
+    throw new Error(
+      `Missing ${isolationEnvironmentKey}; the workflow Vitest config did not allocate an invocation root`,
+    );
+  }
+
+  try {
+    return JSON.parse(serialized) as WorkflowVitestIsolation;
+  } catch (error) {
+    throw new Error(`Invalid ${isolationEnvironmentKey}`, { cause: error });
+  }
+}
+
+export async function cleanupWorkflowVitestIsolation(
+  isolation: WorkflowVitestIsolation,
+): Promise<void> {
+  assertOwnedSuiteLeaf(isolation);
+
+  let invocationStat;
+  try {
+    invocationStat = await lstat(isolation.invocationRoot);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return;
+    throw error;
+  }
+
+  if (!invocationStat.isDirectory() || invocationStat.isSymbolicLink()) {
+    refuseCleanup("the invocation root is not a real directory");
+  }
+
+  const artifactRoot = join(workflowVitestWorkerRoot, ".workflow-vitest");
+  const artifactRootStat = await lstat(artifactRoot);
+  if (!artifactRootStat.isDirectory() || artifactRootStat.isSymbolicLink()) {
+    refuseCleanup("the artifact root is not a real directory");
+  }
+  if (
+    (await realpath(artifactRoot)) !== artifactRoot ||
+    (await realpath(isolation.invocationRoot)) !== isolation.invocationRoot
+  ) {
+    refuseCleanup("the invocation root resolves outside the worker artifact root");
+  }
+
+  const ownerPath = join(isolation.invocationRoot, ownerFileName);
+  const ownerStat = await lstat(ownerPath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      refuseCleanup("the ownership marker is missing");
+    }
+    throw error;
+  });
+  if (!ownerStat.isFile() || ownerStat.isSymbolicLink()) {
+    refuseCleanup("the ownership marker is not a real file");
+  }
+
+  let owner: unknown;
+  try {
+    owner = JSON.parse(await readFile(ownerPath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      "Refusing workflow Vitest cleanup: invalid ownership marker",
+      { cause: error },
+    );
+  }
+  if (
+    !isRecord(owner) ||
+    owner.suite !== isolation.suite ||
+    owner.ownerToken !== isolation.ownerToken
+  ) {
+    refuseCleanup("the ownership marker does not match this invocation");
+  }
+
+  await rm(isolation.invocationRoot, { recursive: true });
+}
+
+function assertOwnedSuiteLeaf(isolation: WorkflowVitestIsolation): void {
+  if (!isRecord(isolation)) refuseCleanup("invalid isolation metadata");
+  const { workerRoot, suite, invocationRoot, dataDir, outDir, ownerToken } =
+    isolation;
+  if (
+    typeof workerRoot !== "string" ||
+    typeof suite !== "string" ||
+    typeof invocationRoot !== "string" ||
+    typeof dataDir !== "string" ||
+    typeof outDir !== "string" ||
+    typeof ownerToken !== "string"
+  ) {
+    refuseCleanup("invalid isolation metadata");
+  }
+
+  assertSuiteName(suite, refuseCleanup);
+  if (workerRoot !== workflowVitestWorkerRoot) {
+    refuseCleanup("the worker root does not match this helper");
+  }
+
+  const artifactRoot = join(workerRoot, ".workflow-vitest");
+  const leafName = basename(invocationRoot);
+  const suffix = leafName.slice(`${suite}-`.length);
+  if (
+    invocationRoot !== resolve(invocationRoot) ||
+    dirname(invocationRoot) !== artifactRoot ||
+    !leafName.startsWith(`${suite}-`) ||
+    !/^[A-Za-z0-9]{6}$/.test(suffix)
+  ) {
+    refuseCleanup("the invocation root is outside the exact owned suite leaf");
+  }
+  if (
+    dataDir !== join(invocationRoot, "data") ||
+    outDir !== join(invocationRoot, "bundles")
+  ) {
+    refuseCleanup("data or bundle directories are outside the invocation root");
+  }
+}
+
+function assertSuiteName(
+  suite: string,
+  fail: (reason: string) => never = (reason) => {
+    throw new Error(`Invalid workflow Vitest suite name: ${reason}`);
+  },
+): void {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(suite)) fail(suite);
+}
+
+function refuseCleanup(reason: string): never {
+  throw new Error(`Refusing workflow Vitest cleanup: ${reason}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error;
+}

--- a/apps/worker/vitest.run-control-workflow.config.ts
+++ b/apps/worker/vitest.run-control-workflow.config.ts
@@ -1,13 +1,16 @@
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { workflow } from "@workflow/vitest";
 import { defineConfig } from "vitest/config";
+import {
+  createWorkflowVitestIsolation,
+  workflowVitestIsolationGlobalSetup,
+} from "./src/test-support/workflow-vitest-isolation.js";
 
 const workerRoot = fileURLToPath(new URL("./", import.meta.url));
 const workflowRoot = fileURLToPath(
   new URL("./workflow-test-fixtures/", import.meta.url),
 );
+const isolation = createWorkflowVitestIsolation("run-control");
 
 // @workflow/vitest's builder and client transform both derive stable function
 // ids from process.cwd(). Keep the dedicated test process rooted at the small
@@ -18,12 +21,15 @@ export default defineConfig({
   plugins: workflow({
     cwd: workflowRoot,
     rootDir: workerRoot,
-    dataDir: resolve(tmpdir(), "ai-workflow-run-control-vitest-data"),
-    outDir: join(workerRoot, ".workflow-vitest", "run-control"),
+    dataDir: isolation.dataDir,
+    outDir: isolation.outDir,
   }),
   root: workerRoot,
   test: {
     environment: "node",
+    // Merged with the Workflow SDK's own global setup; this entry only owns
+    // teardown of this invocation's isolated artifacts.
+    globalSetup: [workflowVitestIsolationGlobalSetup],
     include: ["workflow-sdk-tests/*.test.ts"],
     testTimeout: 30_000,
   },

--- a/apps/worker/vitest.workflow-divergence.config.ts
+++ b/apps/worker/vitest.workflow-divergence.config.ts
@@ -1,20 +1,23 @@
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { workflow } from "@workflow/vitest";
 import { defineConfig } from "vitest/config";
+import {
+  createWorkflowVitestIsolation,
+  workflowVitestIsolationGlobalSetup,
+} from "./src/test-support/workflow-vitest-isolation.js";
 
 const workerRoot = fileURLToPath(new URL("./", import.meta.url));
 const workflowRoot = fileURLToPath(
   new URL("./workflow-test-fixtures/", import.meta.url),
 );
+const isolation = createWorkflowVitestIsolation("divergence");
 
 // The manual-dispatch suite that pins the Workflow SDK's concurrent-wait replay
 // defect. Separate from vitest.run-control-workflow.config.ts so those rows stay
 // out of every pull request's budget: see
 // workflow-sdk-tests/divergence/wdk-wait-divergence.test.ts for what they are for
-// and when to run them. Its own dataDir and outDir so a dispatch run cannot
-// disturb the default suite's builder cache.
+// and when to run them. Its own invocation root so a dispatch run cannot
+// disturb the default suite's runtime data or builder cache.
 //
 // @workflow/vitest's builder and client transform both derive stable function
 // ids from process.cwd(). Keep the dedicated test process rooted at the small
@@ -25,12 +28,15 @@ export default defineConfig({
   plugins: workflow({
     cwd: workflowRoot,
     rootDir: workerRoot,
-    dataDir: resolve(tmpdir(), "ai-workflow-divergence-vitest-data"),
-    outDir: join(workerRoot, ".workflow-vitest", "divergence"),
+    dataDir: isolation.dataDir,
+    outDir: isolation.outDir,
   }),
   root: workerRoot,
   test: {
     environment: "node",
+    // Merged with the Workflow SDK's own global setup; this entry only owns
+    // teardown of this invocation's isolated artifacts.
+    globalSetup: [workflowVitestIsolationGlobalSetup],
     include: ["workflow-sdk-tests/divergence/*.test.ts"],
     // Each pinned row waits out four replay divergences and three recovery
     // replays, and the serial baselines walk a real multi-block poll loop.


### PR DESCRIPTION
Fifth of six stacked PRs. This one is not a dependency bump; it is AIW-327.

## Own scope (1 commit)

Workflow SDK Vitest invocations shared storage and bundle output, so two invocations running at once could read each other's artifacts. Each invocation now gets its own, which removes a class of cross-test contamination that looks like flakiness.

## Stack

Rides on the AIW-323 chain because it was authored on top of it and shares its lockfile state. It is reviewed and merged as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive isolation coverage for concurrent workflow test runs, cleanup ownership, environment stability, unique artifact directories, and SDK setup preservation.

- **Chores**
  - Workflow test runs now use unique per-invocation data and output directories.
  - Added automatic cleanup of temporary workflow artifacts after test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->