### PR TITLE
fix(worker): reuse one test database per file

### DIFF
--- a/apps/worker/src/db/test-db.ts
+++ b/apps/worker/src/db/test-db.ts
@@ -5,20 +5,125 @@ import { drizzle } from "drizzle-orm/pglite";
 import * as schema from "./schema.js";
 import type { Db } from "./client.js";
 
+const migrationDir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
+
+let migrationSql: string[] | null = null;
+
+function migrations(): string[] {
+  migrationSql ??= readdirSync(migrationDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()
+    .map((f) => readFileSync(`${migrationDir}${f}`, "utf8"));
+  return migrationSql;
+}
+
+const quote = (name: string) => `"${name.replace(/"/g, '""')}"`;
+
+/**
+ * The statement that returns a migrated database to the state the migrations
+ * left it in, derived from that state rather than from a hardcoded list so a
+ * future seeding migration is picked up on its own.
+ *
+ * Truncating alone would not do: 0013 seeds a `workflow_definitions` row and
+ * 0021 seeds the built-in `prompt_library` entries, and further migrations
+ * derive from them, so an empty database is not what callers have been handed.
+ * The seeded rows are copied into a private schema once and re-inserted
+ * parent-before-child, because `workflow_definition_triggers` carries a
+ * foreign key into `workflow_definitions`. Identity sequences are then moved
+ * past the restored rows so the next insert cannot collide with the seed.
+ */
+async function buildReset(client: PGlite): Promise<string> {
+  const tables = (
+    await client.query<{ tablename: string }>(
+      "select tablename from pg_tables where schemaname = 'public' order by tablename",
+    )
+  ).rows.map((r) => r.tablename);
+
+  const seeded: string[] = [];
+  for (const table of tables) {
+    const { rows } = await client.query<{ count: number }>(
+      `select count(*)::int as count from ${quote(table)}`,
+    );
+    if (rows[0] && rows[0].count > 0) seeded.push(table);
+  }
+
+  const edges = (
+    await client.query<{ child: string; parent: string }>(
+      `select c.conrelid::regclass::text as child, c.confrelid::regclass::text as parent
+       from pg_constraint c where c.contype = 'f'`,
+    )
+  ).rows
+    .map(({ child, parent }) => [strip(child), strip(parent)] as const)
+    .filter(([child, parent]) => child !== parent && seeded.includes(child) && seeded.includes(parent));
+
+  const restoreOrder: string[] = [];
+  const pending = new Set(seeded);
+  while (pending.size > 0) {
+    const ready = [...pending].filter((t) => !edges.some(([c, p]) => c === t && pending.has(p)));
+    // A cycle would leave nothing ready; emit the rest and let the foreign key
+    // speak for itself rather than looping forever.
+    const next = ready.length > 0 ? ready : [...pending];
+    for (const table of next) {
+      restoreOrder.push(table);
+      pending.delete(table);
+    }
+  }
+
+  await client.exec("create schema if not exists _seed;");
+  for (const table of restoreOrder) {
+    await client.exec(
+      `create table _seed.${quote(table)} as select * from public.${quote(table)};`,
+    );
+  }
+
+  const sequences = (
+    await client.query<{ table_name: string; column_name: string; sequence: string | null }>(
+      `select table_name, column_name,
+              pg_get_serial_sequence('public.' || quote_ident(table_name), column_name) as sequence
+       from information_schema.columns
+       where table_schema = 'public' and column_default like 'nextval%'`,
+    )
+  ).rows.filter((r) => r.sequence !== null && seeded.includes(r.table_name));
+
+  return [
+    `truncate table ${tables.map(quote).join(",")} restart identity cascade;`,
+    ...restoreOrder.map(
+      (t) => `insert into public.${quote(t)} select * from _seed.${quote(t)};`,
+    ),
+    ...sequences.map(
+      (r) =>
+        `select setval('${r.sequence}', coalesce((select max(${quote(r.column_name)}) from public.${quote(r.table_name)}), 1));`,
+    ),
+  ].join("");
+}
+
+function strip(regclass: string): string {
+  return regclass.replace(/^public\./, "").replace(/"/g, "");
+}
+
+let shared: { client: PGlite; db: Db; reset: string } | null = null;
+
 /**
  * In-memory Postgres for unit tests. Applies the committed drizzle/
  * migration SQL so tests run against the exact production schema —
  * uniqueness conflicts, array ops, and expiry filters behave for real
  * instead of being mocked.
+ *
+ * One instance per module registry, which under vitest's default isolation is
+ * one per test file, reset in place on every later call. Booting PGlite costs
+ * around 500 ms while resetting costs around 27 ms, and 83 test files call
+ * this from `beforeEach`, so the boot was the entire price: roughly 1568 of
+ * them per suite run, none of which produced a different schema than the one
+ * before it.
  */
 export async function createTestDb(): Promise<Db> {
-  const client = new PGlite();
-  const dir = fileURLToPath(new URL("../../drizzle/", import.meta.url));
-  const files = readdirSync(dir)
-    .filter((f) => f.endsWith(".sql"))
-    .sort();
-  for (const f of files) {
-    await client.exec(readFileSync(`${dir}${f}`, "utf8"));
+  if (!shared) {
+    const client = new PGlite();
+    for (const sql of migrations()) await client.exec(sql);
+    const reset = await buildReset(client);
+    shared = { client, db: drizzle({ client, schema }) as unknown as Db, reset };
+    return shared.db;
   }
-  return drizzle({ client, schema }) as unknown as Db;
+  await shared.client.exec(shared.reset);
+  return shared.db;
 }


### PR DESCRIPTION
## Problem

Every call to `createTestDb()` booted a fresh PGlite instance and replayed all 58
committed migrations through it. 112 test files use it, 83 of them from
`beforeEach`, which comes to roughly **1568 database creations per suite run**.

Measured on one machine:

| operation | cost |
| --- | --- |
| one `createTestDb()` | 530-840 ms |
| booting an empty PGlite | 470-720 ms |
| replaying all 58 migrations onto a live instance | 114 ms |
| `TRUNCATE` of all 62 tables | 24-27 ms |

The migrations were never the cost. The **boot** was, and it bought nothing: it
produced the same schema 1568 times. On CI the `test` step has grown from
24 min 06 s (run 33833644409) to 28 min 35 s (run 34321391216) out of a 34 min
28 s job, against a 60 minute ceiling.

It also explains the `Hook timed out in 10000ms` failures in
`beforeEach(createTestDb)` under load: that is an exceeded budget, not a flake.

## Change

One instance per module registry, which under vitest's default isolation is one
per test file, reset in place on every later call. **No test file changes.**

Resetting truncates and then restores the seed rather than leaving the database
empty: migration 0013 seeds a `workflow_definitions` row and 0021 seeds the
built-in `prompt_library` entries, so an empty database is not the state callers
have been handed. The seeded rows are copied into a private `_seed` schema once
and re-inserted parent-before-child, because `workflow_definition_triggers`
carries a foreign key into `workflow_definitions`. Identity sequences are then
moved past the restored rows. Table list, seeded set, foreign-key order and
sequences are all derived from the database at boot, not hardcoded, so a future
seeding migration is picked up on its own.

The 16 migration tests construct `new PGlite()` directly and are untouched.

## Evidence

| measurement | before | after |
| --- | --- | --- |
| `src/db/queries/runs-read.test.ts` (46 tests) | 25.15 s | **2.65 s** |
| test time within that file | 24.67 s | 2.20 s |
| 8 heaviest DB files, 469 tests | not reached (killed under load) | **10.7 s wall, 42.4 s CPU** |
| database reset | 550 ms | 27 ms |

- 469/469 green on the heaviest files; 280/280 green on the seed-sensitive set
  (`src/prompt-library`, `src/workflow-definition/store.test.ts`, `src/db`),
  including `migration seed > seeds one enabled default definition handling
  trigger_ticket_ai with no versions`.
- Order independence: `--sequence.shuffle` green on seeds 1337 and 99.
- `tsc --noEmit` clean; `pnpm run verify:changed -- --base origin/main` EXIT=0.
- **Negative control:** disabling the seed restore turns
  `src/workflow-definition/store.test.ts` red, 16 of 56 failing, EXIT=1. The
  restore is load-bearing.

The full-suite effect is deliberately left to this CI run rather than claimed:
the local attempt was killed under load and is not a number I am willing to
report.

## Follow-up

This is stage 1 of a staged plan. Remaining per-file cost is now process and
module startup, which is addressed by splitting the serial `ci` job into
parallel jobs and sharding the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015T2GBKWu19ecsWTeDx41BY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test database setup for faster, more consistent test runs.
  - Test data is now reset reliably between runs while preserving required seed data and relationships.
  - Database state and generated identifiers are restored predictably after each reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->