### PR TITLE
chore(gates): ratchet import cycles at file level so moves do not inflate the count

### DIFF
--- a/docs/adr/ADR-004-gates-and-required-ci.md
+++ b/docs/adr/ADR-004-gates-and-required-ci.md
@@ -56,7 +56,7 @@ One line per gate: what it observes, and whether it carries a baseline.
 | unit tests | worker (4 shards), dashboard, workflow-sdk | no | exists |
 | `build:ci` | pre-sandbox config, local skills, MCP contract, Nitro build | no | exists |
 | generated files current | MCP contract, prompt drift, carry-schema drift, and from stage 4 the block catalog (`gen:blocks --check`) | no | three exist, block catalog in stage 4 |
-| import boundaries and cycles | dependency-cruiser with the tier rules of ADR-001 plus `no-circular` | yes, keyed by tier pair | stage 1 |
+| import boundaries and cycles | dependency-cruiser with the tier rules of ADR-001 plus `no-circular` | yes, keyed by tier pair and distinct file cycle count | stage 1 |
 | unused files, exports, dependencies | knip | yes, today's count | stage 1 |
 | lint | oxlint on `apps/worker`, `apps/dashboard`, `scripts` and `packages` when present, `correctness` deny, `suspicious`, `perf` and `pedantic` warn, `style`, `restriction` and `nursery` off | yes, warning count ratcheted | stage 1 |
 | workflow bundle imports | executable Node imports inside workflow VM code, distinguished from import-like text in string literals (AIW-325) | no | stage 1 |

--- a/scripts/ci/gates.test.ts
+++ b/scripts/ci/gates.test.ts
@@ -5,6 +5,10 @@ import { mkdtemp, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
+import {
+  exceedsFileCycleBaseline,
+  normalizeFileCycles,
+} from "../gates/boundaries.mjs";
 
 const boundaryFixture = (root: string): string => {
     const source = join(root, "apps/worker/src");
@@ -12,7 +16,7 @@ const boundaryFixture = (root: string): string => {
     mkdirSync(join(source, "db"), { recursive: true });
     writeFileSync(join(source, "db/client.ts"), "export const db = 1;\n");
     writeFileSync(join(source, "routes/entry.ts"), 'import { db } from "../db/client.js";\nvoid db;\n');
-    writeFileSync(join(root, "boundaries.baseline.json"), '{"tierPairs":{},"cycles":{},"cycleTotal":0}\n');
+    writeFileSync(join(root, "boundaries.baseline.json"), '{"tierPairs":{},"fileCycleCount":0,"fileCycles":[]}\n');
     return root;
   },
   gateFailure = 1,
@@ -65,13 +69,53 @@ test("the boundary baseline passes and is stable across file renames", async () 
   assert.match(regression.stdout, /app->db\s+1\s+2/);
 });
 
+test("file cycle normalization dedupes reports and detects count regression", () => {
+  const report = {
+    modules: [
+      {
+        source: "src/alpha.ts",
+        dependencies: [{
+          circular: true,
+          cycle: [{ name: "src/beta.ts" }, { name: "src/alpha.ts" }],
+        }],
+      },
+      {
+        source: "src/beta.ts",
+        dependencies: [{
+          circular: true,
+          cycle: [{ name: "src/alpha.ts" }, { name: "src/beta.ts" }],
+        }],
+      },
+      {
+        source: "src/gamma.ts",
+        dependencies: [{
+          circular: true,
+          cycle: [{ name: "src/delta.ts" }, { name: "src/gamma.ts" }],
+        }],
+      },
+    ],
+  };
+  const fileCycles = normalizeFileCycles(report);
+
+  assert.deepEqual(fileCycles, [
+    ["src/alpha.ts", "src/beta.ts"],
+    ["src/delta.ts", "src/gamma.ts"],
+  ]);
+  const baseline = {
+    fileCycleCount: 1,
+    fileCycles: [["src/old-alpha.ts", "src/old-beta.ts"]],
+  };
+  assert.equal(exceedsFileCycleBaseline(fileCycles.slice(0, 1), baseline), false);
+  assert.equal(exceedsFileCycleBaseline(fileCycles, baseline), true);
+});
+
 test("an unknown worker source path fails the boundary gate", async () => {
   const root = await mkdtemp(join(tmpdir(), "boundary-unknown-gate-"));
   const source = join(root, "apps/worker/src/unknown-tier");
   const baseline = join(root, "boundaries.baseline.json");
   await mkdir(source, { recursive: true });
   await writeFile(join(source, "x.ts"), "export const value = 1;\n");
-  await writeFile(baseline, '{"tierPairs":{},"cycles":{},"cycleTotal":0}\n');
+  await writeFile(baseline, '{"tierPairs":{},"fileCycleCount":0,"fileCycles":[]}\n');
 
   const result = gate("boundaries.mjs", ["--root", root, "--baseline", baseline]);
   assert.equal(result.status, 1, result.stderr || result.stdout);

--- a/scripts/gates/boundaries.baseline.json
+++ b/scripts/gates/boundaries.baseline.json
@@ -20,35 +20,49 @@
     "services->app": 4,
     "services->config": 21
   },
-  "cycles": {
-    "worker:(root)<->lib": 1,
-    "worker:(root)<->mcp": 1,
-    "worker:adapters<->db": 1,
-    "worker:adapters<->lib": 1,
-    "worker:adapters<->workflow-definition": 1,
-    "worker:approvals<->lib": 1,
-    "worker:approvals<->workflows": 1,
-    "worker:clarifications<->lib": 1,
-    "worker:clarifications<->workflows": 1,
-    "worker:db<->lib": 1,
-    "worker:db<->pre-pr-checks": 1,
-    "worker:db<->run-analysis": 1,
-    "worker:lib<->post-pr-gate": 1,
-    "worker:lib<->sandbox": 1,
-    "worker:lib<->schedule-trigger": 1,
-    "worker:lib<->workflow-definition": 1,
-    "worker:lib<->workflows": 1,
-    "worker:manual-dispatch<->workflows": 1,
-    "worker:pre-pr-checks<->workflows": 1,
-    "worker:pre-sandbox<->repository-discovery": 1,
-    "worker:prompt-library<->workflow-definition": 1,
-    "worker:prompt-library<->workflows": 1,
-    "worker:run-observability<->sandbox": 1,
-    "worker:sandbox<->workflows": 1,
-    "worker:schedule-trigger<->workflow-definition": 1,
-    "worker:schedule-trigger<->workflows": 1,
-    "worker:webhook-trigger<->workflows": 1,
-    "worker:workflow-definition<->workflows": 1
-  },
-  "cycleTotal": 28
+  "fileCycleCount": 8,
+  "fileCycles": [
+    [
+      "apps/dashboard/components/cockpit/flow-editor/config-fields.tsx",
+      "apps/dashboard/components/cockpit/flow-editor/prompt-field.tsx"
+    ],
+    [
+      "apps/worker/src/lib/dispatch-trigger.ts",
+      "apps/worker/src/lib/dispatch.ts",
+      "apps/worker/src/manual-dispatch/resolve.ts",
+      "apps/worker/src/manual-dispatch/service.ts",
+      "apps/worker/src/workflows/agent.ts",
+      "apps/worker/src/workflows/run-ownership-steps.ts"
+    ],
+    [
+      "apps/worker/src/lib/dispatch-trigger.ts",
+      "apps/worker/src/manual-dispatch/resolve.ts",
+      "apps/worker/src/manual-dispatch/service.ts",
+      "apps/worker/src/workflows/agent.ts",
+      "apps/worker/src/workflows/run-ownership-steps.ts"
+    ],
+    [
+      "apps/worker/src/lib/dispatch.ts",
+      "apps/worker/src/manual-dispatch/service.ts",
+      "apps/worker/src/workflows/agent.ts",
+      "apps/worker/src/workflows/run-ownership-steps.ts"
+    ],
+    [
+      "apps/worker/src/lib/trigger-events.ts",
+      "apps/worker/src/workflows/agent-input.ts"
+    ],
+    [
+      "apps/worker/src/manual-dispatch/service.ts",
+      "apps/worker/src/workflows/agent.ts",
+      "apps/worker/src/workflows/run-ownership-steps.ts"
+    ],
+    [
+      "apps/worker/src/workflow-definition/bindings.ts",
+      "apps/worker/src/workflow-definition/interpreter.ts"
+    ],
+    [
+      "apps/worker/src/workflow-definition/failure-message.ts",
+      "apps/worker/src/workflow-definition/interpreter.ts"
+    ]
+  ]
 }

--- a/scripts/gates/boundaries.mjs
+++ b/scripts/gates/boundaries.mjs
@@ -1,7 +1,7 @@
 /**
- * This gate stops new imports that violate ADR-001 and new top-level directory
+ * This gate stops new imports that violate ADR-001 and growth in distinct file
  * cycles. It exits 1 for unknown paths, tool failures, or counts above the
- * recorded tier-pair and cycle-pair baseline. Run with --update-baseline after
+ * recorded tier-pair and file-cycle baseline. Run with --update-baseline after
  * an approved architecture change and review the complete before and after table.
  */
 import { existsSync, globSync, readFileSync, readdirSync, realpathSync, statSync } from "node:fs";
@@ -287,7 +287,28 @@ function dependencyCounts(root, config) {
       }
     }
   }
-  return { counts: sortedObject(counts), unknown: [...unknown].sort() };
+  return { counts: sortedObject(counts), report, unknown: [...unknown].sort() };
+}
+
+export function normalizeFileCycles(report) {
+  const cycles = new Map();
+  for (const module of report.modules ?? report.output?.modules ?? []) {
+    for (const dependency of module.dependencies ?? []) {
+      if (!dependency.circular || !Array.isArray(dependency.cycle)) continue;
+      const files = [...new Set([
+        module.source,
+        ...dependency.cycle.map((entry) => entry.name),
+      ].filter((path) => typeof path === "string"))].toSorted();
+      cycles.set(JSON.stringify(files), files);
+    }
+  }
+  return [...cycles.values()].toSorted((left, right) =>
+    JSON.stringify(left).localeCompare(JSON.stringify(right)),
+  );
+}
+
+export function exceedsFileCycleBaseline(fileCycles, baseline) {
+  return fileCycles.length > baseline.fileCycleCount;
 }
 
 function walk(dir, output = []) {
@@ -301,7 +322,7 @@ function walk(dir, output = []) {
   return output;
 }
 
-function cycleCounts(root) {
+function directoryCycleCounts(root) {
   const targets = [
     ["worker", join(root, "apps/worker/src")],
     ["dashboard", join(root, "apps/dashboard/src")],
@@ -344,9 +365,10 @@ function main() {
   const root = realpathSync(options.root);
   const baselinePath = options.baseline ?? fileURLToPath(defaultBaseline);
   const config = options.config ?? join(repositoryRoot, ".dependency-cruiser.cjs");
-  const { counts: tierPairs, unknown } = dependencyCounts(root, config);
-  const cycles = cycleCounts(root);
-  const current = { tierPairs, cycles, cycleTotal: Object.values(cycles).reduce((sum, value) => sum + value, 0) };
+  const { counts: tierPairs, report, unknown } = dependencyCounts(root, config);
+  const directoryCycles = directoryCycleCounts(root);
+  const fileCycles = normalizeFileCycles(report);
+  const current = { tierPairs, fileCycleCount: fileCycles.length, fileCycles };
   if (options.updateBaseline) {
     if (unknown.length) throw new Error(`Cannot baseline unknown paths: ${unknown.join(", ")}`);
     writeJson(baselinePath, current);
@@ -355,23 +377,24 @@ function main() {
   const tierKeys = [...new Set([...Object.keys(baseline.tierPairs), ...Object.keys(tierPairs)])].sort();
   console.log("Boundary tier pairs");
   printTable(["pair", "baseline", "now"], tierKeys.map((key) => [key, baseline.tierPairs[key] ?? 0, tierPairs[key] ?? 0]));
-  console.log("Cycle pairs");
-  const cycleKeys = [...new Set([...Object.keys(baseline.cycles), ...Object.keys(cycles)])].sort();
-  printTable(["pair", "baseline", "now"], cycleKeys.map((key) => [key, baseline.cycles[key] ?? 0, cycles[key] ?? 0]));
-  console.log(`cycle total  ${baseline.cycleTotal}  ${current.cycleTotal}`);
+  console.log("Directory cycle pairs (informational)");
+  printTable(["pair", "now"], Object.entries(directoryCycles).map(([key, count]) => [key, count]));
+  console.log(`file cycles  ${baseline.fileCycleCount}  ${current.fileCycleCount}`);
   if (unknown.length) {
     console.log("Unknown paths");
     for (const path of unknown) console.log(path);
   }
   const failed = unknown.length > 0 || countRegression(tierPairs, baseline.tierPairs) ||
-    countRegression(cycles, baseline.cycles) || current.cycleTotal > baseline.cycleTotal;
+    exceedsFileCycleBaseline(fileCycles, baseline);
   console.log(failed ? "boundaries FAIL" : "boundaries PASS");
   process.exitCode = failed ? 1 : 0;
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(`boundaries FAIL: ${error instanceof Error ? error.message : error}`);
-  process.exitCode = 1;
+if (process.argv[1] && realpathSync(process.argv[1]) === import.meta.filename) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`boundaries FAIL: ${error instanceof Error ? error.message : error}`);
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Why

The boundaries gate ratcheted import cycles per pair of top-level worker directories. That metric punishes pure moves: stage 4 of the restructure relocates the workflow blocks from `workflows/blocks` to `engine/blocks` without changing any import in substance, and the gate reported three "new" directory pairs (28 to 31 cycles). Every remaining stage moves files, so the proxy had to change before the moves.

## What

- `scripts/gates/boundaries.mjs`: the ratchet now counts distinct file-level cycles from the dependency-cruiser `no-circular` output (each cycle normalised to its sorted set of files, deduped across entry modules) and fails when the count grows. The count is invariant under moves. The directory-pair table stays in the output as information. The tier-pair ratchet is unchanged. The module exports its normalisation so the CI test can exercise it, with a main guard on `import.meta.filename` (CI runs Node 24).
- `scripts/gates/boundaries.baseline.json`: regenerated by the script. File cycles at this main: 8 (listed for humans; the comparison is count-only on purpose, a stored file list would break on the next move).
- `scripts/ci/gates.test.ts`: a test that the normalisation dedupes the same cycle reported from two entry modules and that one extra cycle fails the gate; the rename-stability test stays.
- `docs/adr/ADR-004-gates-and-required-ci.md`: the gate table row names the new key.

## Verification

- `node scripts/gates/boundaries.mjs`: PASS, file cycles 8/8
- `scripts/ci/gates.test.ts`: 12 pass, 0 fail
- `node scripts/gates/lint.mjs`: PASS
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CI dependency-boundary checks to identify distinct file-level dependency cycles more accurately.
  - Duplicate cycle paths are now normalized, reducing misleading regression reports.
  - Regression detection now compares current file-cycle results against the approved baseline.

- **Documentation**
  - Updated the dependency-boundary gate documentation to reflect file-level cycle tracking and baseline comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->