### PR TITLE
chore(repo): restructure sweep 1, deferred gate nits

### DIFF
--- a/apps/dashboard/AGENTS.md
+++ b/apps/dashboard/AGENTS.md
@@ -22,8 +22,10 @@ pnpm run dev        # next dev on port 3001
 pnpm run build      # next build
 pnpm run typecheck  # tsc --noEmit
 pnpm test           # node --test with tsx over **/*.test.ts and **/*.test.tsx
-pnpm run lint       # next lint, defined but not part of any gate today
 ```
+
+Linting is the root `pnpm run gate:lint` (oxlint over `apps/dashboard` among
+others), not a script in this package.
 
 The test runner is the Node test runner with module mocks, not vitest: tests
 are colocated (`lib/*.test.ts`, `components/**/**.test.tsx`) and render through
@@ -180,8 +182,9 @@ worker.
   form code under `components/cockpit/flow-editor/blocks/`, with shared
   primitives in its support modules and `config-fields.tsx` as the stable
   compatibility facade.
-- **`next lint` exists but no gate runs it.** Do not assume lint feedback; the
-  gate ladder for both apps is [ADR-004](../../docs/adr/ADR-004-gates-and-required-ci.md).
+- **There is no per-app lint script.** Lint feedback comes from the root
+  `pnpm run gate:lint` (oxlint), the same gate the worker answers to; the gate
+  ladder for both apps is [ADR-004](../../docs/adr/ADR-004-gates-and-required-ci.md).
 - **Editor forms are hand-written per block type.** A new block type needs its
   config fields here as well as its worker-side definition and generated
   catalog entry.

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -7,7 +7,6 @@
     "dev": "next dev -p 3001",
     "build": "tsx ../../scripts/gates/generate-block-catalog.ts --check && next build",
     "start": "next start",
-    "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "node --experimental-test-module-mocks --import tsx --test \"**/*.test.ts\" \"**/*.test.tsx\""
   },

--- a/apps/worker/src/db/repositories/repository-suggestions.ts
+++ b/apps/worker/src/db/repositories/repository-suggestions.ts
@@ -6,7 +6,7 @@
  * happened, it cost what it cost, and a later edit to the profile it proposed
  * does not change that.
  */
-import { and, asc, desc, eq, gte, lt, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, lt, or, sql } from "drizzle-orm";
 import type {
   RepositorySuggestionOutcome,
   RepositorySuggestionUsage,
@@ -169,6 +169,10 @@ async function listRepositorySuggestionsPage(
  * Rows, not tokens: the cap exists to stop a stuck screen from making calls in
  * a loop, and a loop is visible in the row count long before it is visible in
  * a bill.
+ *
+ * Aggregated in SQL rather than by reading the window: the window is bounded by
+ * the rate limit, not by anything that stops it growing, so selecting every row
+ * to take its length would scale with how hard a caller hammered the endpoint.
  */
 export async function countRepositorySuggestionsSince(
   db: Db,
@@ -176,16 +180,22 @@ export async function countRepositorySuggestionsSince(
   since: Date,
 ): Promise<{ count: number; oldestAt: Date | null }> {
   const rows = await db
-    .select({ createdAt: repositorySuggestions.createdAt })
+    .select({
+      total: sql<number>`count(*)::int`,
+      // `mapWith` because a raw aggregate skips the column's own driver
+      // mapping, and the driver hands a timestamptz back as a string.
+      oldestAt: sql<Date | null>`min(${repositorySuggestions.createdAt})`.mapWith(
+        repositorySuggestions.createdAt,
+      ),
+    })
     .from(repositorySuggestions)
     .where(
       and(
         eq(repositorySuggestions.repositoryId, repositoryId),
         gte(repositorySuggestions.createdAt, since),
       ),
-    )
-    .orderBy(asc(repositorySuggestions.createdAt));
-  return { count: rows.length, oldestAt: rows[0]?.createdAt ?? null };
+    );
+  return { count: rows[0]?.total ?? 0, oldestAt: rows[0]?.oldestAt ?? null };
 }
 
 export function countConnectedRepositorySuggestionsSince(

--- a/apps/worker/src/engine/definition/__golden__/definition-deployment-issues.test.ts
+++ b/apps/worker/src/engine/definition/__golden__/definition-deployment-issues.test.ts
@@ -29,6 +29,27 @@ describe("definition deployment issue golden", () => {
     );
   });
 
+  /**
+   * The byte assertion above is the contract; this is its diagnosis. A whole-file
+   * `toBe` on a fixture this size reports the first differing character and
+   * leaves the reader to work out which definition moved, so compare record by
+   * record as well: the failure then carries the fixture name and only that
+   * fixture's issues.
+   */
+  it("reports which fixture's issues moved", () => {
+    type GoldenRecord = { fixture: string; issues: unknown[] };
+    const rendered = JSON.parse(renderDefinitionGolden()) as GoldenRecord[];
+    const recorded = JSON.parse(
+      readFileSync(DEFINITION_GOLDEN_PATH, "utf8"),
+    ) as GoldenRecord[];
+    expect(rendered.map((record) => record.fixture)).toEqual(
+      recorded.map((record) => record.fixture),
+    );
+    for (const [index, record] of rendered.entries()) {
+      expect(record).toEqual(recorded[index]);
+    }
+  });
+
   it("is recomputed, not read: every corpus fixture appears once", () => {
     const names = definitionGoldenCorpus().map((entry) => entry.fixture);
     const recorded = (

--- a/apps/worker/src/engine/definition/block-registry.ts
+++ b/apps/worker/src/engine/definition/block-registry.ts
@@ -18,7 +18,6 @@ import {
   type ParsedJsonSchema,
 } from "./json-schema.js";
 
-
 export interface ContractDefinition {
   output: WorkflowValueSchema;
   /** Top-level fields guaranteed whenever the block advances through a normal

--- a/apps/worker/src/engine/pre-pr-checks/config.ts
+++ b/apps/worker/src/engine/pre-pr-checks/config.ts
@@ -1,8 +1,6 @@
 import {
-  REPOSITORY_SCRIPT_GROUP_NAME_MAX_LENGTH,
-  REPOSITORY_SCRIPT_GROUP_NAME_MESSAGE,
-  REPOSITORY_SCRIPT_GROUP_NAME_PATTERN,
   findExtendsCycle,
+  repositoryScriptGroupNameSchema,
   sortedGroupNames,
 } from "@shared/contracts";
 import { z } from "zod";
@@ -96,21 +94,6 @@ export const emptyRepoScriptsConfig: RepoScriptsConfig = { repositories: [] };
 
 const repoScriptsCommandSchema = z.string().trim().min(1);
 
-// Group names are user-facing identifiers (referenced from extends, gateGroups,
-// and eventually a block's group picker), so they get the same shape as any
-// other short slug: lowercase, digits, hyphens, capped so it stays readable
-// in a dropdown. Built from the shared constants rather than from literals of
-// its own: the dashboard blocks a Save against the same three values, and a
-// name accepted on one side and refused on the other could never match
-// anything at run time.
-const repoScriptsGroupNameSchema = z
-  .string()
-  .max(
-    REPOSITORY_SCRIPT_GROUP_NAME_MAX_LENGTH,
-    `group name must be at most ${REPOSITORY_SCRIPT_GROUP_NAME_MAX_LENGTH} characters`,
-  )
-  .regex(REPOSITORY_SCRIPT_GROUP_NAME_PATTERN, REPOSITORY_SCRIPT_GROUP_NAME_MESSAGE);
-
 // Env entries are NAMES, never values: the actual secret lives in the worker's
 // own environment and is looked up by name at execution time, so it never
 // gets stored in this config or persisted anywhere near a run record.
@@ -123,7 +106,7 @@ const repoScriptsEnvNameSchema = z
 const repoScriptsGroupConfigSchema = z
   .object({
     commands: z.array(repoScriptsCommandSchema).default([]),
-    extends: z.array(repoScriptsGroupNameSchema).optional(),
+    extends: z.array(repositoryScriptGroupNameSchema).optional(),
     // Defaulted rather than optional, so a parsed group always answers the
     // question and no consumer has to remember which way the absent case goes.
     restoreTree: z.boolean().default(true),
@@ -141,7 +124,7 @@ const repoScriptsGroupConfigSchema = z
   });
 
 const repoScriptsGroupsSchema = z
-  .record(repoScriptsGroupNameSchema, repoScriptsGroupConfigSchema)
+  .record(repositoryScriptGroupNameSchema, repoScriptsGroupConfigSchema)
   .refine((groups) => Object.keys(groups).length > 0, {
     message: "groups must contain at least one entry",
   });
@@ -209,7 +192,7 @@ const repoScriptsNewRepositoryRawSchema = z
     // would return it unchanged and the publication gate would run zero groups
     // and pass every run forever, with ok true and nothing verified. Omit the
     // field to mean "every group"; an empty array is a validation error.
-    gateGroups: z.array(repoScriptsGroupNameSchema).min(1).optional(),
+    gateGroups: z.array(repositoryScriptGroupNameSchema).min(1).optional(),
     commandTimeoutMinutes: repoScriptsTimeoutMinutesSchema.optional(),
   })
   .strict();

--- a/apps/worker/src/mcp/run-diagnosis.test.ts
+++ b/apps/worker/src/mcp/run-diagnosis.test.ts
@@ -185,7 +185,7 @@ describe("diagnoseRun", () => {
   // publication (workflows/blocks/finalize-workspace.ts:70-74), and
   // publication.reason is one of the WorkspaceGateError messages
   // (workflows/workspace-gate.ts:135-137). deriveFailureMessage then composes
-  // "The checks could not be started. (<reason>)" (workflow-definition/
+  // "The checks could not be started. (<reason>)" (packages/workflow-graph/
   // failure-message.ts, interpreter.ts for the generic sentence).
   it("classifies a workspace-gate failure message as workspace_gate, with low confidence", () => {
     const result = diagnoseRun({
@@ -379,11 +379,13 @@ describe("diagnoseRun", () => {
     });
   });
 
-  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.schema (workflow-definition/
-  // interpreter.ts:94) is the generic sentence used whenever a block or trigger
-  // output fails contract validation (interpreter.ts:439 contractViolation,
-  // block-registry output checks), and validateStructuredValue's schema_mismatch
-  // (sandbox/agents/protocol.ts:205-219) produces the agent-protocol variant.
+  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.schema (packages/workflow-graph/
+  // interpreter.ts) is the generic sentence used whenever a block or trigger
+  // output fails contract validation (V2Scheduler.processResult in
+  // packages/workflow-graph/scheduler.ts, `{ category: "schema", phase:
+  // "contract" }`, plus the block-registry output checks), and
+  // validateStructuredValue's schema_mismatch (sandbox/agents/protocol.ts:205-219)
+  // produces the agent-protocol variant.
   it("classifies a schema/contract-violation message as validation_failed, with low confidence", () => {
     const result = diagnoseRun({
       status: "failed",
@@ -401,8 +403,8 @@ describe("diagnoseRun", () => {
     });
   });
 
-  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.binding (interpreter.ts:91),
-  // used when a block input reference cannot be resolved: a workflow-definition
+  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.binding (same table),
+  // used when a block input reference cannot be resolved: a workflow definition
   // configuration defect, not a transient runtime problem, so nextActions
   // should point at the block/trigger configuration.
   it("classifies a block-input-binding failure message as validation_failed, pointing at the block configuration", () => {
@@ -416,7 +418,7 @@ describe("diagnoseRun", () => {
     expect(result.nextActions.join(" ")).toMatch(/config/i);
   });
 
-  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.parsing (interpreter.ts:93).
+  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.parsing (same table).
   it("classifies a response-parsing failure message as validation_failed, with low confidence", () => {
     const result = diagnoseRun({
       status: "failed",
@@ -477,7 +479,7 @@ describe("diagnoseRun", () => {
     expect(result.nextActions.join(" ")).not.toMatch(/status page/i);
   });
 
-  // Real shape: PROVIDER_CAUSES rate-limit entry (workflow-definition/
+  // Real shape: PROVIDER_CAUSES rate-limit entry (packages/workflow-graph/
   // failure-message.ts), reached the same way as the auth case above.
   it("classifies the curated AI-provider rate-limit message as dependency_unavailable, with low confidence", () => {
     const result = diagnoseRun({
@@ -493,7 +495,7 @@ describe("diagnoseRun", () => {
     });
   });
 
-  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.provider (interpreter.ts:89), the
+  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.provider (same table), the
   // uncurated fallback for a "provider"-category block whose raw error text
   // matched none of the curated PROVIDER_CAUSES patterns.
   it("classifies the generic external-service failure message as dependency_unavailable, with low confidence", () => {
@@ -567,8 +569,8 @@ describe("diagnoseRun", () => {
     });
   });
 
-  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.timeout (workflow-definition/
-  // interpreter.ts:92) composed with a "phase timed out" detail, e.g.
+  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.timeout (packages/workflow-graph/
+  // interpreter.ts) composed with a "phase timed out" detail, e.g.
   // workflows/blocks/generic-agent.ts:470 ("agent phase timed out") or
   // engine/agent-workflow.ts ("phase timed out").
   it("classifies a phase-timeout message as sandbox_timeout, with low confidence", () => {
@@ -585,7 +587,7 @@ describe("diagnoseRun", () => {
     });
   });
 
-  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.sandbox (interpreter.ts:88), the
+  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.sandbox (same table), the
   // generic "sandbox"-category sentence (e.g. workflows/blocks/prepare-workspace.ts's
   // outer catch, `category: "sandbox"`).
   it("classifies a workspace-environment failure message as workspace_unavailable, with low confidence", () => {
@@ -602,9 +604,9 @@ describe("diagnoseRun", () => {
     });
   });
 
-  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.engine (interpreter.ts:90), used
+  // Real shape: SAFE_EXECUTION_ERROR_MESSAGES.engine (same table), used
   // for engine-level failures (e.g. an unresolvable entry trigger or waiting
-  // node, interpreter.ts:409-422).
+  // node, V2SchedulerDefinitionError in packages/workflow-graph/scheduler.ts).
   it("classifies a workflow-engine failure message as engine_error, with low confidence", () => {
     const result = diagnoseRun({
       status: "failed",

--- a/apps/worker/src/mcp/tool-catalog.ts
+++ b/apps/worker/src/mcp/tool-catalog.ts
@@ -79,16 +79,18 @@ const WORKFLOW_NAME_MAX_LENGTH = 200;
 // reach the agent as INTERNAL_ERROR instead of NOT_FOUND.
 const DEFINITION_ID_MAX = 2_147_483_647;
 // Exactly the ceilings the definition schema already enforces on a graph
-// (workflow-definition/schema.ts, MAX_NODES and MAX_EDGES, applied to the v1 and the
-// v2 shape alike), deliberately neither higher nor lower: higher would let a graph
-// through that the store then refuses, and lower would leave an agent able to READ a
+// (`MAX_NODES` and `MAX_EDGES` in packages/workflow-graph/limits.ts, applied to the
+// v1 and the v2 shape alike), deliberately neither higher nor lower: higher would
+// let a graph through that the store then refuses, and lower would leave an agent able to READ a
 // deployed workflow it can never save back. Restated here so an oversized graph is
 // refused before it is hashed, audited and charged a mutation slot. The outer bound
 // stays MCP_MAX_REQUEST_BYTES, which caps the whole request rather than this field.
 //
-// Restated and not imported because that schema drags every block module in, which
-// the module doc above forbids on the transport path, so the equality is a claim a
-// test has to hold: tool-catalog.test.ts asserts it against the exported constants.
+// Restated and not imported because @shared/workflow-graph publishes only its
+// barrel, so importing the two numbers would load the whole definition schema on the
+// transport path, which the module doc above forbids; the equality is therefore a
+// claim a test has to hold: tool-catalog.test.ts asserts it against the exported
+// constants.
 export const WORKFLOW_MAX_NODES = 200;
 export const WORKFLOW_MAX_EDGES = 400;
 const RUN_ID_MAX_LENGTH = 200;
@@ -238,7 +240,8 @@ const preflightInputSchema = z
  * A graph, admitted by SIZE only. Deliberately not the real definition schema:
  * this module is loaded by the transport gate on every request before it has
  * decided whether a call is servable, so it must stay free of the database and the
- * block registry, and workflow-definition/schema.ts pulls in every block module
+ * block registry, and the definition schema (@shared/workflow-graph, resolved
+ * against engine/definition/block-registry.ts) pulls in every block module
  * behind it. The one authority on whether a graph is legal is that schema, called
  * from the tool where a validation failure can be answered as VALIDATION_FAILED;
  * a second copy here would be a second set of domain rules to keep in step.

--- a/apps/worker/src/mcp/tools/discovery.test.ts
+++ b/apps/worker/src/mcp/tools/discovery.test.ts
@@ -43,7 +43,8 @@ beforeEach(async () => {
   // tests start from an empty one: asserting around a seed instead would make
   // them fail the next time somebody adds a built-in prompt, which says nothing
   // about either tool. Same clearing the definition store's own tests do
-  // (workflow-definition/store.test.ts:1070).
+  // (services/workflow-definitions/persistence.test.ts, "back-compat wrappers
+  // on a single-definition db").
   await db.delete(workflowDefinitionTriggers);
   await db.delete(workflowDefinitionVersions);
   await db.delete(workflowDefinitions);

--- a/apps/worker/src/mcp/tools/workflow-authoring.test.ts
+++ b/apps/worker/src/mcp/tools/workflow-authoring.test.ts
@@ -6,10 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RETIRED_SCHEMA_MESSAGE } from "@shared/contracts";
 
 // The MCP fields the execute wrapper reads, plus the deployment facts the workflow
-// block registry resolves a graph against (mirroring workflow-definition/
-// store-v2.test.ts): a definition is validated against what this deployment can
-// actually run, so the providers have to be configured or every deploy fails for a
-// reason that has nothing to do with these tools. WEBHOOK_TRIGGER_ENCRYPTION_KEY
+// block registry resolves a graph against (mirroring
+// services/workflow-definitions/persistence-v2.test.ts): a definition is validated
+// against what this deployment can actually run, so the providers have to be
+// configured or every deploy fails for a reason that has nothing to do with these tools. WEBHOOK_TRIGGER_ENCRYPTION_KEY
 // stays unset, which is what keeps the endpoint mint on the deploy path a no-op.
 // The schedule reader, so the "the liveness check itself failed" branch can be
 // reached: everything else in this module runs against the real store, and the
@@ -121,7 +121,8 @@ const HOSTILE_NAME = `Ship <https://attacker.example|approved by platform>\n<@U1
 
 /** The smallest graph this deployment will actually deploy: one manually
  *  dispatchable trigger and nothing else, exactly the fixture the store's own v2
- *  tests deploy (workflow-definition/store-v2.test.ts:36). */
+ *  tests deploy (`definitionV2` in
+ *  services/workflow-definitions/persistence-v2.test.ts). */
 function graph(over: Record<string, unknown> = {}) {
   return {
     schemaVersion: 2,
@@ -551,6 +552,8 @@ describe("workflows.save_draft", () => {
     expect(errorPayload(result).message).toContain(
       "/nodes/0/type: Unknown workflow block type.",
     );
+    // Guards against the retired `workflow-definition/` source path leaking into
+    // error text: the graph rules now live in @shared/workflow-graph.
     expect(errorPayload(result).message).not.toContain("workflow-definition/");
     expect(await versionsOf(definitionId)).toEqual([]);
     expect(await auditedErrorCodes()).toEqual(["VALIDATION_FAILED"]);

--- a/apps/worker/src/mcp/tools/workflow-authoring.ts
+++ b/apps/worker/src/mcp/tools/workflow-authoring.ts
@@ -45,8 +45,9 @@ import {
  *   - a scope of its own (contracts.ts:12) and a role list without "service"
  *     (policy.ts), with request-context.ts stripping the scope out of an
  *     unattended token's actor;
- *   - every graph goes through workflow-definition/schema.ts, and a publish
- *     through the deployment gate inside deployWorkflowDefinition, which is the
+ *   - every graph goes through the definition schema in @shared/workflow-graph
+ *     (`workflowDefinitionV2Schema`, packages/workflow-graph/schema.ts), and a
+ *     publish through the deployment gate inside deployWorkflowDefinition, which is the
  *     whole of what the dashboard's Deploy button calls
  *     (routes/api/v1/workflow-definitions/[id]/deploy.post.ts:51);
  *   - compare-and-set on both writes that touch existing state, enforced by the

--- a/apps/worker/src/routes/webhooks/github.post.test.ts
+++ b/apps/worker/src/routes/webhooks/github.post.test.ts
@@ -297,6 +297,24 @@ describe("POST /webhooks/github", () => {
     expect(mocks.getConnectedRepositoryCatalogStateRow).toHaveBeenCalled();
   });
 
+  // Fail closed, the same bargain the poll pass strikes from the other side
+  // (routes/cron/poll.get.test.ts, "keeps the maintenance phases when the
+  // repository catalog cannot be read"): the tick may skip a dispatch phase
+  // because nothing is waiting on its answer, but an ingress holding a real
+  // delivery has to refuse it. Dispatching without the catalog would run a
+  // workflow on a repository an operator may have disabled, and the 5xx is
+  // what makes GitHub redeliver once the database answers again.
+  it("refuses the delivery and dispatches nothing when the repository catalog cannot be read", async () => {
+    mocks.getConnectedRepositoryCatalogStateRow.mockRejectedValueOnce(
+      new Error("neon: connection reset"),
+    );
+
+    const response = await makeApp()(makeRequest(pullRequestBody("opened")));
+
+    expect(response.status).toBeGreaterThanOrEqual(500);
+    expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
+  });
+
   it("starts a definition run and supersedes the gate for a bot PR", async () => {
     mockDispatchTriggerEvent.mockResolvedValueOnce({ result: "started", runId: "run_pr" });
 

--- a/apps/worker/src/routes/webhooks/gitlab.post.test.ts
+++ b/apps/worker/src/routes/webhooks/gitlab.post.test.ts
@@ -337,6 +337,24 @@ describe("POST /webhooks/gitlab", () => {
     expect(mocks.getConnectedRepositoryCatalogStateRow).toHaveBeenCalled();
   });
 
+  // Fail closed, the same bargain the poll pass strikes from the other side
+  // (routes/cron/poll.get.test.ts, "keeps the maintenance phases when the
+  // repository catalog cannot be read"): the tick may skip a dispatch phase
+  // because nothing is waiting on its answer, but an ingress holding a real
+  // delivery has to refuse it. Dispatching without the catalog would run a
+  // workflow on a repository an operator may have disabled, and the 5xx is
+  // what makes GitLab redeliver once the database answers again.
+  it("refuses the delivery and dispatches nothing when the repository catalog cannot be read", async () => {
+    mocks.getConnectedRepositoryCatalogStateRow.mockRejectedValueOnce(
+      new Error("neon: connection reset"),
+    );
+
+    const response = await makeApp()(makeRequest(validMergeRequestPayload()));
+
+    expect(response.status).toBeGreaterThanOrEqual(500);
+    expect(mockDispatchTriggerEvent).not.toHaveBeenCalled();
+  });
+
   it("dispatches a valid merge request webhook", async () => {
     mockDispatchPostPrGateWebhook.mockResolvedValueOnce({
       status: "dispatched",

--- a/apps/worker/src/services/mcp/run-diagnosis.ts
+++ b/apps/worker/src/services/mcp/run-diagnosis.ts
@@ -13,7 +13,7 @@
  * (`SAFE_EXECUTION_ERROR_MESSAGES` in packages/workflow-graph/interpreter.ts,
  * the repository scripts classes in workflows/blocks/repository-scripts-
  * output.ts) and the repository enforces the first with
- * `workflow-definition/execution-error-invariant.test.ts`: a copy of the table
+ * `engine/execution-error-invariant.test.ts`: a copy of the table
  * is how the scheduler path once drifted into producing a right-looking
  * sentence while skipping derivation. Re-typing those sentences here to keep
  * the file import-free would recreate exactly that failure surface, and it
@@ -198,11 +198,12 @@ const NO_WORKFLOW_MATCHED_MESSAGE =
 // generic "checks" category sentence, so it needs its own rule.
 const LEAK_REVIEW_GATE_PREFIX = "Leak review blocked publication before the branch was pushed:";
 
-// Prefix produced by SAFE_EXECUTION_ERROR_MESSAGES.checks (workflow-definition/
-// interpreter.ts:95) whenever a block reports `category: "checks"`. The pre-pr-gate
-// failure (AIW-223) is one of two sources of that category; the other is an
-// unrelated unmet-checks message, so a keyword from the WorkspaceGateError
-// messages (workflows/workspace-gate.ts:122-137) is required too.
+// Prefix produced by SAFE_EXECUTION_ERROR_MESSAGES.checks
+// (packages/workflow-graph/interpreter.ts) whenever a block reports
+// `category: "checks"`. The pre-pr-gate failure (AIW-223) is one of two sources
+// of that category; the other is an unrelated unmet-checks message, so a keyword
+// from the WorkspaceGateError messages (workflows/workspace-gate.ts:122-137) is
+// required too.
 const WORKSPACE_GATE_PREFIX = SAFE_EXECUTION_ERROR_MESSAGES.checks;
 const WORKSPACE_GATE_KEYWORDS = ["Run Workspace", "pre-publication check"];
 // The gate having no record leads with its own sentence rather than the checks
@@ -261,12 +262,12 @@ const STOPPED_WITHOUT_REASON_PREFIX =
   "This run was stopped before it finished, but no specific reason was recorded.";
 
 // Generic sentences for schema/contract failures: SAFE_EXECUTION_ERROR_MESSAGES.schema
-// (packages/workflow-graph/interpreter.ts:50, used wherever the scheduler rejects
+// (packages/workflow-graph/interpreter.ts, used wherever the scheduler rejects
 // a block output against its contract) and the agent-protocol schema_mismatch
-// message (sandbox/agents/protocol.ts:211). Also
-// SAFE_EXECUTION_ERROR_MESSAGES.binding (interpreter.ts:47, an unresolvable block
-// input reference: a definition configuration defect) and .parsing
-// (interpreter.ts:49, an unparsable response).
+// message (sandbox/agents/protocol.ts, validateStructuredValue). Also
+// SAFE_EXECUTION_ERROR_MESSAGES.binding (an unresolvable block input reference:
+// a definition configuration defect) and .parsing (an unparsable response),
+// both from the same table.
 const VALIDATION_FAILED_PREFIXES = [
   SAFE_EXECUTION_ERROR_MESSAGES.schema,
   "The current agent phase returned an invalid structured response.",
@@ -297,7 +298,7 @@ const PROVIDER_SPEND_LIMIT_ACTIONS = [
 // The other PROVIDER_CAUSES sentences (packages/workflow-graph/
 // failure-message.ts:102-181): billing/credit, rate limit, model unavailable,
 // and overloaded. Plus SAFE_EXECUTION_ERROR_MESSAGES.provider
-// (interpreter.ts:45), the uncurated fallback for a "provider"-category failure
+// (same table), the uncurated fallback for a "provider"-category failure
 // that matched none of those. Plus
 // the agent-CLI runtime-prep/execution sentences set directly as
 // `options.message` (protocol.ts:122/131/243/418 "The agent runtime could not
@@ -317,19 +318,19 @@ const DEPENDENCY_UNAVAILABLE_PREFIXES = [
   "The current agent phase could not be completed.",
 ];
 
-// SAFE_EXECUTION_ERROR_MESSAGES.timeout (packages/workflow-graph/interpreter.ts:48),
+// SAFE_EXECUTION_ERROR_MESSAGES.timeout (packages/workflow-graph/interpreter.ts),
 // composed whenever a block reports `category: "timeout"` (e.g. workflows/blocks/
 // generic-agent.ts:470, engine/agent-workflow.ts).
 const SANDBOX_TIMEOUT_PREFIX = SAFE_EXECUTION_ERROR_MESSAGES.timeout;
 
-// SAFE_EXECUTION_ERROR_MESSAGES.sandbox (interpreter.ts:88), the generic
+// SAFE_EXECUTION_ERROR_MESSAGES.sandbox (same table), the generic
 // "sandbox"-category sentence (e.g. workflows/blocks/prepare-workspace.ts's
 // outer catches, `category: "sandbox"`).
 const WORKSPACE_UNAVAILABLE_PREFIX = SAFE_EXECUTION_ERROR_MESSAGES.sandbox;
 
-// SAFE_EXECUTION_ERROR_MESSAGES.engine (interpreter.ts:90), used for
+// SAFE_EXECUTION_ERROR_MESSAGES.engine (same table), used for
 // engine-level failures (e.g. an unresolvable entry trigger or waiting node,
-// interpreter.ts:409-422).
+// V2SchedulerDefinitionError in packages/workflow-graph/scheduler.ts).
 const ENGINE_ERROR_PREFIX = SAFE_EXECUTION_ERROR_MESSAGES.engine;
 
 /** Stable references only: stepId of steps that failed, plus their error

--- a/apps/worker/src/services/triggers/polling/poll-pass.ts
+++ b/apps/worker/src/services/triggers/polling/poll-pass.ts
@@ -93,7 +93,13 @@ export async function runPollPass(
   const repositoryCatalogOrNull = async (
     phase: string,
   ): Promise<RepositoryCatalogSnapshot | null> => {
-    if (catalogFailed) return null;
+    if (catalogFailed) {
+      // Every later phase says so by name. Without this the tick reports one
+      // failed load and silently skips however many dispatch phases came after
+      // it, which reads in the log as those phases simply having nothing to do.
+      logger.warn({ phase }, "poll_repository_catalog_skipped");
+      return null;
+    }
     try {
       return await loadRepositoryCatalog();
     } catch (error) {

--- a/apps/worker/src/workflow-graph-suites/scenarios/loop-branch-early-exit.scenario.test.ts
+++ b/apps/worker/src/workflow-graph-suites/scenarios/loop-branch-early-exit.scenario.test.ts
@@ -56,9 +56,9 @@ const BLOCK_DATA = testBlockData(REGISTRY_CONTEXT);
  * exactly this shape, from the boundary being resolved twice. It does not fire,
  * but not because a repeated write is harmless. `setEdgeToken` only tolerates a
  * write of the value an edge already carries
- * (`packages/workflow-graph/scheduler.ts:874`); writing "active" over an
- * "inactive" a first pass left is still a contradiction, and a
- * region with two exits produces exactly that write. What keeps the boundary
+ * (`setEdgeToken` in `packages/workflow-graph/scheduler.ts`); writing "active"
+ * over an "inactive" a first pass left is still a contradiction, and a region
+ * with two exits produces exactly that write. What keeps the boundary
  * consistent is the deferral: a member resolves only the edges its own selected
  * port takes, leaves the rest of the region's boundary unresolved because a
  * retry may still select it, and `settleLoopBoundaryEdges` fills in the leftover
@@ -69,12 +69,12 @@ const BLOCK_DATA = testBlockData(REGISTRY_CONTEXT);
  * What the shape really tests is quieter, and for an agent block worse.
  * `seed -> loop` goes active the moment `seed` finishes, and a node is admitted
  * when *any* incoming edge is active rather than when a particular one is
- * (`resolveNodeIfReady`, `packages/workflow-graph/scheduler.ts:956-959`), so the
+ * (`resolveNodeIfReady`, `packages/workflow-graph/scheduler.ts`), so the
  * Loop's own arm going inactive is not enough to keep it from running. AIW-242
  * was exactly that: the Loop was admitted after `gate` had already left the
  * region, and its fresh branch spawned an iteration
- * (`packages/workflow-graph/scheduler.ts:1363`) that re-ran the whole region in
- * a child scope. Nothing surfaced it, because the run's bookkeeping is
+ * (`spawnLoopIteration`, `packages/workflow-graph/scheduler.ts`) that re-ran the
+ * whole region in a child scope. Nothing surfaced it, because the run's bookkeeping is
  * reconciled afterwards and the outcome reads `completed` with no error while
  * `work` had really executed twice.
  *

--- a/apps/worker/src/workflow-graph-suites/transform.test.ts
+++ b/apps/worker/src/workflow-graph-suites/transform.test.ts
@@ -75,30 +75,34 @@ describe("Transform", () => {
 
   it("rejects empty and unsupported regex patterns at deployment", () => {
     expect(
-      validateTransformDefinition({
-        configuration: {
-          operation: "replace_text",
-          source: "steps.entry.output.text",
-          mode: "plain",
-          pattern: "",
-          replacement: "",
-          ignoreCase: false,
+      validateTransformDefinition(
+        {
+          configuration: {
+            operation: "replace_text",
+            source: "steps.entry.output.text",
+            mode: "plain",
+            pattern: "",
+            replacement: "",
+            ignoreCase: false,
+          },
         },
-      },
-      JSON_SCHEMA_SUPPORT),
+        JSON_SCHEMA_SUPPORT,
+      ),
     ).toHaveLength(1);
     expect(
-      validateTransformDefinition({
-        configuration: {
-          operation: "replace_text",
-          source: "steps.entry.output.text",
-          mode: "regex",
-          pattern: "(?=x)",
-          replacement: "",
-          ignoreCase: false,
+      validateTransformDefinition(
+        {
+          configuration: {
+            operation: "replace_text",
+            source: "steps.entry.output.text",
+            mode: "regex",
+            pattern: "(?=x)",
+            replacement: "",
+            ignoreCase: false,
+          },
         },
-      },
-      JSON_SCHEMA_SUPPORT),
+        JSON_SCHEMA_SUPPORT,
+      ),
     ).toHaveLength(1);
   });
 
@@ -212,35 +216,41 @@ describe("Transform", () => {
 
   it("validates object names and zero-row drafts", () => {
     expect(
-      validateTransformDefinition({
-        configuration: { operation: "build_object", fields: [] },
-      },
-      JSON_SCHEMA_SUPPORT),
+      validateTransformDefinition(
+        {
+          configuration: { operation: "build_object", fields: [] },
+        },
+        JSON_SCHEMA_SUPPORT,
+      ),
     ).toHaveLength(1);
     expect(
-      validateTransformDefinition({
-        configuration: {
-          operation: "build_object",
-          fields: [
-            { name: "__proto__", value: { kind: "literal", value: 1 } },
-            { name: "ok", value: { kind: "literal", value: 1 } },
-            { name: "ok", value: { kind: "literal", value: 2 } },
-          ],
+      validateTransformDefinition(
+        {
+          configuration: {
+            operation: "build_object",
+            fields: [
+              { name: "__proto__", value: { kind: "literal", value: 1 } },
+              { name: "ok", value: { kind: "literal", value: 1 } },
+              { name: "ok", value: { kind: "literal", value: 2 } },
+            ],
+          },
         },
-      },
-      JSON_SCHEMA_SUPPORT),
+        JSON_SCHEMA_SUPPORT,
+      ),
     ).toHaveLength(2);
   });
 
   it("derives deterministic result schemas", () => {
     expect(
-      deriveTransformOutputSchema({
-        configuration: {
-          operation: "text_to_number",
-          source: "steps.entry.output.text",
+      deriveTransformOutputSchema(
+        {
+          configuration: {
+            operation: "text_to_number",
+            source: "steps.entry.output.text",
+          },
         },
-      },
-      JSON_SCHEMA_SUPPORT),
+        JSON_SCHEMA_SUPPORT,
+      ),
     ).toMatchObject({
       type: "object",
       properties: {

--- a/docs/adr/ADR-004-gates-and-required-ci.md
+++ b/docs/adr/ADR-004-gates-and-required-ci.md
@@ -19,7 +19,8 @@ pre-push only; the unit suites (worker sharded into four, dashboard,
 workflow-sdk) run in CI on every pull request behind an aggregate job named
 `ci`; the validators run through `build:ci`; `verify-deployment-identity` and
 the e2e suites run nightly, off the PR path. The worker has no linter, the
-dashboard's `next lint` is defined and never run, and there is no import
+dashboard's `next lint` script is defined and never run (deleted in the
+2026-09 sweep once `gate:lint` covered the dashboard), and there is no import
 boundary or unused-code tool at all.
 
 None of it blocks a merge. `main` has no branch protection and no ruleset, by

--- a/docs/architecture/repository-scripts.md
+++ b/docs/architecture/repository-scripts.md
@@ -507,7 +507,7 @@ message.
 | `provider_unavailable` | 503 | yes | An import named a key whose provider could not be listed. Nothing was written. |
 | `invalid_script_group_name` | 400 | no | A profile save carried a group name the checks engine cannot resolve. Refused, never repaired. |
 | `suggestion_rate_limited` | 429 | yes, after `retryAfterSeconds` | This repository has had 10 suggestions in the last hour. Nothing was spent or recorded. |
-| `repository_missing_at_provider` | 404 | no | The provider does not have the repository any more. Recorded as `missing`, no model call, no spend. |
+| `repository_missing_at_provider` | 404 | no | The provider does not answer for the repository any more. Recorded as `missing`, no model call, no spend. |
 | `profile_source_timed_out` | 503 | yes | The 60 second profile read deadline fired. Recorded as `timeout`. |
 | `profile_source_failed` | 502 | no | The provider refused the read, or no provider of that kind is configured here. Recorded as `failed`. |
 | `suggestion_timed_out` | 503 | yes | The 90 second model call deadline fired. Recorded as `timeout`. |
@@ -516,6 +516,14 @@ message.
 | `suggestion_malformed` | 502 | no | The answer did not parse against the contract. Recorded as `malformed`, tokens included. |
 | `repository_profile_conflict` | 409 | no, reload first | The save carried `expectedProfileVersion` and the stored profile has moved since. Nothing was written; the body carries `currentVersion`. |
 | `invalid_cursor` | 400 | no | A suggestion history request carried a cursor this deployment did not issue. |
+
+`repository_missing_at_provider` also covers a repository the deployment's
+token has lost access to, and the code cannot tell the two apart: GitHub and
+GitLab both answer 404 for a project the caller may not see, so a revoked scope,
+a rotated token and a deleted repository arrive as the same status
+(`RepositoryMissingAtProviderError`, thrown from
+`adapters/vcs/github/profile-source.ts` and `adapters/vcs/gitlab/profile-source.ts`).
+Check the token before removing the row the code suggests removing.
 
 Every row of that table except the first two and `suggestion_rate_limited`
 writes exactly one `repository_suggestions` row. A 403 (wrong role) and a 404

--- a/packages/contracts/execution-error.test.ts
+++ b/packages/contracts/execution-error.test.ts
@@ -1,9 +1,6 @@
 import { describe, it } from "node:test";
 import { expect } from "./test-expect.js";
-import {
-  createWorkflowExecutionErrorState,
-  isWorkflowExecutionErrorState,
-} from "./execution-error.js";
+import { createWorkflowExecutionErrorState } from "./execution-error.js";
 
 describe("execution error state", () => {
   it("derives the diagnostic id from the run, the node and the attempt", () => {
@@ -39,21 +36,5 @@ describe("execution error state", () => {
         detail: "402 insufficient credits for account acct_42",
       }),
     ).not.toHaveProperty("detail");
-  });
-
-  it("recognises a minted state and refuses a near miss", () => {
-    const state = createWorkflowExecutionErrorState("run-1", "block-a", 1, {
-      category: "timeout",
-      message: "The block timed out.",
-    });
-    expect(isWorkflowExecutionErrorState(state)).toBe(true);
-    expect(isWorkflowExecutionErrorState({ ...state, attempt: "1" })).toBe(
-      false,
-    );
-    expect(isWorkflowExecutionErrorState({ ...state, phase: 7 })).toBe(false);
-    expect(isWorkflowExecutionErrorState(null)).toBe(false);
-    expect(isWorkflowExecutionErrorState("AIW-DIAG-run-1-block-a-1")).toBe(
-      false,
-    );
   });
 });

--- a/packages/contracts/execution-error.ts
+++ b/packages/contracts/execution-error.ts
@@ -82,23 +82,3 @@ export function createWorkflowExecutionErrorState(
     attempt,
   };
 }
-
-/**
- * Recognises a stored or journaled value as an execution error state. Written
- * structurally on purpose: the value arrives from a checkpoint or a database
- * row, so it has no prototype to test and no class to be an instance of.
- */
-export function isWorkflowExecutionErrorState(
-  value: unknown,
-): value is WorkflowExecutionErrorState {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as Record<string, unknown>;
-  return (
-    typeof candidate.category === "string" &&
-    typeof candidate.message === "string" &&
-    typeof candidate.diagnosticId === "string" &&
-    typeof candidate.nodeId === "string" &&
-    typeof candidate.attempt === "number" &&
-    (candidate.phase === undefined || typeof candidate.phase === "string")
-  );
-}

--- a/packages/contracts/repository-catalog.test.ts
+++ b/packages/contracts/repository-catalog.test.ts
@@ -389,6 +389,17 @@ describe("looksLikeRemoteExecution", () => {
       "sudo apt-get install -y make",
       "echo cGF5bG9hZA== | base64 --decode | sh",
       "CURL https://install.example | SH",
+      // No space after the pipe, which is how a README that fits on one line
+      // writes it.
+      "curl -sSL https://install.example |sh",
+      "wget -qO- https://install.example|bash",
+      // `eval` on a variable, with nothing fetched in the same command: the
+      // fetch happened in an earlier step, so only the eval is visible here.
+      'eval "$INSTALL_SCRIPT"',
+      // The short decode flag, and a decode whose output is redirected rather
+      // than piped: the pipe rule cannot see either.
+      "echo cGF5bG9hZA== | base64 -d",
+      "base64 -d payload.b64 > run.sh",
     ]) {
       expect(looksLikeRemoteExecution(command)).toBe(true);
     }

--- a/packages/contracts/repository-script-group.test.ts
+++ b/packages/contracts/repository-script-group.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from "node:test";
+import { expect } from "./test-expect.js";
+import {
+  REPOSITORY_SCRIPT_GROUP_NAME_MAX_LENGTH,
+  REPOSITORY_SCRIPT_GROUP_NAME_MESSAGE,
+  repositoryScriptGroupNameSchema,
+} from "./index.js";
+
+/**
+ * The one schema every group-name check goes through: the checks engine config
+ * (`engine/pre-pr-checks/config.ts`), the block params schemas, and the
+ * dashboard all parse against this object rather than a copy of the rule. A
+ * name accepted on one side and refused on another would be a profile that
+ * saves and then fails to resolve at run time.
+ */
+describe("repositoryScriptGroupNameSchema", () => {
+  it("accepts a lowercase slug with digits and hyphens", () => {
+    for (const name of ["lint", "a", "build-2", "e2e-smoke-3"]) {
+      expect(repositoryScriptGroupNameSchema.safeParse(name).success).toBe(true);
+    }
+  });
+
+  it("refuses a name that does not start with a lowercase letter", () => {
+    for (const name of ["", "2fast", "-lead", "Lint", "lint_test", "lint test"]) {
+      const result = repositoryScriptGroupNameSchema.safeParse(name);
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.message).toBe(
+        REPOSITORY_SCRIPT_GROUP_NAME_MESSAGE,
+      );
+    }
+  });
+
+  it("caps the name at the shared maximum length", () => {
+    const atMax = "a".repeat(REPOSITORY_SCRIPT_GROUP_NAME_MAX_LENGTH);
+    expect(repositoryScriptGroupNameSchema.safeParse(atMax).success).toBe(true);
+    expect(
+      repositoryScriptGroupNameSchema.safeParse(`${atMax}a`).success,
+    ).toBe(false);
+  });
+});

--- a/packages/contracts/repository-script-group.ts
+++ b/packages/contracts/repository-script-group.ts
@@ -6,10 +6,22 @@ import {
 } from "./repository-scripts";
 
 /**
- * One repository script group name, as a runtime schema, for the workflow
- * definition rules that validate a node's selected groups. It is built from the
- * same constants the repository script contracts declare, so a group name a
- * definition may name is exactly a group name a repository may declare.
+ * One repository script group name, as a runtime schema.
+ *
+ * Group names are user-facing identifiers (a group's own key, an `extends`
+ * entry, a `gateGroups` entry, a block's group picker), so they get the shape of
+ * any other short slug: lowercase, digits, hyphens, capped so it stays readable
+ * in a dropdown.
+ *
+ * Every zod parse of a group name goes through THIS object rather than a copy of
+ * the rule: the workflow definition rules that validate a node's selected groups
+ * (`engine/definition/block-params-schemas.ts`) and the checks engine's own
+ * stored config (`engine/pre-pr-checks/config.ts`). A name accepted on one side
+ * and refused on the other would be a profile that saves and then fails to
+ * resolve at run time. It is built from the same constants the repository script
+ * contracts declare (which is also what the dashboard's client-side
+ * `isRepositoryScriptGroupName` reads), so a group name a definition may name is
+ * exactly a group name a repository may declare.
  *
  * The `run_checks` and `run_scripts` manifests restate the same schema instead
  * of importing it: the catalog generator parses a manifest and allows runtime

--- a/packages/workflow-graph/policies.ts
+++ b/packages/workflow-graph/policies.ts
@@ -24,13 +24,11 @@
  * to think about. Both use the one `dedupeWorkflowDefinitionIssues`.
  */
 import type { z } from "zod";
-import type {
-  WorkflowDefinition,
-  WorkflowDefinitionValidationIssue,
-} from "@shared/contracts";
 import {
   WORKFLOW_SCHEMA_VERSION,
   workflowDefinitionSchemaVersionOf,
+  type WorkflowDefinition,
+  type WorkflowDefinitionValidationIssue,
 } from "@shared/contracts";
 import {
   dedupeWorkflowDefinitionIssues,


### PR DESCRIPTION
## Restructure sweep 1: deferred gate nits (AIW-338)

Base `8e0591d7a4d483416a0435ab17a1d55d78cac1b3` (catalog stage M merge). Eleven of the twelve items in the sweep brief, all mechanical; item 12 skipped on purpose (the two block-params schema type names are a deliberate package-versus-worker split, not a duplicate).

- Every `workflow-definition/` path comment under `apps/worker/src` and `packages` repointed to the module's real home; the two golden-test narrations that describe where a fixture was recorded stay as history.
- Stale line citations in `services/mcp/run-diagnosis.ts`, `mcp/run-diagnosis.test.ts`, `mcp/tool-catalog.ts` and the loop-branch scenario replaced by symbol names.
- The pre-PR checks config parsed group names with a byte-identical copy of `repositoryScriptGroupNameSchema`; it now imports the contract schema, which gained a direct test.
- `isWorkflowExecutionErrorState` (no importer outside its test) deleted from `@shared/contracts`.
- `countRepositorySuggestionsSince` counts in SQL (`count(*)`, `min(created_at)`) instead of loading every row in the window; same return shape.
- The poll pass logs `poll_repository_catalog_skipped` with the phase on every early return; the GitHub and GitLab webhook routes gained fail-closed tests (catalog read rejects, 5xx, no dispatch).
- Five extra matcher cases for the script safety rules; a per-fixture loop in the deployment-issues golden test (golden unchanged, sha256 `587bfaf0…`); docs note on `repository_missing_at_provider` covering lost token access; the dashboard `lint` script that fell into the ESLint wizard removed (the real gate is `gate:lint`).

Invariants: no step file moved, `build:ci` untouched, MCP contract hash unchanged (`2a731485…`), no golden or test expectation altered.

### Gate

Reviewer (sonnet, mechanical stage): Spec APPROVE with one nit (a sentence in ADR-004 about the deleted dashboard lint script, fixed by the advisor before the commit), Standards APPROVE. Reviewer commands: typecheck PASS, `pnpm run gates` exit 0, packages 0 fail, worker vitest 9 files / 163 tests and 19 files / 383 tests on the touched suites, `mcp:contract:check` PASS at the unchanged hash, dashboard typecheck clean. `verify:changed --worktree` failed once on `workflow-sdk-tests/v2-concurrent.test.ts` (30 s timeout under machine load, unrelated to the diff), green when rerun alone; recorded, not erased.

Candidate `99e39da6c5b46baa7d9023d90d40ffb0f60bd485`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DEhby4LyviBuyNqC1KN3s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostic logging when repository polling is skipped after an earlier catalog failure.
  - Webhook processing now remains fail-closed when the repository catalog cannot be read, preventing unintended dispatches.

- **Documentation**
  - Updated guidance for shared linting, repository access errors, workflow-graph references, and repository script group-name rules.

- **Tests**
  - Expanded coverage for remote execution detection, webhook failure handling, group-name validation, and deployment issue diagnostics.

- **Chores**
  - Removed the dashboard-specific lint command in favor of the shared lint gate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->