### PR TITLE
feat(worker): let a deployment prove which commit it serves

### DIFF
--- a/apps/worker/env.ts
+++ b/apps/worker/env.ts
@@ -221,6 +221,11 @@ export const env = createEnv({
 
     // Vercel (optional — auto via OIDC on Vercel)
     VERCEL_ENV: z.string().min(1).optional(),
+    // The commit this deployment was built from, so /health can prove which
+    // candidate an endpoint actually serves. A Vercel system variable: absent
+    // when the project does not expose them, which /health reports as null
+    // rather than guessing.
+    VERCEL_GIT_COMMIT_SHA: z.string().min(1).optional(),
     VERCEL_TOKEN: z.string().min(1).optional(),
     VERCEL_TEAM_ID: z.string().min(1).optional(),
     VERCEL_PROJECT_ID: z.string().min(1).optional(),

--- a/apps/worker/src/db/database-fingerprint.ts
+++ b/apps/worker/src/db/database-fingerprint.ts
@@ -1,0 +1,31 @@
+import { createHash } from "node:crypto";
+
+/**
+ * A database branch as a value that can be compared but not read back.
+ *
+ * Two callers hold different things: the deployment holds the `env_marker` row
+ * written at build time, and a CI job holds a connection string. Neither can
+ * show the other its host (`/health` is public, and a connection string is a
+ * secret), so they compare fingerprints instead.
+ *
+ * Normalised exactly as `apps/worker/scripts/db-migrate.ts` normalises before
+ * claiming the marker: lower-cased, Neon's `-pooler` suffix stripped, so a
+ * pooled and a direct url for one branch fingerprint the same. Truncated
+ * because this is an equality token and not a secret store.
+ *
+ * Lives alone, importing only `node:crypto`, so the CI gate can use it without
+ * dragging the worker's environment validation into a script.
+ */
+export function databaseFingerprint(endpointHost: string): string {
+  const host = endpointHost.toLowerCase().replace(/-pooler(?=\.)/, "");
+  return createHash("sha256").update(host).digest("hex").slice(0, 12);
+}
+
+/** The same fingerprint, taken from a connection string rather than a host. */
+export function databaseFingerprintFromUrl(connectionString: string): string | null {
+  try {
+    return databaseFingerprint(new URL(connectionString).hostname);
+  } catch {
+    return null;
+  }
+}

--- a/apps/worker/src/deployment-identity.test.ts
+++ b/apps/worker/src/deployment-identity.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Db } from "./db/client.js";
+import { deploymentIdentity, resetDeploymentIdentityCache } from "./deployment-identity.js";
+import { logger } from "./lib/logger.js";
+
+const mockEnv: { VERCEL_GIT_COMMIT_SHA?: string; VERCEL_ENV?: string } = {};
+
+vi.mock("../env.js", () => ({
+  get env() {
+    return mockEnv;
+  },
+}));
+vi.mock("./lib/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** A db whose marker read resolves to `rows`, or rejects when given an error. */
+function markerDb(result: Array<{ env: string }> | Error): {
+  db: () => Db;
+  reads: () => number;
+} {
+  let reads = 0;
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => {
+            reads += 1;
+            return result instanceof Error ? Promise.reject(result) : Promise.resolve(result);
+          },
+        }),
+      }),
+    }),
+  };
+  return { db: () => db as unknown as Db, reads: () => reads };
+}
+
+describe("deploymentIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDeploymentIdentityCache();
+    delete mockEnv.VERCEL_GIT_COMMIT_SHA;
+    delete mockEnv.VERCEL_ENV;
+  });
+
+  it("reports the commit, the environment and the database's own claim", async () => {
+    mockEnv.VERCEL_GIT_COMMIT_SHA = "a".repeat(40);
+    mockEnv.VERCEL_ENV = "production";
+    const { db } = markerDb([{ env: "production" }]);
+
+    expect(await deploymentIdentity(db)).toEqual({
+      commit: "a".repeat(40),
+      env: "production",
+      databaseEnv: "production",
+    });
+  });
+
+  it("says null rather than guessing when the platform names no commit", async () => {
+    mockEnv.VERCEL_ENV = "preview";
+    const { db } = markerDb([{ env: "preview" }]);
+
+    // A verifier reads this as unproven and refuses; inventing a value here
+    // would turn "we cannot tell" into a passing gate.
+    expect(await deploymentIdentity(db)).toMatchObject({ commit: null, env: "preview" });
+  });
+
+  it("surfaces a database claimed by another environment instead of hiding it", async () => {
+    mockEnv.VERCEL_ENV = "preview";
+    const { db } = markerDb([{ env: "production" }]);
+
+    // Preview pointed at the production branch is the failure the env marker
+    // exists for. Health must report it, not normalise it away.
+    expect(await deploymentIdentity(db)).toMatchObject({
+      env: "preview",
+      databaseEnv: "production",
+    });
+  });
+
+  it("reads the marker once per process, because a build cannot change it", async () => {
+    const { db, reads } = markerDb([{ env: "production" }]);
+
+    await deploymentIdentity(db);
+    await deploymentIdentity(db);
+    await deploymentIdentity(db);
+
+    expect(reads()).toBe(1);
+  });
+
+  it("degrades to null on an unreadable database instead of failing health", async () => {
+    const { db } = markerDb(new Error("connection refused"));
+
+    const identity = await deploymentIdentity(db);
+
+    expect(identity.databaseEnv).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "connection refused" }),
+      "deployment_identity_database_env_unreadable",
+    );
+  });
+
+  it("retries after a failed read, so one blip does not pin the deployment to unknown", async () => {
+    const failing = markerDb(new Error("connection refused"));
+    expect((await deploymentIdentity(failing.db)).databaseEnv).toBeNull();
+
+    const healthy = markerDb([{ env: "production" }]);
+    expect((await deploymentIdentity(healthy.db)).databaseEnv).toBe("production");
+  });
+
+  it("reports null when the marker row is missing, not an empty string", async () => {
+    const { db } = markerDb([]);
+
+    expect((await deploymentIdentity(db)).databaseEnv).toBeNull();
+  });
+
+  it("still answers when the database handle cannot even be opened", async () => {
+    // /health answered before it knew anything about the database, and a
+    // deployment too broken to open a connection is exactly when somebody is
+    // asking health what is going on.
+    mockEnv.VERCEL_ENV = "production";
+    const openDb = () => {
+      throw new Error("DATABASE_URL is not a valid connection string");
+    };
+
+    expect(await deploymentIdentity(openDb)).toEqual({
+      commit: null,
+      env: "production",
+      databaseEnv: null,
+    });
+  });
+});

--- a/apps/worker/src/deployment-identity.test.ts
+++ b/apps/worker/src/deployment-identity.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Db } from "./db/client.js";
+import { databaseFingerprint } from "./db/database-fingerprint.js";
 import { deploymentIdentity, resetDeploymentIdentityCache } from "./deployment-identity.js";
 import { logger } from "./lib/logger.js";
 
@@ -14,8 +15,10 @@ vi.mock("./lib/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+const HOST = "ep-cool-name-123456.eu-central-1.aws.neon.tech";
+
 /** A db whose marker read resolves to `rows`, or rejects when given an error. */
-function markerDb(result: Array<{ env: string }> | Error): {
+function markerDb(result: Array<{ env: string; endpointHost: string }> | Error): {
   db: () => Db;
   reads: () => number;
 } {
@@ -46,18 +49,19 @@ describe("deploymentIdentity", () => {
   it("reports the commit, the environment and the database's own claim", async () => {
     mockEnv.VERCEL_GIT_COMMIT_SHA = "a".repeat(40);
     mockEnv.VERCEL_ENV = "production";
-    const { db } = markerDb([{ env: "production" }]);
+    const { db } = markerDb([{ env: "production", endpointHost: HOST }]);
 
     expect(await deploymentIdentity(db)).toEqual({
       commit: "a".repeat(40),
       env: "production",
       databaseEnv: "production",
+      databaseFingerprint: databaseFingerprint(HOST),
     });
   });
 
   it("says null rather than guessing when the platform names no commit", async () => {
     mockEnv.VERCEL_ENV = "preview";
-    const { db } = markerDb([{ env: "preview" }]);
+    const { db } = markerDb([{ env: "preview", endpointHost: HOST }]);
 
     // A verifier reads this as unproven and refuses; inventing a value here
     // would turn "we cannot tell" into a passing gate.
@@ -66,7 +70,7 @@ describe("deploymentIdentity", () => {
 
   it("surfaces a database claimed by another environment instead of hiding it", async () => {
     mockEnv.VERCEL_ENV = "preview";
-    const { db } = markerDb([{ env: "production" }]);
+    const { db } = markerDb([{ env: "production", endpointHost: HOST }]);
 
     // Preview pointed at the production branch is the failure the env marker
     // exists for. Health must report it, not normalise it away.
@@ -77,7 +81,7 @@ describe("deploymentIdentity", () => {
   });
 
   it("reads the marker once per process, because a build cannot change it", async () => {
-    const { db, reads } = markerDb([{ env: "production" }]);
+    const { db, reads } = markerDb([{ env: "production", endpointHost: HOST }]);
 
     await deploymentIdentity(db);
     await deploymentIdentity(db);
@@ -102,7 +106,7 @@ describe("deploymentIdentity", () => {
     const failing = markerDb(new Error("connection refused"));
     expect((await deploymentIdentity(failing.db)).databaseEnv).toBeNull();
 
-    const healthy = markerDb([{ env: "production" }]);
+    const healthy = markerDb([{ env: "production", endpointHost: HOST }]);
     expect((await deploymentIdentity(healthy.db)).databaseEnv).toBe("production");
   });
 
@@ -110,6 +114,28 @@ describe("deploymentIdentity", () => {
     const { db } = markerDb([]);
 
     expect((await deploymentIdentity(db)).databaseEnv).toBeNull();
+  });
+
+  it("fingerprints a pooled and a direct url for one branch identically", () => {
+    // db-migrate.ts strips the same suffix before claiming the marker, so a
+    // deployment on the pooled url and a caller on the direct one must agree.
+    expect(databaseFingerprint(`ep-x-123.eu.aws.neon.tech`)).toBe(
+      databaseFingerprint(`EP-X-123-pooler.eu.aws.neon.tech`),
+    );
+  });
+
+  it("gives different branches different fingerprints", () => {
+    expect(databaseFingerprint("ep-a-1.eu.aws.neon.tech")).not.toBe(
+      databaseFingerprint("ep-b-2.eu.aws.neon.tech"),
+    );
+  });
+
+  it("never puts the host itself in the payload", async () => {
+    // /health is public and unauthenticated. The fingerprint exists so callers
+    // can compare branches without the endpoint being readable off it.
+    const { db } = markerDb([{ env: "production", endpointHost: HOST }]);
+
+    expect(JSON.stringify(await deploymentIdentity(db))).not.toContain("neon.tech");
   });
 
   it("still answers when the database handle cannot even be opened", async () => {
@@ -125,6 +151,7 @@ describe("deploymentIdentity", () => {
       commit: null,
       env: "production",
       databaseEnv: null,
+      databaseFingerprint: null,
     });
   });
 });

--- a/apps/worker/src/deployment-identity.ts
+++ b/apps/worker/src/deployment-identity.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { env } from "../env.js";
 import type { Db } from "./db/client.js";
+import { databaseFingerprint } from "./db/database-fingerprint.js";
 import { envMarker } from "./db/schema.js";
 import { logger } from "./lib/logger.js";
 
@@ -25,26 +26,41 @@ export interface DeploymentIdentity {
    *  read: an unreachable database must degrade this field, never fail the
    *  health check, because the gate refusing on null is the strict half. */
   databaseEnv: string | null;
+  /** Which database branch, as a value that can be compared but not read back.
+   *
+   *  `apps/worker/e2e/scripts/check-db.ts` says outright that it proves the e2e
+   *  DATABASE_URL reaches a migrated database and not that it is the same
+   *  branch the deployment uses, because two migrated branches look identical
+   *  from there. This is what makes them distinguishable: a caller holding a
+   *  connection string derives the same fingerprint and compares. The host
+   *  itself stays out of a public endpoint. */
+  databaseFingerprint: string | null;
 }
 
 // The marker is written once per build and never changes while a deployment
 // lives, so one read per cold start is the whole cost.
-let cachedDatabaseEnv: string | null | undefined;
+type Marker = { env: string | null; fingerprint: string | null };
+
+const UNKNOWN_MARKER: Marker = { env: null, fingerprint: null };
+
+let cachedMarker: Marker | undefined;
 
 /** Test-only: forget the cached marker so a case can observe the read again. */
 export function resetDeploymentIdentityCache(): void {
-  cachedDatabaseEnv = undefined;
+  cachedMarker = undefined;
 }
 
-async function readDatabaseEnv(openDb: () => Db): Promise<string | null> {
-  if (cachedDatabaseEnv !== undefined) return cachedDatabaseEnv;
+async function readMarker(openDb: () => Db): Promise<Marker> {
+  if (cachedMarker !== undefined) return cachedMarker;
   try {
     const [row] = await openDb()
-      .select({ env: envMarker.env })
+      .select({ env: envMarker.env, endpointHost: envMarker.endpointHost })
       .from(envMarker)
       .where(eq(envMarker.id, 1))
       .limit(1);
-    cachedDatabaseEnv = row?.env ?? null;
+    cachedMarker = row
+      ? { env: row.env, fingerprint: databaseFingerprint(row.endpointHost) }
+      : UNKNOWN_MARKER;
   } catch (error) {
     // Deliberately not cached: a transient failure must not pin this
     // deployment to "unknown database" for the rest of its life.
@@ -52,9 +68,9 @@ async function readDatabaseEnv(openDb: () => Db): Promise<string | null> {
       { error: (error as Error).message },
       "deployment_identity_database_env_unreadable",
     );
-    return null;
+    return UNKNOWN_MARKER;
   }
-  return cachedDatabaseEnv;
+  return cachedMarker;
 }
 
 /**
@@ -65,9 +81,11 @@ async function readDatabaseEnv(openDb: () => Db): Promise<string | null> {
  * null is what makes that safe.
  */
 export async function deploymentIdentity(openDb: () => Db): Promise<DeploymentIdentity> {
+  const marker = await readMarker(openDb);
   return {
     commit: env.VERCEL_GIT_COMMIT_SHA ?? null,
     env: env.VERCEL_ENV ?? null,
-    databaseEnv: await readDatabaseEnv(openDb),
+    databaseEnv: marker.env,
+    databaseFingerprint: marker.fingerprint,
   };
 }

--- a/apps/worker/src/deployment-identity.ts
+++ b/apps/worker/src/deployment-identity.ts
@@ -1,0 +1,73 @@
+import { eq } from "drizzle-orm";
+import { env } from "../env.js";
+import type { Db } from "./db/client.js";
+import { envMarker } from "./db/schema.js";
+import { logger } from "./lib/logger.js";
+
+/**
+ * What a deployment has to be able to say about itself before anything running
+ * against it counts as evidence.
+ *
+ * `docs/delivery-gates.md` records G3 as BLOCKED for exactly two missing facts:
+ * nothing proves the endpoint serves the candidate commit, and nothing proves
+ * the deployment and the database belong together. This is those two facts and
+ * nothing else, so `/health` can answer them without a caller having to trust
+ * an alias, a deployment URL, or the order two pipelines happened to run in.
+ */
+export interface DeploymentIdentity {
+  /** The commit this deployment was built from; null when the platform did not
+   *  say, which a verifier must treat as unproven rather than as a match. */
+  commit: string | null;
+  /** The environment the running code believes it is. */
+  env: string | null;
+  /** The environment the database claims, read from the `env_marker` row that
+   *  `scripts/db-migrate.ts` writes at build time. Null when it could not be
+   *  read: an unreachable database must degrade this field, never fail the
+   *  health check, because the gate refusing on null is the strict half. */
+  databaseEnv: string | null;
+}
+
+// The marker is written once per build and never changes while a deployment
+// lives, so one read per cold start is the whole cost.
+let cachedDatabaseEnv: string | null | undefined;
+
+/** Test-only: forget the cached marker so a case can observe the read again. */
+export function resetDeploymentIdentityCache(): void {
+  cachedDatabaseEnv = undefined;
+}
+
+async function readDatabaseEnv(openDb: () => Db): Promise<string | null> {
+  if (cachedDatabaseEnv !== undefined) return cachedDatabaseEnv;
+  try {
+    const [row] = await openDb()
+      .select({ env: envMarker.env })
+      .from(envMarker)
+      .where(eq(envMarker.id, 1))
+      .limit(1);
+    cachedDatabaseEnv = row?.env ?? null;
+  } catch (error) {
+    // Deliberately not cached: a transient failure must not pin this
+    // deployment to "unknown database" for the rest of its life.
+    logger.warn(
+      { error: (error as Error).message },
+      "deployment_identity_database_env_unreadable",
+    );
+    return null;
+  }
+  return cachedDatabaseEnv;
+}
+
+/**
+ * Takes the handle lazily, and catches around opening it as well as around the
+ * query. /health answered before this route knew anything about the database
+ * and has to keep answering: a deployment too broken to open a connection is
+ * exactly when somebody is asking health what is going on. The gate refusing a
+ * null is what makes that safe.
+ */
+export async function deploymentIdentity(openDb: () => Db): Promise<DeploymentIdentity> {
+  return {
+    commit: env.VERCEL_GIT_COMMIT_SHA ?? null,
+    env: env.VERCEL_ENV ?? null,
+    databaseEnv: await readDatabaseEnv(openDb),
+  };
+}

--- a/apps/worker/src/routes/health.get.ts
+++ b/apps/worker/src/routes/health.get.ts
@@ -1,5 +1,11 @@
 import { defineEventHandler } from "h3";
+import { getDb } from "../db/client.js";
+import { deploymentIdentity } from "../deployment-identity.js";
 
-export default defineEventHandler(() => {
-  return { status: "ok", timestamp: new Date().toISOString() };
+export default defineEventHandler(async () => {
+  return {
+    status: "ok",
+    timestamp: new Date().toISOString(),
+    ...(await deploymentIdentity(getDb)),
+  };
 });

--- a/scripts/ci/verify-deployment-identity.test.ts
+++ b/scripts/ci/verify-deployment-identity.test.ts
@@ -77,3 +77,38 @@ test("parses flag pairs and ignores a flag with no value", () => {
     commit: SHA,
   });
 });
+
+test("refuses a deployment reading a different database branch than the caller", () => {
+  // The case check-db.ts says it cannot see: both databases are migrated, and
+  // they are not the same branch.
+  const problems = checkDeploymentIdentity(
+    { ...healthy, databaseFingerprint: "aaaaaaaaaaaa" },
+    { ...expected, databaseFingerprint: "bbbbbbbbbbbb" },
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /different database branch/);
+});
+
+test("refuses when the branch was to be checked and health reported none", () => {
+  const problems = checkDeploymentIdentity(healthy, {
+    ...expected,
+    databaseFingerprint: "aaaaaaaaaaaa",
+  });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /did not report a database fingerprint/);
+});
+
+test("makes no branch claim when the caller holds no connection string", () => {
+  // Silence about an unmade check, never a pass implied for it.
+  assert.deepEqual(checkDeploymentIdentity(healthy, expected), []);
+});
+
+test("accepts a matching branch", () => {
+  assert.deepEqual(
+    checkDeploymentIdentity(
+      { ...healthy, databaseFingerprint: "aaaaaaaaaaaa" },
+      { ...expected, databaseFingerprint: "aaaaaaaaaaaa" },
+    ),
+    [],
+  );
+});

--- a/scripts/ci/verify-deployment-identity.test.ts
+++ b/scripts/ci/verify-deployment-identity.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  checkDeploymentIdentity,
+  parseArgs,
+  type HealthPayload,
+} from "./verify-deployment-identity.ts";
+
+const SHA = "a".repeat(40);
+const OTHER = "b".repeat(40);
+
+const healthy: HealthPayload = {
+  status: "ok",
+  commit: SHA,
+  env: "production",
+  databaseEnv: "production",
+};
+
+const expected = { commit: SHA, env: "production" };
+
+test("agrees only when every fact matches", () => {
+  assert.deepEqual(checkDeploymentIdentity(healthy, expected), []);
+});
+
+test("refuses a deployment serving a different commit, and names both", () => {
+  const problems = checkDeploymentIdentity({ ...healthy, commit: OTHER }, expected);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, new RegExp(`serves commit ${OTHER}`));
+  assert.match(problems[0]!, new RegExp(`candidate is ${SHA}`));
+});
+
+test("refuses when the deployment names no commit at all", () => {
+  // The dangerous shape: a health check that answers 200 and proves nothing.
+  // Treating a missing field as a match would make the gate decorative.
+  const problems = checkDeploymentIdentity({ ...healthy, commit: undefined }, expected);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /did not report a commit/);
+});
+
+test("refuses a preview pointed at the production database", () => {
+  const problems = checkDeploymentIdentity(
+    { status: "ok", commit: SHA, env: "preview", databaseEnv: "production" },
+    { commit: SHA, env: "preview" },
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /claimed by 'production'/);
+});
+
+test("refuses when the database env could not be read", () => {
+  const problems = checkDeploymentIdentity({ ...healthy, databaseEnv: null }, expected);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /belong together/);
+});
+
+test("refuses an abbreviated candidate sha, which cannot identify a commit", () => {
+  const problems = checkDeploymentIdentity(healthy, { commit: "a1b2c3d", env: "production" });
+  assert.ok(problems.some((problem) => /not a 40-character sha/.test(problem)));
+});
+
+test("reports every mismatch at once, not the first one", () => {
+  const problems = checkDeploymentIdentity(
+    { status: "degraded", commit: OTHER, env: "preview", databaseEnv: undefined },
+    expected,
+  );
+  assert.equal(problems.length, 4);
+});
+
+test("refuses a health body that is not ok", () => {
+  const problems = checkDeploymentIdentity({ ...healthy, status: "degraded" }, expected);
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /status 'degraded'/);
+});
+
+test("parses flag pairs and ignores a flag with no value", () => {
+  assert.deepEqual(parseArgs(["--url", "https://x", "--commit", SHA, "--env"]), {
+    url: "https://x",
+    commit: SHA,
+  });
+});

--- a/scripts/ci/verify-deployment-identity.ts
+++ b/scripts/ci/verify-deployment-identity.ts
@@ -1,0 +1,142 @@
+/**
+ * Refuses to agree that a URL serves a candidate.
+ *
+ * `docs/delivery-gates.md` records G3 as BLOCKED because nothing proves that an
+ * endpoint serves the exact candidate commit, or that the deployment and the
+ * database behind it belong together. A deployment URL, an alias, and the order
+ * two pipelines happened to finish in prove none of that: an alias is re-pointed
+ * by whoever deploys last, and a preview sharing a production database looks
+ * identical from outside.
+ *
+ * So this asks the deployment itself, over its own /health, and treats every
+ * unproven answer as a refusal. Silence is never a pass.
+ *
+ * Usage:
+ *   node --import tsx scripts/ci/verify-deployment-identity.ts \
+ *     --url https://example.vercel.app --commit <40-hex> --env production
+ */
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+export interface HealthPayload {
+  status?: unknown;
+  commit?: unknown;
+  env?: unknown;
+  databaseEnv?: unknown;
+}
+
+export interface IdentityExpectation {
+  commit: string;
+  env: string;
+}
+
+/**
+ * Every reason this deployment is not the candidate, in one pass. All of them,
+ * not the first: a report naming one mismatch invites a fix-and-retry loop that
+ * discovers the next one a deploy later.
+ */
+export function checkDeploymentIdentity(
+  payload: HealthPayload,
+  expected: IdentityExpectation,
+): string[] {
+  const problems: string[] = [];
+
+  if (!SHA_PATTERN.test(expected.commit)) {
+    problems.push(
+      `the expected commit '${expected.commit}' is not a 40-character sha; an` +
+        " abbreviated sha, a branch or a tag cannot identify a candidate",
+    );
+  }
+
+  if (payload.status !== "ok") {
+    problems.push(`/health reported status '${String(payload.status)}', not 'ok'`);
+  }
+
+  if (typeof payload.commit !== "string") {
+    problems.push(
+      "/health did not report a commit, so nothing proves which code answers" +
+        " here (on Vercel this is the project's system environment variables" +
+        " not being exposed to the runtime)",
+    );
+  } else if (payload.commit !== expected.commit) {
+    problems.push(
+      `/health serves commit ${payload.commit}, and the candidate is ${expected.commit}`,
+    );
+  }
+
+  if (typeof payload.env !== "string") {
+    problems.push("/health did not report an environment");
+  } else if (payload.env !== expected.env) {
+    problems.push(
+      `/health reports environment '${payload.env}', and '${expected.env}' was expected`,
+    );
+  }
+
+  if (typeof payload.databaseEnv !== "string") {
+    problems.push(
+      "/health could not read the database env marker, so nothing proves the" +
+        " deployment and its database belong together",
+    );
+  } else if (payload.databaseEnv !== expected.env) {
+    problems.push(
+      `the database behind this deployment is claimed by '${payload.databaseEnv}',` +
+        ` and this deployment is '${expected.env}'`,
+    );
+  }
+
+  return problems;
+}
+
+export function parseArgs(argv: string[]): Record<string, string> {
+  const args: Record<string, string> = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === undefined || !token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) continue;
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const url = args.url;
+  const commit = args.commit;
+  const environment = args.env;
+  if (!url || !commit || !environment) {
+    console.error(
+      "usage: verify-deployment-identity --url <base-url> --commit <40-hex> --env <environment>",
+    );
+    process.exit(2);
+  }
+
+  const health = new URL("/health", url).toString();
+  let payload: HealthPayload;
+  try {
+    const response = await fetch(health, { headers: { accept: "application/json" } });
+    if (!response.ok) {
+      console.error(`FAIL ${health} answered ${response.status} ${response.statusText}`);
+      process.exit(1);
+    }
+    payload = (await response.json()) as HealthPayload;
+  } catch (error) {
+    console.error(`FAIL could not read ${health}: ${(error as Error).message}`);
+    process.exit(1);
+  }
+
+  const problems = checkDeploymentIdentity(payload, { commit, env: environment });
+  if (problems.length > 0) {
+    console.error(`FAIL ${health} does not serve ${commit}:`);
+    for (const problem of problems) console.error(`  - ${problem}`);
+    process.exit(1);
+  }
+  console.log(`OK ${health} serves ${commit} in ${environment}`);
+}
+
+// Only when run as a program: importing this from a test must not make a request.
+if (process.argv[1]?.endsWith("verify-deployment-identity.ts")) {
+  await main();
+}

--- a/scripts/ci/verify-deployment-identity.ts
+++ b/scripts/ci/verify-deployment-identity.ts
@@ -13,8 +13,15 @@
  *
  * Usage:
  *   node --import tsx scripts/ci/verify-deployment-identity.ts \
- *     --url https://example.vercel.app --commit <40-hex> --env production
+ *     --url https://example.vercel.app --commit <40-hex> --env production \
+ *     [--database-url "$DATABASE_URL"]
+ *
+ * With --database-url it also proves the caller's database is the deployment's
+ * database, which `apps/worker/e2e/scripts/check-db.ts` says outright it cannot
+ * do: two migrated branches are indistinguishable from a connection string
+ * alone. Neither side shows the other its host; both fingerprint it.
  */
+import { databaseFingerprintFromUrl } from "../../apps/worker/src/db/database-fingerprint.ts";
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 
@@ -23,11 +30,16 @@ export interface HealthPayload {
   commit?: unknown;
   env?: unknown;
   databaseEnv?: unknown;
+  databaseFingerprint?: unknown;
 }
 
 export interface IdentityExpectation {
   commit: string;
   env: string;
+  /** Omitted when the caller holds no connection string; the branch check is
+   *  then simply not made, and the report says so rather than implying it
+   *  passed. */
+  databaseFingerprint?: string;
 }
 
 /**
@@ -84,6 +96,20 @@ export function checkDeploymentIdentity(
     );
   }
 
+  if (expected.databaseFingerprint !== undefined) {
+    if (typeof payload.databaseFingerprint !== "string") {
+      problems.push(
+        "/health did not report a database fingerprint, so nothing proves this" +
+          " deployment reads the same branch the caller does",
+      );
+    } else if (payload.databaseFingerprint !== expected.databaseFingerprint) {
+      problems.push(
+        "this deployment reads a different database branch than the caller" +
+          ` (deployment ${payload.databaseFingerprint}, caller ${expected.databaseFingerprint})`,
+      );
+    }
+  }
+
   return problems;
 }
 
@@ -127,13 +153,30 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const problems = checkDeploymentIdentity(payload, { commit, env: environment });
+  let fingerprint: string | undefined;
+  if (args["database-url"]) {
+    const derived = databaseFingerprintFromUrl(args["database-url"]);
+    if (derived === null) {
+      console.error("FAIL --database-url is not a parseable connection string");
+      process.exit(1);
+    }
+    fingerprint = derived;
+  }
+
+  const problems = checkDeploymentIdentity(payload, {
+    commit,
+    env: environment,
+    ...(fingerprint ? { databaseFingerprint: fingerprint } : {}),
+  });
   if (problems.length > 0) {
     console.error(`FAIL ${health} does not serve ${commit}:`);
     for (const problem of problems) console.error(`  - ${problem}`);
     process.exit(1);
   }
-  console.log(`OK ${health} serves ${commit} in ${environment}`);
+  console.log(
+    `OK ${health} serves ${commit} in ${environment}` +
+      (fingerprint ? ` on database branch ${fingerprint}` : ", database branch not checked"),
+  );
 }
 
 // Only when run as a program: importing this from a test must not make a request.


### PR DESCRIPTION
## Problem

`docs/delivery-gates.md` records G3 as `BLOCKED` for two named reasons: nothing proves that an endpoint serves the exact candidate commit, and nothing proves that the deployment and its database belong together. Both were true. `/health` returned five lines, `{ status, timestamp }`, and no build commit existed anywhere in the worker.

That leaves a deployment URL, an alias, and the order two pipelines happened to finish in as the only evidence, and none of them prove anything: an alias is re-pointed by whoever deploys last, and a preview sharing the production database branch looks identical from outside.

## What this adds

`/health` now answers the two questions:

```json
{ "status": "ok", "timestamp": "...", "commit": "<40-hex>", "env": "production", "databaseEnv": "production" }
```

- `commit` is `VERCEL_GIT_COMMIT_SHA`, newly declared in `apps/worker/env.ts`. Absent becomes `null`, never a guess.
- `databaseEnv` is the `env_marker` row that `apps/worker/scripts/db-migrate.ts` already writes at build time. Reading it back at runtime is what proves the deployment and the database are the same environment.

`scripts/ci/verify-deployment-identity.ts` is the gate. It reads `/health` and refuses unless every fact matches, reporting all mismatches at once rather than the first:

```sh
node --import tsx scripts/ci/verify-deployment-identity.ts \
  --url https://example.vercel.app --commit <40-hex> --env production
```

It refuses an abbreviated candidate sha, a missing `commit`, an unreadable `databaseEnv`, and a database claimed by another environment.

## Two decisions worth stating

**`/health` must not get more fragile than it was.** It answered before it knew anything about the database, and a deployment too broken to open a connection is exactly when somebody asks health what is going on. So the identity read is caught around opening the handle as well as around the query, and degrades to `null`. The gate refusing on `null` is the strict half; the health check staying up is the useful half.

**The marker is read once per cold start**, because a build cannot change it while a deployment lives. A failed read is deliberately not cached, so one blip does not pin a deployment to "unknown database" for the rest of its life.

## Evidence

| check | outcome |
| --- | --- |
| `pnpm run test:ci` | 32 passed (23 before, 9 new) |
| `npx vitest run src/deployment-identity.test.ts` | 8 passed |
| `pnpm run typecheck` | clean |
| `pnpm run verify:changed` | passed, 41 tests |

Five mutations, each observed red and then restored:

| mutation | test that went red |
| --- | --- |
| a missing `commit` stops being a problem | refuses when the deployment names no commit at all |
| a database from another environment stops being a problem | refuses a preview pointed at the production database |
| the sha pattern accepts an abbreviated sha | refuses an abbreviated candidate sha |
| a failed marker read gets cached | retries after a failed read |
| `openDb()` moves outside the try | still answers when the database handle cannot even be opened |

## Scope

This changes no deployment, no environment variable, and no workflow file. It makes the proof available; wiring the gate into the e2e workflow belongs with the stage that already touches `e2e.yml`. G3 stays `BLOCKED` until that wiring exists and a real deployment has been checked, and this PR does not claim otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015T2GBKWu19ecsWTeDx41BY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The health endpoint now reports deployment commit, runtime environment, and database environment details when available.
  * Added deployment verification tooling to confirm that a deployment matches the expected commit and environment.
  * Health checks remain available with unknown identity values when deployment metadata or database access is unavailable.

* **Tests**
  * Added coverage for deployment identity reporting, caching, error handling, and verification failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->