### PR TITLE
fix(worker): enforce the run duration budget in checks and workspace setup

### DIFF
--- a/apps/worker/src/pre-pr-checks/runner.test.ts
+++ b/apps/worker/src/pre-pr-checks/runner.test.ts
@@ -310,6 +310,7 @@ describe("startRepoCheckBatchStep", () => {
       skipped: false,
       commandId: "cmd-batch",
       localPath: "/vercel/sandbox",
+      checksClockObservedAtMs: expect.any(Number),
     });
     expect(started.skipped).toBe(false);
     if (started.skipped || started.envFailure) throw new Error("unreachable");
@@ -346,7 +347,10 @@ describe("startRepoCheckBatchStep", () => {
       0,
     );
 
-    expect(started).toEqual({ skipped: true });
+    expect(started).toEqual({
+      skipped: true,
+      checksClockObservedAtMs: expect.any(Number),
+    });
     expect(mockWriteFiles).not.toHaveBeenCalled();
   });
 
@@ -363,7 +367,10 @@ describe("startRepoCheckBatchStep", () => {
       0,
     );
 
-    expect(started).toEqual({ skipped: true });
+    expect(started).toEqual({
+      skipped: true,
+      checksClockObservedAtMs: expect.any(Number),
+    });
     expect(mockWriteFiles).not.toHaveBeenCalled();
   });
 
@@ -479,6 +486,7 @@ describe("collectRepoCheckBatchStep", () => {
     expect(collected.failures).toHaveLength(1);
     expect(collected.failures[0]).toMatchObject({ command: "pnpm lint", stderr: "lint failed" });
     expect(collected.setupFailed).toBe(false);
+    expect(collected.checksClockObservedAtMs).toEqual(expect.any(Number));
   });
 
   it("stops a repository's checks at a failing setup command", async () => {

--- a/apps/worker/src/pre-pr-checks/runner.ts
+++ b/apps/worker/src/pre-pr-checks/runner.ts
@@ -725,6 +725,16 @@ export interface RepoCheckBatchStartOptions {
   restoreTree?: boolean;
 }
 
+interface ChecksClockStepObservation {
+  /** Clock reading captured in this durable step result. Optional so a result
+   *  journaled by an older deployment remains valid on replay. */
+  checksClockObservedAtMs?: number;
+}
+
+function withChecksClockObservation<T extends object>(value: T): T & ChecksClockStepObservation {
+  return { ...value, checksClockObservedAtMs: Date.now() };
+}
+
 /**
  * Write and launch one repository's check batch, detached, and return at once.
  *
@@ -753,15 +763,17 @@ export async function startRepoCheckBatchStep(
   requireChange = true,
   options: RepoCheckBatchStartOptions = {},
 ): Promise<
-  | { skipped: true }
-  | { skipped: false; envFailure: PrePrCheckFailure }
-  | {
-      skipped: false;
-      envFailure?: undefined;
-      commandId: string;
-      localPath: string;
-      paths: RepoCheckBatchPaths;
-    }
+  (
+    | { skipped: true }
+    | { skipped: false; envFailure: PrePrCheckFailure }
+    | {
+        skipped: false;
+        envFailure?: undefined;
+        commandId: string;
+        localPath: string;
+        paths: RepoCheckBatchPaths;
+      }
+  ) & ChecksClockStepObservation
 > {
   "use step";
   const { Sandbox } = await import("@vercel/sandbox");
@@ -771,7 +783,7 @@ export async function startRepoCheckBatchStep(
     (candidate) =>
       candidate.provider === provider && candidate.repoPath === repoPath,
   );
-  if (!repo) return { skipped: true };
+  if (!repo) return withChecksClockObservation({ skipped: true });
 
   if (requireChange) {
     const headResult = await sandbox.runCommand("git", [
@@ -787,7 +799,9 @@ export async function startRepoCheckBatchStep(
         `Could not inspect workspace HEAD for ${provider}:${repoPath}`,
       );
     }
-    if (repo.preAgentSha && repo.preAgentSha === headSha) return { skipped: true };
+    if (repo.preAgentSha && repo.preAgentSha === headSha) {
+      return withChecksClockObservation({ skipped: true });
+    }
   }
 
   // Resolved inside the step, never in workflow scope: a value resolved out
@@ -796,10 +810,10 @@ export async function startRepoCheckBatchStep(
   // anything is written, so a misconfigured secret cannot half-run a batch.
   const resolvedEnv = resolveRepoEnv(options.envNames ?? []);
   if (resolvedEnv.rejected.length > 0) {
-    return {
+    return withChecksClockObservation({
       skipped: false,
       envFailure: repoEnvFailure(provider, repoPath, resolvedEnv.rejected),
-    };
+    });
   }
 
   const paths = repoCheckBatchPaths(fixCycle, repoIndex, newLaunchId());
@@ -844,12 +858,12 @@ export async function startRepoCheckBatchStep(
       `The repository scripts batch for ${provider}:${repoPath} exited ${launch.exitCode} before it started.`,
     );
   }
-  return {
+  return withChecksClockObservation({
     skipped: false,
     commandId: launch.cmdId,
     localPath: repo.localPath,
     paths,
-  };
+  });
 }
 startRepoCheckBatchStep.maxRetries = 0;
 
@@ -921,6 +935,9 @@ export interface CollectedRepoCheckBatch {
    *  it is only slower, and an operator should still be able to find out. */
   setupMarkerFailed: boolean;
   progress: RepoCheckBatchProgress;
+  /** Clock reading captured in this durable step result. Optional for replay
+   *  compatibility with results journaled before this field existed. */
+  checksClockObservedAtMs?: number;
 }
 
 /** Extra inputs the collect step takes, bundled for the same reason the start
@@ -1001,7 +1018,7 @@ export async function collectRepoCheckBatchStep(
   // maxRetries is 0. Same guard checkPhaseDone makes for the same reason
   // (sandbox/poll-agent.ts).
   if (sandbox.status !== "running") {
-    return workspaceIncident(BATCH_SANDBOX_GONE_REASON);
+    return withChecksClockObservation(workspaceIncident(BATCH_SANDBOX_GONE_REASON));
   }
 
   const read = await readBatchFiles(sandbox, paths, total);
@@ -1009,7 +1026,9 @@ export async function collectRepoCheckBatchStep(
   // must never be reported as each other. The reader runs under `bash -lc`,
   // which sources the very profile these setup commands append to, so a broken
   // profile fails the read while the batch itself is fine.
-  if (!read.ok) return workspaceIncident(BATCH_READER_FAILED_REASON);
+  if (!read.ok) {
+    return withChecksClockObservation(workspaceIncident(BATCH_READER_FAILED_REASON));
+  }
   const files = read.files;
   // Zero records is the reader losing its own stdout, not a batch that never
   // started. `names` always asks for `launch` and `stopped-at`, and the script
@@ -1017,7 +1036,9 @@ export async function collectRepoCheckBatchStep(
   // reader cannot return nothing. A login profile that redirects the shell's
   // stdout (`exec 1>/dev/null`) produces exactly this, and reporting it as
   // "the wrapper never started" sends the operator to look at the wrapper.
-  if (files.size === 0) return workspaceIncident(BATCH_READER_FAILED_REASON);
+  if (files.size === 0) {
+    return withChecksClockObservation(workspaceIncident(BATCH_READER_FAILED_REASON));
+  }
 
   // Identity before content. A directory whose `launch` marker is not this
   // launch's was written by a different wrapper, so nothing in it describes the
@@ -1030,17 +1051,17 @@ export async function collectRepoCheckBatchStep(
     // The wrapper writes this marker before anything else it does, so its
     // absence means the wrapper never ran, which is worth saying plainly
     // instead of arriving later as "the first command recorded no exit".
-    return workspaceIncident(BATCH_NEVER_STARTED_REASON);
+    return withChecksClockObservation(workspaceIncident(BATCH_NEVER_STARTED_REASON));
   }
   if (decodeBatchFile(launch) !== paths.launchId) {
-    return workspaceIncident(BATCH_IDENTITY_REASON);
+    return withChecksClockObservation(workspaceIncident(BATCH_IDENTITY_REASON));
   }
 
   const stoppedAtFile = files.get("stopped-at");
   const stoppedAtText = stoppedAtFile ? decodeBatchFile(stoppedAtFile) : "";
   const stoppedAt = /^-?\d+$/.test(stoppedAtText) ? Number(stoppedAtText) : null;
   if (stoppedAt === BATCH_NO_COMMAND_RAN) {
-    return {
+    return withChecksClockObservation({
       results: [],
       failures: [
         batchFailure(
@@ -1056,7 +1077,7 @@ export async function collectRepoCheckBatchStep(
       preExistingDirty: [],
       setupMarkerFailed: false,
       progress: emptyProgress,
-    };
+    });
   }
 
   // Setup that the marker skipped left no exit files, and a collector that
@@ -1201,7 +1222,7 @@ export async function collectRepoCheckBatchStep(
     }
   }
 
-  return {
+  return withChecksClockObservation({
     results,
     // The ordering guarantee: every byte of every stream was scrubbed by
     // decodeBatchFile as it was decoded, edges included, so no value survives
@@ -1218,7 +1239,7 @@ export async function collectRepoCheckBatchStep(
     preExistingDirty: parseDirtyFiles(streamText(files.get("dirty-before"))),
     setupMarkerFailed,
     progress: { completed, total: commands.length, stoppedAt: stoppedAtCommand },
-  };
+  });
 }
 collectRepoCheckBatchStep.maxRetries = 0;
 

--- a/apps/worker/src/run-observability/sanitizer.test.ts
+++ b/apps/worker/src/run-observability/sanitizer.test.ts
@@ -139,6 +139,22 @@ describe("sanitizeReplayValue", () => {
     expect(envelope.metadata.redactions.phone).toBeUndefined();
   });
 
+  it.each([
+    "budget_exceeded: the run took 31 min 12 s, over the 30 min limit from " +
+      "JOB_TIMEOUT_MS (this workflow sets no budgets.maxDurationMs). Raise " +
+      "budgets.maxDurationMs on the workflow definition, or JOB_TIMEOUT_MS, to allow longer runs.",
+    "budget_exceeded: the run took 48 min 3 s, over the 45 min limit from " +
+      "budgets.maxDurationMs on this workflow definition. Raise budgets.maxDurationMs to allow longer runs.",
+    "budget_exceeded: this invocation took 12 min 5 s, over the 10 min limit from " +
+      "the harness profile \"Strict profile\" (runtimeLimits.maxDurationMs). " +
+      "Raise that limit on the profile to allow longer invocations.",
+  ])("keeps a duration budget message unchanged", (message) => {
+    const envelope = sanitizeReplayValue(message);
+
+    expect(envelope.value).toBe(message);
+    expect(envelope.metadata.redactions.phone).toBeUndefined();
+  });
+
   it("keeps a UUID intact when embedded in a JSON-ish sentence", () => {
     const uuid = "0b363504-6791-4963-9492-0cdea08acfe2";
     const envelope = sanitizeReplayValue(

--- a/apps/worker/src/sandbox/harness-runtime-limits.ts
+++ b/apps/worker/src/sandbox/harness-runtime-limits.ts
@@ -2,12 +2,14 @@ import type { HarnessProfileManifestV1 } from "@shared/contracts";
 
 export interface HarnessEffectiveLimits {
   maxDurationMs: number;
+  maxDurationSource?: "definition" | "env" | "profile";
+  maxDurationProfileName?: string;
   maxTokens?: number;
   maxCostUsd?: number;
 }
 
 interface HarnessRuntimeLimits {
-  manifest: Pick<HarnessProfileManifestV1, "limits">;
+  manifest: Pick<HarnessProfileManifestV1, "displayName" | "limits">;
 }
 
 /** Apply only the profile selected for the active invocation. */
@@ -18,11 +20,13 @@ export function combineHarnessRuntimeLimits(
   const result = { ...workflowLimits };
   if (!runtime) return result;
   const limits = runtime.manifest.limits;
-  if (limits.maxDurationMs !== null) {
-    result.maxDurationMs = Math.min(
-      result.maxDurationMs,
-      limits.maxDurationMs,
-    );
+  if (
+    limits.maxDurationMs !== null &&
+    limits.maxDurationMs < result.maxDurationMs
+  ) {
+    result.maxDurationMs = limits.maxDurationMs;
+    result.maxDurationSource = "profile";
+    result.maxDurationProfileName = runtime.manifest.displayName;
   }
   if (limits.maxTokens !== null) {
     result.maxTokens =

--- a/apps/worker/src/sandbox/harness-runtime.test.ts
+++ b/apps/worker/src/sandbox/harness-runtime.test.ts
@@ -257,6 +257,8 @@ describe("Harness Profile runtime resolution", () => {
       combineHarnessRuntimeLimits(workflowLimits, active),
     ).toEqual({
       maxDurationMs: 20_000,
+      maxDurationSource: "profile",
+      maxDurationProfileName: "Codex",
       maxTokens: 5_000,
       maxCostUsd: 5,
     });

--- a/apps/worker/src/workflows/agent-budget.test.ts
+++ b/apps/worker/src/workflows/agent-budget.test.ts
@@ -75,6 +75,8 @@ describe("agent workflow budget integration", () => {
 
     expect(budget.limits).toEqual({
       maxDurationMs: 20_000,
+      maxDurationSource: "profile",
+      maxDurationProfileName: "Claude",
       maxTokens: 100,
       maxCostUsd: 2,
     });
@@ -104,6 +106,75 @@ describe("agent workflow budget integration", () => {
     // so it is the one that has to know which total to charge.
     expect(observeWorkflowBudget).toHaveBeenCalledWith(false, "duration");
   });
+
+  it("reports invocation time when a strict profile expires after more run time", async () => {
+    const active = makeHarnessRuntime("active", "generic_agent", {
+      limits: {
+        maxDurationMs: 600_000,
+        maxTokens: null,
+        maxCostUsd: null,
+      },
+    });
+    let clock = 0;
+    const observeWorkflowBudget = vi.fn().mockResolvedValue({
+      check: { status: "ok" },
+      remainingDurationMs: 300_000,
+      durationLimitMs: 1_800_000,
+      activeElapsedMs: 1_500_000,
+      maxDurationSource: "definition",
+    });
+    const budget = await createHarnessInvocationBudget({
+      workflowLimits: {
+        maxDurationMs: 1_800_000,
+        maxDurationSource: "definition",
+      },
+      runtime: active,
+      observeWorkflowBudget,
+      readClock: () => Promise.resolve(clock),
+    });
+
+    clock = 725_999;
+
+    await expect(budget.observeBudget(false)).resolves.toMatchObject({
+      check: {
+        status: "budget_exceeded",
+        metric: "duration",
+        limit: 600_000,
+        consumed: 725_999,
+        reason:
+          "budget_exceeded: this invocation took 12 min 5 s, over the 10 min limit from " +
+          "the harness profile \"Claude\" (runtimeLimits.maxDurationMs). " +
+          "Raise that limit on the profile to allow longer invocations.",
+      },
+    });
+  });
+
+  it.each(["env", "definition"] as const)(
+    "keeps the %s workflow duration source when the profile is not tighter",
+    async (maxDurationSource) => {
+      const active = makeHarnessRuntime("active", "generic_agent", {
+        limits: {
+          maxDurationMs: 600_000,
+          maxTokens: null,
+          maxCostUsd: null,
+        },
+      });
+      const budget = await createHarnessInvocationBudget({
+        workflowLimits: {
+          maxDurationMs: 600_000,
+          maxDurationSource,
+        },
+        runtime: active,
+        observeWorkflowBudget: vi.fn(),
+        readClock: () => Promise.resolve(0),
+      });
+
+      expect(budget.limits).toEqual({
+        maxDurationMs: 600_000,
+        maxDurationSource,
+      });
+    },
+  );
 
   it("does not reconcile still-running sibling usage on v2 block finishes", () => {
     expect(shouldReconcilePhaseUsageOnBlockFinish(1)).toBe(true);

--- a/apps/worker/src/workflows/agent-clarification-telemetry.test.ts
+++ b/apps/worker/src/workflows/agent-clarification-telemetry.test.ts
@@ -20,15 +20,16 @@ vi.mock("../lib/overview/collect-run-detail.js", () => ({
 vi.mock("workflow/runtime", () => ({ getWorld: () => ({ world: true }) }));
 
 import { recordRunTelemetryStep } from "./agent.js";
+import { durationBudgetFailure } from "./run-budget.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.captureRunSteps.mockResolvedValue(null);
+  mocks.getClarification.mockResolvedValue({ status: "answered" });
+  mocks.recordRunUsage.mockResolvedValue(undefined);
+});
 
 describe("clarification terminal telemetry", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mocks.captureRunSteps.mockResolvedValue(null);
-    mocks.getClarification.mockResolvedValue({ status: "answered" });
-    mocks.recordRunUsage.mockResolvedValue(undefined);
-  });
-
   it("always records the asking run as awaiting even when the answer raced its finally", async () => {
     await recordRunTelemetryStep({
       runId: "run-asking",
@@ -56,6 +57,48 @@ describe("clarification terminal telemetry", () => {
     expect(mocks.recordRunUsage).toHaveBeenCalledWith(
       { db: true },
       expect.objectContaining({ runId: "run-asking", status: "awaiting" }),
+    );
+  });
+});
+
+describe("duration terminal telemetry", () => {
+  it("keeps the telemetry prefix in front of the actionable duration message", async () => {
+    const failure = durationBudgetFailure({
+      durationLimitMs: 1_800_000,
+      activeElapsedMs: 1_872_999,
+      maxDurationSource: "env",
+    });
+
+    await recordRunTelemetryStep({
+      runId: "run-duration-budget",
+      subjectKey: "ticket:jira:AWT-1",
+      status: "failed",
+      ticketKey: "AWT-1",
+      ticketTitle: "Ticket",
+      ticketUrl: "https://jira.example/browse/AWT-1",
+      model: null,
+      totals: {
+        costUsd: 0,
+        costKnown: true,
+        tokensInput: 0,
+        tokensCached: 0,
+        tokensOutput: 0,
+        phases: {},
+      },
+      budgetFailure: failure,
+      pr: null,
+      prs: null,
+      executionError: null,
+    });
+
+    expect(mocks.recordRunUsage).toHaveBeenCalledWith(
+      { db: true },
+      expect.objectContaining({
+        statusReason:
+          "Run stopped on budget: budget_exceeded: the run took 31 min 12 s, over the " +
+          "30 min limit from JOB_TIMEOUT_MS (this workflow sets no budgets.maxDurationMs). " +
+          "Raise budgets.maxDurationMs on the workflow definition, or JOB_TIMEOUT_MS, to allow longer runs.",
+      }),
     );
   });
 });

--- a/apps/worker/src/workflows/agent-pre-pr-checks-failure.test.ts
+++ b/apps/worker/src/workflows/agent-pre-pr-checks-failure.test.ts
@@ -43,9 +43,12 @@ import {
   nodeCanRecordGate,
   repositoryScriptFailureEntry,
   recoverLatestRepositoryScriptsFailureFromSteps,
+  reconcileRunBudgetErrorAtBoundary,
   repositoryScriptsFailureComment,
   repositoryScriptsOutput,
   repositoryScriptsStatus,
+  shouldRethrowAgentExecutionError,
+  unhandledAgentExecutionError,
 } from "./agent.js";
 import {
   expectOutputConformsToRegistry,
@@ -71,7 +74,10 @@ import {
   REPOSITORY_SCRIPTS_BUDGET_CLASS,
 } from "./blocks/repository-scripts-output.js";
 import type { PrePrCheckRunResult } from "../pre-pr-checks/runner.js";
-import { isDurationAbortError } from "./run-budget.js";
+import {
+  checksCeilingExceededError,
+  isDurationAbortError,
+} from "./run-budget.js";
 import { isRunControlError } from "./run-control-error.js";
 import { runControlErrorCases } from "./blocks/test-support.js";
 
@@ -94,6 +100,49 @@ function describe_(error: unknown, version: number | null = 7) {
 }
 
 describe("pre-PR checks step failure cause", () => {
+  it("keeps a checks ceiling cause when almost no duration remains", async () => {
+    const ceiling = checksCeilingExceededError(
+      900_000,
+      "Checks batch for github:acme/web",
+    );
+    const observeBudget = vi.fn().mockResolvedValue({
+      check: {
+        status: "budget_exceeded",
+        metric: "duration",
+        limit: 1_800_000,
+        consumed: 1_800_001,
+        reason: "budget_exceeded: duration 1800001 exceeds limit 1800000",
+      },
+      remainingDurationMs: 0,
+    });
+
+    await expect(
+      reconcileRunBudgetErrorAtBoundary(ceiling, observeBudget),
+    ).resolves.toBe(ceiling);
+    expect(observeBudget).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new DOMException("sandbox request aborted", "AbortError"),
+    Object.assign(new Error("superseded"), { name: "V2InvocationCancelledError" }),
+  ])("keeps %s untouched when duration is already exhausted", async (cause) => {
+    const observeBudget = vi.fn().mockResolvedValue({
+      check: {
+        status: "budget_exceeded",
+        metric: "duration",
+        limit: 1_800_000,
+        consumed: 1_800_001,
+        reason: "budget_exceeded: duration 1800001 exceeds limit 1800000",
+      },
+      remainingDurationMs: 0,
+    });
+
+    await expect(
+      reconcileRunBudgetErrorAtBoundary(cause, observeBudget),
+    ).resolves.toBe(cause);
+    expect(observeBudget).not.toHaveBeenCalled();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -169,7 +218,7 @@ describe("pre-PR checks step failure cause", () => {
   );
 
   it.each([["AbortError"], ["TimeoutError"]])(
-    "keeps a %s out of the wrap so the duration budget stop survives",
+    "keeps a %s out of the wrap without claiming it hit a budget",
     (name) => {
       const error = namedError(name, "The operation was aborted.");
 
@@ -181,7 +230,7 @@ describe("pre-PR checks step failure cause", () => {
   it("wraps only what wrapping cannot break", () => {
     // Why the two predicates gate the wrap at all: both match structurally on
     // `name`, so a control error re-thrown as `new Error(message)` stops being
-    // one, and a duration budget stop would report as a generic failure.
+    // one, and an abort would report as a generic checks failure.
     const budgetStop = namedError("RunBudgetError", "budget exceeded");
     const abort = namedError("AbortError", "The operation was aborted.");
     const identity = (value: string) => value;
@@ -1887,6 +1936,86 @@ describe("v2 terminal failure exit", () => {
   ): WorkflowDefinitionV2Node {
     return { id, type, x: 0, y: 0, configuration: {}, inputs: {}, additionalInputs: [] };
   }
+
+  it.each(["run_pre_pr_checks", "run_scripts"] as const)(
+    "keeps a checks ceiling from %s intact through scheduler execution",
+    async (type) => {
+      const ceiling = checksCeilingExceededError(
+        900_000,
+        `Checks batch for github:acme/${type === "run_scripts" ? "scripts" : "gate"}`,
+      );
+      const currentDefinition: WorkflowDefinitionV2 = {
+        schemaVersion: 2,
+        nodes: [v2Node("trigger", "trigger_ticket_ai"), v2Node("checks", type)],
+        edges: [{ id: "trigger-checks", from: "trigger", to: "checks" }],
+      };
+
+      let caught: unknown;
+      try {
+        await executeV2Graph({
+          definition: currentDefinition,
+          entryTriggerId: "trigger",
+          triggerOutput: { status: "fired" },
+          shouldRethrowExecutionError: shouldRethrowAgentExecutionError,
+          executeBlock: () => {
+            throw ceiling;
+          },
+        });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).toBe(ceiling);
+      expect(unhandledAgentExecutionError(caught, "checks")).toMatchObject({
+        category: "checks",
+        message: ceiling.message,
+      });
+    },
+  );
+
+  it("wires the shared rethrow predicate into both graph engines", () => {
+    const source = readFileSync(
+      fileURLToPath(new URL("./agent.ts", import.meta.url)),
+      "utf8",
+    );
+
+    expect(
+      source.split("shouldRethrowExecutionError: shouldRethrowAgentExecutionError").length - 1,
+    ).toBe(2);
+  });
+
+  it("keeps the actionable checks ceiling text in the run reason, telemetry and Jira comment", () => {
+    const ceilingReason =
+      "The repository checks did not finish within the 15 minute checks ceiling. " +
+      "Raise batchTimeoutMinutes for this definition or split the run. " +
+      "(checks_ceiling_exceeded: Checks batch for github:acme/web reached the 15 minute checks ceiling)";
+    const failure = executionError(
+      "checks_ceiling_exceeded: Checks batch for github:acme/web reached the 15 minute checks ceiling",
+      {
+      category: "checks",
+      message: ceilingReason,
+      },
+    ).error;
+    const state: WorkflowExecutionErrorState = {
+      ...failure,
+      diagnosticId: "AIW-DIAG-wrun-checks-checks-1",
+      nodeId: "checks",
+      attempt: 1,
+    };
+    const expected =
+      "The repository checks did not finish within the 15 minute checks ceiling. " +
+      "Raise batchTimeoutMinutes for this definition or split the run. " +
+      "(checks_ceiling_exceeded: Checks batch for github:acme/web reached the 15 minute checks ceiling) " +
+      "Diagnostic ID: AIW-DIAG-wrun-checks-checks-1";
+
+    const runReason = formatExecutionErrorForUser(state);
+    const telemetryMessage = formatExecutionErrorForUser(state);
+    const jiraComment = commentForWalk({ executionError: state, steps: {} });
+
+    expect(runReason).toBe(expected);
+    expect(telemetryMessage).toBe(expected);
+    expect(jiraComment).toBe(expected);
+  });
 
   const definition: WorkflowDefinitionV2 = {
     schemaVersion: 2,

--- a/apps/worker/src/workflows/agent.ts
+++ b/apps/worker/src/workflows/agent.ts
@@ -212,12 +212,15 @@ import {
   RunBudgetError,
   addActiveElapsed,
   addElapsed,
+  checksCeilingErrorDetail,
   checksElapsedOf,
   createRunBudgetState,
-  durationBudgetFailure,
+  isChecksCeilingExceededError,
   isDurationAbortError,
+  isV2InvocationCancelledError,
   missingRequiredPriceFailure,
   observeRunBudget,
+  propagateInvocationInterruption,
   recordBudgetUsage,
   runBudgetFailureFromError,
   type RunBudgetAttribution,
@@ -501,9 +504,7 @@ export const executeRunScripts: BlockExecuteFn = async (
       model: ctx.defaults[ctx.runDefaultKind],
       groupSelection: { kind: "named", groups },
       observeBudget: blockBudgetObserver(ctx, execution),
-      observeChecksBudget: blockBudgetObserver(ctx, execution, {
-        attribution: "checks",
-      }),
+      observeChecksBudget: checksBudgetObserver(ctx, execution),
       ...checksCeilingOption(steps),
       cancellation: execution?.cancellation,
       // So a batch that runs for forty minutes reports progress instead of
@@ -512,12 +513,10 @@ export const executeRunScripts: BlockExecuteFn = async (
       ...(execution?.observations ? { observations: execution.observations } : {}),
     });
   } catch (err) {
-    if (isRunControlError(err)) throw err;
-    const after = await ctx.observeBudget();
+    if (isRunControlError(err) || isChecksCeilingExceededError(err)) throw err;
+    propagateInvocationInterruption(err);
+    const after = await ctx.observeBudget(false, "checks");
     if (after.check.status !== "ok") throw new RunBudgetError(after.check);
-    if (isDurationAbortError(err)) {
-      throw new RunBudgetError(durationBudgetFailure(after, "Repository scripts"));
-    }
     throw new Error(await prePrChecksFailureMessage(err, current.version));
   }
   const output = repositoryScriptsOutput(run, groups);
@@ -3231,18 +3230,39 @@ export const PRE_PR_CHECKS_FAILURE_CAUSE_MAX_LENGTH = 200;
  *  frames leak internal paths and are what turns a detail into a firehose. */
 export const PRE_PR_CHECKS_FAILURE_STACK_TAIL_MAX_LENGTH = 600;
 
+type BoundaryCapableBudgetObserver = (
+  requireRemainingDuration?: boolean,
+  attribution?: RunBudgetAttribution,
+  observedAtMs?: number,
+) => Promise<RunBudgetObservation>;
+
+function checksBudgetObserver(
+  ctx: Pick<EngineCtx, "observeBudget">,
+  execution?: BlockExecutionContext,
+): (
+  requireRemainingDuration?: boolean,
+  observedAtMs?: number,
+) => Promise<RunBudgetObservation> {
+  const observe = (execution?.observeBudget ?? ctx.observeBudget) as BoundaryCapableBudgetObserver;
+  return (requireRemainingDuration, observedAtMs) =>
+    observe(requireRemainingDuration, "checks", observedAtMs);
+}
+
 /**
  * Errors the Pre-PR checks call site must rethrow untouched.
  *
- * Both predicates identify an error structurally, by `name`
- * (run-budget.ts:52, run-budget.ts:280) or by a sentinel in its message
- * (run-control-errors.ts:16), because Workflow serializes step errors across
- * VMs. Wrapping one in a new Error therefore destroys the identity the call
- * site depends on, and a budget stop would start reporting as a generic
- * failure.
+ * These predicates identify errors structurally because Workflow serializes
+ * step errors across VMs. Wrapping one in a new Error destroys the identity
+ * the call site depends on, so checks ceilings, aborts and cancellations must
+ * pass through unchanged.
  */
 export function prePrChecksFailureMustPropagate(error: unknown): boolean {
-  return isRunControlError(error) || isDurationAbortError(error);
+  return (
+    isRunControlError(error) ||
+    isChecksCeilingExceededError(error) ||
+    isDurationAbortError(error) ||
+    isV2InvocationCancelledError(error)
+  );
 }
 
 /**
@@ -4004,6 +4024,8 @@ export interface HarnessInvocationBudget {
   limits: RunBudgetLimits;
   observeBudget(
     requireRemainingDuration?: boolean,
+    attribution?: RunBudgetAttribution,
+    observedAtMs?: number,
   ): Promise<RunBudgetObservation>;
   recordUsage(usage: PhaseUsage | null, model: string): void;
 }
@@ -4019,6 +4041,7 @@ export async function createHarnessInvocationBudget(input: {
   observeWorkflowBudget(
     requireRemainingDuration?: boolean,
     attribution?: RunBudgetAttribution,
+    observedAtMs?: number,
   ): Promise<RunBudgetObservation>;
   readClock(): Promise<number>;
   priceLookup?(
@@ -4042,9 +4065,12 @@ export async function createHarnessInvocationBudget(input: {
     async observeBudget(
       requireRemainingDuration = true,
       attribution: RunBudgetAttribution = "duration",
+      observedAtMs?: number,
     ) {
-      const workflow = await observeWorkflowBudget(requireRemainingDuration, attribution);
-      const now = await readClock();
+      const workflow = observedAtMs === undefined
+        ? await observeWorkflowBudget(requireRemainingDuration, attribution)
+        : await observeWorkflowBudget(requireRemainingDuration, attribution, observedAtMs);
+      const now = observedAtMs ?? await readClock();
       state = addElapsed(state, now - lastClockMs, attribution);
       lastClockMs = Math.max(lastClockMs, now);
       const profile = observeRunBudget(
@@ -4052,7 +4078,10 @@ export async function createHarnessInvocationBudget(input: {
         limits,
         requireRemainingDuration,
       );
-      return mergeBudgetObservations(workflow, profile);
+      return {
+        ...mergeBudgetObservations(workflow, profile),
+        observedAtMs: lastClockMs,
+      };
     },
     recordUsage(usage, model) {
       state = recordBudgetUsage(state, usage, priceLookup?.(model) ?? null);
@@ -4076,11 +4105,17 @@ export function mergeBudgetObservations(
     checksElapsedOf(workflow),
     checksElapsedOf(profile),
   );
+  const observedAtValues = [workflow.observedAtMs, profile.observedAtMs].filter(
+    (value): value is number => value !== undefined,
+  );
+  const observedAt = observedAtValues.length > 0
+    ? { observedAtMs: Math.max(...observedAtValues) }
+    : {};
   if (workflow.check.status !== "ok") {
-    return { ...workflow, remainingDurationMs, checksElapsedMs };
+    return { ...workflow, remainingDurationMs, checksElapsedMs, ...observedAt };
   }
   if (profile.check.status !== "ok") {
-    return { ...profile, remainingDurationMs, checksElapsedMs };
+    return { ...profile, remainingDurationMs, checksElapsedMs, ...observedAt };
   }
   const tighter =
     profile.remainingDurationMs < workflow.remainingDurationMs
@@ -4091,7 +4126,49 @@ export function mergeBudgetObservations(
     check: { status: "ok" },
     remainingDurationMs,
     checksElapsedMs,
+    ...observedAt,
   };
+}
+
+export async function reconcileRunBudgetErrorAtBoundary(
+  caught: unknown,
+  observeBudget: (requireRemainingDuration: boolean) => Promise<RunBudgetObservation>,
+): Promise<unknown> {
+  if (
+    isRunControlError(caught) ||
+    isChecksCeilingExceededError(caught) ||
+    isDurationAbortError(caught) ||
+    isV2InvocationCancelledError(caught)
+  ) {
+    return caught;
+  }
+  const observation = await observeBudget(false);
+  return observation.check.status === "ok"
+    ? caught
+    : new RunBudgetError(observation.check);
+}
+
+/** Graph engines must not flatten errors whose identity drives workflow-level
+ * terminal handling. Keep this as the single predicate supplied to both
+ * schema engines. */
+export function shouldRethrowAgentExecutionError(error: unknown): boolean {
+  return isRunControlError(error) || isChecksCeilingExceededError(error);
+}
+
+/** Classify an error that reached the workflow boundary after graph execution. */
+export function unhandledAgentExecutionError(
+  error: unknown,
+  currentBlockId: string | null,
+) {
+  return isChecksCeilingExceededError(error)
+    ? executionError(checksCeilingErrorDetail(error), {
+        category: "checks",
+        message: error.message,
+      }).error
+    : executionError(errorMessage(error), {
+        category: currentBlockId ? "unknown" : "engine",
+        phase: currentBlockId ? undefined : "engine",
+      }).error;
 }
 
 /**
@@ -4749,6 +4826,8 @@ async function agentWorkflowBody(
     .sort((left, right) => left.nodeId.localeCompare(right.nodeId));
   const budgetLimits: RunBudgetLimits = {
     maxDurationMs: plan.budgets?.maxDurationMs ?? env.JOB_TIMEOUT_MS,
+    maxDurationSource:
+      plan.budgets?.maxDurationMs === undefined ? "env" : "definition",
     ...(plan.budgets?.maxTokens !== undefined
       ? { maxTokens: plan.budgets.maxTokens }
       : {}),
@@ -4761,15 +4840,19 @@ async function agentWorkflowBody(
   const observeBudgetAtBoundary = async (
     requireRemainingDuration: boolean,
     attribution: RunBudgetAttribution = "duration",
+    observedAtMs?: number,
   ): Promise<RunBudgetObservation> => {
-    const now = await readRunBudgetClockStep();
+    const now = observedAtMs ?? await readRunBudgetClockStep();
     // The clock is journaled, so a replay re-reads the same instants and lands
     // on the same split between the two totals. Attributing from Date.now()
     // here would give a resumed run a different checks bill than the one it
     // was already charged.
     budgetState = addElapsed(budgetState, now - lastBudgetClockMs, attribution);
     lastBudgetClockMs = Math.max(lastBudgetClockMs, now);
-    return observeRunBudget(budgetState, budgetLimits, requireRemainingDuration);
+    return {
+      ...observeRunBudget(budgetState, budgetLimits, requireRemainingDuration),
+      observedAtMs: lastBudgetClockMs,
+    };
   };
   const enforceBudgetAtBoundary = async (requireRemainingDuration: boolean): Promise<void> => {
     const observation = await observeBudgetAtBoundary(requireRemainingDuration);
@@ -5200,8 +5283,8 @@ async function agentWorkflowBody(
         taskId: null,
       },
       checksCeilingMs: null,
-      observeBudget: (requireRemainingDuration = true, attribution) =>
-        observeBudgetAtBoundary(requireRemainingDuration, attribution),
+      observeBudget: (requireRemainingDuration = true, attribution, observedAtMs?: number) =>
+        observeBudgetAtBoundary(requireRemainingDuration, attribution, observedAtMs),
       recordUsage: (label, usage, model, attempt) => {
         const key = phaseKey(label, attempt ?? state.attempt);
         phaseUsages[key] = usage;
@@ -7137,9 +7220,7 @@ async function agentWorkflowBody(
                 agentKind: repairKind,
                 model: repairModel,
                 observeBudget: blockBudgetObserver(ctx, execution),
-                observeChecksBudget: blockBudgetObserver(ctx, execution, {
-                  attribution: "checks",
-                }),
+                observeChecksBudget: checksBudgetObserver(ctx, execution),
                 ...checksCeilingOption(steps),
                 cancellation: execution?.cancellation,
                 ...(execution?.observations
@@ -7154,12 +7235,10 @@ async function agentWorkflowBody(
                 arthurTaskId: ctx.arthur.taskId,
               });
             } catch (err) {
-              if (isRunControlError(err)) throw err;
-              const after = await ctx.observeBudget();
+              if (isRunControlError(err) || isChecksCeilingExceededError(err)) throw err;
+              propagateInvocationInterruption(err);
+              const after = await ctx.observeBudget(false, "checks");
               if (after.check.status !== "ok") throw new RunBudgetError(after.check);
-              if (isDurationAbortError(err)) {
-                throw new RunBudgetError(durationBudgetFailure(after, "Pre-PR checks"));
-              }
               // Everything prePrChecksFailureMustPropagate covers has already
               // left through the two branches above, so what remains cannot
               // have an identity that wrapping destroys. It must still be
@@ -7815,7 +7894,7 @@ async function agentWorkflowBody(
           runValues,
           executeBlock,
           hooks,
-          shouldRethrowExecutionError: isRunControlError,
+          shouldRethrowExecutionError: shouldRethrowAgentExecutionError,
           maxTotalExecutions: 200,
         });
       } else {
@@ -7845,7 +7924,7 @@ async function agentWorkflowBody(
             ),
             maxTotalExecutions:
               V2_PRODUCTION_SCHEDULER_BOUNDS.maxTotalExecutions,
-            shouldRethrowExecutionError: isRunControlError,
+            shouldRethrowExecutionError: shouldRethrowAgentExecutionError,
             ...(resume ? { resume } : {}),
           });
           if (v2Walk.outcome !== "paused") {
@@ -8041,20 +8120,13 @@ async function agentWorkflowBody(
     }
   } catch (caught) {
     reconcileMissingPhaseUsages();
-    let err = caught;
-    if (!isRunControlError(err)) {
-      const observation = await observeBudgetAtBoundary(false);
-      if (observation.check.status !== "ok") err = new RunBudgetError(observation.check);
-    }
+    let err = await reconcileRunBudgetErrorAtBoundary(caught, observeBudgetAtBoundary);
     terminalBudgetFailure = runBudgetFailureFromError(err);
     const controlError = isRunControlError(err);
     if (!controlError) {
       const nodeId = currentBlockId ?? "engine";
       const attempt = blockStatuses[nodeId]?.attempt ?? 1;
-      const blockError = executionError(errorMessage(err), {
-        category: currentBlockId ? "unknown" : "engine",
-        phase: currentBlockId ? undefined : "engine",
-      }).error;
+      const blockError = unhandledAgentExecutionError(err, currentBlockId);
       const diagnostic = createWorkflowExecutionErrorState(
         workflowRunId,
         nodeId,

--- a/apps/worker/src/workflows/blocks/call-llm.ts
+++ b/apps/worker/src/workflows/blocks/call-llm.ts
@@ -6,7 +6,7 @@ import {
   validateJsonSchemaValue,
   type ParsedJsonSchema,
 } from "../../workflow-definition/json-schema.js";
-import { RunBudgetError } from "../run-budget.js";
+import { durationBudgetFailure, RunBudgetError } from "../run-budget.js";
 import { isRunControlError } from "../run-control-error.js";
 import {
   executionError,
@@ -198,15 +198,7 @@ export const execute: BlockExecuteFn = async (
     const after = await ctx.observeBudget();
     if (after.check.status !== "ok") throw new RunBudgetError(after.check);
     if (after.remainingDurationMs <= 0) {
-      const limit = after.durationLimitMs ?? after.activeElapsedMs ?? 0;
-      const consumed = after.activeElapsedMs ?? limit;
-      throw new RunBudgetError({
-        status: "budget_exceeded",
-        metric: "duration",
-        limit,
-        consumed,
-        reason: `budget_exceeded: duration ${consumed} reached limit ${limit} during Call LLM`,
-      });
+      throw new RunBudgetError(durationBudgetFailure(after));
     }
     return executionError(err instanceof Error ? err.message : String(err), {
       category: "provider",

--- a/apps/worker/src/workflows/blocks/leak-review.test.ts
+++ b/apps/worker/src/workflows/blocks/leak-review.test.ts
@@ -670,7 +670,7 @@ describe("leak_review execute", () => {
       });
 
     await expect(execute(makeNode("leak_review"), {}, ctx)).rejects.toThrow(
-      /budget_exceeded: duration/,
+      /budget_exceeded: the run took/,
     );
   });
 

--- a/apps/worker/src/workflows/blocks/leak-review.ts
+++ b/apps/worker/src/workflows/blocks/leak-review.ts
@@ -7,7 +7,7 @@ import {
   workspaceRepositoryAccess,
   type WorkspaceManifest,
 } from "../../sandbox/repo-workspace.js";
-import { RunBudgetError } from "../run-budget.js";
+import { durationBudgetFailure, RunBudgetError } from "../run-budget.js";
 import { isRunControlError } from "../run-control-error.js";
 import { resolveCallLlmTarget } from "./call-llm.js";
 import {
@@ -723,15 +723,7 @@ export const execute: BlockExecuteFn = async (
     const after = await ctx.observeBudget();
     if (after.check.status !== "ok") throw new RunBudgetError(after.check);
     if (after.remainingDurationMs <= 0) {
-      const limit = after.durationLimitMs ?? after.activeElapsedMs ?? 0;
-      const consumed = after.activeElapsedMs ?? limit;
-      throw new RunBudgetError({
-        status: "budget_exceeded",
-        metric: "duration",
-        limit,
-        consumed,
-        reason: `budget_exceeded: duration ${consumed} reached limit ${limit} during Leak review`,
-      });
+      throw new RunBudgetError(durationBudgetFailure(after));
     }
     return reportOnly("The LLM scan was skipped after a provider error.");
   };

--- a/apps/worker/src/workflows/blocks/poll-phase.ts
+++ b/apps/worker/src/workflows/blocks/poll-phase.ts
@@ -1,4 +1,8 @@
-import { RunBudgetError, type RunBudgetObservation } from "../run-budget.js";
+import {
+  durationBudgetFailure,
+  RunBudgetError,
+  type RunBudgetObservation,
+} from "../run-budget.js";
 import {
   V2InvocationCancelledError,
   type V2InvocationCancellation,
@@ -180,16 +184,8 @@ export async function pollPhaseUntilDone(
       ? Math.min(tickMs, phaseLimitMs - phaseElapsedMs)
       : Math.min(tickMs, phaseLimitMs - phaseElapsedMs, before.remainingDurationMs);
     if (sleepMs <= 0) {
-      const limit = before.durationLimitMs ?? before.activeElapsedMs ?? 0;
-      const consumed = before.activeElapsedMs ?? limit;
       await stopPhaseCommand(sandboxId, commandId);
-      throw new RunBudgetError({
-        status: "budget_exceeded",
-        metric: "duration",
-        limit,
-        consumed,
-        reason: `budget_exceeded: duration ${consumed} reached limit ${limit} while command is active`,
-      });
+      throw new RunBudgetError(durationBudgetFailure(before));
     }
 
     if (cancellation) {
@@ -243,16 +239,8 @@ export async function pollPhaseUntilDone(
       consecutiveStopped = 0;
     }
     if (!ignoreRemainingDuration && after.remainingDurationMs === 0) {
-      const limit = after.durationLimitMs ?? after.activeElapsedMs ?? 0;
-      const consumed = after.activeElapsedMs ?? limit;
       await stopPhaseCommand(sandboxId, commandId);
-      throw new RunBudgetError({
-        status: "budget_exceeded",
-        metric: "duration",
-        limit,
-        consumed,
-        reason: `budget_exceeded: duration ${consumed} reached limit ${limit} while command is active`,
-      });
+      throw new RunBudgetError(durationBudgetFailure(after));
     }
   }
   await stopPhaseCommand(sandboxId, commandId);

--- a/apps/worker/src/workflows/blocks/pre-pr-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/pre-pr-checks.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrePrCheckConfig } from "../../pre-pr-checks/config.js";
-import {
-  RunBudgetError,
-  createRunBudgetState,
-  type RunBudgetObservation,
-} from "../run-budget.js";
+import type { RunBudgetObservation } from "../run-budget.js";
 
 const mocks = vi.hoisted(() => ({
   startRepoCheckBatchStep: vi.fn(),
@@ -46,6 +42,7 @@ import type { PhasePollOutcome, PhasePollTuning } from "./poll-phase.js";
 import {
   createV2InvocationCancellationController,
   createV2InvocationContext,
+  V2InvocationCancelledError,
   type V2InvocationObservationHooks,
 } from "../../workflow-definition/invocation-context.js";
 
@@ -92,6 +89,36 @@ function started(repoIndex: number) {
   };
 }
 
+function fakeChecksClock(input: {
+  readings: number[];
+  initialChecksElapsedMs?: number;
+  recordStep?: (name: string) => void;
+}) {
+  let checksElapsedMs = input.initialChecksElapsedMs ?? 0;
+  let lastObservedAtMs = input.readings[0] ?? 0;
+  let readingIndex = 0;
+  return vi.fn((_requireRemainingDuration?: boolean, observedAtMs?: number) => {
+    const now = observedAtMs ?? input.readings[readingIndex++] ?? lastObservedAtMs;
+    if (observedAtMs === undefined) input.recordStep?.("readRunBudgetClockStep");
+    checksElapsedMs += Math.max(0, now - lastObservedAtMs);
+    lastObservedAtMs = Math.max(lastObservedAtMs, now);
+    return Promise.resolve({
+      check: { status: "ok" as const },
+      remainingDurationMs: 1_800_000,
+      checksElapsedMs,
+      observedAtMs: lastObservedAtMs,
+    });
+  });
+}
+
+function budgetObservers(clock: ReturnType<typeof fakeChecksClock>) {
+  return {
+    observeBudget: (requireRemainingDuration?: boolean) =>
+      clock(requireRemainingDuration),
+    observeChecksBudget: clock,
+  };
+}
+
 /**
  * A poll that ends the way the real one does: it records what it consumed into
  * the tuning it was handed before returning. Everything downstream of a stall
@@ -130,6 +157,7 @@ function collected(overrides: {
   preExistingDirty?: string[];
   setupMarkerFailed?: boolean;
   progress?: { completed: number; total: number; stoppedAt: string | null };
+  checksClockObservedAtMs?: number;
 } = {}) {
   const results = overrides.results ?? [];
   const failures = overrides.failures ?? [];
@@ -145,8 +173,24 @@ function collected(overrides: {
       total: results.length,
       stoppedAt: null,
     },
+    ...(overrides.checksClockObservedAtMs === undefined
+      ? {}
+      : { checksClockObservedAtMs: overrides.checksClockObservedAtMs }),
   };
 }
+
+const HEAD_PRE_PR_CHECK_STEP_ORDER = [
+  "readRunBudgetClockStep",
+  "loadPrePrCheckConfigStep",
+  "readRunBudgetClockStep",
+  "startRepoCheckBatchStep",
+  "checkPhaseDone",
+  "readRunBudgetClockStep",
+  "delayPhasePollStep",
+  "readRunBudgetClockStep",
+  "checkPhaseDone",
+  "collectRepoCheckBatchStep",
+] as const;
 
 describe("runPrePrChecksWithFixes", () => {
   beforeEach(() => {
@@ -243,14 +287,15 @@ describe("runPrePrChecksWithFixes", () => {
 
     expect(result.passed).toBe(false);
     expect(result.outcome).toBe("failed");
-    // The elapsed time the poll actually consumed, not the cap it was given:
-    // the cap is derived from the remaining budget and the poll can end early,
-    // so a fixed sentence would eventually be a false one.
-    expect(result.summary).toContain("ran for 25 minutes without finishing");
+    expect(result.summary).toContain(
+      "The checks batch for github:acme/web reached the 60 minute checks ceiling",
+    );
     expect(result.summary).toContain(
       "while running `uv run pytest tests/ -m integration`; 3 of 5 script commands had finished",
     );
-    expect(result.summary).toContain("this is a timeout");
+    expect(result.summary).toContain(
+      "this is a checks timeout, not a duration budget failure",
+    );
     // The abandoned batch is still read back: those files are the only record
     // of where it died. It is read as abandoned, so the commands after the one
     // that was running are not reported at all.
@@ -289,7 +334,7 @@ describe("runPrePrChecksWithFixes", () => {
 
     const entries = result.summary.split("\n\n");
     const setupEntry = entries.find((entry) => entry.startsWith("SETUP FAILED"));
-    const stallEntry = entries.find((entry) => entry.includes("this is a timeout"));
+    const stallEntry = entries.find((entry) => entry.includes("this is a checks timeout"));
     expect(setupEntry).toBeDefined();
     expect(stallEntry).toContain("CHECK BATCH ABANDONED for gitlab:acme/api");
     // The proof the phase is doing the work: it is not headed by the bare
@@ -359,22 +404,21 @@ describe("runPrePrChecksWithFixes", () => {
     // outlive the budget that pays for the agent's work without the run
     // halting as budget_exceeded with a green check run behind it.
     mocks.collectRepoCheckBatchStep.mockResolvedValue(collected());
-    observeBudget.mockResolvedValueOnce({
-      check: { status: "ok" as const },
-      remainingDurationMs: 60_000,
-      checksElapsedMs: 900_000,
+    const checksClock = fakeChecksClock({
+      readings: [10_000],
+      initialChecksElapsedMs: 900_000,
     });
 
-    await runPrePrChecksWithFixes(options());
+    await runPrePrChecksWithFixes(options(budgetObservers(checksClock)));
 
     const tuning = mocks.pollPhaseUntilDone.mock.calls[0]![6] as PhasePollTuning;
-    expect(tuning.phaseLimitMs).toBe(60 * 60_000 - 900_000);
+    expect(tuning.phaseLimitMs).toBe(2_700_000);
     // And the poll is told not to consult the run's duration at all, so an
     // exhausted run budget cannot pre-empt the checks report.
     expect(tuning.ignoreRemainingDuration).toBe(true);
   });
 
-  it("hands the poll the observer that charges its waiting to the checks ceiling", async () => {
+  it("hands the poll a boundary observer that charges its waiting to the checks ceiling", async () => {
     // Two observers, because the split is a boundary: everything up to the
     // launch is the run's time, everything the poll waits through is the
     // checks phase's.
@@ -383,7 +427,162 @@ describe("runPrePrChecksWithFixes", () => {
 
     await runPrePrChecksWithFixes(options({ observeChecksBudget }));
 
-    expect(mocks.pollPhaseUntilDone.mock.calls[0]![4]).toBe(observeChecksBudget);
+    const pollObserver = mocks.pollPhaseUntilDone.mock.calls[0]![4] as (
+      requireRemainingDuration?: boolean,
+    ) => Promise<RunBudgetObservation>;
+    await pollObserver(false);
+    expect(observeChecksBudget).toHaveBeenLastCalledWith(false);
+  });
+
+  it("reduces the polling cap by the allowance spent launching the batch", async () => {
+    const checksClock = fakeChecksClock({ readings: [1_000] });
+    mocks.startRepoCheckBatchStep.mockResolvedValue({
+      ...started(0),
+      checksClockObservedAtMs: 51_000,
+    });
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("finished", 0));
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({ checksClockObservedAtMs: 51_000 }),
+    );
+
+    await runPrePrChecksWithFixes(options({
+      checksCeilingMs: 60_000,
+      ...budgetObservers(checksClock),
+    }));
+
+    const tuning = mocks.pollPhaseUntilDone.mock.calls[0]![6] as PhasePollTuning;
+    expect(tuning.phaseLimitMs).toBe(10_000);
+  });
+
+  it("fails when collection crosses the checks ceiling", async () => {
+    const checksClock = fakeChecksClock({ readings: [0] });
+    mocks.startRepoCheckBatchStep.mockResolvedValue({
+      ...started(0),
+      checksClockObservedAtMs: 1_000,
+    });
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("finished", 0));
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({ checksClockObservedAtMs: 61_000 }),
+    );
+
+    await expect(runPrePrChecksWithFixes(options({
+      checksCeilingMs: 60_000,
+      ...budgetObservers(checksClock),
+    }))).rejects.toThrow(
+      "The repository checks did not finish within the 1 minute checks ceiling. " +
+      "Raise batchTimeoutMinutes for this definition or split the run. " +
+      "(checks_ceiling_exceeded: Checks batch for github:acme/web reached the 1 minute checks ceiling)",
+    );
+  });
+
+  it("rethrows an ordinary sandbox abort without calling it the checks ceiling", async () => {
+    const abort = new DOMException("sandbox request aborted", "AbortError");
+    mocks.startRepoCheckBatchStep.mockRejectedValue(abort);
+
+    await expect(runPrePrChecksWithFixes(options())).rejects.toBe(abort);
+  });
+
+  it("rethrows invocation cancellation without calling it the checks ceiling", async () => {
+    const cancellation = new V2InvocationCancelledError("superseded");
+    mocks.pollPhaseUntilDone.mockRejectedValue(cancellation);
+
+    await expect(runPrePrChecksWithFixes(options())).rejects.toBe(cancellation);
+  });
+
+  it("fails immediately when a replay re-enters after the durable checks start exceeded the ceiling", async () => {
+    const checksClock = fakeChecksClock({ readings: [0] });
+    mocks.startRepoCheckBatchStep.mockResolvedValue({
+      ...started(0),
+      checksClockObservedAtMs: 1_200_000,
+    });
+
+    await expect(runPrePrChecksWithFixes(options({
+      checksCeilingMs: 900_000,
+      ...budgetObservers(checksClock),
+    }))).rejects.toThrow(
+      "The repository checks did not finish within the 15 minute checks ceiling. " +
+      "Raise batchTimeoutMinutes for this definition or split the run. " +
+      "(checks_ceiling_exceeded: Checks batch for github:acme/web reached the 15 minute checks ceiling)",
+    );
+    expect(mocks.pollPhaseUntilDone).not.toHaveBeenCalled();
+    expect(mocks.collectRepoCheckBatchStep).not.toHaveBeenCalled();
+  });
+
+  it("falls back at start and collect for old-shaped step results without adding a step", async () => {
+    const durableStepCalls: string[] = [];
+    const checksClock = fakeChecksClock({
+      readings: [123_000],
+      recordStep: (name) => durableStepCalls.push(name),
+    });
+    mocks.startRepoCheckBatchStep.mockResolvedValue(started(0));
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("finished", 0));
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(collected());
+
+    await expect(runPrePrChecksWithFixes(options({
+      checksCeilingMs: 900_000,
+      ...budgetObservers(checksClock),
+    }))).resolves.toMatchObject({ passed: true });
+
+    const tuning = mocks.pollPhaseUntilDone.mock.calls[0]![6] as PhasePollTuning;
+    expect(tuning.phaseLimitMs).toBe(900_000);
+    expect(checksClock.mock.calls).toEqual([
+      [false],
+      [false, 123_000],
+      [false, 123_000],
+      [false, 123_000],
+    ]);
+    expect(durableStepCalls).toEqual(["readRunBudgetClockStep"]);
+  });
+
+  it.each([
+    { label: "timestamped start and collect outputs", oldShaped: false },
+    { label: "old-shaped start and collect outputs", oldShaped: true },
+  ])("keeps the full HEAD pre-PR checks step order for $label", async ({ oldShaped }) => {
+    const calls: string[] = [];
+    const checksClock = fakeChecksClock({
+      readings: [0, 2_000, 4_000, 6_000],
+      recordStep: (name) => calls.push(name),
+    });
+    mocks.getCurrentPrePrCheckConfig.mockImplementation(() => {
+      calls.push("loadPrePrCheckConfigStep");
+      return Promise.resolve({ version: 7, config: oneRepoConfig });
+    });
+    mocks.startRepoCheckBatchStep.mockImplementation(() => {
+      calls.push("startRepoCheckBatchStep");
+      return Promise.resolve(
+        oldShaped
+          ? started(0)
+          : { ...started(0), checksClockObservedAtMs: 2_000 },
+      );
+    });
+    mocks.pollPhaseUntilDone.mockImplementation(async (...args: unknown[]) => {
+      calls.push("checkPhaseDone");
+      const pollObserver = args[4] as (required?: boolean) => Promise<RunBudgetObservation>;
+      await pollObserver(false);
+      calls.push("delayPhasePollStep");
+      await pollObserver(false);
+      calls.push("checkPhaseDone");
+      const tuning = args[6] as PhasePollTuning;
+      Object.assign(tuning.outcome!, { reason: "finished", elapsedMs: 2_000, ticks: 1 });
+      return true;
+    });
+    mocks.collectRepoCheckBatchStep.mockImplementation(() => {
+      calls.push("collectRepoCheckBatchStep");
+      return Promise.resolve(
+        oldShaped
+          ? collected()
+          : collected({ checksClockObservedAtMs: 7_000 }),
+      );
+    });
+
+    await checksClock(false);
+    const loaded = await loadPrePrCheckConfigStep();
+    await runPrePrChecksWithFixes(options({
+      config: loaded.config,
+      ...budgetObservers(checksClock),
+    }));
+
+    expect(calls).toEqual(HEAD_PRE_PR_CHECK_STEP_ORDER);
   });
 
   it("stops launching once the ceiling is spent, and says so exactly once", async () => {
@@ -469,21 +668,14 @@ describe("runPrePrChecksWithFixes", () => {
     // never by a refreshed ceiling. The checks total lives on the run's budget
     // state and the ceiling is journaled, so a run that resumes mid-phase
     // continues spending the same minutes rather than starting them again.
-    mocks.collectRepoCheckBatchStep.mockResolvedValue(collected());
-    observeBudget
-      .mockResolvedValueOnce({
-        check: { status: "ok" as const },
-        remainingDurationMs: 1_800_000,
-        checksElapsedMs: 0,
-      })
-      .mockResolvedValueOnce({
-        check: { status: "ok" as const },
-        remainingDurationMs: 1_800_000,
-        checksElapsedMs: 1_200_000,
-      });
+    mocks.collectRepoCheckBatchStep
+      .mockResolvedValueOnce(collected({ checksClockObservedAtMs: 1_200_000 }))
+      .mockResolvedValueOnce(collected({ checksClockObservedAtMs: 1_200_000 }));
+    const checksClock = fakeChecksClock({ readings: [0, 1_200_000] });
 
     await runPrePrChecksWithFixes(
       options({
+        ...budgetObservers(checksClock),
         config: {
           repositories: [
             { provider: "github" as const, repoPath: "acme/web", commands: ["pnpm typecheck"] },
@@ -495,8 +687,8 @@ describe("runPrePrChecksWithFixes", () => {
 
     const first = mocks.pollPhaseUntilDone.mock.calls[0]![6] as PhasePollTuning;
     const second = mocks.pollPhaseUntilDone.mock.calls[1]![6] as PhasePollTuning;
-    expect(first.phaseLimitMs).toBe(60 * 60_000);
-    expect(second.phaseLimitMs).toBe(60 * 60_000 - 1_200_000);
+    expect(first.phaseLimitMs).toBe(3_600_000);
+    expect(second.phaseLimitMs).toBe(2_400_000);
   });
 
   it("prefers the ceiling prepare_workspace published over the configuration's own", async () => {
@@ -1583,6 +1775,57 @@ describe("runRepositorySetup", () => {
     expect(requireChange).toBe(false);
   });
 
+  it("fails before counting a second repository whose setup cannot start", async () => {
+    const available = {
+      check: { status: "ok" as const },
+      remainingDurationMs: 1_800_000,
+      checksElapsedMs: 0,
+    };
+    const spent = {
+      ...available,
+      checksElapsedMs: 3_600_000,
+    };
+    observeBudget
+      .mockResolvedValueOnce(available)
+      .mockResolvedValueOnce(available)
+      .mockResolvedValueOnce(available)
+      .mockResolvedValueOnce(available)
+      .mockResolvedValue(spent);
+    await expect(
+      runRepositorySetup({
+        sandboxId: "sbx-test-123",
+        config: {
+          repositories: [
+            {
+              provider: "github" as const,
+              repoPath: "acme/web",
+              setup: ["make bootstrap"],
+              commands: ["pnpm test"],
+            },
+            {
+              provider: "gitlab" as const,
+              repoPath: "acme/api",
+              setup: ["pnpm install"],
+              commands: ["pnpm test"],
+            },
+          ],
+        },
+        observeBudget,
+        checksCeilingMs: 3_600_000,
+      }),
+    ).rejects.toMatchObject({
+      name: "ChecksCeilingExceededError",
+      message:
+        "The repository checks did not finish within the 60 minute checks ceiling. " +
+        "Raise batchTimeoutMinutes for this definition or split the run. " +
+        "(checks_ceiling_exceeded: Setup batch for gitlab:acme/api reached the 60 minute checks ceiling)",
+    });
+    // Only the first repository launched. The second is not counted as ran,
+    // and a thrown ceiling error leaves no success summary to report.
+    expect(mocks.startRepoCheckBatchStep).toHaveBeenCalledOnce();
+    expect(mocks.startRepoCheckBatchStep.mock.calls[0]![2]).toBe("acme/web");
+  });
+
   it("skips a repository that configured no setup at all", async () => {
     const outcome = await runRepositorySetup({
       sandboxId: "sbx-test-123",
@@ -1634,11 +1877,8 @@ describe("runRepositorySetup", () => {
     expect(outcome.summary).toBe("Setup failed in 1 of 1 repositories.");
   });
 
-  it("charges its waiting to the run's duration, with the ceiling only as a backstop", async () => {
-    // Setup is provisioning, not verification. A toolchain install is work the
-    // agent needs done before it can start, so it spends the run's minutes and
-    // is bounded by them tick by tick; the checks ceiling only stops a setup
-    // that would otherwise run unbounded.
+  it("charges setup batch start and polling to the checks clock only", async () => {
+    const setupBudget = vi.fn(observeBudget);
     await runRepositorySetup({
       sandboxId: "sbx-test-123",
       config: {
@@ -1651,50 +1891,47 @@ describe("runRepositorySetup", () => {
           },
         ],
       },
-      observeBudget,
+      observeBudget: setupBudget,
       checksCeilingMs: 60 * 60_000,
     });
 
     const tuning = mocks.pollPhaseUntilDone.mock.calls[0]![6] as PhasePollTuning;
-    expect(tuning.ignoreRemainingDuration).toBe(false);
+    expect(tuning.ignoreRemainingDuration).toBe(true);
     expect(tuning.phaseLimitMs).toBe(60 * 60_000);
-    // And no separate checks observer: the one budget context it polls through
-    // is the run's, which is what makes the elapsed land on duration.
-    expect(mocks.pollPhaseUntilDone.mock.calls[0]![4]).toBe(observeBudget);
+    const checksObserver = mocks.pollPhaseUntilDone.mock.calls[0]![4] as (
+      requireRemainingDuration?: boolean,
+    ) => Promise<RunBudgetObservation>;
+    await checksObserver(false);
+    expect(setupBudget).toHaveBeenLastCalledWith(false, "checks");
   });
 
-  it("names setup, not checks, when the run's budget stops it", async () => {
-    // Two phases spend two different budgets, and an operator reading "setup
-    // stopped" reaches for a different knob than one reading "checks stopped".
-    mocks.pollPhaseUntilDone.mockRejectedValue(
-      new RunBudgetError({
-        status: "budget_exceeded",
-        metric: "duration",
-        limit: 1_800_000,
-        consumed: 1_800_001,
-        reason: "budget_exceeded: duration 1800001 reached limit 1800000",
-      }),
+  it("names the checks ceiling when a setup batch spends it", async () => {
+    mocks.pollPhaseUntilDone.mockImplementation(pollEnds("duration_cap", 3_600_000));
+    mocks.collectRepoCheckBatchStep.mockResolvedValue(
+      collected({ progress: { completed: 0, total: 1, stoppedAt: "make bootstrap" } }),
     );
 
-    await expect(
-      runRepositorySetup({
-        sandboxId: "sbx-test-123",
-        config: {
-          repositories: [
-            {
-              provider: "github" as const,
-              repoPath: "acme/web",
-              setup: ["make bootstrap"],
-              commands: ["pnpm typecheck"],
-            },
-          ],
-        },
-        observeBudget,
-      }),
-    ).rejects.toMatchObject({
-      name: "RunBudgetError",
-      failure: { reason: expect.stringContaining("setup for github:acme/web stopped") },
+    const outcome = await runRepositorySetup({
+      sandboxId: "sbx-test-123",
+      config: {
+        repositories: [
+          {
+            provider: "github" as const,
+            repoPath: "acme/web",
+            setup: ["make bootstrap"],
+            commands: ["pnpm typecheck"],
+          },
+        ],
+      },
+      observeBudget,
+      checksCeilingMs: 3_600_000,
     });
+
+    expect(outcome.failures[0]!.note).toBe(
+      "The setup batch for github:acme/web reached the 60 minute checks ceiling while running " +
+        "`make bootstrap`; 0 of 1 script command had finished. Nothing was verified: this is " +
+        "a checks timeout, not a duration budget failure.",
+    );
   });
 
   it("leaves the workspace alone when the configuration cannot be read", async () => {
@@ -1919,11 +2156,7 @@ describe("checks phase progress observations", () => {
     expect(run.outcome).toBe("passed");
   });
 
-  it("reports the setup substep too, which is where a run is silent longest", async () => {
-    // Provisioning precedes every block that produces output, so an operator
-    // watching a five minute `uv sync` has nothing else at all to look at. A
-    // setup batch spends the run's duration rather than the checks ceiling, so
-    // its elapsed is its own wait and nothing is claimed about the ceiling.
+  it("reports setup progress against the checks ceiling", async () => {
     const emit = vi.fn();
     mocks.pollPhaseUntilDone.mockImplementation(
       pollTicking([
@@ -1948,13 +2181,10 @@ describe("checks phase progress observations", () => {
       observations: wired({ emit }),
     });
 
-    // Setup is charged to the run's duration budget and is deliberately outside
-    // the checks ceiling, so the line names no ceiling at all: its bound is
-    // what the duration budget had left at this tick.
     expect(emit).toHaveBeenCalledWith({
       kind: "log",
       value:
-        "Setup running: about 2 seconds in, 15 minutes of run budget left, " +
+        "Setup running: about 2 seconds of 60 minutes, " +
         "1 command launched, github:acme/web",
     });
   });

--- a/apps/worker/src/workflows/blocks/pre-pr-checks.ts
+++ b/apps/worker/src/workflows/blocks/pre-pr-checks.ts
@@ -33,9 +33,14 @@ import type {
   V2InvocationObservationHooks,
 } from "../../workflow-definition/invocation-context.js";
 import {
+  checksCeilingExceededError,
   RunBudgetError,
+  isChecksCeilingExceededError,
   isRunBudgetError,
+  propagateInvocationInterruption,
   remainingChecksMs,
+  type ChecksCeilingExceededError,
+  type RunBudgetAttribution,
   type RunBudgetObservation,
 } from "../run-budget.js";
 import {
@@ -85,19 +90,20 @@ export interface PrePrChecksOptions {
    *  survives a replay instead of being recomputed from Date.now(). */
   observeBudget: (
     requireRemainingDuration?: boolean,
+    attribution?: RunBudgetAttribution,
+    observedAtMs?: number,
   ) => Promise<RunBudgetObservation>;
   /**
    * The same observer, charging what it measures to the checks ceiling instead
    * of to the run's duration.
    *
-   * Two observers rather than one flag, because the split is a boundary and not
-   * a mode: `observeBudget` closes the run's clock at the launch, and this one
-   * carries every tick the poll then waits through. A caller that supplies only
-   * the first keeps the old behaviour, which is what run_checks' explicit
-   * command mode does when nothing prepared a workspace.
+   * The optional timestamp charges an existing durable step result without
+   * calling another clock step. Older results omit it and fall back to the
+   * durable checks start already held by the caller.
    */
   observeChecksBudget?: (
     requireRemainingDuration?: boolean,
+    observedAtMs?: number,
   ) => Promise<RunBudgetObservation>;
   cancellation?: V2InvocationCancellation;
   /** Where a running batch reports its progress. Absent for a caller with no
@@ -168,16 +174,12 @@ export function newPhasePollOutcome(): PhasePollOutcome {
 export function batchPollTuning(
   outcome: PhasePollOutcome,
   capMs: number,
-  phase: RepoBatchPhase = "checks",
 ): PhasePollTuning {
   return {
     checkBeforeFirstTick: true,
-    // Checks time is charged to the checks ceiling, and that ceiling is
-    // already the phase cap, so consulting the run's duration would halt the
-    // run as budget_exceeded instead of reporting checks that outlived their
-    // bound. Setup is the opposite case: it is provisioning, its time IS the
-    // run's, and a run that dies during `uv sync` genuinely ran out of time.
-    ignoreRemainingDuration: phase !== "setup",
+    // Repository checks infrastructure, including setup, spends the checks
+    // ceiling. The run's remaining duration must not pre-empt that report.
+    ignoreRemainingDuration: true,
     initialTickMs: 2_000,
     tickGrowthFactor: 1.6,
     maxTicks: maxTicksFor(capMs),
@@ -209,20 +211,16 @@ export interface RepositoryScriptsProgressObservation {
   /** provider:repoPath of the repository being polled. */
   repo: string;
   /** Checks time this run has spent against its ceiling, this batch's wait
-   *  included. Zero-based for a setup batch, which spends the run's duration
-   *  rather than the checks ceiling.
+   *  included.
    *
    *  Approximate, and the rendered line says so: it is the sum of the sleeps
    *  the poll REQUESTED, so an SDK retry or a slow resume between ticks is time
    *  this never counted. It under-reports, never over-reports. */
   elapsedMs: number;
-  /** The checks ceiling, and null for a setup batch: setup is charged to the
-   *  run's duration budget and is deliberately outside the checks ceiling, so
-   *  printing one beside it would name a clock this wait is not on. */
+  /** The checks ceiling shared by setup and repository script batches. */
   ceilingMs: number | null;
   /** The bound that actually applies to this batch: what was left of the checks
-   *  ceiling when it launched, or, for setup, what the run's duration budget
-   *  had left at this tick. */
+   *  ceiling when it launched. */
   boundMs: number;
   ticks: number;
   /** How many commands this batch LAUNCHED. Never how many have finished. */
@@ -317,28 +315,38 @@ export async function emitRepositoryScriptsProgress(
  * launched. The poll would raise the same error on its first tick, but only
  * after a wrapper had been written, chmodded and started in the sandbox.
  */
-export async function batchCapMs(
-  observeBudget: PrePrChecksOptions["observeBudget"],
+interface ChecksAllowanceBoundary {
+  observation: RunBudgetObservation;
+  observedAtMs: number;
+  remainingMs: number;
+  failure: ChecksCeilingExceededError | null;
+}
+
+async function observeChecksAllowance(
+  observeBudget: () => Promise<RunBudgetObservation>,
   ceilingMs: number,
-  phase: RepoBatchPhase = "checks",
-): Promise<number> {
-  const observed = await observeBudget(false);
+  activity: string,
+  observedAtMs?: number,
+): Promise<ChecksAllowanceBoundary> {
+  const observed = await observeBudget();
   if (observed.check.status !== "ok") throw new RunBudgetError(observed.check);
-  // Setup spends the run's duration, not the checks ceiling, so the ceiling is
-  // only a backstop against an unbounded poll here. The bound that actually
-  // binds is the remaining duration, which the poll re-reads on every tick.
-  return phase === "setup" ? ceilingMs : remainingChecksMs(observed, ceilingMs);
+  const remainingMs = remainingChecksMs(observed, ceilingMs);
+  return {
+    observation: observed,
+    observedAtMs: observed.observedAtMs ?? observedAtMs ?? 0,
+    remainingMs,
+    failure:
+      remainingMs <= 0
+        ? checksCeilingExceededError(ceilingMs, activity)
+        : null,
+  };
 }
 
 /**
  * Which budget a batch is spending.
  *
- * "setup" is provisioning a workspace (a toolchain install, a registry login):
- * it is the run's own time, bounded by the run's duration budget. "checks" is
- * verification, charged to the checks ceiling and deliberately outside the
- * duration budget. The distinction decides three things at once: which clock
- * the elapsed time lands on, which bound the poll obeys, and which knob an
- * operator is told to turn when it runs out.
+ * Both phases spend the checks ceiling. The distinction controls labels and
+ * result formatting, not budget attribution.
  */
 export type RepoBatchPhase = "checks" | "setup";
 
@@ -475,12 +483,9 @@ export interface RepositorySetupOutcome {
  * hash of the setup array (setupMarkerPath), so a batch carrying the same setup
  * finds the marker and skips straight to its commands.
  *
- * Its time is the RUN's, not the checks phase's. Setup is provisioning, and
- * three repositories running `uv sync` must not eat the budget the tests were
- * given; an operator whose run dies inside it has to be pointed at the setup
- * commands, never at batchTimeoutMinutes. So it takes no checks observer and
- * runs with phase "setup", which keeps the run's remaining duration binding
- * the poll tick by tick, exactly as every other block is bound.
+ * Its time belongs to the checks phase. Setup, launch and polling all exist to
+ * run repository checks, so they share the checks ceiling and never spend the
+ * run's duration budget.
  *
  * It never fails on a configuration it cannot read. That failure belongs to the
  * checks block, which names the field that broke; refusing to create a
@@ -519,7 +524,7 @@ export async function runRepositorySetup(options: {
   sandboxId: string;
   config: unknown;
   observeBudget: PrePrChecksOptions["observeBudget"];
-  /** Only a backstop on the poll here, never a budget setup draws from. */
+  /** The checks ceiling shared by setup and repository script batches. */
   checksCeilingMs?: number;
   cancellation?: V2InvocationCancellation;
   /** Where a running setup batch reports its progress. Provisioning is the
@@ -561,6 +566,10 @@ export async function runRepositorySetup(options: {
       // there is no agent work yet at this point in the run.
       requireChange: false,
       observeBudget: options.observeBudget,
+      observeChecksBudget: (requireRemainingDuration, observedAtMs) =>
+        observedAtMs === undefined
+          ? options.observeBudget(requireRemainingDuration, "checks")
+          : options.observeBudget(requireRemainingDuration, "checks", observedAtMs),
       phase: "setup",
       ...(options.observations ? { observations: options.observations } : {}),
       ...(options.checksCeilingMs === undefined
@@ -572,6 +581,12 @@ export async function runRepositorySetup(options: {
         ? {}
         : { commandTimeoutMinutes: repo.commandTimeoutMinutes }),
     });
+    if (run.budgetExhausted) {
+      throw checksCeilingExceededError(
+        options.checksCeilingMs ?? checksCeilingMsOf(parsed.data.batchTimeoutMinutes),
+        `Setup batch for ${repo.provider}:${repo.repoPath}`,
+      );
+    }
     if (run.skipped) continue;
     ran += 1;
     if (run.stall) {
@@ -582,12 +597,16 @@ export async function runRepositorySetup(options: {
         exitCode: -1,
         stdout: "",
         stderr: "",
-        note:
-          `Setup for ${repo.repoPath} ${
-            run.stall === "sandbox_stopped"
-              ? "lost its sandbox"
-              : `did not finish within ${formatElapsed(run.elapsedMs)}`
-          }, so the workspace is not provisioned.`,
+        note: batchStallReason(
+          run.stall,
+          run.collected.progress,
+          {
+            phase: "setup",
+            provider: repo.provider,
+            repoPath: repo.repoPath,
+            ceilingMs: options.checksCeilingMs ?? checksCeilingMsOf(parsed.data.batchTimeoutMinutes),
+          },
+        ),
         phase: "setup",
       });
     }
@@ -646,7 +665,6 @@ export async function runPrePrChecksWithFixes(
         `${describePrePrCheckIssues(parsed.error)}. Fix it in the dashboard and re-run.`,
     });
   }
-
   const config = parsed.data;
   if (config.repositories.length === 0) {
     return emptyRunResult({
@@ -655,7 +673,6 @@ export async function runPrePrChecksWithFixes(
       summary: NO_CONFIGURATION_SUMMARY,
     });
   }
-
   const batch = await runCheckBatches(options, config);
   return {
     outcome: batch.outcome,
@@ -702,7 +719,8 @@ export function checksBudgetExhaustedFailure(
     note:
       `Nothing ran in ${names.length} ${names.length === 1 ? "repository" : "repositories"} ` +
       `(${names.join(", ")}): this run's ${minutes} minute checks budget was already ` +
-      "spent by the repositories before them. Raise batchTimeoutMinutes in the " +
+      "spent by the repositories before them, so the checks ceiling was reached. " +
+      "Raise batchTimeoutMinutes in the " +
       "repository scripts configuration, or split the run.",
     phase: "budget",
   };
@@ -856,9 +874,8 @@ export async function runRepoCheckBatch(args: {
    *  batches already run is this batch's bound. */
   checksCeilingMs?: number;
   /** The observer to hand the poll, already charging its time to the checks
-   *  ceiling. Absent for callers with no attribution seam, which then spend the
-   *  run's duration as before. */
-  observeChecksBudget?: PrePrChecksOptions["observeBudget"];
+   *  ceiling. */
+  observeChecksBudget?: NonNullable<PrePrChecksOptions["observeChecksBudget"]>;
   /** Which budget this batch spends. Default "checks". */
   phase?: RepoBatchPhase;
   /** Where this batch reports its progress while it runs. Absent means no
@@ -879,13 +896,18 @@ export async function runRepoCheckBatch(args: {
   const total = args.setup.length + args.commands.length;
   const phase = args.phase ?? "checks";
   const ceilingMs = args.checksCeilingMs ?? checksCeilingMsOf();
-  const capMs = await batchCapMs(args.observeBudget, ceilingMs, phase);
-  if (capMs <= 0) {
-    // Nothing is launched, and nothing is claimed about this repository. A
-    // batch given no time would be collected as a batch that reported nothing,
-    // which reads as an infrastructure fault; the truth is that earlier
-    // repositories spent the run's ceiling. The caller turns this into one
-    // failure for the whole slice it could not reach.
+  const activity = `${phase === "setup" ? "Setup" : "Checks"} batch for ${args.provider}:${args.repoPath}`;
+  const observeChecksBudget = args.observeChecksBudget ??
+    ((requireRemainingDuration?: boolean, observedAtMs?: number) =>
+      args.observeBudget(requireRemainingDuration, "checks", observedAtMs));
+  const entryBoundary = await observeChecksAllowance(
+    () => args.observeBudget(false),
+    ceilingMs,
+    activity,
+  );
+  if (entryBoundary.failure) {
+    // The ceiling was spent before this repository. Nothing is launched, and
+    // the caller records the whole unreached slice as not run.
     return {
       skipped: false,
       collected: {
@@ -919,6 +941,16 @@ export async function runRepoCheckBatch(args: {
       ...(args.restoreTree === undefined ? {} : { restoreTree: args.restoreTree }),
     },
   );
+  const launchBoundary = await observeChecksAllowance(
+    () => observeChecksBudget(
+      false,
+      started.checksClockObservedAtMs ?? entryBoundary.observedAtMs,
+    ),
+    ceilingMs,
+    activity,
+    started.checksClockObservedAtMs ?? entryBoundary.observedAtMs,
+  );
+  if (launchBoundary.failure) throw launchBoundary.failure;
   if (started.skipped) {
     return { skipped: true, collected: unreadableBatch(), stall: null, elapsedMs: 0 };
   }
@@ -942,8 +974,8 @@ export async function runRepoCheckBatch(args: {
     };
   }
 
-  const collect = (batchFinished: boolean): Promise<CollectedRepoCheckBatch> =>
-    collectRepoCheckBatchStep(
+  const collect = async (batchFinished: boolean): Promise<CollectedRepoCheckBatch> => {
+    const collected = await collectRepoCheckBatchStep(
       args.sandboxId,
       args.provider,
       args.repoPath,
@@ -960,13 +992,25 @@ export async function runRepoCheckBatch(args: {
           : { commandTimeoutMinutes: args.commandTimeoutMinutes }),
       },
     );
+    const collectionBoundary = await observeChecksAllowance(
+      () => observeChecksBudget(
+        false,
+        collected.checksClockObservedAtMs ?? launchBoundary.observedAtMs,
+      ),
+      ceilingMs,
+      activity,
+      collected.checksClockObservedAtMs ?? launchBoundary.observedAtMs,
+    );
+    if (collectionBoundary.failure) throw collectionBoundary.failure;
+    return collected;
+  };
 
   const outcome = newPhasePollOutcome();
-  // What the ceiling had already lost before this batch launched. capMs is the
-  // remainder the observer just measured, so the difference is the only place
+  // What the ceiling had already lost before this batch launched. The entry
+  // allowance is the remainder the observer measured, so the difference is the only place
   // the run's cumulative checks time is readable from here: the running total
   // itself lives in the in-memory budget state, not on any durable output.
-  const spentBeforeBatchMs = phase === "checks" ? Math.max(0, ceilingMs - capMs) : 0;
+  const spentBeforeBatchMs = Math.max(0, ceilingMs - entryBoundary.remainingMs);
   let lastProgressMs: number | null = null;
   const reportProgress = async (progress: {
     elapsedMs: number;
@@ -992,8 +1036,8 @@ export async function runRepoCheckBatch(args: {
       phase,
       repo: `${args.provider}:${args.repoPath}`,
       elapsedMs: spentBeforeBatchMs + progress.elapsedMs,
-      ceilingMs: phase === "setup" ? null : ceilingMs,
-      boundMs: phase === "setup" ? progress.remainingDurationMs : capMs,
+      ceilingMs,
+      boundMs: launchBoundary.remainingMs,
       ticks: progress.ticks,
       commandsLaunched: total,
     });
@@ -1007,19 +1051,32 @@ export async function runRepoCheckBatch(args: {
       // checks ceiling in milliseconds rather than a whole number of minutes.
       0,
       started.commandId,
-      // Setup deliberately keeps the plain observer: its waiting is the run's
-      // time, so it must land on the duration clock like every other block.
-      phase === "setup"
-        ? args.observeBudget
-        : args.observeChecksBudget ?? args.observeBudget,
+      async (_requireRemainingDuration) => {
+        const boundary = await observeChecksAllowance(
+          () => observeChecksBudget(false),
+          ceilingMs,
+          activity,
+        );
+        if (boundary.failure) throw boundary.failure;
+        return boundary.observation;
+      },
       args.cancellation,
       {
-        ...batchPollTuning(outcome, capMs, phase),
-        phaseLimitMs: capMs,
+        ...batchPollTuning(outcome, launchBoundary.remainingMs),
+        phaseLimitMs: launchBoundary.remainingMs,
         onTick: reportProgress,
       },
     );
   } catch (error) {
+    propagateInvocationInterruption(error);
+    if (isChecksCeilingExceededError(error)) {
+      try {
+        await collect(false);
+      } catch (collectionError) {
+        propagateInvocationInterruption(collectionError);
+      }
+      throw error;
+    }
     // A budget stop still ends the run, but the wrapper's files say exactly how
     // far the checks got and the operator has no other way to find out.
     throw await budgetErrorNamingProgress(
@@ -1029,6 +1086,24 @@ export async function runRepoCheckBatch(args: {
       collect,
       phase,
     );
+  }
+
+  const pollBoundary = await observeChecksAllowance(
+    () => observeChecksBudget(
+      false,
+      launchBoundary.observedAtMs + outcome.elapsedMs,
+    ),
+    ceilingMs,
+    activity,
+    launchBoundary.observedAtMs + outcome.elapsedMs,
+  );
+  if (pollBoundary.failure) {
+    try {
+      await collect(false);
+    } catch (error) {
+      propagateInvocationInterruption(error);
+    }
+    throw pollBoundary.failure;
   }
 
   if (!done) {
@@ -1070,7 +1145,9 @@ async function collectAbandonedBatch(
 ): Promise<CollectedRepoCheckBatch> {
   try {
     return await collect(false);
-  } catch {
+  } catch (error) {
+    if (isChecksCeilingExceededError(error)) throw error;
+    propagateInvocationInterruption(error);
     return unreadableBatch();
   }
 }
@@ -1466,7 +1543,7 @@ async function runCheckBatches(
         repo.provider,
         repo.repoPath,
         run.stall,
-        run.elapsedMs,
+        ceilingMs,
         run.collected,
         results,
         failures,
@@ -1558,22 +1635,30 @@ function formatProgress(progress: RepoCheckBatchProgress): string {
 /**
  * The sentence a stalled batch reports, in either check mode.
  *
- * It states the time that actually elapsed, never the cap that was requested: a
- * poll can end early, the cap itself is derived from the remaining budget, and
- * a message that can be false is worse than no message.
+ * A live timed-out batch reports the checks ceiling that stopped it. Every caller
+ * supplies the phase and repository context used to name that ceiling.
  */
 export function batchStallReason(
   stall: Exclude<PrePrPhaseStall, "none">,
-  elapsedMs: number,
   progress: RepoCheckBatchProgress,
+  context: {
+    phase: RepoBatchPhase;
+    provider: PrePrCheckFailure["provider"];
+    repoPath: string;
+    ceilingMs: number;
+  },
 ): string {
   const where = formatProgress(progress);
-  return stall === "sandbox_stopped"
-    ? `The Run Workspace sandbox stopped while this repository's checks were running${where}. ` +
-        "Nothing was verified: this is a lost workspace, not a failing check."
-    : `The checks for this repository ran for ${formatElapsed(elapsedMs)} without finishing and ` +
-        `were stopped${where}. Nothing was verified: this is a timeout, not a passing or a ` +
-        "failing check result.";
+  if (stall === "sandbox_stopped") {
+    return `The Run Workspace sandbox stopped while this repository's checks were running${where}. ` +
+      "Nothing was verified: this is a lost workspace, not a failing check.";
+  }
+  const activity = context.phase === "setup" ? "setup batch" : "checks batch";
+  return (
+    `The ${activity} for ${context.provider}:${context.repoPath} reached the ` +
+    `${Math.round(context.ceilingMs / 60_000)} minute checks ceiling${where}. ` +
+    "Nothing was verified: this is a checks timeout, not a duration budget failure."
+  );
 }
 
 /**
@@ -1588,7 +1673,7 @@ function stalledBatches(
   provider: PrePrCheckFailure["provider"],
   repoPath: string,
   stall: Exclude<PrePrPhaseStall, "none">,
-  elapsedMs: number,
+  ceilingMs: number,
   collected: CollectedRepoCheckBatch,
   results: PrePrCheckCommandResult[],
   failures: PrePrCheckFailure[],
@@ -1607,7 +1692,12 @@ function stalledBatches(
     command: collected.progress.stoppedAt ?? "(pre-PR check batch)",
     exitCode: -1,
     stdout: "",
-    stderr: batchStallReason(stall, elapsedMs, collected.progress),
+    stderr: batchStallReason(stall, collected.progress, {
+      phase: "checks",
+      provider,
+      repoPath,
+      ceilingMs,
+    }),
     // The batch never reported, so this is not a check result at all. Without a
     // phase it reads as an ordinary failing check, and every sentence that only
     // makes sense for a command that ran would be attached to it.

--- a/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.test.ts
@@ -120,6 +120,7 @@ import {
 } from "./prepare-workspace.js";
 import type { WorkspaceManifestV2 } from "../../sandbox/repo-workspace.js";
 import { teardownSandboxes } from "../../sandbox/poll-agent.js";
+import { checksCeilingExceededError } from "../run-budget.js";
 import {
   expectOutputConformsToRegistry,
   makeCtx,
@@ -141,6 +142,15 @@ const MOVED_SHA = "b".repeat(40);
 
 function contextsFor(repository: SelectedRepository, hasConflicts = false) {
   return [{ repository, prComments: [], checkResults: [], hasConflicts }];
+}
+
+function restoreAgentAdapterMock(): void {
+  mocks.createAgentAdapter.mockImplementation((kind: string) => ({
+    kind,
+    cliSpec: { displayName: kind, binName: kind },
+    install: mocks.agentInstall,
+    configure: mocks.agentConfigure,
+  }));
 }
 
 // vi.clearAllMocks() clears calls but keeps implementations, and mocks.env is a
@@ -192,9 +202,43 @@ const SCRIPT_NODES = [
   { id: "checks", type: "run_pre_pr_checks", name: "Run pre-PR checks", params: {} },
 ] as unknown as NonNullable<Parameters<typeof makeCtx>[0]>["definitionNodes"];
 
+const SETUP_BOUNDARY_ERROR_CASES = [
+  {
+    label: "checks ceiling",
+    create: () =>
+      checksCeilingExceededError(900_000, "Setup batch for github:acme/api"),
+    expected: {
+      name: "ChecksCeilingExceededError",
+      message:
+        "The repository checks did not finish within the 15 minute checks ceiling. " +
+        "Raise batchTimeoutMinutes for this definition or split the run. " +
+        "(checks_ceiling_exceeded: Setup batch for github:acme/api reached the 15 minute checks ceiling)",
+    },
+  },
+  {
+    label: "ordinary abort",
+    create: () => new DOMException("sandbox request aborted", "AbortError"),
+    expected: { name: "AbortError", message: "sandbox request aborted" },
+  },
+  {
+    label: "invocation cancellation",
+    create: () =>
+      Object.assign(new Error("invocation superseded"), {
+        name: "V2InvocationCancelledError",
+      }),
+    expected: {
+      name: "V2InvocationCancelledError",
+      message: "invocation superseded",
+    },
+  },
+] as const;
+
 describe("prepare_workspace execute", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // Setup failures and registration failures must not survive into the next case.
+    vi.resetAllMocks();
+    restoreAgentAdapterMock();
+    mocks.captureDefaultBranchFilesStep.mockResolvedValue({});
     // No stored configuration and the default ceiling: what a deployment with
     // nothing configured sees, and what every test that is not about the
     // checks phase should get.
@@ -858,14 +902,68 @@ describe("prepare_workspace execute", () => {
     expect(mocks.runRepositorySetup).toHaveBeenCalledWith(
       expect.objectContaining({ sandboxId: "sbx-9", config, checksCeilingMs: 900_000 }),
     );
-    // The plain observer only. Setup is provisioning, so its time is the run's
-    // duration and must never be charged to the checks ceiling: three repos of
-    // `uv sync` would otherwise eat the budget the tests were given, and the
-    // failure would point an operator at batchTimeoutMinutes, the wrong knob.
+    // One observer is enough: runRepositorySetup attributes its durable phase
+    // boundaries to the checks clock through that observer.
     expect(mocks.runRepositorySetup.mock.calls[0]![0]).not.toHaveProperty(
       "observeChecksBudget",
     );
   });
+
+  it.each(SETUP_BOUNDARY_ERROR_CASES)(
+    "rethrows a $label from setup while reusing a workspace",
+    async ({ create, expected }) => {
+      mocks.resolveChecksProvisioningStep.mockResolvedValue({
+        ceilingMs: 900_000,
+        config: { repositories: [{ provider: "github", repoPath: "acme/api" }] },
+      });
+      const error = create();
+      mocks.runRepositorySetup.mockRejectedValue(error);
+      let caught: unknown;
+
+      try {
+        await ensureWorkspace(
+          makeCtx({ sandboxId: "code-1", definitionNodes: SCRIPT_NODES }),
+          undefined,
+          {},
+        );
+      } catch (thrown) {
+        caught = thrown;
+      }
+
+      expect(caught).toBe(error);
+      expect(caught).toMatchObject(expected);
+    },
+  );
+
+  it.each(SETUP_BOUNDARY_ERROR_CASES)(
+    "rethrows a $label from setup after creating a workspace",
+    async ({ create, expected }) => {
+      mocks.resolveChecksProvisioningStep.mockResolvedValue({
+        ceilingMs: 900_000,
+        config: { repositories: [{ provider: "github", repoPath: "acme/api" }] },
+      });
+      mocks.runPreSandboxPhase.mockResolvedValue({
+        status: "continue",
+        promptAdditions: { research: [], implementation: [], review: [] },
+        selectedRepositories: [repo],
+      });
+      mocks.blockFetchPrContextsStep.mockResolvedValue(contextsFor(repo));
+      const error = create();
+      mocks.runRepositorySetup.mockRejectedValue(error);
+      const ctx = makeCtx({ sandboxId: null, definitionNodes: SCRIPT_NODES });
+      let caught: unknown;
+
+      try {
+        await ensureWorkspace(ctx, undefined, {});
+      } catch (thrown) {
+        caught = thrown;
+      }
+
+      expect(ctx.sandboxId).toBe("sbx-9");
+      expect(caught).toBe(error);
+      expect(caught).toMatchObject(expected);
+    },
+  );
 
   it("hands the setup substep the observation channel it reports progress on", async () => {
     // Provisioning precedes every block that produces output, so a five minute

--- a/apps/worker/src/workflows/blocks/prepare-workspace.ts
+++ b/apps/worker/src/workflows/blocks/prepare-workspace.ts
@@ -13,6 +13,10 @@ import type {
 } from "../../sandbox/repo-workspace.js";
 import { resolveBlockAgent } from "../../workflow-definition/resolve-agent.js";
 import { isRunControlError } from "../run-control-error.js";
+import {
+  isChecksCeilingExceededError,
+  propagateInvocationInterruption,
+} from "../run-budget.js";
 import { hydrateWorkspaceMemoryStep } from "../memory-steps.js";
 import { captureDefaultBranchFilesStep } from "../repo-memory-steps.js";
 import { seedRepoMemoryStep } from "../repo-seed-steps.js";
@@ -679,7 +683,8 @@ async function verifyRepositorySetup(
   const setup = await runRepositorySetup({
     sandboxId,
     config,
-    // The plain observer: setup time is the run's, never the checks ceiling's.
+    // The observer can attribute a known durable boundary to the checks clock;
+    // setup, launch, polling and collection all share that ceiling.
     observeBudget: blockBudgetObserver(ctx, execution),
     checksCeilingMs,
     ...(execution?.cancellation ? { cancellation: execution.cancellation } : {}),
@@ -771,7 +776,8 @@ export async function ensureWorkspace(
         },
       };
     } catch (err) {
-      if (isRunControlError(err)) throw err;
+      if (isRunControlError(err) || isChecksCeilingExceededError(err)) throw err;
+      propagateInvocationInterruption(err);
       return executionError(err instanceof Error ? err.message : String(err), {
         category: "sandbox",
       });
@@ -1105,7 +1111,8 @@ export async function ensureWorkspace(
       },
     };
   } catch (err) {
-    if (isRunControlError(err)) throw err;
+    if (isRunControlError(err) || isChecksCeilingExceededError(err)) throw err;
+    propagateInvocationInterruption(err);
     return executionError(err instanceof Error ? err.message : String(err), {
       category: "sandbox",
     });

--- a/apps/worker/src/workflows/blocks/run-checks.test.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.test.ts
@@ -136,7 +136,8 @@ function pollEnds(reason: string, elapsedMs: number) {
 
 describe("run_checks execute", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // Rejections and one-shot results must not survive into the next case.
+    vi.resetAllMocks();
     mocks.pollPhaseUntilDone.mockImplementation(pollEnds("finished", 30_000));
     mocks.resolvePhaseStall.mockResolvedValue("none");
     mocks.listWorkspaceRepositoriesStep.mockResolvedValue([
@@ -371,9 +372,13 @@ describe("run_checks execute", () => {
     });
     // The same rule as the configured path: a stall is never a pass, and the
     // sentence says where the batch actually got to.
-    expect(failures[0]!.output).toContain("ran for 25 minutes without finishing");
+    expect(failures[0]!.output).toContain(
+      "The checks batch for github:acme/web reached the 60 minute checks ceiling",
+    );
     expect(failures[0]!.output).toContain("0 of 2 script commands had finished");
-    expect(failures[0]!.output).toContain("this is a timeout");
+    expect(failures[0]!.output).toContain(
+      "this is a checks timeout, not a duration budget failure",
+    );
     // The finished repository's commands are still reported, but they never
     // become a pass, and the stalled batch is read back as abandoned.
     expect(result.output!.results).toEqual([
@@ -690,18 +695,35 @@ describe("run_checks execute", () => {
     });
   });
 
-  it("hands configured checks the run budget observer and classifies their abort", async () => {
-    mocks.loadPrePrCheckConfigStep.mockResolvedValue({ version: null, config: { repositories: [] } });
-    mocks.runPrePrChecksWithFixes.mockRejectedValue(
-      new DOMException("duration expired", "TimeoutError"),
-    );
+  it("fails duration before configured checks start", async () => {
     const failure = {
       status: "budget_exceeded" as const,
       metric: "duration" as const,
-      limit: 100,
-      consumed: 100,
-      reason: "budget_exceeded: duration 100 reached limit 100 during Run checks",
+      limit: 1_800_000,
+      consumed: 1_800_001,
+      reason: "budget_exceeded: duration 1800001 exceeds limit 1800000",
     };
+    const ctx = makeCtx({
+      observeBudget: vi.fn().mockResolvedValue({
+        check: failure,
+        remainingDurationMs: 0,
+        durationLimitMs: 1_800_000,
+        activeElapsedMs: 1_800_001,
+      }),
+    });
+
+    await expect(execute(makeNode("run_checks"), {}, ctx)).rejects.toMatchObject({
+      name: "RunBudgetError",
+      failure,
+    });
+    expect(mocks.loadPrePrCheckConfigStep).not.toHaveBeenCalled();
+    expect(mocks.runPrePrChecksWithFixes).not.toHaveBeenCalled();
+  });
+
+  it("rethrows an ordinary abort during configured checks untouched", async () => {
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({ version: null, config: { repositories: [] } });
+    const abort = new DOMException("sandbox request aborted", "AbortError");
+    mocks.runPrePrChecksWithFixes.mockRejectedValue(abort);
     const ctx = makeCtx({
       observeBudget: vi
         .fn()
@@ -711,13 +733,16 @@ describe("run_checks execute", () => {
           durationLimitMs: 100,
           activeElapsedMs: 75,
         })
-        .mockResolvedValueOnce({ check: failure, remainingDurationMs: 0 }),
+        .mockResolvedValueOnce({
+          check: { status: "ok" },
+          remainingDurationMs: 25,
+          durationLimitMs: 100,
+          activeElapsedMs: 75,
+          checksElapsedMs: 3_600_000,
+        }),
     });
 
-    await expect(execute(makeNode("run_checks"), {}, ctx)).rejects.toMatchObject({
-      name: "RunBudgetError",
-      failure,
-    });
+    await expect(execute(makeNode("run_checks"), {}, ctx)).rejects.toBe(abort);
     expect(mocks.runPrePrChecksWithFixes).toHaveBeenCalledWith(
       expect.objectContaining({
         sandboxId: "sbx-1",
@@ -729,6 +754,35 @@ describe("run_checks execute", () => {
         observeBudget: expect.any(Function),
       }),
     );
+  });
+
+  it("preserves a configured checks ceiling in the execution failure", async () => {
+    mocks.loadPrePrCheckConfigStep.mockResolvedValue({ version: null, config: { repositories: [] } });
+    const replayed = new Error(
+      "The repository checks did not finish within the 7 minute checks ceiling. " +
+      "Raise batchTimeoutMinutes for this definition or split the run. " +
+      "(checks_ceiling_exceeded: Checks batch for github:acme/web reached the 7 minute checks ceiling)",
+    );
+    replayed.name = "ChecksCeilingExceededError";
+    mocks.runPrePrChecksWithFixes.mockRejectedValue(replayed);
+
+    const result = await execute(
+      makeNode("run_checks"),
+      { prepare: { output: { status: "ok", checksCeilingMs: 420_000 } } },
+      makeCtx(),
+    );
+
+    expect(result).toMatchObject({
+      kind: "execution_error",
+      error: {
+        message:
+          "The repository checks did not finish within the 7 minute checks ceiling. " +
+          "Raise batchTimeoutMinutes for this definition or split the run. " +
+          "(checks_ceiling_exceeded: Checks batch for github:acme/web reached the 7 minute checks ceiling)",
+        detail:
+          "checks_ceiling_exceeded: Checks batch for github:acme/web reached the 7 minute checks ceiling",
+      },
+    });
   });
 
   it("dispatches named groups to the engine, leaving report-only semantics alone", async () => {

--- a/apps/worker/src/workflows/blocks/run-checks.ts
+++ b/apps/worker/src/workflows/blocks/run-checks.ts
@@ -19,9 +19,12 @@ import {
   type RepositoryScriptGroupCoverage,
 } from "./repository-scripts-output.js";
 import {
+  checksCeilingErrorDetail,
+  isChecksCeilingExceededError,
   RunBudgetError,
-  durationBudgetFailure,
-  isDurationAbortError,
+  propagateInvocationInterruption,
+  type RunBudgetAttribution,
+  type RunBudgetObservation,
 } from "../run-budget.js";
 import { isRunControlError } from "../run-control-error.js";
 import {
@@ -119,6 +122,13 @@ interface RunChecksStepResult {
  *  as no coverage for its own reasons. */
 const NO_GROUP_COVERAGE: RepositoryScriptGroupCoverage[] = [];
 
+type BoundaryCapableBudgetObserver = (
+  requireRemainingDuration?: boolean,
+  attribution?: RunBudgetAttribution,
+  observedAtMs?: number,
+) => Promise<RunBudgetObservation>;
+
+
 function toBlockResults(
   collected: CollectedRepoCheckBatch,
 ): RunChecksStepResult["results"] {
@@ -185,7 +195,7 @@ async function runExplicitCommands(
   sandboxId: string,
   commands: string[],
   observeBudget: PrePrChecksOptions["observeBudget"],
-  observeChecksBudget: PrePrChecksOptions["observeBudget"],
+  observeChecksBudget: NonNullable<PrePrChecksOptions["observeChecksBudget"]>,
   cancellation: PrePrChecksOptions["cancellation"],
   checksCeilingMs: number | null,
 ): Promise<RunChecksStepResult> {
@@ -251,7 +261,12 @@ async function runExplicitCommands(
             command: run.collected.progress.stoppedAt ?? "(check batch)",
             exitCode: -1,
             output: boundFailureOutput(
-              batchStallReason(run.stall, run.elapsedMs, run.collected.progress),
+              batchStallReason(run.stall, run.collected.progress, {
+                phase: "checks",
+                provider: repo.provider,
+                repoPath: repo.repoPath,
+                ceilingMs: checksCeilingMs ?? checksCeilingMsOf(),
+              }),
               OUTPUT_TRUNCATE,
             ),
           },
@@ -288,7 +303,7 @@ async function runConfiguredChecks(
   agentKind: PrePrChecksOptions["agentKind"],
   model: string,
   observeBudget: PrePrChecksOptions["observeBudget"],
-  observeChecksBudget: PrePrChecksOptions["observeBudget"],
+  observeChecksBudget: NonNullable<PrePrChecksOptions["observeChecksBudget"]>,
   cancellation: PrePrChecksOptions["cancellation"],
   groups: string[],
   checksCeilingMs: number | null,
@@ -394,9 +409,12 @@ export const execute: BlockExecuteFn = async (
   // Two views of one budget context: the plain observer closes the run's clock
   // at each launch, the checks one carries every tick the poll waits through.
   const observeBudget = blockBudgetObserver(ctx, execution);
-  const observeChecksBudget = blockBudgetObserver(ctx, execution, {
-    attribution: "checks",
-  });
+  const boundaryObserver = (execution?.observeBudget ?? ctx.observeBudget) as
+    BoundaryCapableBudgetObserver;
+  const observeChecksBudget = (
+    requireRemainingDuration?: boolean,
+    observedAtMs?: number,
+  ) => boundaryObserver(requireRemainingDuration, "checks", observedAtMs);
   const checksCeilingMs = recoverChecksCeilingFromSteps(steps);
   try {
     const result =
@@ -473,11 +491,15 @@ export const execute: BlockExecuteFn = async (
     };
   } catch (err) {
     if (isRunControlError(err)) throw err;
-    const after = await ctx.observeBudget();
-    if (after.check.status !== "ok") throw new RunBudgetError(after.check);
-    if (isDurationAbortError(err)) {
-      throw new RunBudgetError(durationBudgetFailure(after, "Run checks"));
+    if (isChecksCeilingExceededError(err)) {
+      return executionError(checksCeilingErrorDetail(err), {
+        category: "checks",
+        message: err.message,
+      });
     }
+    propagateInvocationInterruption(err);
+    const after = await observeChecksBudget(false);
+    if (after.check.status !== "ok") throw new RunBudgetError(after.check);
     return executionError(err instanceof Error ? err.message : String(err), {
       category: "checks",
     });

--- a/apps/worker/src/workflows/run-budget.test.ts
+++ b/apps/worker/src/workflows/run-budget.test.ts
@@ -81,6 +81,52 @@ describe("mergeBudgetObservations", () => {
         .checksElapsedMs,
     ).toBe(120_000);
     expect(mergeBudgetObservations(legacy, legacy).checksElapsedMs).toBe(0);
+    expect(mergeBudgetObservations(legacy, legacy)).not.toHaveProperty("observedAtMs");
+  });
+});
+
+describe("checks phase duration pause", () => {
+  const envLimits = { maxDurationMs: 1_800_000, maxDurationSource: "env" } as const;
+
+  it("pauses duration for repository checks and names the env fallback when it resumes over budget", () => {
+    let state = addActiveElapsed(createRunBudgetState(), 1_572_999);
+    state = addChecksElapsed(state, 900_000);
+    expect(checksElapsedOf(state)).toBe(900_000);
+    expect(checkRunBudget(state, envLimits)).toEqual({ status: "ok" });
+    state = addActiveElapsed(state, 300_000);
+    expect(checkRunBudget(state, envLimits)).toEqual({
+      status: "budget_exceeded",
+      metric: "duration",
+      limit: 1_800_000,
+      consumed: 1_872_999,
+      reason: "budget_exceeded: the run took 31 min 12 s, over the 30 min limit from JOB_TIMEOUT_MS (this workflow sets no budgets.maxDurationMs). Raise budgets.maxDurationMs on the workflow definition, or JOB_TIMEOUT_MS, to allow longer runs.",
+    });
+    const exact = addActiveElapsed(createRunBudgetState(), 1_800_000);
+    expect(observeRunBudget(exact, envLimits, false).check).toEqual({ status: "ok" });
+    expect(observeRunBudget(exact, envLimits, true).check).toMatchObject({ consumed: 1_800_000 });
+  });
+
+  it("names the workflow definition when its duration budget is exceeded", () => {
+    const state = addActiveElapsed(createRunBudgetState(), 2_883_999);
+    expect(checkRunBudget(state, { maxDurationMs: 2_700_000, maxDurationSource: "definition" })).toEqual({
+      status: "budget_exceeded",
+      metric: "duration",
+      limit: 2_700_000,
+      consumed: 2_883_999,
+      reason: "budget_exceeded: the run took 48 min 3 s, over the 45 min limit from budgets.maxDurationMs on this workflow definition. Raise budgets.maxDurationMs to allow longer runs.",
+    });
+  });
+
+  it.each([
+    ["Strict profile", "the harness profile \"Strict profile\""],
+    [undefined, "the harness profile"],
+  ] as const)("formats the exact profile duration message for name %s", (name, source) => {
+    const check = checkRunBudget(addActiveElapsed(createRunBudgetState(), 725_999), {
+      maxDurationMs: 600_000, maxDurationSource: "profile", maxDurationProfileName: name,
+    });
+    expect(check).toMatchObject({
+      reason: `budget_exceeded: this invocation took 12 min 5 s, over the 10 min limit from ${source} (runtimeLimits.maxDurationMs). Raise that limit on the profile to allow longer invocations.`,
+    });
   });
 });
 
@@ -134,32 +180,6 @@ describe("checks phase accounting", () => {
 });
 
 describe("run budget accounting", () => {
-  it("tracks active elapsed time without reading the clock itself", () => {
-    const state = addActiveElapsed(addActiveElapsed(createRunBudgetState(), 400), 600);
-
-    expect(state.activeElapsedMs).toBe(1_000);
-    expect(checkRunBudget(state, { maxDurationMs: 1_000 })).toEqual({ status: "ok" });
-    expect(checkRunBudget(addActiveElapsed(state, 1), { maxDurationMs: 1_000 })).toMatchObject({
-      status: "budget_exceeded",
-      metric: "duration",
-      limit: 1_000,
-      consumed: 1_001,
-    });
-  });
-
-  it("allows exact duration on completion but not when more work would start", () => {
-    const state = addActiveElapsed(createRunBudgetState(), 1_000);
-    const limits = { maxDurationMs: 1_000 };
-
-    expect(observeRunBudget(state, limits, false).check).toEqual({ status: "ok" });
-    expect(observeRunBudget(state, limits, true).check).toMatchObject({
-      status: "budget_exceeded",
-      metric: "duration",
-      limit: 1_000,
-      consumed: 1_000,
-    });
-  });
-
   it("counts input, cached input, and output tokens", () => {
     const state = recordBudgetUsage(createRunBudgetState(), usage(), null);
 

--- a/apps/worker/src/workflows/run-budget.ts
+++ b/apps/worker/src/workflows/run-budget.ts
@@ -4,6 +4,10 @@ import type { TokenPrice } from "../sandbox/agents/pricing.js";
 
 export interface RunBudgetLimits {
   maxDurationMs: number;
+  /** Where the workflow-level duration ceiling came from. Optional only for
+   *  legacy journaled values and lightweight callers that predate this field. */
+  maxDurationSource?: "definition" | "env" | "profile";
+  maxDurationProfileName?: string;
   maxTokens?: number;
   maxCostUsd?: number;
 }
@@ -42,8 +46,16 @@ export type RunBudgetCheck = { status: "ok" } | RunBudgetFailure;
 export interface RunBudgetObservation {
   check: RunBudgetCheck;
   remainingDurationMs: number;
+  /** Durable clock reading that produced this observation. Optional because
+   *  older deployments and lightweight callers do not include it. */
+  observedAtMs?: number;
   durationLimitMs?: number;
   activeElapsedMs?: number;
+  /** Source paired with durationLimitMs. Absent legacy observations use the
+   *  JOB_TIMEOUT_MS fallback wording. */
+  maxDurationSource?: "definition" | "env" | "profile";
+  /** Display name paired with a profile-sourced duration limit, when known. */
+  maxDurationProfileName?: string;
   /** Checks time this observation has seen. Optional for the same reason the
    *  state field is: an observation produced by an older deployment carries no
    *  such number, and remainingChecksMs treats that as zero spent. */
@@ -70,6 +82,49 @@ export class RunBudgetError extends Error {
     this.name = "RunBudgetError";
     this.failure = failure;
   }
+}
+
+export interface ChecksCeilingExceededError extends Error {
+  readonly ceilingMs: number;
+  readonly detail: string;
+}
+
+export function checksCeilingExceededError(
+  ceilingMs: number,
+  activity: string,
+): ChecksCeilingExceededError {
+  return Object.assign(
+    new Error(checksCeilingFailureReason(ceilingMs, activity)),
+    {
+      name: "ChecksCeilingExceededError",
+      ceilingMs,
+      detail: checksCeilingFailureDetail(ceilingMs, activity),
+    },
+  );
+}
+
+export function isChecksCeilingExceededError(
+  error: unknown,
+): error is ChecksCeilingExceededError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "ChecksCeilingExceededError" &&
+    "message" in error &&
+    typeof error.message === "string"
+  );
+}
+
+export function checksCeilingErrorDetail(
+  error: Pick<Error, "message"> & { detail?: string },
+): string {
+  if (error.detail) return error.detail;
+  const marker = "(checks_ceiling_exceeded:";
+  const start = error.message.lastIndexOf(marker);
+  return start >= 0 && error.message.endsWith(")")
+    ? error.message.slice(start + 1, -1)
+    : error.message;
 }
 
 export function isRunBudgetError(error: unknown): error is RunBudgetError {
@@ -243,14 +298,15 @@ export function totalBudgetTokens(state: RunBudgetState): number {
   return state.tokensInput + state.tokensCached + state.tokensOutput;
 }
 
-export function checkRunBudget(
-  state: RunBudgetState,
-  limits: RunBudgetLimits,
-): RunBudgetCheck {
+export function checkRunBudget(state: RunBudgetState, limits: RunBudgetLimits): RunBudgetCheck {
   if (state.activeElapsedMs > limits.maxDurationMs) {
-    return exceeded("duration", limits.maxDurationMs, state.activeElapsedMs);
+    return durationBudgetFailure({
+      durationLimitMs: limits.maxDurationMs,
+      activeElapsedMs: state.activeElapsedMs,
+      maxDurationSource: limits.maxDurationSource,
+      maxDurationProfileName: limits.maxDurationProfileName,
+    });
   }
-
   if (limits.maxTokens !== undefined) {
     if (!state.tokensKnown) {
       return {
@@ -264,7 +320,6 @@ export function checkRunBudget(
     const tokens = totalBudgetTokens(state);
     if (tokens > limits.maxTokens) return exceeded("tokens", limits.maxTokens, tokens);
   }
-
   if (limits.maxCostUsd !== undefined) {
     if (!state.costKnown) {
       return {
@@ -333,19 +388,20 @@ export function observeRunBudget(
   const remainingDurationMs = Math.max(0, limits.maxDurationMs - state.activeElapsedMs);
   let check = checkRunBudget(state, limits);
   if (check.status === "ok" && requireRemainingDuration && remainingDurationMs === 0) {
-    check = {
-      status: "budget_exceeded",
-      metric: "duration",
-      limit: limits.maxDurationMs,
-      consumed: state.activeElapsedMs,
-      reason: `budget_exceeded: duration ${state.activeElapsedMs} reached limit ${limits.maxDurationMs} before more work`,
-    };
+    check = durationBudgetFailure({
+      durationLimitMs: limits.maxDurationMs,
+      activeElapsedMs: state.activeElapsedMs,
+      maxDurationSource: limits.maxDurationSource,
+      maxDurationProfileName: limits.maxDurationProfileName,
+    });
   }
   return {
     check,
     remainingDurationMs,
     durationLimitMs: limits.maxDurationMs,
     activeElapsedMs: state.activeElapsedMs,
+    maxDurationSource: limits.maxDurationSource ?? "env",
+    maxDurationProfileName: limits.maxDurationProfileName,
     checksElapsedMs: checksElapsedOf(state),
   };
 }
@@ -359,23 +415,93 @@ export function isDurationAbortError(error: unknown): boolean {
   );
 }
 
+/** Workflow rehydrates invocation cancellation as a plain Error, so the name
+ *  is the only identity that survives the durable boundary. */
+export function isV2InvocationCancelledError(error: unknown): error is Error {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    error.name === "V2InvocationCancelledError"
+  );
+}
+
+/** Keep infrastructure aborts and invocation cancellation out of error
+ *  conversion paths. Both must reach the workflow boundary unchanged. */
+export function propagateInvocationInterruption(error: unknown): void {
+  if (isDurationAbortError(error) || isV2InvocationCancelledError(error)) {
+    throw error;
+  }
+}
+
 export function durationBudgetFailure(
-  observation: RunBudgetObservation,
-  activity: string,
+  observation: Pick<
+    RunBudgetObservation,
+    | "durationLimitMs"
+    | "activeElapsedMs"
+    | "maxDurationSource"
+    | "maxDurationProfileName"
+  >,
 ): RunBudgetFailure {
   const limit = observation.durationLimitMs ?? observation.activeElapsedMs ?? 0;
   const consumed = Math.max(limit, observation.activeElapsedMs ?? limit);
+  const elapsed = formatBudgetDuration(consumed);
+  const configuredLimit = formatBudgetDuration(limit);
+  const source = observation.maxDurationSource ?? "env";
+  const profileLabel = observation.maxDurationProfileName
+    ? ` "${observation.maxDurationProfileName}"`
+    : "";
   return {
     status: "budget_exceeded",
     metric: "duration",
     limit,
     consumed,
-    reason: `budget_exceeded: duration ${consumed} reached limit ${limit} during ${activity}`,
+    reason:
+      source === "profile"
+        ? `budget_exceeded: this invocation took ${elapsed}, over the ${configuredLimit} limit from ` +
+          `the harness profile${profileLabel} (runtimeLimits.maxDurationMs). ` +
+          "Raise that limit on the profile to allow longer invocations."
+        : source === "definition"
+        ? `budget_exceeded: the run took ${elapsed}, over the ${configuredLimit} limit from ` +
+          "budgets.maxDurationMs on this workflow definition. Raise budgets.maxDurationMs to allow longer runs."
+        : `budget_exceeded: the run took ${elapsed}, over the ${configuredLimit} limit from ` +
+          "JOB_TIMEOUT_MS (this workflow sets no budgets.maxDurationMs). Raise " +
+          "budgets.maxDurationMs on the workflow definition, or JOB_TIMEOUT_MS, to allow longer runs.",
   };
 }
 
+function formatBudgetDuration(durationMs: number): string {
+  const wholeSeconds = Math.floor(Math.max(0, durationMs) / 1_000);
+  const minutes = Math.floor(wholeSeconds / 60);
+  const seconds = wholeSeconds % 60;
+  if (minutes === 0) return `${seconds} s`;
+  return seconds === 0 ? `${minutes} min` : `${minutes} min ${seconds} s`;
+}
+
+function checksCeilingFailureReason(
+  ceilingMs: number,
+  activity: string,
+): string {
+  return checksCeilingUserMessage(ceilingMs) +
+    " " +
+    `(${checksCeilingFailureDetail(ceilingMs, activity)})`;
+}
+
+function checksCeilingUserMessage(ceilingMs: number): string {
+  const minutes = Math.round(ceilingMs / 60_000);
+  return (
+    `The repository checks did not finish within the ${minutes} minute checks ceiling. ` +
+    "Raise batchTimeoutMinutes for this definition or split the run."
+  );
+}
+
+function checksCeilingFailureDetail(ceilingMs: number, activity: string): string {
+  const minutes = Math.round(ceilingMs / 60_000);
+  return `checks_ceiling_exceeded: ${activity} reached the ${minutes} minute checks ceiling`;
+}
+
 function exceeded(
-  metric: "duration" | "tokens" | "cost",
+  metric: "tokens" | "cost",
   limit: number,
   consumed: number,
 ): RunBudgetFailure {


### PR DESCRIPTION
Closes AIW-292.

## What changed

- Pre-PR checks run on their own clock. The run duration budget pauses while checks execute, and the checks setup is charged to the checks clock, so a tenant whose checks take 10 to 20 minutes reaches `finalize_workspace` and `open_pr` with the default `JOB_TIMEOUT_MS`. A run that loops without progress is still stopped by the run budget outside checks and by the checks ceiling inside them.
- The budget failure message is human: `budget_exceeded: the run took 31 min 12 s, over the 30 min limit from JOB_TIMEOUT_MS (this workflow sets no budgets.maxDurationMs). Raise budgets.maxDurationMs on the workflow definition, or JOB_TIMEOUT_MS, to allow longer runs.` The definition variant names `budgets.maxDurationMs`; a harness profile ceiling (`runtimeLimits.maxDurationMs`) is reported per invocation and names the profile. No raw milliseconds, so the replay sanitizer's phone rule no longer scrubs the digits; the sanitizer itself is unchanged.
- Both graph engines rethrow the checks-ceiling error through the shared run-control predicate, so the terminal handling keeps the `checks` category and the "raise batchTimeoutMinutes" instruction instead of an `unknown` block error.
- Repository setup stops with the checks-ceiling failure when an earlier repository spent the ceiling, instead of counting the skipped setup as done.
- Workspace preparation no longer swallows checks-ceiling, abort or invocation-cancellation errors.
- Replay safety: the checks clock start rides as optional timestamps on the existing start and collect step outputs, with a fallback for old-shaped outputs. No `"use step"` call was added, renamed, moved or reordered (167 on main and on the branch), so suspended runs resume.
- Four flaky block tests fixed at the root (shared mock state kept by `vi.clearAllMocks`).

## Evidence

Candidate `f9d2ed5f46b458637353658d1fb40134c9212582` on `db604530093dc9fccb6c4bb408cea8ed8536ecf8` (main).

Pre-push `pnpm run verify:changed` (scopes worker, product-workflow, gates, worker-tests):

```text
git diff --check: clean
Test Files  17 passed (17)
     Tests  564 passed (564)
boundaries PASS
unused-code PASS
lint PASS
no-resurrected-paths PASS
package-contracts PASS
check-deps-consistency PASS
docs-status: every checked document has a valid, current, reachable header
```

Reviewer round 5 (gpt-5.6-sol high) on the same tree before the rebase:

```text
Test Files  144 passed (144)
Tests       2478 passed (2478)
apps/dashboard typecheck: Done
apps/worker typecheck: Done
"use step" main/branch: 167 / 167
added Unicode dash scan: no matches
```

Production evidence (health plus a real run on a QA ticket) is recorded on AIW-292 after the merge.

Reviewed in five rounds (Codex gpt-5.6-sol high, reviewer and skeptic lanes); follow-up for per-call sandbox deadlines in the checks phase is AIW-358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqdnSbazEyNghAeky7yuDf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pre-PR setup and repository checks now share a dedicated checks time ceiling.
  - Check progress, setup activity, and timeout messages now clearly identify the checks limit and affected repository.
  - Duration-limit messages indicate whether the limit came from a profile, workflow definition, or environment setting.
  - Timeout and cancellation errors now preserve their original details for clearer run results and telemetry.

- **Bug Fixes**
  - Improved replay handling and timestamp consistency for interrupted or resumed checks.
  - Prevented checks failures from being incorrectly reported as general duration-budget failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->