### PR TITLE
docs: record the active main ruleset and close AIW-313

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,12 +96,11 @@ currently empty. The gate is advisory and bypassable: `git push --no-verify` is
 an audited bypass, so record why it was used and do not report the gate as
 passed.
 
-Nothing enforces CI at merge time yet. `main` has no branch protection and no
-ruleset, by recorded decision, so a red `ci` job stops nothing. ADR-004 decides
-what replaces that (a ruleset requiring the `ci` aggregator, with exactly one
-named bypass actor, every use of the bypass opening a Jira issue) and that flip
-is the open remainder of AIW-313. Until it lands, a green run is evidence of
-correctness, never proof that a red candidate could not land.
+`main` carries the branch ruleset decided in ADR-004: since 2026-09-09 it
+requires the `ci` aggregator to pass, so a red `ci` job blocks the merge. The
+only bypass is one named user account, and every use of it must open a Jira
+issue recording what was merged and why. Whether that audit happens every time
+is the remaining gap.
 
 The full gate ladder, the evidence-bundle schema, the Jira disposition rules
 and release authority live in [docs/delivery-gates.md](docs/delivery-gates.md).

--- a/docs/adr/ADR-004-gates-and-required-ci.md
+++ b/docs/adr/ADR-004-gates-and-required-ci.md
@@ -124,8 +124,9 @@ Every use of the bypass opens a Jira issue recording what was merged and why,
 mirroring the `--no-verify` audit rule in `AGENTS.md`: the bypass is auditable,
 so a merge that skipped `ci` is never reported as a merge that passed it.
 
-This is the open remainder of AIW-313. PR #358 already merged the
-credential-free bundle and the validators into CI; the flip is what is left.
+PR #358 already merged the credential-free bundle and the validators into CI.
+The ruleset itself was created on 2026-09-09 (id 22668605, name "main requires
+ci") with exactly the shape above. AIW-313 is closed by it.
 
 ### 5. A behavioural gate is planned, not present
 

--- a/docs/delivery-gates.md
+++ b/docs/delivery-gates.md
@@ -46,7 +46,7 @@ These gates are executable today and produce evidence an agent can cite.
 | --- | --- |
 | **G0 — clean task/source freeze** | Confirm the recorded worktree, branch/upstream, start SHA, clean state, Jira scope, and target environment/tenant before edits. Stop on an unexplained mismatch or unrelated dirty state. |
 | **G1 — fast local pre-push** | Run `pnpm run verify:changed` plus any ticket-specific reproducer not selected by that scope-aware gate. This gate is advisory and bypassable; record every skip, bypass, or failure honestly. Local hooks are never authoritative. |
-| **G2 — PR CI** | The candidate must pass the full PR CI run. Nothing enforces this at merge time, so a green run is evidence of correctness and never proof that a red candidate could not land. |
+| **G2 — PR CI** | The candidate must pass the full PR CI run. A repository ruleset on `main` requires the `ci` aggregator before merge, so a red `ci` blocks the merge. The only bypass is one named user account, and every use of it must open a Jira issue recording what was merged and why; that audit is not itself machinery-checked. |
 | **G4 — per-ticket evidence** | Map each ticket's acceptance criteria to its reproduction, exact commands and outcomes, CI, candidate/merge SHA, and residual risk. Do not use another ticket's evidence as a substitute. |
 
 ### Not enforced by machinery
@@ -62,12 +62,14 @@ checked them for you.
 
 ### Enforcement limits
 
-External G2 enforcement is `BLOCKED` by a deliberate waiver: branch protection
-on `main` was declined as delivery policy, not deferred pending setup. The
-observed state is `main.protected=false` with no rulesets, so do not claim that
-branch protection or required-check enforcement exists, and do not open work to
-configure it without a new decision. G2 evidence is the PR CI run itself, which
-nothing enforces at merge time.
+External G2 enforcement runs through a repository ruleset on `main` (id
+22668605, "main requires ci"), not classic branch protection: one
+`required_status_checks` rule naming `ci`, strict policy off, and one
+`bypass_actors` entry (a `User`, always mode) for the repository owner's
+account, with no role-based exemption. GitHub enforces the required check and
+the bypass allowlist; it does not enforce that a bypass records why. The Jira
+issue for each bypass use is a human-enforced rule, so verify it was actually
+opened rather than assume the policy was followed.
 
 Dated documents that describe CI as informational remain historical context.
 


### PR DESCRIPTION
Closes the open remainder of AIW-313. The branch ruleset decided in ADR-004 section 4 is active on `main` since 2026-09-09 (id 22668605: one `required_status_checks` rule on the `ci` aggregator, exactly one User bypass actor, no role bypass). This PR updates the three documents that still said nothing enforces CI at merge time: AGENTS.md (Evidence), docs/delivery-gates.md (G2 in force, enforcement limits) and ADR-004 (dated status sentence).

Verification: `node scripts/gates/docs-status.mjs` exit 0, `git diff --check` clean, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated delivery-gate guidance to reflect that changes to `main` require the CI aggregator to pass before merging.
  - Documented the configured ruleset and its enforcement boundaries.
  - Clarified that a single authorized bypass account is available, and each bypass requires a Jira audit issue.
  - Updated the architecture decision record and evidence documentation to reflect the current enforcement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->