### PR TITLE
chore(ci): probe reportable ci aggregator (throwaway)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,16 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:workflow-sdk
 
-  # The one check branch protection requires. `always()` is deliberate: without
-  # it a failed or cancelled source job would leave this job skipped, and GitHub
-  # reads a skipped required check as satisfied, which is the single outcome
-  # this job exists to prevent.
+  # The one check branch protection requires (ADR-004). It has to reach a
+  # verdict on every pull request, so three things about it are load bearing.
+  # `always()`: without it a failed or cancelled source job would leave this job
+  # skipped, and GitHub reads a skipped required check as satisfied. The
+  # per-job result check below: the log has to name which job was not green,
+  # not just that something was not. And no `paths:` or `paths-ignore:` filter
+  # may stand between a pull request and this workflow: a filtered-out workflow
+  # never creates its check runs, and a required check that is never created
+  # leaves the pull request on a permanent "Expected". Path filtering belongs
+  # on the expensive jobs behind this one, never on the trigger or on this job.
   ci:
     needs: [source-checks, unit-worker, unit-dashboard, workflow-sdk]
     if: always()
@@ -117,14 +123,32 @@ jobs:
     steps:
       - name: Require every source job to have succeeded
         run: |
-          results="${{ join(needs.*.result, ' ') }}"
-          echo "source job results: $results"
-          for result in $results; do
+          failed=""
+          for entry in \
+            "source-checks:${{ needs.source-checks.result }}" \
+            "unit-worker:${{ needs.unit-worker.result }}" \
+            "unit-dashboard:${{ needs.unit-dashboard.result }}" \
+            "workflow-sdk:${{ needs.workflow-sdk.result }}"; do
+            name="${entry%%:*}"
+            result="${entry#*:}"
+            echo "$name: $result"
             if [ "$result" != "success" ]; then
-              echo "::error::a source job reported '$result'"
-              exit 1
+              echo "::error::source job '$name' reported '$result'"
+              failed="$failed $name"
             fi
           done
+          # `needs.*.result` is the count guard: a job added to `needs:` above
+          # without a line in the loop would otherwise go unchecked here.
+          declared=$(echo "${{ join(needs.*.result, ' ') }}" | wc -w | tr -d ' ')
+          if [ "$declared" != "4" ]; then
+            echo "::error::ci needs $declared jobs but checks 4 by name"
+            failed="$failed needs-list"
+          fi
+          if [ -n "$failed" ]; then
+            echo "::error::ci is red because of:$failed"
+            exit 1
+          fi
+          echo "every source job succeeded"
 
 # The three e2e suites used to be duplicated here behind
 # `if: merge_group || workflow_dispatch`. They never ran: `main` carries no

--- a/docs/adr/ADR-001-layering-and-packages.md
+++ b/docs/adr/ADR-001-layering-and-packages.md
@@ -1,0 +1,200 @@
+Status: current
+Last-verified: 2026-09-09
+
+# ADR-001: Layering and packages
+
+Decision status: Accepted
+
+Source: decisions D1, D2 and D3 of
+[docs/plans/2026-09-09-architecture-restructure.md](../plans/2026-09-09-architecture-restructure.md).
+Measurements cited below come from
+[docs/research/2026-09-09-architecture-audit.md](../research/2026-09-09-architecture-audit.md),
+sections 2 and 3; they are not re-measured here.
+
+## Context
+
+The worker has 28 top-level directories under `apps/worker/src` and 28 two-way
+import cycles between them (audit section 2). `routes/` imports from 24 of
+those directories, `workflows/` from 21; 21 directories import `lib/`, 22
+import `db/`, and 16 import `env.ts` directly. The heaviest edges are
+`routes->lib` 215, `workflows->lib` 183, `workflows->sandbox` 149; the
+heaviest cycles are `workflow-definition<->workflows` 28/38,
+`sandbox<->workflows` 7/149 and `lib<->workflows` 8/183.
+
+There is no service layer: `lib/` is the domain (audit section 3.5). A block
+type is declared in eight places, and adding one touched 24 files in 8
+directories (audit section 3.1, commit `9b52286f`). Nothing checks the
+direction of an import: the worker has no linter and no boundary tool (audit
+section 6).
+
+The cost is not the cycle count itself. It is that "where does this file go
+and what may it import" has no answer inside the repository, so every new file
+picks a directory by resemblance, and every gate proposed to fix that has
+nothing to reference. A boundary rule needs a destination for every directory
+that exists today, or the ratchet to zero never terminates.
+
+## Decision
+
+Three parts: a tier per directory, a fixed set of allowed edges between tiers,
+and a destination for all 28 directories and all 8 root files.
+
+### Tiers
+
+| Tier | What lives there |
+|---|---|
+| `app` | the server surface: HTTP routes, middleware, plugins, MCP tools and auth wiring |
+| `services` | use cases the surface calls; one cluster per domain, `index.ts` as the cluster interface |
+| `engine` | the workflow runtime: the `"use workflow"` body, the `"use step"` functions, blocks, definition handling |
+| `adapters` | outbound integrations behind an interface (VCS, issue tracker, messaging) |
+| `db` | schema, client, repositories; the only tier that knows the driver |
+| `config` | environment access and derived configuration |
+| `infra` | cross-cutting mechanics with no domain knowledge (logging, telemetry, crypto, provider clients) |
+| `testing` | fixtures, harnesses and colocated tests |
+| `packages/*` | pure code with two consumers, outside `apps/worker/src` |
+
+### Allowed edges
+
+Top to bottom:
+
+```
+app        -> services, engine (the workflow entrypoint only), packages, config
+services   -> engine, adapters, db, packages, infra
+engine     -> adapters, db, packages, infra
+adapters   -> packages, infra
+db         -> packages/contracts, infra
+config     -> nothing
+infra      -> nothing
+testing    -> anything; imported by nothing outside tests
+packages/* -> packages/contracts (workflow-graph may also use conditions;
+              harness may use skills)
+```
+
+No upward edge, no sideways edge except those listed. `env` is imported only
+by `config`. `db/client` is imported only by `db`. Routes and MCP tools never
+call `getDb()`.
+
+### Packages
+
+A package needs two consumers. `contracts`, `conditions`, `prompts`,
+`harness`, `skills`, `costs` and `workflow-graph` are used by both apps and
+are pure, so they become `packages/*`. Each `package.json` carries a
+`description` that states what the package may and may not do; a gate fails
+when one is missing. Each package exposes a curated `exports` map, one entry
+per public module, not one per file.
+
+The engine, the adapters, the services and the DB layer have one consumer (the
+worker) and stay directories inside `apps/worker/src`, fenced by dependency
+rules rather than by a package boundary.
+
+### Where today's code goes
+
+This is the D3 table with one row per top-level entry of `apps/worker/src`, so
+it can be checked against `ls apps/worker/src` without reading a group. No
+tier differs from D3. Every entry has exactly one destination, and the
+dependency-cruiser rules of stage 1 reference this table.
+
+The 28 directories:
+
+| Today (`apps/worker/src/`) | Tier | Note |
+|---|---|---|
+| `adapters/` | adapters | `adapters/vcs`, `adapters/issue-tracker`, `adapters/messaging` are adapters; `adapters/run-registry` is db, because it is one implementation, that is, a repository |
+| `approvals/` | services | mixed: `*-schema.ts` and `store.ts` to db (stage 7), files carrying `"use step"` to `engine/steps` (stage 5), the rest to services |
+| `clarifications/` | services | mixed, split by file as above |
+| `db/` | db | |
+| `dispatch-queue/` | services | mixed, split by file as above |
+| `harness-profiles/` | engine (runtime) | `store.ts` to db in stage 7; pure parts to `packages/harness` and `packages/skills` in stage 8 |
+| `lib/` | split by file | `env` accessors to config; logger, telemetry, llm-provider, llm, github-webhook-sig, webhook-crypto, unique-violation, vcs-urls to infra; everything else to services (dispatch, run-lifecycle, tickets, publication, overview, auth, slack) |
+| `manual-dispatch/` | services | mixed, split by file as above |
+| `mcp/` | app | tools, auth, catalog |
+| `mcp-dogfood/` | testing | |
+| `memory/` | engine | |
+| `middleware/` | app | |
+| `plugins/` | app | |
+| `post-pr-gate/` | engine | |
+| `pre-pr-checks/` | engine | |
+| `pre-sandbox/` | engine | |
+| `prompt-library/` | engine (runtime) | `store.ts` to db in stage 7; pure parts to `packages/prompts` in stage 8 |
+| `repository-discovery/` | services | mixed, split by file as above |
+| `routes/` | app | keeps its name and path because Nitro scans it |
+| `run-analysis/` | engine | |
+| `run-observability/` | engine | |
+| `sandbox/` | engine | |
+| `schedule-trigger/` | services | mixed, split by file as above |
+| `system-health/` | services | mixed, split by file as above |
+| `test-support/` | testing | |
+| `webhook-trigger/` | services | mixed, split by file as above |
+| `workflow-definition/` | engine (`engine/definition/`) | `store.ts` to `db/repositories/definitions` in stage 7; pure schema, validation, bindings, scheduler, interpreter to `packages/workflow-graph` in stage 12 |
+| `workflows/` | engine | |
+
+The 8 root files:
+
+| Today (`apps/worker/src/`) | Tier | Note |
+|---|---|---|
+| `auth.ts` | app | |
+| `auth-instance.ts` | app | |
+| `auth.test.ts` | testing | colocated test of `auth.ts`; stays next to its subject |
+| `deployment-identity.ts` | services (`services/system`) | |
+| `deployment-identity.test.ts` | testing | colocated test of `deployment-identity.ts`; stays next to its subject |
+| `nitro.d.ts` | app | |
+| `preview-harness-canary.test.ts` | testing | |
+| `preview-replay-canary.test.ts` | testing | |
+
+`auth.test.ts` and `deployment-identity.test.ts` are the two entries D3 does
+not name. They are assigned here by the rule D3 already applies to the two
+preview canaries: a `*.test.ts` file is `testing`, may import anything, and is
+imported by nothing outside tests. That is a completeness fix to the plan's
+table, not a new rule.
+
+## Consequences
+
+**Stage 1 turns this table into a gate.** dependency-cruiser gets one rule per
+allowed edge plus `no-circular`, generated against this table, and three
+specific rules: `env` imported only by `config`, `db/client` imported only by
+`db`, no `getDb()` in `routes/` or `mcp/`. Today's violations are recorded as
+a baseline keyed by tier pair (`services->app: 4`), never by file path, so
+moving a file cannot reset the count; the cycle rows of that baseline sum to
+the audited 28. Every later stage attaches the before and after tier-pair
+table, and "the baseline got smaller" is the difference between them. Stage 11
+drives the baseline to zero and deletes it, which terminates only because
+every directory in the table above has a tier.
+
+**Nothing moves in this stage.** The tiers are recorded before the code is
+rearranged, so that the gate has something to reference and so a reviewer can
+reject a misplaced file today by citing a document rather than a preference.
+
+**What moves later.** Stage 5 splits `workflows/agent.ts` into
+`engine/agent-workflow.ts` and `engine/steps/*.ts`, and moves the `"use step"`
+files out of the mixed service directories. Stage 6a creates `config/` and
+`infra/` and makes `config/env.ts` the only importer of `apps/worker/env.ts`.
+Stage 6b moves the `lib/` clusters and the non-store, non-step files of the
+mixed directories into `services/<cluster>/`. Stage 6c makes the server
+surface thin. Stage 7 creates `db/repositories/<domain>.ts`, moves the
+`store.ts` and `*-schema.ts` files there, and fences transactions and
+`db/client` imports. Until those stages land, this ADR describes the intended
+destination, and the baseline describes the distance to it.
+
+**Cost.** A file with a mixed role has to be split before it can move, and the
+mixed directories are named above so the split is not rediscovered per stage.
+The `"use step"` files carry the additional constraint that Vercel Workflow
+discovers steps by file content inside the Nitro build, so their move is
+guarded by the discovery tests, not by the boundary gate.
+
+## Options considered
+
+**The engine as a workspace package.** Rejected (assumption A2). Vercel
+Workflow discovers step files by content inside the Nitro build; a step file
+inside another package is discovered only if its directory is listed in the
+`dirs` option, whose glob and escape semantics no primary source documents. A
+fenced directory inside `srcDir` with `engine/index.ts` as its only public
+export behaves like a package and needs none of that.
+
+**`no-circular` alone, with no tiers.** Rejected. A cycle count says two
+directories point at each other but not which direction is wrong, so a fix can
+reverse a cycle instead of removing it, and the ratchet has no end state. A
+tier per directory gives every cycle exactly one legal direction and gives
+stage 11 a termination condition.
+
+**Packages for the engine, the services and the DB layer as well.** Rejected
+by D2: each has one consumer. A package boundary there costs a build step, an
+`exports` map and a version story, and buys a fence that dependency-cruiser
+already provides inside one app.

--- a/docs/adr/ADR-004-gates-and-required-ci.md
+++ b/docs/adr/ADR-004-gates-and-required-ci.md
@@ -1,0 +1,165 @@
+Status: current
+Last-verified: 2026-09-09
+
+# ADR-004: Gates and required CI
+
+Decision status: Accepted
+
+Source: decisions D8 and D11 and assumption A1 of
+[docs/plans/2026-09-09-architecture-restructure.md](../plans/2026-09-09-architecture-restructure.md).
+Measurements cited below come from
+[docs/research/2026-09-09-architecture-audit.md](../research/2026-09-09-architecture-audit.md),
+section 6; they are not re-measured here.
+
+## Context
+
+The repository has checks and no enforcement. Audit section 6 lists what runs
+where: `git diff --check` and the scoped typechecks run in `verify:changed` at
+pre-push only; the unit suites (worker sharded into four, dashboard,
+workflow-sdk) run in CI on every pull request behind an aggregate job named
+`ci`; the validators run through `build:ci`; `verify-deployment-identity` and
+the e2e suites run nightly, off the PR path. The worker has no linter, the
+dashboard's `next lint` is defined and never run, and there is no import
+boundary or unused-code tool at all.
+
+None of it blocks a merge. `main` has no branch protection, by recorded
+decision, so a red `ci` job stops nothing, and `core.hooksPath` makes the local
+gate advisory: `AGENTS.md` says so itself, and `--no-verify` is one flag away.
+
+The cheapest large improvement is therefore a repository setting rather than
+code. It has one precondition. A required check that never reaches a verdict
+is worse than no required check: GitHub leaves the pull request on a permanent
+"Expected", and within a week the admin bypass becomes the normal way to
+merge. So the aggregator has to be made reportable before it is required, and
+the bypass has to be narrow enough that using it is visible.
+
+## Decision
+
+### 1. One shape for every gate
+
+Gates are dependency-free Node scripts under `scripts/gates/`, each with a
+header stating why it exists and what makes it exit non-zero, a baseline JSON
+where a ratchet is needed, a test under `scripts/ci/`, and one entry each in
+`verify:changed` and `.github/workflows/ci.yml`. Third-party tools
+(dependency-cruiser, knip, oxlint) are invoked by those scripts rather than
+configured separately, so the ladder has one shape and one place to read.
+
+### 2. The ladder
+
+One line per gate: what it observes, and whether it carries a baseline.
+
+| Gate | Observes | Baseline | Lands in |
+|---|---|---|---|
+| `git diff --check` | whitespace errors and conflict markers in the diff | no | exists (pre-push), stage 1 adds it to CI |
+| typecheck | TypeScript across worker, dashboard and root scripts | no | exists (`source-checks`) |
+| unit tests | worker (4 shards), dashboard, workflow-sdk | no | exists |
+| `build:ci` | pre-sandbox config, local skills, MCP contract, Nitro build | no | exists |
+| generated files current | MCP contract, prompt drift, carry-schema drift, and from stage 4 the block catalog (`gen:blocks --check`) | no | three exist, block catalog in stage 4 |
+| import boundaries and cycles | dependency-cruiser with the tier rules of ADR-001 plus `no-circular` | yes, keyed by tier pair | stage 1 |
+| unused files, exports, dependencies | knip | yes, today's count | stage 1 |
+| lint | oxlint on both apps, correctness rules deny, the rest warn | yes, warning count ratcheted | stage 1 |
+| workflow bundle imports | executable Node imports inside workflow VM code, distinguished from import-like text in string literals (AIW-325) | no | stage 1 |
+| `no-resurrected-paths` | a path a completed stage deleted reappearing after a rebase | yes, a path list that starts empty and each stage appends to | stage 1 |
+| `package-contracts` | every `packages/*/package.json` has a `description` | no | stage 1 |
+| `docs-status` | `Status:` and `Last-verified:` headers, a `current` file older than 90 days, a current file unreachable in two hops | no | stage 2 |
+| `check-deps-consistency` | the pnpm catalog and the four dependency rules | no | stage 3 |
+| `single-schema-version` | a reinstated `schemaVersion === 1` branch | no | stage 3b |
+| `transactions-in-repositories` | `.transaction(` outside `db/repositories` | no | stage 7 |
+| `db-client-fence` | `db/client` imports outside `db/` | yes, 357 ratcheted down | stage 7 |
+
+Baselines that ratchet are driven to zero and deleted in stage 11, at which
+point the rules become hard.
+
+### 3. The aggregator must be reportable
+
+A required check has to end green or red on every pull request that can touch
+it. "Reportable" means all four of these, and all four are load bearing:
+
+- The job runs with `if: always()`. Without it, a failed or cancelled
+  dependency leaves the job skipped, and GitHub counts a skipped required
+  check as satisfied.
+- It `needs` every source job.
+- It checks each needed job's result by name and fails when that result is not
+  `success`, printing the job name and the result it reported. A summary that
+  only says "something failed" costs the reader a hunt through four job logs,
+  and a name-by-name check also catches a job added to `needs:` that nothing
+  asserts on.
+- No `paths:` or `paths-ignore:` filter stands between a pull request and this
+  job. A workflow filtered out by paths never creates its check runs at all,
+  so a required check that is never created leaves the pull request on
+  "Expected" forever. A docs-only pull request must still get a green `ci`.
+  Path filtering belongs on the expensive jobs behind the aggregator (as in
+  stage 5b), never on the aggregator or on the workflow trigger.
+
+Job names are stable, because branch protection references the string `ci`.
+
+### 4. `ci` is required on `main`, with no standing bypass
+
+Branch protection on `main` requires the `ci` status check and enforces for
+administrators. Bypass is GitHub's "allow specified actors" with exactly one
+named account, not a standing admin exemption and not a role. Every use of the
+bypass opens a Jira issue recording what was merged and why, mirroring the
+`--no-verify` audit rule in `AGENTS.md`: the bypass is auditable, so a merge
+that skipped `ci` is never reported as a merge that passed it.
+
+This is the open remainder of AIW-313. PR #358 already merged the
+credential-free bundle and the validators into CI; the flip is what is left.
+
+### 5. A behavioural gate is planned, not present
+
+Static gates observe structure, not behaviour, and the failure mode they miss
+is the one this repository actually has: green locally, broken only on Vercel.
+Stage 5b adds a CI job that, for pull requests touching
+`apps/worker/src/engine/**`, `apps/worker/src/db/**` or `packages/**`, deploys
+a preview and runs both non-dry canaries (`e2e/replay/preview-canary.ts`,
+`e2e/harness-profiles/preview-canary.ts`), dispatching one run that executes
+at least one `"use step"` and one WDK webhook function. That job joins the
+`ci` aggregator's `needs`, which is why its path filter lives on the job and
+not on the workflow. Until 5b exists, stages 3 and 5 run the same canaries by
+hand as their definition of done.
+
+## Consequences
+
+- A red merge stops being possible without a recorded bypass. The delivery
+  gates document keeps its sentence that a green run is evidence of
+  correctness and never proof that a red candidate could not land, because a
+  bypass still exists; what changes is that using it leaves a trace.
+- Every new CI job that a stage adds must either join the aggregator's `needs`
+  or be irrelevant to the merge decision. A job outside `needs` is
+  decoration.
+- The aggregator's own timeout (5 minutes) is not a gate: it waits on jobs
+  with 30-minute timeouts. A shard that hits its ceiling reports `failure` and
+  the aggregator reports it by name.
+- A cancelled dependency (a superseded push, a manual `gh run cancel`) is not
+  `success`, so `ci` reports red rather than green. That is deliberate: the
+  concurrency group cancels superseded runs, and the run that matters is the
+  one for the current head SHA.
+- Branch protection is a repository setting. It is not in the diff, it is not
+  reviewed, and it can be turned off without a commit. ADR-004 is the record
+  of what it is supposed to be; a periodic check against
+  `gh api repos/Blazity/ai-workflow/branches/main/protection` is the only way
+  to know it still is.
+
+## Options considered
+
+**Require the four source jobs individually instead of the aggregator.**
+Rejected. `unit-worker` is a matrix of four shards that report as four
+separate contexts, so the required list would carry seven entries, and every
+job a stage adds or renames would need a protection edit made by an admin
+outside the pull request. The aggregator keeps the required list at one string
+and moves the composition into the diff.
+
+**Leave `main` unprotected and rely on the pre-push hook.** Rejected. The hook
+is opt-in through `core.hooksPath`, scoped to changed paths, and bypassable
+with `--no-verify`; `AGENTS.md` already calls it advisory. It is a fast local
+signal, not a merge gate.
+
+**Require `ci` with a standing admin bypass.** Rejected by the owner (A1). A
+standing bypass makes the gate advisory again the first time a shard is flaky,
+and nothing records that it happened. One named actor plus a Jira issue per
+use keeps the escape hatch and makes it visible.
+
+**Require `ci` before making the aggregator reportable.** Rejected as the
+ordering that produces the failure the pre-mortem names: a non-reportable
+aggregator leaves every pull request on a permanent "Expected", and the bypass
+becomes the default path within a week.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,90 @@
+Status: current
+Last-verified: 2026-09-09
+
+# Architecture decision records
+
+This directory holds the decisions that outlived the pull request that made
+them. An ADR answers three questions for a reader who arrives a year later:
+what forced the decision, what was decided, and what the repository now has to
+live with. It is not a design document and not a plan: plans live in
+`docs/plans/`, measurements live in `docs/research/`.
+
+## Shape
+
+Every ADR is MADR with these sections, in this order:
+
+- **Context.** The forces: what is true in the repository today, with
+  `file:line` citations or a link to the research that measured it, and what
+  breaks if nothing is decided.
+- **Decision.** The rule, stated so a reviewer can apply it without reading
+  the rest of the file.
+- **Consequences.** What follows: what becomes enforceable, what becomes
+  harder, what has to move later and in which stage.
+- **Options considered.** Only when real alternatives existed. Each option
+  gets the reason it lost. A section listing one option is noise: leave it
+  out.
+
+## Header and status
+
+The first two lines of every ADR are the docs header from the documentation
+taxonomy:
+
+```
+Status: current
+Last-verified: YYYY-MM-DD
+```
+
+`Status:` takes the docs enum (`current`, `draft`, `superseded-by <path>`) and
+describes the document. The MADR decision status is a separate field written
+in the body as `Decision status: Accepted` (or `Proposed`, `Rejected`,
+`Superseded by ADR-NNN`) and describes the decision. The two never merge: a
+`current` document can record a superseded decision, and a superseded document
+is still read by whoever is undoing it.
+
+## When to write one
+
+Write an ADR when a decision constrains code structure, tooling, data or
+process for longer than one pull request. In practice that means:
+
+- a rule a reviewer will cite against someone else's PR (import tiers, where a
+  transaction may live, what a package must expose);
+- a tool or gate the repository now depends on, and what happens when it is
+  bypassed;
+- a data or schema commitment that outlives one release (retiring a schema
+  version, one owner for a catalog);
+- a process the team is expected to keep (required checks, freezes).
+
+Do not write one for: a bug fix, a refactor with no new rule, a library
+version bump, or anything a code comment next to the code says better.
+
+One decision per ADR. A decision that changes later is superseded by a new
+ADR, never edited in place: the old file keeps its number, gains
+`Decision status: Superseded by ADR-NNN`, and its `Status:` becomes
+`superseded-by docs/adr/ADR-NNN-<slug>.md`.
+
+## Numbering
+
+- Files are `ADR-NNN-kebab-slug.md`, `NNN` zero padded to three digits.
+- Numbers are assigned in order, never reused and never renumbered, including
+  for a rejected or superseded ADR.
+- A number may be reserved before the file exists when a planned stage owns
+  it. The index below is the reservation list: take the next free number from
+  it, and if you claim a reserved number for something else, renumber the
+  reservation, not the existing files.
+
+## Index
+
+| ADR | Title | Decision status | State |
+|---|---|---|---|
+| [ADR-001](./ADR-001-layering-and-packages.md) | Layering and packages | Accepted | Written |
+| ADR-002 | Block manifest | Proposed | Planned, written in stage 2 |
+| ADR-003 | Definition schema v1 retirement | Proposed | Planned, written in stage 2 |
+| [ADR-004](./ADR-004-gates-and-required-ci.md) | Gates and required CI | Accepted | Written |
+| ADR-005 | Documentation taxonomy | Proposed | Planned, written in stage 2 |
+| ADR-006 | Model catalog | Proposed | Planned, written in stage 8b |
+
+Stage numbers refer to the stage table in
+[docs/plans/2026-09-09-architecture-restructure.md](../plans/2026-09-09-architecture-restructure.md).
+Stage 2 and stage 8b fill the four planned rows: they replace `Proposed` with
+the decision status the ADR lands with and change `State` to `Written`. No
+other row moves.

--- a/docs/plans/2026-09-09-architecture-restructure-tickets.md
+++ b/docs/plans/2026-09-09-architecture-restructure-tickets.md
@@ -1,0 +1,502 @@
+# Architecture restructure: Jira drafts
+
+Status: DRAFT for creation, 2026-09-09. Source: [2026-09-09-architecture-restructure.md](2026-09-09-architecture-restructure.md) revision 4 (approved by the owner). After creation, fill the "Jira key" field of each entry so this file becomes the stage-to-ticket map.
+
+## Epic
+
+- Jira type: Epic
+- Jira key: (fill after creation)
+- Summary: Architecture restructure 2026-09: tiers, packages, gates, docs
+- Labels: architecture, restructure
+- Description:
+
+An engineer or an agent who wants to add a feature today cannot answer where it goes, what it may import, or what proves nothing broke. Adding one block type touches 24 files in 8 directories, and the worker's 28 top-level directories carry 28 two-way import cycles. Four concepts (prompts, skills, harness profiles, costs) each have two to four competing definitions, and two definition schema versions are live even though nothing creates a v1 definition any more. Nothing blocks a regression at merge time: `main` has no branch protection, the worker has no linter, no tool checks import boundaries, and 357 files outside `db/` write to the database directly.
+
+Rules that bind every ticket:
+- Enforcement before structure: stage 1 installs dependency-cruiser, knip and lint with today's violations recorded as a baseline before any files move.
+- Behaviour of v2 runs does not change in any stage, except stage 3b, which deliberately retires schema v1 (the plan's only intentional behaviour change).
+- Bugs first, freezes second: the open High bugs AIW-277, AIW-279, AIW-280, AIW-292, AIW-284 and AIW-187 must merge, or be deferred by the owner, before the first freeze starts; a High bug found during a freeze is fixed on the restructure branch, never on `main`.
+- Two event-tied freezes: `apps/worker/src/workflows` is frozen from the start of stage 3b until stage 5 lands on `main`; `apps/worker/src/lib` and `apps/worker/src/routes` are frozen from the start of stage 6a until stage 6c lands on `main`.
+- Evidence rules from AGENTS.md apply to every stage: record the branch and the exact start SHA before editing, freeze the candidate SHA before verification, and never report a result that was not actually observed.
+
+Order and parallelism: 1 and 2 are disjoint and may run concurrently after 0. 3 waits for 1. 3b waits for 3 and for AIW-195/197 and opens the first freeze; 3b -> 4 -> 5 -> 5b are sequential and 3b, 4 and 5 sit inside that freeze. 6a -> 6b -> 6c are sequential inside the second freeze. 7 waits for 6c. 8a, 8b, 8c and 8d are mutually disjoint and may run concurrently after 7. 9 waits for all of 8. 10 and 11 close.
+
+Later: stage 12 (`packages/workflow-graph`: v2 schema, validation, bindings, scheduler, interpreter, layout; dashboard forms generated from block manifests) is not a ticket in this epic. It is a separate plan and a separate `/opus-orchestration` run, to start after stage 11 closes.
+
+## Tickets
+
+### Stage 0: Finish AIW-313, ADRs, and require `ci` on `main`
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-0
+- Depends on / Related: AIW-313 (open remainder, do not duplicate); AIW-326 (this stage is its "G2 enforcement" step)
+- Freeze: none
+- Suggested executor: opus (ADRs) + human (branch-protection setting), skeptic no, TDD no, delegation no
+- Summary: ADR-001 and ADR-004 are Accepted, the `ci` aggregator reports a real green/red on every PR, and `main` requires `ci` with no standing bypass.
+- Scope:
+  - Write ADR-001 (layering, packages, the D3 tier table covering all 28 directories and 8 root files)
+  - Write ADR-004 (gates and required CI)
+  - Make the `ci` aggregator job reportable: `if: always()`, an explicit per-need result check, no `paths:` filter
+  - Require the `ci` status check on `main` per A1, with no standing admin bypass
+  - Close AIW-313 with this evidence
+  - Baseline fact: `main` currently has no branch protection, by decision; this stage changes that record
+  - PR #358 already merged the credential-free bundle and the validators into CI; this stage is only the aggregator fix, the ADRs, and the branch-protection flip
+- File scope: `docs/adr/README.md`, `docs/adr/ADR-001-layering-and-packages.md`, `docs/adr/ADR-004-gates-and-required-ci.md`, `.github/workflows/ci.yml` (aggregator job only), GitHub branch protection settings
+- Acceptance criteria:
+  - [ ] A throwaway docs-only PR and a PR with one shard deliberately cancelled both end in a reportable green or red on `ci`, never a permanent "expected"
+  - [ ] `gh api repos/Blazity/ai-workflow/branches/main/protection` returns `required_status_checks.contexts` containing `ci` and `enforce_admins.enabled: true`
+  - [ ] ADR-001 lists all 28 directories and 8 root files with a tier
+  - [ ] Both ADR-001 and ADR-004 are marked Accepted
+- Notes: Executes A1 (branch protection, no standing bypass). This ticket is the open remainder of AIW-313, not a duplicate: it covers the ADRs and the aggregator change; link AIW-313 for the branch-protection flip evidence.
+
+### Stage 1: Gate ladder with tier-pair baselines (absorbs AIW-325)
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-1
+- Depends on / Related: after stage 0; absorbs AIW-325
+- Freeze: none
+- Suggested executor: sonnet, skeptic no, TDD yes (fixture with forbidden tier edge fails; baseline passes; a rename does not change tier-pair counts), delegation yes (baseline capture)
+- Summary: dependency-cruiser enforces the ADR-001 tier rules and `no-circular` with a baseline keyed by tier pair; knip, oxlint, and two new gates (`no-resurrected-paths`, `package-contracts`) run in `verify:changed` and `ci.yml`.
+- Scope:
+  - Add dependency-cruiser with tier rules from ADR-001 plus `no-circular`, baseline keyed by tier pair (not file path)
+  - Add a knip baseline and a minimal oxlint config for both apps
+  - Add `git diff --check` to CI
+  - Add `no-resurrected-paths` (starts empty) and `package-contracts` gates
+  - Fold in AIW-325: the WDK bundle check distinguishes executable Node imports from import-like text in string literals and fails closed on a negative fixture; dependency-cruiser owns directory tiers, the bundle check owns "no Node import in workflow VM code"
+  - Wire everything into `verify:changed` and `ci.yml`
+- File scope: `.dependency-cruiser.cjs`, `knip.json`, `.oxlintrc.json`, `scripts/gates/**`, `scripts/ci/verify-changed.ts`, `scripts/ci/*.test.ts`, `.github/workflows/ci.yml` (ladder steps), root `package.json`, `pnpm-lock.yaml`, `apps/worker/src/workflows/workflow-import-boundary.test.ts` and its fixtures (AIW-325); after stage 0
+- Acceptance criteria:
+  - [ ] `pnpm run verify:changed` exits 0 on `main`
+  - [ ] `pnpm run test:ci` passes
+  - [ ] The boundary baseline is a tier-pair table whose cycle rows sum to the audited 28
+  - [ ] A test that adds `app -> db/client` makes the gate exit 1
+  - [ ] A test that renames a baselined file leaves the gate output unchanged
+  - [ ] `ci.yml` runs the ladder on a PR
+- Notes: Executes D1 (enforcement before structure, baseline keyed by tier pair) and A5 (oxlint for style, dependency-cruiser for boundaries).
+
+### Stage 2: Docs taxonomy and agent routing
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-2
+- Depends on / Related: after stage 0; disjoint from stage 1 except the shared gate file
+- Freeze: none
+- Suggested executor: opus for `workflow-definition.md`, both ADRs and both root `AGENTS.md` files; sonnet for moves and headers; skeptic yes (agent-facing text is behaviour); TDD no; delegation yes (git mv sweep, headers)
+- Summary: docs move into `docs/index.md` plus `architecture/`, `adr/`, `product/`, `runbooks/`, `research/`, `archive/`, every current file gets a status and last-verified header, and root plus per-app `AGENTS.md` route an agent to the right document in two hops.
+- Scope:
+  - Write `docs/index.md` as the only list of current documents
+  - Write ADR-002 (block manifest), ADR-003 (v1 retirement, Accepted per A11/D12, citing the production count), ADR-005 (docs taxonomy)
+  - `git mv` journals to `docs/archive/`; delete `.agents/skills/`, `.kimi-code/`, `docs/workflow-workspace/index.html` per A7
+  - Add `Status:` and `Last-verified:` headers to every current doc
+  - Rewrite `docs/workflow-definitions.md` to `docs/architecture/workflow-definition.md` against the v2 files
+  - Fix README capability claims against the roadmap
+  - Correct `init-vcs/SKILL.md` and add `GITLAB_HOST` to `SETUP.md` per A9
+  - Trim root `AGENTS.md` to a routing table under 200 lines, keeping the four production gotchas verbatim
+  - Add `apps/worker/AGENTS.md` + `CLAUDE.md`, `apps/dashboard/AGENTS.md` + `CLAUDE.md`
+  - Mine `.claude/learnings.md` into `.claude/rules/*.md` with `paths:` frontmatter per A10, then archive it
+  - Add `scripts/gates/docs-status.mjs` (headers, age, reachability)
+- File scope: `README.md`, `AGENTS.md`, `SETUP.md`, `design-qa.md`, `docs/**` except `docs/research/` and `docs/adr/ADR-00{1,4}*`, `apps/worker/{AGENTS,CLAUDE}.md`, `apps/dashboard/{AGENTS,CLAUDE}.md`, `apps/*/docs/**`, `.claude/rules/**`, `.claude/learnings.md`, `.claude/skills/init-*/SKILL.md`, `.agents/**`, `scripts/gates/docs-status.mjs`; after stage 0
+- Acceptance criteria:
+  - [ ] `docs-status` gate exits 0: every current doc has both headers, none older than 90 days, all reachable in two hops
+  - [ ] Root `AGENTS.md` is under 200 lines and contains the four gotchas verbatim
+  - [ ] `rg -n 'schemaVersion' docs/architecture/workflow-definition.md` shows v2
+  - [ ] The six audited contradictions each have a commit that closes them
+  - [ ] `pnpm run verify:changed` exits 0
+- Notes: Executes D9 (docs taxonomy with currency), A7 (archive not delete), A9 (GitLab clone URL fact), A10 (learnings mined into rules), and writes ADR-003 (v1 retirement), which stage 3b executes.
+
+### Stage 3: `packages/` directory: contracts and conditions
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-3
+- Depends on / Related: after stage 1
+- Freeze: none
+- Suggested executor: opus, skeptic no, TDD no, delegation no
+- Summary: `apps/shared/contracts` and `apps/shared/conditions` become `packages/contracts` and `packages/conditions` with curated `exports` maps, and the worker either consumes them as source (if the A3 spike holds) or via `dist` with project references.
+- Scope:
+  - Open with the A3 spike on a preview: does the Vercel tracer bundle workspace `.ts` sources into every `.func`?
+  - Move `apps/shared/contracts` -> `packages/contracts`, `apps/shared/conditions` -> `packages/conditions`
+  - Add curated `exports` maps (one entry per public module) and a `description` per package
+  - Source consumption per A3, or keep `dist` with TypeScript project references if the spike fails
+  - Drop `build:shared` if A3 holds; remove the worker `tsconfig.json` include of shared sources
+  - Add `packages/AGENTS.md`
+  - Add a pnpm catalog for dependencies both apps share, plus a `check-deps-consistency` gate
+- File scope: `apps/shared/**`, `packages/**`, `pnpm-workspace.yaml`, `apps/worker/tsconfig.json`, `apps/dashboard/tsconfig.json`, `apps/worker/package.json`, `apps/dashboard/package.json`, `apps/worker/nitro.config.ts`, `apps/dashboard/next.config.ts`, `scripts/gates/check-deps-consistency.mjs`; after stage 1
+- Acceptance criteria:
+  - [ ] `pnpm typecheck` passes
+  - [ ] `pnpm --filter worker exec vitest run src/workflows/workflow-import-boundary.test.ts` passes
+  - [ ] `pnpm --filter worker build:ci` passes
+  - [ ] `pnpm --filter ai-workflow-dashboard build` passes
+  - [ ] `package-contracts` gate passes
+  - [ ] A preview deploy of the worker answers `/health`, and `pnpm run test:e2e:replay` and `pnpm run test:e2e:harness-profiles` (the non-dry canaries) pass against that preview, executing at least one step and one WDK webhook function
+  - [ ] The boundary tier-pair table is unchanged or smaller (attached to the PR)
+- Notes: Executes D2 (a package needs two consumers), A3 (source-consumption spike), A4 (package names stay `@shared/*` for now).
+
+### Stage 3b: Retire schema v1 (D12)
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-3b
+- Depends on / Related: after stage 3; waits for AIW-195 and AIW-197 (A14) to land first; opens the first freeze; stages 4 and 5 share `blocks/*`, `prompt-references-step.ts` and `contracts/domain.ts` with it and list it under "after"
+- Freeze: first (workflows) - opens at the start of this stage
+- Suggested executor: opus, skeptic yes (deployability, rollback, fresh-install default and MCP authoring change), TDD yes (dispatch-with-no-deployed-definition test, rollback 409 test, `save_draft` VALIDATION_FAILED test, history-read legacy-v1-arm test, clipboard-rejection test, gate fixture test), delegation yes (test-file trimming from the list of 26)
+- Summary: a stored definition is valid, deployable, dispatchable and authorable only as v2; the v1 default, the v1 graph walker, the converter and migration paths, and every `schemaVersion` branch are deleted, while a stored v1 row stays listed read-only in history. This is the plan's only deliberate behaviour change.
+- Scope:
+  - Measure archived and history v1 rows by SQL on production and hand the counts to ADR-003
+  - Switch the five consumers of the v1 default (`definition-step.ts` `buildDefault`, the clone and seed fallbacks in `workflow-definitions.post.ts`, `builtin-prompt-drift.ts`, `carry-schema-drift.ts`) to `defaultWorkflowDefinitionV2`, then delete the v1 default
+  - Delete `executeGraph` and its private helpers; collapse every `schemaVersion === 1` branch and every constant `=== 2` guard to the v2 arm across `workflows/agent.ts`, `definition-step.ts`, `prompt-references-step.ts`, the listed block files, `lib/dispatch*.ts`, and the workflow-definition store/runtime files
+  - Rename `toLegacyRuntimeShape` to `toRuntimeShape` (shape kept, not deleted)
+  - Delete `isV2OnlyBlockType`, the three singular shim routes, `v2-converter.ts`, `v2-migration*.ts`, `[id]/migrate.post.ts`, and the dashboard migration drawer
+  - Narrow the runnable `WorkflowDefinition` to v2; make the version-history read return `{ kind: "v2", definition } | { kind: "legacy-v1", raw }`
+  - Rollback to a v1 version returns 409 naming the retired schema; editor hides Restore on v1 rows; clipboard rejects a v1 payload
+  - Update the `save_draft` tool description sentence and regenerate `mcp-contract.json`
+  - Add the permanent gate `scripts/gates/single-schema-version.mjs`, registered in `verify:changed` and `ci.yml`
+  - Append the shim and migrate route paths to the resurrected-paths list
+  - Drop v1 cases from the 18 worker and 8 dashboard test files that pin them
+- File scope: `apps/worker/src/workflow-definition/{interpreter,schema,validation,store,default,templates,v2-converter,v2-migration,v2-migration-prompts,v2-migration-harness-profiles,harness-profile-runtime,layout,graph-fixtures}.ts`, `apps/worker/src/workflows/{agent,definition-step,prompt-references-step}.ts` (version branches only), `apps/worker/src/workflows/blocks/{fix-agent,prepare-workspace,types,test-support}.ts` (version branches only), `apps/worker/src/lib/{dispatch,dispatch-trigger}.ts` (three lookups only), `apps/worker/src/prompt-library/builtin-prompt-drift.ts`, the v1 route files under `apps/worker/src/routes/api/v1/` (workflow-definitions.post, workflow-definition.get/put, workflow-definition/restore.post, workflow-definitions/[id]/migrate.post), `apps/worker/src/mcp/tool-catalog.ts` and `mcp-contract.json`, `packages/contracts/src/{domain,workflow-graph}.ts`, `apps/dashboard/lib/{flows.ts,workflow-editor/**}`, dashboard editor and flow-editor components, `scripts/gates/single-schema-version.mjs`, `scripts/gates/no-resurrected-paths.json`, `verify-changed.ts` and `ci.yml` (one gate entry each), the 26 test files that pin v1; after stage 3
+- Acceptance criteria:
+  - [ ] `node scripts/gates/single-schema-version.mjs` exits 0 (pattern: `schemaVersion (===|!==) [12]\b|schemaVersion: 1( \| 2)?\b|isV2OnlyBlockType|executeGraph\b` over `apps` and `packages`, excluding tests, the harness-profile manifest files and the single history parser), and a fixture reintroducing `schemaVersion === 1` fails it
+  - [ ] `pnpm typecheck` passes
+  - [ ] `pnpm --filter worker exec vitest run src/workflow-definition src/workflows src/routes src/lib src/prompt-library` passes
+  - [ ] `pnpm --filter ai-workflow-dashboard test` passes
+  - [ ] `pnpm --filter worker mcp:contract:check` passes and the recorded hash differs from the start-SHA hash
+  - [ ] `pnpm --filter worker run db:generate` produces no migration
+  - [ ] The reviewer attaches a table of every collapsed version site (6 `=== 1` and 13 `=== 2` in `agent.ts` at the start SHA, 2 in the store, 3 in dispatch, the rest per file) showing the v2 arm kept verbatim
+  - [ ] Preview deploy plus both non-dry canaries pass
+  - [ ] A `workflows.get_graph` sweep on production after deploy returns all 9 definitions
+  - [ ] ADR-003 carries the SQL counts
+- Notes: Executes D12 and A11 (owner reversed Q4 the same day: v1 is retired inside this plan, not as a separate plan).
+
+### Stage 4: Block manifest and generator
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-4
+- Depends on / Related: after stage 3b (shares `blocks/*` and `contracts/domain.ts` with it); inside the first freeze; AIW-293 block-contract tasks (AIW-294, 297, 305, 306, 300, 301) land only after this stage
+- Freeze: first (workflows) - inside
+- Suggested executor: opus, skeptic yes (block contracts are business logic), TDD yes (generator fixture: block dir -> three expected outputs; a manifest importing a runtime module fails generation; existing registry/schema/catalog tests are the regression net), delegation yes (moving 26 block files into directories)
+- Summary: each block type gets one directory with `manifest.ts` and `execute.ts`; a generator writes the block-catalog, params-schema-map and executor-map files from those manifests only, so definition validation never imports an executor.
+- Scope:
+  - Move each block into `engine/blocks/<type>/{manifest,execute}.ts` (move, not rewrite)
+  - Add `scripts/gates/generate-block-catalog.ts` writing `packages/contracts/src/block-catalog.generated.ts`, `engine/definition/params.generated.ts`, `engine/blocks/executors.generated.ts`
+  - `schema.ts` and `block-registry.ts` consume `params.generated.ts`
+  - Turn `block-catalog-sync.test.ts` into `gen:blocks --check`
+  - Delete `docs/workflow-workspace/index.html` (replaced by the generated catalog, per A7)
+  - Dashboard palette reads `BLOCK_TYPE_SPECS` from the generated file; block forms untouched
+  - Write `docs/architecture/blocks.md`
+- File scope: `apps/worker/src/workflows/blocks/**`, `apps/worker/src/engine/blocks/**` (new), `apps/worker/src/workflow-definition/{block-registry,schema}.ts` (import sections), the `BLOCK_EXECUTORS` section of `workflows/agent.ts` only, `packages/contracts/src/{domain,workflow-graph,block-catalog.generated}.ts`, `scripts/gates/generate-block-catalog.ts`, root `package.json` (`gen:blocks` script), `docs/workflow-workspace/**`, `docs/architecture/blocks.md`; after stage 3b
+- Acceptance criteria:
+  - [ ] `pnpm --filter worker exec vitest run src/workflow-definition src/engine/blocks` passes
+  - [ ] `gen:blocks --check` fails after editing a manifest and passes after `pnpm run gen:blocks`
+  - [ ] `pnpm --filter ai-workflow-dashboard build` and `pnpm --filter ai-workflow-dashboard test` pass from a fresh checkout with no manual generation step
+  - [ ] The attached tier-pair table shows zero `engine/definition -> engine/blocks/*/execute` edges and the `definition <-> blocks` cycle row at 0
+  - [ ] `docs/architecture/blocks.md` walks through adding a block in one directory, and a reviewer follows it on a throwaway block that is then deleted
+- Notes: Executes D4 (blocks as self-describing modules with a pure manifest).
+
+### Stage 5: Split `agent.ts` into `engine/agent-workflow` and `engine/steps`
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-5
+- Depends on / Related: after stage 4; inside the first freeze
+- Freeze: first (workflows) - inside, closes when this stage lands on `main`
+- Suggested executor: opus, skeptic yes (the run state machine lives here), TDD no (pure move; the existing `workflows/` tests plus the two discovery tests are the net), delegation no
+- Summary: `agent.ts` splits into `engine/agent-workflow.ts` (the `"use workflow"` function, body unchanged), `engine/steps/*.ts`, and pure helpers; the six dispatchers import only from `engine/index.ts`.
+- Scope:
+  - Split `agent.ts` into `engine/agent-workflow.ts`, `engine/steps/*.ts`, pure helpers
+  - `engine/index.ts` exports `agentWorkflow`; the six dispatchers import from it
+  - Move `"use step"` files in the mixed service directories (per the D3 table) to `engine/steps/` in the same PR
+  - The six dispatcher import sites are `lib/dispatch.ts:27`, `lib/dispatch-trigger.ts:15`, `approvals/dispatch.ts:7`, `schedule-trigger/dispatch-schedule-trigger.ts:9`, `webhook-trigger/dispatch-webhook-trigger.ts:6`, `manual-dispatch/service.ts:16`
+  - Append `apps/worker/src/workflows` to the resurrected-paths list
+- File scope: `apps/worker/src/workflows/**`, `apps/worker/src/engine/**`, `"use step"` files under `approvals/`, `clarifications/`, `manual-dispatch/`, `webhook-trigger/`, `schedule-trigger/`, `pre-sandbox/`, `pre-pr-checks/`, `sandbox/`, `workflow-definition/` (move only), the six dispatcher import lines, `scripts/gates/no-resurrected-paths.json`; after stage 4; inside the first freeze
+- Acceptance criteria:
+  - [ ] `workflow-import-boundary.test.ts` and `step-registration-coverage.test.ts` pass
+  - [ ] `pnpm --filter worker exec vitest run src/engine` passes
+  - [ ] The reviewer confirms with `git diff --color-moved=dimmed-zebra` that the workflow body moved with zero logic edits, recording the before and after SHA of the function in the PR
+  - [ ] Preview deploy plus both non-dry canaries pass (as in stage 3)
+  - [ ] `rg -l '"use step"' apps/worker/src --glob '!src/engine/**'` is empty
+  - [ ] The tier-pair table shows `lib <-> workflows` and `sandbox <-> workflows` rows at 0
+- Notes: Executes D5 (the workflow body as its own module). Landing this stage on `main` closes the first freeze (D10, A8).
+
+### Stage 5b: Behavioural PR gate on the engine (D11)
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-5b
+- Depends on / Related: after stage 5 (sequential per the plan's Parallelism paragraph); requires AIW-316 merged; delivers the live-canary half of AIW-199 and the production-dispatch mode of AIW-196
+- Freeze: none
+- Suggested executor: sonnet, skeptic no, TDD no, delegation no
+- Summary: a CI job that, for any PR touching `apps/worker/src/engine/**`, `apps/worker/src/db/**` or `packages/**`, deploys a preview and runs both non-dry canaries, joining the `ci` aggregator's needs.
+- Scope:
+  - Add a CI job scoped to `apps/worker/src/engine/**`, `apps/worker/src/db/**`, `packages/**`
+  - The job deploys a preview and dispatches a run that executes at least one `"use step"` and one WDK webhook function, asserting the replay
+  - The job joins the `ci` aggregator's needs
+  - Until this stage exists, stages 3 and 5 ran the same two canaries manually as their own DoD; this job makes that automatic and required
+  - Static gates observe structure, not behaviour: this is the plan's only PR check that runs a real workflow against a real deployment
+  - Scope stays narrowed to the engine, the DB layer and the packages, per A12, so a docs or dashboard PR never pays for a preview deploy plus an LLM-backed run
+- File scope: `.github/workflows/ci.yml` (new job), `e2e/replay/preview-canary.ts`, `e2e/harness-profiles/preview-canary.ts` (CI-mode flags only), `docs/architecture/gates.md`
+- Acceptance criteria:
+  - [ ] A PR that edits one step body triggers the job and it passes
+  - [ ] A PR that only edits `docs/` does not trigger it, and `ci` still reports
+  - [ ] A PR that deliberately renames a step function without re-registering it fails the job with the "not registered" message visible in the log
+- Notes: Executes D11 and A12 (owner: yes, pay one preview deploy plus one LLM-backed run per PR on this narrowed scope). Requires AIW-316 merged so a canary can never dispatch against production.
+
+### Stage 6a: `config/` and `infra/` tiers
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-6a
+- Depends on / Related: after stage 5b; opens the second freeze
+- Freeze: second (lib, routes) - opens at the start of this stage
+- Suggested executor: sonnet, skeptic no, TDD no, delegation yes (import sweep)
+- Summary: `config/env.ts` becomes the single importer of the worker's `env.ts`; infra modules named in the D3 table move to `infra/`; every other file gets its `env` import replaced by a parameter or a `config` accessor.
+- Scope:
+  - Move `env` access behind `config/env.ts` as the single importer of `apps/worker/env.ts`
+  - Move the infra modules named in the D3 table (logger, telemetry, llm-provider, llm, github-webhook-sig, webhook-crypto, unique-violation, vcs-urls) to `infra/`
+  - Replace every other `env` import with a parameter or a `config` accessor
+  - Per D3, allowed edges here are `config -> nothing` and `infra -> nothing`: neither tier may import anything else in the worker
+  - This stage opens the second freeze; per A8 the window is expected to last two to four working days if 6a, 6b and 6c run back to back
+- File scope: `apps/worker/src/config/**`, `apps/worker/src/infra/**`, the infra files listed in D3, every file whose only change is an `env` import line; after stage 5b; inside the second freeze
+- Acceptance criteria:
+  - [ ] `rg -l 'from ".*env\.js"' apps/worker/src --glob '!src/config/**'` is empty
+  - [ ] `pnpm typecheck` passes
+  - [ ] `pnpm --filter worker exec vitest run src/lib src/config src/infra` passes
+  - [ ] The tier-pair table is attached and smaller
+- Notes: Executes D3 (worker tiers, allowed edges) and opens the second freeze (D10, A8: `apps/worker/src/lib` and `apps/worker/src/routes` frozen until stage 6c lands).
+
+### Stage 6b: `services/` clusters
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-6b
+- Depends on / Related: after stage 6a; inside the second freeze
+- Freeze: second (lib, routes) - inside
+- Suggested executor: sonnet, skeptic no, TDD no, delegation yes (cluster moves from the audit's inventory)
+- Summary: the `lib/` clusters and the mixed service directories of D3 move into `services/<cluster>/` with an `index.ts` per cluster as its interface; store and schema files stay in place for stage 7.
+- Scope:
+  - Move the `lib/` clusters (dispatch, run-lifecycle, tickets, publication, overview, auth, slack) into `services/<cluster>/` with an `index.ts` interface each
+  - Move the mixed service directories (approvals, clarifications, manual-dispatch, dispatch-queue, webhook-trigger, schedule-trigger, system-health, repository-discovery), non-store and non-step files only
+  - Leave store and schema files in place for stage 7
+  - Append `apps/worker/src/lib` and each moved directory to the resurrected-paths list
+- File scope: `apps/worker/src/lib/**` (not moved in 6a), `apps/worker/src/services/**`, the eight mixed service directories (non-store, non-step files), `apps/worker/src/deployment-identity.ts`, `scripts/gates/no-resurrected-paths.json`; after stage 6a; inside the second freeze
+- Acceptance criteria:
+  - [ ] `apps/worker/src/lib` no longer exists, and `no-resurrected-paths` lists it
+  - [ ] `pnpm typecheck` passes
+  - [ ] `pnpm --filter worker exec vitest run src/services` passes
+  - [ ] The tier-pair table is attached and smaller
+  - [ ] `docs/architecture/overview.md` lists the clusters with one-sentence contracts
+- Notes: Executes D3 (services tier); the mixed-directory split rule (store/schema to db in stage 7, `"use step"` files to engine in stage 5, the rest here) comes from the D3 table.
+
+### Stage 6c: Server surface becomes thin
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-6c
+- Depends on / Related: after stage 6b; closes the second freeze; AIW-293 trigger-scope tasks (AIW-295, AIW-298) land only after this stage
+- Freeze: second (lib, routes) - closes when this stage lands on `main`
+- Suggested executor: opus (permissions and webhook verification live here), skeptic yes (webhook auth, rate limit, revocation), TDD yes for the extracted services (existing route tests become service tests), delegation no
+- Summary: the three audited handlers and the MCP tools move their branching into services; no route or MCP tool imports `db/client` or `env`; every POST validates with a `@shared/contracts` schema.
+- Scope:
+  - Move branching out of the three audited handlers (`webhooks/jira.post.ts`, `cron/poll.get.ts`, `webhooks/custom/[endpointId].post.ts`) and the MCP tools, into services
+  - No route or MCP tool imports `db/client` or `env`
+  - Every POST validates with a `@shared/contracts` schema (fixes `invites.post.ts` and `webhooks/resend.post.ts`)
+  - `routes/` keeps its path and name (Nitro scans it)
+  - New service files under `apps/worker/src/services/{triggers,polling,custom-webhooks,mcp}/`
+- File scope: `apps/worker/src/routes/**`, `apps/worker/src/mcp/**`, `apps/worker/src/middleware/**`, `apps/worker/src/plugins/**`, `apps/worker/src/auth*.ts`, new files under `apps/worker/src/services/{triggers,polling,custom-webhooks,mcp}/`; after stage 6b; inside the second freeze
+- Acceptance criteria:
+  - [ ] `rg -l 'getDb\(|from ".*db/client' apps/worker/src/routes apps/worker/src/mcp` is empty
+  - [ ] `rg -l 'readBody<' apps/worker/src/routes` is empty
+  - [ ] `pnpm --filter worker exec vitest run src/routes src/mcp src/services` passes
+  - [ ] `workflow-import-boundary.test.ts` passes
+  - [ ] `pnpm --filter worker build:ci` passes
+  - [ ] The 5b behavioural job passes on the PR
+- Notes: Executes D3 (app tier, thin server surface). Landing this stage on `main` closes the second freeze (D10, A8).
+
+### Stage 7: DB repositories and fences (D7)
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-7
+- Depends on / Related: after stage 6c; waits for AIW-335 (production driver becomes `node-postgres`) to merge; AIW-293 memory tasks (AIW-303) land only after this stage
+- Freeze: none
+- Suggested executor: sonnet, with opus for the auth repository; skeptic yes (auth writes move behind a repository); TDD yes (gates first; the AIW-335 production-driver BEGIN/ROLLBACK contract test runs against the repository layer; repository functions covered by moving the existing `db/queries` tests); delegation yes (call-site sweep)
+- Summary: repositories per domain own the operations on their tables, starting with the three hottest (`workflowRuns`, `workflowDefinitions`, `activeRuns`); transactions become legal only inside `db/repositories/*`; the `db/client` fence count ratchets down from 357.
+- Scope:
+  - Add `db/repositories/{runs,definitions,active-runs,auth}.ts`; move the auth writes behind the repository, keeping their transactions there
+  - Add `scripts/gates/transactions-in-repositories.mjs` (fails on `.transaction(` outside `db/repositories`)
+  - Split `db/schema/<domain>.ts`, re-exported from `db/schema.ts`
+  - Move `store.ts` and `*-schema.ts` files from the mixed directories under `db/`
+  - Add `scripts/gates/db-client-fence.mjs` (baseline 357, ratchet down)
+  - Write `docs/architecture/data-model.md` with the 62-table ownership table
+- File scope: `apps/worker/src/db/**`, `apps/worker/src/services/auth/**` (call sites), `store.ts`/`*-schema.ts` files of the mixed directories, `scripts/gates/{transactions-in-repositories,db-client-fence}.mjs`, `docs/architecture/data-model.md`; call-site migration touches `services/**` and `engine/**`; after stage 6c and after AIW-335
+- Acceptance criteria:
+  - [ ] `pnpm --filter worker run db:generate` produces no new migration
+  - [ ] All `*-migration.test.ts` pass
+  - [ ] `transactions-in-repositories` gate exits 0
+  - [ ] The AIW-335 BEGIN/ROLLBACK contract test passes through `db/repositories/auth.ts`
+  - [ ] The `db-client-fence` baseline drops below 300 in this stage
+  - [ ] The 5b behavioural job passes
+- Notes: Executes D7 (repositories per domain, transactions only inside them). If AIW-335 is cancelled, per A13, this stage reverts to the pre-revision rule: no transactions anywhere, four auth sites rewritten as single statements.
+
+### Stage 8a: `packages/prompts`
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-8a
+- Depends on / Related: after stage 7; disjoint from stages 8b, 8c, 8d
+- Freeze: none
+- Suggested executor: opus, skeptic yes (what a prompt resolves to is product behaviour), TDD yes (the 14 dashboard test files and the worker prompt tests move first and must stay green), delegation no
+- Summary: slot, reference, variable, composition and builtin-default logic move into one package; the dashboard's separate `lib/prompt-library` copy is deleted; the drift gate moves with it.
+- Scope:
+  - Move prompt logic from `packages/contracts/prompt-*.ts`, `workflow-definition/prompt-*.ts`, `lib/prompts.ts`, `engine/steps/prompt*.ts` (pure parts) and `apps/dashboard/lib/prompt-library/*` into `packages/prompts`
+  - Delete the dashboard copy; its 14 test files move with the code
+  - Move the builtin drift gate with it
+- File scope: `packages/prompts/**`, `packages/contracts/src/prompt-*.ts`, `apps/worker/src/engine/prompt-library/**`, `apps/worker/src/engine/definition/prompt-*.ts`, `apps/worker/src/engine/steps/prompt*.ts`, `apps/dashboard/lib/prompt-library/**`, `apps/dashboard/components/cockpit/prompt-editor/**` (imports only); after stage 7
+- Acceptance criteria:
+  - [ ] `apps/dashboard/lib/prompt-library` no longer exists, and it is on the resurrected-paths list
+  - [ ] `pnpm --filter @shared/prompts test` passes
+  - [ ] The builtin drift gate passes
+  - [ ] A fixture prompt resolves byte-identically through worker and dashboard entry points (parity test)
+  - [ ] The 5b behavioural job passes
+- Notes: Executes D6 (one owner per concept, one drift test each) for prompt composition.
+
+### Stage 8b: `packages/harness`, model catalog (D6, A6)
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-8b
+- Depends on / Related: after stage 7; disjoint from stages 8a, 8c, 8d
+- Freeze: none
+- Suggested executor: sonnet, skeptic yes (which models a user may pick; the gate receives ADR-006's table and asks about every model the union would newly expose), TDD yes (drift test first; a test asserts `selectable()` equals the pre-change picker list per provider), delegation no
+- Summary: `model-catalog.ts` owns model ids with `recognised` (union, for parsing) and `selectable(providerContract)` (intersection, for pickers); the dashboard, the manifest, and the capability catalog derive from it.
+- Scope:
+  - Add `packages/harness/src/model-catalog.ts` with `recognised` and `selectable()` per D6
+  - First commit is the four-column comparison table of today's four model lists, committed as `docs/adr/ADR-006-model-catalog.md`
+  - `manifest.ts`, `capability-catalog.ts`, `workflow-definition/models.ts` and `apps/dashboard/lib/harness-profiles/*` derive from the owner
+  - Add a drift test that greps the repo for model-id literals outside the owner
+  - This is a NEW seam: today four separate lists exist and none of them is disjoint from the others
+  - The four lists are not four copies of one fact, so unifying them naively could widen what a user may select (A6); any newly exposed model is a deliberate one-line change to `selectable()`, made after this stage
+- File scope: `packages/harness/**`, `packages/contracts/src/harness-profiles.ts`, `apps/worker/src/engine/harness-profiles/**` (non-skill files), `apps/worker/src/engine/definition/models.ts`, `apps/dashboard/lib/harness-profiles/**`, `docs/adr/ADR-006-model-catalog.md`; after stage 7; disjoint from stages 8a, 8c, 8d
+- Acceptance criteria:
+  - [ ] `rg -n 'claude-(opus|sonnet|haiku|fable)-|gpt-5' apps packages --glob '!**/model-catalog.ts' --glob '!*.test.ts' --glob '!docs/**'` is empty
+  - [ ] `pnpm run test:e2e:harness-profiles:dry` passes
+  - [ ] The dashboard picker snapshot test is unchanged
+- Notes: Executes D6 and A6 (owner: intersection for pickers, union for parsers; no model becomes newly selectable without a deliberate one-line change to `selectable()`).
+
+### Stage 8c: `packages/costs`
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-8c
+- Depends on / Related: after stage 7; disjoint from stages 8a, 8b, 8d
+- Freeze: none
+- Suggested executor: sonnet, skeptic no, TDD yes (parity test first), delegation no
+- Summary: one `costForUsage(provider, usage)` function owns price table shape and usage aggregation, used by Slack formatting, run budget and the dashboard cost screen, with a parity test for the Claude and Codex paths.
+- Scope:
+  - Add `packages/costs/**` with `costForUsage(provider, usage)`
+  - Move price table shape and usage aggregation logic from `sandbox/usage.ts`, `sandbox/agents/pricing.ts`, `run-budget.ts`
+  - Add a parity test for Claude `cost_usd` and Codex token pricing
+  - Satisfies D2 (a package needs two consumers): the worker's sandbox, run-budget and Slack formatting, and the dashboard's cost screen
+  - The observed behaviour this seam guarantees per the Seams table: one number for one usage record, regardless of provider
+- File scope: `packages/costs/**`, `apps/worker/src/engine/sandbox/{usage,agents/pricing}.ts`, `apps/worker/src/engine/run-budget.ts`, `apps/dashboard/app/cost-data.tsx`, `apps/dashboard/app/(cockpit)/cost/**`; after stage 7; disjoint from stages 8a, 8b, 8d
+- Acceptance criteria:
+  - [ ] `pnpm --filter @shared/costs test` passes
+  - [ ] A recorded usage fixture yields the same cost in worker and dashboard
+  - [ ] Slack message snapshot tests are unchanged
+- Notes: Executes D6 (one owner per concept) for the cost function.
+
+### Stage 8d: `packages/skills`
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-8d
+- Depends on / Related: after stage 7; disjoint from stages 8a, 8b, 8c
+- Freeze: none
+- Suggested executor: opus (two discovery paths become one interface), skeptic no, TDD yes (conformance test run against both adapters; a malformed manifest fails identically from both), delegation no
+- Summary: manifest schema, lock-file format, validator and one `SkillSource` interface move into one package; the GitHub and local adapters satisfy it; the drift gate covers both sources.
+- Scope:
+  - Move manifest schema, lock-file format, validator from `harness-profiles/{github-skills,configured-github-skills,local-skills,skill-artifact}.ts` and `scripts/validate-local-skills.ts` into `packages/skills`
+  - Define one `SkillSource` interface; the GitHub and local adapters satisfy it
+  - The drift gate covers both sources
+  - Write `docs/architecture/skills.md` stating the product-skill vs Claude-Code-skill distinction and why `skills/` sits at the repository root
+  - Satisfies D2 (a package needs two consumers): the worker's harness-profiles runtime and the dashboard's skill picker and validator both read through `SkillSource`
+- File scope: `packages/skills/**`, `apps/worker/src/engine/harness-profiles/*skill*.ts`, `apps/worker/scripts/validate-local-skills.ts`, `apps/worker/skills-lock.json`, `docs/architecture/skills.md`; after stage 7; disjoint from stages 8a, 8b, 8c
+- Acceptance criteria:
+  - [ ] `pnpm --filter worker validate:local-skills` passes
+  - [ ] The conformance test passes for both adapters
+  - [ ] A GitHub-sourced skill with a hash mismatch fails the drift gate (fixture)
+- Notes: Executes D6 (one owner per concept) for the skill source; folds in pre-mortem finding #8 (skills should not stay folded into harness).
+
+### Stage 9: Dashboard hygiene: one API client, block form split
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-9
+- Depends on / Related: after stages 8a, 8b, 8c, 8d
+- Freeze: none
+- Suggested executor: sonnet, skeptic no, TDD no (119 existing tests, the two 2000-line render tests are the net), delegation yes (case-by-case split)
+- Summary: one API client in `lib/api/client.ts` with typed endpoints from contracts replaces 29 direct `fetch(` sites; `config-fields.tsx` splits mechanically into one file per block type.
+- Scope:
+  - Add `lib/api/client.ts` with typed endpoints from `@shared/contracts`
+  - Route the 29 direct `fetch(` sites through the client
+  - Split `config-fields.tsx` into `flow-editor/blocks/<type>.tsx`, one file per `case` (mechanical)
+  - The existing 119 dashboard tests, including the two 2000-line render tests, are the regression net; no new tests are scoped for this stage
+- File scope: `apps/dashboard/lib/api/**`, `apps/dashboard/components/**`, `apps/dashboard/app/api/**`, `apps/dashboard/AGENTS.md`; after stages 8a, 8b, 8c, 8d
+- Acceptance criteria:
+  - [ ] `rg -l 'fetch\(' apps/dashboard/components apps/dashboard/app --glob '!lib/api/**' --glob '!*.test.*'` is empty
+  - [ ] `pnpm --filter ai-workflow-dashboard test` passes
+  - [ ] No file under `components/` exceeds 1000 lines
+- Notes: The docs-routing seam (D9) gains this rule in dashboard `AGENTS.md`.
+
+### Stage 10: Agent configuration alignment
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-10
+- Depends on / Related: after stage 9
+- Freeze: none
+- Suggested executor: sonnet, skeptic yes (agent behaviour), TDD no, delegation no
+- Summary: `verify:changed` runs as a `Stop` hook, the gate ladder and release procedures become skills linking to docs, and a proof exists that per-app and path-scoped instructions actually load.
+- Scope:
+  - Wire `verify:changed` as a `Stop` hook in `.claude/settings.json`
+  - Turn the gate ladder and release procedures into skills that link to docs
+  - Trim `AGENTS.md` files to their final form
+  - Prove per-app and path-scoped instructions load, via a `/context` transcript
+  - Per D9, procedures (the gate ladder, the release process) become skills, not docs; docs stay reference material
+- File scope: `.claude/settings.json`, `.claude/rules/**`, `.claude/skills/**`, `AGENTS.md`, `apps/*/AGENTS.md`; after stage 9
+- Acceptance criteria:
+  - [ ] A `/context` transcript from a session started at the repo root, editing one file under `apps/worker/src/services/auth`, shows `apps/worker/AGENTS.md` and one `.claude/rules/*.md` loaded
+  - [ ] Root `AGENTS.md` is under 200 lines
+  - [ ] The hook fires on a test push in a throwaway branch
+- Notes: Executes D9 (docs routing seam) for the agent-facing half.
+
+### Stage 11: Ratchet to zero: delete every baseline
+- Jira type: Task
+- Jira key: (fill after creation)
+- Parent: the epic above
+- Labels: architecture, restructure, stage-11
+- Depends on / Related: after stage 10
+- Freeze: none
+- Suggested executor: sonnet, skeptic no, TDD no, delegation yes (sweep)
+- Summary: remaining boundary violations, knip findings and the `db/client` fence count are driven to zero; every baseline file is deleted and the rules become hard, since ADR-001 gives every directory a tier.
+- Scope:
+  - Drive remaining boundary violations, knip findings and `db/client` fence count to zero
+  - Delete all `*.baseline.json` files
+- File scope: any file a baseline names; `scripts/gates/*.baseline.json`; after stage 10
+- Acceptance criteria:
+  - [ ] All `*.baseline.json` files are deleted
+  - [ ] `pnpm run verify:changed` and CI are green with hard rules (no baseline exceptions)
+  - [ ] `docs/architecture/gates.md` lists the ladder with no baseline column
+- Notes: Terminates because every directory already has a tier (ADR-001); this stage has no open-ended scope left to ratchet.
+
+## Creation checklist
+
+1. Create the epic first ("Architecture restructure 2026-09: tiers, packages, gates, docs"), labelled `architecture`, `restructure`.
+2. Create the 19 tickets in stage order (0, 1, 2, 3, 3b, 4, 5, 5b, 6a, 6b, 6c, 7, 8a, 8b, 8c, 8d, 9, 10, 11), setting Parent to the epic on each.
+3. Paste each ticket's Summary, Scope and Notes into the description, and its Acceptance criteria as the checkbox list (or the project's Acceptance Criteria field, if it has one).
+4. Add the Labels listed per ticket, including the `stage-N` label.
+5. Link each "Depends on / Related" key with the matching Jira issue-link type (`blocks` / `is blocked by`, `relates to`).
+6. Write every created key back into this file's "Jira key" fields.
+7. Write every created key into the plan's stage table (`2026-09-09-architecture-restructure.md`) as a new "Jira" column.

--- a/docs/plans/2026-09-09-architecture-restructure.md
+++ b/docs/plans/2026-09-09-architecture-restructure.md
@@ -1,0 +1,520 @@
+# Architecture restructure: layers, packages, gates, docs
+
+Status: APPROVED by the owner on 2026-09-09, revision 4 (skeptic pre-mortem, roadmap and backlog fit, v1 retirement folded in as stage 3b with its own pre-mortem). Owner answered Q1-Q8 and reversed Q4 the same day. Ready for `/opus-orchestration`. Not started. Jira tickets per stage: see `2026-09-09-architecture-restructure-tickets.md` beside this file.
+Start SHA: `687a6bbb040b5a4baa1d8018cfe1a8d9ebb4db43` (main, 2026-09-09).
+Evidence base:
+[../research/2026-09-09-architecture-audit.md](../research/2026-09-09-architecture-audit.md)
+(every number and `file:line` below is cited there),
+[../research/2026-09-09-agent-navigable-codebase.md](../research/2026-09-09-agent-navigable-codebase.md),
+[../research/2026-09-09-monorepo-boundary-enforcement.md](../research/2026-09-09-monorepo-boundary-enforcement.md),
+[../research/2026-09-09-roadmap-backlog-fit.md](../research/2026-09-09-roadmap-backlog-fit.md)
+(the 27 Aug roadmap and the 100 open AIW issues against this plan).
+
+Execution: `/opus-orchestration` takes the stage table below as input. This
+plan writes no production code.
+
+## Problem
+
+An engineer or an agent who wants to add a feature today cannot answer "where
+does this go, what may it import, and what proves I broke nothing" from the
+repository. Adding one block type touches 24 files in 8 directories. The
+worker's 28 top-level directories have 28 two-way import cycles. Four concepts
+(prompts, skills, harness profiles, costs) each have two to four competing
+definitions, and the model catalog alone lives in four files. Two definition
+schema versions are live, with two graph walkers and about thirty
+`schemaVersion` branches, although nothing creates a v1 definition any more.
+The 153
+documents include about 110 dated journals and no navigable path to any
+decision. Nothing blocks a regression at merge time: `main` has no branch
+protection, the worker has no linter, no tool checks import boundaries, and
+357 files outside `db/` write to the database directly.
+
+## Solution
+
+After this plan, the repository has fenced tiers inside the worker (`app`,
+`services`, `engine`, `adapters`, `db`, `config`, `infra`, `testing`), seven
+pure workspace packages under `packages/` (`contracts`, `conditions`,
+`prompts`, `harness`, `skills`, `costs`, later `workflow-graph`), one owner
+file per concept with a drift test proving it, a block model where one
+directory per block generates registry, executor map and catalog, and a gate
+ladder (boundaries, cycles, unused code, lint, formatting, generated files,
+dependency consistency, resurrected paths, package contracts, doc status) that
+runs in `verify:changed` and in a CI job that `main` requires, plus a
+behavioural check (preview deploy and the two existing canaries) on changes to
+the engine and the packages. Documentation is an index plus `architecture/`,
+`adr/`, `product/`, `runbooks/`, `research/`, `archive/`, every current file
+carrying a status and a last-verified date, with per-app `AGENTS.md` files
+bridged to `CLAUDE.md`, so an agent starting in any directory loads only what
+that directory needs. Behaviour of v2 runs does not change in any stage; the
+one deliberate behaviour change is stage 3b, which retires schema v1 (D12,
+A11).
+
+## User stories
+
+1. As an engineer adding a block, I want to create one directory and have the
+   registry, executor map, params schema map, catalog and dashboard palette
+   pick it up, so that a block is one PR in one place.
+2. As an engineer adding a route or an MCP tool, I want a rule that tells me it
+   may call a service and nothing else, and a gate that fails the PR if I break
+   it, so that the server surface stops accumulating domain logic.
+3. As an engineer changing the model list, I want one file to edit and a test
+   that fails if any other file still lists a model id, so that the dashboard,
+   the harness runtime and the definition validator agree.
+4. As a reviewer, I want the PR check to be required on `main`, to include
+   boundaries, cycles, unused code and lint, and to run a real workflow on a
+   preview when the engine changed, so that green means something.
+5. As an agent starting a session, I want a root `AGENTS.md` under 200 lines
+   that routes me to the one current document per topic and keeps the four
+   runtime gotchas that break production, and a per-app `AGENTS.md` that loads
+   when I work in that app, so that I am neither flooded nor misled.
+6. As a maintainer, I want every decision recorded as an ADR reachable in two
+   hops from `README.md`, so that "why is v1 still live" has an answer.
+7. As a dashboard engineer, I want prompt composition, model capabilities,
+   skill manifests and cost math to come from packages shared with the
+   worker, so that I stop re-implementing worker logic in `apps/dashboard/lib`.
+8. As an operator, I want `SETUP.md` and the `init-*` skills to agree, so that
+   whichever one I read gives the same env var names and constraints.
+9. As an engineer or an agent authoring a workflow, I want exactly one
+   definition schema to exist in code, storage rules and the editor, so that
+   every block, validator, tool description and document describes one shape.
+
+## Implementation decisions
+
+Vocabulary: module, interface, seam, adapter, depth, leverage, locality, as in
+the codebase-design skill.
+
+**D1. Enforcement before structure, keyed so renames cannot hide
+regressions.** The first code stage installs dependency-cruiser (tier rules
+plus `no-circular`), knip and a minimal lint with today's violations recorded
+as a baseline. The boundary baseline is keyed by tier pair
+(`services->app: 4`), never by file path, so moving 140 files does not reset
+it; every stage that regenerates a baseline attaches the before and after
+tier-pair table as evidence, and a stage's "baseline smaller" claim is the
+difference between those two tables.
+
+**D2. A package needs two consumers.** `contracts`, `conditions`, `prompts`,
+`harness`, `skills`, `costs` and `workflow-graph` are used by both apps and
+are pure, so they become `packages/*`. Each `package.json` carries a
+`description` that states what the package may and may not do; a gate fails
+when one is missing. Each package exposes a curated `exports` map, one entry
+per public module, not one per file. The engine, the adapters, the services
+and the DB layer have one consumer (the worker) and stay directories inside
+`apps/worker/src`, fenced by dependency rules (Assumption A2).
+
+**D3. Worker tiers, allowed edges, and the complete mapping of today's
+directories.** Allowed edges, top to bottom:
+
+```
+app        -> services, engine (the workflow entrypoint only), packages, config
+services   -> engine, adapters, db, packages, infra
+engine     -> adapters, db, packages, infra
+adapters   -> packages, infra
+db         -> packages/contracts, infra
+config     -> nothing
+infra      -> nothing
+testing    -> anything; imported by nothing outside tests
+packages/* -> packages/contracts (workflow-graph may also use conditions;
+              harness may use skills)
+```
+
+No upward edge, no sideways edge except those listed. `env` is imported only
+by `config`. `db/client` is imported only by `db`. Routes and MCP tools never
+call `getDb()`. Every one of today's 28 directories and 8 root files has
+exactly one destination; this table is ADR-001 and the dependency-cruiser
+rules reference it:
+
+| Today (`apps/worker/src/`) | Tier | Note |
+|---|---|---|
+| `routes/`, `middleware/`, `plugins/`, `mcp/` (tools, auth, catalog), `auth.ts`, `auth-instance.ts`, `nitro.d.ts` | app | server surface; `routes/` keeps its name and path because Nitro scans it |
+| `lib/` | split by file | `env` accessors -> config; logger, telemetry, llm-provider, llm, github-webhook-sig, webhook-crypto, unique-violation, vcs-urls -> infra; everything else -> services (dispatch, run-lifecycle, tickets, publication, overview, auth, slack) |
+| `approvals/`, `clarifications/`, `manual-dispatch/`, `dispatch-queue/`, `webhook-trigger/`, `schedule-trigger/`, `system-health/`, `repository-discovery/` | services | mixed directories split by file: `*-schema.ts` and `store.ts` -> db (stage 7), files carrying `"use step"` -> engine/steps (stage 5), the rest -> services |
+| `workflows/` | engine | |
+| `workflow-definition/` | engine (`engine/definition/`) | `store.ts` -> db/repositories/definitions in stage 7; pure schema, validation, bindings, scheduler, interpreter -> `packages/workflow-graph` in stage 12 |
+| `sandbox/`, `pre-sandbox/`, `pre-pr-checks/`, `memory/`, `run-observability/`, `run-analysis/`, `post-pr-gate/` | engine | |
+| `harness-profiles/`, `prompt-library/` | engine (runtime) | `store.ts` -> db in stage 7; pure parts -> `packages/harness`, `packages/skills`, `packages/prompts` in stage 8 |
+| `adapters/vcs`, `adapters/issue-tracker`, `adapters/messaging` | adapters | |
+| `adapters/run-registry` | db | one implementation, it is a repository |
+| `db/` | db | |
+| `deployment-identity.ts` | services (`services/system`) | |
+| `test-support/`, `mcp-dogfood/`, `preview-harness-canary.test.ts`, `preview-replay-canary.test.ts` | testing | |
+
+**D4. Blocks are self-describing modules with a pure manifest.** One directory
+per block under `engine/blocks/<type>/` with two files: `manifest.ts` (type,
+params schema, contract, ui hints; no runtime imports) and `execute.ts` (the
+executor). A generator writes `packages/contracts/src/block-catalog.generated.ts`
+(type union plus `BLOCK_TYPE_SPECS`, from manifests only),
+`engine/definition/params.generated.ts` (params schema map, from manifests
+only) and `engine/blocks/executors.generated.ts` (executor map, from
+`execute.ts` files). Definition validation therefore never imports an
+executor, which is what actually removes the `workflow-definition <-> workflows`
+cycle rather than renaming it. The existing catalog-sync test becomes
+"generated files are current" (`gen:blocks --check`), and the HTML mock stops
+being a fixture.
+
+**D5. The workflow body is a module of its own.** `agent.ts` splits into
+`engine/agent-workflow.ts` (the `"use workflow"` function, body unchanged),
+`engine/steps/*.ts` (the `"use step"` functions grouped as the file's own
+section comments already group them), `engine/blocks/executors.generated.ts`,
+and pure helpers. `engine/index.ts` is the only export the six dispatchers
+import. The WDK discovery test and the step registration coverage test are the
+guard on every move, and a real run on a preview deployment is the DoD of
+every stage that moves engine files (D11).
+
+**D6. One owner per concept, one drift test each.**
+`packages/harness/src/model-catalog.ts` owns model ids with two derived
+views: `recognised` (the union of today's four lists, for parsing stored
+data) and `selectable(providerContract)` (the intersection of what the
+provider contract, the capability catalog and the dashboard offered before,
+for pickers). `manifest.ts`, `capability-catalog.ts`,
+`workflow-definition/models.ts` and the dashboard derive from it, and a test
+greps the repo for model-id literals outside the owner. `packages/prompts`
+owns slot, reference and variable composition; the dashboard's
+`lib/prompt-library` copy is deleted and its 14 test files move with the
+code. `packages/skills` owns the skill manifest schema, the lock-file format,
+the validator, and one `SkillSource` interface that the GitHub and local
+adapters satisfy. `packages/costs` owns one `costForUsage(provider, usage)`
+function with a parity test for the Claude and Codex paths.
+
+**D7. Repositories per domain, and transactions only inside them.**
+`db/repositories/<domain>.ts` exports the allowed operations on the tables
+that domain owns, starting with the three hottest tables (`workflowRuns`,
+`workflowDefinitions`, `activeRuns`). A gate counts `db/client` imports
+outside `db/` and ratchets from 357 down. Transactions: AIW-335 ports the
+production `getDb()` from `neon-http` (no transactions) to
+`drizzle-orm/node-postgres` with a real BEGIN/ROLLBACK contract test, because
+Better Auth 1.7 needs adapter transactions. Once that lands, a transaction is
+legal only inside `db/repositories/*`, a gate fails `.transaction(` anywhere
+else, and the repository layer is the only place that knows the driver.
+Until AIW-335 lands, the production driver has no transactions and the four
+`lib/auth` sites remain the known exception; stage 7 runs after AIW-335.
+
+**D8. Gates are dependency-free Node scripts** under `scripts/gates/`, each
+with a header (why, exit condition), a baseline JSON where a ratchet is
+needed, a test under `scripts/ci/`, and one entry each in `verify:changed`
+and `ci.yml`. Third-party tools (dependency-cruiser, knip, oxlint) are invoked
+by those scripts so the ladder has one shape. Two gates exist only because of
+this restructure: `no-resurrected-paths` (fails when a path a completed stage
+deleted reappears, fed by a list the stage appends to) and
+`package-contracts` (every `packages/*/package.json` has a `description`).
+
+**D9. Documentation taxonomy with currency, not just reachability.**
+`docs/index.md` is the only list of current documents. `docs/architecture/`
+(overview, blocks, workflow-definition rewritten for v2, data-model with
+table ownership, gates), `docs/adr/` (MADR, README says when to write one),
+`docs/product/` (SPEC, user stories, roadmap), `docs/runbooks/`,
+`docs/research/`, `docs/archive/`. Every file outside `archive/` and
+`research/` carries `Status:` from a fixed enum (`current`, `draft`,
+`superseded-by <path>`) and `Last-verified: YYYY-MM-DD`; the docs gate fails
+on a missing header, on a `current` file older than 90 days, and on a current
+file unreachable in two hops from `README.md` or `AGENTS.md`. Root `AGENTS.md`
+becomes a routing table under 200 lines and keeps, verbatim, the four gotchas
+that break production (neon-http has no transactions, WDK discovers steps by
+content, `build` runs migrations, the 300 s invocation ceiling). Per-app
+instructions are `apps/worker/AGENTS.md` and `apps/dashboard/AGENTS.md`, each
+bridged by a one-line `CLAUDE.md` importing it, because this repo also runs
+Codex sessions and the agents.md convention is "nearest file wins" while
+Claude Code reads `CLAUDE.md`. `.claude/rules/*.md` with `paths:` frontmatter
+carry Claude-only path-scoped gotchas mined from `learnings.md`. Procedures
+(gate ladder, release) are skills, not docs. `SETUP.md` is the fact
+reference; the `init-*` skills link to its sections and never restate a
+constraint.
+
+**D10. Freezes are tied to events, not dates, and cover what moves.** No PR
+touching `apps/worker/src/workflows` merges between the start of stage 3b and
+stage 5 landing on `main`; no PR touching `apps/worker/src/lib` or
+`apps/worker/src/routes` merges between the start of 6a and 6c landing on
+`main`. The `no-resurrected-paths` gate catches the rebase failure mode where
+git recreates a moved file under its old path.
+
+**D12. One schema version.** Stage 3b retires definition schema v1 for
+everything that runs, deploys or is authored; stored history stays readable.
+Deleted: the v1 graph walker (`executeGraph` in
+`workflow-definition/interpreter.ts`; `buildRuntimeGraph`, `executionError`,
+`formatExecutionErrorForUser` and `createWorkflowExecutionErrorState` stay
+because the v2 walker uses them), every `schemaVersion === 1` branch and every
+now-constant `schemaVersion === 2` guard in the workflow body, the steps, the
+blocks, dispatch, definition loading, the prompt drift gates and the store,
+`isV2OnlyBlockType`, the v1-to-v2 converter and migration (worker module,
+migrate route, dashboard drawer), the three singular shim routes, and the
+dashboard's `schemaVersion = 1` defaults and branches. Replaced, not deleted:
+the fresh-install default. `buildDefault` in `definition-step.ts`, the clone
+and seed fallbacks in `workflow-definitions.post.ts` and the two drift gates
+take `defaultWorkflowDefinitionV2` instead of the v1 default, so a deployment
+with no deployed definition runs the v2 default through the v2 walker; the v1
+default is deleted only after those five consumers moved. Kept: the runtime
+plan shape (`WorkflowDefinitionNode` with `params`, `LoadedWorkflowPlan`,
+`toLegacyRuntimeShape`) is an internal representation the v2 walker already
+consumes, not a schema version; 3b renames the function to `toRuntimeShape`
+and changes nothing else about it. Types: the runnable `WorkflowDefinition`
+narrows to v2 in contracts; `WorkflowDefinitionV1` stays in contracts as a
+read-only stored type returned by exactly one path, the version-history read
+in `store.ts:149`, whose result becomes
+`{ kind: "v2", definition } | { kind: "legacy-v1", raw }`; dispatch, deploy,
+rollback and MCP authoring accept only the v2 arm. History: a v1 row stays
+listed with its badge, the editor removes its Restore action, and the API
+refuses rollback to it with 409 and a message naming the retired schema; an
+archived v1 definition stays listed as archived;
+`workflow_run_observations.definition_schema_version` keeps its historical 1s
+and its check constraint, so no migration ships. Harness-profile manifests
+carry their own `schemaVersion` 1|2 and are not touched. MCP:
+`workflows.save_draft` accepts v1 today; after 3b it returns VALIDATION_FAILED
+with an issue naming the retired schema, and the tool description gains one
+sentence naming 2 as the only accepted value, which is what changes the
+contract hash; the dashboard clipboard rejects a v1 payload with the same
+message. Enforcement: the DoD grep is a permanent gate,
+`scripts/gates/single-schema-version.mjs`, registered in `verify:changed` and
+`ci.yml` in the same PR, so a rebase of an in-flight dispatch or route branch
+that reinstates a version branch fails CI; the deleted route files join the
+resurrected-paths list. Preconditions, recorded in ADR-003: production holds
+zero deployed and zero draft v1 definitions across its 9 non-archived
+definitions (`workflows.get_graph`, 2026-09-09), the Arthur tenant is out of
+support, and the scenario harness (A14) is green before and after. The counts
+the MCP surface cannot see (archived definitions, history rows) are measured
+by SQL on production at the start of 3b and written into ADR-003; they change
+what users see in history, not the design.
+
+**D11. A behavioural gate on the engine.** Static gates observe structure,
+not behaviour. Stage 5b makes the existing preview canaries
+(`e2e/replay/preview-canary.ts`, `e2e/harness-profiles/preview-canary.ts`) a
+required PR check for any change under `apps/worker/src/engine/**`,
+`apps/worker/src/db/**` or `packages/**`: deploy a preview, dispatch one run
+that executes at least one `"use step"` and one WDK webhook function, assert
+the replay. Until 5b exists, stages 3 and 5 run the same canaries manually as
+their DoD.
+
+## Seams and test decisions
+
+| Seam | Observed behaviour | Prior art (`file:line`) |
+|---|---|---|
+| Block manifest | a block directory alone makes the type valid in a definition, executable in a run, visible in the catalog; validation never loads an executor | `workflows/blocks/*.ts` export `paramsSchema`; `agent.ts:530` `BLOCK_EXECUTORS`; `block-catalog-sync.test.ts`, `block-registry.test.ts`, `schema.test.ts` |
+| WDK step discovery | every `"use step"`/`"use workflow"` file is discovered by the builder and a real run executes on a preview | `workflows/workflow-import-boundary.test.ts:55-70`, `step-registration-coverage.test.ts`, `e2e/replay/preview-canary.ts`, `e2e/harness-profiles/preview-canary.ts` |
+| Engine entrypoint | dispatchers start a run through one import | six import sites of `agentWorkflow` (`lib/dispatch.ts:27`, `lib/dispatch-trigger.ts:15`, `approvals/dispatch.ts:7`, `schedule-trigger/dispatch-schedule-trigger.ts:9`, `webhook-trigger/dispatch-webhook-trigger.ts:6`, `manual-dispatch/service.ts:16`) |
+| Import boundaries | a forbidden tier edge fails the gate; the tier-pair baseline only shrinks | `scripts/ci/verify-changed.ts` and its test (gate-as-script pattern) |
+| DB repository | a domain's tables are written only through its repository; transactions only inside repositories | `db/queries/*` (4 files, 37 functions); `db/client.ts`, `db/test-db.ts` |
+| Adapters | VCS, agent runtime, messaging behind one interface each, with a fake | `adapters/vcs/types.ts`, `sandbox/agents/types.ts`, `adapters/messaging/noop.ts:8` |
+| Prompt composition | slots, references and variables resolve identically in worker and dashboard | `apps/dashboard/lib/prompt-library/*.test.ts` (14 files), `prompt-library/builtin-prompt-drift-gate.ts` |
+| Model catalog | one list of model ids; pickers offer the intersection, parsers accept the union | NEW seam (today four lists); its product-visible half is Assumption A6 and question Q7 |
+| Skill source | GitHub-sourced and local skills are read through one interface, validated by one schema | `harness-profiles/skill-artifact.ts`, `scripts/validate-local-skills.ts`, `skills-lock.json` |
+| Cost function | one number for one usage record regardless of provider | `sandbox/usage.ts`, `sandbox/agents/pricing.ts`, `workflows/run-budget.ts` |
+| Docs routing | an agent reaches the current document for any topic in two hops, and the document says when it was last true | `CLAUDE.md -> @AGENTS.md -> docs/delivery-gates.md` (the one working chain today) |
+| Single schema version | a stored definition is valid, deployable, dispatchable and authorable only as v2; a stored v1 version is listed but not restorable; the runtime plan shape is internal and not a schema version | `workflow-definition/schema.ts` (both parsers), `store.ts:1243,1407` (per-version validation on rollback and deploy), `workflows/agent.ts:7809` (walker choice), `v2-migration.test.ts`, `routes/api/v1/workflow-definitions.test.ts:2280` (shim tests) |
+
+## Out of scope
+
+* Rewriting the engine, the adapters or the block executors. They keep their
+  behaviour and most of their code.
+* Extracting `workflow-graph` as a package and making dashboard block forms
+  schema-driven. Listed as stage 12; it gets its own plan and
+  `/opus-orchestration` may stop before it.
+* Turborepo, graphify, a full oxlint/tsgolint/knip adoption as a package deal.
+  Only the ideas transfer (audit section 8).
+* Any change to Jira, Slack, GitHub or GitLab behaviour, and any migration.
+
+## Assumptions
+
+Uncertainties with the recommendation adopted. Items marked (Q) were put to
+the owner on 2026-09-09; the owner's answer is recorded inline.
+
+* **A1 (Q1, owner: yes, no standing bypass). Branch protection on `main`
+  requiring the `ci` job is switched on in stage 0, with no standing admin
+  bypass.** The repo records "no branch
+  protection, by decision". Adopted: require `ci`; bypass only through
+  GitHub's "allow specified actors" for one named account, and every use
+  opens a Jira issue, mirroring the `--no-verify` audit rule in `AGENTS.md`.
+  The aggregator must be made reportable first (stage 0 DoD), or the bypass
+  becomes the default path within a week. This is the open remainder of
+  AIW-313: PR #358 already merged the credential-free bundle and the
+  validators into CI, the ticket is in verification, and the flip is what is
+  left.
+* **A2 (Q2, owner: "whatever is cleanest", decided: fenced directory). The
+  engine stays a fenced directory inside `apps/worker/src`, not a workspace
+  package, with `engine/index.ts` as its only public interface, so it behaves
+  like a package without fighting WDK discovery.** Adopted because Vercel Workflow discovers step
+  files by content inside the Nitro build and the repo's own boundary test
+  exists precisely because that discovery fails silently. The research
+  settled this as a choice, not a hard constraint: `workflow/nitro` roots
+  discovery at Nitro's `workspaceDir` (the pnpm root) so sibling packages may
+  be imported, but a step file inside another package is discovered only if
+  its directory is listed in the `dirs` option, whose glob and escape
+  semantics no primary source documents. A fenced directory inside `srcDir`
+  needs none of that, so the default holds.
+* **A3 (Q3, owner: yes). `packages/*` are consumed as source, removing
+  `build:shared` from every script, only if a spike at the start of stage 3 shows the Vercel
+  tracer bundles workspace `.ts` sources into every `.func`.** The research
+  did not settle this: Node's `exports` map is what gates access at runtime
+  and this repo already mixes source typechecking with `dist` resolution,
+  which is why every script runs `build:shared` first. If the spike fails,
+  keep `dist` with TypeScript project references in the same stage. Either way the worker `tsconfig.json` stops
+  including `../shared/contracts/**/*.ts` as its own source, and either way
+  stage 3's DoD includes a real run on a preview (the `zod/v3` incident is
+  the precedent for "local green, Vercel broken").
+* **A4. Package names stay `@shared/contracts` and `@shared/conditions` in
+  stage 3.** Renaming to `@ai-workflow/*` is a mechanical sweep across
+  roughly 280 import sites and can happen later without moving files again.
+* **A5. Lint is oxlint with `correctness` at deny and everything else at
+  warn with a counted baseline; import boundaries come from
+  dependency-cruiser, not from a lint plugin.** Confirmed by the research:
+  oxlint implements `import/no-cycle` and `no-restricted-imports` but has no
+  architecture or boundaries rule; dependency-cruiser is the only compared
+  tool with a native baseline mechanism (`--baseline`, `--ignore-known`),
+  which is path-keyed, so the stage 1 wrapper aggregates its JSON output by
+  tier pair instead of using `--ignore-known` directly. pnpm's default strict
+  linking blocks phantom dependencies only and does nothing against a relative
+  `../../other/src/x` import, which is exactly the edge the cruiser rules
+  close.
+* **A6 (Q7, owner: "as you see fit", decided: intersection). Pickers offer
+  the intersection of today's model lists; parsers accept the union.** The four lists are not four copies of one
+  fact, so unifying them can widen what a user may select. Adopted: no model
+  becomes selectable that was not selectable before; stage 8b's first commit
+  is the four-column comparison table, and any model the owner wants newly
+  exposed is a one-line change to `selectable()` after the fact.
+* **A7. Journals are archived, not deleted.** `git mv` to `docs/archive/`
+  keeps history and links. Deleted outright: `.agents/skills/` (vendored,
+  unreferenced since 2026-05-28), `.kimi-code/` (untracked, diverged),
+  `docs/workflow-workspace/index.html` (replaced by the generated catalog).
+* **A8 (Q5, owner: yes). Two event-tied freezes are acceptable**: `apps/worker/src/workflows`
+  from the start of stage 3b until stage 5 is on `main`; `apps/worker/src/lib`
+  and `apps/worker/src/routes` from the start of 6a until 6c is on `main`.
+  Each is expected to last two to four working days if the stages are
+  executed back to back. Without them the moves conflict with everything in
+  flight and rebases resurrect deleted paths.
+* **A9. The GitLab numeric-id contradiction is resolved against the code,
+  not by asking or by a live call.** `lib/vcs-urls.ts:4` builds the sandbox
+  clone URL from the project path, so numeric ids cannot work regardless of
+  what a customer's instance accepts: `init-vcs/SKILL.md:61` is wrong and
+  gets corrected in stage 2. `GITLAB_HOST` is real (`env.ts:49`), so
+  `SETUP.md` gains it in the same stage.
+* **A10. `.claude/learnings.md` content is mined into `.claude/rules/*.md`
+  with `paths:` frontmatter and the file itself is archived**, except the
+  four production gotchas, which stay in root `AGENTS.md` (D9). It is loaded
+  by nothing today.
+* **A11 (Q4, owner first said "separate", then reversed it on 2026-09-09:
+  v1 is retired inside this plan as stage 3b).** Owner's reason: no customer
+  runs v1 (the Arthur tenant is out of support) and two live schemas create
+  chaos for people and agents. Evidence: nothing creates v1 any more
+  (definition POST and templates emit v2; only the three singular shim routes
+  still serve the v1 default and only their own tests call them); production
+  holds zero deployed and zero draft v1 definitions across its 9 non-archived
+  definitions (`workflows.get_graph`, 2026-09-09); the eight scenario
+  snapshots are v2. ADR-003 is therefore written as Accepted in stage 2 and
+  stage 3b executes it; stage 12 loses its condition. This is the plan's only
+  deliberate behaviour change and D12 fences it.
+* **A12 (Q6, owner: "as you see fit", decided: yes). The behavioural gate
+  (5b) costs one preview deploy and one LLM-backed run per PR that touches the engine, the DB layer or the
+  packages.** Adopted because no static gate observes behaviour and nightly
+  e2e runs against a different SHA than the one being merged. Scope is
+  narrowed to those paths so a docs or dashboard PR never pays for it.
+
+* **A13. AIW-335 lands before stage 7 and stays in scope as written.** The
+  production DB driver becomes `node-postgres` with bounded pooling; the
+  plan's transaction rule (repositories only) is written for that driver.
+  If AIW-335 is cancelled, stage 7 reverts to the pre-revision rule: no
+  transactions anywhere, four auth sites rewritten as single statements.
+  Open risk owned by AIW-335, not by this plan: `neon-http` was chosen in
+  2026-07 because the DB client must load inside WDK step bundles where a
+  socket pool could not run; AIW-335 must prove a `pg` pool works there.
+* **A14 (Q8, owner: yes). AIW-195 and AIW-197 (strict template scenario
+  harness) are pulled forward and land before stage 4.** They give stages 4
+  and 5 a behavioural net beyond unit tests and one preview run. Cost: two
+  Backlog tickets move ahead of feature work. The eight scenario snapshots
+  under `workflow-definition/scenarios/snapshots/` are all `schemaVersion: 2`,
+  so the harness guards v2 behaviour only.
+
+## Backlog and roadmap fit
+
+Detail in the fit document. Rules that bind the stage table:
+
+* **Bugs first, freezes second.** Stages 0 to 3 (not 3b) touch none of the files the
+  open High bugs touch (AIW-277, 279, 280, 292, 284, 187 live in
+  `lib/dispatch*`, `clarifications/`, `workflows/agent.ts`). Bug fixes flow
+  in parallel with stages 0-3. The first freeze starts only when those bugs
+  are merged or the owner defers them. A High bug found during a freeze is
+  fixed on the restructure branch by its executor, never on `main`.
+* **AIW-293 tasks that change block contracts land after stage 4** (AIW-294,
+  297, 305, 306, 300, 301); UI-only ones land any time (AIW-296, 299, 304,
+  288, 290); trigger-scope ones after 6c (AIW-295, 298); memory after 7
+  (AIW-303).
+* **Stage 5b and every canary DoD depend on AIW-316** (isolated deployment
+  identity) so a canary can never dispatch against production.
+* **The P0 stabilisation order in AIW-326 is respected**: stage 0 is its
+  "G2 enforcement" step; nothing in stages 1-3 blocks AIW-316 -> 317 -> 320
+  -> 318.
+* **Tickets for the stages** are created on approval, one per stage under a
+  new epic, DoD copied as acceptance criteria.
+
+## Stages
+
+Tiers: `opus` for judgment-heavy or high-blast-radius work, `sonnet` for
+well-specified moves with a strong test net, `haiku` never. File scopes are
+disjoint between stages that may run in parallel; a stage that shares a file
+with an earlier stage lists it under "after".
+
+| # | Stage | Seam | File scope | Tier | Skeptic | TDD | Delegation | DoD |
+|---|-------|------|------------|------|---------|-----|------------|-----|
+| 0 | Finish AIW-313 and record the decisions: ADR-001 (layering, packages, the D3 tier table), ADR-004 (gates and required CI); make the `ci` aggregator reportable (`if: always()`, explicit per-need result check, no `paths:` filter); then require `ci` on `main` per A1 and close AIW-313 with its evidence | Import boundaries | `docs/adr/README.md`, `docs/adr/ADR-001-layering-and-packages.md`, `docs/adr/ADR-004-gates-and-required-ci.md`, `.github/workflows/ci.yml` (aggregator job only), GitHub branch protection | opus (ADRs) + human (setting) | no | no | no | a throwaway docs-only PR and a PR with one shard deliberately cancelled both end in a reportable green or red on `ci`, never a permanent "expected"; `gh api repos/Blazity/ai-workflow/branches/main/protection` returns `required_status_checks.contexts` containing `ci` and `enforce_admins.enabled: true`; ADR-001 lists all 28 directories and 8 root files with a tier; both ADRs Accepted |
+| 1 | Gate ladder with baselines: dependency-cruiser with tier rules from ADR-001 and `no-circular`, baseline keyed by tier pair; knip baseline; oxlint minimal for both apps; `git diff --check` in CI; `no-resurrected-paths` (empty list) and `package-contracts` gates; AIW-325 folded in: the WDK bundle check distinguishes executable Node imports from import-like text in string literals and fails closed on a negative fixture, so dependency-cruiser owns directory tiers and the bundle check owns "no Node import in workflow VM code"; all wired into `verify:changed` and `ci.yml` | Import boundaries | `.dependency-cruiser.cjs`, `knip.json`, `.oxlintrc.json`, `scripts/gates/**`, `scripts/ci/verify-changed.ts`, `scripts/ci/*.test.ts`, `.github/workflows/ci.yml` (ladder steps), root `package.json`, `pnpm-lock.yaml`, `apps/worker/src/workflows/workflow-import-boundary.test.ts` and its fixtures (AIW-325); after 0 | sonnet | no | yes (a fixture with a forbidden tier edge fails; the baseline passes; a renamed file does not change the tier-pair counts) | yes (baseline capture) | `pnpm run verify:changed` exits 0 on `main`; `pnpm run test:ci` passes; the boundary baseline is a tier-pair table whose cycle rows sum to the audited 28; a test adds `app -> db/client` and the gate exits 1; a test renames a baselined file and the gate output is unchanged; `ci.yml` runs the ladder on a PR |
+| 2 | Docs taxonomy and agent routing: `docs/index.md`; ADR-002 block manifest, ADR-003 v1 retirement (Accepted per A11 and D12, citing the production count), ADR-005 docs taxonomy; `git mv` journals to `docs/archive/`; `Status:` and `Last-verified:` headers on every current doc; rewrite `docs/workflow-definitions.md` -> `docs/architecture/workflow-definition.md` against the v2 files; fix README capability claims against the roadmap; correct `init-vcs/SKILL.md` and add `GITLAB_HOST` to `SETUP.md` per A9; skills link to SETUP sections; root `AGENTS.md` to a routing table under 200 lines keeping the four production gotchas; `apps/worker/AGENTS.md` + `CLAUDE.md`, `apps/dashboard/AGENTS.md` + `CLAUDE.md`; `.claude/rules/*.md` per A10; `scripts/gates/docs-status.mjs` (headers, age, reachability); delete `.agents/skills` | Docs routing | `README.md`, `AGENTS.md`, `SETUP.md`, `design-qa.md`, `docs/**` except `docs/research/` and `docs/adr/ADR-00{1,4}*`, `apps/worker/{AGENTS,CLAUDE}.md`, `apps/dashboard/{AGENTS,CLAUDE}.md`, `apps/*/docs/**`, `.claude/rules/**`, `.claude/learnings.md`, `.claude/skills/init-*/SKILL.md`, `.agents/**`, `scripts/gates/docs-status.mjs`; after 0; disjoint from 1 except the new gate file, which 1 registers and 2 fills | opus for `workflow-definition.md`, ADRs and both `AGENTS.md` roots; sonnet for moves and headers | yes (agent-facing text is behaviour) | no | yes (git mv sweep, headers) | `docs-status` gate exits 0: every current doc has both headers, none older than 90 days, all reachable in two hops; root `AGENTS.md` under 200 lines and contains the four gotchas verbatim; `rg -n 'schemaVersion' docs/architecture/workflow-definition.md` shows v2; the six audited contradictions each have a commit that closes them; `pnpm run verify:changed` exits 0 |
+| 3 | `packages/` directory: opens with the A3 spike on a preview (source consumption, canaries), then move `apps/shared/contracts` -> `packages/contracts`, `apps/shared/conditions` -> `packages/conditions`; curated `exports` maps; `description` per package; source consumption per A3 or project references; drop `build:shared` if A3 holds; remove the worker tsconfig include of shared sources; `packages/AGENTS.md`; pnpm catalog for deps both apps share plus `check-deps-consistency` gate | Import boundaries | `apps/shared/**`, `packages/**`, `pnpm-workspace.yaml`, `apps/worker/tsconfig.json`, `apps/dashboard/tsconfig.json`, `apps/worker/package.json`, `apps/dashboard/package.json`, `apps/worker/nitro.config.ts`, `apps/dashboard/next.config.ts`, `scripts/gates/check-deps-consistency.mjs`; after 1 | opus | no | no | no | `pnpm typecheck`; `pnpm --filter worker exec vitest run src/workflows/workflow-import-boundary.test.ts`; `pnpm --filter worker build:ci`; `pnpm --filter ai-workflow-dashboard build`; `package-contracts` gate passes; a preview deploy of the worker answers `/health` AND `pnpm run test:e2e:replay` and `pnpm run test:e2e:harness-profiles` (the non-dry canaries) pass against that preview, executing at least one step and one WDK webhook function; boundary tier-pair table unchanged or smaller (attached) |
+| 3b | Retire schema v1 (D12, A11): measure archived and history v1 rows by SQL on production and hand the counts to ADR-003; switch the five consumers of the v1 default (`definition-step.ts` `buildDefault`, clone and seed fallbacks in `workflow-definitions.post.ts`, `builtin-prompt-drift.ts`, `carry-schema-drift.ts`) to `defaultWorkflowDefinitionV2`, then delete the v1 default; delete `executeGraph` and its private helpers; collapse every `schemaVersion === 1` branch and every constant `=== 2` guard in `workflows/agent.ts`, `workflows/definition-step.ts`, `workflows/prompt-references-step.ts`, `workflows/blocks/{fix-agent,prepare-workspace,types,test-support}.ts`, `lib/dispatch.ts`, `lib/dispatch-trigger.ts`, `workflow-definition/{store,harness-profile-runtime,layout,graph-fixtures}.ts`, `prompt-library/builtin-prompt-drift.ts` to the v2 arm; rename `toLegacyRuntimeShape` to `toRuntimeShape`; delete `isV2OnlyBlockType`, the three singular shim routes, `v2-converter.ts`, `v2-migration*.ts`, `[id]/migrate.post.ts` and the dashboard migration drawer; narrow the runnable `WorkflowDefinition` to v2 and make the history read return the `v2 | legacy-v1` result of D12; rollback to a v1 version returns 409 with the retired-schema message; editor hides Restore on v1 rows; clipboard rejects v1; `save_draft` description sentence and regenerated `mcp-contract.json`; remove dashboard `schemaVersion = 1` defaults and branches; new gate `scripts/gates/single-schema-version.mjs` registered in `verify:changed` and `ci.yml`; shim and migrate route paths appended to the resurrected-paths list; v1 cases dropped from the 18 worker and 8 dashboard test files | Single schema version | `apps/worker/src/workflow-definition/{interpreter,schema,validation,store,default,templates,v2-converter,v2-migration,v2-migration-prompts,v2-migration-harness-profiles,harness-profile-runtime,layout,graph-fixtures}.ts`, `apps/worker/src/workflows/{agent,definition-step,prompt-references-step}.ts` (version branches only), `apps/worker/src/workflows/blocks/{fix-agent,prepare-workspace,types,test-support}.ts` (version branches only), `apps/worker/src/lib/{dispatch,dispatch-trigger}.ts` (three lookups only), `apps/worker/src/prompt-library/builtin-prompt-drift.ts`, `apps/worker/src/routes/api/v1/workflow-definitions.post.ts`, `apps/worker/src/routes/api/v1/workflow-definition.{get,put}.ts`, `apps/worker/src/routes/api/v1/workflow-definition/restore.post.ts`, `apps/worker/src/routes/api/v1/workflow-definitions/[id]/migrate.post.ts`, `apps/worker/src/mcp/tool-catalog.ts` (one description sentence), `apps/worker/src/mcp/contracts/mcp-contract.json`, `packages/contracts/src/{domain,workflow-graph}.ts`, `apps/dashboard/lib/{flows.ts,workflow-editor/**}`, `apps/dashboard/components/cockpit/screens/workflow-editor.tsx`, `apps/dashboard/components/cockpit/flow-editor/**` (except `agent-harness-profile.tsx`), `scripts/gates/single-schema-version.mjs`, `scripts/gates/no-resurrected-paths.json`, `scripts/ci/verify-changed.ts` and `.github/workflows/ci.yml` (one gate entry each), the 26 test files that pin v1; after 3 and after AIW-195/197 (A14); 4 and 5 share `blocks/*`, `prompt-references-step.ts` and contracts `domain.ts` with it and list it under after; opens the first A8 freeze | opus | yes (deployability, rollback, fresh-install default and MCP authoring change) | yes (a dispatch with no deployed definition plans from `defaultWorkflowDefinitionV2` and walks through `executeV2Graph`; rollback to a stored v1 version returns 409 with the message; `workflows.save_draft` with `schemaVersion: 1` returns VALIDATION_FAILED with the message; the history read returns the `legacy-v1` arm for a stored v1 row and the editor renders it without Restore; the clipboard rejects a v1 payload; a fixture that reintroduces `schemaVersion === 1` fails the new gate; the scenario harness passes before and after, as the v2 regression floor only, since it drives `executeV2Graph` with scripted blocks and does not reach harness runtime resolution, pricing, prompt references or the failure exit, which the existing unit tests in `harness-profile-runtime.test.ts`, `planning-agent-provisioning.test.ts`, `definition-step.test.ts`, the prompt-references tests and the canaries cover) | yes (test-file trimming from the list of 26) | `node scripts/gates/single-schema-version.mjs` exits 0, its pattern is `schemaVersion (===|!==) [12]\b|schemaVersion: 1( \| 2)?\b|isV2OnlyBlockType|executeGraph\b` over `apps` and `packages` (both exist after stage 3) excluding tests, the harness-profile manifest files it lists and the single history parser, and the fixture test fails it; `pnpm typecheck`; `pnpm --filter worker exec vitest run src/workflow-definition src/workflows src/routes src/lib src/prompt-library` and `pnpm --filter ai-workflow-dashboard test` pass; `pnpm --filter worker mcp:contract:check` passes and the recorded hash differs from the start-SHA hash; `pnpm --filter worker run db:generate` produces no migration; the reviewer attaches a table of every collapsed version site (6 `=== 1` and 13 `=== 2` in `agent.ts` at the start SHA, 2 in the store, 3 in dispatch, the rest per file) showing the v2 arm kept verbatim; preview deploy plus both non-dry canaries pass; a `workflows.get_graph` sweep on production after deploy returns all 9 definitions; ADR-003 carries the SQL counts |
+| 4 | Block manifest and generator: `engine/blocks/<type>/{manifest,execute}.ts` per block (move, not rewrite); `scripts/gates/generate-block-catalog.ts` writing the three generated files of D4; `schema.ts:35-50` and `block-registry.ts` consume `params.generated.ts`; `block-catalog-sync.test.ts` becomes `gen:blocks --check`; delete `docs/workflow-workspace/index.html`; dashboard palette reads `BLOCK_TYPE_SPECS` from the generated file (forms untouched); `docs/architecture/blocks.md` | Block manifest | `apps/worker/src/workflows/blocks/**`, `apps/worker/src/engine/blocks/**` (new), `apps/worker/src/workflow-definition/{block-registry,schema}.ts` (import sections), the `BLOCK_EXECUTORS` section of `apps/worker/src/workflows/agent.ts` only (lines 461-566 at the start SHA, renumbered by 3b), `packages/contracts/src/{domain,workflow-graph}.ts`, `packages/contracts/src/block-catalog.generated.ts`, `scripts/gates/generate-block-catalog.ts`, root `package.json` (`gen:blocks` script), `docs/workflow-workspace/**`, `docs/architecture/blocks.md`; after 3b (shares `blocks/*` and contracts `domain.ts` with it); inside the first A8 freeze | opus | yes (block contracts are business logic) | yes (A14: AIW-195/197 scenarios land first and run on every commit; generator: fixture block dir -> expected three outputs; a manifest that imports a runtime module fails generation; existing registry, schema and catalog tests are the regression net) | yes (moving 26 block files into directories) | `pnpm --filter worker exec vitest run src/workflow-definition src/engine/blocks` passes; `gen:blocks --check` fails after editing a manifest and passes after `pnpm run gen:blocks`; `pnpm --filter ai-workflow-dashboard build` and `pnpm --filter ai-workflow-dashboard test` pass from a fresh checkout without a manual generation step (the check runs in `build`); the attached tier-pair table shows zero `engine/definition -> engine/blocks/*/execute` edges and the `definition <-> blocks` cycle row at 0; `docs/architecture/blocks.md` walks through adding a block in one directory and a reviewer follows it on a throwaway block that is then deleted |
+| 5 | Split `agent.ts` into `engine/agent-workflow.ts`, `engine/steps/*.ts`, pure helpers; `engine/index.ts` exports `agentWorkflow`; the six dispatchers import from `engine/index.ts`; `"use step"` files in the mixed service directories (D3 table) move to `engine/steps/` in the same PR; append `apps/worker/src/workflows` to the resurrected-paths list | WDK step discovery, Engine entrypoint | `apps/worker/src/workflows/**`, `apps/worker/src/engine/**`, `"use step"` files under `approvals/`, `clarifications/`, `manual-dispatch/`, `webhook-trigger/`, `schedule-trigger/`, `pre-sandbox/`, `pre-pr-checks/`, `sandbox/`, `workflow-definition/` (move only), the six dispatcher import lines, `scripts/gates/no-resurrected-paths.json`; after 4; inside the first A8 freeze | opus | yes (the run state machine lives here) | no (pure move; the existing tests in `workflows/` (79 files at the start SHA, fewer after 3b) plus the two discovery tests are the net) | no | `workflow-import-boundary.test.ts` and `step-registration-coverage.test.ts` pass; `pnpm --filter worker exec vitest run src/engine` passes; reviewer confirms with `git diff --color-moved=dimmed-zebra` that the workflow body moved with zero logic edits, recorded in the PR as the before and after SHA of the function; preview deploy plus both non-dry canaries pass (as in stage 3); `rg -l '"use step"' apps/worker/src --glob '!src/engine/**'` is empty; tier-pair table shows `lib <-> workflows` and `sandbox <-> workflows` rows at 0 |
+| 5b | Behavioural PR gate (D11, A12; delivers the live-canary half of AIW-199 and the production-dispatch mode of AIW-196; requires AIW-316 merged): a CI job that, for PRs touching `apps/worker/src/engine/**`, `apps/worker/src/db/**` or `packages/**`, deploys a preview and runs both non-dry canaries; the job joins the `ci` aggregator's needs | WDK step discovery | `.github/workflows/ci.yml` (new job), `e2e/replay/preview-canary.ts`, `e2e/harness-profiles/preview-canary.ts` (CI-mode flags only), `docs/architecture/gates.md` | sonnet | no | no | no | a PR that edits one step body triggers the job and it passes; a PR that only edits `docs/` does not trigger it and `ci` still reports; a PR that deliberately renames a step function without re-registering it fails the job with the "not registered" message visible in the log |
+| 6a | `config/` and `infra/`: `config/env.ts` is the single importer of `apps/worker/env.ts`; move the infra modules named in the D3 table to `infra/`; every other `env` import replaced by a parameter or a `config` accessor | Import boundaries | `apps/worker/src/config/**`, `apps/worker/src/infra/**`, the infra files listed in D3, every file whose only change is an `env` import line; after 5b; inside the second A8 freeze | sonnet | no | no | yes (import sweep) | `rg -l 'from ".*env\.js"' apps/worker/src --glob '!src/config/**'` is empty; `pnpm typecheck`; `pnpm --filter worker exec vitest run src/lib src/config src/infra` passes; tier-pair table attached and smaller |
+| 6b | `services/`: the `lib/` clusters and the mixed service directories of D3 move into `services/<cluster>/` with an `index.ts` per cluster as its interface; store and schema files stay in place for stage 7; append `apps/worker/src/lib` and each moved directory to the resurrected-paths list | Import boundaries | `apps/worker/src/lib/**` (not moved in 6a), `apps/worker/src/services/**`, `apps/worker/src/{approvals,clarifications,manual-dispatch,dispatch-queue,webhook-trigger,schedule-trigger,system-health,repository-discovery}/**` (non-store, non-step files), `apps/worker/src/deployment-identity.ts`, `scripts/gates/no-resurrected-paths.json`; after 6a; inside the second A8 freeze | sonnet | no | no | yes (cluster moves from the audit's inventory) | `apps/worker/src/lib` no longer exists and `no-resurrected-paths` lists it; `pnpm typecheck`; `pnpm --filter worker exec vitest run src/services` passes; tier-pair table attached and smaller; `docs/architecture/overview.md` lists the clusters with one-sentence contracts |
+| 6c | Server surface becomes thin: the three audited handlers (`webhooks/jira.post.ts`, `cron/poll.get.ts`, `webhooks/custom/[endpointId].post.ts`) and the MCP tools move their branching into services; no route or MCP tool imports `db/client` or `env`; every POST validates with a `@shared/contracts` schema (fixes `invites.post.ts` and `webhooks/resend.post.ts`); `routes/` keeps its path and name | Import boundaries | `apps/worker/src/routes/**`, `apps/worker/src/mcp/**`, `apps/worker/src/middleware/**`, `apps/worker/src/plugins/**`, `apps/worker/src/auth*.ts`, new service files under `apps/worker/src/services/{triggers,polling,custom-webhooks,mcp}/`; after 6b; inside the second A8 freeze | opus (permissions and webhook verification live here) | yes (webhook auth, rate limit, revocation) | yes for the extracted services (existing route tests become service tests) | no | `rg -l 'getDb\(|from ".*db/client' apps/worker/src/routes apps/worker/src/mcp` is empty; `rg -l 'readBody<' apps/worker/src/routes` is empty; `pnpm --filter worker exec vitest run src/routes src/mcp src/services` passes; `workflow-import-boundary.test.ts` passes; `pnpm --filter worker build:ci` passes; the 5b job passes on the PR |
+| 7 | DB repositories and fences (D7, after AIW-335): `db/repositories/{runs,definitions,active-runs,auth}.ts` with the auth writes moved behind the repository and their transactions kept there; `scripts/gates/transactions-in-repositories.mjs` (fails on `.transaction(` outside `db/repositories`); `db/schema/<domain>.ts` split re-exported from `db/schema.ts`; `store.ts` and `*-schema.ts` files from the mixed directories move under `db/`; `scripts/gates/db-client-fence.mjs` (baseline 357, ratchet); `docs/architecture/data-model.md` with the 62-table ownership table | DB repository | `apps/worker/src/db/**`, `apps/worker/src/services/auth/**` (call sites), `store.ts`/`*-schema.ts` files of the mixed directories, `scripts/gates/{transactions-in-repositories,db-client-fence}.mjs`, `docs/architecture/data-model.md`; the call-site migration for the three tables touches `services/**` and `engine/**`; after 6c and after AIW-335 is merged | sonnet, with opus for the auth repository | yes (auth writes move behind a repository) | yes (gates first; the AIW-335 production-driver contract test runs against the repository layer; repository functions covered by moving the existing `db/queries` tests) | yes (call-site sweep) | `pnpm --filter worker run db:generate` produces no new migration; all `*-migration.test.ts` pass; `transactions-in-repositories` gate exits 0; the AIW-335 BEGIN/ROLLBACK contract test passes through `db/repositories/auth.ts`; fence baseline drops below 300 in this stage; the 5b job passes |
+| 8a | `packages/prompts`: move slot, reference, variable, composition and builtin-default logic from `packages/contracts/prompt-*.ts`, `workflow-definition/prompt-*.ts`, `lib/prompts.ts`, `engine/steps/prompt*.ts` (pure parts) and `apps/dashboard/lib/prompt-library/*` into one package; delete the dashboard copy; the drift gate moves with it | Prompt composition | `packages/prompts/**`, `packages/contracts/src/prompt-*.ts`, `apps/worker/src/engine/prompt-library/**`, `apps/worker/src/engine/definition/prompt-*.ts`, `apps/worker/src/engine/steps/prompt*.ts`, `apps/dashboard/lib/prompt-library/**`, `apps/dashboard/components/cockpit/prompt-editor/**` (imports only); after 7 | opus | yes (what a prompt resolves to is product behaviour) | yes (the 14 dashboard test files and the worker prompt tests move first and must stay green) | no | `apps/dashboard/lib/prompt-library` no longer exists and is on the resurrected-paths list; `pnpm --filter @shared/prompts test` passes; the builtin drift gate passes; a fixture prompt resolves byte-identically through worker and dashboard entry points (parity test); 5b passes |
+| 8b | `packages/harness`: `model-catalog.ts` with `recognised` and `selectable()` per D6, first commit is the four-column comparison table committed as `docs/adr/ADR-006-model-catalog.md`; `manifest.ts`, `capability-catalog.ts`, `workflow-definition/models.ts` and `apps/dashboard/lib/harness-profiles/*` derive from it; drift test greps for model-id literals outside the owner | Model catalog | `packages/harness/**`, `packages/contracts/src/harness-profiles.ts`, `apps/worker/src/engine/harness-profiles/**` (non-skill files), `apps/worker/src/engine/definition/models.ts`, `apps/dashboard/lib/harness-profiles/**`, `docs/adr/ADR-006-model-catalog.md`; after 7; disjoint from 8a, 8c, 8d | sonnet | yes (which models a user may pick; the gate receives ADR-006's table and asks about every model the union would newly expose) | yes (drift test first; a test asserts `selectable()` equals the pre-change picker list per provider) | no | `rg -n 'claude-(opus|sonnet|haiku|fable)-|gpt-5' apps packages --glob '!**/model-catalog.ts' --glob '!*.test.ts' --glob '!docs/**'` is empty; `pnpm run test:e2e:harness-profiles:dry` passes; the dashboard picker snapshot test is unchanged |
+| 8c | `packages/costs`: price table shape, usage aggregation, `costForUsage(provider, usage)` used by Slack formatting, run budget and the dashboard cost screen; parity test for Claude `cost_usd` and Codex token pricing | Cost function | `packages/costs/**`, `apps/worker/src/engine/sandbox/{usage,agents/pricing}.ts`, `apps/worker/src/engine/run-budget.ts`, `apps/dashboard/app/cost-data.tsx`, `apps/dashboard/app/(cockpit)/cost/**`; after 7; disjoint from 8a, 8b, 8d | sonnet | no | yes (parity test first) | no | `pnpm --filter @shared/costs test` passes; a recorded usage fixture yields the same cost in worker and dashboard; Slack message snapshot tests unchanged |
+| 8d | `packages/skills`: manifest schema, lock-file format, validator and `SkillSource` interface move from `harness-profiles/{github-skills,configured-github-skills,local-skills,skill-artifact}.ts` and `scripts/validate-local-skills.ts`; the GitHub and local adapters satisfy `SkillSource`; the drift gate covers both sources; `docs/architecture/skills.md` states the product-skill vs Claude-Code-skill distinction and why `skills/` sits at the repository root | Skill source | `packages/skills/**`, `apps/worker/src/engine/harness-profiles/*skill*.ts`, `apps/worker/scripts/validate-local-skills.ts`, `apps/worker/skills-lock.json`, `docs/architecture/skills.md`; after 7; disjoint from 8a, 8b, 8c | opus (two discovery paths become one interface) | no | yes (conformance test run against both adapters; a malformed manifest fails identically from both) | no | `pnpm --filter worker validate:local-skills` passes; the conformance test passes for both adapters; a GitHub-sourced skill with a hash mismatch fails the drift gate (fixture) |
+| 9 | Dashboard hygiene: one API client in `lib/api/client.ts` with typed endpoints from contracts; the 29 direct `fetch(` sites go through it; `config-fields.tsx` split into `flow-editor/blocks/<type>.tsx` (mechanical, one file per `case`) | Docs routing (dashboard `AGENTS.md` gains the rule) | `apps/dashboard/lib/api/**`, `apps/dashboard/components/**`, `apps/dashboard/app/api/**`, `apps/dashboard/AGENTS.md`; after 8a, 8b, 8c, 8d | sonnet | no | no (119 existing tests, the two 2000-line render tests are the net) | yes (case-by-case split) | `rg -l 'fetch\(' apps/dashboard/components apps/dashboard/app --glob '!lib/api/**' --glob '!*.test.*'` is empty; `pnpm --filter ai-workflow-dashboard test` passes; no file under `components/` exceeds 1000 lines |
+| 10 | Agent configuration alignment: `verify:changed` as a `Stop` hook in `.claude/settings.json`; gate ladder and release as skills linking to docs; final `AGENTS.md` trims; proof that per-app and path-scoped instructions actually load | Docs routing | `.claude/settings.json`, `.claude/rules/**`, `.claude/skills/**`, `AGENTS.md`, `apps/*/AGENTS.md`; after 9 | sonnet | yes (agent behaviour) | no | no | a `/context` transcript from a session started at the repo root that edits one file under `apps/worker/src/services/auth` shows `apps/worker/AGENTS.md` and one `.claude/rules/*.md` loaded; root `AGENTS.md` under 200 lines; the hook fires on a test push in a throwaway branch |
+| 11 | Ratchet to zero: remaining boundary violations, knip findings and `db/client` fence count driven to zero; baselines deleted; rules become hard. Terminates because every directory has a tier (ADR-001) | Import boundaries, DB repository | any file a baseline names; `scripts/gates/*.baseline.json`; after 10 | sonnet | no | no | yes (sweep) | all `*.baseline.json` deleted; `pnpm run verify:changed` and CI green with hard rules; `docs/architecture/gates.md` lists the ladder with no baseline column |
+| 12 | `packages/workflow-graph`: v2 schema, validation, bindings, scheduler, interpreter, layout; dashboard forms generated from block manifests | Block manifest | `apps/worker/src/engine/definition/**`, `packages/workflow-graph/**`, `apps/dashboard/components/cockpit/flow-editor/**`; after 11 | opus | yes | yes | no | separate plan; not part of this run |
+
+Parallelism: 1 and 2 are disjoint and may run concurrently after 0. 3 waits
+for 1. 3b waits for 3 and for AIW-195/197 and opens the first freeze;
+3b -> 4 -> 5 -> 5b are sequential and 3b, 4 and 5 sit inside that freeze.
+6a -> 6b -> 6c are sequential inside the second freeze. 7 waits for 6c. 8a,
+8b, 8c and 8d are mutually disjoint and may run concurrently after 7. 9 waits
+for all of 8. 10 and 11 close.
+
+## Pre-mortem
+
+Skeptic (opus, fresh context, plan and audit only): REVISE, 8 HIGH, 2 MEDIUM.
+Fate of each finding: **corrected** (design flaw, plan changed), **owner**
+(product decision, asked in the handoff), **rejected** (deliberate, reason
+recorded).
+
+| # | Finding (condensed) | Fate | Where in revision 2 |
+|---|---|---|---|
+| 1 | Stage 7's directory rule moves the neon-http transaction bug into `db/` and calls it green | corrected, then superseded by AIW-335 | D7, stage 7: the production driver becomes transaction-capable (`node-postgres`, AIW-335); transactions legal only inside `db/repositories`, gate covers everything else, stage 7 ordered after AIW-335 |
+| 2 | Stages 3, 5, 6c can be green locally and broken only on Vercel; 6c could move `srcDir` and lose all step files | corrected | D11, stage 5b; non-dry canaries in the DoD of 3 and 5; `srcDir` rename option deleted from 6c; discovery test added to 6c |
+| 3 | Path-keyed baseline resets on every rename, "baseline smaller" is unfalsifiable | corrected | D1: tier-pair keyed baseline, before and after table attached per stage |
+| 4 | Stage 4 renames the heaviest cycle instead of removing it; dashboard consumer untested; nobody runs the generator in a fresh checkout | corrected | D4: `manifest.ts` without runtime imports, three generated files, dashboard build and `gen:blocks --check` in the DoD, check runs inside `build` |
+| 5 | `workflow-definition` had no tier; approvals and clarifications were assigned two tiers; stage 11 could not terminate | corrected | D3 table covers all 28 directories and 8 root files; mixed directories split by file; ADR-001 moved to stage 0 |
+| 6 | Freeze on the wrong directories, date-based, and rebases resurrect deleted paths | corrected + owner | D10 and A8: two event-tied freezes; `no-resurrected-paths` gate; window scope is Q5 |
+| 7 | Required `ci` with a non-reportable aggregator becomes permanently pending; the admin bypass becomes the default | corrected + owner | Stage 0 DoD makes the aggregator reportable first; A1 removes the standing bypass; Q1 |
+| 8 | Only static gates; skills folded into harness; package contracts not adopted | corrected + owner | D11 and stage 5b (Q6); `packages/skills` as stage 8d; `package-contracts` gate in stage 1 and D2 |
+| 9 | Unifying four model lists as a union widens what users can pick | corrected + owner | D6 and A6: intersection for pickers, union for parsers; ADR-006 table first; Q7 |
+| 10 | Docs gate proves reachability not currency; rules and per-app files may never load; Codex reads neither | corrected | D9: `Status:` and `Last-verified:` headers with a 90-day rule; four gotchas stay in root `AGENTS.md`; per-app `AGENTS.md` bridged by `CLAUDE.md`; stage 10 DoD requires a `/context` transcript |
+| n1 | A9 should be a live GitLab call, not a code read | rejected | the clone URL is built from the path by our own code (`lib/vcs-urls.ts:4`), so the instance's acceptance is irrelevant |
+| n2 | Granular `exports` on every file makes every internal module public | corrected | D2: curated `exports`, one entry per public module |
+
+### Pre-mortem of stage 3b (revision 4)
+
+Skeptic (opus, fresh context, plan and code, stage 3b only): REVISE, 5 HIGH,
+4 MEDIUM, 1 LOW. Same three fates.
+
+| # | Finding (condensed) | Fate | Where in revision 4 |
+|---|---|---|---|
+| b1 | The v1 default is the live fresh-install run path (`definition-step.ts:132` `buildDefault`, `workflow-definitions.post.ts:141,224`, two drift gates), not shim filler | corrected | D12 "replaced, not deleted": five consumers move to `defaultWorkflowDefinitionV2` first; dispatch-without-definition test in 3b TDD |
+| b2 | "Narrow contracts to v2" and "keep a read-only v1 parser" contradict: one read path (`store.ts:149`, `schema.ts:1384`) | corrected | D12: the runnable type narrows, `WorkflowDefinitionV1` stays as a stored type behind a `v2 \| legacy-v1` history read |
+| b3 | The v2 runtime runs on the v1 data shape (`toLegacyRuntimeShape`, `node.params`) | corrected | D12: runtime plan shape is internal, kept, renamed; seam row reworded |
+| b4 | Two DoD commands cannot run: `packages/` absent, root has no `db:generate` | corrected in part, rejected in part | `db:generate` filtered to the worker in 3b and 7; `packages/` exists after stage 3, which 3b follows |
+| b5 | The DoD grep misses the 13 `=== 2` guards that go dead | corrected | gate pattern covers both comparisons and the `1 \| 2` type |
+| b6 | Scope misses nine files and overlaps stages 4 and 5 | corrected | files added; 4 and 5 list 3b under after |
+| b7 | The freeze does not cover dispatch and routes 3b edits, where the High bugs live | corrected | permanent `single-schema-version` gate plus resurrected-paths entries instead of a wider freeze |
+| b8 | The A14 harness cannot see the v2 code 3b touches | corrected | D12 and the TDD column name the unit tests and canaries as the net; harness is the v2 floor only |
+| b9 | A v1 history row keeps Restore and the 409 is a generic banner (`workflow-editor.tsx:1080-1103`) | corrected | 3b removes the action, shows the message; dashboard test in TDD |
+| b10 | The MCP change is unobservable; the contract hash need not change | corrected | one description sentence changes the hash; VALIDATION_FAILED carries the message; clipboard covered |

--- a/docs/product/roadmap-2026-08-27.md
+++ b/docs/product/roadmap-2026-08-27.md
@@ -1,0 +1,219 @@
+Status: current
+Last-verified: 2026-09-09
+Source: checked in from the 27 Aug 2026 roadmap document so that no decision record points at a laptop path. `docs/AI-WORKFLOW-ROADMAP.md` (2026-08-13) is the historical snapshot AIW-326 refers to. Fit against the restructure plan: `docs/research/2026-09-09-roadmap-backlog-fit.md`.
+
+# AI Workflow Roadmap
+
+## Goal
+
+Make AI Workflow reliable, configurable, observable, and safe across tenants, repositories, version-control providers, and workflow types.
+
+## Delivery Rules
+
+- Verify fixes in the target tenant before requesting another client test.  
+- Treat configuration, workflow definitions, models, and behavior changes as versioned release artifacts.  
+- Prefer event-driven workflows over manual ticket re-entry.  
+- Keep the core platform provider-neutral; third-party engines remain optional.  
+- Keep visual changes and ambiguous outcomes under human review.
+
+## P0 — Reliability and Release Safety
+
+### Prompt composition and governance
+
+- [ ] Inventory all system, workflow, block, tenant, harness, skill, and runtime-composed instructions.  
+- [ ] Define explicit precedence rules so pending feedback cannot be overridden by an unrelated no-op rule.  
+- [ ] Show the exact effective instructions and context used by every run.  
+- [ ] Add ownership, versioning, diffs, approval history, rollback, and a changelog.  
+- [ ] Add regression tests for feedback handling, no-op reruns, repository selection, clarification, failed checks, and concurrent comments.  
+- [ ] Require tenant-level verification before releasing behavior changes.
+
+### Tenant release verification
+
+- [ ] Show the deployed application, workflow, schema, model, and configuration versions for every tenant.  
+- [ ] Detect drift between internal and client environments.  
+- [ ] Migrate deployed workflow definitions when schemas change.  
+- [ ] Add a release checklist: reproduce, fix, test internally, deploy, rerun in the tenant, record evidence.  
+- [ ] Support safe rollback when a tenant release fails.
+
+### PR and MR feedback handling
+
+- [ ] Make pending review feedback block the `nothing to do` exit.  
+- [ ] Track each comment by identity, author, revision, classification, status, and handling run.  
+- [ ] Distinguish new, edited, addressed, rejected, ignored, and already-processed comments.  
+- [ ] Support human and bot feedback with configurable classification rules.  
+- [ ] Define how rapid comment events are queued, coalesced, superseded, or cancelled.  
+- [ ] Prevent conflicting parallel fixes on the same PR or MR.
+
+### Webhooks and integration health
+
+- [ ] Add an admin health page for Jira, GitHub, GitLab, Slack, SSO, database, and webhook readiness.  
+- [ ] Show authentication state, permissions, repository access, webhook configuration, last delivery, last success, last failure, and setup owner.  
+- [ ] Add tenant onboarding checks for webhook URL, secret, event types, SSL, and test delivery.  
+- [ ] Distinguish missing delivery from invalid signatures, permissions, and provider outages.  
+- [ ] Store sufficient delivery history so diagnosis does not depend on short-lived provider logs.  
+- [ ] Handle duplicate, delayed, and out-of-order webhook events idempotently.
+
+### Failed-check remediation
+
+- [ ] Implement `failed check → fix agent → same PR/MR → CI rerun → result comment` for GitHub and GitLab.  
+- [ ] Detect stale heads and distinguish the workflow's own push from an external update.  
+- [ ] Fail explicitly when a successful agent run produces no commit.  
+- [ ] Add configurable retry limits and stop conditions per PR or MR.  
+- [ ] Support ignored checks and provider-specific check policies.  
+- [ ] Keep visual-regression failures manual by default.
+
+### Pre-PR checks and repository environments
+
+- [ ] Add repository-specific setup commands, runtimes, package managers, dependency installation, and network requirements.  
+- [ ] Run setup only for repositories selected for the job.  
+- [ ] Distinguish `checks failed` from `checks could not start`.  
+- [ ] Show the failing command and a bounded, redacted output tail in the run and ticket.  
+- [ ] Support realistic duration, token, and repair-cycle budgets.  
+- [ ] Preserve useful partial progress when a run exhausts its budget.
+
+### Runtime resilience
+
+- [ ] Retry bounded transient provider and network failures with backoff.  
+- [ ] Fix sandbox provisioning, temporary-directory, runtime, and PATH failures.  
+- [ ] Give every failure a diagnostic ID, typed cause, and actionable message.  
+- [ ] Report capacity exhaustion instead of silently refusing ticket dispatch.  
+- [ ] Prevent terminated work from being claimed again.  
+- [ ] Reliably resume runs after clarification answers.  
+- [ ] Retry invalid structured model responses within a bounded policy.
+
+## P1 — Workflow Domain and Multi-Repository Model
+
+### Explicit domain model
+
+- [ ] Model tickets, issues, repositories, branches, PRs/MRs, review threads, comments, checks, and workflow runs as linked entities.  
+- [ ] Support one ticket connected to multiple repositories and multiple PRs or MRs.  
+- [ ] Require explicit selection when more than one target is valid.  
+- [ ] Show which repositories were available, selected, cloned, searched, skipped, or unavailable, with reasons.  
+- [ ] Show the exact PR/MR, comment set, check state, and ticket context used by each run.  
+- [ ] Support large repository catalogs without hidden result limits.
+
+### Ticket and PR workflow decomposition
+
+- [ ] Keep ticket workflows responsible for research, planning, implementation, and opening PRs or MRs.  
+- [ ] Move review feedback, failed checks, and repeated PR lifecycle work into separate PR/MR workflows.  
+- [ ] Add a context-resolution block that selects the PR/MR and combines ticket, repository, comment, check, and memory context.  
+- [ ] Limit workspace preparation to provisioning and cloning; expose context selection and checks as separate steps.  
+- [ ] Document the expected ticket-to-PR and PR-follow-up lifecycle.
+
+### Trigger-owned configuration
+
+- [ ] Configure Jira project, board, and column mappings per trigger.  
+- [ ] Support custom columns for implementation, research, planning, review, and remediation workflows.  
+- [ ] Configure visible repository scope per trigger instead of globally.  
+- [ ] Allow one repository event to trigger a workflow that can access approved related repositories.  
+- [ ] Support independently enabled ticket, PR/MR comment, review request, failed check, schedule, and authenticated webhook triggers.
+
+### Repository profiles
+
+- [ ] Add repository descriptions for planning and selection.  
+- [ ] Store repository relationships and dependencies.  
+- [ ] Add reusable setup and command groups without assuming one language or package manager.  
+- [ ] Version and audit repository profile changes.
+
+## P2 — Builder, Context, and Operations
+
+### Typed workflow composition
+
+- [ ] Define typed inputs, outputs, decisions, statuses, failure routes, and retry policies for every block.  
+- [ ] Stop the main workflow when a mandatory safety check is flagged.  
+- [ ] Add input descriptions and infer types for existing bindings.  
+- [ ] Automatically remove bindings when their connections are removed.  
+- [ ] Standardize parameter names across the UI, API, and MCP.  
+- [ ] Support structured JSON inputs on generic agent blocks.  
+- [ ] Make skills visible and configurable on agent blocks.  
+- [ ] Clarify PR blocks, completion states, check results, and repair-cycle settings.
+
+### Context and run transparency
+
+- [ ] Show only context explicitly bound to an agent.  
+- [ ] Prevent access to unbound runtime data.  
+- [ ] Show each block's inputs, outputs, model, tools, skills, repositories, context sources, and evidence.  
+- [ ] Surface research findings, decisions, milestones, blockers, changes, and completion summaries in the main run view.  
+- [ ] Keep reusable memory clean and separate from raw logs.  
+- [ ] Make workspace setup and sandbox-close checks visible.
+
+### Permissions and onboarding
+
+- [ ] Make workflow creation visible and explain when permissions block it.  
+- [ ] Show the current role, missing capability, and responsible administrator.  
+- [ ] Add owner-controlled pilot permissions or a self-service access-request path.  
+- [ ] Detect SSO, database-capacity, and permission failures before the user starts a run.
+
+### Documentation and reusable workflows
+
+- [ ] Publish documentation for blocks, bindings, templates, examples, triggers, and MCP authoring.  
+- [ ] Add cloneable workflows for ticket implementation, research, PR feedback, and failed-check remediation.  
+- [ ] Add GitHub and GitLab regression fixtures covering multiple repositories, multiple PRs/MRs, concurrent comments, clarification, safety checks, release migration, and rollback.  
+- [ ] Ensure workflow rollback loads the selected version into the editor.
+
+### Operational dashboard
+
+- [ ] Show success, failure, retry, duration, cost, model, tenant, user, and workflow attribution.  
+- [ ] Separate execution evidence from summary charts.  
+- [ ] Fix incomplete or clipped visualizations.  
+- [ ] Group or feature-flag unfinished product areas.
+
+## P3 — External Entry Points and Extensions
+
+### Chat-agent integration
+
+- [ ] Expose safe MCP actions to list workflows, inspect requirements, dispatch typed inputs, monitor runs, answer clarifications, and retrieve results.  
+- [ ] Let Claude Tag, Buzz, Slack agents, and similar assistants trigger workflows without reproducing workflow logic.  
+- [ ] Add scoped machine-to-machine authentication and write permissions.  
+- [ ] Support conversational planning before deterministic workflow execution.  
+- [ ] Return structured status, blockers, evidence, and final results to the calling agent.
+
+### Third-party integrations
+
+- [ ] Add an Extensions tab with provider cards, setup state, permissions, health, documentation, and disable controls.  
+- [ ] Add an optional Arthur Engine card linking to setup and enabling provider-specific evaluation blocks after configuration.  
+- [ ] Keep third-party blocks separately authenticated and optional to core execution.  
+- [ ] Define a reusable extension contract for support systems, browser testing, evaluation engines, and other providers.
+
+### Provider-neutral safety and observability
+
+- [ ] Define a provider-neutral interface for traces, evaluations, safety checks, and policy outcomes.  
+- [ ] Return typed `pass`, `block`, and `human review` outcomes with evidence.  
+- [ ] Add secret and sensitive-data scanning before execution and before output leaves the sandbox.  
+- [ ] Record outbound network activity and policy decisions.  
+- [ ] Test workflows when optional providers are enabled, disabled, unavailable, or misconfigured.
+
+### Hosted and on-premise execution
+
+- [ ] Define explicit infrastructure and sandbox adapters instead of tenant-specific forks.  
+- [ ] Add secure secret delivery, workspace transfer, result collection, cleanup, recovery, and capacity controls.  
+- [ ] Preserve feature parity for supported workflows across hosted and on-premise environments.  
+- [ ] Document ownership for upgrades, incidents, backups, and disaster recovery.
+
+## Release Milestones
+
+### Milestone 1 — Stable pilot
+
+- P0 scenarios pass in a deployed tenant.  
+- Feedback is handled automatically and cannot false-exit as completed.  
+- Integrations and webhooks are visible and verified before use.  
+- Failures are explicit, diagnosable, and recoverable.
+
+### Milestone 2 — Correct multi-repository workflows
+
+- Ticket, repository, PR/MR, comment, and check relationships are explicit.  
+- Ticket implementation and PR follow-up run as separate workflows.  
+- Trigger and repository configuration is workflow-specific and visible.
+
+### Milestone 3 — Self-service builder and operations
+
+- Authorized users can create, validate, publish, inspect, and roll back workflows.  
+- Blocks are typed, documented, and transparent.  
+- Tenant regressions run automatically before release.
+
+### Milestone 4 — External orchestration and extensions
+
+- Chat agents can safely trigger and monitor workflows.  
+- Optional third-party capabilities can be installed without changing core correctness.  
+- Supported workflows operate consistently across providers and deployment models.
+

--- a/docs/research/2026-09-09-agent-navigable-codebase.md
+++ b/docs/research/2026-09-09-agent-navigable-codebase.md
@@ -1,0 +1,303 @@
+# What Anthropic actually publishes about agent-navigable codebases
+
+Primary-source research, 2026-09-09. Question: how does Anthropic say a codebase and its
+documentation should be structured so Claude Code navigates it reliably and cheaply?
+
+## 1. Scope and method
+
+### What counts as primary here
+
+* `code.claude.com/docs/*` (Claude Code product docs). Note: `docs.claude.com/en/docs/claude-code/*`
+  now 301-redirects here, and `docs.anthropic.com/en/docs/agents-and-tools/agent-skills/*`
+  302-redirects to `platform.claude.com/docs/en/agents-and-tools/agent-skills/*`. Both old paths
+  still appear in search results, so cite the new canonical hosts.
+* `platform.claude.com/docs/*` (Claude Platform docs, including the Agent Skills spec).
+* `anthropic.com/engineering/*` (Anthropic engineering blog).
+* `claude.com/blog/*` (Claude product blog, Anthropic-owned).
+* `raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md` (first-party changelog).
+* `agents.md` (first-party spec, but NOT Anthropic. Flagged wherever cited.)
+* Local first-party artifacts on this machine:
+  `~/.claude/plugins/cache/claude-plugins-official/skill-creator/*/skills/skill-creator/SKILL.md`,
+  shipped by Anthropic through the `claude-plugins-official` marketplace.
+
+### What was searched
+
+Fetched in full: `/docs/en/memory`, `/docs/en/skills`, `/docs/en/large-codebases`,
+`/docs/en/sub-agents`, `/docs/en/features-overview`, `/docs/en/context-window`,
+`/docs/en/best-practices`, `/docs/en/hooks` on `code.claude.com`; the Agent Skills authoring
+best-practices page on `platform.claude.com`; two engineering posts; one Claude blog post;
+`agents.md`; the Claude Code changelog (6419 lines, grepped).
+
+### Excluded
+
+No Medium, dev.to, YouTube, Reddit or third-party write-up is cited. Where a claim exists only
+in a secondary source, it is not in this document at all.
+
+### Reading the tables
+
+**Hard rule** means the docs state a mechanism Claude Code executes: a filename it reads, an
+order it loads in, a numeric cap it enforces. **Recommendation** means Anthropic advises it
+("we recommend", "keep it under", "target"). Adherence to a recommendation is not enforced.
+
+---
+
+## 2. Hard rules
+
+| # | Rule | Exact quote | Source |
+|---|------|-------------|--------|
+| H1 | Claude Code does not read AGENTS.md | "Claude Code reads `CLAUDE.md`, not `AGENTS.md`. If your repository already uses `AGENTS.md` for other coding agents, create a `CLAUDE.md` that imports it so both tools read the same instructions without duplicating them." | https://code.claude.com/docs/en/memory |
+| H2 | Four CLAUDE.md scopes, fixed load order | "The table below lists them in load order, from broadest scope to most specific, so a project instruction appears in context after a user instruction." Scopes: Managed policy, User instructions (`~/.claude/CLAUDE.md`), Project instructions (`./CLAUDE.md` or `./.claude/CLAUDE.md`), Local instructions (`./CLAUDE.local.md`). | https://code.claude.com/docs/en/memory |
+| H3 | Ancestors load at launch, descendants load lazily | "CLAUDE.md and CLAUDE.local.md files in the directory hierarchy above the working directory are loaded at launch. Files in subdirectories load on demand when Claude reads files in those directories." | https://code.claude.com/docs/en/memory |
+| H4 | Memory files concatenate, they do not override | "All discovered files are concatenated into context rather than overriding each other. Across the directory tree, content is ordered from the filesystem root down to your working directory." | https://code.claude.com/docs/en/memory |
+| H5 | Import syntax and depth cap | "CLAUDE.md files can import additional files using `@path/to/import` syntax... Imported files can recursively import other files, with a maximum depth of four hops." | https://code.claude.com/docs/en/memory |
+| H6 | Imports do not save context | "Splitting into `@path` imports helps organization but doesn't reduce context, since imported files load at launch." | https://code.claude.com/docs/en/memory |
+| H7 | Backticks disable an import | "Import parsing skips Markdown code spans and fenced code blocks. To mention a path in your CLAUDE.md without importing it, wrap it in backticks." | https://code.claude.com/docs/en/memory |
+| H8 | Hard CLAUDE.md size ceiling | "Claude Code loads a CLAUDE.md file of up to 4 MiB in full and skips a larger file." | https://code.claude.com/docs/en/memory |
+| H9 | CLAUDE.md is a user message, not the system prompt | "CLAUDE.md content is delivered as a user message after the system prompt, not as part of the system prompt itself. Claude reads it and tries to follow it, but there's no guarantee of strict compliance." | https://code.claude.com/docs/en/memory |
+| H10 | HTML comments are stripped before injection | "Block-level HTML comments (`<!-- maintainer notes -->`) in CLAUDE.md files are stripped before the content is injected into Claude's context." | https://code.claude.com/docs/en/memory |
+| H11 | `.claude/rules/` exists and loads recursively | "Place markdown files in your project's `.claude/rules/` directory... All `.md` files are discovered recursively." Rules without `paths` frontmatter "are loaded at launch with the same priority as `.claude/CLAUDE.md`." | https://code.claude.com/docs/en/memory |
+| H12 | Path-scoped rules trigger on file reads | "Path-scoped rules trigger when Claude reads files matching the pattern, not on every tool use." | https://code.claude.com/docs/en/memory |
+| H13 | `claudeMdExcludes` skips memory files by glob | "The `claudeMdExcludes` setting lets you skip specific files by path or glob pattern... Patterns are matched against absolute file paths using glob syntax." Managed policy CLAUDE.md "cannot be excluded". | https://code.claude.com/docs/en/memory |
+| H14 | `additionalDirectories` never loads instructions | Table: `additionalDirectories` setting loads CLAUDE.md and rules "Never", loads skills "Never". `--add-dir` loads CLAUDE.md "Only with the environment variable below" (`CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD`) and loads skills "Yes". | https://code.claude.com/docs/en/large-codebases |
+| H15 | Starting directory decides what loads | Table: starting from repository root loads "Root only; subdirectory files load on demand when Claude reads there"; starting from a subdirectory loads "That directory's plus every ancestor's". | https://code.claude.com/docs/en/large-codebases |
+| H16 | Project settings do not inherit up the tree | "Project settings in `.claude/settings.json` aren't inherited from parent directories the way CLAUDE.md files are." | https://code.claude.com/docs/en/large-codebases |
+| H17 | SKILL.md filename and locations are fixed | Personal `~/.claude/skills/<skill-name>/SKILL.md`, project `.claude/skills/<skill-name>/SKILL.md`, nested `<subdir>/.claude/skills/<skill-name>/SKILL.md`, plugin `<plugin>/skills/<skill-name>/SKILL.md`. | https://code.claude.com/docs/en/skills |
+| H18 | Frontmatter must be the first line | "Claude Code reads the frontmatter only when the opening `---` is the file's first line. Otherwise it treats the whole file, `---` markers included, as skill content." | https://code.claude.com/docs/en/skills |
+| H19 | Skill frontmatter validation limits | "`name`: Maximum 64 characters, lowercase letters/numbers/hyphens only, no XML tags, no reserved words"; "`description`: Maximum 1,024 characters, non-empty, no XML tags". | https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices |
+| H20 | Skill listing is truncated under a budget | "The listing always contains every skill name, but if you have many skills, Claude Code shortens descriptions to fit the listing's character budget... The budget scales at 1% of the model's context window." | https://code.claude.com/docs/en/skills |
+| H21 | Three levels of progressive disclosure | Metadata is "the **first level** of _progressive disclosure_"; the SKILL.md body is "the **second level** of detail"; linked files are "the **third level** (and beyond) of detail, which Claude can choose to navigate and discover only as needed." | https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills |
+| H22 | Nested skills load lazily, on file access | "Skills in a `.claude/skills/` directory below where you started don't load at startup. They load the first time Claude reads or edits a file in that subdirectory and stay available for the rest of the session." | https://code.claude.com/docs/en/skills |
+| H23 | Nested skill name collision is path-qualified | "on a name clash, the nested skill appears as `<dir>:<name>` so both stay available" (changelog v2.1.178). Docs: "`/apps/web:deploy` runs the nested skill on its own." | https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md and https://code.claude.com/docs/en/skills |
+| H24 | Parent-directory skills load at startup | "Claude Code loads project skills from `.claude/skills/` in the directory where you start it and in every parent directory up to the repository root, so starting in `packages/frontend/` still picks up skills defined at the root." | https://code.claude.com/docs/en/skills |
+| H25 | Subagents get CLAUDE.md, not auto memory | Non-fork subagent context contains "**CLAUDE.md files**: every level of the CLAUDE.md hierarchy the main conversation loads". But: "**Auto memory**: the main conversation's auto memory isn't loaded." | https://code.claude.com/docs/en/sub-agents |
+| H26 | Explore and Plan skip CLAUDE.md entirely | "Explore and Plan skip your CLAUDE.md files and the parent session's git status to keep research fast and inexpensive." And: "There is no frontmatter field or per-agent setting to change which agents skip them." | https://code.claude.com/docs/en/sub-agents |
+| H27 | Subagent descriptions have a warning threshold | "When the combined descriptions of your subagents, except the built-in ones, exceed 15,000 tokens, Claude Code shows a warning at startup with the total token count." | https://code.claude.com/docs/en/sub-agents |
+| H28 | Subagent definition locations and priority | Managed settings (1, highest), `--agents` CLI flag (2), `.claude/agents/` (3), `~/.claude/agents/` (4), plugin `agents/` (5, lowest). Identity "comes only from the `name` frontmatter field". | https://code.claude.com/docs/en/sub-agents |
+| H29 | Compaction re-injects some memory, not all | Table: project-root CLAUDE.md and unscoped rules are "Re-injected from disk"; rules with `paths:` frontmatter and nested CLAUDE.md are reloaded only "as Claude reads files" that match; invoked skill bodies are "Re-injected, capped at 5,000 tokens per skill and 25,000 tokens total; oldest dropped first". | https://code.claude.com/docs/en/context-window |
+| H30 | Skill truncation keeps the top of the file | "Truncation keeps the start of the file, so put the most important instructions near the top of `SKILL.md`." | https://code.claude.com/docs/en/context-window |
+| H31 | Auto memory index read limit | "The first 200 lines of `MEMORY.md`, or the first 25KB, whichever comes first, are loaded at the start of every conversation. Content beyond that threshold is not loaded at session start." | https://code.claude.com/docs/en/memory |
+| H32 | Hooks are the only enforcement layer | "Settings rules are enforced by the client regardless of what Claude decides to do. CLAUDE.md instructions shape Claude's behavior but are not a hard enforcement layer." | https://code.claude.com/docs/en/memory |
+| H33 | An instruction-loading hook event exists | `InstructionsLoaded`: "When a CLAUDE.md or `.claude/rules/*.md` file is loaded into context. Fires at session start and when files are lazily loaded during a session". Added in v2.1.69. | https://code.claude.com/docs/en/hooks |
+| H34 | Hooks merge, they do not override | "**Hooks** merge: all registered hooks fire for their matching events regardless of source." | https://code.claude.com/docs/en/features-overview |
+| H35 | Content search already respects .gitignore | "Claude's content searches respect `.gitignore` by default, so paths already listed there, such as `node_modules/`, `dist/`, and `build/`, stay out of search results without additional configuration." | https://code.claude.com/docs/en/large-codebases |
+| H36 | Read deny rules leak through shell recursion | "A Bash search such as `grep -r` or `find` over a directory that contains denied files still includes them in its output." | https://code.claude.com/docs/en/large-codebases |
+| H37 | Sparse worktrees always include root files | "Root-level files like `package.json`, `tsconfig.base.json`, and lock files are always checked out alongside the directories you list. Root-level directories are not, so include `.claude` in the list." | https://code.claude.com/docs/en/large-codebases |
+| H38 | Non-Anthropic: nearest AGENTS.md wins | "Agents automatically read the nearest file in the directory tree, so the closest one takes precedence and every subproject can ship tailored instructions." Note: this is the agents.md spec's rule for agents that implement it. Claude Code is not one of them (see H1). | https://agents.md/ |
+
+---
+
+## 3. Recommendations Anthropic makes
+
+Advisory. Nothing enforces these.
+
+### CLAUDE.md sizing and content
+
+* "**Size**: target under 200 lines per CLAUDE.md file. Longer files consume more context and
+  reduce adherence." (https://code.claude.com/docs/en/memory)
+* "Keep it concise. For each line, ask: *Would removing this cause Claude to make mistakes?* If
+  not, cut it. Bloated CLAUDE.md files cause Claude to ignore your actual instructions!"
+  (https://code.claude.com/docs/en/best-practices)
+* The include/exclude table (https://code.claude.com/docs/en/best-practices). Include: "Bash
+  commands Claude can't guess", "Code style rules that differ from defaults", "Repository
+  etiquette (branch naming, PR conventions)", "Architectural decisions specific to your project",
+  "Developer environment quirks (required env vars)", "Common gotchas or non-obvious behaviors".
+  Exclude: "Anything Claude can figure out by reading code", "Detailed API documentation (link to
+  docs instead)", "Information that changes frequently", "Long explanations or tutorials",
+  "File-by-file descriptions of the codebase".
+* "If an entry is a multi-step procedure or only matters for one part of the codebase, move it to
+  a skill or a path-scoped rule instead." (https://code.claude.com/docs/en/memory)
+* "Keep CLAUDE.md under 200 lines, give it an owner, and review changes to it like code"
+  (https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more)
+* Emphasis is a scarce resource: "If Claude keeps skipping one instruction, add emphasis such as
+  IMPORTANT to that line alone. If you emphasize many lines, none of them stands out."
+  (https://code.claude.com/docs/en/best-practices)
+* `/doctor` proposes trims for a checked-in CLAUDE.md, "cutting content Claude could derive from
+  the codebase" (changelog v2.1.206).
+
+### Monorepo layout
+
+* The canonical example tree (https://code.claude.com/docs/en/large-codebases):
+  root `CLAUDE.md`, then `packages/api/CLAUDE.md` + `packages/api/.claude/skills/`,
+  `packages/web/CLAUDE.md` + `packages/web/.claude/skills/`, `packages/shared/CLAUDE.md`.
+* "A common split is two levels: **Root `CLAUDE.md`**: instructions that apply everywhere...
+  **Per-subdirectory `CLAUDE.md`**: conventions specific to that area's stack."
+* "In monorepos, give each team's directory its own subdirectory CLAUDE.md so teams only load
+  their own conventions" (https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more)
+* Per-directory CLAUDE.md vs path-scoped rule: use the former when "Directory owners maintain
+  their own conventions; instructions are versioned with the code"; use the latter when "You want
+  all conventions in one place, or the same rule applies to many scattered paths."
+* Keep files current: "Review in pull requests", "Revisit after major model releases", "Add a
+  Stop hook that proposes updates".
+* When layering stops scaling, move conventions into plugins or MCP: "Per-directory CLAUDE.md
+  files can become hard to govern as the codebase grows. Conventions drift, files go stale, and
+  no one owns the root."
+
+### Skills
+
+* "Keep `SKILL.md` under 500 lines. Move detailed reference material to separate files."
+  (https://code.claude.com/docs/en/skills and the identical rule at
+  https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+* "**Keep references one level deep from SKILL.md**. All reference files should link directly
+  from SKILL.md to ensure Claude reads complete files when needed." Deep nesting causes partial
+  reads: "Claude might use commands like `head -100` to preview content rather than reading
+  entire files, resulting in incomplete information."
+* "For reference files longer than 100 lines, include a table of contents at the top."
+* "**Name files descriptively:** Use names that indicate content: `form_validation_rules.md`, not
+  `doc2.md`"; "**Organize for discovery:** Structure directories by domain or feature. Good:
+  `reference/finance.md`, `reference/sales.md`. Bad: `docs/file1.md`, `docs/file2.md`"
+* Descriptions: "Always write in third person"; include "both what the Skill does and when to use
+  it"; "Keep descriptions short and lead with words a request would contain, like writing or
+  modifying tests in `packages/api/`."
+* Naming: "Consider using **gerund form** (verb + -ing) for Skill names". Avoid "Vague names:
+  `helper`, `utils`, `tools`".
+* Match specificity to fragility: high freedom for open problems, low freedom ("Run exactly this
+  script") for fragile ones.
+* "Bundle comprehensive resources: Include complete API docs, extensive examples, large datasets;
+  no context penalty until accessed."
+* Skill vs CLAUDE.md, verbatim rule of thumb: "**Put it in CLAUDE.md** if Claude should always
+  know it... **Put it in a skill** if it's reference material Claude needs sometimes (API docs,
+  style guides) or a workflow you trigger with `/<name>`."
+  (https://code.claude.com/docs/en/features-overview)
+
+### Subagents and context
+
+* "Since context is your fundamental constraint, use subagents to keep research out of it."
+  (https://code.claude.com/docs/en/best-practices)
+* "**The infinite exploration.** You ask Claude to investigate something without scoping it.
+  Claude reads hundreds of files, filling the context. **Fix**: Scope investigations narrowly or
+  use subagents so the exploration doesn't consume your main context."
+* "Each subagent might explore extensively, using tens of thousands of tokens or more, but returns
+  only a condensed, distilled summary of its work."
+  (https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+* "Context, therefore, must be treated as a finite resource with diminishing marginal returns."
+  (same source)
+* "Letting agents navigate and retrieve data autonomously also enables progressive disclosure"
+  and "Folder hierarchies, naming conventions, and timestamps all provide important signals that
+  help both humans and agents understand how and when to utilize information." (same source).
+  This is the closest Anthropic comes to a general statement about repository layout for agents.
+* Adoption order (https://code.claude.com/docs/en/features-overview): convention wrong twice goes
+  to CLAUDE.md; a playbook pasted a third time becomes a skill; a side task that floods the
+  conversation goes to a subagent; "You want something to happen every time without asking" goes
+  to a hook; "A second repository needs the same setup" goes to a plugin.
+
+### Cost controls specific to large repos
+
+* Per-directory skills, `claudeMdExcludes`, `Read` deny rules under `permissions.deny`, a code
+  intelligence (LSP) plugin, `worktree.sparsePaths` plus `symlinkDirectories`, and
+  `additionalDirectories` / `--add-dir`. All from https://code.claude.com/docs/en/large-codebases.
+* "This pairs well with `claudeMdExcludes` and the `Read` deny rules above. Those keep irrelevant
+  content out of context, and code intelligence keeps Claude from reading through what remains to
+  locate a definition."
+
+---
+
+## 4. What Anthropic does not say
+
+Findings, not gaps to fill with invention.
+
+1. **No prescribed `docs/` layout.** No Anthropic page states how prose documentation inside a
+   repository should be named, foldered, or indexed for an agent. The only naming and structure
+   advice is scoped to files inside a *skill directory* (see the `reference/finance.md` guidance
+   above), not to the repository's own `docs/`. Anything claiming an official `docs/` convention
+   for Claude Code is unsourced.
+2. **No README.md role.** The docs mention `@README` only as an import example. Claude Code has
+   no documented special handling of `README.md`.
+3. **No AGENTS.md support and no roadmap for it.** H1 is the whole story. `AGENTS.md` appears
+   0 times in the Claude Code changelog (6419 lines, checked 2026-09-09). The only first-party
+   bridges are the `@AGENTS.md` import, a symlink, `/init` under `CLAUDE_CODE_NEW_INIT=1`, and
+   the one-time `/import` copy.
+4. **No documented precedence between conflicting CLAUDE.md files.** The mechanism is
+   concatenation (H4), and resolution is left to the model: "When instructions conflict, Claude
+   uses judgment to reconcile them, with more specific instructions typically taking precedence"
+   (https://code.claude.com/docs/en/features-overview) and "If two rules contradict each other,
+   Claude may pick one arbitrarily" (https://code.claude.com/docs/en/memory). There is no
+   deterministic last-wins guarantee. Do not design around one.
+5. **No enforced CLAUDE.md size limit below 4 MiB.** The 200-line figure is a target, never a
+   cap. Nothing rejects a 900-line file.
+6. **No stated cost of a nested CLAUDE.md that never loads.** The docs say subdirectory files
+   load on demand, but give no token accounting for how many nested files a root-started session
+   accumulates over a long run, beyond the warning that root-started skill discovery "can
+   accumulate into the hundreds".
+7. **No guidance on package boundaries as a code-design question.** Everything Anthropic
+   publishes about monorepos is about *configuration placement* (which file in which directory),
+   not about how to draw module seams, name exports, or size a package so an agent can navigate
+   it. Claims that Anthropic recommends a particular module granularity are unsupported.
+8. **No official CLAUDE.md template or schema.** "There's no required format for CLAUDE.md files,
+   but keep it short and human-readable." (https://code.claude.com/docs/en/best-practices)
+9. **No stated interaction between `.claude/rules/` and per-package directories in a monorepo
+   beyond the comparison table.** Rules live in a "Central `.claude/` at the repo root"; whether
+   `apps/worker/.claude/rules/` is discovered is only implied by the changelog entry about
+   "nested `.claude/rules/*.md` files" (v2.1.211 era) and by H11's recursive discovery, not
+   stated as a monorepo pattern.
+
+---
+
+## 5. Implications for this repo
+
+Current state (2026-09-09): root `CLAUDE.md` is 1 line (`@AGENTS.md`), root `AGENTS.md` is 105
+lines, `docs/` holds roughly 20 prose files and subdirectories, `skills/` sits at the repo root
+outside `.claude/`, and neither `apps/worker`, `apps/dashboard` nor `apps/shared` carries its own
+memory file.
+
+### What is already right
+
+* The `CLAUDE.md` -> `@AGENTS.md` import is exactly the documented bridge (H1). Keep it. Note H6:
+  the import saves nothing in tokens, so the 105 lines of `AGENTS.md` are paid every session.
+* 105 lines is inside the 200-line target.
+
+### What the sources imply we should change
+
+1. **Per-app `CLAUDE.md` files are the documented pattern we are not using.** The canonical tree
+   at https://code.claude.com/docs/en/large-codebases maps one to one onto
+   `apps/worker/CLAUDE.md` (Nitro, sandbox, migrations, the 300 s invocation ceiling),
+   `apps/dashboard/CLAUDE.md` (Next.js), `apps/shared/CLAUDE.md`. Under H3 these cost nothing at
+   launch from the root and load only when Claude touches that app. Anything currently in
+   `AGENTS.md` that is worker-only or dashboard-only belongs there instead.
+2. **Two skill trees exist and only one of them is a Claude Code skill tree.** `.claude/skills/`
+   is the documented project location (H17) and loads. The separate top-level
+   `skills/ai-workflow-review/` is not a location Claude Code scans: H17 lists personal, project,
+   nested and plugin paths only. If those files are meant to be product-side workflow skills,
+   fine. If they were meant for Claude Code, they never load.
+3. **`.claude/learnings.md` (56 KB) is loaded by nothing.** Claude Code reads `.claude/CLAUDE.md`
+   and `.claude/rules/*.md` (H2, H11). A bare `.claude/learnings.md` matches neither, so it is
+   inert unless something imports or reads it. Either move it under `.claude/rules/` with `paths:`
+   frontmatter, turn it into a skill, or accept that it is human-only documentation.
+4. **`docs/` is where our verification and gate procedure should NOT live for agent purposes.**
+   `AGENTS.md` already points at `docs/delivery-gates.md` for the gate ladder, which matches the
+   "link to docs instead" advice. But under the CLAUDE.md-vs-skill rule, a multi-step procedure
+   that Claude must execute (the gate ladder, the release flow) is skill-shaped, not doc-shaped:
+   a skill body loads on demand and a doc only loads if Claude decides to read it. Note that
+   Anthropic prescribes nothing about `docs/` itself (finding 4.1), so the choice is ours.
+5. **`verify:changed` should probably be a hook, not a sentence.** H32 and the blog are blunt:
+   "an instruction is the wrong tool" when something must not happen. `AGENTS.md` already
+   acknowledges the gate is "advisory and bypassable". A `Stop` or `PreToolUse` hook makes it
+   deterministic without spending context.
+6. **`permissions.deny` for `Read` on generated output.** We have `node_modules` covered by
+   `.gitignore` (H35), but any checked-in generated code or `_archive-*` bundles are not, and
+   H36 warns that a Bash `grep -r` still surfaces denied paths, which is directly relevant given
+   this repo's `rtk`-wrapped shell usage.
+7. **Per-app skills over one root skill pile.** With per-directory skills, "Neither directory's
+   skills load during the other's tasks." With everything at the root, every description competes
+   inside the 1% listing budget (H20) and gets truncated.
+
+---
+
+## Source list
+
+1. https://code.claude.com/docs/en/memory
+2. https://code.claude.com/docs/en/skills
+3. https://code.claude.com/docs/en/large-codebases
+4. https://code.claude.com/docs/en/sub-agents
+5. https://code.claude.com/docs/en/features-overview
+6. https://code.claude.com/docs/en/context-window
+7. https://code.claude.com/docs/en/best-practices
+8. https://code.claude.com/docs/en/hooks
+9. https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+10. https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+11. https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents
+12. https://claude.com/blog/steering-claude-code-skills-hooks-rules-subagents-and-more
+13. https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md (v2.1.266 head)
+14. https://agents.md/ (first-party spec, not Anthropic)
+15. Local: `~/.claude/plugins/cache/claude-plugins-official/skill-creator/0120fb83da5d/skills/skill-creator/SKILL.md`
+    (Anthropic-shipped skill; two-field frontmatter, `references/`, `scripts/`, `agents/` subdirectories,
+    a working example of the H21 progressive-disclosure layout)

--- a/docs/research/2026-09-09-architecture-audit.md
+++ b/docs/research/2026-09-09-architecture-audit.md
@@ -1,0 +1,647 @@
+# Architecture audit: current state and target shape
+
+Date: 2026-09-09. Scope: the whole monorepo (`apps/worker`, `apps/dashboard`,
+`apps/shared/*`, `docs/`, agent configuration). Method: one deterministic
+import-graph script plus eight read-only reconnaissance agents, each on one
+topic, every claim cited as `file:line`. Companion documents:
+
+* [2026-09-09-agent-navigable-codebase.md](./2026-09-09-agent-navigable-codebase.md):
+  what Anthropic publishes about agent-navigable repositories (primary sources).
+* [2026-09-09-monorepo-boundary-enforcement.md](./2026-09-09-monorepo-boundary-enforcement.md):
+  primary sources on package contracts, import-boundary enforcement, and the
+  constraints Vercel Workflow and Nitro impose.
+* [2026-09-09-roadmap-backlog-fit.md](./2026-09-09-roadmap-backlog-fit.md):
+  the 27 Aug roadmap and the 100 open AIW issues mapped onto the plan.
+* [../plans/2026-09-09-architecture-restructure.md](../plans/2026-09-09-architecture-restructure.md):
+  the staged plan that follows from this audit.
+
+Vocabulary follows the codebase-design skill: **module** (interface plus
+implementation), **interface** (everything a caller must know), **seam** (where
+an interface lives), **adapter** (a thing that satisfies an interface at a
+seam), **depth** (behaviour per unit of interface), **leverage** (what callers
+get from depth), **locality** (what maintainers get from depth).
+
+---
+
+## 1. Verdict in one paragraph
+
+The code is layered in the small and tangled in the large. Real seams exist
+(VCS adapters, agent runtimes, messaging, block executors), but the directory
+tree above them is a flat set of 28 folders with 28 two-way import cycles, no
+service layer, a 140-file `lib/` that holds most of the domain logic, and an
+8209-line file that is simultaneously the workflow body, the step library and
+the block executor table. Adding one block type touches 24 files in 8
+directories. Four cross-cutting concepts (prompts, skills, harness profiles,
+costs) each have two to four competing definitions. Documentation is 153 files,
+roughly 110 of them dated journals, with no navigable path from the entry
+points to any rationale. Nothing enforces any of this at merge time: `main`
+has no branch protection, the worker has no linter, and no tool checks import
+boundaries. **A rewrite is not warranted and would be the wrong move; a
+behaviour-neutral restructure with enforcement first is.** The engine, the
+adapters and the block executors are worth keeping as they are. What has to
+change is where things live, what may import what, and which single file owns
+each concept.
+
+---
+
+## 2. Measurements
+
+Source: `tokei`, `git log --since='90 days ago'`, and the import-graph script
+([2026-09-09-import-graph.mjs](./2026-09-09-import-graph.mjs), directory-level,
+non-test edges only; rerun with `node docs/research/2026-09-09-import-graph.mjs "$PWD"`).
+
+| Metric | Value |
+|---|---|
+| Files (apps/*, excluding node_modules, dist, .next) | 1518 |
+| TypeScript lines (code) | 278 576 in 1184 files |
+| TSX lines (code) | 47 614 in 173 files |
+| Worker `src/` top-level directories | 28 |
+| Two-way import cycles between those directories | 28 |
+| Directories `routes/` imports from | 24 |
+| Directories `workflows/` imports from | 21 |
+| Directories that import `lib/` | 21 |
+| Directories that import `db/` | 22 |
+| Directories that import `env.ts` directly | 16 |
+| Files carrying `"use step"` (WDK step scope) | 46 (39 in `workflows/`) |
+| Files carrying `"use workflow"` | 2 |
+| Largest file | `apps/worker/src/workflows/agent.ts`, 8209 lines |
+| Largest dashboard file | `components/cockpit/flow-editor/config-fields.tsx`, 5090 lines |
+| Test files: worker / dashboard / scripts | 414 / 77 / 14 |
+| Churn (files touched, 90 days): `workflows/` | 1277 |
+| Churn: `workflow-definition/` / `lib/` / `routes/` | 688 / 659 / 600 |
+
+Heaviest edges: `routes->lib` 215, `workflows->lib` 183, `workflows->sandbox`
+149, `routes->db` 106, `workflows->db` 86, `routes->@shared/contracts` 82.
+
+Heaviest cycles (A->B / B->A import counts): `workflow-definition<->workflows`
+28/38, `sandbox<->workflows` 7/149, `lib<->workflows` 8/183, `lib<->adapters`
+10/40, `db<->lib` 3/49, `lib<->sandbox` 5/19.
+
+The churn numbers matter for the plan: `workflows/` is the hottest directory
+in the repo and also the one every cycle passes through. Any restructure of it
+competes with feature work for the same files.
+
+---
+
+## 3. Findings: worker runtime
+
+### 3.1 Block definition is smeared across eight places
+
+A block type today is declared in:
+
+1. the type union `WorkflowBlockType` in `apps/shared/contracts/domain.ts:290`;
+2. `BLOCK_TYPE_SPECS` in `apps/shared/contracts/workflow-graph.ts:42`;
+3. the registry builder `buildWorkflowBlockRegistry` in
+   `apps/worker/src/workflow-definition/block-registry.ts:1944` (1972-line file);
+4. the params schema map in `apps/worker/src/workflow-definition/schema.ts:35-50`,
+   which imports `paramsSchema` from every executor file (this import is the
+   heaviest cycle in the repo, `schema.ts:41` reaching into
+   `workflows/blocks/investigate.js`);
+5. the executor map `BLOCK_EXECUTORS` at `apps/worker/src/workflows/agent.ts:530`
+   plus an inline `switch` for `INLINE_EXECUTED_BLOCK_TYPES` (`agent.ts:~555`)
+   and the guard `blockTypesMissingExecutor()` (`agent.ts:567`);
+6. the executor itself, one file per block under `apps/worker/src/workflows/blocks/`
+   (14 of them already export their own `paramsSchema`);
+7. the dashboard form, a hand-written `switch` over block type in
+   `apps/dashboard/components/cockpit/flow-editor/config-fields.tsx:4404-4830`;
+8. a hand-maintained HTML catalog `docs/workflow-workspace/index.html` (123 KB)
+   that `block-catalog-sync.test.ts` parses with `node:vm` and asserts against
+   the registry.
+
+Evidence of cost: commit `9b52286f` (leak_review block) touched 24 files in 8
+directories; commit `38fe3415` (investigate block) touched 47 files including
+a migration and a scenario snapshot.
+
+Judgment: each block file already exports `paramsSchema` and `execute`. The
+repo is one export short of a self-describing block module. Generating the
+registry entries, the executor map and the catalog from a directory scan
+removes items 3, 4, 5 and 8 from the touch list and deletes the heaviest cycle.
+
+### 3.2 `agent.ts` is three modules in one file
+
+Outline (line ranges): 1-289 imports and constants; 289-460 v2 prompt and
+provenance helpers; 461-566 `executeRunScripts` and `BLOCK_EXECUTORS`;
+567-1515 pure helpers; 1515-2350 step functions (ticket comments, run
+analysis); 2350-2960 terminal disposition and review ledger; 2965-3230
+clarification parking; 3232-3700 pre-PR and repository-script failure
+reporting; 3700-4590 budgets and telemetry steps; 4591-8209 the single
+`"use workflow"` function `agentWorkflow`, roughly 3600 lines in one body.
+
+This is the only chokepoint every run passes through. It is also why
+`lib/dispatch.ts:27` must import `agentWorkflow`, closing the `lib<->workflows`
+cycle.
+
+The one guard that makes a split safe already exists:
+`workflows/workflow-import-boundary.test.ts:55-70` runs the real WDK builder
+and asserts every file containing `"use step"` or `"use workflow"` appears in
+its discovered lists, because discovery is content-based and an unrecognised
+file fails silently at runtime ("not registered in the current deployment").
+`step-registration-coverage.test.ts` covers the other direction.
+
+### 3.3 v1 definitions are live, not legacy
+
+`workflow-definition/definition-step.ts:89` branches on `schemaVersion === 1`
+and passes v1 through; v2 definitions are flattened *down* to the v1 runtime
+shape (`:91-108`). The built-in default definition is still emitted as
+`schemaVersion: 1` (`workflow-definition/default.ts:90`), a v2 default exists
+beside it (`default.ts:149`), `store.ts:1243,1407` branches per version, and
+blocks are partitioned into v1-executable and v2-only (`isV2OnlyBlockType`,
+`agent.ts:248,571`). No decision record says why both are kept;
+`docs/workflow-definitions.md` describes v1 only (see 7.2).
+
+### 3.4 Seams that are real today
+
+| Seam | Interface | Adapters | Test double |
+|---|---|---|---|
+| VCS | `adapters/vcs/types.ts` (`VCSAdapter`, capability mixins at `:64-70`) | `github.ts:397`, `gitlab.ts:161` | none shared; hand-rolled object literals per test (`post-pr-gate/runner.test.ts`, `review-thread-conformance.test.ts:20`) |
+| Agent runtime | `sandbox/agents/types.ts` (`AgentAdapter`), factory `agents/index.ts:11` | `claude.ts`, `codex.ts` | protocol fixtures (`agents/fixtures`, `protocol-fixtures.test.ts`) |
+| Messaging | `adapters/messaging/types.ts:62` | `chatsdk.ts`, `noop.ts:8` | `NoopMessagingAdapter` is a production fake |
+| Issue tracker | `adapters/issue-tracker/types.ts:72` | `jira.ts` only | hypothetical seam (one adapter) |
+| Run registry | `adapters/run-registry/types.ts:61` | `postgres.ts` only | hypothetical seam |
+
+The sandbox is deep in the good sense: 53 files, five externally used exports
+(`createAgentAdapter`/`AgentKind`, `WORKSPACE_ROOT_DIR`/`WorkspaceManifest`,
+`ResolvedHarnessRuntime`, `computeUsageTotals`, `formatPRComments`). Its one
+accidental leak is `sandbox/context.ts:16` importing
+`workflows/review-ledger.js` while `workflows/prompt-vars.ts:8` imports
+`sandbox/context.js`: two halves of one review-ledger formatter split across
+directories.
+
+### 3.5 No service layer; `lib/` is the domain
+
+`lib/` (140 files) clusters into: trigger dispatch and coalescing
+(`dispatch.ts`, `dispatch-trigger.ts`, `post-pr-gate-dispatch.ts`,
+`pr-autofix-*.ts`, `active-run-owner.ts`), run lifecycle (`cancel-run.ts`,
+`reconcile.ts`, `human-decisions-memory.ts`), VCS and webhook runtime
+(`github-auth.ts`, `github-webhook-sig.ts`, `gitlab-webhook.ts`,
+`create-vcs.ts`, `adapters.ts`), ticket and AI-review transitions
+(`ai-review-*.ts`, `move-targets.ts`, `labels.ts`), publication scrubbing,
+prompts and LLM wrappers, `auth/` (invites, roles, SSO handoff), `email/`,
+`overview/` (eleven `collect-*` read models for the dashboard), `slack/`,
+`telemetry/`, and about six pure infrastructure modules (logger, llm-provider,
+signature verification, request context, trusted origins). Roughly 60 of the
+70 modules are domain logic.
+
+Routes are not thin. `routes/webhooks/jira.post.ts` (736 lines) calls
+`decideAiReviewRun`, `classifyProtectedClarificationSubjects` and
+`listApprovalParkedSubjects` against `getDb()` inline (`:279, :308-311, :356,
+:382`) and computes an HMAC digest in the handler (`:584`).
+`routes/cron/poll.get.ts` (612 lines) loops over approvals, dispatches and
+triggers and branches on result variants (`:107-138, :406-469`);
+`routes/webhooks/custom/[endpointId].post.ts` (442 lines) does lookup,
+revocation, rate limit, decrypt, verify and dispatch branching (`:155-277`).
+29 route files obtain the raw `Db` handle via `getDb()` and thread it into
+`lib` helpers. No route builds a Drizzle query inline, which is the one
+layering rule the code already satisfies.
+
+`db/queries/` holds four modules (run reads, PR siblings, workflow-owned
+branches) and is not a repository layer; everything else queries through ad
+hoc `lib` functions taking a `Db` parameter.
+
+`apps/worker/env.ts` (561 lines, `createEnv` from `@t3-oss/env-core`) is
+imported directly from more than a dozen directories, including domain code
+(`routes/cron/poll.get.ts:3` reads `env.CRON_SECRET` at `:489`).
+
+Input validation at the boundary is inconsistent: `api/v1` CRUD POSTs validate
+with `@shared/contracts` (`workflow-definitions.post.ts:12`,
+`harness-profiles.post.ts:4`, `prompt-library.post.ts:5`); `invites.post.ts:12`
+uses an untyped `readBody<{...}>`; `webhooks/resend.post.ts:50` is a bare
+`JSON.parse(rawBody) as ResendEmailDeliveryEvent`.
+
+### 3.6 Database: 62 tables, no owner per table
+
+Schema files: `db/schema.ts` (46 tables, 1747 lines), `db/auth-schema.ts` (14),
+and one table each in `approvals-schema.ts:27`, `clarifications-schema.ts`,
+`email-delivery-schema.ts`, `memory-schema.ts`. 58 migrations
+(`drizzle/0000_elite_paibok.sql` to `0057_run_analysis_report.sql`, journal in
+`drizzle/meta/_journal.json`, no duplicate numbers). Production applies them
+during `build` (`apps/worker/package.json:7` -> `scripts/db-migrate.ts:38`,
+guarded by the `env_marker` check at `:47-69`). The `*-migration.test.ts`
+files replay the real SQL on PGlite, so they test migrations, not TS logic.
+
+Access pattern: 357 files outside `db/` import the client directly
+(`routes/api/v1` 34, `lib` 31, `workflows` 28, `workflows/blocks` 23, `mcp`
+17). `db/queries/` has 4 files and 37 exported functions, used from
+`workflows/blocks` (9), `lib` (8) and `workflows` (5). The three most shared
+tables are written from many directories: `workflowRuns` (`schema.ts:454`)
+from 15, `workflowDefinitions` (`schema.ts:914`) from 13, `activeRuns` from 10.
+
+Transactions: six `.transaction(` call sites, four in production
+(`lib/auth/invite-acceptance.ts:126,191`, `lib/auth/invites.ts:76,205`). The
+memory note that `neon-http` has no transactions and returns 500 in production
+while PGlite passes is tribal knowledge only: `db/client.ts` has no guard, no
+lint, no wrapper. AIW-335 (open) ports the production driver to
+`drizzle-orm/node-postgres` with a BEGIN/ROLLBACK contract test because Better
+Auth 1.7 needs adapter transactions; the plan's rule is written for that
+driver.
+
+Judgment: the one rule that would give each table an owner without a migration
+is "only `db/` imports the client; everything else goes through a repository
+module per domain that exports the allowed operations", ratcheted down from
+today's 357 call sites. A runtime throw or lint on `db.transaction()` under
+`neon-http` is a separate, cheap fix.
+
+### 3.7 Nitro and WDK facts that constrain any move
+
+`apps/worker/nitro.config.ts`: preset `vercel`, `srcDir: "src"`, tests ignored
+by the file router, `workflow/nitro` module, and a `compiled` hook that copies
+optional YAML files and the repository-root `skills/` directory into every
+`.func` bundle (WDK emits separate step, flow and webhook functions, each with
+its own `/var/task`). `externals: { inline: ["zod/v3"] }` exists because the
+Vercel tracer otherwise installs only Zod 4 while the MCP catalog imports
+`zod/v3`.
+
+The worker `tsconfig.json` includes `../shared/contracts/**/*.ts` as source
+while runtime resolution goes through the built `dist/` declared in
+`apps/shared/contracts/package.json` `exports`. Every `test`, `typecheck` and
+`dev` script therefore starts with `pnpm build:shared`. Two resolution paths
+for one package is a latent drift point and a tax on every command.
+
+From the boundary-enforcement research (primary sources): `workflow/nitro`
+roots step and workflow discovery at Nitro's `workspaceDir`, the pnpm root,
+so sibling workspace packages may be imported by workflow code, but discovery
+is directory-list based (`dirs`, default `workflows/` plus all layer source
+directories) and the semantics of custom entries are undocumented. `"use
+workflow"` bodies run sandboxed and must be deterministic; `"use step"` bodies
+have full Node access, which is where DB clients and side effects belong. The
+pinned `nitropack@2.13.4` ships `srcDir` as a live option; the current
+`nitro.build` docs describe Nitro 3, where `srcDir` is deprecated for
+`serverDir`, so any Nitro upgrade changes the scan root and must re-run the
+discovery test. Node's `exports` map is the real access gate at runtime
+(unlisted subpaths throw `ERR_PACKAGE_PATH_NOT_EXPORTED`). pnpm's default
+strict linking blocks phantom dependencies only; a relative import across
+packages is not stopped by anything today.
+
+---
+
+## 4. Findings: four cross-cutting concepts
+
+| Concept | Where it is defined today | Source of truth | Duplication | Drift gate |
+|---|---|---|---|---|
+| **Prompts** | `apps/shared/contracts/{default-prompts,default-agent-prompt-references,prompt-references,prompt-slots,prompt-variables}.ts`; `apps/worker/src/prompt-library/{store,builtin-prompts,builtin-prompt-drift,builtin-prompt-drift-gate}.ts`; `workflow-definition/{prompt-authoring,prompt-preview,v2-migration-prompts}.ts`; `lib/prompts.ts`; `workflows/{prompts-step,prompt-references,prompt-references-step,prompt-vars,effective-prompt}.ts`; `apps/dashboard/lib/prompt-library/*` (about 15 files); `components/cockpit/prompt-editor/*`; migration `0022_prompt_slots.sql` plus five `*_builtin_prompt_resync.sql` | `default-prompts.ts` for shape and defaults, `prompt-library/store.ts` for state | the dashboard re-implements slot resolution and composition instead of reusing the worker's; five resync migrations record repeated drift | present (`builtin-prompt-drift-gate.ts`, and a vitest test) |
+| **Skills** (product-side, shipped into the sandbox) | `harness-profiles/{github-skills,configured-github-skills,local-skills,skill-artifact}.ts`; `apps/worker/scripts/validate-local-skills.ts`; `apps/worker/skills-lock.json`; repository-root `skills/ai-workflow-review/SKILL.md` (copied into every function bundle by `nitro.config.ts`); `docs/example-skill/SKILL.md` | none: manifest schema in `skill-artifact.ts`, versions in `skills-lock.json`, two discovery paths (GitHub source vs local source) | the product skill tree and the Claude Code skill tree (`.claude/skills`) share the `SKILL.md` convention and are easy to confuse; the Anthropic research confirms `skills/` at the root is not a Claude Code location, which is correct for a product artifact but undocumented | local skills only; none for GitHub-sourced |
+| **Harness profiles** | `apps/shared/contracts/harness-profiles.ts`; `harness-profiles/manifest.ts` (`HARNESS_PROVIDER_CONTRACTS`, model list 1); `harness-profiles/capability-catalog.ts` (model list 2); `workflow-definition/models.ts` (`FALLBACK_MODELS`, list 3); `apps/dashboard/lib/harness-profiles/{capabilities,editor,selection}.ts` (list 4); `harness-profiles/store.ts` (CRUD, fork, publish, archive); `workflow-definition/harness-profile-runtime.ts` | none; model identifiers are hard-coded in three to four files with no shared enum | yes, four lists | absent |
+| **Costs / usage** | `sandbox/agents/pricing.ts` (price table, live fetch from LiteLLM); `sandbox/usage.ts` (aggregation, Slack formatting); `workflows/run-budget.ts` (budget limits); `run-observability/*`; `apps/dashboard/app/cost-data.tsx` and `app/(cockpit)/cost/page.tsx` (`CostResponse` from contracts) | split cleanly into price (`pricing.ts`) and usage (`usage.ts`, `run-budget.ts`) | two cost paths: Claude reports `cost_usd` directly, Codex is tokens times price in `usage.ts`; dashboard aggregation is not reconciled with the Slack figure | absent |
+
+Extractability ranking: prompts (module exists, contracts shared, gate exists;
+the work is a move plus deleting the dashboard copy), then costs (clean split,
+needs one shared cost function), then skills (manifest and lock exist, two
+discovery paths need one interface), then harness profiles (must unify the
+model catalog before anything can move).
+
+---
+
+## 5. Findings: dashboard
+
+* Twelve cockpit pages under `app/(cockpit)/`, each a server component pair
+  `app/<screen>-data.tsx` plus `<screen>-skeleton.tsx` behind `Suspense`. Data
+  chain: `app/(cockpit)/page.tsx:8-17` -> `app/overview-data.tsx:44-52`
+  (`getJSON<KpisResponse>`) -> `lib/api/server.ts:31-41` (`fetch` to
+  `WORKER_BASE_URL`, bearer session cookie) -> `apps/worker/src/routes/api/v1/overview/*`.
+* `lib/api/` is one typed helper (`getJSON`, `withQuery`), not a client with
+  per-endpoint types. 29 files outside `lib/api` call `fetch(` directly
+  (`components/cockpit/screens/health.tsx:116`,
+  `manual-dispatch-modal.tsx:70,95`, most of `flow-editor/*.tsx`), some through
+  the dashboard's own `app/api/*` proxies.
+* 176 files import `@shared/contracts`; `lib/types.ts` adds UI-only views
+  (`Span`, `EvalMetric`, `CostByModel`) rather than duplicating domain types.
+  The dashboard is a thin client at the type level.
+* It is not thin at the logic level: `config-fields.tsx` (5090 lines) is a
+  hand-written form per block type (`:4404-4830`), with large custom editors
+  for webhook triggers (`:878-2107`), schedules (`:2107-3530`) and repository
+  scripts (`:3658-4268`). A comment at `:4396` says the palette is data-driven;
+  the forms are not. `lib/prompt-library/*` and `lib/harness-profiles/*`
+  re-implement worker logic (section 4).
+* Design layer exists: `components/ui.tsx` (23 importers), `charts.tsx`;
+  `lib/theme.ts` is only span colours.
+* 119 test files; the two largest render with `react-test-renderer`
+  (`screens/repository-scripts.test.tsx` 2445 lines,
+  `config-fields-schedule-trigger.test.tsx` 1853 lines).
+* Both dashboard-local docs are stale: `docs/overview-api-requirements.md:1-4`
+  describes a migration that already happened;
+  `docs/superpowers/plans/2026-05-28-overview-real-data.md:9-24` specifies
+  `lib/integrations/*` and SWR hooks that were never built.
+
+---
+
+## 6. Findings: verification gates
+
+What runs where today:
+
+| Gate | Where | Enforced? |
+|---|---|---|
+| `git diff --check` | `verify:changed` (pre-push) only | local, bypassable |
+| typecheck (worker / dashboard / root) | pre-push, scoped to changed paths; CI `source-checks` | CI not required |
+| unit tests (worker sharded, dashboard, workflow-sdk) | CI on every PR, 30-minute timeouts, 5-minute aggregator `ci` | CI not required |
+| `validate:pre-sandbox`, `validate:local-skills`, `mcp:contract:check` | pre-push (worker paths) and `build:ci` | via build |
+| `check:prompt-drift`, `check:carry-schema-drift` | plain vitest tests, caught by `unit-worker` | via CI |
+| `verify-deployment-identity` | `e2e.yml` only (nightly) | no |
+| e2e (agent / orchestration / capacity projects) | nightly cron or manual, needs a deployment | no |
+| linter (worker) | none exists | no |
+| `next lint` (dashboard) | defined, never run in CI | no |
+| import boundaries, unused code (dependency-cruiser, knip or similar) | none | no |
+| coverage threshold | none | no |
+
+`core.hooksPath` is set to `.githooks` in this checkout, so pre-push runs, but
+`--no-verify` is one flag away and `AGENTS.md` itself calls the gate advisory.
+`main` has no branch protection, by recorded decision, so a red `ci` job blocks
+nothing. The memory note "ci on a 35-minute ceiling" does not match the current
+`ci.yml` (30/30/30/30/5).
+
+Judgment: the cheapest large improvement is a repository setting, not code:
+require the existing `ci` aggregator on `main`. After that, the missing gates
+are lint, boundaries and unused-code detection, none of which exist in any form.
+
+---
+
+## 7. Findings: documentation and decisions
+
+### 7.1 Inventory summary
+
+153 documents. Sources of truth that are current and mutually consistent:
+`AGENTS.md` and `docs/delivery-gates.md` (process), `docs/SPEC.md` and
+`docs/user-stories.md` (behaviour), `docs/AI-WORKFLOW-ROADMAP.md` (status; it
+beats the README wherever they disagree), `CONTEXT.md` (vocabulary),
+`docs/releases/artur/` (release contract), `docs/repository-scripts.md`,
+`docs/GITHUB-APP-SETUP.md`, `docs/GITLAB-SETUP.md`, `SETUP.md` (environment,
+contested by the setup skills).
+
+Journals (dated, describing a past state): `docs/plans/` (32),
+`docs/superpowers/` (55, split across three trees: `docs/`, `apps/worker/docs/`,
+`apps/dashboard/docs/`), `docs/qa/` (11 plus an 85 KB HTML playbook),
+`docs/testing/` (8), `docs/research/` (4), `docs/assumptions/` (2),
+`.claude/learnings.md` (56 KB, cold since 2026-06-29, loaded by nothing).
+
+Dead or orphaned: `design-qa.md` (root, referenced nowhere),
+`docs/agent-runtime-diagnostics.md` (referenced nowhere),
+`docs/workflow-workspace/index.html` (a generated design mock used as a test
+fixture), `.agents/skills/` (20 vendored third-party skills, untouched since
+2026-05-28, referenced nowhere), `.kimi-code/skills/` (a diverged copy of
+`.claude/skills`, 14 files differ, one skill missing, git-ignored through
+`.git/info/exclude`, so nothing keeps it in sync).
+
+### 7.2 Contradictions found
+
+1. **Post-PR gate.** `docs/plans/2026-08-04-legacy-post-pr-gate-neutralization.md:3`
+   says "Status: APPLIED", `apps/worker/post-pr-gate.yaml` carries the sentinel
+   and `steps: []`, yet `docs/post-pr-gate-spec.md` (73 KB, last commit
+   2026-05-22) has no status header across 2270 lines, and
+   `.claude/skills/init-neon/SKILL.md:4` still describes Neon as the "post-PR
+   gate store".
+2. **GitLab project id.** `SETUP.md:134`: numeric project IDs are not
+   supported. `.claude/skills/init-vcs/SKILL.md:61`: numeric ID works.
+   `GITLAB_HOST` exists only in the skill (`:63,76`). `SETUP.md:713` points at
+   the skills; `init-neon/SKILL.md:12` points back at `SETUP.md`. Resolved
+   against the code: `lib/vcs-urls.ts:4` builds the sandbox clone URL as
+   `${host}/${repoPath}.git`, so a numeric id cannot work and `SETUP.md` is
+   right on that point; `GITLAB_HOST` is a real variable (`env.ts:49`, default
+   `https://gitlab.com`), so `SETUP.md` is missing it. Both documents need one
+   edit each.
+3. **Workflow definitions doc describes v1 only.** `docs/workflow-definitions.md:3`
+   declares `schemaVersion: 1`; its "V1"/"V2" headings (`:32`, `:54`) are two
+   fixtures both at version 1; the v2 layer (`v2-converter.ts`, `v2-bindings.ts`,
+   `v2-branch.ts`, `v2-migration.ts`, `v2-scheduler.ts`) is never mentioned.
+   `README.md:89` sends readers to this file for the block catalog.
+4. **README vs roadmap.** `README.md:57` lists PR/MR lifecycle triggers as
+   present; `docs/AI-WORKFLOW-ROADMAP.md:66` (AIW-221) has them "implemented,
+   awaiting verification". `README.md:64` lists customer-controlled deployment;
+   the roadmap (`:83-87`, AIW-260) has it "planned, not started".
+5. **A decision record sourced from a laptop path.**
+   `docs/plans/2026-07-23-ai-workflow-improvements-decisions.md:5` cites
+   `/Users/karol/Downloads/AI workflow improvements.md`.
+6. **The dashboard plan describes an architecture that does not exist**
+   (`lib/integrations/*`, section 5).
+
+Checked and consistent: `SPEC.md` and `CONTEXT.md` agree on "block" (and
+`CONTEXT.md` deprecates "node"); `delivery-gates.md` and `AGENTS.md` list the
+same six commands.
+
+### 7.3 Decision records
+
+No ADR convention. Rationale lives in four incompatible formats:
+`docs/assumptions/` (an "Assumption Ledger" table, used twice, abandoned
+2026-07-03), one `*-decisions.md` plan, 28 `docs/superpowers/specs/*-design.md`
+files (the de facto ADR store, unlinked), and 32 dated plans mixing decisions,
+runbooks and incident write-ups. `README.md` links to none of them;
+`AGENTS.md` links only to `delivery-gates.md`; `docs/SPEC.md` is reachable
+from neither. Every rationale document is found by `ls`, never by a link.
+
+A new agent needs about six documents to add a feature safely (`AGENTS.md`,
+`delivery-gates.md`, `CONTEXT.md`, `SPEC.md`, `workflow-definitions.md`,
+`SETUP.md`), and two of the six will mislead it.
+
+### 7.4 Agent configuration against the Anthropic research
+
+From `2026-09-09-agent-navigable-codebase.md`: the `CLAUDE.md -> @AGENTS.md`
+bridge is correct (H1) and 105 lines is under the 200-line target; the
+documented monorepo pattern (per-app `CLAUDE.md`, loaded lazily under H3) is
+not used; `.claude/learnings.md` matches no loaded path (H2, H11) and is
+inert; multi-step procedures (gate ladder, release) are skill-shaped, not
+doc-shaped; `verify:changed` as a sentence is advisory where a hook would be
+deterministic (H32); root `skills/` is a product artifact, not a Claude Code
+location (H17), which is fine but must be stated somewhere.
+
+---
+
+## 8. What a reference monorepo does differently
+
+`/Users/filip/Desktop/projekty/portivo` (12 apps, 22 packages, Go plus TS) was
+read for transferable ideas only. Not transferable at this size: Turborepo, the
+full oxlint/tsgolint/knip stack as a package deal, the 98 KB pre-push hook that
+exists because CI is not required there either, and graphify (500 MB of
+per-machine artifacts). Transferable, ranked:
+
+1. **Package `description` is the contract**: one sentence saying what the
+   package may and may not do (`packages/money/package.json`: "formatting only,
+   never conversion"), quoted verbatim in the repo atlas.
+2. **A gate is a dependency-free Node script with a baseline JSON and a header
+   stating its exit condition** (`scripts/zod-import-gate.mjs:1-50`,
+   `scripts/check-deps-consistency.mjs:1-33`). Ratchet down, never mass-fix.
+3. **Granular `exports` maps, consumed as source, no build step**
+   (`packages/mobile-storefront/package.json` has about 60 subpath entries).
+4. **Contract chain by npm script** (`gen:api`) with a drift diff in the push
+   hook and a breaking-change gate with a ratchet baseline
+   (`scripts/openapi-breaking-gate.mjs`).
+5. **Two lint tiers split by "may this fix run unattended"**
+   (`.oxlintrc.precommit.json` extends `.oxlintrc.json`, type-aware off).
+6. **`CLAUDE.md` as a routing table with a byte budget** (facts ->
+   `AGENTS.md`, setup -> `SETUP.md`, procedures -> skills, prohibitions ->
+   hooks, per-path rules -> `.claude/rules/`), plus the compaction rule that
+   decides what lives where.
+7. **`docs/adr/` in MADR form with a README index that says when to write one.**
+8. **pnpm catalog plus a four-rule consistency check** even when the catalog is
+   small.
+
+Portivo has no mechanical import-boundary rule either; its boundaries are
+prose in `AGENTS.md:25-44`. That is the one place this repo should go further
+than the reference, because its cycle count says prose has not worked here.
+
+---
+
+## 9. Target shape
+
+### 9.1 Principles
+
+1. **Behaviour-neutral first.** Every stage below is a move, a fence, or a
+   generator. No stage changes what a v2 run does. v1 retirement is the one
+   deliberate behaviour change; the owner folded it into the plan as stage 3b
+   on 2026-09-09 after production showed zero v1 definitions (plan D12, A11).
+2. **Enforcement before structure.** A boundary that nothing checks is a
+   comment. The first stage installs the checks with today's graph as the
+   baseline, so every later stage can only ratchet down.
+3. **A package earns its `package.json` by having two consumers.** Pure domain
+   modules used by both apps become workspace packages. Modules with one
+   consumer (the worker engine, the adapters, the DB layer) become fenced
+   directories inside the worker, because a package boundary there buys
+   nothing that dependency rules do not, and it fights WDK step discovery and
+   Nitro bundling (see the boundary-enforcement research for the exact
+   constraints).
+4. **One file owns each concept.** Model catalog, block catalog, prompt
+   defaults, price table: one module each, everything else derives from it,
+   and a drift test proves it.
+5. **Docs are either current, archived, or deleted.** Current documents are
+   reachable in two hops from `README.md` or `AGENTS.md`. Archived documents
+   sit under `docs/archive/` with a status line. Nothing else exists.
+
+### 9.2 Workspace layout
+
+```
+apps/
+  worker/                 Nitro shell. src/app holds routes, cron, webhooks,
+                          mcp surface, auth wiring. Parse, validate, call a
+                          service, respond. Never getDb(), never env.
+  dashboard/              Next shell. Screens and UI kit. Domain logic only
+                          through packages. One API client.
+packages/
+  contracts/              (today apps/shared/contracts) wire and domain types,
+                          zod schemas, generated block catalog. Leaf.
+  conditions/             (today apps/shared/conditions) pure evaluation.
+  prompts/                slots, references, variables, composition, builtin
+                          defaults, drift fixture. Pure. Both apps.
+  harness/                profile manifest, capability catalog, THE model
+                          catalog, skill manifest schema and lock format. Pure.
+  costs/                  price table shape, usage aggregation, one cost
+                          function for both providers, budget rules. Pure.
+  workflow-graph/         v2 schema, validation, bindings, scheduler,
+                          interpreter, layout, json-schema authoring. Pure.
+```
+
+Inside `apps/worker/src`, five fenced tiers:
+
+```
+app/        routes, cron, webhooks, mcp, middleware, plugins (Nitro srcDir)
+services/   dispatch, run lifecycle, ticket transitions, overview read models,
+            auth domain, publication (today: most of lib/)
+engine/     blocks/, steps/, agent-workflow.ts, sandbox, pre-sandbox,
+            pre-pr-checks, memory, clarifications, approvals, harness runtime,
+            prompt runtime, run observability
+adapters/   vcs, issue-tracker, messaging, agent-runtime, with one shared fake
+            per interface
+db/         schema per domain, migrations, repositories per domain,
+            run-registry (today an "adapter" with one implementation)
+config/     the single import point for env; everything else receives values
+infra/      logger, telemetry, llm provider, crypto helpers (the ~6 pure
+            infrastructure modules in lib/)
+```
+
+Allowed dependencies, top to bottom, no upward edges, no sideways edges except
+where listed:
+
+```
+app        -> services, engine (only the workflow entrypoint), packages, config
+services   -> engine, adapters, db, packages, infra
+engine     -> adapters, db, packages, infra
+adapters   -> packages, infra
+db         -> packages/contracts, infra
+config     -> nothing
+infra      -> nothing
+packages/* -> packages/contracts only (workflow-graph may use conditions)
+```
+
+Blocks become self-describing: one directory per block under `engine/blocks/`,
+exporting a single `manifest` (type, params schema, contract, ui hints,
+execute). Registry, executor map, `BLOCK_TYPE_SPECS` and the catalog are
+generated from a directory scan into `packages/contracts/src/block-catalog.generated.ts`;
+the existing `block-catalog-sync.test.ts` becomes a "generated file is up to
+date" check and the HTML mock stops being a fixture.
+
+### 9.3 Gates
+
+Portivo's pattern applied minimally. All gates are plain Node scripts under
+`scripts/gates/`, each with a header (why, exit condition), a baseline JSON
+where a ratchet is needed, a test in `scripts/ci/`, and a single entry in both
+`verify:changed` and `ci.yml`:
+
+| Gate | Tool | Baseline |
+|---|---|---|
+| import boundaries and cycles | dependency-cruiser, rules for the tiers above | today's 28 cycles as known violations, ratcheted to zero by stage |
+| unused files, exports, dependencies | knip | today's count |
+| lint (both apps) | oxlint, correctness rules deny, rest warn | warnings counted, ratcheted |
+| formatting | `git diff --check` in CI too | none |
+| generated files current | block catalog, MCP contract, prompt drift, carry schema | none (already exist for three of four) |
+| dependency consistency | pnpm catalog plus the four-rule check | none |
+| required CI | branch protection on `main` requiring the `ci` job | repository setting, not code |
+
+### 9.4 Documentation taxonomy
+
+```
+README.md              product entry; links the docs index
+CLAUDE.md              @AGENTS.md (unchanged)
+AGENTS.md              routing table under 200 lines: where is X, commands,
+                       gate ladder pointer, conventions; nothing procedural
+CONTEXT.md             glossary (linked from AGENTS.md)
+SETUP.md               reference facts for humans; init-* skills are the
+                       procedures and link to its sections; one direction only
+apps/worker/CLAUDE.md  Nitro, WDK step discovery, migrations on build, the
+                       300 s ceiling, neon-http has no transactions
+apps/dashboard/CLAUDE.md
+packages/CLAUDE.md
+.claude/rules/*.md     path-scoped gotchas mined from learnings.md and memory
+docs/
+  index.md             the only list of current documents
+  architecture/        overview (layers, allowed deps, one diagram), blocks
+                       (how to add one), workflow-definition (v2, rewritten),
+                       data-model (table ownership), gates
+  adr/                 MADR records plus README index; first five:
+                       layering and packages, block manifest, v1 retirement,
+                       gates and required CI, docs taxonomy
+  product/             SPEC.md, user-stories.md, roadmap
+  runbooks/            releases/artur, GitHub app, GitLab, agent runtime
+                       diagnostics, on-prem (with a status line)
+  research/            as today
+  archive/             plans, qa, testing, superpowers (all three trees),
+                       assumptions, post-pr-gate-spec, pre-sandbox-plan,
+                       security-observability, design-qa, learnings
+```
+
+Deleted, not archived: `.agents/skills/` (vendored, unreferenced),
+`.kimi-code/` (local, diverged, untracked), `docs/workflow-workspace/index.html`
+(replaced by the generated catalog).
+
+---
+
+## 10. Risks specific to this restructure
+
+* **WDK discovery is content-based.** Moving a `"use step"` file to a path the
+  builder does not scan fails at runtime, not at build. The existing
+  `workflow-import-boundary.test.ts` is the guard; it must run in every stage
+  that moves engine files, and the boundary-enforcement research decides
+  whether steps may live outside `srcDir` at all.
+* **`workflows/` churn.** 1277 file-touches in 90 days. Stages that move it
+  need a short freeze on feature branches touching `apps/worker/src/workflows`,
+  or they will conflict with everything in flight (see the memory note on
+  sequential tickets producing conflicting PRs).
+* **`build:shared` coupling.** Every command rebuilds the contracts package.
+  Switching packages to source consumption removes the tax but changes how
+  Nitro's Vercel tracer sees them; that is a research-gated decision.
+* **Nothing is required on `main`.** Until branch protection exists, every
+  gate in section 9.3 is advisory. The restructure should not start before that
+  setting is flipped, because the first stage's whole value is that regressions
+  cannot land.
+* **Nitro 3 renames the scan root.** The pinned Nitro 2 uses `srcDir`; Nitro 3
+  deprecates it for `serverDir`. An upgrade silently changes which directories
+  the file router and WDK discovery scan. The discovery test must be part of
+  any Nitro bump.
+* **Migrations run during `build`.** `apps/worker/package.json` `build` calls
+  `db:migrate`. Any stage that touches `db/` must keep that path working or
+  the next preview deploy mutates a database.

--- a/docs/research/2026-09-09-import-graph.mjs
+++ b/docs/research/2026-09-09-import-graph.mjs
@@ -1,0 +1,90 @@
+// Computes directory-level import graph for apps/worker/src, apps/dashboard/src, apps/shared.
+// Usage: node import-graph.mjs <repoRoot>
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.argv[2];
+const targets = [
+  { name: "worker", base: path.join(root, "apps/worker/src") },
+  { name: "dashboard", base: path.join(root, "apps/dashboard/src") },
+];
+
+function walk(dir, out = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === "node_modules" || e.name === ".next" || e.name === "dist") continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (/\.(ts|tsx)$/.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+const importRe = /(?:import|export)\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]|import\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+for (const t of targets) {
+  if (!fs.existsSync(t.base)) continue;
+  const files = walk(t.base);
+  const edges = new Map(); // "from->to" -> count
+  const external = new Map(); // pkg -> count
+  const fileCount = new Map();
+  const testEdges = new Map();
+  for (const f of files) {
+    const rel = path.relative(t.base, f);
+    const fromDir = rel.includes(path.sep) ? rel.split(path.sep)[0] : "(root)";
+    fileCount.set(fromDir, (fileCount.get(fromDir) ?? 0) + 1);
+    const isTest = /\.test\.tsx?$/.test(f);
+    const src = fs.readFileSync(f, "utf8");
+    let m;
+    while ((m = importRe.exec(src))) {
+      const spec = m[1] ?? m[2];
+      if (!spec) continue;
+      if (spec.startsWith(".")) {
+        const abs = path.resolve(path.dirname(f), spec);
+        const relTo = path.relative(t.base, abs);
+        if (relTo.startsWith("..")) {
+          const key = `${fromDir}->(outside:${relTo.split(path.sep).slice(0, 3).join("/")})`;
+          (isTest ? testEdges : edges).set(key, ((isTest ? testEdges : edges).get(key) ?? 0) + 1);
+          continue;
+        }
+        const toDir = relTo.includes(path.sep) ? relTo.split(path.sep)[0] : "(root)";
+        if (toDir === fromDir) continue;
+        const key = `${fromDir}->${toDir}`;
+        (isTest ? testEdges : edges).set(key, ((isTest ? testEdges : edges).get(key) ?? 0) + 1);
+      } else if (spec.startsWith("@shared/") || spec.startsWith("@ai-workflow/") || spec.startsWith("~") || spec.startsWith("@/")) {
+        const key = `${fromDir}->${spec.split("/").slice(0, 2).join("/")}`;
+        (isTest ? testEdges : edges).set(key, ((isTest ? testEdges : edges).get(key) ?? 0) + 1);
+      } else {
+        const pkg = spec.startsWith("@") ? spec.split("/").slice(0, 2).join("/") : spec.split("/")[0];
+        external.set(pkg, (external.get(pkg) ?? 0) + 1);
+      }
+    }
+  }
+  console.log(`\n===== ${t.name} : ${files.length} files =====`);
+  console.log("--- files per top-level dir ---");
+  for (const [d, c] of [...fileCount].sort((a, b) => b[1] - a[1])) console.log(`${d}: ${c}`);
+  console.log("--- non-test import edges (from->to: count), sorted ---");
+  for (const [k, c] of [...edges].sort((a, b) => b[1] - a[1])) console.log(`${k}: ${c}`);
+  // fan-in / fan-out per dir
+  const fanIn = new Map(), fanOut = new Map();
+  for (const k of edges.keys()) {
+    const [a, b] = k.split("->");
+    fanOut.set(a, (fanOut.get(a) ?? 0) + 1);
+    fanIn.set(b, (fanIn.get(b) ?? 0) + 1);
+  }
+  console.log("--- fan-in (how many dirs depend on X) ---");
+  for (const [d, c] of [...fanIn].sort((a, b) => b[1] - a[1])) console.log(`${d}: ${c}`);
+  console.log("--- fan-out (how many dirs X depends on) ---");
+  for (const [d, c] of [...fanOut].sort((a, b) => b[1] - a[1])) console.log(`${d}: ${c}`);
+  // cycles (2-cycles)
+  console.log("--- 2-cycles (A->B and B->A) ---");
+  const seen = new Set();
+  for (const k of edges.keys()) {
+    const [a, b] = k.split("->");
+    if (edges.has(`${b}->${a}`) && !seen.has(`${b}->${a}`)) {
+      seen.add(k);
+      console.log(`${a} <-> ${b} (${edges.get(k)} / ${edges.get(`${b}->${a}`)})`);
+    }
+  }
+  console.log("--- top external packages ---");
+  for (const [p, c] of [...external].sort((a, b) => b[1] - a[1]).slice(0, 25)) console.log(`${p}: ${c}`);
+}

--- a/docs/research/2026-09-09-monorepo-boundary-enforcement.md
+++ b/docs/research/2026-09-09-monorepo-boundary-enforcement.md
@@ -1,0 +1,273 @@
+# Package contracts and import-boundary enforcement in a pnpm/TypeScript/Nitro/Workflow monorepo
+
+Primary-source research, 2026-09-09. Question: for a pnpm workspace monorepo (Node 22+, ESM, a
+Nitro 2 server hosting Vercel Workflow, a Next.js 15 App Router app), what mechanisms exist to
+define package contracts, enforce import boundaries, respect Vercel Workflow/Nitro's placement
+constraints, and use pnpm catalogs plus TS project references.
+
+## 1. Scope and method
+
+Primary sources only: `nodejs.org/api`, `pnpm.io`, `typescriptlang.org`, the `sverweij/dependency-cruiser`
+and `javierbrea/eslint-plugin-boundaries` GitHub repos (READMEs, doc files, and the published npm
+package contents), `typescript-eslint.io`, `oxc.rs`, `knip.dev`, `vercel.com/docs/workflows` and
+`workflow-sdk.dev`, the `vercel/workflow` GitHub repo (including npm package internals, since
+`packages/nitro/README.md` on `main` is a single line and the fuller answer lives in the published
+docs site and the `nitropack`/`nitro` npm packages themselves), `nitro.build`, and the shipped
+`nitropack@2.13.4` npm package (this repo's pinned dependency). No Medium, dev.to, or Reddit
+content is cited.
+
+Per task scope, the only repo files read were `apps/worker/nitro.config.ts`, `apps/worker/package.json`,
+`apps/shared/contracts/package.json`, and `apps/worker/tsconfig.json`. That confirmed: Nitro preset
+`vercel`, `srcDir: "src"`, `nitropack@2.13.4`, `workflow@4.8.0`; `@shared/contracts` ships `"main": "./dist/index.js"`
+plus an `exports["."]` map to `dist/index.d.ts`/`dist/index.js` and a `build` script (`tsc -p tsconfig.build.json`);
+and `apps/worker/tsconfig.json` `include`s `../shared/contracts/**/*.ts` directly alongside `moduleResolution: "Bundler"`.
+
+**Version note, checked directly against the pinned dependency.** `nitro.build`'s current docs and
+the `nitro` GitHub repo's `main` branch describe Nitro 3 (`nitro@3.0.260903-beta` as of this
+writing), where the config field is `serverDir` and `srcDir` carries `/** @deprecated Migrate to
+`serverDir`. */`. This repo depends on `nitropack@2.13.4`. Its published type declarations
+(`dist/shared/nitro.D682J6aL.d.mts` inside the npm tarball) list `srcDir: string;` as a plain,
+non-deprecated field alongside `workspaceDir`, `rootDir`, `scanDirs`, `apiDir`, `routesDir`; there
+is no top-level `serverDir: string | false` scan-root field in 2.13.4. Any Hard Rule below sourced
+from `nitro.build` therefore documents Nitro 3 behavior; where it differs from the pinned 2.13.4,
+that is called out explicitly rather than silently applied to this repo.
+
+---
+
+## 2. Hard rules
+
+| # | Mechanism | Exact quote | Source |
+|---|-----------|-------------|--------|
+| H1 | `exports` replaces `main` and blocks unlisted subpaths | "The `\"exports\"` provides a modern alternative to `\"main\"` allowing multiple entry points to be defined, conditional entry resolution support between environments, and **preventing any other entry points besides those defined in `\"exports\"`**." | https://nodejs.org/api/packages.html |
+| H2 | Deep imports outside `exports` throw | "When the `\"exports\"` field is defined, all subpaths of the package are encapsulated and no longer available to importers... `require('pkg/subpath.js')` throws an `ERR_PACKAGE_PATH_NOT_EXPORTED` error." | https://nodejs.org/api/packages.html |
+| H3 | `exports` wins over `main` | "If both `\"exports\"` and `\"main\"` are defined, the `\"exports\"` field takes precedence over `\"main\"`." | https://nodejs.org/api/packages.html |
+| H4 | Encapsulation is not absolute | "It is not a strong encapsulation since a direct require of any absolute subpath of the package such as `require('/path/to/node_modules/pkg/subpath.js')` will still load `subpath.js`." | https://nodejs.org/api/packages.html |
+| H5 | Conditions ordered most-to-least specific | "The general rule is that conditions should be from most specific to least specific in object order." | https://nodejs.org/api/packages.html |
+| H6 | `imports` is private and `#`-prefixed | "There is a package `\"imports\"` field to create private mappings that only apply to import specifiers from within the package itself... Entries in the `\"imports\"` field must always start with `#`." | https://nodejs.org/api/packages.html |
+| H7 | `null` targets exclude subpaths | "To exclude private subfolders from patterns, `null` targets can be used" (example: `"./features/private-internal/*": null`). | https://nodejs.org/api/packages.html |
+| H8 | TypeScript always tries `types`/`default` conditions | "When using conditional `\"exports\"`, TypeScript always matches the `\"types\"` and `\"default\"` conditions if present." | https://www.typescriptlang.org/docs/handbook/modules/reference.html |
+| H9 | A workspace needs `pnpm-workspace.yaml` | "A workspace must have a `pnpm-workspace.yaml` file in its root." | https://pnpm.io/workspaces |
+| H10 | `workspace:` protocol refuses non-local resolution | "When this protocol is used, pnpm will refuse to resolve to anything other than a local workspace package." | https://pnpm.io/workspaces |
+| H11 | pnpm blocks phantom dependencies by default | "Even though all the dependencies will be hard linked into the root `node_modules`, packages will have access only to those dependencies that are declared in their `package.json`, so pnpm's strictness is preserved." | https://pnpm.io/workspaces |
+| H12 | Semistrict default, `shamefully-hoist` opts out | "By default, pnpm creates a semistrict `node_modules`, meaning dependencies have access to undeclared dependencies but modules outside of `node_modules` do not." (`shamefullyHoist` default `false`.) | https://pnpm.io/settings/node-modules |
+| H13 | `hoistPattern`/`publicHoistPattern` control what leaks | `publicHoistPattern` "hoists dependencies matching the pattern to the root modules directory," enabling application code to reach otherwise-undeclared (phantom) dependencies; `hoistPattern` defaults to `['*']` and hoists only into the hidden virtual-store `node_modules`. | https://pnpm.io/settings/node-modules |
+| H14 | `strictPeerDependencies` default is off | "If this is enabled, commands will fail if there is a missing or invalid peer dependency in the tree." Default: `false`. | https://pnpm.io/settings/peer-dependencies |
+| H15 | Catalogs are reusable version constants | "*Catalogs* are a workspace feature for defining dependency version ranges as reusable constants." Declared via the `catalog:` protocol plus a `catalog` or `catalogs` key in `pnpm-workspace.yaml`. | https://pnpm.io/catalogs |
+| H16 | Catalog protocol is stripped on publish | "The `catalog:` protocol is removed when running `pnpm publish` or `pnpm pack`." | https://pnpm.io/catalogs |
+| H17 | `pnpm deploy` needs injected workspace packages | "By default, the deploy command only works with workspaces that have the `inject-workspace-packages` setting set to `true`." | https://pnpm.io/cli/deploy |
+| H18 | `pnpm deploy` produces an isolated, portable tree | "During deployment, the files of the deployed package are copied to the target directory. All dependencies of the deployed package, including dependencies from the workspace, are installed inside an isolated `node_modules` directory at the target directory." | https://pnpm.io/cli/deploy |
+| H19 | `composite` is required for project references | "Referenced projects must have the new `composite` setting enabled... The `rootDir` setting, if not explicitly set, defaults to the directory containing the `tsconfig` file; all implementation files must be matched by an `include` pattern or listed in `files`; `declaration` must be turned on." | https://www.typescriptlang.org/docs/handbook/project-references.html |
+| H20 | Cross-project imports load `.d.ts`, not source | "Importing modules from a referenced project will instead load its _output_ declaration file (`.d.ts`)." | https://www.typescriptlang.org/docs/handbook/project-references.html |
+| H21 | `tsc -b` builds referenced projects in order | "Running `tsc --build` (`tsc -b`)... Find all referenced projects, Detect if they are up-to-date, Build out-of-date projects in the correct order." | https://www.typescriptlang.org/docs/handbook/project-references.html |
+| H22 | `isolatedDeclarations`, one line | "Require sufficient annotation on exports so other tools can trivially generate declaration files." | https://www.typescriptlang.org/tsconfig/#isolatedDeclarations |
+| H23 | `verbatimModuleSyntax`, one line | "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting." | https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax |
+| H24 | `customConditions` feeds `exports`/`imports` resolution | "`--customConditions` takes a list of additional conditions that should succeed when TypeScript resolves from an `exports` or `imports` field of a `package.json`." | https://www.typescriptlang.org/tsconfig/#customConditions |
+| H25 | dependency-cruiser validates a dependency graph against rules | "Validate and visualise dependencies. With your rules." It "validates them against (your own) rules [and] reports violated rules." | https://github.com/sverweij/dependency-cruiser (README) |
+| H26 | `circular` rule matches cycles | "A Boolean indicating whether or not to match module dependencies that end up where you started (a.k.a. circular dependencies)." | https://github.com/sverweij/dependency-cruiser/blob/main/doc/rules-reference.md |
+| H27 | `from`/`to` define a forbidden-path rule | "Conditions an end of a dependency should match to be caught by this rule. Leave it empty if you want any module to be matched." `from` is "the path from the current working directory... to the file containing a dependency"; `to` is the same for "the file the dependency resolves to." | https://github.com/sverweij/dependency-cruiser/blob/main/doc/rules-reference.md |
+| H28 | `reachable` targets transitive dead wood | "`reachable` is a Boolean indicating whether or not modules matching the `to` part of the rule are _reachable_ (either directly or via other modules) from modules matching the `from` part." | https://github.com/sverweij/dependency-cruiser/blob/main/doc/rules-reference.md |
+| H29 | `required` rules describe mandatory dependencies | "A list of rules that describe what dependencies modules _must_ have, like 'every controller _must depend on_ the base controller'." Has "a mandatory `module` attribute" plus a `to`. | https://github.com/sverweij/dependency-cruiser/blob/main/doc/rules-reference.md |
+| H30 | `--ignore-known` is the baseline mechanism | "With this option engaged dependency-cruiser will ignore known violations as saved in the file you pass it as a parameter" (default `.dependency-cruiser-known-violations.json`). | https://github.com/sverweij/dependency-cruiser/blob/main/doc/cli.md |
+| H31 | `--baseline` writes/updates that file | "This option creates or updates the known violations... This option implies `--no-ignore-known` and `--no-cache`." | https://github.com/sverweij/dependency-cruiser/blob/main/doc/cli.md |
+| H32 | eslint-plugin-boundaries classifies files by pattern | Settings define element types via folder patterns, e.g. `type: "controller", pattern: "controllers/*"`, under `settings["boundaries/elements"]`. | https://github.com/javierbrea/eslint-plugin-boundaries (README) |
+| H33 | `boundaries/dependencies` is the core rule (7.x) | The published package (`eslint-plugin-boundaries@7.2.0`) ships rule modules `Dependencies`, `EntryPoint`, `External`, `NoIgnored`, `NoPrivate`, `NoUnknown`, `NoUnknownFiles`, confirmed against the package's own `dist/Rules/*` file listing. `entry-point` "ensures that elements cannot import files from another element except through the defined entry point"; `no-private` "ensures that elements cannot import the children of another element"; `external` "checks which external dependencies can be used by each element." | https://www.jsboundaries.dev/docs/rules/ and jsdelivr package metadata for `eslint-plugin-boundaries@7.2.0` |
+| H34 | `@typescript-eslint/no-restricted-imports` adds type-aware paths | "Disallow specified modules when loaded by `import`," extended with an `allowTypeImports` option, default `false`, and support for `import type`/`export type` syntax. | https://typescript-eslint.io/rules/no-restricted-imports/ |
+| H35 | oxlint implements `no-cycle` and `no-restricted-imports`, not a boundaries rule | oxlint's rule list carries `import/no-cycle` (restriction category) and `eslint/no-restricted-imports` (restriction category). No rule named `boundaries` or equivalent appears in the reference. | https://oxc.rs/docs/guide/usage/linter/rules.html |
+| H36 | knip finds unused files, exports, and dependencies | "Knip finds unused dependencies, exports and files in your JavaScript and TypeScript projects," via "advanced analysis starting from fine-grained entry points based on the actual frameworks and tooling in (mono)repos." | https://knip.dev/ |
+| H37 | knip ships 150+ framework plugins including Next.js and Vitest | "Knip comes with 150+ plugins for tools and frameworks like Astro, Cypress, ESLint, Jest, GitHub Actions, Next.js, Nx, Remix, Storybook, Svelte, Vite, Vitest, Webpack and many, many more." | https://knip.dev/ |
+| H38 | `'use workflow'` marks a durable, replayed function | "The `'use workflow'` directive marks a function as durable, which means it remembers its progress and can resume exactly where it left off... If a deploy or crash happens, the system replays execution deterministically from where it stopped." | https://vercel.com/docs/workflows/concepts |
+| H39 | `'use step'` marks retried, isolated work | "A step is a stateless function that runs a unit of durable work inside a workflow. The `'use step'` directive marks a function as a step, which gives it built-in retries... Each step compiles into an isolated API route." | https://vercel.com/docs/workflows/concepts |
+| H40 | Workflows run sandboxed and must be deterministic; steps get full Node | Workflow functions run "in a sandboxed environment without full Node.js access" and "must be deterministic," with `Math.random` and `Date` fixed during replay; steps have "full Node.js runtime and npm package access." | https://workflow-sdk.dev/docs/foundations/workflows-and-steps (Context7 `/vercel/workflow`, and confirmed independently by the `@workflow/nest` example: "Steps have full Node.js and npm access") |
+| H41 | Cross-boundary values must be serializable, passed by value | "All function arguments and return values passed between workflow and step functions must be serializable... Parameters are passed by value, not by reference. Steps receive deserialized copies of data." | https://workflow-sdk.dev/docs/foundations/serialization |
+| H42 | Directives are AST-recognized per file, not string-matched | "The plugin eliminates false positives (for example, directive-like strings inside template literals) because it recognizes only genuine directive expression statements." Directives must be "at the beginning (above any other code, including imports for module-level)" and use straight quotes. | https://github.com/vercel/workflow/blob/main/packages/swc-plugin-workflow/spec.md |
+| H43 | `detect` mode is the build-discovery walk | "Detect mode is a lightweight, non-transforming mode used during the build discovery phase. It walks the AST to find `\"use workflow\"` and `\"use step\"` directives." | https://github.com/vercel/workflow/blob/main/packages/swc-plugin-workflow/spec.md |
+| H44 | `@workflow/builders` is the shared bundler substrate | "This package contains the core build logic for transforming workflow source files into deployable bundles. It is used by: `@workflow/cli`... `@workflow/next`... `@workflow/nitro`." Architecture: "esbuild for bundling and tree-shaking," "SWC for transforming workflow directives," "Enhanced resolve for TypeScript path mapping." | https://github.com/vercel/workflow/blob/main/packages/builders/README.md |
+| H45 | `workflow/nitro`'s `dirs` option and its default | Module options read from the Nitro config's `workflow` key. `dirs: string[]`: "Directories to scan for workflows and steps. By default, the `workflows/` directory is scanned from the project root and all layer source directories." | https://workflow-sdk.dev/docs/api-reference/workflow-nitro |
+| H46 | `workflow/nitro` roots discovery at `workspaceDir`, not `srcDir` | "Uses Nitro's `workspaceDir` as the workflow project root so monorepo apps can import sibling workspace packages without extra workflow config." (Identical sentence also stands alone as the entire `packages/nitro/README.md` on `vercel/workflow` `main`.) | https://workflow-sdk.dev/docs/api-reference/workflow-nitro and https://github.com/vercel/workflow/blob/main/packages/nitro/README.md |
+| H47 | Nitro's `workspaceDir` auto-detects the pnpm workspace | "Project workspace root directory. Auto-detected from the workspace (e.g. pnpm workspace) when not set." | https://nitro.build/config#workspacedir (Nitro 3; see version note above) |
+| H48 | Nitro 3 deprecates `srcDir` in favor of `serverDir` | Nitro 3's `NitroConfig.srcDir` carries `/** @deprecated Migrate to \`serverDir\`. */`; `serverDir` is "Server directory for scanning `api/`, `routes/`, `plugins/`, `utils/`, `middleware/`, `modules/`, and `tasks/` folders." Default `false`. | https://raw.githubusercontent.com/nitrojs/nitro/main/src/types/config.ts (Nitro 3 source; not the version this repo pins) |
+| H49 | Nitro 2 (`nitropack@2.13.4`, this repo's pin) keeps `srcDir` live | The shipped `nitropack@2.13.4` type declarations list `workspaceDir`, `rootDir`, `srcDir`, `scanDirs`, `apiDir`, `routesDir` as sibling `NitroConfig` fields, with no `@deprecated` marker on `srcDir` and no top-level `serverDir` scan-root field. | npm package `nitropack@2.13.4`, file `dist/shared/nitro.D682J6aL.d.mts` |
+| H50 | `scanDirs` auto-registers extra route directories | "Additional directories to scan and auto-register files such as API route handlers." | https://nitro.build/config#scandirs |
+| H51 | Externalized packages skip Nitro's `alias` | "Externalized packages are imported at runtime instead of being bundled, so they do not see your `alias` configuration." | https://nitro.build/guide (config section) |
+| H52 | `transpilePackages` compiles monorepo/`node_modules` source | "Use `transpilePackages` to compile and bundle a dependency instead of treating it as untouched runtime code... Next.js does not compile code inside `node_modules` by default." | https://nextjs.org/docs/app/api-reference/config/next-config-js/transpilePackages |
+| H53 | Turbopack auto-transpiles workspace packages; webpack needs the list for Pages Router cross-app source | "Turbopack transpiles workspace packages (npm, pnpm, or Yarn workspaces) in your monorepo automatically under both routers... Add a package to `transpilePackages` when... the dependency's source lives outside the next app's directory. For example, an `apps/web` app importing `packages/ui` in the same monorepo." | https://nextjs.org/docs/app/api-reference/config/next-config-js/transpilePackages |
+| H54 | A package cannot be both transpiled and external | "A package cannot appear in both `transpilePackages` and `serverExternalPackages`; Next.js throws at build start if it does." | https://nextjs.org/docs/app/api-reference/config/next-config-js/transpilePackages |
+| H55 | `typescript.tsconfigPath` can swap the build's tsconfig | "In some cases, you might want to use a different TypeScript configuration for builds or tooling... You might need to relax checks in scenarios like monorepos, where the build also validates shared dependencies that don't match your project's standards." | https://nextjs.org/docs/app/api-reference/config/typescript |
+
+---
+
+## 3. What this means for a 2-app pnpm monorepo
+
+### (a) Package contracts
+
+`exports` (H1-H4) is the actual contract surface: whatever is not listed is unreachable from
+outside the package, and Node enforces this at resolution time, not just by convention. A
+type-only package (one that ships only a `.d.ts` and no runtime file) is not a distinct mechanism
+in the Node spec: it is just a package whose `exports["."].default` happens to point at a stub or
+whose only meaningful condition is `types`; TypeScript's own rule (H8) that it always tries `types`
+first is what makes that work reliably under `moduleResolution: "bundler"`. `@shared/contracts` in
+this repo is the concrete pattern: `package.json` declares `exports["."] = { types: "./dist/index.d.ts",
+default: "./dist/index.js" }`, so any consumer resolves through the built `dist/`, never the
+package's `src/`. But `apps/worker/tsconfig.json` also lists `../shared/contracts/**/*.ts` in
+`include`, meaning the *editor/typecheck* experience reads shared source directly for fast
+feedback, while the *runtime and build* resolve through the compiled `dist/` via the workspace
+symlink. That combination (source for typechecking, dist for `exports`) is exactly why
+`build:shared` has to run before `nitro build`/`nitro dev` in `apps/worker/package.json`: if `dist/`
+is stale or missing, `exports` still points at it and Node/Nitro will bundle whatever is there,
+independent of what `tsc` just saw.
+
+### (b) Import-boundary and cycle rules
+
+Nothing in Node, pnpm, or plain TypeScript enforces "directory X may not import directory Y"
+inside one package. pnpm's strictness (H9-H14) only guards the *dependency-declaration* boundary:
+a package can't reach a peer's transitive dependency it never declared. It says nothing about
+`apps/worker/src/foo.ts` importing `apps/dashboard/src/bar.ts` by relative path, or about
+`workflow-definition/` importing `sandbox/` when the intent is a one-way layering. That gap is
+exactly what dependency-cruiser, eslint-plugin-boundaries, and (partially) oxlint fill (H25-H35,
+compared in §4). TS project references (H19-H21) enforce a *different*, coarser boundary: only
+between declared `composite` projects, and only by making the compiler physically unable to see a
+non-referenced project's private types, useful between `apps/worker` and `apps/shared/*`, useless
+for rules inside `apps/worker/src`.
+
+### (c) Vercel Workflow / Nitro placement constraints
+
+Two mechanisms compose here, and they answer the deliverable question directly (spelled out in
+§5): `workflow/nitro` roots step/workflow discovery at Nitro's `workspaceDir`, i.e. the pnpm
+workspace root, not at `srcDir`/`apps/worker/src` (H46-H47); and discovery itself is directory-list
+based, not "anything reachable": the `dirs` option defaults to "`workflows/` ... from the project
+root and all layer source directories" (H45). Discovery is driven by an SWC AST walk over files
+inside those directories (H42-H43), not by directory naming inside `apps/worker` specifically. What
+goes in a `"use workflow"` body is constrained to deterministic, sandboxed code (H40); what goes in
+a `"use step"` body gets full Node/npm access, so that is where a database client, an SDK call, or
+any side-effecting workspace-package import belongs. Values crossing the boundary must serialize
+(H41), which constrains what kind of object a shared `@shared/contracts` type can carry across it
+(plain data, not class instances, unless the class implements the SDK's serialize/deserialize
+hooks).
+
+### (d) pnpm catalogs and TS project references
+
+Catalogs (H15-H16) solve version drift, not import boundaries: a `catalog:` entry in one
+`package.json` still resolves to a real semver range pinned once in `pnpm-workspace.yaml`, so
+`apps/worker` and `apps/dashboard` can share a `zod` or `typescript` version without every
+`package.json` repeating it, and `pnpm publish` strips the protocol back to a concrete range so a
+published package never leaks an unresolvable specifier. Project references (H19-H21) give a
+monorepo incremental, dependency-ordered builds and a hard type wall between `composite` projects
+(consumers only ever see `.d.ts`, H20), but only where `references` arrays are actually declared
+and `tsc -b` is actually the thing being run; a plain `tsc --noEmit` invocated per-package (as
+`apps/worker/package.json`'s `typecheck` script does, per the file read for this task) does not
+require or benefit from `composite`/`references` at all.
+
+---
+
+## 4. Comparison of import-boundary enforcement options
+
+| Option | What it enforces | Where it runs | Cost to adopt | Baseline/ratchet support | Citation |
+|---|---|---|---|---|---|
+| dependency-cruiser | Arbitrary `from`/`to` path-pattern rules, `no-circular`, `reachable` (dead/transitive code), `required` (mandatory deps), on the actual resolved module graph | Standalone CLI; drop into a pre-commit hook, `pnpm` script, or CI step; also produces graphs (dot/mermaid) | Medium: `--init` scaffolds a config with sane defaults (circular detection out of the box); custom `from`/`to` rules for app-vs-app boundaries need to be hand-written | Yes, native: `--baseline` writes a known-violations file, `--ignore-known` (default filename `.dependency-cruiser-known-violations.json`) silences only what's already recorded | H25-H31 |
+| eslint-plugin-boundaries | Which "element type" (folder pattern) may import which other element type, entry-point-only access, external-package allowlists per element, unknown-file/unknown-dependency detection | ESLint, so editor-time and CI lint step | Medium-high: requires defining an explicit element taxonomy (`settings["boundaries/elements"]`) that matches the repo's real architecture before any rule is useful | None built in; relies on generic ESLint suppression (inline disable comments), no baseline/ratchet file format of its own | H32-H33 |
+| oxlint | `import/no-cycle` (circular-import detection) and `eslint/no-restricted-imports` (path/pattern bans); no dedicated architecture-boundary rule | Rust-based linter binary; very fast, fits in CI or as a pre-commit gate alongside/instead of ESLint | Low: single binary, `.oxlintrc.json` toggles rules; but it cannot replace eslint-plugin-boundaries since it has no element-type concept | Not documented on the fetched rules page | H35 |
+| TS project references | Which `composite` project's private source is visible to which other project; consumers only ever see the referenced project's `.d.ts` output | `tsc -b` (build orchestrator) and IDE project-aware navigation | High: every package needs `composite: true`, an explicit `references` array, and `declaration: true`; restructures the whole build pipeline around it | None: a reference either resolves and typechecks or it doesn't; no partial/known-violation mode | H19-H21 |
+| pnpm strict linking (default, no `shamefully-hoist`) | That a package can only `require`/`import` a dependency it declares itself in its own `package.json` (blocks phantom-dependency access); `workspace:` protocol blocks resolving to a non-local package | pnpm's install-time `node_modules` layout; enforced by Node's own resolution at runtime, nothing to "run" separately | Zero: this is pnpm's default behavior | N/A: it's structural prevention, not a violation-reporting tool, so there is nothing to baseline | H9-H14 |
+
+---
+
+## 5. Can Vercel Workflow step files live in a workspace package outside `apps/worker/src`, and under what condition?
+
+Yes, with two conditions that both come from primary sources, not inference:
+
+1. **The file must sit inside (or be re-exported into) a directory the `workflow/nitro` module
+   actually scans.** Discovery is not "anything reachable through imports": it is a directory
+   list, defaulting to `workflows/` at the Nitro project root "and all layer source directories"
+   (H45). A workspace package that is one of Nitro's configured layers, or whose `workflows/`
+   subdirectory is added via the module's `dirs` option, satisfies this; a package that is neither
+   a layer nor named in `dirs` does not get scanned even if it's a normal workspace dependency.
+2. **The Nitro *project root* for this purpose is the pnpm workspace root (`workspaceDir`), not
+   `apps/worker/src`.** H46: "Uses Nitro's `workspaceDir` as the workflow project root so monorepo
+   apps can import sibling workspace packages without extra workflow config." That sentence is the
+   entire content of `packages/nitro/README.md` on `vercel/workflow`'s `main` branch, and it is
+   repeated verbatim in the published API reference (H45-H46). Practically: a `'use step'` function
+   in `apps/shared/some-package/src/foo.ts` can be imported by an `apps/worker` workflow file and
+   still get discovered/bundled correctly, because `workflow/nitro` resolves the whole workspace as
+   one project, not just `apps/worker`.
+
+What is not shown by any source fetched: whether `dirs` accepts a path like
+`../shared/some-package/workflows` (a relative escape from the Nitro `rootDir`) or only paths
+inside `rootDir`/`workspaceDir`'s own layer list. The docs describe the default and the
+`workspaceDir` rooting, not the exact glob/escape semantics of a custom `dirs` entry.
+
+---
+
+## 6. What the sources do not say
+
+1. **No stated glob/escape semantics for `workflow/nitro`'s `dirs` option.** Confirmed it exists and
+   its default (H45); not confirmed whether an entry can point outside `workspaceDir`, or whether
+   symlinked workspace packages are walked the same way as real directories.
+2. **No monorepo-specific statement from Node.js itself.** `exports`/`imports`/conditions (H1-H8)
+   are package-level rules with no awareness of workspaces; every workspace-specific behavior
+   (H9-H18) comes from pnpm, not Node.
+3. **No native "ratchet" or baseline feature in eslint-plugin-boundaries or oxlint.** Only
+   dependency-cruiser documents a first-party baseline/known-violations workflow (H30-H31).
+4. **No confirmation that the fetched `nitro.build/config` pages describe the exact `nitropack@2.13.4`
+   this repo pins.** They document the current Nitro 3 line; H48-H49 record the concrete difference
+   found by inspecting the published 2.13.4 package directly, but no page states a version-by-version
+   changelog for `srcDir`; the deprecation date/version is not documented anywhere fetched.
+5. **No pnpm statement about relative cross-package source imports.** pnpm's strictness (H9-H14) is
+   entirely about the dependency-declaration graph inside `node_modules`; nothing in `pnpm.io`
+   claims it blocks or permits `import ... from "../../other-app/src/x"`; that path never touches
+   pnpm's linking layer at all, which is exactly why a separate boundary tool (§4) is needed.
+6. **No first-party "world" page found.** `workflow-sdk.dev/docs/worlds` and `.../docs/concepts/world`
+   both 404'd; the concept ("world" as a pluggable persistence backend, e.g. `@workflow/world-postgres`,
+   present in this repo's `apps/worker/package.json` devDependencies) is referenced only in passing by
+   the pricing page's Events section, not documented on a fetched page.
+7. **No fetched Vercel Workflow "limitations" page.** `vercel.com/docs/workflows/limits` 404'd; the
+   closest primary content is the numeric ceilings on `vercel.com/docs/workflows/pricing` (not given
+   an H-number above, since these are quantitative limits rather than a boundary/contract rule): 25,000 events/run,
+   10,000 steps/run, 50 MB max payload, 240s max workflow replay duration, 250 MB max total bundle size.
+8. **No statement tying `isolatedDeclarations` or `verbatimModuleSyntax` specifically to monorepos.**
+   Both are general TypeScript emit-correctness options (H22-H23); no fetched page frames them as a
+   monorepo-boundary mechanism, though `isolatedDeclarations`'s stated purpose (per-file
+   transpilation safety) is why a tool like esbuild/SWC-based bundling (as `@workflow/builders` uses,
+   H44) benefits from it.
+
+---
+
+## Source list
+
+1. https://nodejs.org/api/packages.html
+2. https://pnpm.io/workspaces
+3. https://pnpm.io/catalogs
+4. https://pnpm.io/settings/peer-dependencies
+5. https://pnpm.io/settings/node-modules
+6. https://pnpm.io/cli/deploy
+7. https://www.typescriptlang.org/docs/handbook/project-references.html
+8. https://www.typescriptlang.org/tsconfig/ (plus per-option anchors: `#paths`, `#customConditions`, `#verbatimModuleSyntax`, `#isolatedDeclarations`, `#composite`)
+9. https://www.typescriptlang.org/docs/handbook/modules/reference.html
+10. https://github.com/sverweij/dependency-cruiser (README.md)
+11. https://github.com/sverweij/dependency-cruiser/blob/main/doc/rules-reference.md
+12. https://github.com/sverweij/dependency-cruiser/blob/main/doc/cli.md
+13. https://github.com/javierbrea/eslint-plugin-boundaries (README) and https://www.jsboundaries.dev/docs/rules/
+14. jsdelivr package file listing for `eslint-plugin-boundaries@7.2.0` (https://data.jsdelivr.com/v1/packages/npm/eslint-plugin-boundaries@7.2.0)
+15. https://typescript-eslint.io/rules/no-restricted-imports/
+16. https://oxc.rs/docs/guide/usage/linter/rules.html
+17. https://knip.dev/
+18. https://vercel.com/docs/workflows
+19. https://vercel.com/docs/workflows/concepts
+20. https://vercel.com/docs/workflows/pricing
+21. https://workflow-sdk.dev/docs/foundations/workflows-and-steps
+22. https://workflow-sdk.dev/docs/foundations/serialization
+23. https://workflow-sdk.dev/docs/api-reference/workflow-nitro
+24. https://github.com/vercel/workflow/blob/main/packages/nitro/README.md
+25. https://github.com/vercel/workflow/blob/main/packages/builders/README.md
+26. https://github.com/vercel/workflow/blob/main/packages/swc-plugin-workflow/spec.md
+27. https://github.com/vercel/workflow/blob/main/packages/nest/README.md
+28. https://nitro.build/config (and `#workspacedir`, `#scandirs` anchors)
+29. https://nitro.build/guide
+30. https://raw.githubusercontent.com/nitrojs/nitro/main/src/types/config.ts (Nitro 3, `main` branch)
+31. npm package `nitropack@2.13.4` (published tarball, `dist/shared/nitro.D682J6aL.d.mts`): this repo's pinned Nitro version
+32. https://nextjs.org/docs/app/api-reference/config/next-config-js/transpilePackages
+33. https://nextjs.org/docs/app/api-reference/config/typescript
+34. https://workflow-sdk.dev/docs/worlds and https://workflow-sdk.dev/docs/concepts/world; both 404, recorded in §6
+35. https://vercel.com/docs/workflows/limits; 404, recorded in §6
+
+Repo files read (per task scope, not cited as external sources): `apps/worker/nitro.config.ts`,
+`apps/worker/package.json`, `apps/shared/contracts/package.json`, `apps/worker/tsconfig.json`.

--- a/docs/research/2026-09-09-roadmap-backlog-fit.md
+++ b/docs/research/2026-09-09-roadmap-backlog-fit.md
@@ -1,0 +1,239 @@
+# Roadmap and Jira backlog against the restructure plan
+
+Date: 2026-09-09. Inputs: the 27 Aug 2026 roadmap (checked in as
+[../product/roadmap-2026-08-27.md](../product/roadmap-2026-08-27.md), 106
+unchecked items across P0-P3 and four milestones), the full open AIW backlog
+(100 issues, `project = AIW AND statusCategory != Done`, fetched 2026-09-09:
+45 To do, 33 Backlog, 9 in verification as tasks, plus 10 subtasks and 3
+epics), the descriptions of AIW-199, AIW-260, AIW-313, AIW-325, AIW-326,
+AIW-335, the merge state of PRs #358-#360, and the plan
+[../plans/2026-09-09-architecture-restructure.md](../plans/2026-09-09-architecture-restructure.md).
+
+Question answered: does the plan give a clean base for the roadmap, the bug
+fixes and the backlog, and where does it collide with work already in flight?
+
+Short answer: the plan and the stabilisation track already in Jira want the
+same things and were about to build three of them twice. Four plan elements
+change (stage 0, stage 1, stage 5b, D7 with stage 7); the rest of the plan
+turns out to be the missing precondition for most of the roadmap's P1-P3.
+
+---
+
+## 1. Where the stabilisation track stands
+
+AIW-326 records the executable P0 order as of `main@172de9c6` (2026-09-04):
+AIW-313/#358 -> AIW-314/#360 -> G2 enforcement -> AIW-322/#359; then
+AIW-315/321/323; then AIW-316 -> AIW-317 -> AIW-320 -> AIW-318 (exact-SHA
+go/no-go for the isolated demo environment).
+
+State on 2026-09-09:
+
+| Item | State | Evidence |
+|---|---|---|
+| AIW-313 credential-free production bundle in CI | PR #358 merged 2026-09-06; ticket in verification | `build:ci` in `apps/worker/package.json` runs validators plus `nitro build` without `db:migrate` or `seed:auth-user`; `ci.yml` has `source-checks`, `unit-worker`, `unit-dashboard`, `workflow-sdk`, aggregator `ci` |
+| AIW-314 poll-agent test isolation | Done, PR #360 merged | |
+| AIW-322 capacity fixtures fail closed | Done, PR #359 merged | |
+| AIW-315 scope-aware pre-push gate | Done | `.githooks/pre-push`, `scripts/ci/verify-changed.ts` |
+| AIW-323 Dependabot reconciliation | Done | |
+| **G2 enforcement** (required check on `main`) | **not done** | GitHub API: no protection, no rulesets |
+| AIW-321 pin Actions, minimise token persistence | To do, High | |
+| AIW-316 / 317 / 318 isolated demo identity, fixtures, go/no-go | To do, High, p0 | `deployment-identity.ts`, `verify-deployment-identity.ts` exist |
+| AIW-320 harden secret-bearing e2e | To do, High | |
+| AIW-326 reconcile roadmap and Jira graph | To do, High | says `docs/AI-WORKFLOW-ROADMAP.md` is a 2026-08-13 historical snapshot |
+| AIW-327 / 328 / 329-335 Better Auth 1.7 rollout | in verification; AIW-335 (transaction-capable driver) To do | |
+
+The next gate in that order is exactly the plan's stage 0.
+
+---
+
+## 2. Collisions between the plan and the backlog
+
+| Ticket | Plan element | What was about to happen twice | Resolution applied to the plan |
+|---|---|---|---|
+| AIW-313 (verification) | Stage 0 "required `ci` on `main`" | Both define the aggregate check and the branch-protection flip. AIW-313 also separated bundling from migration, which the audit listed as a risk. | Stage 0 is the open remainder of AIW-313: make `ci` reportable, require it, close the ticket with the evidence it asks for. No new ticket. The audit's "migrations run during build" risk is reduced to `vercel build` only. |
+| AIW-335 (To do) | D7 and stage 7 "throw on `.transaction(`, gate everything" | AIW-335 ports production `getDb()` to `drizzle-orm/node-postgres` with `pg` 8.20.0 because Better Auth 1.7 needs adapter transactions, with a real BEGIN/ROLLBACK contract test. The plan was about to forbid the thing AIW-335 makes work. | D7 reversed: transactions become legal, but only inside `db/repositories/*`; the gate fails `.transaction(` anywhere else; stage 7 runs after AIW-335 merges and reuses its contract test. The memory note "neon-http has no transactions" stays true until AIW-335 lands. |
+| AIW-325 (To do) | Stage 1 boundary gate; stage 5 WDK discovery test | AIW-325 wants the workflow import-boundary check to distinguish executable Node imports from import-like text in string literals and to fail closed on a real forbidden import. Stage 1 would have added a second boundary tool beside it. | AIW-325 becomes part of stage 1's scope: dependency-cruiser owns directory tiers, the WDK bundle check owns "no Node import in workflow VM code", and both get a negative fixture. |
+| AIW-199, AIW-196 (Backlog) | Stage 5b behavioural PR gate | AIW-199 defines deterministic template-scenario CI plus environment-gated live canaries; AIW-196 adds a production-dispatch mode to the scenario harness. Stage 5b is the live-canary half, written without knowing the ticket. | Stage 5b delivers the live-canary half of AIW-199 and AIW-196's dispatch mode against the preview. The deterministic half (AIW-195, 197, 198) is pulled forward as a prerequisite of stage 4, see section 5. |
+| AIW-260 / 316 / 317 / 318 (To do, High) | Stage 5b preview deployment; stage 3 and 5 canary DoD | The preview the canaries run against must be the isolated identity AIW-316 proves, or a canary can dispatch against production tickets. | Stage 5b and the canary DoDs depend on AIW-316 (identity fence) being merged; `verify-deployment-identity.ts` is the preflight. AIW-317 fixtures are what the canaries should seed. |
+| AIW-326 (To do, High) | Stage 2 docs taxonomy | AIW-326 wants one dated executable baseline linked from the canonical roadmap, the 2026-08-13 file kept as history, superseded statements recorded. Stage 2 wants `docs/product/roadmap` and an archive. | The roadmap is now checked in at `docs/product/roadmap-2026-08-27.md` with a status header; stage 2 archives `docs/AI-WORKFLOW-ROADMAP.md` under AIW-326's rules and AIW-326 owns the Jira link cleanup. |
+| AIW-182 (Backlog, High) "capability-driven model and compaction controls" | D6 model catalog, stage 8b | AIW-182 needs one place that says which models a provider supports and what they can do. Today that is four files. | Stage 8b is the precondition; AIW-182 is the first feature that lands on the new catalog. |
+| AIW-294 "injection check: typed output enum, halt main workflow" and AIW-297 "unify input/param naming for MCP" (AIW-293 epic) | D4 block manifest, stage 4 | Both edit block contracts in `block-registry.ts`, `schema.ts` and `config-fields.tsx`, the files stage 4 restructures. | Land after stage 4 (one directory per block) or they are done twice. Section 6. |
+
+---
+
+## 3. Roadmap themes and where they land
+
+Each theme of the 27 Aug roadmap, the tier or package it lands in after the
+plan, the stage that makes it cheap, and what stays hard until then.
+
+| Roadmap theme | Landing zone | Enabling stage | Hard until then because |
+|---|---|---|---|
+| **P0 Prompt composition and governance** (inventory of instruction sources, precedence rules, exact effective instructions per run, versioning, diffs, rollback) | `packages/prompts` plus `engine/steps/prompt*` | 8a | composition logic exists twice (worker and dashboard); "show the exact effective instructions" cannot be true while the dashboard computes its own version (AIW-300 is the same item) |
+| **P0 Tenant release verification** (deployed versions per tenant, drift detection, definition migration on schema change, rollback) | `services/system` (deployment identity, exists), `packages/workflow-graph` for definition migration | 2 (ADR-003), 3b, 12 | migrating deployed definitions when schemas change needs one schema (3b) and a pure graph package; the version surface itself is already there |
+| **P0 PR and MR feedback handling** (pending feedback blocks the no-op exit, comment identity and status, coalescing, no parallel fixes on one PR) | `services/dispatch` (coalescing, ownership), `engine/steps` (review ledger, exists) | 6b | the coalescing and ownership logic sits in `lib/dispatch*.ts` and the three big route handlers; it can be fixed today but every fix is another branch in a 700-line handler |
+| **P0 Webhooks and integration health** (admin health page, delivery history, idempotent duplicates) | `services/system-health` (exists), `app/routes/webhooks` thin, dashboard health screen | 6c | webhook handlers verify, decrypt, rate-limit and dispatch inline; delivery history storage belongs to a repository the plan creates in 7 |
+| **P0 Failed-check remediation** (fix agent on same PR, stale heads, explicit no-commit failure, retry caps) | `engine/pre-pr-checks`, `engine/steps` | 5 | `agent.ts` owns terminal disposition and the autofix loop in one 3600-line body; AIW-292 (duration budget kills runs) and AIW-311 (finalize failure mislabelled) are symptoms |
+| **P0 Pre-PR checks and repository environments** (setup commands, "failed" vs "could not start", redacted output tail, budgets) | `engine/pre-pr-checks`, repository scripts (exist) | 5 | same file |
+| **P0 Runtime resilience** (diagnostic IDs, typed causes, capacity exhaustion reported, no re-claim of terminated work, resume after clarification) | `services/run-lifecycle`, `engine/steps/clarification*` | 6b, 5 | AIW-277, 279, 280, 289 are all here; they are fixable now and should be fixed before the freezes (section 5) |
+| **P1 Explicit domain model** (tickets, repos, branches, PRs, threads, comments, checks, runs as linked entities) | `db/repositories` per domain, `packages/contracts` | 7 | 62 tables written from 15 directories with no owner; the data-model document with table ownership is the first artefact of this theme |
+| **P1 Ticket and PR workflow decomposition** (separate PR/MR workflows, context-resolution block, workspace preparation limited to provisioning) | `engine/agent-workflow.ts` plus a second `"use workflow"` entrypoint, `engine/blocks/context-resolution` | 4, 5 | a second workflow entrypoint is a copy of 3600 lines today; after stage 5 it is a new file that composes existing steps |
+| **P1 Trigger-owned configuration** (Jira mapping per trigger, repo scope per trigger, independently enabled triggers) | `services/triggers`, `packages/contracts` | 6c | trigger config is split between `env.ts` (global) and definition triggers; AIW-295 is the same item |
+| **P1 Repository profiles** (descriptions, relationships, setup groups, versioned) | `db/repositories/repositories`, repository scripts (exist) | 7 | |
+| **P2 Typed workflow composition** (typed inputs, outputs, decisions, failure routes per block; halt on flagged safety check) | `engine/blocks/*/manifest.ts`, `packages/workflow-graph` | 4, 12 | the manifest is where a typed output contract lives; AIW-294, 296, 297, 305, 306 are this theme |
+| **P2 Context and run transparency** (only bound context reaches the agent, per-block inputs, outputs, model, tools, skills) | `engine` (prompt runtime, sandbox context), `run-observability` | 5, 8a | AIW-300, 301, 302 |
+| **P2 Permissions and onboarding** | `app` (Better Auth wiring), `services/auth` | 6b, AIW-328 | |
+| **P2 Documentation and reusable workflows** (block docs, cloneable workflows, regression fixtures, rollback loads into editor) | `docs/architecture/blocks.md` (generated from manifests), scenario harness (AIW-194) | 2, 4 | AIW-307, AIW-288 |
+| **P2 Operational dashboard** (attribution by cost, model, tenant; separate evidence from charts; feature-flag unfinished areas) | `packages/costs`, dashboard | 8c, 9 | AIW-290, 304 |
+| **P3 Chat-agent integration** (MCP actions to list, dispatch, monitor, answer, retrieve) | `app/mcp` thin over `services` | 6c | the MCP tools already exist (28-tool contract) and already duplicate route logic (fan-out to 14 directories); without a service layer every new MCP action is a second implementation |
+| **P3 Third-party integrations** (Extensions tab, Arthur card, reusable extension contract) | a new `adapters/extensions` seam plus `packages/contracts` extension types | after 6b | not in the plan; the adapter tier is where it goes, and it should not start before the tiers exist |
+| **P3 Provider-neutral safety and observability** (typed pass / block / human-review outcomes with evidence) | `packages/contracts`, `engine/blocks` (injection check) | 4 | AIW-294 is the first block to get a typed outcome |
+| **P3 Hosted and on-premise execution** (infrastructure and sandbox adapters instead of forks) | `adapters/sandbox` (new seam; one adapter today, Vercel Sandbox) | after 6b | a seam with one adapter is hypothetical; do not build it until an on-prem tenant is real (AIW-43) |
+
+Reading of the table: the plan is the precondition for two thirds of the
+roadmap. The P0 rows are mostly fixable today at a higher cost per fix; the
+P1-P3 rows are not reasonably buildable on the current structure without
+adding to the tangle.
+
+---
+
+## 4. Milestones against stages
+
+| Roadmap milestone | Plan stages that must land first |
+|---|---|
+| M1 Stable pilot (P0 scenarios pass in a tenant, feedback cannot false-exit, integrations visible, failures diagnosable) | 0 (required CI), 5b with AIW-316 (real run on an isolated preview); the P0 bug fixes themselves do not wait for the restructure |
+| M2 Correct multi-repository workflows (explicit relationships, separate PR follow-up workflow, trigger-specific config) | 4, 5, 6c, 7 |
+| M3 Self-service builder and operations (typed, documented blocks; tenant regressions before release) | 4, 8a-8d, 9, AIW-194 epic |
+| M4 External orchestration and extensions | 6c, then the extension seam |
+
+---
+
+## 5. Open bugs and the freeze windows
+
+High-priority open bugs (all labelled `client-arthur-ai`): AIW-277 dispatch
+refuses silently when the pool is full; AIW-279 a parked run never notices
+its ticket was deleted; AIW-280 an answered clarification whose resume never
+completed parks the run forever; AIW-292 the default duration budget kills
+runs mid-checks; AIW-284 (verification) expansion gates on a human when the
+model requests only attached repos; AIW-187 copied agent blocks retain
+overrides. Medium: AIW-268, 269, 275, 283, 287, 289, 311, 337.
+
+Every one of them touches `lib/dispatch*`, `clarifications/`, or
+`workflows/agent.ts`, which is exactly the freeze zone of stages 4-5 and 6a-6c.
+
+Rule adopted in the plan: **bugs first, freezes second.** Stages 0-3 touch
+none of those files, so bug fixes flow in parallel with them. The first freeze
+does not start until the High bugs above are merged or explicitly deferred by
+the owner. During a freeze, a High bug in the frozen directory is fixed on
+top of the restructure branch by the same executor, not on `main`.
+
+Recommended prerequisite: AIW-195 and AIW-197 (strict scenario harness for
+the standard templates, both Backlog) before stage 4. They turn the 79
+workflow tests plus two discovery tests into a behavioural net for the two
+riskiest moves. Without them stages 4 and 5 rely on unit tests and one
+preview run.
+
+---
+
+## 6. The AIW-293 epic (workflow builder fixes) and stage 4
+
+Fourteen tasks from the 2026-08-17 review. Split by whether they edit block
+contracts:
+
+* **After stage 4** (they change what a block declares): AIW-294 typed
+  injection output and halt, AIW-297 param naming unification, AIW-305
+  structured JSON input on generic agent, AIW-306 skills visible on agent
+  blocks (also after 8d), AIW-300 effective prompt shows bound data (also
+  after 8a), AIW-301 no unbound runtime data in the sandbox (engine, after 5).
+* **Any time** (UI or isolated): AIW-296 bindings UX, AIW-299 PR block copy
+  and fix-cycle display, AIW-304 cost graph clipping, AIW-288 rollback loads
+  into the editor, AIW-290 feature-flag dashboard tabs.
+* **After 6c**: AIW-295 repo scope at the trigger, AIW-298 ticket context for
+  PR-triggered workflows.
+* **After 7**: AIW-303 memory filtering and cleanup process.
+* **Docs**: AIW-307 composition docs, produced by stage 4's generator plus
+  stage 2's taxonomy.
+
+---
+
+## 7. Changes applied to the plan (revision 3)
+
+1. Stage 0 is the open remainder of AIW-313, not a new gate.
+2. Stage 1 absorbs AIW-325 (string-literal false positives, fail-closed
+   negative fixture) and states which tool owns which boundary.
+3. D7 and stage 7 reversed: transactions legal only inside `db/repositories`
+   once AIW-335's `node-postgres` driver lands; stage 7 ordered after AIW-335
+   and reuses its BEGIN/ROLLBACK contract test.
+4. Stage 5b delivers the live-canary half of AIW-199 plus AIW-196, depends on
+   AIW-316 for the isolated identity.
+5. New assumptions A13 (AIW-335 driver) and A14 (AIW-195/197 before stage 4),
+   the latter also a question to the owner.
+6. Sequencing rule "bugs first, freezes second" and the AIW-293 split written
+   into the plan.
+7. The roadmap is checked into `docs/product/` so AIW-326 has a canonical
+   file to link and no decision record points at a Downloads path.
+
+One risk surfaced for AIW-335 itself, recorded here because the ticket does
+not mention it: the memory note from 2026-07-13 says `neon-http` was chosen
+deliberately because `getDb()` must also load inside Workflow DevKit step
+bundles (the run path and the `send_plan_approval` block run there), where a
+socket-based pool could not run at the time. AIW-335's acceptance criteria
+prove BEGIN/ROLLBACK through the production factory and Neon-over-TCP pool
+behaviour, but not that a `pg` pool initialises and executes inside a step
+bundle on Vercel. That proof belongs in AIW-335 before stage 7 depends on it.
+
+---
+
+## 7b. Changes applied in revision 4 (v1 retirement, 2026-09-09)
+
+The owner reversed Q4 after reading the plan: v1 is retired inside this plan
+instead of in a separate one. Reason given: no customer runs v1 (the Arthur
+tenant is out of support) and two live schemas create chaos. Evidence
+gathered before the change:
+
+* Production (`workflows.list` then `workflows.get_graph`, 2026-09-09): 9
+  non-archived definitions (ids 2, 11, 12, 14, 23, 25, 28, 29, 32), every
+  deployed graph and every draft at `schemaVersion: 2`. Archived definitions
+  and `workflow_definition_versions` rows are not visible through MCP and are
+  measured by SQL at the start of stage 3b.
+* Nothing creates v1 any more: `workflow-definitions.post.ts:177` and
+  `templates.ts:1505` emit v2; the singular shim routes
+  (`workflow-definition.get.ts`, `.put.ts`, `workflow-definition/restore.post.ts`)
+  still serve the v1 default and are called only by their own tests
+  (`workflow-definitions.test.ts:2280,2319`).
+* The eight scenario snapshots under `workflow-definition/scenarios/snapshots/`
+  are all v2, so AIW-195/197 (A14) is the behavioural net for the deletion.
+* Blast radius in code: the v1 walker (`interpreter.ts:414`), about 30
+  `schemaVersion` branches in `agent.ts`, three in dispatch, two in the store,
+  the converter and migration modules (about 2300 lines), the dashboard's
+  v1 defaults in `lib/workflow-editor/*` and `lib/flows.ts`, 18 worker and 8
+  dashboard test files. Harness-profile manifests have their own
+  `schemaVersion` and are excluded.
+
+Plan changes: D12 added, A11 rewritten, stage 3b inserted between 3 and 4
+(opens the first freeze), stage 2 writes ADR-003 as Accepted, stage 12 loses
+its condition, D10 and A8 start the first freeze at 3b.
+Stage 3b then had its own skeptic pass (REVISE, 10 findings); all ten are
+triaged in the plan's second pre-mortem table, the largest being that the v1
+default is still the fresh-install run path (`definition-step.ts:132`) and is
+now replaced by the v2 default rather than deleted.
+
+Backlog effect: AIW-293 tasks that touch the editor's serialisation (AIW-294,
+297) should land after 3b as well as after 4, since 3b removes the
+`schemaVersion = 1` defaults they would otherwise build on. No open ticket
+asks for v1 support.
+
+## 8. What the backlog lacks
+
+* **Tickets for the restructure stages themselves.** Nothing in AIW tracks
+  the tier map, the block manifest, the `agent.ts` split, the packages, or
+  the docs taxonomy. Recommendation: one ticket per stage, parented to a new
+  epic, created when the owner approves the plan, with the plan's DoD copied
+  as acceptance criteria. AIW-326's rule applies: statuses move on merged
+  evidence, not prose.
+* **A ticket for the extension seam** (roadmap P3, third-party integrations)
+  so it is not improvised inside the Arthur work.
+* **AIW-239** (MCP endpoint) is still "To do" although the MCP trilogy merged
+  on 2026-08-26 and the 28-tool contract is in the repo; AIW-326's status
+  reconciliation should close or re-scope it.
+* **Vendored `.agents/skills`, `.kimi-code`, `design-qa.md`** have no ticket;
+  stage 2 deletes them and needs none.


### PR DESCRIPTION
Throwaway probe for stage 0 of the architecture restructure plan (docs/plans/2026-09-09-architecture-restructure.md). It exists to prove that the `ci` aggregator reports a real verdict on a pull request that also carries a docs-only change, instead of sitting on a permanent "Expected".

Will be closed unmerged. Nothing here is meant to land on main from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CI now reports all failing checks together, validates the expected check set, and provides more reliable required-check results.

- **Documentation**
  - Added architecture decision records covering package layering, CI gates, and documentation conventions.
  - Added a comprehensive architecture restructuring plan and implementation ticket draft.
  - Added product roadmap documentation and research on codebase navigation, architecture boundaries, import analysis, and roadmap alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->