### PR TITLE
ci: run e2e nightly from one workflow and gate it on deployment identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,9 @@ on:
   push:
     branches: [main]
   merge_group:
-  # The e2e suites below are gated on the merge queue, and no merge queue is
-  # configured, so they had never run: 11 of 11 recorded runs skipped all three.
-  # A manual dispatch is the only way to exercise them without changing how
-  # merges work, and their secrets live in the `e2e` environment, which is
-  # reachable from Actions and nowhere else.
+  # Kept so the source gate can be re-run by hand on a branch, which is the
+  # only thing this workflow does now: the e2e suites it used to carry live in
+  # `e2e.yml`, and the note above the jobs says why.
   workflow_dispatch:
 
 concurrency:
@@ -128,185 +126,14 @@ jobs:
             fi
           done
 
-  e2e-orchestration:
-    needs: [ci]
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    concurrency:
-      group: aiw-e2e-${{ github.repository_id }}
-      cancel-in-progress: false
-      queue: max
-    timeout-minutes: 60
-    environment: e2e
-    env:
-      E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
-      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-      JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
-      JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
-      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
-      COLUMN_AI: ${{ secrets.COLUMN_AI }}
-      COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
-      COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}
-      E2E_GITHUB_APP_ID: ${{ secrets.E2E_GITHUB_APP_ID }}
-      E2E_GITHUB_APP_PRIVATE_KEY: ${{ secrets.E2E_GITHUB_APP_PRIVATE_KEY }}
-      E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GITHUB_INSTALLATION_ID }}
-      E2E_GITHUB_OWNER: ${{ secrets.E2E_GITHUB_OWNER }}
-      E2E_GITHUB_REPO: ${{ secrets.E2E_GITHUB_REPO }}
-      CRON_SECRET: ${{ secrets.CRON_SECRET }}
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      MAX_CONCURRENT_AGENTS: ${{ secrets.MAX_CONCURRENT_AGENTS }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - name: Verify required e2e secrets present
-        run: |
-          : "${DATABASE_URL:?DATABASE_URL missing in e2e environment — must be the Neon branch the deployment under test (ai-workflow-demo) uses}"
-          : "${VERCEL_TOKEN:?VERCEL_TOKEN missing in e2e environment}"
-          : "${VERCEL_TEAM_ID:?VERCEL_TEAM_ID missing in e2e environment}"
-          : "${VERCEL_PROJECT_ID:?VERCEL_PROJECT_ID missing in e2e environment}"
-      - name: Preflight — verify e2e DATABASE_URL is the migrated branch
-        working-directory: apps/worker
-        run: pnpm exec tsx e2e/scripts/check-db.ts
-      - run: pnpm run test:e2e:orchestration
-      - if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-orchestration-results
-          path: |
-            apps/worker/e2e/**/*.log
-          retention-days: 7
-
-  e2e-capacity:
-    needs: [e2e-orchestration]
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    concurrency:
-      group: aiw-e2e-${{ github.repository_id }}
-      cancel-in-progress: false
-      queue: max
-    timeout-minutes: 60
-    environment: e2e
-    env:
-      E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
-      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-      JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
-      JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
-      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
-      COLUMN_AI: ${{ secrets.COLUMN_AI }}
-      COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
-      COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}
-      E2E_GITHUB_APP_ID: ${{ secrets.E2E_GITHUB_APP_ID }}
-      E2E_GITHUB_APP_PRIVATE_KEY: ${{ secrets.E2E_GITHUB_APP_PRIVATE_KEY }}
-      E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GITHUB_INSTALLATION_ID }}
-      E2E_GITHUB_OWNER: ${{ secrets.E2E_GITHUB_OWNER }}
-      E2E_GITHUB_REPO: ${{ secrets.E2E_GITHUB_REPO }}
-      CRON_SECRET: ${{ secrets.CRON_SECRET }}
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      MAX_CONCURRENT_AGENTS: ${{ secrets.MAX_CONCURRENT_AGENTS }}
-      E2E_CAPACITY_CAMPAIGN_ID: ${{ github.repository_id }}:${{ github.run_id }}:${{ github.run_attempt }}:e2e-capacity
-      E2E_CAPACITY_RELEASE_MARKER: ${{ github.workspace }}/.aiw-capacity-release-${{ github.run_id }}-${{ github.run_attempt }}.json
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - name: Verify required e2e secrets present
-        run: |
-          : "${DATABASE_URL:?DATABASE_URL missing in e2e environment — must be the Neon branch the deployment under test (ai-workflow-demo) uses}"
-          : "${VERCEL_TOKEN:?VERCEL_TOKEN missing in e2e environment}"
-          : "${VERCEL_TEAM_ID:?VERCEL_TEAM_ID missing in e2e environment}"
-          : "${VERCEL_PROJECT_ID:?VERCEL_PROJECT_ID missing in e2e environment}"
-      - name: Preflight — verify e2e DATABASE_URL is the migrated branch
-        working-directory: apps/worker
-        run: pnpm exec tsx e2e/scripts/check-db.ts
-      - name: Run capacity E2E
-        timeout-minutes: 30
-        run: pnpm run test:e2e:capacity
-      - name: Finalize capacity reservations
-        if: always()
-        timeout-minutes: 10
-        working-directory: apps/worker
-        run: pnpm exec tsx e2e/scripts/finalize-capacity.ts
-      - if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-capacity-results
-          path: |
-            apps/worker/e2e/**/*.log
-          retention-days: 7
-
-  e2e-agent:
-    needs: [e2e-capacity]
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    concurrency:
-      group: aiw-e2e-${{ github.repository_id }}
-      cancel-in-progress: false
-      queue: max
-    timeout-minutes: 120
-    environment: e2e
-    env:
-      E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
-      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
-      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-      JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
-      JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
-      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
-      COLUMN_AI: ${{ secrets.COLUMN_AI }}
-      COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
-      COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}
-      E2E_GITHUB_APP_ID: ${{ secrets.E2E_GITHUB_APP_ID }}
-      E2E_GITHUB_APP_PRIVATE_KEY: ${{ secrets.E2E_GITHUB_APP_PRIVATE_KEY }}
-      E2E_GITHUB_INSTALLATION_ID: ${{ secrets.E2E_GITHUB_INSTALLATION_ID }}
-      E2E_GITHUB_OWNER: ${{ secrets.E2E_GITHUB_OWNER }}
-      E2E_GITHUB_REPO: ${{ secrets.E2E_GITHUB_REPO }}
-      CRON_SECRET: ${{ secrets.CRON_SECRET }}
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      MAX_CONCURRENT_AGENTS: ${{ secrets.MAX_CONCURRENT_AGENTS }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - name: Verify required e2e secrets present
-        run: |
-          : "${DATABASE_URL:?DATABASE_URL missing in e2e environment — must be the Neon branch the deployment under test (ai-workflow-demo) uses}"
-          : "${VERCEL_TOKEN:?VERCEL_TOKEN missing in e2e environment}"
-          : "${VERCEL_TEAM_ID:?VERCEL_TEAM_ID missing in e2e environment}"
-          : "${VERCEL_PROJECT_ID:?VERCEL_PROJECT_ID missing in e2e environment}"
-      - name: Preflight — verify e2e DATABASE_URL is the migrated branch
-        working-directory: apps/worker
-        run: pnpm exec tsx e2e/scripts/check-db.ts
-      - run: pnpm run test:e2e:agent
-      - if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-agent-results
-          path: |
-            apps/worker/e2e/**/*.log
-          retention-days: 7
+# The three e2e suites used to be duplicated here behind
+# `if: merge_group || workflow_dispatch`. They never ran: `main` carries no
+# protection and no rulesets, so there is no merge queue and `merge_group`
+# cannot fire, and the dispatch path duplicated `e2e.yml`'s own dispatch
+# without its tier selector. The two copies had already drifted apart (this
+# one carried a JIRA_E2E_COMMENTER_TOKEN the other lacked), which is the
+# usual end of a duplicated job. They live in `.github/workflows/e2e.yml`
+# alone now, where they also run nightly.
+#
+# The `on:` triggers above are deliberately unchanged: `merge_group` still
+# runs the source gate, which is what a merge queue would want from it.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,12 @@
-name: E2E Tests (Manual)
+name: E2E Tests
 
 on:
+  # Nightly, off the hour: GitHub fires scheduled jobs at :00 and queues them,
+  # so an odd minute starts sooner. A schedule run gets no inputs at all, which
+  # is why every job below reads `github.event_name == 'schedule'` explicitly
+  # rather than leaning on an input default that is not there.
+  schedule:
+    - cron: "17 3 * * *"
   workflow_dispatch:
     inputs:
       tier:
@@ -19,10 +25,14 @@ on:
           - claude
           - codex
         default: claude
+      commit:
+        description: "Refuse to run unless the deployment serves this 40-character commit (blank: only the database branch is checked)"
+        type: string
+        default: ""
 
 jobs:
   e2e-orchestration:
-    if: inputs.tier == 'orchestration' || inputs.tier == 'all'
+    if: github.event_name == 'schedule' || inputs.tier == 'orchestration' || inputs.tier == 'all'
     runs-on: ubuntu-latest
     concurrency:
       group: aiw-e2e-${{ github.repository_id }}
@@ -36,6 +46,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
       JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
+      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
       COLUMN_AI: ${{ secrets.COLUMN_AI }}
       COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
       COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}
@@ -68,6 +79,23 @@ jobs:
       - name: Preflight — verify e2e DATABASE_URL is the migrated branch
         working-directory: apps/worker
         run: pnpm exec tsx e2e/scripts/check-db.ts
+      # check-db.ts above rules out an unmigrated or plainly wrong database. It
+      # says outright that it cannot rule out the other one: two migrated
+      # branches are indistinguishable from a connection string, so it cannot
+      # tell that this is the branch the deployment reads. This can, by asking
+      # the deployment for its own branch fingerprint. With a candidate named
+      # on dispatch it also refuses a deployment serving different code, which
+      # is what a pre-release run needs and a nightly has no use for.
+      - name: "Preflight: the deployment reads the branch these tests write to"
+        env:
+          CANDIDATE: ${{ inputs.commit }}
+        run: |
+          set -euo pipefail
+          args=(--url "$E2E_BASE_URL" --database-url "$DATABASE_URL")
+          if [ -n "${CANDIDATE:-}" ]; then
+            args+=(--commit "$CANDIDATE")
+          fi
+          node --import tsx scripts/ci/verify-deployment-identity.ts "${args[@]}"
       - run: pnpm run test:e2e:orchestration
       - if: failure()
         uses: actions/upload-artifact@v4
@@ -82,7 +110,7 @@ jobs:
     if: |
       always() &&
       (needs.e2e-orchestration.result == 'success' || needs.e2e-orchestration.result == 'skipped') &&
-      (inputs.tier == 'capacity' || inputs.tier == 'all')
+      (github.event_name == 'schedule' || inputs.tier == 'capacity' || inputs.tier == 'all')
     runs-on: ubuntu-latest
     concurrency:
       group: aiw-e2e-${{ github.repository_id }}
@@ -96,6 +124,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
       JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
+      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
       COLUMN_AI: ${{ secrets.COLUMN_AI }}
       COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
       COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}
@@ -130,6 +159,23 @@ jobs:
       - name: Preflight — verify e2e DATABASE_URL is the migrated branch
         working-directory: apps/worker
         run: pnpm exec tsx e2e/scripts/check-db.ts
+      # check-db.ts above rules out an unmigrated or plainly wrong database. It
+      # says outright that it cannot rule out the other one: two migrated
+      # branches are indistinguishable from a connection string, so it cannot
+      # tell that this is the branch the deployment reads. This can, by asking
+      # the deployment for its own branch fingerprint. With a candidate named
+      # on dispatch it also refuses a deployment serving different code, which
+      # is what a pre-release run needs and a nightly has no use for.
+      - name: "Preflight: the deployment reads the branch these tests write to"
+        env:
+          CANDIDATE: ${{ inputs.commit }}
+        run: |
+          set -euo pipefail
+          args=(--url "$E2E_BASE_URL" --database-url "$DATABASE_URL")
+          if [ -n "${CANDIDATE:-}" ]; then
+            args+=(--commit "$CANDIDATE")
+          fi
+          node --import tsx scripts/ci/verify-deployment-identity.ts "${args[@]}"
       - name: Run capacity E2E
         timeout-minutes: 30
         run: pnpm run test:e2e:capacity
@@ -165,6 +211,7 @@ jobs:
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
       JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
       JIRA_WEBHOOK_SECRET: ${{ secrets.JIRA_WEBHOOK_SECRET }}
+      JIRA_E2E_COMMENTER_TOKEN: ${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}
       COLUMN_AI: ${{ secrets.COLUMN_AI }}
       COLUMN_AI_REVIEW: ${{ secrets.COLUMN_AI_REVIEW }}
       COLUMN_BACKLOG: ${{ secrets.COLUMN_BACKLOG }}
@@ -198,6 +245,23 @@ jobs:
       - name: Preflight — verify e2e DATABASE_URL is the migrated branch
         working-directory: apps/worker
         run: pnpm exec tsx e2e/scripts/check-db.ts
+      # check-db.ts above rules out an unmigrated or plainly wrong database. It
+      # says outright that it cannot rule out the other one: two migrated
+      # branches are indistinguishable from a connection string, so it cannot
+      # tell that this is the branch the deployment reads. This can, by asking
+      # the deployment for its own branch fingerprint. With a candidate named
+      # on dispatch it also refuses a deployment serving different code, which
+      # is what a pre-release run needs and a nightly has no use for.
+      - name: "Preflight: the deployment reads the branch these tests write to"
+        env:
+          CANDIDATE: ${{ inputs.commit }}
+        run: |
+          set -euo pipefail
+          args=(--url "$E2E_BASE_URL" --database-url "$DATABASE_URL")
+          if [ -n "${CANDIDATE:-}" ]; then
+            args+=(--commit "$CANDIDATE")
+          fi
+          node --import tsx scripts/ci/verify-deployment-identity.ts "${args[@]}"
       - run: pnpm run test:e2e:agent
       - if: failure()
         uses: actions/upload-artifact@v4
@@ -206,3 +270,40 @@ jobs:
           path: |
             apps/worker/e2e/**/*.log
           retention-days: 7
+
+  # A dispatch failure has the person who pressed the button. A nightly failure
+  # has nobody, and a red run nobody reads is the same as no run at all, so the
+  # schedule gets one issue and only one: the second consecutive failure has to
+  # land as a comment on the open issue, never as a second issue, or a week of
+  # silence turns into seven tickets nobody triages.
+  report-nightly-failure:
+    needs: [e2e-orchestration, e2e-capacity, e2e-agent]
+    if: always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the single nightly e2e issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RESULT_ORCHESTRATION: ${{ needs.e2e-orchestration.result }}
+          RESULT_CAPACITY: ${{ needs.e2e-capacity.result }}
+          RESULT_AGENT: ${{ needs.e2e-agent.result }}
+        run: |
+          set -euo pipefail
+          title="Nightly e2e is failing"
+          body=$(printf '%s\n\norchestration: %s\ncapacity: %s\nagent: %s\n' \
+            "$RUN_URL" "$RESULT_ORCHESTRATION" "$RESULT_CAPACITY" "$RESULT_AGENT")
+          # Matched on the exact title rather than a label, so this needs no
+          # label to exist in the repository before it can run for the first time.
+          number=$(gh issue list --state open --search "$title in:title" \
+            --json number,title \
+            --jq "[.[] | select(.title == \"$title\")] | .[0].number // empty")
+          if [ -n "$number" ]; then
+            gh issue comment "$number" --body "$body"
+            echo "commented on #$number"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi

--- a/docs/delivery-gates.md
+++ b/docs/delivery-gates.md
@@ -53,7 +53,7 @@ checked them for you.
 
 | Gate | Status |
 | --- | --- |
-| **G3 — merge-group candidate E2E** | The merge-group E2E jobs exist, but G3 cannot be authoritative until evidence proves both that the endpoint serves the exact candidate SHA and that the deployment and E2E database belong together. Until then record G3 as `BLOCKED`, even if a configured E2E run passes. |
+| **G3 — candidate E2E** | The E2E suites run nightly and on dispatch from [`e2e.yml`](../.github/workflows/e2e.yml); they are no longer duplicated into `ci.yml` behind `merge_group`, which cannot fire while no merge queue is configured. Each tier now preflights `scripts/ci/verify-deployment-identity.ts`, which refuses unless the deployment reports the same database-branch fingerprint the tests connect to, and unless it serves the named candidate when a dispatch names one. G3 stays `BLOCKED` until an actual run produces that evidence: the machinery existing is not the evidence, and a configured E2E run passing is not either. |
 | **G5 — isolated deployment verification** | Policy, separately authorized each time. With that authorization, deploy the exact SHA only to the named isolated environment/tenant, prove deployment identity, run authenticated smoke and required tenant reruns, capture runtime/smoke IDs, and verify cleanup. |
 | **G6 — release or rollback approval** | Policy, separately authorized each time. Release and rollback are decisions separate from implementation and verification. Record the approved candidate or rollback baseline and the result; this document defines no deployment or rollback procedure. |
 
@@ -172,8 +172,8 @@ that boundary; record and verify cleanup before G5 can pass.
 
 - Commands: [root package scripts](../package.json) and
   [worker package scripts](../apps/worker/package.json).
-- CI and E2E: [PR/merge-group CI](../.github/workflows/ci.yml) and
-  [manual E2E](../.github/workflows/e2e.yml).
+- CI and E2E: [source gate](../.github/workflows/ci.yml) and
+  [nightly and manual E2E](../.github/workflows/e2e.yml).
 - Artur release: [release runbook](releases/artur/README.md),
   [upgrade preflight](releases/artur/upgrade-preflight.md), and
   [rehearsal runbook](releases/artur/rehearsals/README.md).

--- a/scripts/ci/ci-workflow.test.ts
+++ b/scripts/ci/ci-workflow.test.ts
@@ -248,9 +248,13 @@ test("all setup-node workflow jobs use Node 24", async () => {
     }
   }
 
+  // Four source jobs in ci.yml (the `ci` aggregate installs nothing) and three
+  // e2e tiers in e2e.yml. The count is pinned so a new job cannot quietly join
+  // on an older Node; it dropped from ten when the three e2e tiers duplicated
+  // into ci.yml behind an unreachable `merge_group` were removed.
   assert.equal(
     setupNodeJobs,
-    10,
-    `expected 10 setup-node jobs across CI workflows, found ${setupNodeJobs}`,
+    7,
+    `expected 7 setup-node jobs across CI workflows, found ${setupNodeJobs}`,
   );
 });

--- a/scripts/ci/e2e-workflows.test.ts
+++ b/scripts/ci/e2e-workflows.test.ts
@@ -12,6 +12,9 @@ type Step = {
 };
 
 type Job = {
+  if?: string;
+  needs?: string[];
+  permissions?: Record<string, string>;
   concurrency?: {
     group?: string;
     "cancel-in-progress"?: boolean;
@@ -25,6 +28,7 @@ type Job = {
 type Workflow = {
   on?: {
     workflow_dispatch?: { inputs?: Record<string, unknown> } | null;
+    schedule?: Array<{ cron?: string }>;
   };
   concurrency?: {
     group?: string;
@@ -38,6 +42,9 @@ const workflowPaths = [
   ".github/workflows/e2e.yml",
 ] as const;
 
+const CI = workflowPaths[0];
+const E2E = workflowPaths[1];
+
 async function loadWorkflows(): Promise<Array<[string, Workflow]>> {
   return Promise.all(
     workflowPaths.map(async (path) => [
@@ -47,8 +54,20 @@ async function loadWorkflows(): Promise<Array<[string, Workflow]>> {
   );
 }
 
+/**
+ * The e2e suites live in one workflow now. They used to be duplicated into
+ * `ci.yml` behind `merge_group`, which cannot fire (no merge queue is
+ * configured), so that copy never ran and drifted from this one instead. These
+ * assertions therefore hold the line on the file that actually runs, and the
+ * "no live environment" test below holds the line on the file that must never
+ * grow them back.
+ */
+async function loadE2e(): Promise<Array<[string, Workflow]>> {
+  return [[E2E, parse(await readFile(E2E, "utf8")) as Workflow]];
+}
+
 test("all E2E jobs share the repository-wide non-canceling max queue", async () => {
-  for (const [path, workflow] of await loadWorkflows()) {
+  for (const [path, workflow] of await loadE2e()) {
     for (const jobName of [
       "e2e-orchestration",
       "e2e-capacity",
@@ -86,7 +105,7 @@ test("capacity jobs use trusted campaign identity and leave teardown time", asyn
   const expectedMarker =
     "${{ github.workspace }}/.aiw-capacity-release-${{ github.run_id }}-${{ github.run_attempt }}.json";
 
-  for (const [path, workflow] of await loadWorkflows()) {
+  for (const [path, workflow] of await loadE2e()) {
     const capacity = workflow.jobs?.["e2e-capacity"];
     assert.ok(capacity, `${path} is missing e2e-capacity`);
     assert.equal(capacity["timeout-minutes"], 60);
@@ -127,4 +146,105 @@ test("manual workflow exposes no operator-provided campaign identity", async () 
     Object.keys(inputs).some((name) => /campaign/i.test(name)),
     false,
   );
+});
+
+test("the source gate carries no secret, no environment and no e2e job", async () => {
+  const source = await readFile(CI, "utf8");
+  const workflow = parse(source) as Workflow;
+
+  // The strong form, and the reason the duplicated copies could go: a source
+  // gate proves the checkout compiles and nothing else. One `secrets.` in this
+  // file is a job that can reach a live tenant on an untrusted pull request.
+  assert.doesNotMatch(source, /secrets\./, `${CI} must not reference any secret`);
+  assert.doesNotMatch(source, /^\s*environment:/m, `${CI} must not name an environment`);
+  for (const jobName of Object.keys(workflow.jobs ?? {})) {
+    assert.doesNotMatch(jobName, /e2e/, `${CI} must not define ${jobName}`);
+  }
+});
+
+test("the nightly schedule reaches the two tiers that cost nothing to repeat", async () => {
+  const [, workflow] = (await loadE2e())[0]!;
+
+  const cron = workflow.on?.schedule?.[0]?.cron;
+  assert.ok(cron, "e2e.yml must carry a schedule");
+  assert.doesNotMatch(cron, /^0 /, "an on-the-hour cron queues behind everything GitHub fires at :00");
+
+  // A schedule run receives no inputs, so a job whose condition only reads
+  // `inputs.tier` is skipped and the nightly silently covers nothing.
+  for (const jobName of ["e2e-orchestration", "e2e-capacity"]) {
+    assert.match(
+      workflow.jobs?.[jobName]?.if ?? "",
+      /github\.event_name == 'schedule'/,
+      `${jobName} would be skipped on the nightly`,
+    );
+  }
+});
+
+test("the agent tier stays off the schedule, where nobody watches the spend", async () => {
+  const [, workflow] = (await loadE2e())[0]!;
+
+  assert.doesNotMatch(
+    workflow.jobs?.["e2e-agent"]?.if ?? "",
+    /github\.event_name == 'schedule'/,
+    "the agent tier launches a real provider run; a nightly spends budget unwatched",
+  );
+});
+
+test("a nightly failure opens one issue and keeps using it", async () => {
+  const [, workflow] = (await loadE2e())[0]!;
+  const report = workflow.jobs?.["report-nightly-failure"];
+  assert.ok(report, "e2e.yml must report a nightly failure somewhere");
+
+  assert.match(report.if ?? "", /github\.event_name == 'schedule'/);
+  assert.match(report.if ?? "", /always\(\)/);
+  assert.match(report.if ?? "", /contains\(needs\.\*\.result, 'failure'\)/);
+  assert.equal(report.permissions?.issues, "write");
+  assert.deepEqual(report.needs, ["e2e-orchestration", "e2e-capacity", "e2e-agent"]);
+
+  const script = report.steps?.map((step) => step.run ?? "").join("\n") ?? "";
+  // Both halves, or this is a job that files a fresh ticket every night.
+  assert.match(script, /gh issue list/, "must look for the open issue first");
+  assert.match(script, /gh issue comment/, "a repeat failure comments");
+  assert.match(script, /gh issue create/, "the first failure opens the issue");
+});
+
+test("every e2e job carries the commenter token its agent tier fails without", async () => {
+  const [, workflow] = (await loadE2e())[0]!;
+
+  // us06-clarification-answered throws when this is missing, deliberately, so
+  // that a skipped resume path cannot report the same green as an exercised
+  // one. It was present only on the ci.yml copies that never ran.
+  for (const jobName of ["e2e-orchestration", "e2e-capacity", "e2e-agent"]) {
+    assert.equal(
+      workflow.jobs?.[jobName]?.env?.JIRA_E2E_COMMENTER_TOKEN,
+      "${{ secrets.JIRA_E2E_COMMENTER_TOKEN }}",
+      `${jobName} is missing JIRA_E2E_COMMENTER_TOKEN`,
+    );
+  }
+});
+
+test("every e2e tier proves the deployment reads the branch it writes to", async () => {
+  const [, workflow] = (await loadE2e())[0]!;
+
+  for (const jobName of ["e2e-orchestration", "e2e-capacity", "e2e-agent"]) {
+    const job = workflow.jobs?.[jobName];
+    const preflight = job?.steps?.find((step) =>
+      (step.run ?? "").includes("verify-deployment-identity"),
+    );
+    assert.ok(preflight, `${jobName} does not verify deployment identity`);
+
+    // Without --database-url this degrades to a commit check on a dispatch and
+    // to nothing at all on the nightly, which is the whole failure it exists to
+    // prevent: check-db.ts already says it cannot tell two migrated branches
+    // apart.
+    assert.match(preflight.run ?? "", /--database-url/, `${jobName} must tie the branch`);
+
+    const testStep = job?.steps?.findIndex((step) =>
+      (step.run ?? "").startsWith("pnpm run test:e2e"),
+    );
+    assert.ok(
+      job!.steps!.indexOf(preflight) < testStep!,
+      `${jobName} must verify before it runs anything against the deployment`,
+    );
+  }
 });

--- a/scripts/ci/verify-deployment-identity.test.ts
+++ b/scripts/ci/verify-deployment-identity.test.ts
@@ -112,3 +112,55 @@ test("accepts a matching branch", () => {
     [],
   );
 });
+
+test("makes no environment claim when the caller does not name one", () => {
+  // The e2e job knows the branch it connects to, not what the deployment under
+  // test calls its environment. Guessing would fail for a reason nobody can act
+  // on, and the branch fingerprint already proves more than the name.
+  assert.deepEqual(
+    checkDeploymentIdentity(
+      { status: "ok", commit: SHA, env: "whatever", databaseEnv: "whatever", databaseFingerprint: "aaaaaaaaaaaa" },
+      { commit: SHA, databaseFingerprint: "aaaaaaaaaaaa" },
+    ),
+    [],
+  );
+});
+
+test("still refuses a wrong commit when no environment is named", () => {
+  const problems = checkDeploymentIdentity(
+    { status: "ok", commit: OTHER, databaseFingerprint: "aaaaaaaaaaaa" },
+    { commit: SHA, databaseFingerprint: "aaaaaaaaaaaa" },
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /serves commit/);
+});
+
+test("checks the database branch alone when no candidate is named", () => {
+  // The nightly's shape: nothing to confirm a commit against, but the tests
+  // and the deployment still have to be reading the same branch.
+  assert.deepEqual(
+    checkDeploymentIdentity(
+      { status: "ok", commit: OTHER, databaseFingerprint: "aaaaaaaaaaaa" },
+      { databaseFingerprint: "aaaaaaaaaaaa" },
+    ),
+    [],
+  );
+});
+
+test("still refuses a wrong branch when no candidate is named", () => {
+  const problems = checkDeploymentIdentity(
+    { status: "ok", commit: OTHER, databaseFingerprint: "bbbbbbbbbbbb" },
+    { databaseFingerprint: "aaaaaaaaaaaa" },
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /different database branch/);
+});
+
+test("still refuses a health body that is not ok when nothing else is named", () => {
+  const problems = checkDeploymentIdentity(
+    { status: "degraded", databaseFingerprint: "aaaaaaaaaaaa" },
+    { databaseFingerprint: "aaaaaaaaaaaa" },
+  );
+  assert.equal(problems.length, 1);
+  assert.match(problems[0]!, /status 'degraded'/);
+});

--- a/scripts/ci/verify-deployment-identity.ts
+++ b/scripts/ci/verify-deployment-identity.ts
@@ -34,8 +34,15 @@ export interface HealthPayload {
 }
 
 export interface IdentityExpectation {
-  commit: string;
-  env: string;
+  /** Omitted by a caller with no candidate in hand. The nightly is one: there
+   *  is no commit it is trying to confirm, only a deployment it wants tied to
+   *  the database the tests write to. */
+  commit?: string;
+  /** Omitted by a caller that does not know what the deployment under test
+   *  calls its environment. The e2e target is one such caller, and a guess
+   *  there would be a gate failing for a reason nobody can act on. The branch
+   *  fingerprint proves more than this name does anyway. */
+  env?: string;
   /** Omitted when the caller holds no connection string; the branch check is
    *  then simply not made, and the report says so rather than implying it
    *  passed. */
@@ -53,47 +60,51 @@ export function checkDeploymentIdentity(
 ): string[] {
   const problems: string[] = [];
 
-  if (!SHA_PATTERN.test(expected.commit)) {
-    problems.push(
-      `the expected commit '${expected.commit}' is not a 40-character sha; an` +
-        " abbreviated sha, a branch or a tag cannot identify a candidate",
-    );
-  }
-
   if (payload.status !== "ok") {
     problems.push(`/health reported status '${String(payload.status)}', not 'ok'`);
   }
 
-  if (typeof payload.commit !== "string") {
-    problems.push(
-      "/health did not report a commit, so nothing proves which code answers" +
-        " here (on Vercel this is the project's system environment variables" +
-        " not being exposed to the runtime)",
-    );
-  } else if (payload.commit !== expected.commit) {
-    problems.push(
-      `/health serves commit ${payload.commit}, and the candidate is ${expected.commit}`,
-    );
+  if (expected.commit !== undefined) {
+    if (!SHA_PATTERN.test(expected.commit)) {
+      problems.push(
+        `the expected commit '${expected.commit}' is not a 40-character sha; an` +
+          " abbreviated sha, a branch or a tag cannot identify a candidate",
+      );
+    }
+
+    if (typeof payload.commit !== "string") {
+      problems.push(
+        "/health did not report a commit, so nothing proves which code answers" +
+          " here (on Vercel this is the project's system environment variables" +
+          " not being exposed to the runtime)",
+      );
+    } else if (payload.commit !== expected.commit) {
+      problems.push(
+        `/health serves commit ${payload.commit}, and the candidate is ${expected.commit}`,
+      );
+    }
   }
 
-  if (typeof payload.env !== "string") {
-    problems.push("/health did not report an environment");
-  } else if (payload.env !== expected.env) {
-    problems.push(
-      `/health reports environment '${payload.env}', and '${expected.env}' was expected`,
-    );
-  }
+  if (expected.env !== undefined) {
+    if (typeof payload.env !== "string") {
+      problems.push("/health did not report an environment");
+    } else if (payload.env !== expected.env) {
+      problems.push(
+        `/health reports environment '${payload.env}', and '${expected.env}' was expected`,
+      );
+    }
 
-  if (typeof payload.databaseEnv !== "string") {
-    problems.push(
-      "/health could not read the database env marker, so nothing proves the" +
-        " deployment and its database belong together",
-    );
-  } else if (payload.databaseEnv !== expected.env) {
-    problems.push(
-      `the database behind this deployment is claimed by '${payload.databaseEnv}',` +
-        ` and this deployment is '${expected.env}'`,
-    );
+    if (typeof payload.databaseEnv !== "string") {
+      problems.push(
+        "/health could not read the database env marker, so nothing proves the" +
+          " deployment and its database belong together",
+      );
+    } else if (payload.databaseEnv !== expected.env) {
+      problems.push(
+        `the database behind this deployment is claimed by '${payload.databaseEnv}',` +
+          ` and this deployment is '${expected.env}'`,
+      );
+    }
   }
 
   if (expected.databaseFingerprint !== undefined) {
@@ -132,9 +143,19 @@ async function main(): Promise<void> {
   const url = args.url;
   const commit = args.commit;
   const environment = args.env;
-  if (!url || !commit || !environment) {
+  if (!url) {
     console.error(
-      "usage: verify-deployment-identity --url <base-url> --commit <40-hex> --env <environment>",
+      "usage: verify-deployment-identity --url <base-url>" +
+        " [--commit <40-hex>] [--env <environment>] [--database-url <connection-string>]",
+    );
+    process.exit(2);
+  }
+  if (!commit && !environment && !args["database-url"]) {
+    // Every flag is optional and at least one is required, so this can never
+    // degrade into a request that checks nothing and reports OK.
+    console.error(
+      "FAIL pass at least one of --commit, --env or --database-url: a bare" +
+        " request to /health proves nothing about this deployment",
     );
     process.exit(2);
   }
@@ -142,7 +163,16 @@ async function main(): Promise<void> {
   const health = new URL("/health", url).toString();
   let payload: HealthPayload;
   try {
-    const response = await fetch(health, { headers: { accept: "application/json" } });
+    // Vercel deployment protection answers 401 to an unauthenticated request,
+    // which would read as "the gate failed" when the truth is the gate never
+    // saw the deployment. The e2e jobs already hold this secret.
+    const bypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+    const response = await fetch(health, {
+      headers: {
+        accept: "application/json",
+        ...(bypass ? { "x-vercel-protection-bypass": bypass } : {}),
+      },
+    });
     if (!response.ok) {
       console.error(`FAIL ${health} answered ${response.status} ${response.statusText}`);
       process.exit(1);
@@ -164,18 +194,22 @@ async function main(): Promise<void> {
   }
 
   const problems = checkDeploymentIdentity(payload, {
-    commit,
-    env: environment,
+    ...(commit ? { commit } : {}),
+    ...(environment ? { env: environment } : {}),
     ...(fingerprint ? { databaseFingerprint: fingerprint } : {}),
   });
   if (problems.length > 0) {
-    console.error(`FAIL ${health} does not serve ${commit}:`);
+    console.error(`FAIL ${health} did not answer for this candidate:`);
     for (const problem of problems) console.error(`  - ${problem}`);
     process.exit(1);
   }
   console.log(
-    `OK ${health} serves ${commit} in ${environment}` +
-      (fingerprint ? ` on database branch ${fingerprint}` : ", database branch not checked"),
+    `OK ${health}: ` +
+      [
+        commit ? `commit ${commit}` : "commit not checked",
+        environment ? `environment ${environment}` : "environment not checked",
+        fingerprint ? `database branch ${fingerprint}` : "database branch not checked",
+      ].join(", "),
   );
 }
 


### PR DESCRIPTION
## What was wrong

The three e2e suites existed twice: in `e2e.yml` behind a manual dispatch, and in `ci.yml` behind `if: merge_group || workflow_dispatch`.

The `ci.yml` copies never ran. `main` carries no protection and no rulesets, so there is no merge queue and `merge_group` cannot fire; the last 100 recorded runs of `ci.yml` are 65 `pull_request` and 35 `push`, zero `merge_group`. `ci.yml` says so itself in a comment: "11 of 11 recorded runs skipped all three".

And the copies had already drifted, which is how duplicated jobs end. All three `ci.yml` copies carried `JIRA_E2E_COMMENTER_TOKEN`; no job in `e2e.yml` did. `e2e/tier2/us06-clarification-answered.test.ts` throws without it, deliberately, so that a skipped resume path cannot report the same green as an exercised one. `us06` runs in the **agent** project. So the workflow that actually runs has been unable to pass its agent tier, and the workflow that carried the secret could never start.

Meanwhile nothing ran e2e on its own. Every execution needed somebody to remember.

## What this does

**One workflow.** The three duplicated jobs leave `ci.yml`. Its `on:` triggers are unchanged: `merge_group` still runs the source gate, which is what a merge queue would want from it. The missing `JIRA_E2E_COMMENTER_TOKEN` is added to all three `e2e.yml` jobs, matching the removed copies exactly.

**A nightly.** `e2e.yml` gains `schedule: "17 3 * * *"`, off the hour because GitHub fires scheduled jobs at `:00` and queues them. A schedule run receives no inputs at all, so each job's condition reads `github.event_name == 'schedule'` explicitly rather than leaning on an input default that is not there.

The **agent tier deliberately stays off the schedule**: it launches a real agent against a real provider, so a nightly would spend model budget every night for a signal the other two tiers already give. It runs when somebody asks, which is also when somebody is watching the spend.

**One issue, not seven.** A dispatch failure has the person who pressed the button. A nightly failure has nobody, and a red run nobody reads is the same as no run. `report-nightly-failure` opens one issue and comments on it thereafter, matched on exact title so it needs no label to exist first.

**A preflight that ties the deployment to the data.** `apps/worker/e2e/scripts/check-db.ts` states its own limit: it proves the e2e `DATABASE_URL` reaches a migrated database, and not that it is the branch the deployment reads, because two migrated branches are indistinguishable from a connection string. Every tier now also asks the deployment for its own branch fingerprint and compares. On a dispatch carrying the new `commit` input it additionally refuses a deployment serving different code, which is what a pre-release run needs and a nightly has no use for.

`verify-deployment-identity.ts` grew to match: every flag is optional, at least one is required, and the success line names what was **not** checked rather than implying it passed. It also sends `x-vercel-protection-bypass` when the secret is present, because a 401 from deployment protection would otherwise read as a failed gate when the gate never saw the deployment.

## The contract test, strengthened rather than relaxed

`scripts/ci/e2e-workflows.test.ts` used to assert the queue and campaign-identity rules across both files. Those now apply to the file that runs, and in place of the assertions that covered the dead copies there is a stronger one: **`ci.yml` may not reference a single `secrets.`, may not name an `environment:`, and may not define any job whose name contains `e2e`.** One secret in the source gate is a job that can reach a live tenant from an untrusted pull request.

New assertions also pin: the schedule exists and is not on the hour, the two cheap tiers are actually reachable on it, the agent tier is not, the failure report looks up before it creates, every tier carries the commenter token, and every tier verifies identity with `--database-url` before it runs anything against the deployment.

`ci-workflow.test.ts`'s pinned `setup-node` count moves 10 to 7, with the reason recorded.

## Evidence

| check | outcome |
| --- | --- |
| `pnpm run test:ci` | 47 passed |
| `pnpm run typecheck` | clean |
| `pnpm run verify:changed` | passed |
| `git diff --check` | clean |

Seven mutations, each observed red on exactly the intended test and then restored:

| mutation | test that went red |
| --- | --- |
| the schedule is removed | the nightly schedule reaches the two tiers |
| a source job gains a `secrets.` reference | the source gate carries no secret |
| one tier's preflight drops `--database-url` | every e2e tier proves the deployment reads the branch |
| the failure report always creates a new issue | a nightly failure opens one issue and keeps using it |
| the agent tier joins the schedule | the agent tier stays off the schedule |
| one job loses the commenter token | every e2e job carries the commenter token |
| the gate demands a candidate again | checks the database branch alone when no candidate is named (plus 2) |

## What this does not claim

The nightly has not run yet, and no deployment has been checked by the new preflight. G3 stays `BLOCKED` in `docs/delivery-gates.md` until a real run produces that evidence. This PR makes the check exist and puts it in the path; it does not assert a result nobody has observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015T2GBKWu19ecsWTeDx41BY