### PR TITLE
feat(worker): settings registry, store, snapshot, seed and routes (catalog stage A)

### DIFF
--- a/apps/worker/AGENTS.md
+++ b/apps/worker/AGENTS.md
@@ -1,5 +1,5 @@
 Status: current
-Last-verified: 2026-09-11
+Last-verified: 2026-09-12
 
 # apps/worker
 
@@ -50,6 +50,38 @@ service-cluster contracts. The current runtime entrypoints are under
 under `src/routes` and `src/mcp`, and configuration helpers are under
 `src/config` and `src/infra`. Use those documents when a change crosses a
 boundary instead of copying their ownership tables here.
+
+## Settings
+
+Product-behaviour switches (limits, feature flags, MCP bounds, board column
+names, harness defaults) are rows in the `settings` table, described once in
+`packages/contracts/settings-registry.ts` and changed through
+`PATCH /api/v1/settings` by an owner or admin, with every change recorded in
+`settings_versions` with the actor and a reason.
+
+- **One snapshot per entry, passed down.** `loadSettingsSnapshot()` is
+  asynchronous and everything below it is not: an accessor returns a value, and
+  an accessor that quietly returned a promise would read as truthy and turn a
+  feature on. Load the snapshot where the work starts (an HTTP handler, a cron
+  tick, the MCP transport, and later a run at its start) and hand it down.
+- **The transition rule.** Every accessor that reads a migrated key has two
+  forms: `accessor(snapshot)`, which is the one to use, and a deprecated
+  zero-argument form that resolves from the environment through
+  `settingsSnapshotFromEnvironment()`. The second exists only so callers that
+  have not been converted yet behave exactly as before; both disappear into one
+  when the cleanup stage removes the environment parsing.
+- **Resolution order.** Stored row, then the value the environment already
+  resolved to, then the registry default. A deployment with a configured
+  environment and an empty table behaves exactly as it did before the table
+  existed, which is what makes the migration safe to deploy on its own.
+- **The seed.** `pnpm db:seed-settings` runs right after `db:migrate` in
+  `build` (not in `build:ci`) and inserts one row per key whose variable this
+  deployment actually sets, doing nothing on conflict. It never overwrites a
+  decision made in the dashboard, and it writes no version rows: the
+  environment is not an actor. A later save of the same value writes no version
+  row either, because the write skips a row whose value is not distinct from
+  the one stored, so an empty history on a seeded key means "never changed",
+  not "never decided".
 
 ## Traps specific to this app
 

--- a/apps/worker/drizzle/0059_settings_store.sql
+++ b/apps/worker/drizzle/0059_settings_store.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "settings" (
+	"key" text PRIMARY KEY NOT NULL,
+	"value" jsonb NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_by" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "settings_versions" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"key" text NOT NULL,
+	"previous_value" jsonb,
+	"new_value" jsonb NOT NULL,
+	"actor" text NOT NULL,
+	"reason" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "settings_versions_key_id_idx" ON "settings_versions" USING btree ("key","id");

--- a/apps/worker/drizzle/meta/0059_snapshot.json
+++ b/apps/worker/drizzle/meta/0059_snapshot.json
@@ -1,0 +1,7500 @@
+{
+  "id": "535044e6-654c-4cd2-9372-e37a2d322a9c",
+  "prevId": "15693e20-2fcd-49a4-af86-5da8f9f4075d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.active_run_sandboxes": {
+      "name": "active_run_sandboxes",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "active_run_sandboxes_subject_owner_fk": {
+          "name": "active_run_sandboxes_subject_owner_fk",
+          "tableFrom": "active_run_sandboxes",
+          "tableTo": "active_runs",
+          "columnsFrom": [
+            "subject_key",
+            "owner_token"
+          ],
+          "columnsTo": [
+            "subject_key",
+            "owner_token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk": {
+          "name": "active_run_sandboxes_subject_key_owner_token_sandbox_id_pk",
+          "columns": [
+            "subject_key",
+            "owner_token",
+            "sandbox_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.active_runs": {
+      "name": "active_runs",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "run_kind": {
+          "name": "run_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ticket'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "active_runs_ticket_key_idx": {
+          "name": "active_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "active_runs_subject_owner_idx": {
+          "name": "active_runs_subject_owner_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "active_runs_state_check": {
+          "name": "active_runs_state_check",
+          "value": "\"active_runs\".\"state\" in ('reserved', 'bound', 'parking', 'parked', 'cancelling')"
+        },
+        "active_runs_state_run_id_check": {
+          "name": "active_runs_state_run_id_check",
+          "value": "(\"active_runs\".\"state\" = 'reserved' and \"active_runs\".\"run_id\" is null) or (\"active_runs\".\"state\" in ('bound', 'parking', 'parked') and \"active_runs\".\"run_id\" is not null) or \"active_runs\".\"state\" = 'cancelling'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.failed_tickets": {
+      "name": "failed_tickets",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_parents": {
+      "name": "thread_parents",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.carry_schema_resync_audit": {
+      "name": "carry_schema_resync_audit",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_index": {
+          "name": "node_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carry_index": {
+          "name": "carry_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before_schema": {
+          "name": "before_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk": {
+          "name": "carry_schema_resync_audit_definition_id_version_node_index_carry_index_pk",
+          "columns": [
+            "definition_id",
+            "version",
+            "node_index",
+            "carry_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_triggers": {
+      "name": "workflow_definition_triggers",
+      "schema": "",
+      "columns": {
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_triggers_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_triggers_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_triggers",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definition_versions": {
+      "name": "workflow_definition_versions",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_definition_versions_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_definition_versions_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_definition_versions",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_definition_versions_definition_id_version_pk": {
+          "name": "workflow_definition_versions_definition_id_version_pk",
+          "columns": [
+            "definition_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_definitions": {
+      "name": "workflow_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trigger_types": {
+          "name": "trigger_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"nodes\":{}}'::jsonb"
+        },
+        "layout_revision": {
+          "name": "layout_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deployed_version": {
+          "name": "deployed_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_definitions_name_active_idx": {
+          "name": "workflow_definitions_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_definitions\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_definitions_deployed_version_fk": {
+          "name": "workflow_definitions_deployed_version_fk",
+          "tableFrom": "workflow_definitions",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "id",
+            "deployed_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispatch_capacity_queue": {
+      "name": "dispatch_capacity_queue",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manual_dispatch_requests": {
+      "name": "manual_dispatch_requests",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_node_id": {
+          "name": "trigger_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_kind": {
+          "name": "input_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_payload": {
+          "name": "input_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manual_dispatch_requests_status_idx": {
+          "name": "manual_dispatch_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_subject_key_idx": {
+          "name": "manual_dispatch_requests_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "manual_dispatch_requests_run_id_idx": {
+          "name": "manual_dispatch_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "manual_dispatch_requests_definition_version_fk": {
+          "name": "manual_dispatch_requests_definition_version_fk",
+          "tableFrom": "manual_dispatch_requests",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "manual_dispatch_requests_status_check": {
+          "name": "manual_dispatch_requests_status_check",
+          "value": "\"manual_dispatch_requests\".\"status\" in ('pending', 'reserved', 'prepared', 'candidate_started', 'started', 'failed')"
+        },
+        "manual_dispatch_requests_input_kind_check": {
+          "name": "manual_dispatch_requests_input_kind_check",
+          "value": "\"manual_dispatch_requests\".\"input_kind\" in ('ticket', 'pull_request')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.trigger_deliveries": {
+      "name": "trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "producer": {
+          "name": "producer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "semantic_key": {
+          "name": "semantic_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trigger_deliveries_semantic_key_idx": {
+          "name": "trigger_deliveries_semantic_key_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "semantic_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"trigger_deliveries\".\"semantic_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_deliveries_definition_version_fk": {
+          "name": "trigger_deliveries_definition_version_fk",
+          "tableFrom": "trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "trigger_deliveries_provider_delivery_id_pk": {
+          "name": "trigger_deliveries_provider_delivery_id_pk",
+          "columns": [
+            "provider",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.harness_capability_catalogs": {
+      "name": "harness_capability_catalogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog": {
+          "name": "catalog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "catalog_hash": {
+          "name": "catalog_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh_failed_at": {
+          "name": "last_refresh_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refresh_error": {
+          "name": "last_refresh_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "harness_capability_catalogs_scope_unique": {
+          "name": "harness_capability_catalogs_scope_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cli_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_capability_catalogs_organization_id_organization_id_fk": {
+          "name": "harness_capability_catalogs_organization_id_organization_id_fk",
+          "tableFrom": "harness_capability_catalogs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_capability_catalogs_provider_check": {
+          "name": "harness_capability_catalogs_provider_check",
+          "value": "\"harness_capability_catalogs\".\"provider\" in ('claude', 'codex')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_version_skills": {
+      "name": "harness_profile_version_skills",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_version": {
+          "name": "profile_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profile_version_skills_name_unique": {
+          "name": "harness_profile_version_skills_name_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skill_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profile_version_skills_position_unique": {
+          "name": "harness_profile_version_skills_position_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_profile_version_skills_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "harness_profile_version_skills_profile_version_fk": {
+          "name": "harness_profile_version_skills_profile_version_fk",
+          "tableFrom": "harness_profile_version_skills",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "profile_id",
+            "profile_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk": {
+          "name": "harness_profile_version_skills_profile_id_profile_version_artifact_id_pk",
+          "columns": [
+            "profile_id",
+            "profile_version",
+            "artifact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_version_skills_position_check": {
+          "name": "harness_profile_version_skills_position_check",
+          "value": "\"harness_profile_version_skills\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profile_versions": {
+      "name": "harness_profile_versions",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_hash": {
+          "name": "manifest_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "harness_profile_versions_hash_unique": {
+          "name": "harness_profile_versions_hash_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manifest_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profile_versions_profile_id_harness_profiles_id_fk": {
+          "name": "harness_profile_versions_profile_id_harness_profiles_id_fk",
+          "tableFrom": "harness_profile_versions",
+          "tableTo": "harness_profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_profile_versions_profile_id_version_pk": {
+          "name": "harness_profile_versions_profile_id_version_pk",
+          "columns": [
+            "profile_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profile_versions_version_check": {
+          "name": "harness_profile_versions_version_check",
+          "value": "\"harness_profile_versions\".\"version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_profiles": {
+      "name": "harness_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_revision": {
+          "name": "draft_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "draft_restored_from_version": {
+          "name": "draft_restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_version": {
+          "name": "published_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_id": {
+          "name": "updated_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_profiles_org_slug_unique": {
+          "name": "harness_profiles_org_slug_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_system_slug_unique": {
+          "name": "harness_profiles_system_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"harness_profiles\".\"organization_id\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_profiles_organization_id_idx": {
+          "name": "harness_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_profiles_organization_id_organization_id_fk": {
+          "name": "harness_profiles_organization_id_organization_id_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "harness_profiles_published_version_fk": {
+          "name": "harness_profiles_published_version_fk",
+          "tableFrom": "harness_profiles",
+          "tableTo": "harness_profile_versions",
+          "columnsFrom": [
+            "id",
+            "published_version"
+          ],
+          "columnsTo": [
+            "profile_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_profiles_ownership_check": {
+          "name": "harness_profiles_ownership_check",
+          "value": "(\"harness_profiles\".\"system\" = true and \"harness_profiles\".\"read_only\" = true and \"harness_profiles\".\"organization_id\" is null) or (\"harness_profiles\".\"system\" = false and \"harness_profiles\".\"organization_id\" is not null)"
+        },
+        "harness_profiles_draft_revision_check": {
+          "name": "harness_profiles_draft_revision_check",
+          "value": "\"harness_profiles\".\"draft_revision\" > 0"
+        },
+        "harness_profiles_published_version_check": {
+          "name": "harness_profiles_published_version_check",
+          "value": "\"harness_profiles\".\"published_version\" is null or \"harness_profiles\".\"published_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifact_files": {
+      "name": "harness_skill_artifact_files",
+      "schema": "",
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_base64": {
+          "name": "content_base64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk": {
+          "name": "harness_skill_artifact_files_artifact_id_harness_skill_artifacts_id_fk",
+          "tableFrom": "harness_skill_artifact_files",
+          "tableTo": "harness_skill_artifacts",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "harness_skill_artifact_files_artifact_id_path_pk": {
+          "name": "harness_skill_artifact_files_artifact_id_path_pk",
+          "columns": [
+            "artifact_id",
+            "path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifact_files_mode_check": {
+          "name": "harness_skill_artifact_files_mode_check",
+          "value": "\"harness_skill_artifact_files\".\"mode\" in (420, 493)"
+        },
+        "harness_skill_artifact_files_size_check": {
+          "name": "harness_skill_artifact_files_size_check",
+          "value": "\"harness_skill_artifact_files\".\"size_bytes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.harness_skill_artifacts": {
+      "name": "harness_skill_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_hash": {
+          "name": "artifact_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "source_owner": {
+          "name": "source_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repository": {
+          "name": "source_repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_commit_sha": {
+          "name": "source_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_content_sha256": {
+          "name": "local_content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "harness_skill_artifacts_org_hash_unique": {
+          "name": "harness_skill_artifacts_org_hash_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "harness_skill_artifacts_source_idx": {
+          "name": "harness_skill_artifacts_source_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "harness_skill_artifacts_organization_id_organization_id_fk": {
+          "name": "harness_skill_artifacts_organization_id_organization_id_fk",
+          "tableFrom": "harness_skill_artifacts",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "harness_skill_artifacts_source_kind_check": {
+          "name": "harness_skill_artifacts_source_kind_check",
+          "value": "\"harness_skill_artifacts\".\"source_kind\" in ('github', 'local')"
+        },
+        "harness_skill_artifacts_source_shape_check": {
+          "name": "harness_skill_artifacts_source_shape_check",
+          "value": "(\n        \"harness_skill_artifacts\".\"source_kind\" <> 'github'\n        or (\n          \"harness_skill_artifacts\".\"source_owner\" is not null\n          and \"harness_skill_artifacts\".\"source_repository\" is not null\n          and \"harness_skill_artifacts\".\"source_path\" is not null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is not null\n          and \"harness_skill_artifacts\".\"local_path\" is null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is null\n        )\n      ) and (\n        \"harness_skill_artifacts\".\"source_kind\" <> 'local'\n        or (\n          \"harness_skill_artifacts\".\"local_path\" is not null\n          and \"harness_skill_artifacts\".\"local_content_sha256\" is not null\n          and \"harness_skill_artifacts\".\"source_owner\" is null\n          and \"harness_skill_artifacts\".\"source_repository\" is null\n          and \"harness_skill_artifacts\".\"source_path\" is null\n          and \"harness_skill_artifacts\".\"source_commit_sha\" is null\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_audit_events": {
+      "name": "mcp_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutation_class": {
+          "name": "mutation_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_refs": {
+          "name": "target_refs",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_hash": {
+          "name": "output_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key_hash": {
+          "name": "idempotency_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_version": {
+          "name": "server_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_hash": {
+          "name": "contract_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_audit_events_organization_occurred_at_idx": {
+          "name": "mcp_audit_events_organization_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_audit_events_request_id_idx": {
+          "name": "mcp_audit_events_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_audit_events_organization_id_organization_id_fk": {
+          "name": "mcp_audit_events_organization_id_organization_id_fk",
+          "tableFrom": "mcp_audit_events",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_idempotency_keys": {
+      "name": "mcp_idempotency_keys",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_response": {
+          "name": "safe_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_idempotency_keys_namespace_unique": {
+          "name": "mcp_idempotency_keys_namespace_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_idempotency_keys_expires_at_idx": {
+          "name": "mcp_idempotency_keys_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_idempotency_keys_organization_id_organization_id_fk": {
+          "name": "mcp_idempotency_keys_organization_id_organization_id_fk",
+          "tableFrom": "mcp_idempotency_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mcp_idempotency_keys_state_check": {
+          "name": "mcp_idempotency_keys_state_check",
+          "value": "\"mcp_idempotency_keys\".\"state\" in ('started', 'completed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_rate_limit_windows": {
+      "name": "mcp_rate_limit_windows",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_subject": {
+          "name": "actor_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_rate_limit_windows_expires_at_idx": {
+          "name": "mcp_rate_limit_windows_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_rate_limit_windows_organization_id_organization_id_fk": {
+          "name": "mcp_rate_limit_windows_organization_id_organization_id_fk",
+          "tableFrom": "mcp_rate_limit_windows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mcp_rate_limit_windows_organization_id_actor_subject_client_id_tool_name_window_started_at_pk": {
+          "name": "mcp_rate_limit_windows_organization_id_actor_subject_client_id_tool_name_window_started_at_pk",
+          "columns": [
+            "organization_id",
+            "actor_subject",
+            "client_id",
+            "tool_name",
+            "window_started_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_current": {
+      "name": "gate_current",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_run_ids": {
+          "name": "check_run_ids",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::bigint[]"
+        },
+        "gate_status_refs": {
+          "name": "gate_status_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_current_repo_pr_pk": {
+          "name": "gate_current_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_dedupe": {
+      "name": "gate_dedupe",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_dedupe_repo_pr_head_sha_pk": {
+          "name": "gate_dedupe_repo_pr_head_sha_pk",
+          "columns": [
+            "repo",
+            "pr",
+            "head_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gate_locks": {
+      "name": "gate_locks",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr": {
+          "name": "pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "gate_locks_repo_pr_pk": {
+          "name": "gate_locks_repo_pr_pk",
+          "columns": [
+            "repo",
+            "pr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_pr_check_config_versions": {
+      "name": "pre_pr_check_config_versions",
+      "schema": "",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library": {
+      "name": "prompt_library",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "prompt_library_name_active_idx": {
+          "name": "prompt_library_name_active_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prompt_library_slug_active_idx": {
+          "name": "prompt_library_slug_active_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prompt_library\".\"archived_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prompt_library_versions": {
+      "name": "prompt_library_versions",
+      "schema": "",
+      "columns": {
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slots": {
+          "name": "slots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_label": {
+          "name": "created_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restored_from_version": {
+          "name": "restored_from_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_library_versions_prompt_id_prompt_library_id_fk": {
+          "name": "prompt_library_versions_prompt_id_prompt_library_id_fk",
+          "tableFrom": "prompt_library_versions",
+          "tableTo": "prompt_library",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prompt_library_versions_prompt_id_version_pk": {
+          "name": "prompt_library_versions_prompt_id_version_pk",
+          "columns": [
+            "prompt_id",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_block_attempts": {
+      "name": "workflow_block_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope_id": {
+          "name": "activation_scope_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_transition": {
+          "name": "selected_transition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_envelope": {
+          "name": "input_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_envelope": {
+          "name": "output_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_envelope": {
+          "name": "log_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_envelope": {
+          "name": "metadata_envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observation_revision": {
+          "name": "observation_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_block_attempts_identity_unique": {
+          "name": "workflow_block_attempts_identity_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_run_id_idx": {
+          "name": "workflow_block_attempts_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_block_attempts_org_run_idx": {
+          "name": "workflow_block_attempts_org_run_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_block_attempts_run_org_fk": {
+          "name": "workflow_block_attempts_run_org_fk",
+          "tableFrom": "workflow_block_attempts",
+          "tableTo": "workflow_run_observations",
+          "columnsFrom": [
+            "run_id",
+            "organization_id"
+          ],
+          "columnsTo": [
+            "run_id",
+            "organization_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_block_attempts_attempt_check": {
+          "name": "workflow_block_attempts_attempt_check",
+          "value": "\"workflow_block_attempts\".\"attempt\" > 0"
+        },
+        "workflow_block_attempts_observation_revision_check": {
+          "name": "workflow_block_attempts_observation_revision_check",
+          "value": "\"workflow_block_attempts\".\"observation_revision\" >= 0"
+        },
+        "workflow_block_attempts_state_check": {
+          "name": "workflow_block_attempts_state_check",
+          "value": "\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop', 'waiting_for_clarification', 'completed', 'failed', 'cancelled', 'skipped')"
+        },
+        "workflow_block_attempts_duration_check": {
+          "name": "workflow_block_attempts_duration_check",
+          "value": "\"workflow_block_attempts\".\"duration_ms\" is null or \"workflow_block_attempts\".\"duration_ms\" >= 0"
+        },
+        "workflow_block_attempts_completion_check": {
+          "name": "workflow_block_attempts_completion_check",
+          "value": "(\"workflow_block_attempts\".\"state\" in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is null) or (\"workflow_block_attempts\".\"state\" not in ('running', 'waiting_loop') and \"workflow_block_attempts\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_owned_branches": {
+      "name": "workflow_owned_branches",
+      "schema": "",
+      "columns": {
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_id": {
+          "name": "pr_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_branch_name": {
+          "name": "pr_branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_head_sha": {
+          "name": "published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_branch": {
+          "name": "target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_published_head_sha": {
+          "name": "pr_published_head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_target_branch": {
+          "name": "pr_target_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_correlation_pending": {
+          "name": "pr_correlation_pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workflow_owned_branches_ticket_key_provider_repo_path_pk": {
+          "name": "workflow_owned_branches_ticket_key_provider_repo_path_pk",
+          "columns": [
+            "ticket_key",
+            "provider",
+            "repo_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_owned_branches_provider_check": {
+          "name": "workflow_owned_branches_provider_check",
+          "value": "\"workflow_owned_branches\".\"provider\" in ('github', 'gitlab')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publication_comments": {
+      "name": "workflow_pr_review_publication_comments",
+      "schema": "",
+      "columns": {
+        "publication_id": {
+          "name": "publication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_workflow_pr_review_publications_id_fk",
+          "tableFrom": "workflow_pr_review_publication_comments",
+          "tableTo": "workflow_pr_review_publications",
+          "columnsFrom": [
+            "publication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_pr_review_publication_comments_publication_id_content_hash_pk": {
+          "name": "workflow_pr_review_publication_comments_publication_id_content_hash_pk",
+          "columns": [
+            "publication_id",
+            "content_hash"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publication_comments_state_check": {
+          "name": "workflow_pr_review_publication_comments_state_check",
+          "value": "\"workflow_pr_review_publication_comments\".\"state\" in ('pending', 'published')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_pr_review_publications": {
+      "name": "workflow_pr_review_publications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_comment_count": {
+          "name": "inline_comment_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "summary_fallback_count": {
+          "name": "summary_fallback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_pr_review_publications_content_unique": {
+          "name": "workflow_pr_review_publications_content_unique",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pr_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "head_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pr_review_publications_run_idx": {
+          "name": "workflow_pr_review_publications_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_pr_review_publications_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_pr_review_publications",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_pr_review_publications_state_check": {
+          "name": "workflow_pr_review_publications_state_check",
+          "value": "\"workflow_pr_review_publications\".\"state\" in ('pending', 'published')"
+        },
+        "workflow_pr_review_publications_decision_check": {
+          "name": "workflow_pr_review_publications_decision_check",
+          "value": "\"workflow_pr_review_publications\".\"decision\" in ('approve', 'request_changes')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_external_checks": {
+      "name": "workflow_run_external_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activation_scope": {
+          "name": "activation_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_sha": {
+          "name": "head_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "closure_intent": {
+          "name": "closure_intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_run_external_checks_attempt_unique": {
+          "name": "workflow_run_external_checks_attempt_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activation_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_reconcile_idx": {
+          "name": "workflow_run_external_checks_reconcile_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_external_checks_run_idx": {
+          "name": "workflow_run_external_checks_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_external_checks_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_external_checks_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_external_checks",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_external_checks_state_check": {
+          "name": "workflow_run_external_checks_state_check",
+          "value": "\"workflow_run_external_checks\".\"state\" in ('creating', 'pending', 'closing', 'completed')"
+        },
+        "workflow_run_external_checks_conclusion_check": {
+          "name": "workflow_run_external_checks_conclusion_check",
+          "value": "\"workflow_run_external_checks\".\"conclusion\" is null or \"workflow_run_external_checks\".\"conclusion\" in ('success', 'failure', 'neutral', 'cancelled', 'timed_out', 'superseded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_run_observations": {
+      "name": "workflow_run_observations",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_schema_version": {
+          "name": "definition_schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_manifest": {
+          "name": "runtime_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_status": {
+          "name": "capture_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflow_run_observations_org_captured_idx": {
+          "name": "workflow_run_observations_org_captured_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_run_observations_expires_at_idx": {
+          "name": "workflow_run_observations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_run_observations_run_id_workflow_runs_run_id_fk": {
+          "name": "workflow_run_observations_run_id_workflow_runs_run_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "run_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_organization_id_organization_id_fk": {
+          "name": "workflow_run_observations_organization_id_organization_id_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_run_observations_definition_version_fk": {
+          "name": "workflow_run_observations_definition_version_fk",
+          "tableFrom": "workflow_run_observations",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_run_observations_run_org_unique": {
+          "name": "workflow_run_observations_run_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "run_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflow_run_observations_schema_version_check": {
+          "name": "workflow_run_observations_schema_version_check",
+          "value": "\"workflow_run_observations\".\"definition_schema_version\" in (1, 2)"
+        },
+        "workflow_run_observations_capture_status_check": {
+          "name": "workflow_run_observations_capture_status_check",
+          "value": "\"workflow_run_observations\".\"capture_status\" in ('available', 'unavailable')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_title": {
+          "name": "ticket_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_url": {
+          "name": "ticket_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entry_started_at": {
+          "name": "entry_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startup_deadline_at": {
+          "name": "startup_deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnostic_id": {
+          "name": "diagnostic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_repo": {
+          "name": "pr_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prs": {
+          "name": "prs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(19, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_known": {
+          "name": "cost_known",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_input": {
+          "name": "tokens_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_cached": {
+          "name": "tokens_cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_output": {
+          "name": "tokens_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_report": {
+          "name": "analysis_report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_failure": {
+          "name": "budget_failure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_statuses": {
+          "name": "block_statuses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_manifest": {
+          "name": "prompt_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "harness_manifests": {
+          "name": "harness_manifests",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_organization_id": {
+          "name": "replay_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_captured_at": {
+          "name": "replay_captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_expires_at": {
+          "name": "replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replay_capture_failed_at": {
+          "name": "replay_capture_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_runs_status_idx": {
+          "name": "workflow_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_started_at_idx": {
+          "name": "workflow_runs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_subject_key_idx": {
+          "name": "workflow_runs_subject_key_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_ticket_key_idx": {
+          "name": "workflow_runs_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_definition_id_idx": {
+          "name": "workflow_runs_definition_id_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_startup_watchdog_idx": {
+          "name": "workflow_runs_startup_watchdog_idx",
+          "columns": [
+            {
+              "expression": "startup_deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflow_runs\".\"entry_started_at\" is null and coalesce(\"workflow_runs\".\"status\", 'running') not in ('success', 'failed', 'blocked', 'awaiting', 'completed', 'cancelled')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_replay_organization_id_organization_id_fk": {
+          "name": "workflow_runs_replay_organization_id_organization_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "replay_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_occurrences": {
+      "name": "schedule_occurrences",
+      "schema": "",
+      "columns": {
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrence_at": {
+          "name": "occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_count": {
+          "name": "dropped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dropped_count_capped": {
+          "name": "dropped_count_capped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blocking_run_id": {
+          "name": "blocking_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedule_occurrences_one_pending_per_schedule_idx": {
+          "name": "schedule_occurrences_one_pending_per_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"schedule_occurrences\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedule_occurrences_run_id_idx": {
+          "name": "schedule_occurrences_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedule_occurrences_schedule_id_workflow_schedules_id_fk": {
+          "name": "schedule_occurrences_schedule_id_workflow_schedules_id_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_occurrences_definition_version_fk": {
+          "name": "schedule_occurrences_definition_version_fk",
+          "tableFrom": "schedule_occurrences",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedule_occurrences_schedule_id_occurrence_at_pk": {
+          "name": "schedule_occurrences_schedule_id_occurrence_at_pk",
+          "columns": [
+            "schedule_id",
+            "occurrence_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedule_occurrences_outcome_check": {
+          "name": "schedule_occurrences_outcome_check",
+          "value": "\"schedule_occurrences\".\"outcome\" is null or \"schedule_occurrences\".\"outcome\" in ('started', 'skipped_overlap', 'skipped_stale', 'superseded', 'expired', 'cancelled', 'run_cancelled', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "overlap_policy": {
+          "name": "overlap_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "catch_up_grace_minutes": {
+          "name": "catch_up_grace_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evaluation_watermark_at": {
+          "name": "evaluation_watermark_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_occurrence_at": {
+          "name": "last_started_occurrence_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_started_run_id": {
+          "name": "last_started_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_schedules_definition_node_idx": {
+          "name": "workflow_schedules_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_definition_id_workflow_definitions_id_fk": {
+          "name": "workflow_schedules_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_schedules_overlap_policy_check": {
+          "name": "workflow_schedules_overlap_policy_check",
+          "value": "\"workflow_schedules\".\"overlap_policy\" in ('skip', 'queue', 'allow')"
+        },
+        "workflow_schedules_catch_up_grace_check": {
+          "name": "workflow_schedules_catch_up_grace_check",
+          "value": "\"workflow_schedules\".\"catch_up_grace_minutes\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings_versions": {
+      "name": "settings_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "settings_versions_key_id_idx": {
+          "name": "settings_versions_key_id_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.env_marker": {
+      "name": "env_marker",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_health_observation_counters": {
+      "name": "system_health_observation_counters",
+      "schema": "",
+      "columns": {
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deployment'"
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "system_health_observation_counters_pk": {
+          "name": "system_health_observation_counters_pk",
+          "columns": [
+            "integration_id",
+            "check_id",
+            "scope",
+            "window_start",
+            "outcome",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_health_scans": {
+      "name": "system_health_scans",
+      "schema": "",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'deployment'"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report": {
+          "name": "report",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_autofix_attempts": {
+      "name": "pr_autofix_attempts",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_path": {
+          "name": "repo_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_autofix_attempts_pk": {
+          "name": "pr_autofix_attempts_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "provider",
+            "repo_path",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_rate_limits": {
+      "name": "trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_kind": {
+          "name": "window_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trigger_rate_limits_pk": {
+          "name": "trigger_rate_limits_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "window_kind",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_rejection_counters": {
+      "name": "trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "definition_id": {
+          "name": "definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "trigger_rejection_counters_definition_id_node_id_day_reason_pk": {
+          "name": "trigger_rejection_counters_definition_id_node_id_day_reason_pk",
+          "columns": [
+            "definition_id",
+            "node_id",
+            "day",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_deliveries": {
+      "name": "webhook_trigger_deliveries",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending": {
+          "name": "pending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_deliveries_one_pending_per_subject_idx": {
+          "name": "webhook_trigger_deliveries_one_pending_per_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_trigger_deliveries\".\"pending\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_trigger_deliveries_definition_version_fk": {
+          "name": "webhook_trigger_deliveries_definition_version_fk",
+          "tableFrom": "webhook_trigger_deliveries",
+          "tableTo": "workflow_definition_versions",
+          "columnsFrom": [
+            "definition_id",
+            "definition_version"
+          ],
+          "columnsTo": [
+            "definition_id",
+            "version"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_deliveries_endpoint_id_delivery_id_pk": {
+          "name": "webhook_trigger_deliveries_endpoint_id_delivery_id_pk",
+          "columns": [
+            "endpoint_id",
+            "delivery_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_endpoints": {
+      "name": "webhook_trigger_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_scheme": {
+          "name": "auth_scheme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hmac_sha256'"
+        },
+        "header_name": {
+          "name": "header_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_timestamp": {
+          "name": "require_timestamp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timestamp_header": {
+          "name": "timestamp_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp_tolerance_seconds": {
+          "name": "timestamp_tolerance_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_secret_ciphertext": {
+          "name": "previous_secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_expires_at": {
+          "name": "previous_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_trigger_endpoints_definition_node_idx": {
+          "name": "webhook_trigger_endpoints_definition_node_idx",
+          "columns": [
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk": {
+          "name": "webhook_trigger_endpoints_definition_id_workflow_definitions_id_fk",
+          "tableFrom": "webhook_trigger_endpoints",
+          "tableTo": "workflow_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhook_trigger_endpoints_auth_scheme_check": {
+          "name": "webhook_trigger_endpoints_auth_scheme_check",
+          "value": "\"webhook_trigger_endpoints\".\"auth_scheme\" in ('hmac_sha256', 'shared_token')"
+        },
+        "webhook_trigger_endpoints_timestamp_tolerance_check": {
+          "name": "webhook_trigger_endpoints_timestamp_tolerance_check",
+          "value": "\"webhook_trigger_endpoints\".\"timestamp_tolerance_seconds\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rate_limits": {
+      "name": "webhook_trigger_rate_limits",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inbox'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_webhook_trigger_endpoints_id_fk",
+          "tableFrom": "webhook_trigger_rate_limits",
+          "tableTo": "webhook_trigger_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk": {
+          "name": "webhook_trigger_rate_limits_endpoint_id_window_start_kind_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_trigger_rejection_counters": {
+      "name": "webhook_trigger_rejection_counters",
+      "schema": "",
+      "columns": {
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk": {
+          "name": "webhook_trigger_rejection_counters_endpoint_id_window_start_reason_pk",
+          "columns": [
+            "endpoint_id",
+            "window_start",
+            "reason"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "account_provider_id_account_id_unique": {
+          "name": "account_provider_id_account_id_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_inviter_id_idx": {
+          "name": "invitation_inviter_id_idx",
+          "columns": [
+            {
+              "expression": "inviter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_organization_id_user_id_unique": {
+          "name": "member_organization_id_user_id_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_expires_at_idx": {
+          "name": "oauth_access_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_expires_at_idx": {
+          "name": "oauth_refresh_token_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "session_active_organization_id_organization_id_fk": {
+          "name": "session_active_organization_id_organization_id_fk",
+          "tableFrom": "session",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_verified": {
+          "name": "domain_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "sso_provider_user_id_idx": {
+          "name": "sso_provider_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sso_provider_organization_id_idx": {
+          "name": "sso_provider_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_provider_organization_id_organization_id_fk": {
+          "name": "sso_provider_organization_id_organization_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_lower_unique": {
+          "name": "user_email_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assumptions": {
+          "name": "assumptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_scope": {
+          "name": "repository_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workflow'"
+        },
+        "decided_by_id": {
+          "name": "decided_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by_label": {
+          "name": "decided_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_run_id": {
+          "name": "dispatched_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_ticket_key_idx": {
+          "name": "approval_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_ticket_idx": {
+          "name": "approval_requests_pending_ticket_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clarification_requests": {
+      "name": "clarification_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_answers": {
+          "name": "suggested_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "hook_token": {
+          "name": "hook_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_id": {
+          "name": "answered_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_by_label": {
+          "name": "answered_by_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_sandbox_id": {
+          "name": "source_sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_expires_at": {
+          "name": "snapshot_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_state": {
+          "name": "cleanup_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cleanup_error": {
+          "name": "cleanup_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resume_attempts": {
+          "name": "resume_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "clarification_requests_status_idx": {
+          "name": "clarification_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_ticket_key_idx": {
+          "name": "clarification_requests_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_run_id_idx": {
+          "name": "clarification_requests_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_expiry_idx": {
+          "name": "clarification_requests_expiry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_hook_token_idx": {
+          "name": "clarification_requests_hook_token_idx",
+          "columns": [
+            {
+              "expression": "hook_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clarification_requests_pending_subject_idx": {
+          "name": "clarification_requests_pending_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clarification_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_email_delivery": {
+      "name": "invite_email_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invite_email_delivery_invitation_id_idx": {
+          "name": "invite_email_delivery_invitation_id_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invite_email_delivery_invitation_id_invitation_id_fk": {
+          "name": "invite_email_delivery_invitation_id_invitation_id_fk",
+          "tableFrom": "invite_email_delivery",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_email_delivery_resend_email_id_unique": {
+          "name": "invite_email_delivery_resend_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "resend_email_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_memory_documents": {
+      "name": "agent_memory_documents",
+      "schema": "",
+      "columns": {
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "doc_path": {
+          "name": "doc_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_key": {
+          "name": "ticket_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_run_id": {
+          "name": "source_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_memory_documents_ticket_key_idx": {
+          "name": "agent_memory_documents_ticket_key_idx",
+          "columns": [
+            {
+              "expression": "ticket_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_documents_updated_at_idx": {
+          "name": "agent_memory_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_memory_documents_subject_key_doc_path_pk": {
+          "name": "agent_memory_documents_subject_key_doc_path_pk",
+          "columns": [
+            "subject_key",
+            "doc_path"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/worker/drizzle/meta/_journal.json
+++ b/apps/worker/drizzle/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1788978192502,
       "tag": "0058_odd_darkstar",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1789194356937,
+      "tag": "0059_settings_store",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "rm -rf .nitro/workflow && nitro dev",
-    "build": "pnpm validate:pre-sandbox && pnpm validate:local-skills && pnpm db:migrate && pnpm seed:auth-user && pnpm --dir ../.. run gen:blocks -- --check && rm -rf .nitro/workflow && NODE_OPTIONS=--max-old-space-size=8192 nitro build",
+    "build": "pnpm validate:pre-sandbox && pnpm validate:local-skills && pnpm db:migrate && pnpm db:seed-settings && pnpm seed:auth-user && pnpm --dir ../.. run gen:blocks -- --check && rm -rf .nitro/workflow && NODE_OPTIONS=--max-old-space-size=8192 nitro build",
     "build:ci": "pnpm validate:pre-sandbox && pnpm validate:local-skills && pnpm mcp:contract:check && pnpm --dir ../.. run gen:blocks -- --check && rm -rf .nitro/workflow && NODE_OPTIONS=--max-old-space-size=8192 nitro build",
     "preview": "nitro preview",
     "test": "vitest run",
@@ -34,6 +34,7 @@
     "test:e2e:replay:dry": "vitest run src/preview-harness-canary.test.ts src/preview-replay-canary.test.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx scripts/db-migrate.ts",
+    "db:seed-settings": "tsx scripts/db-seed-settings.ts",
     "seed:auth-user": "tsx scripts/seed-auth-user.ts"
   },
   "dependencies": {

--- a/apps/worker/scripts/db-seed-settings.ts
+++ b/apps/worker/scripts/db-seed-settings.ts
@@ -1,0 +1,37 @@
+/**
+ * Build-time settings seeder. Runs right after `db:migrate` in `pnpm build`,
+ * where Vercel exposes the deployment's environment to the build step, so the
+ * Settings page shows what this deployment is actually configured with instead
+ * of an empty form the operator has to fill in from memory.
+ *
+ * Idempotent by construction: one insert that does nothing on conflict, so a
+ * redeploy never overwrites a decision an operator made in the dashboard, and
+ * a key whose variable is unset gets no row at all and keeps resolving through
+ * the registry default.
+ *
+ * Locally (no DATABASE_URL) this is a warn-and-skip no-op, the same as
+ * `db:migrate`, so `pnpm build` still works without a database. The imports
+ * are dynamic for the same reason the auth seeder's are: reaching the settings
+ * module validates the whole environment, which a machine with no database
+ * configured cannot satisfy.
+ */
+import { config } from "dotenv";
+
+config({ path: [".env.local", ".env"], quiet: true });
+
+if (!process.env.DATABASE_URL) {
+  console.warn("[db-seed-settings] DATABASE_URL not set, skipping settings seed.");
+  process.exit(0);
+}
+
+const { getDb } = await import("../src/db/client.js");
+const { seedSettings } = await import("../src/db/repositories/settings.js");
+const { settingsSeedRows } = await import("../src/services/settings/index.js");
+
+const rows = settingsSeedRows();
+const created = await seedSettings(getDb(), { rows, actor: "environment" });
+console.log(
+  `[db-seed-settings] ${rows.length} configured ${
+    rows.length === 1 ? "setting" : "settings"
+  }, ${created} newly stored.`,
+);

--- a/apps/worker/src/db/repositories/settings.test.ts
+++ b/apps/worker/src/db/repositories/settings.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Db } from "../client.js";
+import { settings, settingsVersions } from "../schema.js";
+import { createTestDb } from "../test-db.js";
+import {
+  latestSettingsVersions,
+  listSettingsVersions,
+  readAllSettings,
+  seedSettings,
+  writeManySettings,
+} from "./settings.js";
+
+/**
+ * Counts the write surface a call reaches for. Production is neon-http, which
+ * cannot open an interactive transaction, so a settings write and its version
+ * row have to leave as one statement or a crash between them leaves a changed
+ * setting nobody can explain.
+ */
+function countWrites(db: Db) {
+  return {
+    execute: vi.spyOn(db, "execute"),
+    insert: vi.spyOn(db, "insert"),
+    update: vi.spyOn(db, "update"),
+    delete: vi.spyOn(db, "delete"),
+  };
+}
+
+describe("settings repository", () => {
+  it("writes the setting rows and their version rows in one statement", async () => {
+    const db = await createTestDb();
+    const writes = countWrites(db);
+
+    const versions = await writeManySettings(db, {
+      patch: { MAX_CONCURRENT_AGENTS: 5, MCP_ENABLED: true },
+      actor: "user_admin",
+      reason: "raising capacity",
+    });
+
+    expect(writes.execute).toHaveBeenCalledTimes(1);
+    expect(writes.insert).not.toHaveBeenCalled();
+    expect(writes.update).not.toHaveBeenCalled();
+    expect(writes.delete).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+
+    expect(versions.map((row) => row.key)).toEqual([
+      "MAX_CONCURRENT_AGENTS",
+      "MCP_ENABLED",
+    ]);
+    expect(versions[0]).toMatchObject({
+      key: "MAX_CONCURRENT_AGENTS",
+      previousValue: null,
+      newValue: 5,
+      actor: "user_admin",
+      reason: "raising capacity",
+    });
+    expect(versions[0]?.createdAt).toBeInstanceOf(Date);
+
+    const rows = await readAllSettings(db);
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.key === "MCP_ENABLED")).toMatchObject({
+      value: true,
+      updatedBy: "user_admin",
+    });
+  });
+
+  it("records the previous value when a stored setting changes", async () => {
+    const db = await createTestDb();
+    await writeManySettings(db, {
+      patch: { COLUMN_AI: "AI" },
+      actor: "user_admin",
+      reason: "first",
+    });
+    const versions = await writeManySettings(db, {
+      patch: { COLUMN_AI: "Agent" },
+      actor: "user_owner",
+      reason: "renamed the column",
+    });
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0]).toMatchObject({
+      key: "COLUMN_AI",
+      previousValue: "AI",
+      newValue: "Agent",
+      actor: "user_owner",
+    });
+    const stored = await readAllSettings(db);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({ value: "Agent", updatedBy: "user_owner" });
+  });
+
+  it("creates no version row for a second identical write", async () => {
+    const db = await createTestDb();
+    await writeManySettings(db, {
+      patch: { MAX_CONCURRENT_AGENTS: 5, COLUMN_AI: "AI" },
+      actor: "user_admin",
+      reason: "first",
+    });
+
+    const versions = await writeManySettings(db, {
+      patch: { MAX_CONCURRENT_AGENTS: 5, COLUMN_AI: "Agent" },
+      actor: "user_admin",
+      reason: "second",
+    });
+
+    expect(versions.map((row) => row.key)).toEqual(["COLUMN_AI"]);
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(3);
+  });
+
+  it("stores a cleared optional setting as a row rather than dropping it", async () => {
+    const db = await createTestDb();
+    const versions = await writeManySettings(db, {
+      patch: { CLAUDE_MODEL: null },
+      actor: "user_admin",
+      reason: "back to the harness default",
+    });
+
+    expect(versions).toHaveLength(1);
+    expect(versions[0]?.newValue).toBeNull();
+    const rows = await readAllSettings(db);
+    expect(rows).toEqual([
+      expect.objectContaining({ key: "CLAUDE_MODEL", value: null }),
+    ]);
+  });
+
+  it("keeps a list setting as a list", async () => {
+    const db = await createTestDb();
+    await writeManySettings(db, {
+      patch: { PRE_PR_CHECKS_ALLOWED_ENV: ["NPM_TOKEN", "ARTHUR_TOKEN"] },
+      actor: "user_admin",
+      reason: "forwarding the registry token",
+    });
+    const rows = await readAllSettings(db);
+    expect(rows[0]?.value).toEqual(["NPM_TOKEN", "ARTHUR_TOKEN"]);
+  });
+
+  it("lists one key's versions newest first and the newest row per key", async () => {
+    const db = await createTestDb();
+    await writeManySettings(db, {
+      patch: { COLUMN_AI: "AI", MCP_ENABLED: true },
+      actor: "user_admin",
+      reason: "first",
+    });
+    await writeManySettings(db, {
+      patch: { COLUMN_AI: "Agent" },
+      actor: "user_admin",
+      reason: "second",
+    });
+    await writeManySettings(db, {
+      patch: { COLUMN_AI: "Robot" },
+      actor: "user_admin",
+      reason: "third",
+    });
+
+    const history = await listSettingsVersions(db, "COLUMN_AI", 2);
+    expect(history.map((row) => row.newValue)).toEqual(["Robot", "Agent"]);
+
+    const latest = await latestSettingsVersions(db);
+    expect(
+      latest.map((row) => [row.key, row.newValue, row.reason]),
+    ).toEqual([
+      ["COLUMN_AI", "Robot", "third"],
+      ["MCP_ENABLED", true, "first"],
+    ]);
+  });
+
+  it("seeds one row per given key in one statement and never overwrites", async () => {
+    const db = await createTestDb();
+    await writeManySettings(db, {
+      patch: { COLUMN_AI: "Agent" },
+      actor: "user_admin",
+      reason: "operator decided",
+    });
+
+    const writes = countWrites(db);
+    const seeded = await seedSettings(db, {
+      rows: [
+        { key: "COLUMN_AI", value: "AI" },
+        { key: "MAX_CONCURRENT_AGENTS", value: 4 },
+      ],
+      actor: "environment",
+    });
+    expect(writes.execute).toHaveBeenCalledTimes(1);
+    expect(writes.insert).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+    expect(seeded).toBe(1);
+
+    const again = await seedSettings(db, {
+      rows: [
+        { key: "COLUMN_AI", value: "AI" },
+        { key: "MAX_CONCURRENT_AGENTS", value: 4 },
+      ],
+      actor: "environment",
+    });
+    expect(again).toBe(0);
+
+    const rows = await readAllSettings(db);
+    expect(rows.map((row) => [row.key, row.value]).sort()).toEqual([
+      ["COLUMN_AI", "Agent"],
+      ["MAX_CONCURRENT_AGENTS", 4],
+    ]);
+    // Seeding is not an operator decision, so it records no history.
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(1);
+  });
+
+  it("writes nothing when the patch is empty", async () => {
+    const db = await createTestDb();
+    await expect(
+      writeManySettings(db, { patch: {}, actor: "user_admin", reason: "nothing" }),
+    ).resolves.toEqual([]);
+    await expect(db.select().from(settings)).resolves.toHaveLength(0);
+    await expect(
+      seedSettings(db, { rows: [], actor: "environment" }),
+    ).resolves.toBe(0);
+  });
+});

--- a/apps/worker/src/db/repositories/settings.ts
+++ b/apps/worker/src/db/repositories/settings.ts
@@ -1,0 +1,230 @@
+import { desc, eq, sql } from "drizzle-orm";
+import type { SettingValue } from "@shared/contracts";
+import { getDb, type Db } from "../client.js";
+import { settings, settingsVersions } from "../schema.js";
+
+/** One stored decision, exactly as the table holds it. */
+export interface SettingRow {
+  key: string;
+  value: SettingValue;
+  updatedAt: Date;
+  updatedBy: string;
+}
+
+/** One recorded change. */
+export interface SettingsVersionRow {
+  id: number;
+  key: string;
+  previousValue: SettingValue;
+  newValue: SettingValue;
+  actor: string;
+  reason: string;
+  createdAt: Date;
+}
+
+type ExecuteRows<T> = { rows: T[] };
+
+type RawVersionRow = {
+  id: number | string;
+  key: string;
+  previousValue: SettingValue;
+  newValue: SettingValue;
+  actor: string;
+  reason: string;
+  createdAt: string | Date;
+};
+
+/**
+ * Raw `execute` gives back whatever the driver decided: neon-http hands
+ * timestamps over as strings and identity columns as numbers or strings
+ * depending on the type, while pglite parses both. Normalizing here keeps the
+ * difference from reaching a caller that only ever ran against one of them.
+ */
+function toVersionRow(row: RawVersionRow): SettingsVersionRow {
+  return {
+    id: Number(row.id),
+    key: row.key,
+    previousValue: row.previousValue ?? null,
+    newValue: row.newValue,
+    actor: row.actor,
+    reason: row.reason,
+    createdAt: new Date(row.createdAt),
+  };
+}
+
+/** Every stored setting. Absence of a key is meaningful, so nothing is filled in here. */
+export async function readAllSettings(db: Db): Promise<SettingRow[]> {
+  const rows = await db.select().from(settings);
+  return rows.map((row) => ({
+    key: row.key,
+    value: row.value,
+    updatedAt: row.updatedAt,
+    updatedBy: row.updatedBy,
+  }));
+}
+
+/**
+ * Apply a patch and record what it changed, in one statement.
+ *
+ * Production uses neon-http and cannot open an interactive transaction, so the
+ * settings rows and their version rows travel as one data-modifying CTE: a
+ * crash can leave both written or neither, never a changed setting with no
+ * record of who changed it.
+ *
+ * The values ride as JSON text rather than as jsonb fields because
+ * `jsonb_to_recordset` turns a JSON null into SQL NULL, which would refuse the
+ * not-null column instead of storing "this setting is deliberately cleared".
+ *
+ * A key whose stored value already equals the new one is skipped by the
+ * conflict clause, so the history holds decisions rather than form
+ * submissions, and a key with no row yet is always recorded even when its
+ * value matches what the environment was already resolving to: the decision
+ * being recorded is "this is now stored", not "this number changed".
+ */
+export async function writeManySettings(
+  db: Db,
+  input: {
+    patch: Readonly<Record<string, SettingValue>>;
+    actor: string;
+    reason: string;
+  },
+): Promise<SettingsVersionRow[]> {
+  const entries = Object.entries(input.patch).map(([key, value]) => ({
+    key,
+    value: JSON.stringify(value ?? null),
+  }));
+  if (entries.length === 0) return [];
+
+  const result = (await db.execute(sql`
+    with input as (
+      select entry.key, entry.value::jsonb as value
+      from jsonb_to_recordset(${JSON.stringify(entries)}::jsonb)
+        as entry(key text, value text)
+    ), previous as (
+      select ${settings.key} as key, ${settings.value} as value
+      from ${settings}
+      where ${settings.key} in (select key from input)
+    ), written as (
+      insert into ${settings} (key, value, updated_at, updated_by)
+      select input.key, input.value, now(), ${input.actor} from input
+      on conflict (key) do update
+        set value = excluded.value,
+            updated_at = excluded.updated_at,
+            updated_by = excluded.updated_by
+        where ${settings}.value is distinct from excluded.value
+      returning key, value
+    ), recorded as (
+      insert into ${settingsVersions} (key, previous_value, new_value, actor, reason)
+      select written.key, previous.value, written.value, ${input.actor}, ${input.reason}
+      from written left join previous on previous.key = written.key
+      returning id, key, previous_value, new_value, actor, reason, created_at
+    )
+    select
+      id,
+      key,
+      previous_value as "previousValue",
+      new_value as "newValue",
+      actor,
+      reason,
+      created_at as "createdAt"
+    from recorded
+    order by key
+  `)) as ExecuteRows<RawVersionRow>;
+  return result.rows.map(toVersionRow);
+}
+
+/**
+ * Insert the deployment's environment values for keys nobody has decided yet.
+ *
+ * One multi-row statement that does nothing on conflict, so an operator's
+ * stored decision is never overwritten by a redeploy, and running it twice
+ * leaves the same rows. It writes no version rows: the environment is not an
+ * actor making a decision, it is the value the deployment already had.
+ * Returns how many rows it actually created.
+ */
+export async function seedSettings(
+  db: Db,
+  input: {
+    rows: ReadonlyArray<{ key: string; value: SettingValue }>;
+    actor: string;
+  },
+): Promise<number> {
+  const entries = input.rows.map((row) => ({
+    key: row.key,
+    value: JSON.stringify(row.value ?? null),
+  }));
+  if (entries.length === 0) return 0;
+
+  const result = (await db.execute(sql`
+    insert into ${settings} (key, value, updated_at, updated_by)
+    select entry.key, entry.value::jsonb, now(), ${input.actor}
+    from jsonb_to_recordset(${JSON.stringify(entries)}::jsonb)
+      as entry(key text, value text)
+    on conflict (key) do nothing
+    returning key
+  `)) as ExecuteRows<{ key: string }>;
+  return result.rows.length;
+}
+
+/** One key's history, newest first. */
+export async function listSettingsVersions(
+  db: Db,
+  key: string,
+  limit: number,
+): Promise<SettingsVersionRow[]> {
+  const rows = await db
+    .select()
+    .from(settingsVersions)
+    .where(eq(settingsVersions.key, key))
+    .orderBy(desc(settingsVersions.id))
+    .limit(limit);
+  return rows.map(toVersionRow);
+}
+
+/**
+ * The newest version row of every key that has one.
+ *
+ * `distinct on` rather than one query per key: the read response names the
+ * last change of every setting, and a deployment with thirty-seven of them
+ * should not pay thirty-seven round trips for it.
+ */
+export async function latestSettingsVersions(db: Db): Promise<SettingsVersionRow[]> {
+  const result = (await db.execute(sql`
+    select distinct on (key)
+      id,
+      key,
+      previous_value as "previousValue",
+      new_value as "newValue",
+      actor,
+      reason,
+      created_at as "createdAt"
+    from ${settingsVersions}
+    order by key, id desc
+  `)) as ExecuteRows<RawVersionRow>;
+  return result.rows.map(toVersionRow);
+}
+
+/** Every stored setting, on the deployment's own connection. */
+export function readAllConnectedSettings(): Promise<SettingRow[]> {
+  return readAllSettings(getDb());
+}
+
+/** Apply a patch on the deployment's own connection. */
+export function writeManyConnectedSettings(
+  input: Parameters<typeof writeManySettings>[1],
+): Promise<SettingsVersionRow[]> {
+  return writeManySettings(getDb(), input);
+}
+
+/** One key's history, on the deployment's own connection. */
+export function listConnectedSettingsVersions(
+  key: string,
+  limit: number,
+): Promise<SettingsVersionRow[]> {
+  return listSettingsVersions(getDb(), key, limit);
+}
+
+/** The newest change per key, on the deployment's own connection. */
+export function latestConnectedSettingsVersions(): Promise<SettingsVersionRow[]> {
+  return latestSettingsVersions(getDb());
+}

--- a/apps/worker/src/db/schema.test.ts
+++ b/apps/worker/src/db/schema.test.ts
@@ -15,7 +15,8 @@ const SQL_TABLES = [
   "mcp_idempotency_keys", "mcp_rate_limit_windows", "member", "oauth_access_token",
   "oauth_client", "oauth_consent", "oauth_refresh_token", "organization",
   "pre_pr_check_config_versions", "pr_autofix_attempts", "prompt_library",
-  "prompt_library_versions", "schedule_occurrences", "session", "sso_provider",
+  "prompt_library_versions", "schedule_occurrences", "session", "settings",
+  "settings_versions", "sso_provider",
   "system_health_observation_counters", "system_health_scans", "thread_parents",
   "trigger_deliveries", "trigger_rate_limits", "trigger_rejection_counters", "user",
   "verification", "webhook_trigger_deliveries", "webhook_trigger_endpoints",
@@ -28,12 +29,12 @@ const SQL_TABLES = [
 ] as const;
 
 describe("schema barrel", () => {
-  it("exports the literal 62-table schema exactly once", () => {
+  it("exports the literal 64-table schema exactly once", () => {
     const names = Object.values(schema)
       .filter((value) => is(value, PgTable))
       .map((table) => getTableName(table as PgTable))
       .sort();
     expect(names).toEqual([...SQL_TABLES].sort());
-    expect(new Set(names).size).toBe(62);
+    expect(new Set(names).size).toBe(64);
   });
 });

--- a/apps/worker/src/db/schema.ts
+++ b/apps/worker/src/db/schema.ts
@@ -9,6 +9,7 @@ export * from "./schema/pre-pr.js";
 export * from "./schema/prompts.js";
 export * from "./schema/runs.js";
 export * from "./schema/schedules.js";
+export * from "./schema/settings.js";
 export * from "./schema/system.js";
 export * from "./schema/triggers.js";
 export * from "./schema/webhooks.js";

--- a/apps/worker/src/db/schema/settings.ts
+++ b/apps/worker/src/db/schema/settings.ts
@@ -1,0 +1,44 @@
+import { index, jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import type { SettingValue } from "@shared/contracts";
+
+/**
+ * One row per setting an operator has actually decided.
+ *
+ * Absence is meaningful: a key with no row resolves from the environment and
+ * then from the registry default, which is what keeps a deployment that has
+ * never opened the Settings page behaving exactly as it did before this table
+ * existed. The value is jsonb rather than text so a boolean, an integer, a
+ * string and a list of strings round-trip as themselves.
+ *
+ * The column is nullable only in the SQL sense that a caller could write SQL
+ * NULL; the writer always sends a jsonb value, so a cleared optional setting
+ * is stored as the jsonb literal `null` and still counts as a stored row.
+ */
+export const settings = pgTable("settings", {
+  key: text("key").primaryKey(),
+  value: jsonb("value").$type<SettingValue>().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedBy: text("updated_by").notNull(),
+});
+
+/**
+ * Append-only log of every settings change, with who made it and why.
+ *
+ * `previousValue` is SQL NULL when the key had no row at all, and the jsonb
+ * literal `null` when the key was stored as cleared. Both read back as null in
+ * JavaScript, which is the one thing the history view cannot tell apart and
+ * does not need to.
+ */
+export const settingsVersions = pgTable(
+  "settings_versions",
+  {
+    id: serial("id").primaryKey(),
+    key: text("key").notNull(),
+    previousValue: jsonb("previous_value").$type<SettingValue>(),
+    newValue: jsonb("new_value").$type<SettingValue>().notNull(),
+    actor: text("actor").notNull(),
+    reason: text("reason").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("settings_versions_key_id_idx").on(table.key, table.id)],
+);

--- a/apps/worker/src/routes/api/v1/settings.get.ts
+++ b/apps/worker/src/routes/api/v1/settings.get.ts
@@ -1,0 +1,32 @@
+import { createError, defineEventHandler, getQuery } from "h3";
+import type { SettingsReadResponse, SettingsVersionsResponse } from "@shared/contracts";
+import {
+  requireDashboardActor,
+  toHttpError,
+} from "../../../services/auth/request-context.js";
+import {
+  SettingsValidationError,
+  readSettings,
+  readSettingsHistory,
+} from "../../../services/settings/index.js";
+
+/** Reading what the deployment is configured to do is open to every role:
+ *  a member who cannot change a limit still has to know which one is in force.
+ *  Without `key` the answer is every setting; with it, that key's history. */
+export default defineEventHandler(
+  async (event): Promise<SettingsReadResponse | SettingsVersionsResponse | undefined> => {
+    try {
+      await requireDashboardActor(event);
+      const key = getQuery(event).key;
+      if (typeof key === "string" && key.length > 0) {
+        return await readSettingsHistory(key);
+      }
+      return await readSettings();
+    } catch (error) {
+      if (error instanceof SettingsValidationError) {
+        throw createError({ statusCode: 400, statusMessage: error.message });
+      }
+      toHttpError(error);
+    }
+  },
+);

--- a/apps/worker/src/routes/api/v1/settings.patch.ts
+++ b/apps/worker/src/routes/api/v1/settings.patch.ts
@@ -1,0 +1,76 @@
+import { createError, defineEventHandler, readBody } from "h3";
+import type { SettingsPatchResponse } from "@shared/contracts";
+import {
+  findSettingDefinition,
+  parseRequestBody,
+  settingsPatchRequestSchema,
+} from "@shared/contracts";
+import {
+  requireDashboardActor,
+  toHttpError,
+} from "../../../services/auth/request-context.js";
+import { canEditSettings } from "../../../services/auth/roles.js";
+import {
+  SettingsValidationError,
+  updateSettings,
+} from "../../../services/settings/index.js";
+
+/**
+ * Which keys this route refuses even though the store can write them.
+ *
+ * Activating the repository catalog decides what the agent may touch at all,
+ * and the dialog that does it names every repository holding an active run
+ * claim that is not enabled, so the admin sees what the next dispatch stops
+ * selecting. A generic patch would flip the same flag with none of that shown,
+ * which is why the group is refused here rather than in the store: the
+ * activation route of the catalog stage writes it through the same repository.
+ */
+const NON_PATCHABLE_GROUP = "repositories";
+
+function refusedKeys(patch: Readonly<Record<string, unknown>>): string[] {
+  return Object.keys(patch).filter(
+    (key) => findSettingDefinition(key)?.group === NON_PATCHABLE_GROUP,
+  );
+}
+
+/** Changing a switch changes it for every run and every user of this
+ *  deployment, so it follows the owner/admin rule, and the reason travels with
+ *  the change: a behaviour change nobody can explain later is the thing the
+ *  version rows exist to prevent. */
+export default defineEventHandler(
+  async (event): Promise<SettingsPatchResponse | undefined> => {
+    try {
+      const actor = await requireDashboardActor(event);
+      if (!canEditSettings(actor.role)) {
+        throw createError({ statusCode: 403, statusMessage: "Forbidden" });
+      }
+      const parsed = parseRequestBody(
+        settingsPatchRequestSchema,
+        (await readBody(event).catch(() => null)) ?? {},
+      );
+      if (!parsed.ok) {
+        throw createError({ statusCode: 400, statusMessage: parsed.message });
+      }
+      const refused = refusedKeys(parsed.value.settings);
+      if (refused.length > 0) {
+        throw createError({
+          statusCode: 400,
+          statusMessage:
+            `Not editable here: ${refused.join(", ")}. ` +
+            "Activate the repository catalog from the Repositories page, " +
+            "which posts to /api/v1/repository-catalog/activate.",
+        });
+      }
+      return await updateSettings({
+        patch: parsed.value.settings,
+        actor: actor.userId,
+        reason: parsed.value.reason,
+      });
+    } catch (error) {
+      if (error instanceof SettingsValidationError) {
+        throw createError({ statusCode: 400, statusMessage: error.message });
+      }
+      toHttpError(error);
+    }
+  },
+);

--- a/apps/worker/src/routes/api/v1/settings.test.ts
+++ b/apps/worker/src/routes/api/v1/settings.test.ts
@@ -1,0 +1,273 @@
+import { createApp, toWebHandler } from "h3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SettingsEntryView } from "@shared/contracts";
+import type { Db } from "../../../db/client.js";
+import { member, organization, settings, settingsVersions, user } from "../../../db/schema.js";
+import { createTestDb } from "../../../db/test-db.js";
+
+const state = vi.hoisted(() => ({
+  db: undefined as unknown,
+  sessionUserId: "user_admin" as string | null,
+  env: {
+    DASHBOARD_ORG_SLUG: "ai-workflow",
+    DASHBOARD_ORG_NAME: "AI Workflow",
+    MAX_CONCURRENT_AGENTS: 3,
+    COLUMN_AI: "AI",
+    MCP_MAX_REQUEST_BYTES: 1_048_576,
+    MCP_MAX_RESULT_BYTES: 524_288,
+  } as Record<string, unknown>,
+}));
+
+vi.mock("../../../infra/vcs-config.js", () => ({ env: state.env }));
+vi.mock("../../../db/client.js", () => ({ getDb: () => state.db }));
+vi.mock("../../../services/auth/auth-instance.js", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(async () =>
+        state.sessionUserId
+          ? { user: { id: state.sessionUserId }, session: { id: "session_test" } }
+          : null,
+      ),
+    },
+  },
+}));
+
+const settingsGet = (await import("./settings.get.js")).default;
+const settingsPatch = (await import("./settings.patch.js")).default;
+
+let db: Db;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handlerFor(route: any) {
+  const app = createApp();
+  app.use("/", route);
+  return toWebHandler(app);
+}
+
+function get(query = ""): Promise<Response> {
+  return handlerFor(settingsGet)(new Request(`http://worker.test/${query}`));
+}
+
+function patch(body: unknown): Promise<Response> {
+  return handlerFor(settingsPatch)(
+    new Request("http://worker.test/", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+function entry(settings: SettingsEntryView[], key: string): SettingsEntryView {
+  const found = settings.find((candidate) => candidate.key === key);
+  if (!found) throw new Error(`no entry for ${key}`);
+  return found;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  state.sessionUserId = "user_admin";
+  db = await createTestDb();
+  state.db = db;
+  await db
+    .insert(organization)
+    .values({ id: "org_aiw", name: "AI Workflow", slug: "ai-workflow" });
+  await db
+    .insert(user)
+    .values({ id: "user_admin", name: "Admin", email: "admin@example.com", emailVerified: true });
+  await db
+    .insert(member)
+    .values({ id: "member_admin", organizationId: "org_aiw", userId: "user_admin", role: "admin" });
+  await db
+    .insert(user)
+    .values({ id: "user_member", name: "Member", email: "member@example.com", emailVerified: true });
+  await db.insert(member).values({
+    id: "member_member",
+    organizationId: "org_aiw",
+    userId: "user_member",
+    role: "member",
+  });
+  await db
+    .insert(user)
+    .values({ id: "user_owner", name: "Owner", email: "owner@example.com", emailVerified: true });
+  await db.insert(member).values({
+    id: "member_owner",
+    organizationId: "org_aiw",
+    userId: "user_owner",
+    role: "owner",
+  });
+});
+
+describe("GET /api/v1/settings", () => {
+  it("answers every registry key with its resolved value and source", async () => {
+    const res = await get();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.settings.length).toBeGreaterThan(30);
+    expect(entry(body.settings, "MAX_CONCURRENT_AGENTS")).toMatchObject({
+      value: 3,
+      default: 3,
+      source: "default",
+      group: "capacity",
+      appliesToRunsInFlight: "immediate",
+      lastVersion: null,
+    });
+    expect(entry(body.settings, "catalog.activated")).toMatchObject({
+      value: false,
+      group: "repositories",
+    });
+  });
+
+  it("is open to a member", async () => {
+    state.sessionUserId = "user_member";
+    const res = await get();
+    expect(res.status).toBe(200);
+  });
+
+  it("refuses a request without a session", async () => {
+    state.sessionUserId = null;
+    const res = await get();
+    expect(res.status).toBe(401);
+  });
+
+  it("answers one key's history and refuses a key that is not a setting", async () => {
+    await patch({ settings: { COLUMN_AI: "Agent" }, reason: "renamed the column" });
+
+    const res = await get("?key=COLUMN_AI");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.versions).toHaveLength(1);
+    expect(body.versions[0]).toMatchObject({
+      key: "COLUMN_AI",
+      previousValue: null,
+      newValue: "Agent",
+      actor: "user_admin",
+      reason: "renamed the column",
+    });
+    expect(typeof body.versions[0].createdAt).toBe("string");
+
+    const unknown = await get("?key=NOT_A_SETTING");
+    expect(unknown.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/v1/settings", () => {
+  it("stores the patch and answers with the updated settings and the versions", async () => {
+    const res = await patch({
+      settings: { MAX_CONCURRENT_AGENTS: 5, COLUMN_AI: "Agent" },
+      reason: "opening up",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(entry(body.settings, "MAX_CONCURRENT_AGENTS")).toMatchObject({
+      value: 5,
+      source: "stored",
+    });
+    expect(entry(body.settings, "MAX_CONCURRENT_AGENTS").lastVersion).toMatchObject({
+      newValue: 5,
+      reason: "opening up",
+    });
+    expect(body.versions.map((version: { key: string }) => version.key)).toEqual([
+      "COLUMN_AI",
+      "MAX_CONCURRENT_AGENTS",
+    ]);
+  });
+
+  it("refuses the repository catalog switch with 400 and writes nothing", async () => {
+    // Activation names the repositories that hold an active claim and are not
+    // enabled; a generic patch would flip the flag without showing any of it.
+    const res = await patch({
+      settings: { MAX_CONCURRENT_AGENTS: 5, "catalog.activated": true },
+      reason: "skipping the dialog",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.statusText).toContain("catalog.activated");
+    expect(res.statusText).toContain("/api/v1/repository-catalog/activate");
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(0);
+    await expect(db.select().from(settings)).resolves.toHaveLength(0);
+  });
+
+  it("lets an owner write", async () => {
+    state.sessionUserId = "user_owner";
+    const res = await patch({
+      settings: { MAX_CONCURRENT_AGENTS: 4 },
+      reason: "owner decides",
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(entry(body.settings, "MAX_CONCURRENT_AGENTS")).toMatchObject({
+      value: 4,
+      source: "stored",
+    });
+    expect(body.versions[0]).toMatchObject({ actor: "user_owner" });
+  });
+
+  it("refuses a member with 403 and writes nothing", async () => {
+    state.sessionUserId = "user_member";
+    const res = await patch({
+      settings: { MAX_CONCURRENT_AGENTS: 5 },
+      reason: "trying",
+    });
+    expect(res.status).toBe(403);
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(0);
+  });
+
+  it("refuses an unknown key with 400 and writes nothing", async () => {
+    const res = await patch({
+      settings: { MAX_CONCURRENT_AGENTS: 5, NOT_A_SETTING: 1 },
+      reason: "typo",
+    });
+    expect(res.status).toBe(400);
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(0);
+  });
+
+  it("refuses a wrong type with 400 and writes nothing", async () => {
+    const res = await patch({
+      settings: { MAX_CONCURRENT_AGENTS: "many" },
+      reason: "typo",
+    });
+    expect(res.status).toBe(400);
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(0);
+  });
+
+  it("refuses a value below the declared minimum with 400 and writes nothing", async () => {
+    const res = await patch({
+      settings: { MAX_CONCURRENT_AGENTS: 0 },
+      reason: "stopping everything",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.statusText).toContain("MAX_CONCURRENT_AGENTS");
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(0);
+  });
+
+  it("refuses a value outside the declared set with 400 and writes nothing", async () => {
+    const res = await patch({
+      settings: { AGENT_KIND: "gemini" },
+      reason: "trying a third agent",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.statusText).toContain("AGENT_KIND");
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(0);
+  });
+
+  it("refuses an MCP result limit above the request limit with 400", async () => {
+    const res = await patch({
+      settings: { MCP_MAX_RESULT_BYTES: 4_000_000 },
+      reason: "bigger answers",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.statusText).toContain("MCP_MAX_RESULT_BYTES");
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(0);
+  });
+
+  it("refuses a body with no reason", async () => {
+    const res = await patch({ settings: { MAX_CONCURRENT_AGENTS: 5 } });
+    expect(res.status).toBe(400);
+    await expect(db.select().from(settingsVersions)).resolves.toHaveLength(0);
+  });
+});

--- a/apps/worker/src/routes/request-body-schema-coverage.test.ts
+++ b/apps/worker/src/routes/request-body-schema-coverage.test.ts
@@ -45,6 +45,7 @@ const JSON_BODY_SCHEMAS: Record<string, string[]> = {
   "api/v1/prompt-library/[id].patch.ts": ["promptLibraryUpdateMetaRequestSchema"],
   "api/v1/prompt-library/[id].put.ts": ["promptLibrarySaveVersionRequestSchema"],
   "api/v1/prompt-library/[id]/restore.post.ts": ["promptLibraryRestoreRequestSchema"],
+  "api/v1/settings.patch.ts": ["settingsPatchRequestSchema"],
   "api/v1/users/[userId]/role.patch.ts": ["dashboardUserRoleUpdateRequestSchema"],
   "api/v1/workflow-definitions.post.ts": ["workflowDefinitionCreateRequestSchema"],
   "api/v1/workflow-definitions/[id].patch.ts": ["workflowDefinitionMetaPatchRequestSchema"],

--- a/apps/worker/src/services/auth/roles.ts
+++ b/apps/worker/src/services/auth/roles.ts
@@ -15,6 +15,7 @@ export {
   canDispatchWorkflowRuns,
   canEditPrePrChecks,
   canEditPromptLibrary,
+  canEditSettings,
   canEditWorkflowDefinitions,
   canInvite,
   canManageHarnessProfiles,

--- a/apps/worker/src/services/settings/index.ts
+++ b/apps/worker/src/services/settings/index.ts
@@ -38,3 +38,19 @@ export {
 export type {
   WebhookProviderId,
 } from "./integration-settings.js";
+export {
+  loadSettingsResolution,
+  loadSettingsSnapshot,
+  settingsSeedRows,
+  settingsSnapshotFromEnvironment,
+} from "./snapshot.js";
+export type {
+  SettingsResolution,
+  SettingsSeedRow,
+} from "./snapshot.js";
+export {
+  SettingsValidationError,
+  readSettings,
+  readSettingsHistory,
+  updateSettings,
+} from "./store.js";

--- a/apps/worker/src/services/settings/integration-settings.ts
+++ b/apps/worker/src/services/settings/integration-settings.ts
@@ -8,6 +8,7 @@
  * module-level snapshots, because the worker's tests replace the environment
  * module per case.
  */
+import type { SettingsSnapshot } from "@shared/contracts";
 import {
   env,
   getConfiguredVcsProviders,
@@ -15,37 +16,66 @@ import {
   type VcsProviderConfig,
   type VcsProviderKind,
 } from "../../infra/vcs-config.js";
+import { settingsSnapshotFromEnvironment } from "./snapshot.js";
 
 /** Provider ids that carry a signed webhook, as system health observes them. */
 export type WebhookProviderId = "github" | "gitlab" | "jira" | "slack" | "email";
 
-/** The per-node trigger budget default a node's own params may override. */
-export function triggerRateLimitDefaults(): {
-  TRIGGER_RATE_LIMIT_MAX?: number;
-  TRIGGER_RATE_LIMIT_WINDOW?: "minute" | "hour" | "day" | "month";
-} {
+/**
+ * The per-node trigger budget default a node's own params may override.
+ *
+ * Like every accessor that reads a migrated key, the form that takes the
+ * snapshot is the one to use; the zero-argument form resolves from the
+ * environment and goes away with the environment parsing in the cleanup stage
+ * (stage H of the repository catalog and settings plan). An unset default
+ * stays `undefined` here rather than becoming null, because that is what its
+ * callers already treat as "no default".
+ */
+export function triggerRateLimitDefaults(
+  settings: SettingsSnapshot,
+): TriggerRateLimitDefaults;
+/** @deprecated Pass the snapshot. Removed with the environment in stage H. */
+export function triggerRateLimitDefaults(): TriggerRateLimitDefaults;
+export function triggerRateLimitDefaults(
+  settings?: SettingsSnapshot,
+): TriggerRateLimitDefaults {
+  const resolved = settings ?? settingsSnapshotFromEnvironment();
   return {
-    TRIGGER_RATE_LIMIT_MAX: env.TRIGGER_RATE_LIMIT_MAX,
-    TRIGGER_RATE_LIMIT_WINDOW: env.TRIGGER_RATE_LIMIT_WINDOW,
+    TRIGGER_RATE_LIMIT_MAX: resolved.TRIGGER_RATE_LIMIT_MAX ?? undefined,
+    TRIGGER_RATE_LIMIT_WINDOW: resolved.TRIGGER_RATE_LIMIT_WINDOW ?? undefined,
   };
 }
 
-/** The issue-tracker columns and project the ticket triggers are scoped to. */
-export function ticketBoardSettings(): {
+interface TriggerRateLimitDefaults {
+  TRIGGER_RATE_LIMIT_MAX?: number;
+  TRIGGER_RATE_LIMIT_WINDOW?: "minute" | "hour" | "day" | "month";
+}
+
+/** The issue-tracker columns and project the ticket triggers are scoped to.
+ *  The project key and the transition id are tracker wiring, not settings. */
+export function ticketBoardSettings(settings: SettingsSnapshot): TicketBoardSettings;
+/** @deprecated Pass the snapshot. Removed with the environment in stage H. */
+export function ticketBoardSettings(): TicketBoardSettings;
+export function ticketBoardSettings(
+  settings?: SettingsSnapshot,
+): TicketBoardSettings {
+  const resolved = settings ?? settingsSnapshotFromEnvironment();
+  return {
+    projectKey: env.JIRA_PROJECT_KEY,
+    aiColumn: resolved.COLUMN_AI,
+    aiReviewColumn: resolved.COLUMN_AI_REVIEW,
+    backlogColumn: resolved.COLUMN_BACKLOG,
+    backlogTransitionId: env.JIRA_BACKLOG_TRANSITION_ID,
+  };
+}
+
+interface TicketBoardSettings {
   projectKey: string;
   aiColumn: string;
   aiReviewColumn: string;
   backlogColumn: string;
   /** Set only where the tracker needs a transition id to reach the backlog. */
   backlogTransitionId?: string;
-} {
-  return {
-    projectKey: env.JIRA_PROJECT_KEY,
-    aiColumn: env.COLUMN_AI,
-    aiReviewColumn: env.COLUMN_AI_REVIEW,
-    backlogColumn: env.COLUMN_BACKLOG,
-    backlogTransitionId: env.JIRA_BACKLOG_TRANSITION_ID,
-  };
 }
 
 /** The shared secret Jira signs its webhook deliveries with, when configured. */

--- a/apps/worker/src/services/settings/runtime-settings.ts
+++ b/apps/worker/src/services/settings/runtime-settings.ts
@@ -11,11 +11,26 @@
  * Accessors are functions, not constants: the worker's tests replace the env
  * module per case, and a module-level snapshot would freeze the first value.
  */
+import type { SettingsSnapshot } from "@shared/contracts";
 import { env } from "../../infra/vcs-config.js";
+import { settingsSnapshotFromEnvironment } from "./snapshot.js";
+
+/**
+ * Every accessor below that reads a migrated key comes in two forms. The form
+ * that takes a snapshot is the one to use: the caller loaded it once at its
+ * entry point, so the value cannot change under it halfway through. The
+ * zero-argument form resolves a snapshot from the environment on the spot and
+ * exists only so callers that have not been converted yet keep compiling and
+ * behaving exactly as before; it goes away with the environment parsing in the
+ * cleanup stage (stage H of the repository catalog and settings plan).
+ */
 
 /** The run-slot ceiling every dispatch path shares. */
-export function maxConcurrentAgents(): number {
-  return env.MAX_CONCURRENT_AGENTS;
+export function maxConcurrentAgents(settings: SettingsSnapshot): number;
+/** @deprecated Pass the snapshot. Removed with the environment in stage H. */
+export function maxConcurrentAgents(): number;
+export function maxConcurrentAgents(settings?: SettingsSnapshot): number {
+  return (settings ?? settingsSnapshotFromEnvironment()).MAX_CONCURRENT_AGENTS;
 }
 
 /** The shared secret the platform sends on scheduled cron invocations. */
@@ -23,21 +38,53 @@ export function cronSecret(): string | undefined {
   return env.CRON_SECRET;
 }
 
-/** Dashboard identity: the organization invites are minted for and its origin. */
+/** Dashboard identity: the organization invites are minted for and its origin.
+ *  The origin stays deployment wiring and is not a setting. */
+export function dashboardOrganizationSettings(settings: SettingsSnapshot): {
+  slug: string;
+  name: string;
+  origin: string;
+};
+/** @deprecated Pass the snapshot. Removed with the environment in stage H. */
 export function dashboardOrganizationSettings(): {
   slug: string;
   name: string;
   origin: string;
+};
+export function dashboardOrganizationSettings(settings?: SettingsSnapshot): {
+  slug: string;
+  name: string;
+  origin: string;
 } {
+  const resolved = settings ?? settingsSnapshotFromEnvironment();
   return {
-    slug: env.DASHBOARD_ORG_SLUG,
-    name: env.DASHBOARD_ORG_NAME,
+    slug: resolved.DASHBOARD_ORG_SLUG,
+    name: resolved.DASHBOARD_ORG_NAME,
     origin: env.DASHBOARD_ORIGIN,
   };
 }
 
-/** MCP protocol limits and switches the transport and its services share. */
-export function mcpSettings(): {
+/** MCP protocol limits and switches the transport and its services share.
+ *  The server version is build metadata, not an operator decision. */
+export function mcpSettings(settings: SettingsSnapshot): McpSettings;
+/** @deprecated Pass the snapshot. Removed with the environment in stage H. */
+export function mcpSettings(): McpSettings;
+export function mcpSettings(settings?: SettingsSnapshot): McpSettings {
+  const resolved = settings ?? settingsSnapshotFromEnvironment();
+  return {
+    enabled: resolved.MCP_ENABLED,
+    serverVersion: env.MCP_SERVER_VERSION,
+    allowPublicDcr: resolved.MCP_ALLOW_PUBLIC_DCR,
+    maxRequestBytes: resolved.MCP_MAX_REQUEST_BYTES,
+    maxResultBytes: resolved.MCP_MAX_RESULT_BYTES,
+    toolTimeoutMs: resolved.MCP_TOOL_TIMEOUT_MS,
+    readRateLimitPerMinute: resolved.MCP_READ_RATE_LIMIT_PER_MINUTE,
+    mutationRateLimitPerMinute: resolved.MCP_MUTATION_RATE_LIMIT_PER_MINUTE,
+    auditRetentionDays: resolved.MCP_AUDIT_RETENTION_DAYS,
+  };
+}
+
+interface McpSettings {
   enabled: boolean;
   serverVersion: string;
   allowPublicDcr: boolean;
@@ -47,18 +94,6 @@ export function mcpSettings(): {
   readRateLimitPerMinute: number;
   mutationRateLimitPerMinute: number;
   auditRetentionDays: number;
-} {
-  return {
-    enabled: env.MCP_ENABLED,
-    serverVersion: env.MCP_SERVER_VERSION,
-    allowPublicDcr: env.MCP_ALLOW_PUBLIC_DCR,
-    maxRequestBytes: env.MCP_MAX_REQUEST_BYTES,
-    maxResultBytes: env.MCP_MAX_RESULT_BYTES,
-    toolTimeoutMs: env.MCP_TOOL_TIMEOUT_MS,
-    readRateLimitPerMinute: env.MCP_READ_RATE_LIMIT_PER_MINUTE,
-    mutationRateLimitPerMinute: env.MCP_MUTATION_RATE_LIMIT_PER_MINUTE,
-    auditRetentionDays: env.MCP_AUDIT_RETENTION_DAYS,
-  };
 }
 
 /** Where the dashboard lives, for links and for the auth cookie's origin. */
@@ -127,16 +162,24 @@ export function configuredSecretValues(): string[] {
  * carries. Read together because every caller that shapes a default definition
  * needs all three at once.
  */
-export function agentRuntimeSettings(): {
+export function agentRuntimeSettings(settings: SettingsSnapshot): AgentRuntimeSettings;
+/** @deprecated Pass the snapshot. Removed with the environment in stage H. */
+export function agentRuntimeSettings(): AgentRuntimeSettings;
+export function agentRuntimeSettings(
+  settings?: SettingsSnapshot,
+): AgentRuntimeSettings {
+  const resolved = settings ?? settingsSnapshotFromEnvironment();
+  return {
+    agentKind: resolved.AGENT_KIND,
+    includeReview: resolved.ENABLE_REVIEW_PHASE,
+    includeLeakReview: resolved.ENABLE_LEAK_REVIEW,
+  };
+}
+
+interface AgentRuntimeSettings {
   agentKind: typeof env.AGENT_KIND;
   includeReview: boolean;
   includeLeakReview: boolean;
-} {
-  return {
-    agentKind: env.AGENT_KIND,
-    includeReview: env.ENABLE_REVIEW_PHASE,
-    includeLeakReview: env.ENABLE_LEAK_REVIEW,
-  };
 }
 
 /**

--- a/apps/worker/src/services/settings/snapshot.test.ts
+++ b/apps/worker/src/services/settings/snapshot.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SETTINGS_REGISTRY } from "@shared/contracts";
+import type { Db } from "../../db/client.js";
+import { createTestDb } from "../../db/test-db.js";
+import { readAllSettings, seedSettings, writeManySettings } from "../../db/repositories/settings.js";
+
+const state = vi.hoisted(() => ({
+  db: undefined as unknown,
+  env: {} as Record<string, unknown>,
+}));
+
+vi.mock("../../infra/vcs-config.js", () => ({ env: state.env }));
+vi.mock("../../db/client.js", () => ({ getDb: () => state.db }));
+
+const {
+  loadSettingsResolution,
+  loadSettingsSnapshot,
+  settingsSnapshotFromEnvironment,
+  settingsSeedRows,
+} = await import("./snapshot.js");
+const {
+  agentRuntimeSettings,
+  dashboardOrganizationSettings,
+  maxConcurrentAgents,
+  mcpSettings,
+} = await import("./runtime-settings.js");
+const { ticketBoardSettings, triggerRateLimitDefaults } = await import(
+  "./integration-settings.js"
+);
+
+let db: Db;
+
+/** What the deployment's parsed environment holds today, in miniature. */
+function environmentAsDeployed(): Record<string, unknown> {
+  return {
+    DASHBOARD_ORG_NAME: "Acme",
+    DASHBOARD_ORG_SLUG: "acme",
+    DASHBOARD_ORIGIN: "https://dash.acme.test",
+    GITHUB_BASE_BRANCH: "main",
+    GITLAB_BASE_BRANCH: "trunk",
+    MAX_CONCURRENT_AGENTS: 7,
+    JOB_TIMEOUT_MS: 1_800_000,
+    POLL_INTERVAL_MS: 300_000,
+    ATTACHMENT_MAX_FILE_SIZE_MB: 25,
+    ATTACHMENT_MAX_TOTAL_SIZE_MB: 100,
+    ATTACHMENT_MAX_COUNT: 20,
+    ATTACHMENT_DOWNLOAD_TIMEOUT_MS: 30_000,
+    ENABLE_REVIEW_PHASE: true,
+    ENABLE_LEAK_REVIEW: false,
+    ENABLE_REPO_MEMORY: true,
+    ENABLE_ORG_MEMORY_PROMOTION: false,
+    ENABLE_REPO_ROUTING_MEMORY: false,
+    REVIEW_LEDGER_ENABLED: true,
+    MCP_ENABLED: true,
+    MCP_SERVER_VERSION: "0.1.0",
+    MCP_ALLOW_PUBLIC_DCR: false,
+    MCP_AUDIT_RETENTION_DAYS: 365,
+    MCP_MAX_REQUEST_BYTES: 1_048_576,
+    MCP_MAX_RESULT_BYTES: 524_288,
+    MCP_TOOL_TIMEOUT_MS: 30_000,
+    MCP_READ_RATE_LIMIT_PER_MINUTE: 120,
+    MCP_MUTATION_RATE_LIMIT_PER_MINUTE: 20,
+    AGENT_KIND: "codex",
+    CLAUDE_MODEL: undefined,
+    CODEX_MODEL: "gpt-5.6-codex",
+    COLUMN_AI: "AI",
+    COLUMN_AI_REVIEW: "AI Review",
+    COLUMN_BACKLOG: "Backlog",
+    JIRA_PROJECT_KEY: "AIW",
+    JIRA_BASE_URL: "https://acme.atlassian.net",
+    TRIGGER_RATE_LIMIT_MAX: 12,
+    TRIGGER_RATE_LIMIT_WINDOW: "hour",
+  };
+}
+
+beforeEach(async () => {
+  vi.unstubAllEnvs();
+  db = await createTestDb();
+  state.db = db;
+  for (const key of Object.keys(state.env)) delete state.env[key];
+  Object.assign(state.env, environmentAsDeployed());
+});
+
+describe("settings snapshot", () => {
+  it("resolves every key from the environment when the table is empty", async () => {
+    const snapshot = await loadSettingsSnapshot();
+
+    // "Empty table plus environment equals today": the value of every key is
+    // what the deployment's parsed environment already held, and the registry
+    // default only where the environment holds nothing.
+    expect(snapshot).toEqual(settingsSnapshotFromEnvironment());
+    expect(snapshot.MAX_CONCURRENT_AGENTS).toBe(7);
+    expect(snapshot.GITLAB_BASE_BRANCH).toBe("trunk");
+    expect(snapshot.AGENT_KIND).toBe("codex");
+    expect(snapshot.ENABLE_REPO_MEMORY).toBe(true);
+    expect(snapshot.TRIGGER_RATE_LIMIT_WINDOW).toBe("hour");
+    // Unset in the environment, so the registry default stands.
+    expect(snapshot.CLAUDE_MODEL).toBeNull();
+    expect(snapshot.V2_MAX_BLOCK_CONCURRENCY).toBeNull();
+    expect(snapshot["catalog.activated"]).toBe(false);
+    expect(snapshot.PRE_PR_COMMAND_TIMEOUT_MINUTES).toBe(10);
+    expect(snapshot.PRE_PR_CHECKS_ALLOWED_ENV).toEqual([]);
+  });
+
+  it("covers every registry key with a plain value, never a promise", async () => {
+    const snapshot = await loadSettingsSnapshot();
+    const synchronous = settingsSnapshotFromEnvironment();
+
+    for (const definition of SETTINGS_REGISTRY) {
+      const key = definition.key as keyof typeof snapshot;
+      expect(snapshot).toHaveProperty(definition.key);
+      const value: unknown = snapshot[key];
+      expect(value).not.toBeInstanceOf(Promise);
+      expect(
+        typeof (value as { then?: unknown })?.then === "function",
+      ).toBe(false);
+      expect(synchronous[key]).toEqual(value);
+    }
+    expect(Object.keys(snapshot).sort()).toEqual(
+      SETTINGS_REGISTRY.map((definition) => definition.key).sort(),
+    );
+  });
+
+  it("reads the checks keys the runner still reads raw", async () => {
+    vi.stubEnv("PRE_PR_COMMAND_TIMEOUT_MINUTES", "25");
+    vi.stubEnv("PRE_PR_CHECKS_ALLOWED_ENV", " NPM_TOKEN , ARTHUR_TOKEN,, ");
+
+    const snapshot = await loadSettingsSnapshot();
+    expect(snapshot.PRE_PR_COMMAND_TIMEOUT_MINUTES).toBe(25);
+    expect(snapshot.PRE_PR_CHECKS_ALLOWED_ENV).toEqual(["NPM_TOKEN", "ARTHUR_TOKEN"]);
+
+    vi.stubEnv("PRE_PR_COMMAND_TIMEOUT_MINUTES", "nonsense");
+    expect(settingsSnapshotFromEnvironment().PRE_PR_COMMAND_TIMEOUT_MINUTES).toBe(10);
+  });
+
+  it("lets a stored row win over the environment", async () => {
+    await writeManySettings(db, {
+      patch: { MAX_CONCURRENT_AGENTS: 1, CLAUDE_MODEL: "claude-opus-5" },
+      actor: "user_admin",
+      reason: "throttling",
+    });
+
+    const snapshot = await loadSettingsSnapshot();
+    expect(snapshot.MAX_CONCURRENT_AGENTS).toBe(1);
+    expect(snapshot.CLAUDE_MODEL).toBe("claude-opus-5");
+    expect(snapshot.COLUMN_AI).toBe("AI");
+  });
+
+  it("names where each value came from", async () => {
+    vi.stubEnv("COLUMN_AI", "AI");
+    await writeManySettings(db, {
+      patch: { MAX_CONCURRENT_AGENTS: 1 },
+      actor: "user_admin",
+      reason: "throttling",
+    });
+
+    const { sources } = await loadSettingsResolution();
+    expect(sources.get("MAX_CONCURRENT_AGENTS")).toBe("stored");
+    expect(sources.get("COLUMN_AI")).toBe("environment");
+    expect(sources.get("catalog.activated")).toBe("default");
+    expect(sources.get("CLAUDE_MODEL")).toBe("default");
+  });
+
+  it("offers one seed row per variable the deployment actually sets", () => {
+    vi.stubEnv("MAX_CONCURRENT_AGENTS", "7");
+    vi.stubEnv("COLUMN_AI", "AI");
+    vi.stubEnv("PRE_PR_CHECKS_ALLOWED_ENV", "NPM_TOKEN");
+
+    const rows = new Map(settingsSeedRows().map((row) => [row.key, row.value]));
+    expect(rows.get("MAX_CONCURRENT_AGENTS")).toBe(7);
+    expect(rows.get("COLUMN_AI")).toBe("AI");
+    expect(rows.get("PRE_PR_CHECKS_ALLOWED_ENV")).toEqual(["NPM_TOKEN"]);
+    // No variable, so nothing to seed from; and an unset variable makes no row.
+    expect(rows.has("catalog.activated")).toBe(false);
+    expect(rows.has("CLAUDE_MODEL")).toBe(false);
+  });
+
+  it("seeds the same rows however often the build runs", async () => {
+    vi.stubEnv("MAX_CONCURRENT_AGENTS", "7");
+    vi.stubEnv("COLUMN_AI", "AI");
+
+    const first = await seedSettings(db, {
+      rows: settingsSeedRows(),
+      actor: "environment",
+    });
+    const afterFirst = await readAllSettings(db);
+    const second = await seedSettings(db, {
+      rows: settingsSeedRows(),
+      actor: "environment",
+    });
+    const afterSecond = await readAllSettings(db);
+
+    expect(first).toBeGreaterThan(0);
+    expect(second).toBe(0);
+    expect(afterSecond.map((row) => [row.key, row.value])).toEqual(
+      afterFirst.map((row) => [row.key, row.value]),
+    );
+    const seeded = new Map(afterSecond.map((row) => [row.key, row.value]));
+    expect(seeded.get("MAX_CONCURRENT_AGENTS")).toBe(7);
+    expect(seeded.get("COLUMN_AI")).toBe("AI");
+    expect(seeded.has("CLAUDE_MODEL")).toBe(false);
+    // Seeded rows are the values already in force, so nothing changes.
+    expect((await loadSettingsSnapshot()).MAX_CONCURRENT_AGENTS).toBe(7);
+  });
+});
+
+describe("settings accessors", () => {
+  it("answer from the snapshot and from the environment alike, synchronously", async () => {
+    const snapshot = await loadSettingsSnapshot();
+
+    expect(maxConcurrentAgents(snapshot)).toBe(7);
+    expect(maxConcurrentAgents()).toBe(7);
+    expect(maxConcurrentAgents()).not.toBeInstanceOf(Promise);
+    expect(dashboardOrganizationSettings(snapshot)).toEqual({
+      slug: "acme",
+      name: "Acme",
+      origin: "https://dash.acme.test",
+    });
+    expect(dashboardOrganizationSettings(snapshot)).toEqual(
+      dashboardOrganizationSettings(),
+    );
+    expect(agentRuntimeSettings(snapshot)).toEqual({
+      agentKind: "codex",
+      includeReview: true,
+      includeLeakReview: false,
+    });
+    expect(agentRuntimeSettings(snapshot)).toEqual(agentRuntimeSettings());
+    expect(mcpSettings(snapshot)).toEqual(mcpSettings());
+    expect(mcpSettings(snapshot)).toMatchObject({
+      enabled: true,
+      serverVersion: "0.1.0",
+      maxResultBytes: 524_288,
+    });
+    expect(ticketBoardSettings(snapshot)).toEqual(ticketBoardSettings());
+    expect(ticketBoardSettings(snapshot)).toMatchObject({
+      projectKey: "AIW",
+      aiColumn: "AI",
+      aiReviewColumn: "AI Review",
+      backlogColumn: "Backlog",
+    });
+    expect(triggerRateLimitDefaults(snapshot)).toEqual({
+      TRIGGER_RATE_LIMIT_MAX: 12,
+      TRIGGER_RATE_LIMIT_WINDOW: "hour",
+    });
+    expect(triggerRateLimitDefaults(snapshot)).toEqual(triggerRateLimitDefaults());
+  });
+
+  it("never return a promise, in either form", async () => {
+    const snapshot = await loadSettingsSnapshot();
+    // A literal list, not a loop over the registry: the registry says which
+    // keys exist, and iterating it over the snapshot would stay green if an
+    // accessor itself became async. Add every new accessor that reads a
+    // migrated key here.
+    const results: unknown[] = [
+      maxConcurrentAgents(snapshot),
+      maxConcurrentAgents(),
+      dashboardOrganizationSettings(snapshot),
+      dashboardOrganizationSettings(),
+      mcpSettings(snapshot),
+      mcpSettings(),
+      agentRuntimeSettings(snapshot),
+      agentRuntimeSettings(),
+      ticketBoardSettings(snapshot),
+      ticketBoardSettings(),
+      triggerRateLimitDefaults(snapshot),
+      triggerRateLimitDefaults(),
+    ];
+
+    expect(results).toHaveLength(12);
+    for (const result of results) {
+      expect(result).not.toBeInstanceOf(Promise);
+      expect(typeof (result as { then?: unknown })?.then === "function").toBe(false);
+    }
+  });
+
+  it("follow a stored row once one exists", async () => {
+    await writeManySettings(db, {
+      patch: { MAX_CONCURRENT_AGENTS: 2, COLUMN_AI: "Agent", AGENT_KIND: "claude" },
+      actor: "user_admin",
+      reason: "tuning",
+    });
+    const snapshot = await loadSettingsSnapshot();
+
+    expect(maxConcurrentAgents(snapshot)).toBe(2);
+    expect(ticketBoardSettings(snapshot).aiColumn).toBe("Agent");
+    expect(agentRuntimeSettings(snapshot).agentKind).toBe("claude");
+    // The deprecated zero-argument form still answers from the environment,
+    // which is what every caller that has not been converted yet relies on.
+    expect(maxConcurrentAgents()).toBe(7);
+  });
+});

--- a/apps/worker/src/services/settings/snapshot.ts
+++ b/apps/worker/src/services/settings/snapshot.ts
@@ -1,0 +1,161 @@
+/**
+ * One resolved value per setting, read once and handed down synchronously.
+ *
+ * The store is asynchronous and the consumers are not: today's accessors
+ * return values, not promises, and an accessor that silently started returning
+ * a promise would read as truthy and flip a feature on. So an entry point (an
+ * HTTP handler, a cron tick, the MCP transport, and later a run at its start)
+ * loads one snapshot and passes it down; nothing below awaits a setting.
+ *
+ * Resolution order, until the cleanup stage removes the environment parsing:
+ * the stored row, then the value the deployment's environment already
+ * resolved to, then the registry default. A deployment with a configured
+ * environment and an empty table therefore behaves exactly as it did before
+ * this table existed.
+ */
+import {
+  SETTINGS_REGISTRY,
+  type SettingDefinition,
+  type SettingValue,
+  type SettingsSnapshot,
+  type SettingsSource,
+} from "@shared/contracts";
+import { readAllConnectedSettings } from "../../db/repositories/settings.js";
+import { env } from "../../infra/vcs-config.js";
+
+/** The snapshot plus where each value came from, for the settings page. */
+export interface SettingsResolution {
+  snapshot: SettingsSnapshot;
+  sources: ReadonlyMap<string, SettingsSource>;
+}
+
+/** One row the build-time seed would create from this deployment's variables. */
+export interface SettingsSeedRow {
+  key: string;
+  value: SettingValue;
+}
+
+/**
+ * The two checks variables are not in the parsed environment schema: the
+ * checks runner reads them straight off `process.env` and says why in its own
+ * comment. Reproducing that read here, rather than adding them to the schema,
+ * keeps this stage from touching the environment module the cleanup stage
+ * owns, and keeps "empty table plus environment equals today" true for them
+ * too. Everything else comes from the parsed `env`, never from `process.env`.
+ */
+const CHECKS_TIMEOUT_VARIABLE = "PRE_PR_COMMAND_TIMEOUT_MINUTES";
+const CHECKS_ALLOWED_ENV_VARIABLE = "PRE_PR_CHECKS_ALLOWED_ENV";
+
+/**
+ * Whether the deployment sets this variable at all.
+ *
+ * A presence question, not a value one: the parsed environment cannot answer
+ * it, because a variable that is unset and one that is set to its schema
+ * default both arrive as the same parsed value, and the seed and the "where
+ * did this come from" label need to tell those apart. An empty string counts
+ * as unset, which is what the environment module decides for every other key.
+ */
+function rawVariable(name: string): string | undefined {
+  const raw = process.env[name];
+  return raw === undefined || raw === "" ? undefined : raw;
+}
+
+/** Today's read of the per-command checks timeout, minus its default. */
+function checksTimeoutMinutes(): number | undefined {
+  const raw = rawVariable(CHECKS_TIMEOUT_VARIABLE);
+  const parsed = raw === undefined || raw.trim() === "" ? Number.NaN : Number(raw);
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.floor(parsed) : undefined;
+}
+
+/** Today's read of the forwarded-variable allowlist. */
+function checksAllowedEnvNames(): readonly string[] | undefined {
+  const raw = rawVariable(CHECKS_ALLOWED_ENV_VARIABLE);
+  if (raw === undefined) return undefined;
+  return raw
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+/** What the environment resolves this key to, or undefined for "nothing". */
+function environmentValue(definition: SettingDefinition): SettingValue | undefined {
+  const name = definition.environmentVariable;
+  if (name === null) return undefined;
+  if (name === CHECKS_TIMEOUT_VARIABLE) return checksTimeoutMinutes();
+  if (name === CHECKS_ALLOWED_ENV_VARIABLE) return checksAllowedEnvNames();
+
+  // Passed through exactly as the environment schema resolved it, bounds
+  // included. The registry's own bounds decide what an operator may write
+  // through the API; applying them here as well would quietly change the value
+  // a deployment already runs on, which is the one thing this stage must not
+  // do. Only "nothing set" falls through to the default.
+  const value = (env as unknown as Record<string, unknown>)[name];
+  return value === undefined || value === null ? undefined : (value as SettingValue);
+}
+
+function resolveFrom(
+  stored: ReadonlyMap<string, SettingValue>,
+): SettingsResolution {
+  const values: Record<string, SettingValue> = {};
+  const sources = new Map<string, SettingsSource>();
+  for (const definition of SETTINGS_REGISTRY) {
+    const fromEnvironment = environmentValue(definition);
+    if (stored.has(definition.key)) {
+      values[definition.key] = stored.get(definition.key) ?? null;
+      sources.set(definition.key, "stored");
+      continue;
+    }
+    const isSet =
+      definition.environmentVariable !== null &&
+      rawVariable(definition.environmentVariable) !== undefined &&
+      fromEnvironment !== undefined;
+    values[definition.key] = fromEnvironment ?? definition.default;
+    sources.set(definition.key, isSet ? "environment" : "default");
+  }
+  // The registry derives SettingsSnapshot key by key, so this object holds
+  // exactly its keys; the cast is the one place that fact is asserted.
+  return {
+    snapshot: Object.freeze(values) as unknown as SettingsSnapshot,
+    sources,
+  };
+}
+
+/**
+ * The snapshot without touching the database.
+ *
+ * The transition fallback: every accessor that has not been handed a snapshot
+ * yet resolves through this, so a caller converted in a later stage and one
+ * that is not both see the same value on a deployment with an empty table.
+ */
+export function settingsSnapshotFromEnvironment(): SettingsSnapshot {
+  return resolveFrom(new Map()).snapshot;
+}
+
+/** The snapshot and its sources, stored rows included. One database read. */
+export async function loadSettingsResolution(): Promise<SettingsResolution> {
+  const rows = await readAllConnectedSettings();
+  return resolveFrom(new Map(rows.map((row) => [row.key, row.value])));
+}
+
+/** The snapshot one entry point loads and hands down. One database read. */
+export async function loadSettingsSnapshot(): Promise<SettingsSnapshot> {
+  return (await loadSettingsResolution()).snapshot;
+}
+
+/**
+ * The rows the build-time seed writes: one per key whose variable this
+ * deployment actually sets, carrying the value the environment already
+ * resolved to. A key with no variable, and a variable left unset, produce no
+ * row, so the resolution order keeps answering for them.
+ */
+export function settingsSeedRows(): SettingsSeedRow[] {
+  const rows: SettingsSeedRow[] = [];
+  for (const definition of SETTINGS_REGISTRY) {
+    if (definition.environmentVariable === null) continue;
+    if (rawVariable(definition.environmentVariable) === undefined) continue;
+    const value = environmentValue(definition);
+    if (value === undefined) continue;
+    rows.push({ key: definition.key, value });
+  }
+  return rows;
+}

--- a/apps/worker/src/services/settings/store.test.ts
+++ b/apps/worker/src/services/settings/store.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Db } from "../../db/client.js";
+import { settings, settingsVersions } from "../../db/schema.js";
+import { createTestDb } from "../../db/test-db.js";
+
+const state = vi.hoisted(() => ({
+  db: undefined as unknown,
+  env: {
+    MCP_MAX_REQUEST_BYTES: 1_048_576,
+    MCP_MAX_RESULT_BYTES: 524_288,
+  } as Record<string, unknown>,
+}));
+
+vi.mock("../../infra/vcs-config.js", () => ({ env: state.env }));
+vi.mock("../../db/client.js", () => ({ getDb: () => state.db }));
+
+const { SettingsValidationError, updateSettings } = await import("./store.js");
+
+let db: Db;
+
+function write(patch: Record<string, unknown>) {
+  return updateSettings({ patch, actor: "user_admin", reason: "tuning MCP" });
+}
+
+async function storedNothing(): Promise<boolean> {
+  const rows = await db.select().from(settings);
+  const versions = await db.select().from(settingsVersions);
+  return rows.length === 0 && versions.length === 0;
+}
+
+beforeEach(async () => {
+  db = await createTestDb();
+  state.db = db;
+});
+
+describe("settings store", () => {
+  it("refuses a result limit raised above the request limit in force", async () => {
+    // The environment schema refuses to boot on this pair, so storing it would
+    // give the deployment a configuration it cannot start with.
+    await expect(write({ MCP_MAX_RESULT_BYTES: 2_000_000 })).rejects.toThrow(
+      SettingsValidationError,
+    );
+    await expect(write({ MCP_MAX_RESULT_BYTES: 2_000_000 })).rejects.toThrow(
+      /MCP_MAX_RESULT_BYTES \(above_request_limit\)/,
+    );
+    expect(await storedNothing()).toBe(true);
+  });
+
+  it("refuses a request limit lowered below the result limit in force", async () => {
+    await expect(write({ MCP_MAX_REQUEST_BYTES: 1_000 })).rejects.toThrow(
+      /MCP_MAX_RESULT_BYTES \(above_request_limit\)/,
+    );
+    expect(await storedNothing()).toBe(true);
+  });
+
+  it("accepts the pair when both move together", async () => {
+    const response = await write({
+      MCP_MAX_REQUEST_BYTES: 2_000_000,
+      MCP_MAX_RESULT_BYTES: 2_000_000,
+    });
+    expect(response.versions.map((version) => version.key).sort()).toEqual([
+      "MCP_MAX_REQUEST_BYTES",
+      "MCP_MAX_RESULT_BYTES",
+    ]);
+
+    // And the pair is judged against what is in force, not against the
+    // environment: raising the result limit alone is fine once the stored
+    // request limit is high enough.
+    await expect(write({ MCP_MAX_RESULT_BYTES: 1_500_000 })).resolves.toMatchObject({
+      versions: [{ key: "MCP_MAX_RESULT_BYTES", newValue: 1_500_000 }],
+    });
+  });
+
+  it("leaves a patch that touches neither limit alone", async () => {
+    await expect(write({ MAX_CONCURRENT_AGENTS: 5 })).resolves.toMatchObject({
+      versions: [{ key: "MAX_CONCURRENT_AGENTS", newValue: 5 }],
+    });
+  });
+});

--- a/apps/worker/src/services/settings/store.ts
+++ b/apps/worker/src/services/settings/store.ts
@@ -1,0 +1,173 @@
+/**
+ * Reading and changing the stored settings, in the shapes the HTTP surface
+ * answers with.
+ *
+ * The handlers above this file do authentication, status codes and nothing
+ * else: which keys exist, what a value may be, and what a change records are
+ * all decided here and in the registry, so the MCP tools a later plan adds
+ * cannot end up with a second, looser answer to the same questions.
+ */
+import {
+  SETTINGS_REGISTRY,
+  findSettingDefinition,
+  validateSettingsPatch,
+  type SettingValidationIssue,
+  type SettingValue,
+  type SettingsEntryView,
+  type SettingsPatchResponse,
+  type SettingsReadResponse,
+  type SettingsSnapshot,
+  type SettingsVersionView,
+  type SettingsVersionsResponse,
+} from "@shared/contracts";
+import {
+  latestConnectedSettingsVersions,
+  listConnectedSettingsVersions,
+  writeManyConnectedSettings,
+  type SettingsVersionRow,
+} from "../../db/repositories/settings.js";
+import { loadSettingsResolution, type SettingsResolution } from "./snapshot.js";
+
+/** How many past changes of one key the history answers with. */
+const HISTORY_LIMIT = 50;
+
+/**
+ * A patch the registry refused. Carries every offending key rather than the
+ * first, so a form that submits a whole group hears about all of them at once.
+ */
+export class SettingsValidationError extends Error {
+  readonly issues: SettingValidationIssue[];
+
+  constructor(issues: SettingValidationIssue[]) {
+    super(
+      `Invalid settings: ${issues
+        .map((issue) => `${issue.key} (${issue.reason})`)
+        .join(", ")}`,
+    );
+    this.name = "SettingsValidationError";
+    this.issues = issues;
+  }
+}
+
+function versionView(row: SettingsVersionRow): SettingsVersionView {
+  return {
+    id: row.id,
+    key: row.key,
+    previousValue: row.previousValue,
+    newValue: row.newValue,
+    actor: row.actor,
+    reason: row.reason,
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function entryViews(
+  resolution: SettingsResolution,
+  latest: SettingsVersionRow[],
+): SettingsEntryView[] {
+  const lastByKey = new Map(latest.map((row) => [row.key, versionView(row)]));
+  return SETTINGS_REGISTRY.map((definition) => ({
+    key: definition.key,
+    value: resolution.snapshot[definition.key],
+    default: definition.default,
+    source: resolution.sources.get(definition.key) ?? "default",
+    group: definition.group,
+    description: definition.description,
+    appliesToRunsInFlight: definition.appliesToRunsInFlight,
+    lastVersion: lastByKey.get(definition.key) ?? null,
+  }));
+}
+
+/** Every setting, resolved, with the change that last touched it. */
+export async function readSettings(): Promise<SettingsReadResponse> {
+  const [resolution, latest] = await Promise.all([
+    loadSettingsResolution(),
+    latestConnectedSettingsVersions(),
+  ]);
+  return { settings: entryViews(resolution, latest) };
+}
+
+/** One key's recorded changes, newest first. A key that is not a setting is
+ *  refused rather than answered with an empty history, so a typo in a link is
+ *  visible instead of looking like "nothing ever changed here". */
+export async function readSettingsHistory(
+  key: string,
+): Promise<SettingsVersionsResponse> {
+  if (!findSettingDefinition(key)) {
+    throw new SettingsValidationError([{ key, reason: "unknown_key" }]);
+  }
+  const rows = await listConnectedSettingsVersions(key, HISTORY_LIMIT);
+  return { versions: rows.map(versionView) };
+}
+
+/**
+ * The bounds no single key can check on its own.
+ *
+ * `runtime-env.ts` refines that the MCP result limit stays at or below the
+ * request limit, and a deployment whose environment breaks that rule refuses
+ * to boot. Without the same check here an admin could store, through the API,
+ * a pair the very same deployment would not start with, and find that out only
+ * at the next deploy. The pair is judged as it would stand after the write
+ * (the patched value where there is one, the value in force otherwise), and
+ * only when the patch touches one of the two, so an unrelated change is never
+ * refused for a state it did not create.
+ */
+function crossFieldIssues(
+  patch: Readonly<Record<string, unknown>>,
+  inForce: SettingsSnapshot,
+): SettingValidationIssue[] {
+  const touchesPair =
+    "MCP_MAX_RESULT_BYTES" in patch || "MCP_MAX_REQUEST_BYTES" in patch;
+  if (!touchesPair) return [];
+  const resultBytes =
+    "MCP_MAX_RESULT_BYTES" in patch
+      ? patch.MCP_MAX_RESULT_BYTES
+      : inForce.MCP_MAX_RESULT_BYTES;
+  const requestBytes =
+    "MCP_MAX_REQUEST_BYTES" in patch
+      ? patch.MCP_MAX_REQUEST_BYTES
+      : inForce.MCP_MAX_REQUEST_BYTES;
+  if (
+    typeof resultBytes === "number" &&
+    typeof requestBytes === "number" &&
+    resultBytes > requestBytes
+  ) {
+    return [{ key: "MCP_MAX_RESULT_BYTES", reason: "above_request_limit" }];
+  }
+  return [];
+}
+
+/**
+ * Store a patch, recording who changed what and why.
+ *
+ * Validation runs before anything is written, so a patch with one bad key
+ * changes nothing at all rather than half of what was asked for. The write
+ * itself is one statement in the repository tier; the snapshot is read back
+ * afterwards because a statement cannot see its own writes.
+ */
+export async function updateSettings(input: {
+  patch: Readonly<Record<string, unknown>>;
+  actor: string;
+  reason: string;
+}): Promise<SettingsPatchResponse> {
+  const issues = validateSettingsPatch(input.patch);
+  if (issues.length > 0) throw new SettingsValidationError(issues);
+
+  const inForce = await loadSettingsResolution();
+  const crossField = crossFieldIssues(input.patch, inForce.snapshot);
+  if (crossField.length > 0) throw new SettingsValidationError(crossField);
+
+  const versions = await writeManyConnectedSettings({
+    patch: input.patch as Readonly<Record<string, SettingValue>>,
+    actor: input.actor,
+    reason: input.reason,
+  });
+  const [resolution, latest] = await Promise.all([
+    loadSettingsResolution(),
+    latestConnectedSettingsVersions(),
+  ]);
+  return {
+    settings: entryViews(resolution, latest),
+    versions: versions.map(versionView),
+  };
+}

--- a/packages/contracts/dashboard-roles.ts
+++ b/packages/contracts/dashboard-roles.ts
@@ -66,3 +66,16 @@ export function canManageHarnessProfiles(role: DashboardRole): boolean {
 export function canDeleteAgentMemory(role: DashboardRole): boolean {
   return role === "owner" || role === "admin";
 }
+
+/** Changing a product-behaviour switch changes it for everyone, so the same
+ *  owner/admin rule as every other deployment-wide mutation. Reading the
+ *  settings page stays open to every member. */
+export function canEditSettings(role: DashboardRole): boolean {
+  return role === "owner" || role === "admin";
+}
+
+/** Adding, editing, disabling or activating repositories decides what the
+ *  agent may touch at all, so it follows the same rule. */
+export function canManageRepositoryCatalog(role: DashboardRole): boolean {
+  return role === "owner" || role === "admin";
+}

--- a/packages/contracts/index.ts
+++ b/packages/contracts/index.ts
@@ -32,4 +32,6 @@ export * from "./requests-webhooks";
 export * from "./requests-workflow-definitions";
 export * from "./requests-workflow-triggers";
 export * from "./requests-admin";
+export * from "./settings-api";
+export * from "./settings-registry";
 export * from "./run-registry";

--- a/packages/contracts/settings-api.ts
+++ b/packages/contracts/settings-api.ts
@@ -1,0 +1,81 @@
+/**
+ * The HTTP shapes of the settings surface.
+ *
+ * The read answers with one entry per registry key, resolved value included,
+ * so the dashboard never has to repeat the resolution order. The patch takes a
+ * partial map plus the reason it is being changed, because a settings change
+ * without a recorded reason is exactly the change nobody can explain later.
+ */
+import { z } from "zod";
+import type {
+  SettingKey,
+  SettingValue,
+  SettingsGroup,
+  SettingsInFlightRule,
+} from "./settings-registry";
+
+/** Where the value the worker is using actually came from. */
+export type SettingsSource = "stored" | "environment" | "default";
+
+/** One recorded change, as the history shows it. */
+export interface SettingsVersionView {
+  readonly id: number;
+  readonly key: string;
+  /** Null both for the first write of a key and for a stored null. */
+  readonly previousValue: SettingValue;
+  readonly newValue: SettingValue;
+  readonly actor: string;
+  readonly reason: string;
+  readonly createdAt: string;
+}
+
+/** One setting, resolved, with everything the form needs to render it. */
+export interface SettingsEntryView {
+  readonly key: SettingKey;
+  readonly value: SettingValue;
+  readonly default: SettingValue;
+  readonly source: SettingsSource;
+  readonly group: SettingsGroup;
+  readonly description: string;
+  readonly appliesToRunsInFlight: SettingsInFlightRule;
+  /** The newest recorded change to this key, or null when never written. */
+  readonly lastVersion: SettingsVersionView | null;
+}
+
+/** GET /api/v1/settings */
+export interface SettingsReadResponse {
+  readonly settings: SettingsEntryView[];
+}
+
+/** GET /api/v1/settings?key=... */
+export interface SettingsVersionsResponse {
+  readonly versions: SettingsVersionView[];
+}
+
+/**
+ * PATCH /api/v1/settings.
+ *
+ * `settings` stays an open map here: which keys exist and what each one
+ * accepts is the registry's question, answered by validateSettingsPatch, whose
+ * refusal names every offending key instead of only the first.
+ */
+export const settingsPatchRequestSchema = z.object(
+  {
+    settings: z.record(z.unknown(), {
+      required_error: "Invalid settings",
+      invalid_type_error: "Invalid settings",
+    }),
+    reason: z
+      .string({ required_error: "Invalid reason", invalid_type_error: "Invalid reason" })
+      .trim()
+      .min(1, { message: "Invalid reason" }),
+  },
+  { required_error: "Invalid settings", invalid_type_error: "Invalid settings" },
+);
+export type SettingsPatchRequest = z.infer<typeof settingsPatchRequestSchema>;
+
+/** The resolved settings after the write, and the rows the write recorded. */
+export interface SettingsPatchResponse {
+  readonly settings: SettingsEntryView[];
+  readonly versions: SettingsVersionView[];
+}

--- a/packages/contracts/settings-registry.test.ts
+++ b/packages/contracts/settings-registry.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  SETTINGS_REGISTRY,
+  findSettingDefinition,
+  validateSettingsPatch,
+} from "./settings-registry";
+
+test("every key is declared once and names its environment variable at most once", () => {
+  const keys = SETTINGS_REGISTRY.map((definition) => definition.key);
+  assert.equal(new Set(keys).size, keys.length);
+  const variables = SETTINGS_REGISTRY.map((d) => d.environmentVariable).filter(
+    (name): name is string => name !== null,
+  );
+  assert.equal(new Set(variables).size, variables.length);
+});
+
+test("a key the workflow body reads may only apply to the next run", () => {
+  // The rule the plan states: a run carries its settings from its start, so
+  // nothing a step reads may claim to change a run already in flight.
+  const workflowBodyKeys = new Set([
+    "DASHBOARD_ORG_SLUG",
+    "JOB_TIMEOUT_MS",
+    "V2_MAX_BLOCK_CONCURRENCY",
+    "ATTACHMENT_MAX_FILE_SIZE_MB",
+    "ATTACHMENT_MAX_TOTAL_SIZE_MB",
+    "ATTACHMENT_MAX_COUNT",
+    "ATTACHMENT_DOWNLOAD_TIMEOUT_MS",
+    "ENABLE_REVIEW_PHASE",
+    "ENABLE_LEAK_REVIEW",
+    "ENABLE_REPO_MEMORY",
+    "ENABLE_ORG_MEMORY_PROMOTION",
+    "ENABLE_REPO_ROUTING_MEMORY",
+    "REVIEW_LEDGER_ENABLED",
+    "COLUMN_AI",
+    "COLUMN_AI_REVIEW",
+    "COLUMN_BACKLOG",
+    "AGENT_KIND",
+    "CLAUDE_MODEL",
+    "CODEX_MODEL",
+    "PRE_PR_COMMAND_TIMEOUT_MINUTES",
+    "PRE_PR_CHECKS_ALLOWED_ENV",
+    "GITHUB_BASE_BRANCH",
+    "GITLAB_BASE_BRANCH",
+  ]);
+  for (const definition of SETTINGS_REGISTRY) {
+    if (workflowBodyKeys.has(definition.key)) {
+      assert.equal(definition.appliesToRunsInFlight, "next run", definition.key);
+    }
+  }
+});
+
+test("a default matches the type it is declared with", () => {
+  for (const definition of SETTINGS_REGISTRY) {
+    if (definition.default === null) continue;
+    const issues = validateSettingsPatch({ [definition.key]: definition.default });
+    assert.deepEqual(issues, [], definition.key);
+  }
+});
+
+test("an unknown key is refused by name", () => {
+  assert.deepEqual(validateSettingsPatch({ NOT_A_SETTING: 1 }), [
+    { key: "NOT_A_SETTING", reason: "unknown_key" },
+  ]);
+});
+
+test("a wrong type is refused per key and every refusal is reported", () => {
+  assert.deepEqual(
+    validateSettingsPatch({ MAX_CONCURRENT_AGENTS: "3", MCP_ENABLED: "true" }),
+    [
+      { key: "MAX_CONCURRENT_AGENTS", reason: "wrong_type" },
+      { key: "MCP_ENABLED", reason: "wrong_type" },
+    ],
+  );
+  assert.deepEqual(validateSettingsPatch({ MAX_CONCURRENT_AGENTS: 2.5 }), [
+    { key: "MAX_CONCURRENT_AGENTS", reason: "wrong_type" },
+  ]);
+  assert.deepEqual(validateSettingsPatch({ PRE_PR_CHECKS_ALLOWED_ENV: ["A", 2] }), [
+    { key: "PRE_PR_CHECKS_ALLOWED_ENV", reason: "wrong_type" },
+  ]);
+});
+
+test("a value outside the declared set or below the declared minimum is refused", () => {
+  assert.deepEqual(validateSettingsPatch({ AGENT_KIND: "gemini" }), [
+    { key: "AGENT_KIND", reason: "not_allowed_value" },
+  ]);
+  assert.deepEqual(validateSettingsPatch({ MAX_CONCURRENT_AGENTS: 0 }), [
+    { key: "MAX_CONCURRENT_AGENTS", reason: "below_minimum" },
+  ]);
+  assert.deepEqual(validateSettingsPatch({ MCP_TOOL_TIMEOUT_MS: 999 }), [
+    { key: "MCP_TOOL_TIMEOUT_MS", reason: "below_minimum" },
+  ]);
+});
+
+test("null clears a key that has no default and is refused for one that has", () => {
+  assert.deepEqual(validateSettingsPatch({ CLAUDE_MODEL: null }), []);
+  assert.deepEqual(validateSettingsPatch({ MAX_CONCURRENT_AGENTS: null }), [
+    { key: "MAX_CONCURRENT_AGENTS", reason: "null_not_allowed" },
+  ]);
+});
+
+test("the catalog switch is a setting with no environment variable", () => {
+  const definition = findSettingDefinition("catalog.activated");
+  assert.ok(definition);
+  assert.equal(definition.environmentVariable, null);
+  assert.equal(definition.default, false);
+});

--- a/packages/contracts/settings-registry.ts
+++ b/packages/contracts/settings-registry.ts
@@ -1,0 +1,569 @@
+/**
+ * Every product-behaviour switch this deployment has, as data.
+ *
+ * One list, in the package both applications share, so the worker resolves a
+ * setting and the dashboard renders it from the same description instead of
+ * two lists drifting apart. A key is in here because an operator can
+ * reasonably change it from the dashboard; credentials, provider identity,
+ * database and auth URLs stay in the environment and are deliberately absent.
+ *
+ * Until the cleanup stage the environment is still the source a missing row
+ * falls back to, so `environmentVariable` names the variable each key is
+ * resolved from today and `default` repeats what that variable's schema
+ * defaults to. A key with no variable (the repository catalog switch) has
+ * only the default and whatever row the dashboard writes.
+ */
+
+/** The panels the dashboard groups these into. */
+export type SettingsGroup =
+  | "general"
+  | "capacity"
+  | "attachments"
+  | "features"
+  | "mcp"
+  | "checks"
+  | "harness"
+  | "issue-tracker"
+  | "triggers"
+  | "repositories";
+
+/** The shapes a stored value may take. */
+export type SettingType = "boolean" | "integer" | "string" | "string-list";
+
+/** Any value a setting may hold, stored or resolved. */
+export type SettingValue = boolean | number | string | readonly string[] | null;
+
+/**
+ * When a change reaches a run.
+ *
+ * "next run" is the only honest answer for every key the workflow body reads:
+ * a run carries its settings from its start so a replay sees what the first
+ * execution saw, and a mid-run change would otherwise flip a branch the log
+ * already recorded. "immediate" is for the keys only a request, a cron tick or
+ * the MCP transport reads, where each entry loads its own snapshot anyway.
+ */
+export type SettingsInFlightRule = "immediate" | "next run";
+
+export interface SettingDefinition {
+  readonly key: string;
+  readonly group: SettingsGroup;
+  readonly type: SettingType;
+  /** The value used when nothing is stored and the variable is unset. */
+  readonly default: SettingValue;
+  readonly description: string;
+  readonly appliesToRunsInFlight: SettingsInFlightRule;
+  /** Whether the trigger-owned configuration work may later override this. */
+  readonly overridablePerTrigger: boolean;
+  /** The variable a missing row still falls back to, until the cleanup stage. */
+  readonly environmentVariable: string | null;
+  /** For a string setting whose value is one of a fixed set. */
+  readonly enumValues?: readonly string[];
+  /** For an integer setting, the smallest value its schema accepts today. */
+  readonly minimum?: number;
+}
+
+export const SETTINGS_REGISTRY = [
+  {
+    key: "DASHBOARD_ORG_NAME",
+    group: "general",
+    type: "string",
+    default: "AI Workflow",
+    description: "Display name of the organization the dashboard mints invites for.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "DASHBOARD_ORG_NAME",
+  },
+  {
+    key: "DASHBOARD_ORG_SLUG",
+    group: "general",
+    type: "string",
+    default: "ai-workflow",
+    description:
+      "Slug of the dashboard organization. Also names the agent's memory scope, so a run reads it at its start.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "DASHBOARD_ORG_SLUG",
+  },
+  {
+    key: "GITHUB_BASE_BRANCH",
+    group: "general",
+    type: "string",
+    default: "main",
+    description: "Branch new GitHub work branches are cut from when a repository names none.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "GITHUB_BASE_BRANCH",
+  },
+  {
+    key: "GITLAB_BASE_BRANCH",
+    group: "general",
+    type: "string",
+    default: "main",
+    description: "Branch new GitLab work branches are cut from when a repository names none.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "GITLAB_BASE_BRANCH",
+  },
+  {
+    key: "MAX_CONCURRENT_AGENTS",
+    group: "capacity",
+    type: "integer",
+    default: 3,
+    minimum: 1,
+    description: "How many runs may hold an agent slot at once. Every dispatch path shares it.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MAX_CONCURRENT_AGENTS",
+  },
+  {
+    key: "JOB_TIMEOUT_MS",
+    group: "capacity",
+    type: "integer",
+    default: 1_800_000,
+    minimum: 1,
+    description: "Wall clock a single agent phase may take before the run gives up on it.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "JOB_TIMEOUT_MS",
+  },
+  {
+    key: "V2_MAX_BLOCK_CONCURRENCY",
+    group: "capacity",
+    type: "integer",
+    default: null,
+    minimum: 1,
+    description:
+      "Operational ceiling on blocks of one run dispatched at once. Unset means the code-owned bound; this only ever lowers it.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "V2_MAX_BLOCK_CONCURRENCY",
+  },
+  {
+    key: "POLL_INTERVAL_MS",
+    group: "capacity",
+    type: "integer",
+    default: 300_000,
+    minimum: 1,
+    description: "Cadence the scheduled tick polls the issue tracker at.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "POLL_INTERVAL_MS",
+  },
+  {
+    key: "ATTACHMENT_MAX_FILE_SIZE_MB",
+    group: "attachments",
+    type: "integer",
+    default: 25,
+    minimum: 1,
+    description: "Largest single ticket attachment the agent will download.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ATTACHMENT_MAX_FILE_SIZE_MB",
+  },
+  {
+    key: "ATTACHMENT_MAX_TOTAL_SIZE_MB",
+    group: "attachments",
+    type: "integer",
+    default: 100,
+    minimum: 1,
+    description: "Total attachment bytes one run may download.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ATTACHMENT_MAX_TOTAL_SIZE_MB",
+  },
+  {
+    key: "ATTACHMENT_MAX_COUNT",
+    group: "attachments",
+    type: "integer",
+    default: 20,
+    minimum: 1,
+    description: "How many attachments of one ticket the agent will download.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ATTACHMENT_MAX_COUNT",
+  },
+  {
+    key: "ATTACHMENT_DOWNLOAD_TIMEOUT_MS",
+    group: "attachments",
+    type: "integer",
+    default: 30_000,
+    minimum: 1,
+    description: "Per-attachment download timeout.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ATTACHMENT_DOWNLOAD_TIMEOUT_MS",
+  },
+  {
+    key: "ENABLE_REVIEW_PHASE",
+    group: "features",
+    type: "boolean",
+    default: false,
+    description:
+      "Shapes the built-in workflow templates with a review phase. A saved definition's blocks decide the rest.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ENABLE_REVIEW_PHASE",
+  },
+  {
+    key: "ENABLE_LEAK_REVIEW",
+    group: "features",
+    type: "boolean",
+    default: false,
+    description:
+      "Shapes the built-in workflow templates with a leak review before the branch is pushed.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ENABLE_LEAK_REVIEW",
+  },
+  {
+    key: "ENABLE_REPO_MEMORY",
+    group: "features",
+    type: "boolean",
+    default: false,
+    description:
+      "The kill switch for per-repository agent memory: gates every read and every write, and leaves stored documents untouched when off.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ENABLE_REPO_MEMORY",
+  },
+  {
+    key: "ENABLE_ORG_MEMORY_PROMOTION",
+    group: "features",
+    type: "boolean",
+    default: false,
+    description:
+      "Promotes facts two repositories of one owner agree on into an organization document. No effect unless repository memory is on.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ENABLE_ORG_MEMORY_PROMOTION",
+  },
+  {
+    key: "ENABLE_REPO_ROUTING_MEMORY",
+    group: "features",
+    type: "boolean",
+    default: false,
+    description:
+      "Remembers which repository a human resolved a ticket label to. No effect unless repository memory is on.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "ENABLE_REPO_ROUTING_MEMORY",
+  },
+  {
+    key: "REVIEW_LEDGER_ENABLED",
+    group: "features",
+    type: "boolean",
+    default: false,
+    description: "Tracks every open review thread on a pull request as a work item with a stable alias.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "REVIEW_LEDGER_ENABLED",
+  },
+  {
+    key: "MCP_ENABLED",
+    group: "features",
+    type: "boolean",
+    default: false,
+    description: "Serves the remote MCP endpoint. Off means the transport refuses every request.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MCP_ENABLED",
+  },
+  {
+    key: "MCP_ALLOW_PUBLIC_DCR",
+    group: "mcp",
+    type: "boolean",
+    default: false,
+    description: "Allows dynamic client registration without a dashboard session.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MCP_ALLOW_PUBLIC_DCR",
+  },
+  {
+    key: "MCP_AUDIT_RETENTION_DAYS",
+    group: "mcp",
+    type: "integer",
+    default: 365,
+    minimum: 1,
+    description: "How long MCP audit rows are kept.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MCP_AUDIT_RETENTION_DAYS",
+  },
+  {
+    key: "MCP_MAX_REQUEST_BYTES",
+    group: "mcp",
+    type: "integer",
+    default: 1_048_576,
+    minimum: 1,
+    description: "Largest MCP request body accepted.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MCP_MAX_REQUEST_BYTES",
+  },
+  {
+    key: "MCP_MAX_RESULT_BYTES",
+    group: "mcp",
+    type: "integer",
+    default: 524_288,
+    minimum: 1,
+    description: "Largest MCP tool result returned. Must stay at or below the request limit.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MCP_MAX_RESULT_BYTES",
+  },
+  {
+    key: "MCP_TOOL_TIMEOUT_MS",
+    group: "mcp",
+    type: "integer",
+    default: 30_000,
+    minimum: 1_000,
+    description: "Wall clock one MCP tool call may take.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MCP_TOOL_TIMEOUT_MS",
+  },
+  {
+    key: "MCP_READ_RATE_LIMIT_PER_MINUTE",
+    group: "mcp",
+    type: "integer",
+    default: 120,
+    minimum: 1,
+    description: "Read calls one MCP client may make per minute.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MCP_READ_RATE_LIMIT_PER_MINUTE",
+  },
+  {
+    key: "MCP_MUTATION_RATE_LIMIT_PER_MINUTE",
+    group: "mcp",
+    type: "integer",
+    default: 20,
+    minimum: 1,
+    description: "Mutating calls one MCP client may make per minute.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: "MCP_MUTATION_RATE_LIMIT_PER_MINUTE",
+  },
+  {
+    key: "PRE_PR_COMMAND_TIMEOUT_MINUTES",
+    group: "checks",
+    type: "integer",
+    default: 10,
+    minimum: 1,
+    description:
+      "Per-command wall clock for repository checks when the repository names none of its own.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "PRE_PR_COMMAND_TIMEOUT_MINUTES",
+  },
+  {
+    key: "PRE_PR_CHECKS_ALLOWED_ENV",
+    group: "checks",
+    type: "string-list",
+    default: [],
+    description:
+      "Variable names the worker is willing to forward into a tenant's check commands. A name absent here is refused at save time.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "PRE_PR_CHECKS_ALLOWED_ENV",
+  },
+  {
+    key: "AGENT_KIND",
+    group: "harness",
+    type: "string",
+    enumValues: ["claude", "codex"],
+    default: "claude",
+    description:
+      "Which coding agent a deployment defaults to. A harness profile still decides the agent of a given run.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "AGENT_KIND",
+  },
+  {
+    key: "CLAUDE_MODEL",
+    group: "harness",
+    type: "string",
+    default: null,
+    description: "Default Claude model when no harness profile pins one.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "CLAUDE_MODEL",
+  },
+  {
+    key: "CODEX_MODEL",
+    group: "harness",
+    type: "string",
+    default: null,
+    description: "Default Codex model when no harness profile pins one.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: false,
+    environmentVariable: "CODEX_MODEL",
+  },
+  {
+    key: "COLUMN_AI",
+    group: "issue-tracker",
+    type: "string",
+    default: "AI",
+    description: "Board column a ticket enters to be assigned to the agent.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: true,
+    environmentVariable: "COLUMN_AI",
+  },
+  {
+    key: "COLUMN_AI_REVIEW",
+    group: "issue-tracker",
+    type: "string",
+    default: "AI Review",
+    description: "Board column a finished ticket is moved to for human review.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: true,
+    environmentVariable: "COLUMN_AI_REVIEW",
+  },
+  {
+    key: "COLUMN_BACKLOG",
+    group: "issue-tracker",
+    type: "string",
+    default: "Backlog",
+    description: "Board column a ticket is bounced back to when the agent needs clarification.",
+    appliesToRunsInFlight: "next run",
+    overridablePerTrigger: true,
+    environmentVariable: "COLUMN_BACKLOG",
+  },
+  {
+    key: "TRIGGER_RATE_LIMIT_MAX",
+    group: "triggers",
+    type: "integer",
+    default: null,
+    minimum: 1,
+    description:
+      "Default start budget for a trigger node that declares none. Unset means unlimited.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: true,
+    environmentVariable: "TRIGGER_RATE_LIMIT_MAX",
+  },
+  {
+    key: "TRIGGER_RATE_LIMIT_WINDOW",
+    group: "triggers",
+    type: "string",
+    enumValues: ["minute", "hour", "day", "month"],
+    default: null,
+    description: "The window the default trigger start budget is counted over.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: true,
+    environmentVariable: "TRIGGER_RATE_LIMIT_WINDOW",
+  },
+  {
+    key: "catalog.activated",
+    group: "repositories",
+    type: "boolean",
+    default: false,
+    description:
+      "Whether the repository catalog decides access. While off the agent sees everything the installation sees. Set only from the Repositories page.",
+    appliesToRunsInFlight: "immediate",
+    overridablePerTrigger: false,
+    environmentVariable: null,
+  },
+] as const satisfies readonly SettingDefinition[];
+
+type RegistryEntry = (typeof SETTINGS_REGISTRY)[number];
+
+/** Every key the registry declares, as a union. */
+export type SettingKey = RegistryEntry["key"];
+
+type ValueOfType<E> = E extends { enumValues: readonly (infer V extends string)[] }
+  ? V
+  : E extends { type: "boolean" }
+    ? boolean
+    : E extends { type: "integer" }
+      ? number
+      : E extends { type: "string" }
+        ? string
+        : E extends { type: "string-list" }
+          ? readonly string[]
+          : never;
+
+/** A key whose default is null has no value at all until one is set. */
+type ValueOfEntry<E> = E extends { default: null }
+  ? ValueOfType<E> | null
+  : ValueOfType<E>;
+
+/**
+ * One resolved value per key, derived from the registry so a key added above
+ * is a compile error everywhere it is not handled.
+ */
+export type SettingsSnapshot = {
+  readonly [E in RegistryEntry as E["key"]]: ValueOfEntry<E>;
+};
+
+const definitionsByKey = new Map<string, SettingDefinition>(
+  SETTINGS_REGISTRY.map((definition) => [definition.key, definition]),
+);
+
+/** The definition of one key, or undefined when the key is not a setting. */
+export function findSettingDefinition(key: string): SettingDefinition | undefined {
+  return definitionsByKey.get(key);
+}
+
+/** Why one entry of a patch was refused. Never carries the value itself. */
+export interface SettingValidationIssue {
+  readonly key: string;
+  readonly reason:
+    | "unknown_key"
+    | "wrong_type"
+    | "not_allowed_value"
+    | "below_minimum"
+    | "null_not_allowed"
+    /** A pair the environment schema refuses to boot with. Decided against the
+     *  values that would be in force after the write, not against the patch
+     *  alone, so it lives with the store rather than in this file. */
+    | "above_request_limit";
+}
+
+function matchesType(definition: SettingDefinition, value: unknown): boolean {
+  switch (definition.type) {
+    case "boolean":
+      return typeof value === "boolean";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "string":
+      return typeof value === "string";
+    case "string-list":
+      return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+  }
+}
+
+/**
+ * Check one patch against the registry.
+ *
+ * Returns every refusal rather than the first, so a form that submits a whole
+ * group is told about all of its bad fields at once. An empty result means the
+ * patch may be written as it is.
+ */
+export function validateSettingsPatch(
+  patch: Readonly<Record<string, unknown>>,
+): SettingValidationIssue[] {
+  const issues: SettingValidationIssue[] = [];
+  for (const [key, value] of Object.entries(patch)) {
+    const definition = findSettingDefinition(key);
+    if (!definition) {
+      issues.push({ key, reason: "unknown_key" });
+      continue;
+    }
+    if (value === null) {
+      if (definition.default !== null) issues.push({ key, reason: "null_not_allowed" });
+      continue;
+    }
+    if (!matchesType(definition, value)) {
+      issues.push({ key, reason: "wrong_type" });
+      continue;
+    }
+    if (definition.enumValues && !definition.enumValues.includes(value as string)) {
+      issues.push({ key, reason: "not_allowed_value" });
+      continue;
+    }
+    if (definition.minimum !== undefined && (value as number) < definition.minimum) {
+      issues.push({ key, reason: "below_minimum" });
+    }
+  }
+  return issues;
+}

--- a/scripts/ci/ci-workflow.test.ts
+++ b/scripts/ci/ci-workflow.test.ts
@@ -208,6 +208,9 @@ test("the source build covers worker and dashboard without deployment side effec
   );
   assert.doesNotMatch(workerPackage.scripts["build:ci"], /db:migrate/);
   assert.doesNotMatch(workerPackage.scripts["build:ci"], /seed:auth-user/);
+  // The settings seed writes rows, so it belongs to the build that owns the
+  // database and not to the one CI runs against no database at all.
+  assert.doesNotMatch(workerPackage.scripts["build:ci"], /db:seed-settings/);
 });
 
 test("the CI gate command reaches both database fences", async () => {
@@ -235,6 +238,7 @@ test("the source build uses the validator entrypoints and preserves deployment s
     "pnpm validate:pre-sandbox",
     "pnpm validate:local-skills",
     "pnpm db:migrate",
+    "pnpm db:seed-settings",
     "pnpm seed:auth-user",
     "pnpm --dir ../.. run gen:blocks -- --check",
     "rm -rf .nitro/workflow",


### PR DESCRIPTION
## Summary

Stage A of the repository catalog and settings plan ([plan](docs/plans/2026-09-11-repository-catalog-and-settings.md), row A; Jira draft T26, epic AIW-338): the settings registry, store, snapshot, build-time seed, role predicates and HTTP routes. Cut from main `d86ec93e4dee01f24289c8fa49c3215479d22b5c` and merged with main after #407 to #410. Nothing reads the store yet except the two routes: every existing accessor keeps its zero-argument form (deprecated) resolving through the environment, so a deployment with an empty table behaves exactly as today. The consumers switch to the snapshot in stages B1, F and X.

## What changed

**Registry.** `packages/contracts/settings-registry.ts` lists 37 keys in 10 groups (general, capacity, attachments, features, mcp, checks, harness, issue-tracker, triggers, repositories), each with type, default, description, whether a change applies to runs in flight or to the next run (23 keys are next run: every key an engine or workflow-definition file reads), and whether a later plan may override it per trigger. Key names equal the environment variables they replace; the one key with no variable is `catalog.activated`. `settings-api.ts` carries the request and response schemas; `dashboard-roles.ts` gains `canEditSettings` and `canManageRepositoryCatalog` (owner or admin).

**Store.** Tables `settings` (key, jsonb value, updated at, updated by) and `settings_versions` (key, previous, new, actor, reason, created at) in migration `0059_settings_store` with its journal entry and snapshot. `writeManySettings` is one data-modifying CTE (`jsonb_to_recordset` input, insert on conflict do update where the value is distinct, insert of the version rows from the written set); a spy test proves one `execute` and zero other statements. A second identical write creates no version row. Writes validate type, minimum, enum and unknown key against the registry, and the cross-field bound the environment enforces at boot (`MCP_MAX_RESULT_BYTES` at most `MCP_MAX_REQUEST_BYTES`) is checked against the values in force after the write.

**Snapshot.** `services/settings/snapshot.ts`: `loadSettingsSnapshot()` loads one immutable snapshot (stored row, else environment value when the variable is set, else registry default); `settingsSnapshotFromEnvironment()` is the synchronous transition form. The six accessors (`maxConcurrentAgents`, `dashboardOrganizationSettings`, `mcpSettings`, `agentRuntimeSettings`, `ticketBoardSettings`, `triggerRateLimitDefaults`) take the snapshot, with a deprecated zero-argument overload; a test iterates the six in both forms and asserts none returns a promise. The environment layer passes parsed values through unchanged, bounds included, so a value a deployment already runs on is never silently altered.

**Seed.** `apps/worker/scripts/db-seed-settings.ts` inserts one row per key whose variable is set (on conflict do nothing) and runs after `db:migrate` in the worker `build` script, never in `build:ci` (asserted by `scripts/ci/ci-workflow.test.ts`). On deploy this creates the two tables and seeds production from its current environment; the row source is recorded as `environment`.

**Routes.** `GET /api/v1/settings` (every role; `?key=` returns that key's history) and `PATCH /api/v1/settings` (owner or admin; member 403; the patch response returns the entries plus the version rows written). The generic patch refuses the `repositories` group with 400 naming the Repositories page: activation is set only through the activation dialog of stage C, whose route writes through the repository.

## Verification

Executor (Claude, opus): `pnpm run typecheck` 0, `pnpm run gates` 0, `gen:blocks --check` 0, `test:ci` 0, `test:packages` 0 (contracts 186 tests), settings suites 5 files and 40 tests passed, the three engine guard suites 106 passed, `build:ci` 0 (188 steps, 9 workflows), `mcp:contract:check` unchanged, `verify:changed -- --base d86ec93e --worktree` 0, `git diff --check` 0, step set identical, full worker suite 407 files and 6654 tests passed.

## Gate

Reviewer (Claude, opus, read-only): Spec CHANGES REQUIRED with one major (the cross-field MCP bound missing on the write path) and three minors (accessor promise test iterated the snapshot rather than the accessors; range and enum refusals proven at the registry but not at the route; owner never exercised on write), Standards APPROVE. It rebuilt the plan-to-registry comparison table (37 of 37 present, defaults equal to `runtime-env.ts`), proved the single-statement writes from the spy tests, and confirmed no importer of the store under `engine/` or `workflow-definition/`. Advisor finding F0 (generic patch must not flip `catalog.activated`) was applied before the review. One fix round closed all five items with new tests. Lean gate policy: after the fix round only blockers block, none remained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
