### PR TITLE
ci: split the serial source gate into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
+  # The source gate is four independent jobs so its verdict arrives in minutes
+  # instead of at the end of a serial half hour, plus one aggregate job named
+  # `ci` so branch protection still has a single check to require.
+  #
+  # Every job below builds from the checkout alone. None of them may carry
+  # secrets, an `if:`, or `continue-on-error`: a source gate that can be skipped
+  # or that can reach a live environment is not a gate.
+  # `scripts/ci/ci-workflow.test.ts` holds that line for all of them.
+  source-checks:
     runs-on: ubuntu-latest
-    # The full job has already approached 36 minutes without the production
-    # bundle below. Keep enough headroom for slow runners so the source gate
-    # reports a real verdict instead of being cancelled mid-step.
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -44,13 +49,84 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck
-      - run: pnpm run test
       - run: pnpm run test:release-notes
       - run: pnpm run test:ci
       - run: pnpm run build:ci
-      # Durable-workflow tests. They need their own Workflow SDK builder config,
-      # so vitest.config.ts cannot pick them up alongside the rest of the suite.
+
+  # 384 worker test files, each paying its own process and module startup, so
+  # sharding buys wall-clock that the suite itself cannot give back.
+  unit-worker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      # Every shard reports. Stopping the others on the first red hides how
+      # much is broken behind whichever shard happened to fail first.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter worker run build:shared
+      # `pnpm run <script> -- --shard=...` does not reach vitest through the
+      # script's own `&&` chain: it ran all 386 files. Invoke the binary.
+      - run: pnpm --filter worker exec vitest run --shard=${{ matrix.shard }}/4
+
+  # The dashboard runs on node --test, which vitest sharding cannot cover, so it
+  # earns its own job rather than sitting on another job's critical path.
+  unit-dashboard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter ai-workflow-dashboard run test
+
+  # Durable-workflow tests. They need their own Workflow SDK builder config,
+  # so vitest.config.ts cannot pick them up alongside the rest of the suite.
+  workflow-sdk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
       - run: pnpm run test:workflow-sdk
+
+  # The one check branch protection requires. `always()` is deliberate: without
+  # it a failed or cancelled source job would leave this job skipped, and GitHub
+  # reads a skipped required check as satisfied, which is the single outcome
+  # this job exists to prevent.
+  ci:
+    needs: [source-checks, unit-worker, unit-dashboard, workflow-sdk]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every source job to have succeeded
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "source job results: $results"
+          for result in $results; do
+            if [ "$result" != "success" ]; then
+              echo "::error::a source job reported '$result'"
+              exit 1
+            fi
+          done
 
   e2e-orchestration:
     needs: [ci]

--- a/scripts/ci/ci-workflow.test.ts
+++ b/scripts/ci/ci-workflow.test.ts
@@ -49,55 +49,117 @@ test("CI preserves every authoritative source trigger", async () => {
   assert.deepEqual(workflow.on.push, { branches: ["main"] });
 });
 
-test("the CI job runs the no-secret production build after its contract tests", async () => {
+/**
+ * The source gate used to be one serial job. It is now four parallel jobs plus
+ * an aggregate, which is only safe if the split provably drops nothing and if
+ * none of the pieces can be skipped or reach a live environment. These three
+ * tests hold exactly those lines, together, rather than pinning one job's steps.
+ */
+const SOURCE_JOBS = ["source-checks", "unit-worker", "unit-dashboard", "workflow-sdk"] as const;
+
+/** Every command the source gate must still run, wherever it now lives. */
+const SOURCE_COMMANDS = [
+  "pnpm --filter ai-workflow-dashboard run test",
+  "pnpm --filter worker exec vitest run --shard=${{ matrix.shard }}/4",
+  "pnpm --filter worker run build:shared",
+  "pnpm install --frozen-lockfile",
+  "pnpm run build:ci",
+  "pnpm run test:ci",
+  "pnpm run test:release-notes",
+  "pnpm run test:workflow-sdk",
+  "pnpm run typecheck",
+];
+
+interface CiJob {
+  "continue-on-error"?: boolean;
+  env?: Record<string, string>;
+  environment?: unknown;
+  if?: string;
+  needs?: string[];
+  "timeout-minutes"?: number;
+  steps?: Array<{
+    "continue-on-error"?: boolean;
+    env?: Record<string, string>;
+    if?: string;
+    name?: string;
+    run?: string;
+    uses?: string;
+  }>;
+}
+
+async function ciJobs(): Promise<Record<string, CiJob>> {
   const source = await readFile(".github/workflows/ci.yml", "utf8");
-  const workflow = parse(source) as {
-    jobs: {
-      ci: {
-        "continue-on-error"?: boolean;
-        env?: Record<string, string>;
-        environment?: unknown;
-        if?: string;
-        "timeout-minutes": number;
-        steps: Array<{
-          "continue-on-error"?: boolean;
-          env?: Record<string, string>;
-          if?: string;
-          run?: string;
-          uses?: string;
-        }>;
-      };
-    };
-  };
-  const runSteps = workflow.jobs.ci.steps.filter(
-    (step): step is { if?: string; run: string } => typeof step.run === "string",
-  );
+  return (parse(source) as { jobs: Record<string, CiJob> }).jobs;
+}
+
+test("the source gate splits into parallel jobs without dropping a check", async () => {
+  const jobs = await ciJobs();
+
+  for (const name of SOURCE_JOBS) {
+    assert.ok(jobs[name], `ci.yml must define the source job "${name}"`);
+    assert.equal(jobs[name]?.needs, undefined, `"${name}" must not wait on another job`);
+  }
+
+  const commands = new Set<string>();
+  for (const name of SOURCE_JOBS) {
+    for (const step of jobs[name]?.steps ?? []) {
+      if (typeof step.run === "string") commands.add(step.run.trim());
+    }
+  }
 
   assert.deepEqual(
-    runSteps.map((step) => step.run),
-    [
-      "pnpm install --frozen-lockfile",
-      "pnpm run typecheck",
-      "pnpm run test",
-      "pnpm run test:release-notes",
-      "pnpm run test:ci",
-      "pnpm run build:ci",
-      "pnpm run test:workflow-sdk",
-    ],
+    [...commands].sort(),
+    SOURCE_COMMANDS,
+    "the parallel source jobs must run exactly the commands the serial job ran",
   );
-  assert.equal(workflow.jobs.ci.if, undefined);
-  assert.equal(workflow.jobs.ci["continue-on-error"], undefined);
-  assert.equal(workflow.jobs.ci["timeout-minutes"], 60);
-  assert.equal(
-    workflow.jobs.ci.steps.every(
-      (step) => step.if === undefined && step["continue-on-error"] === undefined,
-    ),
-    true,
+});
+
+test("no source job can be skipped or reach a live environment", async () => {
+  const jobs = await ciJobs();
+
+  for (const name of SOURCE_JOBS) {
+    const job = jobs[name] as CiJob;
+    assert.equal(job.if, undefined, `"${name}" must not be conditional`);
+    assert.equal(job["continue-on-error"], undefined, `"${name}" must not continue on error`);
+    assert.equal(job.environment, undefined, `"${name}" must not select an environment`);
+    assert.equal(job.env, undefined, `"${name}" must not define job-level env`);
+    assert.doesNotMatch(
+      JSON.stringify(job),
+      /\$\{\{[^}]*\bsecrets\b/,
+      `"${name}" must not read secrets`,
+    );
+    for (const step of job.steps ?? []) {
+      assert.equal(step.if, undefined, `"${name}" must not carry a conditional step`);
+      assert.equal(
+        step["continue-on-error"],
+        undefined,
+        `"${name}" must not carry a step that continues on error`,
+      );
+      assert.equal(step.env, undefined, `"${name}" must not carry step-level env`);
+    }
+  }
+});
+
+test("the required check fails when any source job does not succeed", async () => {
+  const jobs = await ciJobs();
+  const aggregate = jobs.ci as CiJob;
+
+  assert.deepEqual(
+    [...(aggregate.needs ?? [])].sort(),
+    [...SOURCE_JOBS].sort(),
+    "the required check must depend on every source job",
   );
-  assert.equal(runSteps[5]?.env, undefined);
-  assert.equal(workflow.jobs.ci.environment, undefined);
-  assert.equal(workflow.jobs.ci.env, undefined);
-  assert.doesNotMatch(JSON.stringify(workflow.jobs.ci), /\$\{\{[^}]*\bsecrets\b/);
+  // Without always() a failed dependency leaves this job skipped, and GitHub
+  // counts a skipped required check as satisfied.
+  assert.equal(aggregate.if, "always()");
+  assert.equal(aggregate.environment, undefined);
+  assert.equal(aggregate.env, undefined);
+  assert.doesNotMatch(JSON.stringify(aggregate), /\$\{\{[^}]*\bsecrets\b/);
+
+  const script = (aggregate.steps ?? []).map((step) => step.run ?? "").join("\n");
+  assert.match(script, /needs\.\*\.result/, "the check must read every dependency result");
+  assert.match(script, /!=\s*"success"/, "the check must reject any non-success result");
+  assert.match(script, /exit 1/, "the check must fail the job on a non-success result");
 });
 
 test("the source build covers worker and dashboard without deployment side effects", async () => {
@@ -188,7 +250,7 @@ test("all setup-node workflow jobs use Node 24", async () => {
 
   assert.equal(
     setupNodeJobs,
-    7,
-    `expected 7 setup-node jobs across CI workflows, found ${setupNodeJobs}`,
+    10,
+    `expected 10 setup-node jobs across CI workflows, found ${setupNodeJobs}`,
   );
 });


### PR DESCRIPTION
Stacked on #369. Base is `fix/test-db-boot-cost`; it retargets to `main` once
that merges.

## Problem

The source gate was one job running six steps in series. On run 34321391216 it
took 34 min 28 s, and the breakdown says the parallelism was the missing lever:

| step | 4 Sep (33833644409) | 9 Sep (34321391216) |
| --- | --- | --- |
| `pnpm run typecheck` | 21 s | 29 s |
| `pnpm run test` | 24 min 06 s | 28 min 35 s |
| `pnpm run test:release-notes` | 2 s | 2 s |
| `pnpm run test:ci` | 1 s | 1 s |
| `pnpm run build:ci` | — | 1 min 11 s |
| `pnpm run test:workflow-sdk` | 2 min 56 s | 3 min 54 s |

Nothing in that list depends on anything else in it, yet each waited for the one
before. A verdict that arrives after half an hour is a gate people route around.

## Change

Four independent source jobs plus one aggregate named `ci`, so branch protection
still has a single check to require:

- `source-checks` — typecheck, release-note tests, CI contract tests, `build:ci`
- `unit-worker` — the worker vitest suite across a 4-way `--shard` matrix
- `unit-dashboard` — the dashboard suite, which runs on `node --test` and cannot
  be covered by vitest sharding
- `workflow-sdk` — the durable-workflow suite and its own builder config
- `ci` — `needs` all four, `if: always()`, fails on any non-success

`always()` is load-bearing. Without it a failed dependency leaves the aggregate
skipped, and GitHub counts a skipped required check as satisfied.

Sharding is invoked as `pnpm --filter worker exec vitest run --shard=N/4`, not
through `pnpm run test -- --shard=N/4`: the latter does not reach vitest through
the script's own `&&` chain and silently runs all 386 files. That was caught by
running it.

## The guard test was rewritten, not weakened

`scripts/ci/ci-workflow.test.ts` used to pin one job's ordered step list and
assert that job carried no secrets, no `if:`, and no `continue-on-error`. Three
tests now hold the same line across the whole split:

1. **`the source gate splits into parallel jobs without dropping a check`** —
   the union of run commands across the four source jobs must equal an expected
   set, so the split cannot silently lose a check.
2. **`no source job can be skipped or reach a live environment`** — the original
   invariant, applied to every source job and to each of their steps.
3. **`the required check fails when any source job does not succeed`** — the
   aggregate must depend on all four, carry `always()`, and exit non-zero on any
   non-success result.

Negative controls, each confirmed red before this was committed:

| deliberate break | test that fails |
| --- | --- |
| remove the `typecheck` step | splits into parallel jobs without dropping a check |
| add `if:` to a source job | no source job can be skipped or reach a live environment |
| remove `always()` from the aggregate | the required check fails when any source job does not succeed |

`pnpm run test:ci` is 23/23 green with the controls reverted. Triggers, outer
concurrency, and the E2E jobs are untouched; `needs: [ci]` now points at the
aggregate.

## Expected effect

With #369 in place the local worker suite runs in 114 s, so the critical path
becomes the longest single job rather than the sum. This PR's own CI run is the
measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015T2GBKWu19ecsWTeDx41BY
