### PR TITLE
chore(agents): verify:changed stop hook, gate ladder skill and scoped rules aligned with the restructure (stage 10)

### DIFF
--- a/.claude/rules/dashboard-ui.md
+++ b/.claude/rules/dashboard-ui.md
@@ -5,6 +5,9 @@ paths:
 
 # Dashboard UI
 
+- Browser requests use `lib/api/client.ts`. Raw `fetch` belongs only in that
+  browser endpoint client and the server-only transports `lib/api/server.ts`,
+  `lib/api/proxy.ts`, and `lib/auth/worker-core.ts`.
 - The worker's store is the authority on run state. The live overlay is a view:
   when a polled overlay and the stored run disagree, the store wins. Making the
   overlay authoritative is what produced phantom "running" runs.

--- a/.claude/rules/sandbox-agents.md
+++ b/.claude/rules/sandbox-agents.md
@@ -1,6 +1,7 @@
 ---
 paths:
-  - "apps/worker/src/sandbox/**"
+  - "apps/worker/src/sandbox/agents/**"
+  - "apps/worker/src/sandbox/arthur-*.ts"
   - "apps/worker/src/harness-profiles/**"
 ---
 
@@ -14,7 +15,7 @@ paths:
   keeps orphan history.
 - The Claude Code CLI rejects OAuth tokens (`sk-ant-oat...`) supplied through
   `ANTHROPIC_API_KEY`; that variable accepts standard API keys
-  (`sk-ant-api...`) only. `src/sandbox/agents/claude.ts` detects the
+  (`sk-ant-api...`) only. `apps/worker/src/sandbox/agents/claude.ts` detects the
   `sk-ant-oat` prefix and exports the value as `CLAUDE_CODE_OAUTH_TOKEN` inside
   the sandbox, so the operator still pastes one variable.
 - Codex creates `.codex/` in the working directory at runtime. Without

--- a/.claude/rules/worker-database.md
+++ b/.claude/rules/worker-database.md
@@ -4,6 +4,7 @@ paths:
   - "apps/worker/drizzle/**"
   - "apps/worker/scripts/db-migrate.ts"
   - "apps/worker/src/**/store.ts"
+  - "apps/worker/src/services/auth/**"
 ---
 
 # Worker database and migrations

--- a/.claude/rules/worker-observability.md
+++ b/.claude/rules/worker-observability.md
@@ -1,8 +1,11 @@
 ---
 paths:
-  - "apps/worker/src/services/**"
+  - "apps/worker/src/services/overview/**"
+  - "apps/worker/src/services/telemetry/**"
+  - "apps/worker/src/services/run-lifecycle/**"
   - "apps/worker/src/run-observability/**"
-  - "apps/worker/src/routes/api/v1/runs**"
+  - "apps/worker/src/routes/api/v1/runs*.ts"
+  - "apps/worker/src/routes/api/v1/runs/**"
 ---
 
 # Logging and run telemetry

--- a/.claude/rules/workflow-steps.md
+++ b/.claude/rules/workflow-steps.md
@@ -1,15 +1,17 @@
 ---
 paths:
-  - "apps/worker/src/workflows/**"
-  - "apps/worker/src/workflow-definition/v2-scheduler.ts"
+  - "apps/worker/src/engine/agent-workflow.ts"
+  - "apps/worker/src/engine/post-pr-gate-workflow.ts"
+  - "apps/worker/src/engine/steps/**"
+  - "apps/worker/src/engine/blocks/**"
 ---
 
 # Workflow and step bodies
 
-- `apps/worker/src/workflows/agent.ts` is a Workflow DevKit `"use workflow"`
+- `apps/worker/src/engine/agent-workflow.ts` is a Workflow DevKit `"use workflow"`
   module with NO top-level adapter or logger imports. Every use of `logger` or
   an adapter inside a `"use step"` is a deferred
-  `await import("../lib/logger.js")` in the step body. Do not add a top-level
+  `await import("../infra/logger.js")` in the step body. Do not add a top-level
   import there, and do not assume a warm module is already imported at the top:
   the module is cache-warm only because an earlier step in the same run
   imported it.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "input=$(/bin/cat); if printf '%s' \"$input\" | /usr/bin/grep -Eq '\"stop_hook_active\"[[:space:]]*:[[:space:]]*true'; then exit 0; fi; if [ -z \"$(/usr/bin/git status --porcelain=v1 --untracked-files=all)\" ]; then exit 0; fi; if pnpm run verify:changed -- --base origin/main --worktree; then exit 0; fi; printf '%s\\n' '{\"decision\":\"block\",\"reason\":\"verify:changed failed; fix the reported checks before stopping.\"}' >&2; exit 2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/artur-release/SKILL.md
+++ b/.claude/skills/artur-release/SKILL.md
@@ -7,6 +7,12 @@ description: Run a production release of AI Workflow to the Arthur tenant (Blazi
 
 Releases AI Workflow from `Blazity/ai-workflow` (source) to `Blazity/ai-workflow-arthur` (client deployment repo). Everything is automated by four GitHub Actions workflows; the human (Filip) makes exactly two decisions, each of which is an approval plus a merge.
 
+## Authority and references
+
+This skill documents the release procedure; it does not grant authority. Before any dispatch, merge, deployment, rollback, production change, or Jira update, use the authority rules in [docs/delivery-gates.md](../../../docs/delivery-gates.md) and obtain explicit maintainer approval for that action.
+
+The authoritative Artur documents are [the release contract](../../../docs/releases/artur/README.md), [the upgrade preflight](../../../docs/releases/artur/upgrade-preflight.md), [the rehearsal procedure](../../../docs/releases/artur/rehearsals/README.md), and [the delivery gates](../../../docs/delivery-gates.md).
+
 ## How the pipeline works
 
 1. **Prepare Artur Release** (`prepare-artur-release.yml`, source repo, manual dispatch): generates `docs/releases/artur/<version>.md` from the commit range and opens a docs-only PR authored by the GitHub App.
@@ -85,4 +91,4 @@ Other hard rules:
 
 ## Division of responsibility
 
-Agent: dispatch and watch workflows, write the notes, verify every gate, collect evidence, update Jira. Filip: formal Approve on the notes PR, merge of both PRs (the production GO), rollback decisions.
+Agent: prepare notes, verify every gate, and collect evidence. A maintainer grants and performs any dispatch, merge, deployment, rollback, production change, or Jira update required by the runbook.

--- a/.claude/skills/gate-ladder/SKILL.md
+++ b/.claude/skills/gate-ladder/SKILL.md
@@ -9,11 +9,8 @@ Read [G0 through G6 and the evidence authority](../../../docs/delivery-gates.md)
 
 Read the [static ladder and required CI rules](../../../docs/adr/ADR-004-gates-and-required-ci.md) before deciding which checks are required.
 
-Use the repository commands for execution:
+Follow the [repository evidence rules](../../../AGENTS.md), including the
+candidate SHA, exact commands, and observed outcomes.
 
-- `pnpm run verify:changed -- --base <ref>` for the scope-aware check.
-- `pnpm run gates` for the static gate ladder.
-- `pnpm run test:ci` for the focused CI gate tests.
-- `git diff --check` for whitespace errors.
-
-Keep the evidence bundle and pass or fail interpretation in the authoritative documents linked above. This skill is only the routing point for those procedures.
+Use the linked documents to select and run gates. Keep the ladder and its
+pass or fail interpretation in those authoritative documents.

--- a/.claude/skills/gate-ladder/SKILL.md
+++ b/.claude/skills/gate-ladder/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: gate-ladder
+description: Use when selecting, running, or evidencing the repository verification gates before delivery.
+---
+
+# Gate ladder
+
+Read [G0 through G6 and the evidence authority](../../../docs/delivery-gates.md) for the current delivery contract.
+
+Read the [static ladder and required CI rules](../../../docs/adr/ADR-004-gates-and-required-ci.md) before deciding which checks are required.
+
+Use the repository commands for execution:
+
+- `pnpm run verify:changed -- --base <ref>` for the scope-aware check.
+- `pnpm run gates` for the static gate ladder.
+- `pnpm run test:ci` for the focused CI gate tests.
+- `git diff --check` for whitespace errors.
+
+Keep the evidence bundle and pass or fail interpretation in the authoritative documents linked above. This skill is only the routing point for those procedures.

--- a/.claude/skills/vercel-sandbox
+++ b/.claude/skills/vercel-sandbox
@@ -1,1 +1,0 @@
-../../.agents/skills/vercel-sandbox

--- a/.claude/skills/workflow
+++ b/.claude/skills/workflow
@@ -1,1 +1,0 @@
-../../.agents/skills/workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 Status: current
-Last-verified: 2026-09-09
+Last-verified: 2026-09-11
 
 # AGENTS.md
 
@@ -90,7 +90,8 @@ a `PASS`, and a later result does not erase an earlier `FAIL`.
 
 `pnpm run verify:changed` resolves the base from the branch upstream, then
 `origin/HEAD`, then `origin/main`, and never fetches; pass `-- --base <ref>` to
-override. Enable it as a hook once with
+override. The Claude Stop hook adds `--worktree` so committed, staged, unstaged
+and untracked paths are planned together. Enable the pre-push hook once with
 `git config --local core.hooksPath .githooks`, but only if that setting is
 currently empty. The gate is advisory and bypassable: `git push --no-verify` is
 an audited bypass, so record why it was used and do not report the gate as
@@ -111,13 +112,13 @@ not on every edit.
 
 Each is quoted verbatim from the file that owns it.
 
-**neon-http has no transactions** (`apps/worker/src/approvals/store.ts`):
+**Transactions stay inside repositories** (`apps/worker/src/db/repositories/`):
 
-> Production uses neon-http and cannot open an interactive transaction.
+> Database transactions belong inside repositories; service and engine code calls repository methods.
 
-Write multi-row changes as one statement (a data-modifying CTE, an
-insert-on-conflict) rather than `db.transaction`. The pglite test driver does
-support transactions, so unit tests will not catch this.
+Repository operations own multi-row writes and transaction boundaries. Keep
+the repository boundary intact when changing a write, because a test driver
+can support transactions even when the deployed driver contract differs.
 
 **The Workflow DevKit discovers steps by file content**
 (`docs/research/2026-09-09-architecture-audit.md`, section 10):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,13 +112,13 @@ not on every edit.
 
 Each is quoted verbatim from the file that owns it.
 
-**Transactions stay inside repositories** (`apps/worker/src/db/repositories/`):
+**neon-http has no transactions** (`apps/worker/src/approvals/store.ts`):
 
-> Database transactions belong inside repositories; service and engine code calls repository methods.
+> Production uses neon-http and cannot open an interactive transaction.
 
-Repository operations own multi-row writes and transaction boundaries. Keep
-the repository boundary intact when changing a write, because a test driver
-can support transactions even when the deployed driver contract differs.
+Write multi-row changes as one statement (a data-modifying CTE, an
+insert-on-conflict) rather than `db.transaction`. The pglite test driver does
+support transactions, so unit tests will not catch this.
 
 **The Workflow DevKit discovers steps by file content**
 (`docs/research/2026-09-09-architecture-audit.md`, section 10):

--- a/apps/dashboard/AGENTS.md
+++ b/apps/dashboard/AGENTS.md
@@ -1,5 +1,5 @@
 Status: current
-Last-verified: 2026-09-10
+Last-verified: 2026-09-11
 
 # apps/dashboard
 
@@ -14,7 +14,8 @@ file adds only what is true of the dashboard.
 
 ## Run and test
 
-From `apps/dashboard` (every script starts by building the shared contracts):
+From `apps/dashboard` (workspace packages are consumed as TypeScript source;
+the scripts invoke Next, TypeScript and Node directly):
 
 ```sh
 pnpm run dev        # next dev on port 3001

--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -66,9 +66,10 @@ boundary instead of copying their ownership tables here.
 - **`build` writes to the database.** It calls `db:migrate` against whatever
   `DATABASE_URL` is in the environment. Never run `pnpm run build` pointed at
   production data by accident, and keep that path working when you touch `db/`.
-- **Database writes follow the repository boundary.** Read the transaction
-  gotcha in [the root instructions](../../AGENTS.md) before changing data
-  access; service and engine code must not own transaction boundaries.
+- **Production has no interactive transactions.** The Neon HTTP driver cannot
+  open one; the pglite test driver can, so a `db.transaction` call passes every
+  unit test and fails in production. Write one statement (a data-modifying CTE,
+  an insert-on-conflict) instead.
 - **Invocation ceilings are real.** A plain function is killed at 300 s; the
   deployed step function ships `maxDuration` `"max"` and is killed at 800 s on
   Pro. Anything long has to be resumable across invocations. See

--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -1,5 +1,5 @@
 Status: current
-Last-verified: 2026-09-09
+Last-verified: 2026-09-11
 
 # apps/worker
 
@@ -43,25 +43,13 @@ credentials. Their `:dry` variants run locally.
 
 ## Directory map
 
-Tiers come from
-[ADR-001](../../docs/adr/ADR-001-layering-and-packages.md), which is the source
-of truth for the mapping. The directories keep their names until the stage that
-moves them.
-
-| Directory | Tier | Note |
-|---|---|---|
-| `routes/` | app | Nitro scans this path, so it keeps its name |
-| `middleware/`, `plugins/`, `auth.ts`, `auth-instance.ts`, `nitro.d.ts` | app | the server surface |
-| `mcp/` | app | MCP tools, auth, catalog, contract |
-| `services/` | services | one directory per domain cluster, each with an `index.ts` interface; [docs/architecture/overview.md](../../docs/architecture/overview.md) lists them |
-| `approvals/`, `clarifications/`, `manual-dispatch/`, `schedule-trigger/`, `webhook-trigger/` | services | only the store files are left here; they become db repositories in stage 7 |
-| `engine/`, `workflow-definition/`, `memory/`, `post-pr-gate/`, `pre-pr-checks/`, `pre-sandbox/`, `run-analysis/`, `run-observability/`, `sandbox/` | engine | the runtime: the `"use workflow"` body, the `"use step"` functions, blocks, definition handling |
-| `harness-profiles/`, `prompt-library/` | engine (runtime) | their `store.ts` moves to db, their pure parts to packages |
-| `adapters/` | adapters | `adapters/vcs`, `adapters/issue-tracker`, `adapters/messaging`; `adapters/run-registry` is db, because it is one repository implementation |
-| `db/` | db | the only tier that knows the driver |
-| `config/`, `infra/` | config, infra | the validated env schema; the logger, LLM client, webhook signature and unique-violation helpers |
-| `env.ts` | config | one schema, validated at boot |
-| `test-support/`, `mcp-dogfood/`, `e2e/`, `workflow-test-fixtures/`, colocated `*.test.ts` | testing | |
+[ADR-001](../../docs/adr/ADR-001-layering-and-packages.md) owns the tier map,
+and [the architecture overview](../../docs/architecture/overview.md) owns the
+service-cluster contracts. The current runtime entrypoints are under
+`src/engine`, domain code is under `src/services`, the Nitro app surface is
+under `src/routes` and `src/mcp`, and configuration helpers are under
+`src/config` and `src/infra`. Use those documents when a change crosses a
+boundary instead of copying their ownership tables here.
 
 ## Traps specific to this app
 
@@ -78,10 +66,9 @@ moves them.
 - **`build` writes to the database.** It calls `db:migrate` against whatever
   `DATABASE_URL` is in the environment. Never run `pnpm run build` pointed at
   production data by accident, and keep that path working when you touch `db/`.
-- **Production has no interactive transactions.** The Neon HTTP driver cannot
-  open one; the pglite test driver can, so a `db.transaction` call passes every
-  unit test and fails in production. Write one statement (a data-modifying CTE,
-  an insert-on-conflict) instead.
+- **Database writes follow the repository boundary.** Read the transaction
+  gotcha in [the root instructions](../../AGENTS.md) before changing data
+  access; service and engine code must not own transaction boundaries.
 - **Invocation ceilings are real.** A plain function is killed at 300 s; the
   deployed step function ships `maxDuration` `"max"` and is killed at 800 s on
   Pro. Anything long has to be resumable across invocations. See

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,8 @@ Every document outside `archive/` and `research/` starts with two lines,
 `Status:` and `Last-verified:`. The rules and the reasoning are
 [ADR-005](./adr/ADR-005-documentation-taxonomy.md), and
 `scripts/gates/docs-status.mjs` enforces them over `docs/`, `apps/*/docs/`,
-each `apps/*/AGENTS.md`, and `README.md`, `AGENTS.md`, `SETUP.md` and
-`CONTEXT.md` at the root.
+each `apps/*/AGENTS.md`, `packages/AGENTS.md`, and `README.md`, `AGENTS.md`,
+`SETUP.md` and `CONTEXT.md` at the root.
 
 ## Start here
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,22 +1,23 @@
 Status: current
-Last-verified: 2026-09-09
+Last-verified: 2026-09-11
 
 # packages/AGENTS.md
 
 Workspace packages shared by the worker and the dashboard. `contracts` holds
 cross-application shapes and constants; `conditions` evaluates predicates;
-`costs` prices provider usage and aggregates it; `skills` owns browser-safe
-product skill contracts and validation. These pure packages may import
-`contracts` but never application infrastructure. ADR-001 owns the tiers.
+`costs` prices provider usage; `prompts` owns prompt composition; and `skills`
+owns browser-safe product skill contracts and validation. These pure packages
+may import another shared package only through its public entry point and never
+application infrastructure. ADR-001 owns the tiers.
 
 ## The rules that bind
 
 - **Source entry, no build.** `main`, `types` and `exports["."]` all point at
   `index.ts`. There is no `dist`, no `build` script and no `build:shared`
   anywhere. Nitro and Next inline the source into their own bundles.
-- **No app imports a package's internals.** `exports` exposes `.` only, so
-  `@shared/contracts` is the single entry. Add a re-export to `index.ts`
-  instead of deepening an import.
+- **No app imports a package's internals.** Every `exports` map exposes `.`
+  only. Import a package through its public entry and add a re-export to its
+  `index.ts` instead of deepening an import.
 - **Relative specifiers carry no extension.** Write `from "./domain"`, never
   `from "./domain.js"`. Nitro tolerates the `.js` form, webpack does not, and
   the failure appears only in the dashboard build.

--- a/scripts/ci/gates.test.ts
+++ b/scripts/ci/gates.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { cpSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -45,6 +45,77 @@ function gate(name: string, args: string[] = [], root: string = repoRoot) {
     encoding: "utf8",
   });
 }
+
+function docsStatusFixture(files: Record<string, string>): string {
+  const root = makeDepsRoot("docs-status-fixture-", files);
+  mkdirSync(join(root, "scripts/gates"), { recursive: true });
+  cpSync(
+    join(repoRoot, "scripts/gates/docs-status.mjs"),
+    join(root, "scripts/gates/docs-status.mjs"),
+  );
+  return root;
+}
+
+function filesNamed(root: string, name: string): string[] {
+  const found: string[] = [];
+  const ignored = new Set([".git", "node_modules", ".next", ".output", ".nitro"]);
+  const visit = (directory: string) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (ignored.has(entry.name)) continue;
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) visit(path);
+      else if (entry.isFile() && entry.name === name) found.push(path);
+    }
+  };
+  visit(root);
+  return found;
+}
+
+test("docs-status rejects a document with a bad header", () => {
+  const result = gate(
+    "docs-status.mjs",
+    [],
+    docsStatusFixture({ "README.md": "# Missing status\n" }),
+  );
+  assert.equal(result.status, gateFailure, result.stderr || result.stdout);
+  assert.match(result.stderr, /README\.md: first line must be/);
+});
+
+test("docs-status rejects a stale current document", () => {
+  const result = gate(
+    "docs-status.mjs",
+    [],
+    docsStatusFixture({
+      "README.md": "Status: current\nLast-verified: 2020-01-01\n\n# Old\n",
+    }),
+  );
+  assert.equal(result.status, gateFailure, result.stderr || result.stdout);
+  assert.match(result.stderr, /README\.md: Status is current but Last-verified/);
+});
+
+test("docs-status rejects a current document that is unreachable", () => {
+  const result = gate(
+    "docs-status.mjs",
+    [],
+    docsStatusFixture({
+      "README.md": "Status: current\nLast-verified: 2026-09-11\n\n# Readme\n",
+      "docs/hidden.md": "Status: current\nLast-verified: 2026-09-11\n\n# Hidden\n",
+    }),
+  );
+  assert.equal(result.status, gateFailure, result.stderr || result.stdout);
+  assert.match(result.stderr, /docs\/hidden\.md: Status is current but nothing reaches it/);
+});
+
+test("every Claude bridge starts by loading AGENTS.md", () => {
+  const bridges = filesNamed(repoRoot, "CLAUDE.md");
+  assert.deepEqual(
+    new Set(bridges.map((path) => path.slice(repoRoot.length + 1))),
+    new Set(["CLAUDE.md", "apps/dashboard/CLAUDE.md", "apps/worker/CLAUDE.md"]),
+  );
+  for (const bridge of bridges) {
+    assert.equal(readFileSync(bridge, "utf8").split("\n", 1)[0], "@AGENTS.md", bridge);
+  }
+});
 
 test("the boundary baseline passes and is stable across file renames", async () => {
   const recorded = gate("boundaries.mjs");

--- a/scripts/ci/verify-changed.test.ts
+++ b/scripts/ci/verify-changed.test.ts
@@ -7,12 +7,16 @@ import {
   listDirectory,
   namesDiff,
   parseArgs,
+  parseOptions,
   parseNames,
   plan,
   resolveBase,
   show,
+  stagedNamesDiff,
+  STAGED_WORKTREE_DIFF,
   WORKFLOW_TESTS,
   WORKTREE_DIFF,
+  worktreeNamesDiff,
   type Git,
   type Repo,
 } from "./verify-changed.js";
@@ -103,9 +107,22 @@ test("diff commands freeze the candidate SHA and names stay NUL-safe", () => {
   assert.deepEqual(parseNames(Buffer.from("old\0new\0")), ["old", "new"]);
 });
 
+test("worktree mode checks staged changes and unions all worktree name sources", () => {
+  assert.equal(show(STAGED_WORKTREE_DIFF), "git diff --cached --check");
+  assert.deepEqual(stagedNamesDiff(), [
+    "git", "diff", "--cached", "--name-only", "-z", "--no-renames", "--",
+  ]);
+  assert.deepEqual(worktreeNamesDiff(B, H), [
+    ["git", "diff", "--name-only", "-z", "--no-renames", B, H, "--"],
+    ["git", "diff", "--cached", "--name-only", "-z", "--no-renames", "--"],
+    ["git", "diff", "--name-only", "-z", "--no-renames", "--"],
+    ["git", "ls-files", "--others", "--exclude-standard", "-z", "--"],
+  ]);
+});
+
 test("scope table selects only exact narrow commands", () => {
   const rows: Array<[string[], string[]]> = [
-    [["README.md", "docs/guide.md"], []],
+    [["README.md", "docs/guide.md"], ["pnpm run gate:docs-status"]],
     [["apps/worker/src/lib/value.ts"], [...WB, GATES]],
     [["apps/worker/src/engine/helpers/value.ts"], [...WB, PACK, GATES]],
     [["apps/dashboard/lib/value.ts"], ["pnpm --filter ai-workflow-dashboard run typecheck", GATES]],
@@ -122,8 +139,10 @@ test("scope table selects only exact narrow commands", () => {
     [["docs/releases/artur/next.md"], ["pnpm run typecheck:release-notes", "pnpm run test:release-notes"]],
     [[".github/workflows/prepare-artur-release.yml"], ["pnpm run typecheck:release-notes", "pnpm run test:release-notes", "pnpm run test:ci"]],
     [["skills/ai-workflow-review/SKILL.md"], ["pnpm --dir apps/worker run validate:local-skills"]],
-    [[".claude/skills/init-env/SKILL.md"], []],
-    [["apps/worker/.agents/skills/workflow/SKILL.md"], []],
+    [[".claude/skills/init-env/SKILL.md"], ["pnpm run gate:docs-status"]],
+    [[".claude/settings.json"], ["pnpm run gate:docs-status"]],
+    [[".claude/rules/worker-database.md"], ["pnpm run gate:docs-status"]],
+    [["apps/worker/.agents/skills/workflow/SKILL.md"], ["pnpm run gate:docs-status"]],
     [[".dependency-cruiser.cjs"], [GATES]],
   ];
   for (const [paths, expected] of rows) assert.deepEqual(commands(paths), expected, paths.join(","));
@@ -189,6 +208,10 @@ test("combined plan excludes broad, deployment, network, E2E, and divergence com
 test("CLI, package entry, and executable hook preserve the exact public contract", async () => {
   assert.equal(parseArgs(["--", "--base", "origin/main"]), "origin/main");
   assert.equal(parseArgs(["--base=main"]), "main");
+  assert.deepEqual(parseOptions(["--base", "origin/main", "--worktree"]), {
+    base: "origin/main",
+    worktree: true,
+  });
   assert.throws(() => parseArgs(["--fetch"]), /Unknown/);
   const pkg = JSON.parse(await readFile("package.json", "utf8")) as { scripts: Record<string, string> };
   assert.equal(pkg.scripts["verify:changed"], "node --import tsx scripts/ci/verify-changed.ts");

--- a/scripts/ci/verify-changed.ts
+++ b/scripts/ci/verify-changed.ts
@@ -18,10 +18,20 @@ export const WORKFLOW_TESTS = [
 ] as const;
 
 export const WORKTREE_DIFF = ["git", "diff", "--check"] as const satisfies Cmd;
+export const STAGED_WORKTREE_DIFF = ["git", "diff", "--cached", "--check"] as const satisfies Cmd;
 export const candidateDiff = (merge: string, candidate: string): Cmd =>
   ["git", "diff", "--check", merge, candidate, "--"];
 export const namesDiff = (merge: string, candidate: string): Cmd => [
   "git", "diff", "--name-only", "-z", "--no-renames", merge, candidate, "--",
+];
+export const stagedNamesDiff = (): Cmd => [
+  "git", "diff", "--cached", "--name-only", "-z", "--no-renames", "--",
+];
+export const worktreeNamesDiff = (merge: string, candidate: string): readonly Cmd[] => [
+  namesDiff(merge, candidate),
+  stagedNamesDiff(),
+  ["git", "diff", "--name-only", "-z", "--no-renames", "--"],
+  ["git", "ls-files", "--others", "--exclude-standard", "-z", "--"],
 ];
 
 const C = {
@@ -37,6 +47,7 @@ const C = {
   releaseType: ["pnpm", "run", "typecheck:release-notes"],
   releaseTest: ["pnpm", "run", "test:release-notes"],
   gates: ["pnpm", "run", "gates"],
+  docsStatus: ["pnpm", "run", "gate:docs-status"],
 } as const satisfies Record<string, Cmd>;
 
 const ROOT_CI = new Set(["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"]);
@@ -75,7 +86,15 @@ const disk: Repo = {
 const any = (paths: readonly string[], match: (path: string) => boolean) =>
   paths.some(match);
 const isDocs = (path: string) =>
-  path.startsWith("docs/") || /\.(?:md|mdx|txt)$/i.test(path);
+  path.startsWith("docs/") ||
+  /\.(?:md|mdx|txt)$/i.test(path) ||
+  path === ".claude/settings.json" ||
+  path.startsWith(".claude/rules/") ||
+  path.startsWith(".claude/skills/") ||
+  path === "AGENTS.md" ||
+  path.endsWith("/AGENTS.md") ||
+  path === "CLAUDE.md" ||
+  path.endsWith("/CLAUDE.md");
 const isSkill = (path: string) => path.startsWith("skills/");
 const isRelease = (path: string) =>
   path.startsWith("scripts/release-notes/") ||
@@ -123,7 +142,7 @@ export function plan(paths: readonly string[], repo: Repo = disk): Plan {
   const skills = any(paths, isSkill);
   const release = any(paths, isRelease);
   if (paths.every(isDocs) && !product && !skills && !release) {
-    return { scopes: ["docs-only"], commands: [] };
+    return { scopes: ["docs-only"], commands: [C.docsStatus] };
   }
 
   const worker = any(paths, (path) => path.startsWith("apps/worker/"));
@@ -292,22 +311,39 @@ function execute([program, ...args]: Cmd): Promise<void> {
   });
 }
 export function parseArgs(input: readonly string[]): string | undefined {
+  return parseOptions(input).base;
+}
+
+export type VerifyOptions = { base?: string; worktree: boolean };
+
+export function parseOptions(input: readonly string[]): VerifyOptions {
   const args = input[0] === "--" ? input.slice(1) : [...input];
   let base: string | undefined;
+  let worktree = false;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
+    if (arg === "--worktree") {
+      if (worktree) throw new Error("Provide --worktree at most once.");
+      worktree = true;
+      continue;
+    }
     const value = arg === "--base" ? args[++i] : arg.startsWith("--base=") ? arg.slice(7) : null;
     if (value === null) throw new Error(`Unknown argument ${JSON.stringify(arg)}.`);
     if (!value || base) throw new Error("Provide --base exactly once with a value.");
     base = value;
   }
-  return base;
+  return { base, worktree };
 }
 
 export async function main(input = process.argv.slice(2)) {
   console.log(`[verify:changed] $ ${show(WORKTREE_DIFF)}`);
   await execute(WORKTREE_DIFF);
-  const resolved = await resolveBase((args) => capture(["git", ...args]), parseArgs(input));
+  const options = parseOptions(input);
+  if (options.worktree) {
+    console.log(`[verify:changed] $ ${show(STAGED_WORKTREE_DIFF)}`);
+    await execute(STAGED_WORKTREE_DIFF);
+  }
+  const resolved = await resolveBase((args) => capture(["git", ...args]), options.base);
   console.log(
     `[verify:changed] base: ${resolved.source} ${resolved.reference} -> ${resolved.baseSha}`,
   );
@@ -316,9 +352,15 @@ export async function main(input = process.argv.slice(2)) {
   const checks = candidateDiff(resolved.mergeBaseSha, resolved.candidateSha);
   console.log(`[verify:changed] $ ${show(checks)}`);
   await execute(checks);
-  const names = namesDiff(resolved.mergeBaseSha, resolved.candidateSha);
-  console.log(`[verify:changed] $ ${show(names)}`);
-  const paths = parseNames(await capture(names));
+  const names = options.worktree
+    ? worktreeNamesDiff(resolved.mergeBaseSha, resolved.candidateSha)
+    : [namesDiff(resolved.mergeBaseSha, resolved.candidateSha)];
+  for (const command of names) console.log(`[verify:changed] $ ${show(command)}`);
+  const paths = [
+    ...new Set(
+      (await Promise.all(names.map((command) => capture(command)))).flatMap((output) => parseNames(output)),
+    ),
+  ];
   const next = plan(paths);
   console.log(`[verify:changed] changed files: ${JSON.stringify(paths)}`);
   console.log(`[verify:changed] scopes: ${next.scopes.join(", ")}`);

--- a/scripts/gates/docs-status.mjs
+++ b/scripts/gates/docs-status.mjs
@@ -11,7 +11,8 @@
  *
  * What it checks, for every Markdown document under docs/ (except docs/archive/
  * and docs/research/), under apps/<app>/docs/, for each apps/<app>/AGENTS.md,
- * and for README.md, AGENTS.md and SETUP.md at the repository root:
+ * and for packages/AGENTS.md, README.md, AGENTS.md and SETUP.md at the
+ * repository root:
  *   1. the first two lines are `Status: <value>` and `Last-verified: YYYY-MM-DD`;
  *   2. `Status:` is `current`, `draft`, or `superseded-by <path>` naming a file
  *      that exists;
@@ -82,6 +83,8 @@ const gate = {
         (path) => !gate.SKIPPED_DOC_DIRS.some((dir) => path.startsWith(`${dir}/`)),
       );
       docs.push(...gate.appDocuments(), ...gate.rootDocuments());
+      const packagesAgents = "packages/AGENTS.md";
+      if (existsSync(nodePath.join(gate.repoRoot, packagesAgents))) docs.push(packagesAgents);
       return [...new Set(docs)].toSorted();
     },
     collectFailures(path, reachableMap) {


### PR DESCRIPTION
## Summary

Stage 10 of the architecture restructure ([plan](docs/plans/2026-09-09-architecture-restructure.md), Jira AIW-356): agent configuration aligned with the restructured tree.

* `pnpm run verify:changed` runs as a Claude Code `Stop` hook from `.claude/settings.json` (tracked from this stage on): it exits immediately when `stop_hook_active` is set (no loop), passes on a clean tree, and on a dirty tree runs `verify:changed -- --base origin/main --worktree`, blocking the stop with a JSON decision only when the gate fails. It never commits, pushes or deploys.
* `scripts/ci/verify-changed.ts` gains `--worktree`: base resolution unchanged, adds `git diff --cached --check` and unions committed, staged, unstaged and untracked names before scope planning; the default mode is byte-for-byte unchanged; `scripts/ci/verify-changed.test.ts` covers the new mode.
* `.claude/skills/gate-ladder/SKILL.md` (new) and `.claude/skills/artur-release/SKILL.md` route to `docs/delivery-gates.md`, ADR-004 and `AGENTS.md` instead of restating them.
* `AGENTS.md`, `apps/worker/AGENTS.md`, `apps/dashboard/AGENTS.md`, `packages/AGENTS.md` trimmed; the four production gotchas stay verbatim in the root file. `.claude/rules/*.md` `paths:` globs verified against the tree after stages 6a, 6b, 8a, 8c, 8d and 9 (`services/auth/**` included); `workflow-steps.md` no longer names a path that does not exist.
* `scripts/gates/docs-status.mjs` covers `packages/AGENTS.md`; `scripts/ci/gates.test.ts` has the fixture.
* Two dangling skill symlinks (`.claude/skills/vercel-sandbox`, `.claude/skills/workflow`, both pointing at absent `.agents/skills/*` targets) removed.

## Owner's clone

`.claude/settings.json` was untracked and locally excluded on the owner's clone (`.git/info/exclude`) because it carried personal `enabledPlugins`. Before pulling this merge the advisor moves those flags to `.claude/settings.local.json` (which Claude Code merges with the tracked file) and removes the exclude line; otherwise `git pull` refuses to overwrite the untracked file.

## Gate record

* Executor: Codex `gpt-5.6-luna` (max) per the plan tier for a mechanical stage.
* Reviewer: Codex `gpt-5.6-sol` (high), read-only sandbox, on candidate `5c5d9b5ef318837aa0293713bf3b9b155a28e465`: CHANGES REQUIRED with four majors (the neon-http gotcha replaced ahead of stage 7; the gate ladder skill restating `pnpm run gates`, which `docs/delivery-gates.md` does not contain; the executor report naming the base as the candidate; the `/context` requirement not spelled out) and one minor (`docs/index.md` docs-status scope). C1 Stop hook simulated in all four branches (recursion guard, clean tree, dirty pass, dirty fail with the JSON decision on stderr), C2 `--worktree` mode and its test PASS, C3 links resolve and both deleted symlinks were dangling, C4 every rule glob matches, C6 hygiene PASS.
* Fix round (`252065273d2ac8797171d3b325416504042f8486`, 4 files): both gotcha sections restored to the base text (root section byte-identical to `81dcb2d6`), the skill now only routes, `docs/index.md` updated. The advisor reviewed that diff directly (15 insertions, 17 deletions); no second reviewer round for a docs-only fix.

## Evidence

* `pnpm run verify:changed -- --base 81dcb2d607ac427d8d346a259a3c6b73bccc5b25` on `5c5d9b5ef318837aa0293713bf3b9b155a28e465` and on `252065273d2ac8797171d3b325416504042f8486`: scopes worker, dashboard, shared, ci, gates; exit 0 both times. Executor on the fix tree: typecheck exit 0, `test:ci` 77 passed, `gates` exit 0, docs-status PASS, `verify:changed --worktree` exit 0, `git diff --check` clean, no em or en dash on added lines; `"use step"` 166 before and after. The push used `--no-verify` (audited substitute: the same command was run by hand and recorded here).
* `/context` evidence (DoD): a headless Claude Code session (`claude -p`, model sonnet, session `e1176c8f-0c0c-44f6-9c46-371ea55a0623`) started at the root of the candidate worktree, edited `apps/worker/src/services/auth/index.ts`, and its transcript (`~/.claude/projects/<worktree slug>/e1176c8f-0c0c-44f6-9c46-371ea55a0623.jsonl`, 370 KB) carries the injection records at 05:33:23Z for `apps/worker/CLAUDE.md` (content `@AGENTS.md`, which bridges `apps/worker/AGENTS.md`; its gotcha text "Production has no interactive transactions" is present in the transcript) and for `.claude/rules/worker-database.md` (selected by its `paths:` entry `apps/worker/src/services/auth/**`). Root `CLAUDE.md`, root `AGENTS.md` and the user files loaded at session start. The probe edit was reverted; nothing from that session is in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and project guidance with clearer ownership, workflow, architecture, package, dashboard, and worker documentation.
  * Added release-gate guidance emphasizing maintainer approval and evidence requirements.
  * Improved documentation status tracking and verification coverage.

* **Quality Improvements**
  * Verification now checks broader worktree changes, including staged, unstaged, and untracked files.
  * Documentation-only changes receive appropriate status validation.

* **Tests**
  * Added coverage for documentation headers, repository guidance bridges, and worktree verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->