### PR TITLE
test(worker): stop poll-agent tests reaching the real sandbox and raise the hook timeout

### DIFF
--- a/apps/worker/src/sandbox/poll-agent.test.ts
+++ b/apps/worker/src/sandbox/poll-agent.test.ts
@@ -1,8 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Sandbox } from "@vercel/sandbox";
 
-const mockRunCommand = vi.fn();
-const mockStop = vi.fn();
+const {
+  failUnexpectedSandboxGet,
+  mockRunCommand,
+  mockSandboxGet,
+  mockStop,
+  sandboxModule,
+} = vi.hoisted(() => {
+  const mockRunCommand = vi.fn();
+  const mockStop = vi.fn();
+  const failUnexpectedSandboxGet = (..._args: unknown[]): unknown => {
+    throw new Error(
+      "Unexpected Sandbox.get in poll-agent unit test; install an explicit mock implementation before invoking sandbox code",
+    );
+  };
+  const mockSandboxGet = vi.fn(failUnexpectedSandboxGet);
+  return {
+    failUnexpectedSandboxGet,
+    mockRunCommand,
+    mockSandboxGet,
+    mockStop,
+    sandboxModule: { Sandbox: { get: mockSandboxGet } },
+  };
+});
 const trackedFixturePromises = new Set<Promise<void>>();
 const fixtureCleanups = new Set<() => void>();
 
@@ -76,24 +96,16 @@ async function cleanupFixtures() {
   fixtureCleanups.clear();
 }
 
-vi.mock("@vercel/sandbox", () => ({
-  Sandbox: {
-    get: vi.fn(() => ({
-      sandboxId: "sbx-test-123",
-      status: "running",
-      runCommand: mockRunCommand,
-      stop: mockStop,
-    })),
-  },
-}));
+vi.mock("@vercel/sandbox", () => sandboxModule);
 
 vi.mock("./credentials.js", () => ({ getSandboxCredentials: () => ({}) }));
 
-const mockSandboxGet = Sandbox.get as unknown as ReturnType<typeof vi.fn>;
-
 function expectCurrentSandboxGet(sandboxId = "sbx-test-123") {
   expect(mockSandboxGet).toHaveBeenCalledTimes(1);
-  const signal = mockSandboxGet.mock.calls[0]?.[0].signal as AbortSignal;
+  const [options] = mockSandboxGet.mock.calls[0] as [
+    { signal: AbortSignal },
+  ];
+  const signal = options.signal;
   expect(mockSandboxGet).toHaveBeenCalledWith(
     expect.objectContaining({ sandboxId, signal }),
   );
@@ -120,6 +132,7 @@ function resetSandboxMocks() {
   if (trackedFixturePromises.size > 0 || fixtureCleanups.size > 0) {
     throw new Error("sandbox fixtures must be drained before mock reset");
   }
+  vi.doMock("@vercel/sandbox", () => sandboxModule);
   vi.clearAllMocks();
   mockRunCommand.mockReset();
   mockStop.mockReset();
@@ -133,6 +146,7 @@ function resetSandboxMocks() {
 
 afterEach(async () => {
   try {
+    mockSandboxGet.mockReset().mockImplementation(failUnexpectedSandboxGet);
     await cleanupFixtures();
   } finally {
     vi.useRealTimers();
@@ -449,6 +463,7 @@ describe("collectPhase", () => {
   });
 
   it("bounds replay-only partial artifact reads", async () => {
+    vi.useFakeTimers();
     const pendingStdout = createDeferred<string>();
     mockRunCommand.mockResolvedValue({
       exitCode: null,
@@ -463,6 +478,13 @@ describe("collectPhase", () => {
         5,
       ),
     );
+
+    await vi.dynamicImportSettled();
+    expect(mockSandboxGet).toHaveBeenCalledTimes(1);
+    expect(mockSandboxGet).toHaveBeenCalledWith({ sandboxId: "sbx-test-123" });
+    expect(mockRunCommand).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(5);
+
     const error = await failure;
     expect(error).toMatchObject({ message: expect.stringContaining("Replay capture timed out") });
   });

--- a/apps/worker/src/test-support/vercel-sandbox.test.ts
+++ b/apps/worker/src/test-support/vercel-sandbox.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from "vitest";
+import { Sandbox } from "@vercel/sandbox";
+
+it("fails closed instead of loading the real Vercel sandbox client", () => {
+  expect(() => Sandbox.get({ sandboxId: "must-not-connect" })).toThrow(
+    "Unexpected Sandbox.get in a worker unit test",
+  );
+});

--- a/apps/worker/src/test-support/vercel-sandbox.ts
+++ b/apps/worker/src/test-support/vercel-sandbox.ts
@@ -1,0 +1,7 @@
+export const Sandbox = {
+  get(): never {
+    throw new Error(
+      "Unexpected Sandbox.get in a worker unit test; install an explicit @vercel/sandbox mock",
+    );
+  },
+};

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@vercel/sandbox": fileURLToPath(
+        new URL("./src/test-support/vercel-sandbox.ts", import.meta.url),
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: "node",
     include: ["src/**/*.test.ts", "*.test.ts"],
+    hookTimeout: 30_000,
     testTimeout: 15_000,
   },
 });


### PR DESCRIPTION
## Summary

Two flaky-suite defects recorded during stage 11 of the architecture restructure (Jira draft T19, epic AIW-338), fixed with their mechanism named rather than retried around. Cut from the stage 11 phase 2 candidate; runtime code is untouched (test file, vitest configuration and a test-support double only).

## Defect 1: `poll-agent.test.ts` reached the real Vercel sandbox client

The CI shard failed once in about ten runs with `LocalOidcContextError: Could not get credentials from OIDC context` inside a test whose module mocks `@vercel/sandbox`. Root cause: the preceding test ("bounds a Sandbox.get that never settles", a 5 ms real-timer bound) could time out before the production code's dynamic `await import("@vercel/sandbox")` completed, so the late operation continued after the mock reset and contaminated the next test (observed in a full-suite run as four bounded tail reads instead of two). Fix in `apps/worker/src/sandbox/poll-agent.test.ts`: the test awaits dynamic-import readiness under fake timers before advancing the timeout; the sandbox factory has a stable hoisted identity, per-test registration and a throwing teardown default. Guard for every unit test: `apps/worker/vitest.config.ts` aliases `@vercel/sandbox` to `apps/worker/src/test-support/vercel-sandbox.ts`, a fail-closed double that throws a clear assertion on any unexpected use (tested in `vercel-sandbox.test.ts`); the alias applies to vitest only, never to the build.

## Defect 2: the full suite exited 1 with no visible failing test

Reproduced on a pre-fix full-suite run: six test files exceeded vitest's default 10 second hook timeout because `createTestDb()` (PGlite) took 10.2 to 11.1 s under fork contention. Fix: `hookTimeout: 30_000` in `apps/worker/vitest.config.ts` (vitest 3.2.6, forks pool, `testTimeout` 15 s unchanged).

## Verification

Executor (Codex `gpt-5.6-sol`, high): twenty consecutive runs of the file all `22 passed`; full worker suite three consecutive green runs after the fix (405 files, 6629 tests, 72 to 114 s); typecheck 0, gates 0, `verify:changed` 0, `git diff --check` 0.

## Gate

Reviewer (Codex `gpt-5.6-sol`, high) on the uncommitted candidate: APPROVE with two minors, both batched into the residue sweep rather than blocking: the hook timeout applies to every hook although six PGlite-heavy files needed it; the reviewer's own full-suite run showed three unrelated 15 second test-body timeouts under contention (`pre-pr-checks/runner.test.ts`, `prompt-library/builtin-prompt-drift.test.ts`), recorded as flaky-suite evidence for the next pass. Committed by the advisor as `251be929b88f63cbc765480f22c48f31e4c6aadb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved worker test reliability by ensuring unexpected sandbox access fails clearly and immediately.
  * Added coverage confirming sandbox access is blocked unless explicitly mocked.
  * Strengthened timeout and replay test coverage, including command execution and failure handling.

* **Chores**
  * Updated test configuration to provide consistent sandbox behavior and longer-running test support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->