### PR TITLE
test(worker): pin the GitLab capability gaps to a shrink-only ledger

### DIFF
--- a/apps/worker/src/adapters/vcs/capability-gap-ledger.test.ts
+++ b/apps/worker/src/adapters/vcs/capability-gap-ledger.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { GitHubAdapter } from "./github.js";
+import { GitLabAdapter } from "./gitlab.js";
+import * as vcs from "./types.js";
+import type { VCSAdapter } from "./types.js";
+
+/**
+ * GitHub and GitLab are not interchangeable, and every place they differ is
+ * supposed to be declared: either a capability interface with a runtime guard,
+ * or an optional member on `VCSAdapter`. Nothing enforced that. A capability
+ * added on the GitHub side alone simply worked, and GitLab fell behind in
+ * silence — with no CI job exercising GitLab at all, nothing would have said so.
+ *
+ * This is the ledger of the gaps that exist today, and it may only shrink.
+ * Closing one means deleting its entry. Opening one means editing this file on
+ * purpose and filing a parity ticket, which is exactly when that decision
+ * should become visible to a reviewer.
+ *
+ * The guards read `typeof adapter.method === "function"`, which is a fact about
+ * the prototype, so the prototypes are what this checks. No instance, no
+ * credentials, and no chance of a constructor reaching the network.
+ */
+
+type GuardName = Extract<keyof typeof vcs, `has${string}Capability`>;
+
+/**
+ * The other place a gap can hide: a member declared optional on the base
+ * adapter surface rather than split out into a capability interface.
+ */
+type OptionalMember = {
+  [K in keyof VCSAdapter]-?: Record<never, never> extends Pick<VCSAdapter, K> ? K : never;
+}[keyof VCSAdapter];
+
+type Support = "both" | "github-only";
+
+/**
+ * Exhaustive by construction. Export a new capability guard without listing it
+ * here and `pnpm typecheck` fails before any test runs.
+ */
+const CAPABILITY_LEDGER: Record<GuardName, Support> = {
+  hasGateStatusCapability: "both",
+  hasManualDispatchPrCapability: "both",
+  hasPRFilesCapability: "both",
+  hasPRReviewCapability: "both",
+  // GitLab has no equivalent of a Check Run's rich detail payload.
+  hasRichGateStatusCapability: "github-only",
+};
+
+/** Exhaustive in the same way, over the optional members of `VCSAdapter`. */
+const OPTIONAL_MEMBER_LEDGER: Record<OptionalMember, Support> = {
+  // Only GitHub exposes Check Run identities; `types.ts` says so at the
+  // declaration, and this is where that claim is held to account.
+  getLatestCheckRuns: "github-only",
+};
+
+const github = GitHubAdapter.prototype as unknown as VCSAdapter;
+const gitlab = GitLabAdapter.prototype as unknown as VCSAdapter;
+
+const CLOSE = "Closing a gap is good: delete its entry here. This list may only shrink.";
+const OPEN =
+  "Adding a GitHub-only capability widens the parity gap. Implement it for GitLab, or declare it here and file a parity ticket.";
+
+describe("GitLab capability gap ledger", () => {
+  const guards = Object.entries(CAPABILITY_LEDGER) as Array<[GuardName, Support]>;
+
+  it.each(guards)("%s is implemented where the ledger says it is", (name, support) => {
+    const guard = vcs[name] as unknown as (adapter: VCSAdapter) => boolean;
+
+    expect(guard(github), `GitHubAdapter must implement ${name}. ${CLOSE}`).toBe(true);
+    expect(
+      guard(gitlab),
+      support === "both"
+        ? `GITLAB_CAPABILITY_GAPS says GitLab implements ${name}, but it does not. ${OPEN}`
+        : `The ledger records ${name} as a GitLab gap, but GitLabAdapter now implements it. ${CLOSE}`,
+    ).toBe(support === "both");
+  });
+
+  const members = Object.entries(OPTIONAL_MEMBER_LEDGER) as Array<[OptionalMember, Support]>;
+
+  it.each(members)("optional member %s matches the ledger", (name, support) => {
+    const onGitHub = typeof github[name] === "function";
+    const onGitLab = typeof gitlab[name] === "function";
+
+    expect(onGitHub, `GitHubAdapter must implement ${name}. ${CLOSE}`).toBe(true);
+    expect(
+      onGitLab,
+      support === "both"
+        ? `The ledger says GitLab implements ${name}, but it does not. ${OPEN}`
+        : `The ledger records ${name} as a GitLab gap, but GitLabAdapter now implements it. ${CLOSE}`,
+    ).toBe(support === "both");
+  });
+
+  it("declares every capability guard the adapter surface exports", () => {
+    const exported = Object.keys(vcs)
+      .filter((key) => /^has[A-Z]\w*Capability$/.test(key))
+      .sort();
+
+    expect(
+      exported,
+      "a capability guard exists that the ledger does not classify; add it to CAPABILITY_LEDGER",
+    ).toEqual(Object.keys(CAPABILITY_LEDGER).sort());
+  });
+});


### PR DESCRIPTION
## Problem

`VCSAdapter` exposes five capability guards and one optional member. GitLab implements four of the five. Nothing records which gaps are deliberate, so a guard added to the interface can quietly reach production with GitLab unimplemented, and a gap that GitLab later closes leaves the ledger stale with nobody noticing.

## What this adds

One test file, no production code. It pins the current parity to a ledger that can only shrink:

- `CAPABILITY_LEDGER` is a `Record<GuardName, Support>` where `GuardName` is extracted from the adapter module's exports, so a new `has*Capability` guard fails `tsc` until somebody declares whether GitLab supports it.
- `OPTIONAL_MEMBER_LEDGER` does the same for optional members of `VCSAdapter`, extracted via `Record<never, never> extends Pick<VCSAdapter, K>`.
- Every declared `github-only` entry is asserted absent on GitLab. When GitLab implements it, the test goes red and tells the author to delete the entry. Closing a gap is the only legal edit; the list may not grow silently.

Declared gaps today, both real and both GitLab-side: `hasRichGateStatusCapability` and `getLatestCheckRuns`.

The assertions read the prototypes, not instances, so there are no credentials and no constructor makes a network call.

## Why not a method-name diff

A raw prototype diff is 17 GitHub-only and 19 GitLab-only members, almost all private helpers. It would be noise that nobody reads and everybody suppresses. The guards and the optional members of the interface are the surface callers actually branch on.

## Evidence

| check | outcome |
| --- | --- |
| `npx vitest run src/adapters/vcs/capability-gap-ledger.test.ts` | 7 passed |
| `pnpm run typecheck` | clean |
| `pnpm run verify:changed` | passed, selected this file |

Negative controls, each observed red then restored:

1. Renamed `updateGateStatusDetails` off `GitHubAdapter`: red, `GitHubAdapter must implement hasRichGateStatusCapability`.
2. Gave `GitLabAdapter` an `updateGateStatusDetails` stub, so the gap closes: red, `the ledger records hasRichGateStatusCapability as a GitLab gap, but GitLabAdapter now implements it`.
3. Deleted the `hasRichGateStatusCapability` entry from the ledger: `tsc` exit 2, `TS2741: Property 'hasRichGateStatusCapability' is missing`.

## Scope

This does not implement anything missing on GitLab and does not change adapter behavior. It records the gaps so they cannot widen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015T2GBKWu19ecsWTeDx41BY